### PR TITLE
feat(ingestion): instrument pipeline retries and widen persons-Postgres budget

### DIFF
--- a/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
@@ -125,6 +125,6 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
                         })
                     )
             ),
-        { tries: 3, sleepMs: 100, name: 'per_distinct_id' }
+        { tries: 5, sleepMs: 100, name: 'per_distinct_id' }
     )
 }

--- a/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
@@ -125,6 +125,6 @@ export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipeline
                         })
                     )
             ),
-        { tries: 3, sleepMs: 100 }
+        { tries: 3, sleepMs: 100, name: 'per_distinct_id' }
     )
 }

--- a/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -105,7 +105,7 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
             // This step awaits its DB write, so retry transient persons-Postgres failures
             // (e.g. PgBouncer scale-down) instead of letting them crash the consumer loop.
             .pipeBatchWithRetry(processPersonlessDistinctIdsBatchStep(personsStore, personsPrefetchEnabled), {
-                tries: 3,
+                tries: 5,
                 sleepMs: 100,
                 name: 'personless_distinct_ids',
             })

--- a/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/post-team-preprocessing-subpipeline.ts
@@ -107,6 +107,7 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
             .pipeBatchWithRetry(processPersonlessDistinctIdsBatchStep(personsStore, personsPrefetchEnabled), {
                 tries: 3,
                 sleepMs: 100,
+                name: 'personless_distinct_ids',
             })
             // Prefetch hog functions for all teams in the batch
             .pipeBatch(createPrefetchHogFunctionsStep(hogTransformer, cdpHogWatcherSampleRate))

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -278,6 +278,7 @@ export function createErrorTrackingPipeline(
                                         .pipeBatchWithRetry(createCymbalProcessingStep(cymbalClient), {
                                             tries: 3,
                                             sleepMs: 100,
+                                            name: 'cymbal_processing',
                                         })
                                         // Enrich, prepare, create, and emit events
                                         // Batch fetch person (read-only, no updates)

--- a/nodejs/src/ingestion/pipelines/batch-retry.test.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.test.ts
@@ -3,6 +3,7 @@ import { withBatchRetry } from './batch-retry'
 import { newBatchPipelineBuilder } from './builders'
 import { createOkContext } from './helpers'
 import { pipelineRetryAttemptsHistogram } from './metrics'
+import { getRetryAttempts } from './metrics.test-utils'
 import { drop, isDlqResult, isDropResult, isOkResult, ok } from './results'
 
 // Suppress logger output during tests
@@ -30,20 +31,6 @@ class NonRetriableError extends Error {
 // Helper to create a batch of test inputs
 function createTestBatch<T>(values: T[]) {
     return values.map((value) => createOkContext(value, {}))
-}
-
-async function getRetryAttempts(name: string, outcome: string): Promise<{ count: number; sum: number } | null> {
-    const metric = await pipelineRetryAttemptsHistogram.get()
-    const find = (suffix: string): number | undefined =>
-        metric.values.find(
-            (v) =>
-                v.metricName === `ingestion_pipeline_retry_attempts${suffix}` &&
-                v.labels.name === name &&
-                v.labels.outcome === outcome
-        )?.value
-    const count = find('_count')
-    const sum = find('_sum')
-    return count === undefined || sum === undefined ? null : { count, sum }
 }
 
 describe('withBatchRetry', () => {

--- a/nodejs/src/ingestion/pipelines/batch-retry.test.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.test.ts
@@ -2,6 +2,7 @@ import { BatchProcessingStep } from './base-batch-pipeline'
 import { withBatchRetry } from './batch-retry'
 import { newBatchPipelineBuilder } from './builders'
 import { createOkContext } from './helpers'
+import { pipelineRetryAttemptsHistogram } from './metrics'
 import { drop, isDlqResult, isDropResult, isOkResult, ok } from './results'
 
 // Suppress logger output during tests
@@ -31,9 +32,24 @@ function createTestBatch<T>(values: T[]) {
     return values.map((value) => createOkContext(value, {}))
 }
 
+async function getRetryAttempts(name: string, outcome: string): Promise<{ count: number; sum: number } | null> {
+    const metric = await pipelineRetryAttemptsHistogram.get()
+    const find = (suffix: string): number | undefined =>
+        metric.values.find(
+            (v) =>
+                v.metricName === `ingestion_pipeline_retry_attempts${suffix}` &&
+                v.labels.name === name &&
+                v.labels.outcome === outcome
+        )?.value
+    const count = find('_count')
+    const sum = find('_sum')
+    return count === undefined || sum === undefined ? null : { count, sum }
+}
+
 describe('withBatchRetry', () => {
     beforeEach(() => {
         jest.useFakeTimers()
+        pipelineRetryAttemptsHistogram.reset()
     })
 
     afterEach(() => {
@@ -166,5 +182,77 @@ describe('withBatchRetry', () => {
     ])('preserves step name for $description', ({ step, expectedName }) => {
         const wrapped = withBatchRetry(step)
         expect(wrapped.name).toBe(expectedName)
+    })
+
+    describe('retry attempts metric', () => {
+        it('records the attempt count and "completed" outcome when it succeeds after retries', async () => {
+            let attempts = 0
+            const step: BatchProcessingStep<number, string> = (values) => {
+                attempts++
+                if (attempts < 3) {
+                    throw new RetriableError('Temporary failure')
+                }
+                return Promise.resolve(values.map((v) => ok(String(v))))
+            }
+
+            const pipeline = newBatchPipelineBuilder<number>()
+                .pipeBatchWithRetry(step, { tries: 5, sleepMs: 100, name: 'test_batch' })
+                .gather()
+                .build()
+
+            pipeline.feed(createTestBatch([1]))
+            const resultPromise = pipeline.next()
+            await jest.advanceTimersByTimeAsync(300) // 100ms + 200ms for two retries
+            await resultPromise
+
+            expect(await getRetryAttempts('test_batch', 'completed')).toEqual({ count: 1, sum: 3 })
+        })
+
+        it('records "exhausted" outcome with the full attempt count when retries run out', async () => {
+            jest.useRealTimers() // promise rejections + fake timers don't mix well here
+
+            const step: BatchProcessingStep<number, string> = (_values) => {
+                throw new RetriableError('Always fails')
+            }
+
+            const pipeline = newBatchPipelineBuilder<number>()
+                .pipeBatchWithRetry(step, { tries: 2, sleepMs: 1, name: 'test_batch' })
+                .gather()
+                .build()
+
+            pipeline.feed(createTestBatch([1]))
+            await expect(pipeline.next()).rejects.toThrow('Always fails')
+
+            expect(await getRetryAttempts('test_batch', 'exhausted')).toEqual({ count: 1, sum: 2 })
+        })
+
+        it('records "non_retriable" outcome with a single attempt', async () => {
+            const step: BatchProcessingStep<number, string> = (_values) => {
+                throw new NonRetriableError('Validation failed')
+            }
+
+            const pipeline = newBatchPipelineBuilder<number>()
+                .pipeBatchWithRetry(step, { tries: 3, sleepMs: 100, name: 'test_batch' })
+                .gather()
+                .build()
+
+            pipeline.feed(createTestBatch([1, 2]))
+            await pipeline.next()
+
+            expect(await getRetryAttempts('test_batch', 'non_retriable')).toEqual({ count: 1, sum: 1 })
+        })
+
+        it('defaults the metric name to the step name', async () => {
+            const namedStep: BatchProcessingStep<number, string> = function geoipStep(values) {
+                return Promise.resolve(values.map((v) => ok(String(v))))
+            }
+
+            const pipeline = newBatchPipelineBuilder<number>().pipeBatchWithRetry(namedStep).gather().build()
+
+            pipeline.feed(createTestBatch([1]))
+            await pipeline.next()
+
+            expect(await getRetryAttempts('geoipStep', 'completed')).toEqual({ count: 1, sum: 1 })
+        })
     })
 })

--- a/nodejs/src/ingestion/pipelines/batch-retry.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.ts
@@ -2,9 +2,12 @@ import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { retryIfRetriable } from '../../utils/retries'
 import { BatchProcessingStep } from './base-batch-pipeline'
+import { pipelineRetryAttemptsHistogram } from './metrics'
 import { dlq } from './results'
 
 export interface BatchRetryOptions {
+    /** Identifies the retry site in the `ingestion_pipeline_retry_attempts` metric. Defaults to the step name. */
+    name?: string
     tries?: number
     sleepMs?: number
 }
@@ -26,9 +29,20 @@ export function withBatchRetry<T, U, R extends string = never>(
     step: BatchProcessingStep<T, U, R>,
     options: BatchRetryOptions = {}
 ): BatchProcessingStep<T, U, R> {
+    const name = options.name ?? step.name ?? 'unknown'
     const wrappedStep: BatchProcessingStep<T, U, R> = async (values: T[]) => {
+        let attempts = 0
         try {
-            return await retryIfRetriable(() => step(values), options.tries ?? 3, options.sleepMs ?? 100)
+            const result = await retryIfRetriable(
+                () => {
+                    attempts++
+                    return step(values)
+                },
+                options.tries ?? 3,
+                options.sleepMs ?? 100
+            )
+            pipelineRetryAttemptsHistogram.labels({ name, outcome: 'completed' }).observe(attempts)
+            return result
         } catch (error) {
             const isRetriable = (error as any)?.isRetriable
 
@@ -40,10 +54,12 @@ export function withBatchRetry<T, U, R extends string = never>(
             })
 
             if (isRetriable === false) {
+                pipelineRetryAttemptsHistogram.labels({ name, outcome: 'non_retriable' }).observe(attempts)
                 captureException(error as Error)
                 return values.map(() => dlq('Processing error - non-retriable', error))
             }
 
+            pipelineRetryAttemptsHistogram.labels({ name, outcome: 'exhausted' }).observe(attempts)
             throw error
         }
     }

--- a/nodejs/src/ingestion/pipelines/metrics.test-utils.ts
+++ b/nodejs/src/ingestion/pipelines/metrics.test-utils.ts
@@ -1,0 +1,19 @@
+import { pipelineRetryAttemptsHistogram } from './metrics'
+
+/**
+ * Reads the {_count, _sum} of the retry-attempts histogram for a given name/outcome.
+ * _sum holds the observed attempt count (a single observe per call), _count the number of calls.
+ */
+export async function getRetryAttempts(name: string, outcome: string): Promise<{ count: number; sum: number } | null> {
+    const metric = await pipelineRetryAttemptsHistogram.get()
+    const find = (suffix: string): number | undefined =>
+        metric.values.find(
+            (v) =>
+                v.metricName === `ingestion_pipeline_retry_attempts${suffix}` &&
+                v.labels.name === name &&
+                v.labels.outcome === outcome
+        )?.value
+    const count = find('_count')
+    const sum = find('_sum')
+    return count === undefined || sum === undefined ? null : { count, sum }
+}

--- a/nodejs/src/ingestion/pipelines/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/metrics.ts
@@ -12,3 +12,10 @@ export const pipelineStepDurationHistogram = new Histogram({
     labelNames: ['step_name', 'step_type', 'result'],
     buckets: exponentialBuckets(0.001, 2, 15), // 1ms -> ~16s
 })
+
+export const pipelineRetryAttemptsHistogram = new Histogram({
+    name: 'ingestion_pipeline_retry_attempts',
+    help: 'Attempts a retrying pipeline wrapper made before completing, exhausting retries, or hitting a non-retriable error',
+    labelNames: ['name', 'outcome'],
+    buckets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+})

--- a/nodejs/src/ingestion/pipelines/retrying-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/retrying-pipeline.test.ts
@@ -2,6 +2,7 @@ import { Message } from 'node-rdkafka'
 
 import { captureException } from '../../utils/posthog'
 import { createContext, createNewPipeline, createOkContext } from './helpers'
+import { pipelineRetryAttemptsHistogram } from './metrics'
 import { PipelineResultType, dlq, ok } from './results'
 import { RetryingPipeline, RetryingPipelineOptions } from './retrying-pipeline'
 
@@ -13,9 +14,26 @@ jest.mock('../../utils/posthog', () => ({
 
 const mockCaptureException = captureException as jest.MockedFunction<typeof captureException>
 
+// Reads the {_count, _sum} of the retry-attempts histogram for a given name/outcome.
+// _sum holds the observed attempt count (a single observe per process() call), _count the number of calls.
+async function getRetryAttempts(name: string, outcome: string): Promise<{ count: number; sum: number } | null> {
+    const metric = await pipelineRetryAttemptsHistogram.get()
+    const find = (suffix: string): number | undefined =>
+        metric.values.find(
+            (v) =>
+                v.metricName === `ingestion_pipeline_retry_attempts${suffix}` &&
+                v.labels.name === name &&
+                v.labels.outcome === outcome
+        )?.value
+    const count = find('_count')
+    const sum = find('_sum')
+    return count === undefined || sum === undefined ? null : { count, sum }
+}
+
 describe('RetryingPipeline', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        pipelineRetryAttemptsHistogram.reset()
     })
 
     describe('basic functionality', () => {
@@ -532,6 +550,97 @@ describe('RetryingPipeline', () => {
 
             // Should have both context and step warnings
             expect(result.context.warnings).toEqual([contextWarning, stepWarning])
+        })
+    })
+
+    describe('retry attempts metric', () => {
+        const message: Message = {
+            value: Buffer.from('test'),
+            topic: 'test',
+            partition: 0,
+            offset: 1,
+            key: Buffer.from('key'),
+            size: 4,
+            timestamp: Date.now(),
+            headers: [],
+        }
+        const input = createOkContext<{ message: Message }, { message: Message }>({ message }, { message })
+
+        it('records the attempt count and "completed" outcome when it succeeds after retries', async () => {
+            let callCount = 0
+            const step = jest.fn().mockImplementation(() => {
+                callCount++
+                if (callCount < 3) {
+                    const error = new Error('Retriable error')
+                    ;(error as any).isRetriable = true
+                    return Promise.reject(error)
+                }
+                return Promise.resolve(ok({ processed: true }))
+            })
+
+            const pipeline = new RetryingPipeline(createNewPipeline().pipe(step), {
+                name: 'test_retry',
+                tries: 3,
+                sleepMs: 1,
+            })
+            await pipeline.process(input)
+
+            // Succeeded on the 3rd attempt → one observation of value 3.
+            expect(await getRetryAttempts('test_retry', 'completed')).toEqual({ count: 1, sum: 3 })
+            expect(await getRetryAttempts('test_retry', 'exhausted')).toBeNull()
+        })
+
+        it('records "completed" with a single attempt when it succeeds first try', async () => {
+            const step = jest.fn().mockResolvedValue(ok({ processed: true }))
+
+            const pipeline = new RetryingPipeline(createNewPipeline().pipe(step), { name: 'test_retry' })
+            await pipeline.process(input)
+
+            expect(await getRetryAttempts('test_retry', 'completed')).toEqual({ count: 1, sum: 1 })
+        })
+
+        it('records "exhausted" with the full attempt count when retries run out', async () => {
+            const step = jest.fn().mockImplementation(() => {
+                const error = new Error('Always fails')
+                ;(error as any).isRetriable = true
+                return Promise.reject(error)
+            })
+
+            const pipeline = new RetryingPipeline(createNewPipeline().pipe(step), {
+                name: 'test_retry',
+                tries: 4,
+                sleepMs: 1,
+            })
+            await expect(pipeline.process(input)).rejects.toThrow('Always fails')
+
+            expect(await getRetryAttempts('test_retry', 'exhausted')).toEqual({ count: 1, sum: 4 })
+        })
+
+        it('records "non_retriable" with a single attempt and no retries', async () => {
+            const step = jest.fn().mockImplementation(() => {
+                const error = new Error('Non-retriable error')
+                ;(error as any).isRetriable = false
+                return Promise.reject(error)
+            })
+
+            const pipeline = new RetryingPipeline(createNewPipeline().pipe(step), {
+                name: 'test_retry',
+                tries: 5,
+                sleepMs: 1,
+            })
+            await pipeline.process(input)
+
+            expect(await getRetryAttempts('test_retry', 'non_retriable')).toEqual({ count: 1, sum: 1 })
+            expect(step).toHaveBeenCalledTimes(1)
+        })
+
+        it('falls back to the "unknown" name label when none is provided', async () => {
+            const step = jest.fn().mockResolvedValue(ok({ processed: true }))
+
+            const pipeline = new RetryingPipeline(createNewPipeline().pipe(step))
+            await pipeline.process(input)
+
+            expect(await getRetryAttempts('unknown', 'completed')).toEqual({ count: 1, sum: 1 })
         })
     })
 })

--- a/nodejs/src/ingestion/pipelines/retrying-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/retrying-pipeline.test.ts
@@ -3,6 +3,7 @@ import { Message } from 'node-rdkafka'
 import { captureException } from '../../utils/posthog'
 import { createContext, createNewPipeline, createOkContext } from './helpers'
 import { pipelineRetryAttemptsHistogram } from './metrics'
+import { getRetryAttempts } from './metrics.test-utils'
 import { PipelineResultType, dlq, ok } from './results'
 import { RetryingPipeline, RetryingPipelineOptions } from './retrying-pipeline'
 
@@ -13,22 +14,6 @@ jest.mock('../../utils/posthog', () => ({
 }))
 
 const mockCaptureException = captureException as jest.MockedFunction<typeof captureException>
-
-// Reads the {_count, _sum} of the retry-attempts histogram for a given name/outcome.
-// _sum holds the observed attempt count (a single observe per process() call), _count the number of calls.
-async function getRetryAttempts(name: string, outcome: string): Promise<{ count: number; sum: number } | null> {
-    const metric = await pipelineRetryAttemptsHistogram.get()
-    const find = (suffix: string): number | undefined =>
-        metric.values.find(
-            (v) =>
-                v.metricName === `ingestion_pipeline_retry_attempts${suffix}` &&
-                v.labels.name === name &&
-                v.labels.outcome === outcome
-        )?.value
-    const count = find('_count')
-    const sum = find('_sum')
-    return count === undefined || sum === undefined ? null : { count, sum }
-}
 
 describe('RetryingPipeline', () => {
     beforeEach(() => {

--- a/nodejs/src/ingestion/pipelines/retrying-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/retrying-pipeline.ts
@@ -1,10 +1,13 @@
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { retryIfRetriable } from '../../utils/retries'
+import { pipelineRetryAttemptsHistogram } from './metrics'
 import { OkResultWithContext, Pipeline, PipelineResultWithContext } from './pipeline.interface'
 import { dlq } from './results'
 
 export interface RetryingPipelineOptions {
+    /** Identifies the retry site in the `ingestion_pipeline_retry_attempts` metric. */
+    name?: string
     tries?: number
     sleepMs?: number
 }
@@ -19,14 +22,18 @@ export class RetryingPipeline<TInput, TOutput, C, R extends string = never> impl
     ) {}
 
     async process(input: OkResultWithContext<TInput, C>): Promise<PipelineResultWithContext<TOutput, C, R>> {
+        const name = this.options.name ?? 'unknown'
+        let attempts = 0
         try {
             const result = await retryIfRetriable(
                 async () => {
+                    attempts++
                     return await this.innerPipeline.process(input)
                 },
                 this.options.tries ?? 3,
                 this.options.sleepMs ?? 100
             )
+            pipelineRetryAttemptsHistogram.labels({ name, outcome: 'completed' }).observe(attempts)
             return result
         } catch (error) {
             logger.error('🔥', `Error processing message`, {
@@ -35,12 +42,14 @@ export class RetryingPipeline<TInput, TOutput, C, R extends string = never> impl
             })
 
             if (error?.isRetriable === false) {
+                pipelineRetryAttemptsHistogram.labels({ name, outcome: 'non_retriable' }).observe(attempts)
                 captureException(error)
                 return {
                     result: dlq('Processing error - non-retriable', error),
                     context: input.context,
                 }
             } else {
+                pipelineRetryAttemptsHistogram.labels({ name, outcome: 'exhausted' }).observe(attempts)
                 throw error
             }
         }


### PR DESCRIPTION
## Problem

When the persons-Postgres connection pooler restarts, ingestion-analytics worker pods crash. The per-distinct-id pipeline wraps event processing in a retry, but the budget is only 3 tries (~300ms total: 100ms + 200ms backoff). A pooler restart lasts longer than that, so a transient `DependencyUnavailableError` exhausts all retries and is rethrown, which surfaces as an unhandled rejection and crashes the consumer. We saw a cluster of pods crash together this way during a single pooler cycle.

Two gaps:

1. **No visibility.** The retry helpers (`RetryingPipeline`, `withBatchRetry`) emit no metric, so we can't tell whether retries actually recover events or just delay a crash. There was no way to size the retry budget against real behavior.
2. **Budget too short.** ~300ms doesn't cover a pooler restart, so the retry-then-crash path fires when it didn't need to.

## Changes

**Instrumentation.** New `ingestion_pipeline_retry_attempts` histogram (buckets 1–10), labelled by retry-site `name` and `outcome` (`completed` / `exhausted` / `non_retriable`). Both retry wrappers count attempts and observe on every exit path. This makes "did the extra retries recover events, or just exhaust later?" a query (`completed` with attempt count > 1 vs. `exhausted`) instead of a guess.

**Retry budget.** Bumped the two persons-Postgres pooler retries — per-distinct-id and personless-distinct-ids — from 3 to 5 tries (~1.5s: 100/200/400/800ms backoff), enough to absorb a typical pooler restart in-process. Worst-case hold stays well under the Kafka session-timeout / rebalance window.

The Cymbal retry is intentionally **left at 3**: its budget is sized against a 45s per-attempt timeout under a 180s liveness probe (3 × 45s = 135s). Five tries would be 225s and the liveness probe would kill the pod mid-retry — a different case from the fast-failing Postgres one.

## How did you test this code?

I'm an agent; I did not do manual testing. Automated only:

- Added unit tests to `retrying-pipeline.test.ts` and `batch-retry.test.ts` covering all three outcomes (`completed` / `exhausted` / `non_retriable`), the observed attempt count, and the `name` label (explicit and defaulted). `pnpm test` for both suites: 32 passing.
- `pnpm build` (tsc) and `pnpm lint` (eslint) clean; Prettier-clean on all changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
