### PR TITLE
refactor(max): collapse tabId + sidePanel into a single panelId

### DIFF
--- a/frontend/src/scenes/feature-flags/NewFeatureFlagMenu.tsx
+++ b/frontend/src/scenes/feature-flags/NewFeatureFlagMenu.tsx
@@ -18,7 +18,7 @@ import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { getToolDefinition } from 'scenes/max/max-constants'
-import { maxLogic } from 'scenes/max/maxLogic'
+import { SIDE_PANEL_PANEL_ID, maxLogic } from 'scenes/max/maxLogic'
 import { createSuggestionGroup } from 'scenes/max/utils'
 import { urls } from 'scenes/urls'
 
@@ -109,7 +109,7 @@ function IntentSubmenu({ template, onBack }: { template: TemplateKey; onBack: ()
 
 export function OverlayForNewFeatureFlagMenu(): JSX.Element {
     const { featureFlags } = useValues(enabledFeaturesLogic)
-    const { setActiveGroup } = useActions(maxLogic({ sidePanel: true }))
+    const { setActiveGroup } = useActions(maxLogic({ panelId: SIDE_PANEL_PANEL_ID }))
     const { openSidePanel } = useActions(sidePanelLogic)
 
     const intentsEnabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAG_CREATION_INTENTS]

--- a/frontend/src/scenes/inbox/SessionAnalysisSetup.tsx
+++ b/frontend/src/scenes/inbox/SessionAnalysisSetup.tsx
@@ -89,7 +89,7 @@ function SessionAnalysisSetupChat(): JSX.Element {
 
 export function SessionAnalysisSetup(): JSX.Element {
     const { saveSessionAnalysisFilters } = useActions(signalSourcesLogic)
-    const maxLogicProps = { tabId: INBOX_TAB_ID, onAcceptSessionFilters: saveSessionAnalysisFilters }
+    const maxLogicProps = { panelId: INBOX_TAB_ID, onAcceptSessionFilters: saveSessionAnalysisFilters }
     const { threadLogicKey, conversation } = useValues(maxLogic(maxLogicProps))
 
     return (
@@ -98,7 +98,7 @@ export function SessionAnalysisSetup(): JSX.Element {
                 logic={maxThreadLogic}
                 props={
                     {
-                        tabId: INBOX_TAB_ID,
+                        panelId: INBOX_TAB_ID,
                         conversationId: threadLogicKey,
                         conversation,
                     } satisfies MaxThreadLogicProps

--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -128,9 +128,9 @@ export const WelcomeFeaturePreviewAutoEnrolled: Story = {
 
 export const Thread: Story = {
     render: () => {
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
         const { askMax } = useActions(
-            maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+            maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, panelId: 'storybook' })
         )
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -159,8 +159,12 @@ export const EmptyThreadLoading: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -194,8 +198,12 @@ export const GenerationFailureThread: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax, setMessageStatus } = useActions(threadLogic)
         const { threadRaw, threadLoading } = useValues(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
@@ -230,8 +238,12 @@ export const ThreadWithFailedGeneration: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -262,8 +274,12 @@ export const ThreadWithRateLimit: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -294,8 +310,12 @@ export const ThreadWithRateLimitNoRetryAfter: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -331,8 +351,12 @@ export const ThreadWithBillingLimitExceeded: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -361,8 +385,12 @@ export const ThreadWithQuickReplies: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -391,7 +419,7 @@ export const ThreadWithConversationLoading: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             setConversationId(CONVERSATION_ID)
@@ -414,7 +442,7 @@ export const ThreadWithEmptyConversation: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             setConversationId('empty')
@@ -466,7 +494,7 @@ export const SharedThread: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             // Simulate loading a shared conversation via URL parameter
@@ -491,7 +519,7 @@ export const ThreadWithInProgressConversation: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             setConversationId('in_progress')
@@ -531,7 +559,7 @@ export const ChatHistory: Story = {
             },
         })
 
-        const { toggleConversationHistory } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { toggleConversationHistory } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             toggleConversationHistory(true)
@@ -554,7 +582,7 @@ export const ChatHistoryEmpty: Story = {
             },
         })
 
-        const { toggleConversationHistory } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { toggleConversationHistory } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             toggleConversationHistory(true)
@@ -577,7 +605,7 @@ export const ChatHistoryLoading: Story = {
             },
         })
 
-        const { toggleConversationHistory } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { toggleConversationHistory } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             toggleConversationHistory(true)
@@ -594,7 +622,7 @@ export const ChatHistoryLoading: Story = {
 
 export const ThreadWithOpenedSuggestionsMobile: Story = {
     render: () => {
-        const { setActiveGroup } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setActiveGroup } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             // The largest group is the set up group
@@ -617,7 +645,7 @@ export const ThreadWithOpenedSuggestionsMobile: Story = {
 
 export const ThreadWithOpenedSuggestions: Story = {
     render: () => {
-        const { setActiveGroup } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setActiveGroup } = useActions(maxLogic({ panelId: 'storybook' }))
 
         useEffect(() => {
             // The largest group is the set up group
@@ -689,9 +717,9 @@ export const ThreadScrollsToBottomOnNewMessages: Story = {
             },
         })
 
-        const { conversation } = useValues(maxLogic({ tabId: 'storybook' }))
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const logic = maxThreadLogic({ conversationId: 'poem', conversation, tabId: 'storybook' })
+        const { conversation } = useValues(maxLogic({ panelId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const logic = maxThreadLogic({ conversationId: 'poem', conversation, panelId: 'storybook' })
         const { threadRaw } = useValues(logic)
         const { askMax } = useActions(logic)
 
@@ -745,8 +773,12 @@ export const ChatWithUIContext: Story = {
 
         const { contextEvents } = useValues(maxContextLogic)
         const { addOrUpdateContextEvent } = useActions(maxContextLogic)
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -859,8 +891,12 @@ export const PlanningComponent: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -916,8 +952,12 @@ export const ReasoningComponent: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1063,11 +1103,11 @@ export const TaskExecutionComponent: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
         const threadLogic: ReturnType<typeof maxThreadLogic> = maxThreadLogic({
             conversationId: 'in_progress',
             conversation: null,
-            tabId: 'storybook',
+            panelId: 'storybook',
         })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
@@ -1188,8 +1228,12 @@ export const TaskExecutionWithFailure: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1297,8 +1341,12 @@ export const MultiVisualizationInThread: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1327,8 +1375,12 @@ export const ThreadWithSQLQueryOverflow: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1445,8 +1497,12 @@ export const SearchSessionRecordingsEmpty: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1548,8 +1604,12 @@ export const SearchSessionRecordingsWithResults: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1650,8 +1710,12 @@ export const SearchErrorTrackingIssuesEmpty: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1776,8 +1840,12 @@ export const SearchErrorTrackingIssuesWithResults: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -1891,8 +1959,12 @@ export const DangerousOperationPendingApproval: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2081,8 +2153,12 @@ The following services will need to be notified:
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2190,8 +2266,12 @@ export const ThreadWithMultiQuestionForm: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2284,8 +2364,12 @@ export const ThreadWithMultiFieldQuestion: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2364,8 +2448,12 @@ export const ThreadWithSingleQuestionForm: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2515,8 +2603,12 @@ export const ThreadWithMultiQuestionFormLongContent: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2612,8 +2704,12 @@ export const ThreadWithMultiQuestionFormNoCustomAnswer: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2698,8 +2794,12 @@ export const NotebookArtifactMarkdownOnly: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2787,8 +2887,12 @@ export const NotebookArtifactWithVisualizations: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2897,8 +3001,12 @@ export const NotebookArtifactMixedContent: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -2991,8 +3099,12 @@ export const NotebookArtifactWithLoadingAndErrors: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -3249,8 +3361,12 @@ export const ThreadWithMixedFieldTypeForm: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -3345,8 +3461,12 @@ export const ThreadWithTextAndNumberForm: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
@@ -3423,8 +3543,12 @@ export const ThreadWithSliderForm: Story = {
             },
         })
 
-        const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
-        const threadLogic = maxThreadLogic({ conversationId: CONVERSATION_ID, conversation: null, tabId: 'storybook' })
+        const { setConversationId } = useActions(maxLogic({ panelId: 'storybook' }))
+        const threadLogic = maxThreadLogic({
+            conversationId: CONVERSATION_ID,
+            conversation: null,
+            panelId: 'storybook',
+        })
         const { askMax } = useActions(threadLogic)
         const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 

--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -35,7 +35,7 @@ import { ThreadAutoScroller } from './components/ThreadAutoScroller'
 import { ConversationHistory } from './ConversationHistory'
 import { HistoryPreview } from './HistoryPreview'
 import { Intro } from './Intro'
-import { MaxLogicProps, maxLogic } from './maxLogic'
+import { MaxLogicProps, SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from './maxThreadLogic'
 import { Thread } from './Thread'
 
@@ -47,8 +47,8 @@ export const scene: SceneExport = {
 export function Max({ tabId }: { tabId?: string }): JSX.Element {
     const { sidePanelOpen, selectedTab } = useValues(sidePanelLogic)
     const { closeSidePanel } = useActions(sidePanelLogic)
-    const { conversationId: tabConversationId } = useValues(maxLogic({ tabId: tabId || '' }))
-    const { conversationId: sidepanelConversationId } = useValues(maxLogic({ sidePanel: true }))
+    const { conversationId: tabConversationId } = useValues(maxLogic({ panelId: tabId }))
+    const { conversationId: sidepanelConversationId } = useValues(maxLogic({ panelId: SIDE_PANEL_PANEL_ID }))
     if (sidePanelOpen && selectedTab === SidePanelTab.Max && sidepanelConversationId === tabConversationId) {
         return (
             <SceneContent className="px-4 py-4 min-h-[calc(100vh-var(--scene-layout-header-height)-120px)]">
@@ -79,11 +79,11 @@ export interface MaxInstanceProps {
 }
 
 export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }: MaxInstanceProps): JSX.Element {
-    // `sidePanel` here is presentational (side panel chrome/layout) and is independent of which
-    // logic instance we bind: a tabId identifies a scene tab (or a Storybook instance rendered with
-    // side panel chrome), and only the real side panel — which has no tabId — uses the sidePanel
-    // logic identity. Folding the presentational flag into the key would hijack tabbed instances.
-    const logicProps: MaxLogicProps = tabId ? { tabId } : { sidePanel: true }
+    // `sidePanel` here is presentational (side panel chrome/layout) and is independent of the logic
+    // identity we bind: a tabId identifies a scene tab (or a Storybook instance rendered with side
+    // panel chrome), while the real side panel — which has no tabId — binds the side panel panelId.
+    // Folding the presentational flag into the key would hijack tabbed instances.
+    const logicProps: MaxLogicProps = { panelId: tabId ?? SIDE_PANEL_PANEL_ID }
     const {
         threadVisible,
         conversationHistoryVisible,

--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -89,18 +89,18 @@ interface AiFirstMaxInstanceProps {
 }
 
 export function AiFirstMaxInstance({ tabId }: AiFirstMaxInstanceProps): JSX.Element {
-    const { threadVisible, threadLogicKey, conversation, conversationId } = useValues(maxLogic({ tabId }))
-    const { startNewConversation } = useActions(maxLogic({ tabId }))
+    const { threadVisible, threadLogicKey, conversation, conversationId } = useValues(maxLogic({ panelId: tabId }))
+    const { startNewConversation } = useActions(maxLogic({ panelId: tabId }))
 
     const threadProps: MaxThreadLogicProps = {
-        tabId,
+        panelId: tabId,
         conversationId: threadLogicKey,
         conversation,
     }
 
     return (
         <div className="flex grow overflow-hidden h-full">
-            <BindLogic logic={maxLogic} props={{ tabId }}>
+            <BindLogic logic={maxLogic} props={{ panelId: tabId }}>
                 <BindLogic logic={maxThreadLogic} props={threadProps}>
                     <div className="flex flex-col grow overflow-hidden">
                         <ChatHeader conversationId={conversationId} tabId={tabId} />

--- a/frontend/src/scenes/max/components/HandsFreeButton.tsx
+++ b/frontend/src/scenes/max/components/HandsFreeButton.tsx
@@ -10,14 +10,13 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { handsFreeLogic } from '../handsFreeLogic'
 
 interface HandsFreeButtonProps {
-    tabId?: string
-    sidePanel?: boolean
+    panelId?: string
 }
 
-export function HandsFreeButton({ tabId, sidePanel }: HandsFreeButtonProps): JSX.Element | null {
+export function HandsFreeButton({ panelId }: HandsFreeButtonProps): JSX.Element | null {
     const flagEnabled = useFeatureFlag('MAX_HANDS_FREE')
-    const { status, canUseHandsFree } = useValues(handsFreeLogic({ tabId, sidePanel }))
-    const { toggleHandsFree } = useActions(handsFreeLogic({ tabId, sidePanel }))
+    const { status, canUseHandsFree } = useValues(handsFreeLogic({ panelId }))
+    const { toggleHandsFree } = useActions(handsFreeLogic({ panelId }))
 
     if (!flagEnabled || !canUseHandsFree || status !== 'off') {
         return null

--- a/frontend/src/scenes/max/components/HandsFreeSurface.stories.tsx
+++ b/frontend/src/scenes/max/components/HandsFreeSurface.stories.tsx
@@ -18,8 +18,8 @@ interface DriverProps {
 // Mounts maxLogic + handsFreeLogic and drives them into a target state so each story
 // captures a single visual configuration without spinning up real WebSockets or audio.
 function HandsFreeSurfaceStory({ status, connection, partialTranscript, error }: DriverProps): JSX.Element {
-    useMountedLogic(maxLogic({ tabId: TAB_ID }))
-    const logic = handsFreeLogic({ tabId: TAB_ID })
+    useMountedLogic(maxLogic({ panelId: TAB_ID }))
+    const logic = handsFreeLogic({ panelId: TAB_ID })
     useMountedLogic(logic)
     const { setStatus, setConnection, setPartialTranscript, setError } = useActions(logic)
 
@@ -38,7 +38,7 @@ function HandsFreeSurfaceStory({ status, connection, partialTranscript, error }:
 
     return (
         <div className="max-w-md mx-auto p-4 bg-bg-light border rounded">
-            <HandsFreeSurface tabId={TAB_ID} />
+            <HandsFreeSurface panelId={TAB_ID} />
         </div>
     )
 }

--- a/frontend/src/scenes/max/components/HandsFreeSurface.tsx
+++ b/frontend/src/scenes/max/components/HandsFreeSurface.tsx
@@ -11,8 +11,7 @@ import { cn } from 'lib/utils/css-classes'
 import { HandsFreeStatus, handsFreeLogic } from '../handsFreeLogic'
 
 interface HandsFreeSurfaceProps {
-    tabId?: string
-    sidePanel?: boolean
+    panelId?: string
 }
 
 const STATUS_LABEL: Record<HandsFreeStatus, string> = {
@@ -44,17 +43,15 @@ const STATUS_HINT: Record<HandsFreeStatus, string> = {
 }
 
 function HandsFreeTopline({
-    tabId,
-    sidePanel,
+    panelId,
     status,
     isReconnecting,
 }: {
-    tabId?: string
-    sidePanel?: boolean
+    panelId?: string
     status: HandsFreeStatus
     isReconnecting: boolean
 }): JSX.Element {
-    const { partialTranscript, error } = useValues(handsFreeLogic({ tabId, sidePanel }))
+    const { partialTranscript, error } = useValues(handsFreeLogic({ panelId }))
     const hint = isReconnecting ? 'Reconnecting your microphone' : STATUS_HINT[status]
     return (
         <div className="hands-free-surface__top">
@@ -68,9 +65,9 @@ function HandsFreeTopline({
     )
 }
 
-export function HandsFreeSurface({ tabId, sidePanel }: HandsFreeSurfaceProps): JSX.Element | null {
-    const { status, connection, error } = useValues(handsFreeLogic({ tabId, sidePanel }))
-    const { toggleHandsFree } = useActions(handsFreeLogic({ tabId, sidePanel }))
+export function HandsFreeSurface({ panelId }: HandsFreeSurfaceProps): JSX.Element | null {
+    const { status, connection, error } = useValues(handsFreeLogic({ panelId }))
+    const { toggleHandsFree } = useActions(handsFreeLogic({ panelId }))
 
     // Register the v-then-m exit shortcut while the surface is mounted.
     // HandsFreeButton owns the same shortcut for the "enter" path; same-name
@@ -107,7 +104,7 @@ export function HandsFreeSurface({ tabId, sidePanel }: HandsFreeSurfaceProps): J
             data-status={status}
             data-connection={connection}
         >
-            <HandsFreeTopline tabId={tabId} sidePanel={sidePanel} status={status} isReconnecting={isReconnecting} />
+            <HandsFreeTopline panelId={panelId} status={status} isReconnecting={isReconnecting} />
 
             <button
                 type="button"

--- a/frontend/src/scenes/max/components/QuestionInput.test.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.test.tsx
@@ -33,16 +33,16 @@ describe('QuestionInput slash command autocomplete', () => {
         maxGlobalLogicInstance.mount()
         jest.spyOn(maxGlobalLogicInstance.selectors, 'dataProcessingAccepted').mockReturnValue(true)
 
-        maxLogicInstance = maxLogic({ tabId: 'test' })
+        maxLogicInstance = maxLogic({ panelId: 'test' })
         maxLogicInstance.mount()
 
-        const threadProps = { tabId: 'test', conversationId: maxLogicInstance.values.frontendConversationId }
+        const threadProps = { panelId: 'test', conversationId: maxLogicInstance.values.frontendConversationId }
         threadLogicInstance = maxThreadLogic(threadProps)
         threadLogicInstance.mount()
 
         render(
             <Provider>
-                <BindLogic logic={maxLogic} props={{ tabId: 'test' }}>
+                <BindLogic logic={maxLogic} props={{ panelId: 'test' }}>
                     <BindLogic logic={maxThreadLogic} props={threadProps}>
                         <QuestionInput />
                     </BindLogic>

--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -144,7 +144,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
     ref
 ) {
     const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(maxGlobalLogic)
-    const { question, tabId: maxTabId, sidePanel: maxSidePanel } = useValues(maxLogic)
+    const { question, panelId: maxPanelId } = useValues(maxLogic)
     const { setQuestion } = useActions(maxLogic)
     const { user } = useValues(userLogic)
     const {
@@ -166,7 +166,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
     } = useValues(maxThreadLogic)
     const { askMax, stopGeneration, completeThreadGeneration, setSupportOverrideEnabled, updateQueuedMessage } =
         useActions(maxThreadLogic)
-    const { isActive: handsFreeActive } = useValues(handsFreeLogic({ tabId: maxTabId, sidePanel: maxSidePanel }))
+    const { isActive: handsFreeActive } = useValues(handsFreeLogic({ panelId: maxPanelId }))
     // Only the hands-free row needs bottom-aligned pills — it has the mic + submit pair
     // pinned to the bottom and pills sitting in normal flow look misaligned next to them.
     // Keep the legacy items-start layout when the flag is off so existing screenshots
@@ -282,7 +282,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                         )}
                     >
                         {handsFreeActive ? (
-                            <HandsFreeSurface tabId={maxTabId} sidePanel={maxSidePanel} />
+                            <HandsFreeSurface panelId={maxPanelId} />
                         ) : (
                             <SlashCommandAutocomplete
                                 visible={showAutocomplete}
@@ -411,7 +411,7 @@ export const QuestionInput = React.forwardRef<HTMLDivElement, QuestionInputProps
                             isThreadVisible ? 'bottom-[9px] right-[9px]' : 'bottom-[7px] right-[7px]'
                         )}
                     >
-                        <HandsFreeButton tabId={maxTabId} sidePanel={maxSidePanel} />
+                        <HandsFreeButton panelId={maxPanelId} />
                         {!handsFreeActive && (
                             <AIConsentPopoverWrapper
                                 placement="bottom-end"

--- a/frontend/src/scenes/max/handsFreeLogic.test.ts
+++ b/frontend/src/scenes/max/handsFreeLogic.test.ts
@@ -14,9 +14,9 @@ describe('handsFreeLogic state machine', () => {
     beforeEach(() => {
         useMocks(maxMocks)
         initKeaTests()
-        parent = maxLogic({ tabId: 'hands-free-test-tab' })
+        parent = maxLogic({ panelId: 'hands-free-test-tab' })
         parent.mount()
-        logic = handsFreeLogic({ tabId: 'hands-free-test-tab' })
+        logic = handsFreeLogic({ panelId: 'hands-free-test-tab' })
         logic.mount()
     })
 

--- a/frontend/src/scenes/max/handsFreeLogic.ts
+++ b/frontend/src/scenes/max/handsFreeLogic.ts
@@ -18,8 +18,7 @@ export type HandsFreeConnection = 'idle' | 'connecting' | 'connected' | 'reconne
 const SCRIBE_REALTIME_MODEL_ID = 'scribe_v2_realtime'
 
 export interface HandsFreeLogicProps {
-    tabId?: string
-    sidePanel?: boolean // set instead of tabId for the floating side panel chat
+    panelId?: string // identifies the MaxLogic instance backing this panel (scene tab id or side panel)
 }
 
 interface ScribeConnection {
@@ -68,11 +67,11 @@ async function loadScribeSdk(): Promise<{
 
 export const handsFreeLogic = kea<handsFreeLogicType>([
     props({} as HandsFreeLogicProps),
-    key((props) => (props.sidePanel ? 'sidepanel' : props.tabId) as string),
+    key((props) => props.panelId as string),
     path((key) => ['scenes', 'max', 'handsFreeLogic', key]),
 
-    connect(({ tabId, sidePanel }: HandsFreeLogicProps) => ({
-        values: [maxLogic({ tabId, sidePanel }), ['threadLogicKey']],
+    connect(({ panelId }: HandsFreeLogicProps) => ({
+        values: [maxLogic({ panelId }), ['threadLogicKey']],
     })),
 
     actions({
@@ -391,8 +390,7 @@ export const handsFreeLogic = kea<handsFreeLogicType>([
             const threadKey = values.threadLogicKey
             const threadLogic = threadKey
                 ? maxThreadLogic.findMounted({
-                      tabId: props.tabId,
-                      sidePanel: props.sidePanel,
+                      panelId: props.panelId,
                       conversationId: threadKey,
                   })
                 : null

--- a/frontend/src/scenes/max/max.test.ts
+++ b/frontend/src/scenes/max/max.test.ts
@@ -41,11 +41,11 @@ describe('Max Logics Integration Tests', () => {
     it('does not update conversation and thread when stream is active', async () => {
         const streamSpy = mockStream()
 
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ panelId: 'test' })
         logic.mount()
         // Set the conversation ID so activeThreadKey matches the thread logic's conversationId
         logic.actions.setConversationId(MOCK_CONVERSATION_ID)
-        threadLogic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+        threadLogic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
         threadLogic.mount()
 
         // Wait for all the microtasks to finish
@@ -56,7 +56,7 @@ describe('Max Logics Integration Tests', () => {
 
         // update props
         maxThreadLogic({
-            tabId: 'test',
+            panelId: 'test',
             conversationId: MOCK_CONVERSATION_ID,
             conversation: {
                 ...MOCK_IN_PROGRESS_CONVERSATION,

--- a/frontend/src/scenes/max/maxGlobalLogic.test.ts
+++ b/frontend/src/scenes/max/maxGlobalLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
@@ -5,7 +6,8 @@ import { initKeaTests } from '~/test/init'
 
 import { TOOL_DEFINITIONS, ToolDefinition } from './max-constants'
 import { STATIC_TOOLS, maxGlobalLogic } from './maxGlobalLogic'
-import { maxMocks } from './testUtils'
+import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
+import { MOCK_CONVERSATION, MOCK_CONVERSATION_ID, maxMocks } from './testUtils'
 
 describe('maxGlobalLogic tool definitions', () => {
     it('all tool descriptions start with their name when provided', () => {
@@ -41,6 +43,29 @@ describe('maxGlobalLogic', () => {
     afterEach(() => {
         logic?.unmount()
         jest.restoreAllMocks()
+    })
+
+    // Opening a conversation in the side panel must surface it in the side panel chat without
+    // replacing the main content. The side panel floats over whatever scene you're on; the rendered
+    // scene is chosen by the route, so the page (insight, survey, …) must stay put.
+    describe('openSidePanelMax', () => {
+        it.each(['/insights/abc123', '/surveys/xyz789'])(
+            'opens the conversation in the side panel without replacing the main content on %s',
+            async (page) => {
+                useMocks({ get: { '/api/environments/:team_id/conversations/:id': MOCK_CONVERSATION } })
+                router.actions.push(page)
+
+                await expectLogic(logic, () => {
+                    logic.actions.openSidePanelMax(MOCK_CONVERSATION_ID)
+                }).toFinishAllListeners()
+
+                const sidePanelMax = maxLogic.findMounted({ panelId: SIDE_PANEL_PANEL_ID })
+                expect(sidePanelMax?.values.conversationId).toBe(MOCK_CONVERSATION_ID)
+                expect(router.values.location.pathname.endsWith(page)).toBe(true)
+
+                sidePanelMax?.unmount()
+            }
+        )
     })
 
     describe('editInsightToolRegistered selector', () => {

--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -20,7 +20,7 @@ import { conversationsDestroy } from 'products/conversations/frontend/generated/
 
 import { TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
 import type { maxGlobalLogicType } from './maxGlobalLogicType'
-import { maxLogic, mergeConversationHistory, mergeConversations } from './maxLogic'
+import { SIDE_PANEL_PANEL_ID, maxLogic, mergeConversationHistory, mergeConversations } from './maxLogic'
 
 // Keep this stored across all projects, only display this once per device
 const AI_LIABILITY_NOTICE_STORAGE_KEY = 'posthog_ai_liability_notice_dismissed'
@@ -190,9 +190,9 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
                 actions.openSidePanel(SidePanelTab.Max)
             }
             if (conversationId) {
-                let logic = maxLogic.findMounted({ sidePanel: true })
+                let logic = maxLogic.findMounted({ panelId: SIDE_PANEL_PANEL_ID })
                 if (!logic) {
-                    logic = maxLogic({ sidePanel: true })
+                    logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
                     logic.mount() // we're never unmounting this
                 }
                 logic.actions.openConversation(conversationId)

--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -11,7 +11,13 @@ import { AgentMode } from '~/queries/schema/schema-assistant-messages'
 import { initKeaTests } from '~/test/init'
 import { ConversationDetail, SidePanelTab } from '~/types'
 
-import { QUESTION_SUGGESTIONS_DATA, maxLogic, mergeConversationHistory, mergeConversations } from './maxLogic'
+import {
+    QUESTION_SUGGESTIONS_DATA,
+    SIDE_PANEL_PANEL_ID,
+    maxLogic,
+    mergeConversationHistory,
+    mergeConversations,
+} from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
 import { MOCK_CONVERSATION, MOCK_CONVERSATION_ID, maxMocks } from './testUtils'
 
@@ -44,7 +50,7 @@ describe('maxLogic', () => {
         }).toDispatchActions(['openSidePanel'])
 
         // Mount maxLogic after setting up the sidePanelStateLogic state
-        logic = maxLogic({ sidePanel: true })
+        logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
         logic.mount()
 
         // Check that the question has been set to "Foo"
@@ -61,7 +67,7 @@ describe('maxLogic', () => {
         }).toDispatchActions(['openSidePanel'])
 
         // Must create the logic first to spy on its actions
-        logic = maxLogic({ sidePanel: true })
+        logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
         logic.mount()
 
         // Only mount maxLogic after setting up the router and sidePanelStateLogic
@@ -89,7 +95,7 @@ describe('maxLogic', () => {
             },
         })
 
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ panelId: 'test' })
         logic.mount()
 
         // Wait for initial conversationHistory load to complete
@@ -121,7 +127,7 @@ describe('maxLogic', () => {
     })
 
     it('manages suggestion group selection correctly', async () => {
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ panelId: 'test' })
         logic.mount()
 
         await expectLogic(logic).toMatchValues({
@@ -156,7 +162,7 @@ describe('maxLogic', () => {
     })
 
     it('generates and uses frontendConversationId correctly', async () => {
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ panelId: 'test' })
         logic.mount()
 
         const initialFrontendId = logic.values.frontendConversationId
@@ -187,10 +193,10 @@ describe('maxLogic', () => {
     it.each([
         {
             scenario: 'side panel chat keeps the current page',
-            props: { sidePanel: true },
+            props: { panelId: SIDE_PANEL_PANEL_ID },
             expectedSuffix: '/insights/abc123',
         },
-        { scenario: 'scene chat navigates to /ai', props: { tabId: 'test' }, expectedSuffix: urls.ai() },
+        { scenario: 'scene chat navigates to /ai', props: { panelId: 'test' }, expectedSuffix: urls.ai() },
     ])('startNewConversation: $scenario', async ({ props, expectedSuffix }) => {
         router.actions.push('/insights/abc123')
 
@@ -205,7 +211,7 @@ describe('maxLogic', () => {
     })
 
     it('uses threadLogicKey correctly with frontendConversationId', async () => {
-        logic = maxLogic({ tabId: 'test' })
+        logic = maxLogic({ panelId: 'test' })
         logic.mount()
 
         // When no conversation ID is set, should use frontendConversationId
@@ -241,7 +247,7 @@ describe('maxLogic', () => {
                 sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=research:!Question')
             }).toDispatchActions(['openSidePanel'])
 
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
 
             await expectLogic(logic).toMatchValues({
@@ -250,7 +256,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -267,7 +273,7 @@ describe('maxLogic', () => {
                 sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=product_analytics:Question')
             }).toDispatchActions(['openSidePanel'])
 
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
 
             await expectLogic(logic).toMatchValues({
@@ -276,7 +282,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -293,7 +299,7 @@ describe('maxLogic', () => {
                 sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=sql:!Write a query')
             }).toDispatchActions(['openSidePanel'])
 
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
 
             await expectLogic(logic).toMatchValues({
@@ -302,7 +308,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -315,7 +321,7 @@ describe('maxLogic', () => {
 
         it('parses mode=auto:!Question correctly (null mode)', async () => {
             // Mount maxLogic first and reset state to ensure clean slate
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
             logic.actions.startNewConversation()
 
@@ -331,7 +337,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -344,7 +350,7 @@ describe('maxLogic', () => {
 
         it('parses mode=research correctly (mode only, no question)', async () => {
             // Mount maxLogic first and reset state to ensure clean slate
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
             logic.actions.startNewConversation()
 
@@ -360,7 +366,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -377,7 +383,7 @@ describe('maxLogic', () => {
                 sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, 'mode=invalid_mode:!Question')
             }).toDispatchActions(['openSidePanel'])
 
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
 
             await expectLogic(logic).toMatchValues({
@@ -386,7 +392,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -399,7 +405,7 @@ describe('maxLogic', () => {
 
         it('parses !My question correctly (backwards compatibility)', async () => {
             // Mount maxLogic first and reset state to ensure clean slate
-            logic = maxLogic({ sidePanel: true })
+            logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
             logic.mount()
             logic.actions.startNewConversation()
 
@@ -415,7 +421,7 @@ describe('maxLogic', () => {
             })
 
             threadLogic = maxThreadLogic({
-                sidePanel: true,
+                panelId: SIDE_PANEL_PANEL_ID,
                 conversationId: logic.values.frontendConversationId,
                 conversation: null,
             })
@@ -437,7 +443,7 @@ describe('maxLogic', () => {
                 },
             })
 
-            logic = maxLogic({ tabId: 'test' })
+            logic = maxLogic({ panelId: 'test' })
             logic.mount()
 
             // Wait for conversation history to load, then set conversationId
@@ -451,7 +457,7 @@ describe('maxLogic', () => {
         })
 
         it('returns "New chat" when there is a conversationId but no matching conversation in history', async () => {
-            logic = maxLogic({ tabId: 'test' })
+            logic = maxLogic({ panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -462,7 +468,7 @@ describe('maxLogic', () => {
         })
 
         it('returns "Chat history" when conversation history is visible', async () => {
-            logic = maxLogic({ tabId: 'test' })
+            logic = maxLogic({ panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -473,7 +479,7 @@ describe('maxLogic', () => {
         })
 
         it('returns null when there is no conversationId and history is not visible', async () => {
-            logic = maxLogic({ tabId: 'test' })
+            logic = maxLogic({ panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic).toMatchValues({
@@ -486,7 +492,7 @@ describe('maxLogic', () => {
 
     describe('breadcrumbs', () => {
         it('shows "New chat" as the first breadcrumb name when no conversationId is set', async () => {
-            logic = maxLogic({ tabId: 'test' })
+            logic = maxLogic({ panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic).toMatchValues({
@@ -506,7 +512,7 @@ describe('maxLogic', () => {
                 },
             })
 
-            logic = maxLogic({ tabId: 'test' })
+            logic = maxLogic({ panelId: 'test' })
             logic.mount()
 
             // Wait for conversation history to load, then set conversationId

--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -187,27 +187,43 @@ describe('maxLogic', () => {
         expect(logic.values.frontendConversationId).toMatch(uuidRegex)
     })
 
-    // The side panel chat floats over whatever page you're on (e.g. an insight) and must not touch
-    // the route, whereas the scene instance owns /ai. The harness prefixes the project id
-    // (/project/<id>/…), so match the path suffix.
-    it.each([
-        {
-            scenario: 'side panel chat keeps the current page',
-            props: { panelId: SIDE_PANEL_PANEL_ID },
-            expectedSuffix: '/insights/abc123',
-        },
-        { scenario: 'scene chat navigates to /ai', props: { panelId: 'test' }, expectedSuffix: urls.ai() },
-    ])('startNewConversation: $scenario', async ({ props, expectedSuffix }) => {
-        router.actions.push('/insights/abc123')
+    // The side panel chat floats over whatever scene you're on (e.g. an insight or survey). The
+    // rendered scene is chosen by the route, so if the side panel pushes /ai it replaces the main
+    // content — which is the regression. Only the scene instance, which owns /ai, may navigate.
+    // These are every route-affecting action; the side panel must stay silent on all of them,
+    // including setConversationId, which fires a replace nav when a brand-new conversation is minted.
+    // The harness prefixes the project id (/project/<id>/…), so match the path suffix.
+    const PAGES = ['/insights/abc123', '/surveys/xyz789']
+    const routeActions = [
+        { name: 'startNewConversation', act: () => logic.actions.startNewConversation() },
+        { name: 'openConversation', act: () => logic.actions.openConversation(MOCK_CONVERSATION_ID) },
+        { name: 'setConversationId', act: () => logic.actions.setConversationId(logic.values.frontendConversationId) },
+        { name: 'toggleConversationHistory', act: () => logic.actions.toggleConversationHistory() },
+    ]
+    const sidePanelCases = PAGES.flatMap((page) => routeActions.map((action) => ({ page, ...action })))
 
-        logic = maxLogic(props)
+    it.each(sidePanelCases)('side panel chat keeps the main content on $page on $name', async ({ page, act }) => {
+        useMocks({ get: { '/api/environments/:team_id/conversations/:id': MOCK_CONVERSATION } })
+        router.actions.push(page)
+
+        logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
         logic.mount()
 
-        await expectLogic(logic, () => {
-            logic.actions.startNewConversation()
-        }).toFinishAllListeners()
+        await expectLogic(logic, () => act()).toFinishAllListeners()
 
-        expect(router.values.location.pathname.endsWith(expectedSuffix)).toBe(true)
+        expect(router.values.location.pathname.endsWith(page)).toBe(true)
+    })
+
+    it.each(routeActions)('scene chat navigates to /ai on $name', async ({ act }) => {
+        useMocks({ get: { '/api/environments/:team_id/conversations/:id': MOCK_CONVERSATION } })
+        router.actions.push('/insights/abc123')
+
+        logic = maxLogic({ panelId: 'test' })
+        logic.mount()
+
+        await expectLogic(logic, () => act()).toFinishAllListeners()
+
+        expect(router.values.location.pathname).toContain(urls.ai())
     })
 
     it('uses threadLogicKey correctly with frontendConversationId', async () => {

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -133,17 +133,22 @@ function updateInactiveTab(tabId: string, props: Partial<SceneTab>): void {
     }
 }
 
+// Fixed panelId for the floating side panel chat, which is not a scene tab.
+export const SIDE_PANEL_PANEL_ID = 'sidepanel'
+
 export interface MaxLogicProps {
-    tabId?: string
-    // Marks the instance that backs the floating side panel chat. It isn't a scene tab:
-    // it stays mounted across navigation and must never own or rewrite the scene route.
-    sidePanel?: boolean
+    panelId?: string
     onAcceptSessionFilters?: (filters: RecordingUniversalFilters) => void
+}
+
+// Only real scene tabs carry per-tab drafts and tab badges — the side panel and bare scene don't.
+function sceneTabId(panelId?: string): string | null {
+    return panelId && panelId !== SIDE_PANEL_PANEL_ID ? panelId : null
 }
 
 export const maxLogic = kea<maxLogicType>([
     props({} as MaxLogicProps),
-    key((props) => (props.sidePanel ? 'sidepanel' : props.tabId || 'scene')),
+    key((props) => props.panelId || 'scene'),
     path((key) => ['scenes', 'max', 'maxLogic', key]),
 
     connect(() => ({
@@ -281,8 +286,7 @@ export const maxLogic = kea<maxLogicType>([
     }),
 
     selectors({
-        tabId: [() => [(_, props) => props?.tabId || ''], (tabId) => tabId],
-        sidePanel: [() => [(_, props) => !!props?.sidePanel], (sidePanel) => sidePanel],
+        panelId: [() => [(_, props) => props?.panelId || ''], (panelId) => panelId],
         onAcceptSessionFilters: [
             () => [
                 (_, props) =>
@@ -375,10 +379,9 @@ export const maxLogic = kea<maxLogicType>([
         ],
 
         threadLogicProps: [
-            (s) => [s.tabId, s.sidePanel, s.conversation, s.threadLogicKey],
-            (tabId, sidePanel, conversation, threadLogicKey) => ({
-                tabId,
-                sidePanel,
+            (s) => [s.panelId, s.conversation, s.threadLogicKey],
+            (panelId, conversation, threadLogicKey) => ({
+                panelId,
                 conversationId: threadLogicKey,
                 conversation,
             }),
@@ -438,13 +441,15 @@ export const maxLogic = kea<maxLogicType>([
             // Side panel Max stays mounted across the whole app, so its question reducer
             // already survives navigation — and there's no removeTab cleanup for it,
             // which would turn the persisted draft into a memory leak.
-            if (props.tabId && !props.sidePanel) {
-                actions.setChatDraftForTab(props.tabId, question)
+            const tabId = sceneTabId(props.panelId)
+            if (tabId) {
+                actions.setChatDraftForTab(tabId, question)
             }
         },
         incrActiveStreamingThreads: () => {
-            if (props.tabId) {
-                updateInactiveTab(props.tabId, { iconType: 'loading', badge: false })
+            const tabId = sceneTabId(props.panelId)
+            if (tabId) {
+                updateInactiveTab(tabId, { iconType: 'loading', badge: false })
             }
         },
         decrActiveStreamingThreads: () => {
@@ -453,8 +458,9 @@ export const maxLogic = kea<maxLogicType>([
             if (values.activeStreamingThreads > 0) {
                 return
             }
-            if (props.tabId) {
-                updateInactiveTab(props.tabId, { iconType: 'chat', badge: true })
+            const tabId = sceneTabId(props.panelId)
+            if (tabId) {
+                updateInactiveTab(tabId, { iconType: 'chat', badge: true })
             }
         },
         // Listen for when the side panel state changes and check for initial prompt
@@ -577,8 +583,9 @@ export const maxLogic = kea<maxLogicType>([
         startNewConversation: () => {
             actions.resetContext()
             actions.focusInput()
-            if (props.tabId && !props.sidePanel) {
-                actions.setChatDraftForTab(props.tabId, '')
+            const tabId = sceneTabId(props.panelId)
+            if (tabId) {
+                actions.setChatDraftForTab(tabId, '')
             }
         },
     })),
@@ -587,8 +594,9 @@ export const maxLogic = kea<maxLogicType>([
     // This subscription covers inactive tabs, which titleAndIcon doesn't reach.
     subscriptions(({ props }) => ({
         chatTitle: (title: string | null) => {
-            if (title && title !== CHAT_TITLE_NEW && title !== CHAT_TITLE_HISTORY && props.tabId) {
-                updateInactiveTab(props.tabId, { title })
+            const tabId = sceneTabId(props.panelId)
+            if (title && title !== CHAT_TITLE_NEW && title !== CHAT_TITLE_HISTORY && tabId) {
+                updateInactiveTab(tabId, { title })
             }
         },
     })),
@@ -596,8 +604,9 @@ export const maxLogic = kea<maxLogicType>([
     afterMount(({ actions, values, props }) => {
         // Restore per-tab chat draft (typed but unsent input that should survive scene unmount).
         // Side panel Max is excluded — it stays mounted globally, doesn't go through removeTab cleanup.
-        if (!values.question && props.tabId && !props.sidePanel) {
-            const draft = values.chatDraftFor(props.tabId)
+        const tabId = sceneTabId(props.panelId)
+        if (!values.question && tabId) {
+            const draft = values.chatDraftFor(tabId)
             if (draft) {
                 actions.setQuestion(draft)
             }
@@ -686,7 +695,7 @@ export const maxLogic = kea<maxLogicType>([
         // The side panel chat floats over whatever page you're on, so it must never rewrite the
         // scene route — only the scene instance (which owns the /ai route) syncs the URL. Without
         // this guard, opening Max from e.g. an insight navigates you to /ai#panel=max.
-        if (props.sidePanel) {
+        if (props.panelId === SIDE_PANEL_PANEL_ID) {
             return {}
         }
         return {

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -70,11 +70,11 @@ describe('maxThreadLogic', () => {
         jest.spyOn(maxGlobalLogicInstance.selectors, 'dataProcessingAccepted').mockReturnValue(true)
 
         // Set up maxLogic with matching conversationId so that activeThreadKey matches
-        maxLogicInstance = maxLogic({ tabId: 'test' })
+        maxLogicInstance = maxLogic({ panelId: 'test' })
         maxLogicInstance.mount()
         maxLogicInstance.actions.setConversationId(MOCK_CONVERSATION_ID)
 
-        logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+        logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
         logic.mount()
     })
 
@@ -238,7 +238,7 @@ describe('maxThreadLogic', () => {
     })
 
     it('adds a thinking message to an ephemeral group', async () => {
-        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
         logic.mount()
 
         // Only a human message–should create an ephemeral group
@@ -271,7 +271,7 @@ describe('maxThreadLogic', () => {
     })
 
     it('adds a thinking message to the last group of messages with IDs', async () => {
-        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
         logic.mount()
 
         // Human and assistant messages with IDs–should append thinking message
@@ -316,7 +316,7 @@ describe('maxThreadLogic', () => {
     })
 
     it('does not add a thinking message when the last message is without ID', async () => {
-        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
         logic.mount()
 
         // Human with ID and assistant messages without ID–should not add the message
@@ -355,7 +355,7 @@ describe('maxThreadLogic', () => {
         const streamSpy = mockStream()
         logic.unmount()
         maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+        logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
         logic.mount()
 
         expect(streamSpy).toHaveBeenCalledTimes(0)
@@ -409,7 +409,7 @@ describe('maxThreadLogic', () => {
             } as any)
 
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -434,7 +434,7 @@ describe('maxThreadLogic', () => {
 
             // Don't add any context data, so compiledContext will be null
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -456,7 +456,7 @@ describe('maxThreadLogic', () => {
             const streamSpy = mockStream()
 
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             const formAnswers = { q1: 'answer1', q2: 'answer2' }
@@ -488,7 +488,7 @@ describe('maxThreadLogic', () => {
             } as any)
 
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             const formAnswers = { q1: 'answer1' }
@@ -513,7 +513,7 @@ describe('maxThreadLogic', () => {
             const streamSpy = mockStream()
 
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -700,7 +700,7 @@ describe('maxThreadLogic', () => {
             })
 
             logic.unmount()
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
             await new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -843,7 +843,7 @@ describe('maxThreadLogic', () => {
 
             // Create a second thread logic with a different conversation ID
             const otherConversationId = 'other-conversation-id'
-            const otherLogic = maxThreadLogic({ conversationId: otherConversationId, tabId: 'test' })
+            const otherLogic = maxThreadLogic({ conversationId: otherConversationId, panelId: 'test' })
             otherLogic.mount()
 
             // maxLogicInstance is still set to MOCK_CONVERSATION_ID (the first logic's conversation)
@@ -879,7 +879,7 @@ describe('maxThreadLogic', () => {
 
             // Create a second thread logic with a different conversation ID
             const otherConversationId = 'other-conversation-id'
-            const otherLogic = maxThreadLogic({ conversationId: otherConversationId, tabId: 'test' })
+            const otherLogic = maxThreadLogic({ conversationId: otherConversationId, panelId: 'test' })
             otherLogic.mount()
 
             // Now switch maxLogicInstance to point to the other conversation
@@ -993,7 +993,7 @@ describe('maxThreadLogic', () => {
 
             logic.unmount()
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -1017,7 +1017,7 @@ describe('maxThreadLogic', () => {
 
             logic.unmount()
             maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -1131,7 +1131,7 @@ describe('maxThreadLogic', () => {
             logic.unmount()
             logic = maxThreadLogic({
                 conversationId: MOCK_CONVERSATION_ID,
-                tabId: 'test',
+                panelId: 'test',
                 conversation: conversationWithMessages,
             })
             logic.mount()
@@ -1169,7 +1169,7 @@ describe('maxThreadLogic', () => {
             logic.unmount()
             logic = maxThreadLogic({
                 conversationId: MOCK_CONVERSATION_ID,
-                tabId: 'test',
+                panelId: 'test',
                 conversation: conversationWithoutMessages,
             })
             logic.mount()
@@ -1192,7 +1192,7 @@ describe('maxThreadLogic', () => {
             logic.unmount()
             logic = maxThreadLogic({
                 conversationId: MOCK_CONVERSATION_ID,
-                tabId: 'test',
+                panelId: 'test',
                 conversation: conversationWithoutMessages,
             })
 
@@ -1218,7 +1218,7 @@ describe('maxThreadLogic', () => {
 
             logic = maxThreadLogic({
                 conversationId: MOCK_CONVERSATION_ID,
-                tabId: 'test',
+                panelId: 'test',
                 conversation: {
                     // No messages field — simulates a list-level cache entry for an in-progress chat.
                     ...MOCK_IN_PROGRESS_CONVERSATION,
@@ -1254,7 +1254,7 @@ describe('maxThreadLogic', () => {
             const getSpy = jest.spyOn(api.conversations, 'get')
             const streamSpy = mockStream()
 
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
             await new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -1278,7 +1278,7 @@ describe('maxThreadLogic', () => {
             logic.unmount()
             logic = maxThreadLogic({
                 conversationId: MOCK_CONVERSATION_ID,
-                tabId: 'test',
+                panelId: 'test',
                 conversation: initialConversation,
             })
             logic.mount()
@@ -1306,7 +1306,7 @@ describe('maxThreadLogic', () => {
             // Simulate prop change by creating new logic instance with updated conversation
             logic = maxThreadLogic({
                 conversationId: MOCK_CONVERSATION_ID,
-                tabId: 'test',
+                panelId: 'test',
                 conversation: updatedConversation,
             })
             logic.mount()
@@ -1331,7 +1331,7 @@ describe('maxThreadLogic', () => {
 
     describe('command selection and activation', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
         })
 
@@ -1414,7 +1414,7 @@ describe('maxThreadLogic', () => {
 
     describe('assistant update event handling', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
         })
 
@@ -1566,7 +1566,7 @@ describe('maxThreadLogic', () => {
 
     describe('onEventImplementation message streaming', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
         })
 
@@ -2078,7 +2078,7 @@ describe('maxThreadLogic', () => {
 
     describe('enhanceThreadToolCalls', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
         })
 
@@ -2119,7 +2119,7 @@ describe('maxThreadLogic', () => {
         })
 
         it('marks tool call as in_progress when no completion message and still loading', async () => {
-            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             await expectLogic(logic, () => {
@@ -2824,7 +2824,7 @@ describe('maxThreadLogic', () => {
 
     describe('agent mode functionality', () => {
         beforeEach(() => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
         })
 
@@ -2936,7 +2936,7 @@ describe('maxThreadLogic', () => {
 
     describe('scene to agent mode mapping', () => {
         it('does not auto-set mode when conversation already exists', async () => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             // Set a conversation first
@@ -2957,7 +2957,7 @@ describe('maxThreadLogic', () => {
         })
 
         it('syncAgentModeFromConversation does not lock agent mode', async () => {
-            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, tabId: 'test' })
+            logic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID, panelId: 'test' })
             logic.mount()
 
             // Sync should not lock

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -71,7 +71,7 @@ import { summariseAssistantThread } from './handsFreeUtils'
 import { MODE_DEFINITIONS, ToolRegistration } from './max-constants'
 import { MaxBillingContext, MaxBillingContextSubscriptionLevel, maxBillingContextLogic } from './maxBillingContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
-import { maxLogic } from './maxLogic'
+import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import type { maxThreadLogicType } from './maxThreadLogicType'
 import { MaxUIContext } from './maxTypes'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
@@ -102,19 +102,17 @@ const FAILURE_MESSAGE: FailureMessage & ThreadMessage = {
 }
 
 export interface MaxThreadLogicProps {
-    tabId?: string // used to refer back to the scene MaxLogic instance
-    sidePanel?: boolean // set instead of tabId for the floating side panel chat
+    panelId?: string // identifies the MaxLogic instance backing this panel (scene tab id or side panel)
     conversationId: string
     conversation?: ConversationDetail | null
 }
 
 export const maxThreadLogic = kea<maxThreadLogicType>([
     key((props) => {
-        const owner = props.sidePanel ? 'sidepanel' : props.tabId
-        if (!owner) {
-            throw new Error('Max thread logic must have a tabId or sidePanel prop')
+        if (!props.panelId) {
+            throw new Error('Max thread logic must have a panelId prop')
         }
-        return `${props.conversationId}-${owner}`
+        return `${props.conversationId}-${props.panelId}`
     }),
 
     path((key) => ['scenes', 'max', 'maxThreadLogic', key]),
@@ -142,11 +140,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         }
     }),
 
-    connect(({ tabId, sidePanel }: MaxThreadLogicProps) => ({
+    connect(({ panelId }: MaxThreadLogicProps) => ({
         values: [
             maxGlobalLogic,
             ['dataProcessingAccepted', 'toolMap', 'tools', 'availableStaticTools'],
-            maxLogic({ tabId, sidePanel }),
+            maxLogic({ panelId }),
             [
                 'question',
                 'autoRun',
@@ -164,7 +162,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ['sceneId'],
         ],
         actions: [
-            maxLogic({ tabId, sidePanel }),
+            maxLogic({ panelId }),
             [
                 'askMax',
                 'setQuestion',
@@ -1008,7 +1006,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // not just when active. Otherwise a typed turn following a spoken one inherits
             // the earlier <voice_mode> system instruction from conversation history and
             // keeps formatting for speech (no markdown, spelled-out numbers).
-            const handsFree = handsFreeLogic.findMounted({ tabId: props.tabId, sidePanel: props.sidePanel })
+            const handsFree = handsFreeLogic.findMounted({ panelId: props.panelId })
             const voiceMode = handsFree ? { voice_mode: handsFree.values.isActive } : undefined
             const mergedUiContext =
                 uiContext || voiceMode
@@ -1038,7 +1036,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     agentMode: values.agentMode,
                 })
                 actions.setQuestion('')
-                if (props.sidePanel && sidePanelStateLogic.isMounted()) {
+                if (props.panelId === SIDE_PANEL_PANEL_ID && sidePanelStateLogic.isMounted()) {
                     sidePanelStateLogic.actions.setSidePanelOptions(null)
                 }
                 return
@@ -1089,7 +1087,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // Clear the question
             actions.setQuestion('')
             // Drop #panel=max:… options so reload doesn't re-run auto-send from the hash
-            if (props.sidePanel && sidePanelStateLogic.isMounted()) {
+            if (props.panelId === SIDE_PANEL_PANEL_ID && sidePanelStateLogic.isMounted()) {
                 sidePanelStateLogic.actions.setSidePanelOptions(null)
             }
             // For a new conversations, set the frontend conversation ID
@@ -1175,7 +1173,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         },
 
         completeThreadGeneration: () => {
-            const handsFree = handsFreeLogic.findMounted({ tabId: props.tabId, sidePanel: props.sidePanel })
+            const handsFree = handsFreeLogic.findMounted({ panelId: props.panelId })
             if (handsFree?.values.isActive) {
                 handsFree.actions.speakAssistantResponse(summariseAssistantThread(values.threadRaw))
             }
@@ -1746,7 +1744,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         cache.lastConversationId = props.conversationId
         for (const l of maxThreadLogic.findAllMounted()) {
             if (l !== logic && l.props.conversationId === props.conversationId) {
-                // We found a logic with the same conversationId, but a different tabId
+                // We found a logic with the same conversationId, but a different panelId
                 if (l.values.conversation) {
                     actions.setConversation(l.values.conversation)
                 }
@@ -1766,7 +1764,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
         // Check for URL-based mode from side panel options (e.g., #panel=max:mode=research:question)
         // This must be done in maxThreadLogic's afterMount to ensure the correct instance sets the mode
         if (
-            props.sidePanel &&
+            props.panelId === SIDE_PANEL_PANEL_ID &&
             !values.agentMode &&
             sidePanelStateLogic.isMounted() &&
             sidePanelStateLogic.values.selectedTab === SidePanelTab.Max &&

--- a/frontend/src/scenes/max/useMaxTool.ts
+++ b/frontend/src/scenes/max/useMaxTool.ts
@@ -8,7 +8,7 @@ import { SidePanelTab } from '~/types'
 
 import { ToolDefinition, ToolRegistration, getToolDefinition } from './max-constants'
 import { maxGlobalLogic } from './maxGlobalLogic'
-import { maxLogic } from './maxLogic'
+import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import { createSuggestionGroup } from './utils'
 
 export interface UseMaxToolOptions extends Omit<ToolRegistration, 'name' | 'description'> {
@@ -46,7 +46,7 @@ export function useMaxTool({
     const { registerTool, deregisterTool } = useActions(maxGlobalLogic)
     const { openSidePanel } = useActions(sidePanelLogic)
     const { sidePanelOpen, selectedTab } = useValues(sidePanelLogic)
-    const { setActiveGroup, startNewConversation } = useActions(maxLogic({ sidePanel: true }))
+    const { setActiveGroup, startNewConversation } = useActions(maxLogic({ panelId: SIDE_PANEL_PANEL_ID }))
 
     const definition = getToolDefinition(identifier)
     const isMaxOpen = sidePanelOpen && selectedTab === SidePanelTab.Max

--- a/frontend/src/scenes/project-homepage/ai-first/AiFirstHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/AiFirstHomepage.tsx
@@ -22,7 +22,7 @@ function phaseAtLeast(current: string, target: string): boolean {
 
 export function AiFirstHomepage(): JSX.Element {
     const { mode, animationPhase, query, threadStarted } = useValues(aiFirstHomepageLogic)
-    const { conversationId } = useValues(maxLogic({ tabId: HOMEPAGE_TAB_ID }))
+    const { conversationId } = useValues(maxLogic({ panelId: HOMEPAGE_TAB_ID }))
 
     const isIdle = mode === 'idle'
     const isAi = mode === 'ai'
@@ -30,7 +30,7 @@ export function AiFirstHomepage(): JSX.Element {
     const isContent = animationPhase === 'content'
 
     return (
-        <BindLogic logic={maxLogic} props={{ tabId: HOMEPAGE_TAB_ID }}>
+        <BindLogic logic={maxLogic} props={{ panelId: HOMEPAGE_TAB_ID }}>
             <Search.Root
                 logicKey="homepage"
                 showAskAiLink={false}

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -32,7 +32,7 @@ function IdleInput(): JSX.Element {
     const { setQuery, submitQuery, enterAiMode, startHandsFreeChat } = useActions(aiFirstHomepageLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
     const handsFreeFlag = useFeatureFlag('MAX_HANDS_FREE')
-    const { canUseHandsFree } = useValues(handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }))
+    const { canUseHandsFree } = useValues(handsFreeLogic({ panelId: HOMEPAGE_TAB_ID }))
     const inputRef = useRef<HTMLTextAreaElement>(null)
 
     const handsFreeAvailable = handsFreeFlag && canUseHandsFree && dataProcessingAccepted
@@ -169,7 +169,7 @@ function HomepageAiInput(): JSX.Element {
 
     const fallbackConversationId = useMemo(() => uuid(), [])
     const threadProps: MaxThreadLogicProps = {
-        tabId: HOMEPAGE_TAB_ID,
+        panelId: HOMEPAGE_TAB_ID,
         conversationId: threadLogicKey || fallbackConversationId,
         conversation,
     }

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageThread.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageThread.tsx
@@ -13,8 +13,8 @@ import { HOMEPAGE_TAB_ID } from './constants'
 
 export function HomepageThread(): JSX.Element {
     const { query } = useValues(aiFirstHomepageLogic)
-    const { threadLogicKey, conversation } = useValues(maxLogic({ tabId: HOMEPAGE_TAB_ID }))
-    const { askMax, setQuestion } = useActions(maxLogic({ tabId: HOMEPAGE_TAB_ID }))
+    const { threadLogicKey, conversation } = useValues(maxLogic({ panelId: HOMEPAGE_TAB_ID }))
+    const { askMax, setQuestion } = useActions(maxLogic({ panelId: HOMEPAGE_TAB_ID }))
 
     const scrollRef = useRef<HTMLDivElement | null>(null)
 
@@ -37,13 +37,13 @@ export function HomepageThread(): JSX.Element {
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     const threadProps: MaxThreadLogicProps = {
-        tabId: HOMEPAGE_TAB_ID,
+        panelId: HOMEPAGE_TAB_ID,
         conversationId: threadLogicKey || uuid(),
         conversation,
     }
 
     return (
-        <BindLogic logic={maxLogic} props={{ tabId: HOMEPAGE_TAB_ID }}>
+        <BindLogic logic={maxLogic} props={{ panelId: HOMEPAGE_TAB_ID }}>
             <BindLogic logic={maxThreadLogic} props={threadProps}>
                 <ScrollableShadows direction="vertical" styledScrollbars className="grow min-h-0" scrollRef={scrollRef}>
                     <ThreadAutoScroller>

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -76,7 +76,7 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
 
     connect(() => ({
         values: [
-            maxLogic({ tabId: HOMEPAGE_TAB_ID }),
+            maxLogic({ panelId: HOMEPAGE_TAB_ID }),
             ['threadLogicKey', 'conversationId'],
             teamLogic,
             ['currentTeam'],
@@ -92,9 +92,9 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             ['chatDraftFor'],
         ],
         actions: [
-            maxLogic({ tabId: HOMEPAGE_TAB_ID }),
+            maxLogic({ panelId: HOMEPAGE_TAB_ID }),
             ['openConversation', 'startNewConversation', 'setQuestion'],
-            handsFreeLogic({ tabId: HOMEPAGE_TAB_ID }),
+            handsFreeLogic({ panelId: HOMEPAGE_TAB_ID }),
             ['enterHandsFree'],
             sceneLogic,
             ['setHomepage'],


### PR DESCRIPTION
## Problem

Follow-up to #62065 (merged). That PR fixed the side panel chat navigating to `/ai`, but did so by giving Max's chat logics two mutually-exclusive props: a `tabId` string *and* a `sidePanel` boolean. The two encode the same thing — which chat panel an instance backs — and the side panel was never a scene tab to begin with, so `tabId` was a misnomer for it.

The deeper problem: that regression shipped because **opening a conversation in the side panel had no test guarding its route behaviour** — only `startNewConversation` was covered. So this PR also closes that gap.

## Changes

**Collapse the dual props into a single `panelId`** across `maxLogic`, `maxThreadLogic`, and `handsFreeLogic`, plus every call site:

- The floating side panel chat passes a `SIDE_PANEL_PANEL_ID = 'sidepanel'` sentinel instead of `sidePanel: true`. The kea key is simply `props.panelId || 'scene'`.
- The route guard that keeps the side panel from rewriting the scene URL becomes `props.panelId === SIDE_PANEL_PANEL_ID`.
- A `sceneTabId(panelId)` helper expresses "this panel is a real scene tab" once, replacing three duplicated `props.tabId && !props.sidePanel` checks (per-tab drafts and tab badges).
- The **presentational** `sidePanel` prop (side panel chrome/layout on `MaxInstance`, `ConversationHistory`, `HistoryPreview`) is untouched — it's a separate concern from logic identity.
- Scene-layer code keeps its genuine `tabId` / `HOMEPAGE_TAB_ID` / `INBOX_TAB_ID` names and maps them to `panelId` at the logic boundary, so scenes still speak "tab" while the logics speak "panel".

**Close the test-coverage gap:**

- Generalised the `maxLogic` route-guard test from `startNewConversation` only to every route-affecting action (`openConversation`, `toggleConversationHistory`), asserting the side panel stays on the current page and the scene navigates to `/ai`.
- Added a `maxGlobalLogic` test for the real `openSidePanelMax(conversationId)` entry point — the actual "open a conversation in the side panel" flow — asserting the conversation opens in the side panel logic without changing the route.

No behaviour change in the refactor itself — it's a rename + prop collapse.

## How did you test this code?

Automated only (I'm an agent — no manual UI testing performed):

- `maxLogic.test.ts`, `maxThreadLogic.test.ts`, `handsFreeLogic.test.ts`, `max.test.ts`, `QuestionInput.test.tsx`, `maxGlobalLogic.test.ts` all pass, including the new route-guard coverage across side panel and scene.
- `tsc --noEmit` is clean for all touched files (after regenerating kea types).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by PostHog Code (Claude) at Paul's request, picking up review feedback left on #62065 after that PR had already merged. The feedback: `tabId` in Max is really a "panel id", the separate `sidePanel` boolean is redundant once any panel just carries an id, and — root cause — the side panel conversation-open path had no test stopping the regression.

Key decisions: keep `tabId` at the scene boundary (it genuinely is a scene-tab id there) and only rename to `panelId` inside the chat logics and their props; the side panel maps onto the same prop via a named sentinel rather than a boolean. Chose `panelId` over `conversationPanelId` per Paul. Introduced `sceneTabId()` so the "only real scene tabs get drafts/badges" rule lives in one place instead of three. Added the route-guard tests at both the unit (`maxLogic`) and integration (`maxGlobalLogic.openSidePanelMax`) levels.

Agent-authored — requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
