### PR TITLE
fix(tracing): remove root_filter from spans query

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -399,10 +399,10 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
         ts_op = ">=" if self.query.orderBy == "earliest" else "<="
 
         # rootSpans is opt-in and gated on `is True` (not truthiness): the frontend never sends it
-        # (None), so its prefetch-driven waterfall is untouched. An explicit True narrows the result
-        # to root spans only — applied to both the trace-selection subquery (so we pick traces whose
-        # root matches the filter) and the outer fetch (so only those roots come back), keeping
-        # matched_filter consistent instead of surfacing roots flagged 0.
+        # (None), so its prefetch-driven waterfall is untouched. An explicit True narrows the
+        # trace-selection subquery to `is_root_span = 1`, so we only pick traces whose root matches
+        # the filter. The outer fetch is deliberately left unfiltered — it still prefetches every
+        # span of the selected traces so the waterfall gets its children.
         root_only = self.query.rootSpans is True
 
         subquery_where_exprs: list[ast.Expr] = [self.where()]
@@ -489,7 +489,6 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
                 "trace_id_query": trace_id_query,
                 "limit": ast.Constant(value=(self.query.limit or 1) * limit_by_n),
                 "filters": ast.Placeholder(expr=ast.Field(chain=["filters"])),
-                "root_filter": parse_expr("is_root_span = 1") if root_only else ast.Constant(value=True),
                 # The attribute map dominates payload size (db.statement holds multi-KB SQL). When
                 # excluded we still SELECT a column so the positional result mapping stays stable —
                 # an empty map instead of the real one.

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -481,7 +481,7 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
                 min(if({where_for_start}, timestamp, NULL)) OVER (PARTITION BY trace_id) as trace_start,
                 {attributes}
             FROM posthog.trace_spans
