### PR TITLE
feat(experiments): add 4-way A/A test on signup page

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -474,7 +474,7 @@ export const FEATURE_FLAGS = {
     SHOW_DATA_PIPELINES_NAV_ITEM: 'show-data-pipelines-nav-item', // owner: @raquelmsmith
     SHOW_REFERRER_FAVICON: 'show-referrer-favicon', // owner: @jordanm-posthog #team-web-analytics
     SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
-    SIGNUP_AA_TEST: 'signup-aa-test', // owner: @andehen #team-experiments multivariate=control,test
+    SIGNUP_AA_TEST_4_WAY: 'signup-aa-test-4-way', // owner: @andehen #team-experiments multivariate=control,test-1,test-2,test-3
     SLACK_DWH: 'slack-dwh', // owner: @MarconLP #team-warehouse-sources
     SNAPCHAT_ADS_SOURCE: 'snapchat-ads-source', // owner: @jabahamondes #team-web-analytics
     SQL_EDITOR_VIM_MODE: 'sql-editor-vim-mode', // owner: @arthurdedeus

--- a/frontend/src/scenes/authentication/signup/variants/legacy/LegacySignup.tsx
+++ b/frontend/src/scenes/authentication/signup/variants/legacy/LegacySignup.tsx
@@ -19,7 +19,7 @@ export function LegacySignup(): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const isAATestVariant = featureFlags[FEATURE_FLAGS.SIGNUP_AA_TEST] === 'test'
+    const signupAATestVariant = featureFlags[FEATURE_FLAGS.SIGNUP_AA_TEST_4_WAY]
 
     const footerHighlights = {
         cloud: ['Hosted & managed by PostHog', 'Pay per event, cancel anytime', 'Fast and reliable support'],
@@ -41,7 +41,9 @@ export function LegacySignup(): JSX.Element | null {
                 </div>
             }
         >
-            {isAATestVariant && <div data-attr="signup-aa-test-variant" className="hidden" />}
+            {typeof signupAATestVariant === 'string' && (
+                <div data-attr="signup-aa-test-variant" data-variant={signupAATestVariant} className="hidden" />
+            )}
             <SignupForm />
         </AuthShell>
     ) : null


### PR DESCRIPTION
## Problem

Validate the new frequentist sequential-testing engine — specifically false-positive behavior under continuous monitoring — on real signup traffic. The existing `signup-aa-test` flag is 2-variant and already attached to two stopped experiments, so it can't back a fresh 4-arm test.

## Changes

- Add the `signup-aa-test-4-way` flag (`control` + `test-1/2/3`) and read it in `LegacySignup`, replacing the old `signup-aa-test` read.
- All four arms render identically (A/A — no visual change); the hidden marker only surfaces the assigned variant for E2E checks. Reading the flag is what fires the `$feature_flag_called` exposure that enrolls the visitor.

The experiment itself is configured separately via the PostHog MCP (draft): 4×25% split, 100% rollout, frequentist + sequential testing, tuning parameter 30000. Primary metric: signup conversion (funnel on `user signed up`); secondary: signups per exposed user.

## How did you test this code?

Agent-authored — no manual app testing performed. The change is a flag-key swap plus a `typeof === 'string'` render guard; relying on CI for typecheck, lint, and visual regression. The experiment and metrics were created and verified through the PostHog MCP.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Chose a new flag key because `signup-aa-test` is occupied by two stopped experiments and is only 2-variant. The sequential tuning parameter was sized to the signup page's recent exposure volume so the confidence sequence is tightest near the expected end-of-experiment sample size (the test's `n` is the combined size of the two compared arms). Instrumented `LegacySignup`, the default live variant; flagged that a future auth-redesign rollout would need the exposure read moved up into `SignupContainer` to keep covering all signup traffic.