-            WHERE {filters} AND {root_filter} AND trace_id IN ({trace_id_query}) LIMIT {limit}
+            WHERE {filters} AND trace_id IN ({trace_id_query}) LIMIT {limit}
         """,
             placeholders={
                 "where": self.where(),

--- a/products/tracing/backend/tests/test_root_spans_filter.py
+++ b/products/tracing/backend/tests/test_root_spans_filter.py
@@ -15,9 +15,11 @@ from products.tracing.backend.logic import TraceSpansQueryRunner
 
 DATE_FROM = "2026-06-02T07:00:00Z"
 DATE_TO = "2026-06-02T09:00:00Z"
-# One trace: a root ("GET /api") with two children ("redis_cluster.discovery", "clickhouse.query").
+# Trace A (service "web" throughout): root "GET /api" with two children.
 ROOT_NAME = "GET /api"
 CHILD_NAME = "redis_cluster.discovery"
+# Trace B: its root runs on service "worker" (won't match a "web" filter), but a child runs on "web".
+OTHER_ROOT_NAME = "POST /webhook"
 
 
 def _b64(raw: bytes) -> str:
@@ -40,24 +42,32 @@ class TestRootSpansFilter(ClickhouseTestMixin, APIBaseTest):
         )
         sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
 
-        trace_id = _b64((1).to_bytes(16, "big"))
-        root_span_id = _b64((1).to_bytes(8, "big"))
+        trace_a = _b64((1).to_bytes(16, "big"))
+        trace_b = _b64((2).to_bytes(16, "big"))
+        root_a = _b64((1).to_bytes(8, "big"))
+        root_b = _b64((4).to_bytes(8, "big"))
         base = dt.datetime(2026, 6, 2, 8, 0, 0)
 
-        def _row(uuid_suffix: int, span_id: str, parent: str, name: str, offset_ms: int) -> str:
+        def _row(
+            uuid_suffix: int, trace_id: str, span_id: str, parent: str, name: str, service: str, offset_ms: int
+        ) -> str:
             ts = base + dt.timedelta(milliseconds=offset_ms)
             ts_str = ts.strftime("%Y-%m-%d %H:%M:%S.%f")
             return (
                 "("
                 f"'019e8754-0000-0000-0000-{uuid_suffix:012d}', {cls.team.id}, '{trace_id}', "
-                f"'{span_id}', '{parent}', '{name}', 2, '{ts_str}', '{ts_str}', '{ts_str}', 0, 'web'"
+                f"'{span_id}', '{parent}', '{name}', 2, '{ts_str}', '{ts_str}', '{ts_str}', 0, '{service}'"
                 ")"
             )
 
         rows = [
-            _row(1, root_span_id, "", ROOT_NAME, 0),
-            _row(2, _b64((2).to_bytes(8, "big")), root_span_id, CHILD_NAME, 10),
-            _row(3, _b64((3).to_bytes(8, "big")), root_span_id, "clickhouse.query", 20),
+            # Trace A: root and both children on service "web".
+            _row(1, trace_a, root_a, "", ROOT_NAME, "web", 0),
+            _row(2, trace_a, _b64((2).to_bytes(8, "big")), root_a, CHILD_NAME, "web", 10),
+            _row(3, trace_a, _b64((3).to_bytes(8, "big")), root_a, "clickhouse.query", "web", 20),
+            # Trace B: root on "worker" (won't match a "web" filter), child on "web" (will).
+            _row(4, trace_b, root_b, "", OTHER_ROOT_NAME, "worker", 0),
+            _row(5, trace_b, _b64((5).to_bytes(8, "big")), root_b, CHILD_NAME, "web", 10),
         ]
         sync_execute(
             "INSERT INTO trace_spans (uuid, team_id, trace_id, span_id, parent_span_id, name, kind, "
@@ -72,32 +82,36 @@ class TestRootSpansFilter(ClickhouseTestMixin, APIBaseTest):
         sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
         super().tearDownClass()
 
-    def _run(self, *, root_spans: bool | None, prefetch: int) -> list[dict]:
+    def _run(self, *, root_spans: bool | None, prefetch: int, service_names: list[str] | None = None) -> list[dict]:
         query = TraceSpansQuery(
             dateRange=DateRange(date_from=DATE_FROM, date_to=DATE_TO),
             orderBy="latest",
             limit=100,
             rootSpans=root_spans,
             prefetchSpans=prefetch,
+            serviceNames=service_names,
         )
         return TraceSpansQueryRunner(query, self.team).run().results
 
     @parameterized.expand(
         [
-            # rootSpans=True collapses to the single root span even with a high prefetch.
-            ("true_returns_only_root", True, True),
-            # rootSpans=False keeps children so the child span (redis_cluster.discovery) comes through.
-            ("false_includes_children", False, False),
-            # The frontend sends None; it relies on prefetch to populate the waterfall (children present).
-            ("none_unchanged_includes_children", None, False),
+            # rootSpans=True selects traces by ROOT match: only trace A (its root is on "web").
+            # Trace B is dropped because its root is on "worker", even though a child is on "web".
+            ("true_prefetches_children_excludes_nonroot_traces", True, False),
+            # rootSpans=False matches a trace on ANY span, so trace B comes through via its "web" child.
+            ("false_includes_child_matched_traces", False, True),
+            # The frontend sends None; it behaves like False (relies on prefetch for the waterfall).
+            ("none_includes_child_matched_traces", None, True),
         ]
     )
-    def test_root_spans_filter(self, _name, root_spans, expect_only_root):
-        results = self._run(root_spans=root_spans, prefetch=20)
+    def test_root_spans_filter(self, _name, root_spans, expect_other_trace):
+        results = self._run(root_spans=root_spans, prefetch=20, service_names=["web"])
         names = {r["name"] for r in results}
-        if expect_only_root:
-            self.assertEqual([r["name"] for r in results], [ROOT_NAME])
-            self.assertTrue(all(r["is_root_span"] for r in results))
+        # Trace A's root always matches the filter, and its children are always prefetched for the
+        # waterfall regardless of rootSpans — this is the regression guard for the root_filter fix.
+        self.assertIn(ROOT_NAME, names)
+        self.assertIn(CHILD_NAME, names)
+        if expect_other_trace:
+            self.assertIn(OTHER_ROOT_NAME, names)
         else:
-            self.assertIn(CHILD_NAME, names)
-            self.assertIn(ROOT_NAME, names)
+            self.assertNotIn(OTHER_ROOT_NAME, names)


### PR DESCRIPTION

<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem
with the spans query we prefetch child spans, we added the root_filter to this query which meant no child spans were ever found

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
fix query to prefetch non root spans
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
