### PR TITLE
feat(ph AI): add action CRUD tools to ph AI

### DIFF
--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -21,8 +21,12 @@ from ee.hogai.core.agent_modes.toolkit import AgentToolkit, AgentToolkitManager
 from ee.hogai.registry import get_contextual_tool_class
 from ee.hogai.tool import MaxTool
 from ee.hogai.tools import (
+    CreateActionTool,
     CreateFormTool,
     CreateNotebookTool,
+    DeleteActionTool,
+    GetActionTool,
+    ListActionsTool,
     ListDataTool,
     ListFeatureFlagsTool,
     ManageMemoriesTool,
@@ -32,6 +36,7 @@ from ee.hogai.tools import (
     SwitchModeTool,
     TaskTool,
     TodoWriteTool,
+    UpdateActionTool,
 )
 from ee.hogai.tools.call_mcp_server.tool import CallMCPServerTool
 from ee.hogai.tools.finalize_plan.tool import FinalizePlanTool
@@ -50,6 +55,11 @@ DEFAULT_TOOLS: list[type[MaxTool]] = [
     SearchTool,
     ListDataTool,
     ListFeatureFlagsTool,
+    ListActionsTool,
+    GetActionTool,
+    CreateActionTool,
+    UpdateActionTool,
+    DeleteActionTool,
     TodoWriteTool,
     SwitchModeTool,
     CreateFormTool,

--- a/ee/hogai/tools/__init__.py
+++ b/ee/hogai/tools/__init__.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, Any
 # `ee.hogai.tools`; eager re-exports here formed an import cycle that only survived by
 # import-order luck and dragged the whole AI agent core onto the Django startup path.
 _TOOL_MODULES: dict[str, str] = {
+    "ListActionsTool": ".actions",
+    "GetActionTool": ".actions",
+    "CreateActionTool": ".actions",
+    "UpdateActionTool": ".actions",
+    "DeleteActionTool": ".actions",
     "CallMCPServerTool": ".call_mcp_server.tool",
     "CreateFormTool": ".create_form",
     "CreateInsightTool": ".create_insight",
@@ -28,6 +33,11 @@ _TOOL_MODULES: dict[str, str] = {
 }
 
 __all__ = [
+    "ListActionsTool",
+    "GetActionTool",
+    "CreateActionTool",
+    "UpdateActionTool",
+    "DeleteActionTool",
     "CallMCPServerTool",
     "CreateFormTool",
     "ManageMemoriesTool",
@@ -65,6 +75,13 @@ def __getattr__(name: str) -> Any:
 
 
 if TYPE_CHECKING:
+    from .actions import (
+        CreateActionTool as CreateActionTool,
+        DeleteActionTool as DeleteActionTool,
+        GetActionTool as GetActionTool,
+        ListActionsTool as ListActionsTool,
+        UpdateActionTool as UpdateActionTool,
+    )
     from .call_mcp_server.tool import CallMCPServerTool as CallMCPServerTool
     from .create_form import CreateFormTool as CreateFormTool
     from .create_insight import CreateInsightTool as CreateInsightTool

--- a/ee/hogai/tools/actions/__init__.py
+++ b/ee/hogai/tools/actions/__init__.py
@@ -1,0 +1,9 @@
+from .tool import CreateActionTool, DeleteActionTool, GetActionTool, ListActionsTool, UpdateActionTool
+
+__all__ = [
+    "ListActionsTool",
+    "GetActionTool",
+    "CreateActionTool",
+    "UpdateActionTool",
+    "DeleteActionTool",
+]

--- a/ee/hogai/tools/actions/core.py
+++ b/ee/hogai/tools/actions/core.py
@@ -1,0 +1,226 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from posthog.models import Team, User
+from posthog.models.activity_logging.utils import activity_storage
+
+from products.actions.backend.models.action import Action, ActionStepJSON
+
+# Cap how many actions a single list call can return, so the tool can never blow up
+# the agent's context window the way the unbounded REST default could.
+MAX_LIST_LIMIT = 100
+DEFAULT_LIST_LIMIT = 25
+
+# Fields an action step accepts. Anything else passed by the LLM is dropped before
+# it reaches `Action.steps`, which constructs `ActionStepJSON(**step)` and would
+# otherwise raise on an unexpected key.
+_STEP_FIELDS = set(ActionStepJSON.__dataclass_fields__)
+
+
+class ActionStepInput(BaseModel):
+    """One OR-ed trigger condition of an action. All fields optional; an empty step matches every event."""
+
+    event: Optional[str] = Field(
+        default=None, description="Event name to match (e.g. '$pageview', '$autocapture', or a custom event name)."
+    )
+    properties: Optional[list[dict]] = Field(
+        default=None,
+        description="Property filters. Each item: {'key', 'value', 'operator', 'type'} where type is 'event' or 'person'.",
+    )
+    selector: Optional[str] = Field(
+        default=None, description="CSS selector to match the target element (e.g. 'div > button.cta')."
+    )
+    tag_name: Optional[str] = Field(default=None, description='HTML tag name to match (e.g. "button", "a").')
+    text: Optional[str] = Field(default=None, description="Element text content to match.")
+    text_matching: Optional[str] = Field(default=None, description="How to match text: contains, regex, or exact.")
+    href: Optional[str] = Field(default=None, description="Link href attribute to match.")
+    href_matching: Optional[str] = Field(default=None, description="How to match href: contains, regex, or exact.")
+    url: Optional[str] = Field(default=None, description="Page URL to match.")
+    url_matching: Optional[str] = Field(
+        default=None, description="How to match the URL: contains (default), regex, or exact."
+    )
+
+    def to_step_dict(self) -> dict:
+        return {k: v for k, v in self.model_dump(exclude_none=True).items() if k in _STEP_FIELDS}
+
+
+class ListActionsToolArgs(BaseModel):
+    search: Optional[str] = Field(
+        default=None,
+        description="Case-insensitive substring match on the action name. Use this to find a specific action.",
+    )
+    limit: Optional[int] = Field(
+        default=None,
+        description=f"Maximum number of actions to return (1-{MAX_LIST_LIMIT}, default {DEFAULT_LIST_LIMIT}).",
+    )
+    offset: Optional[int] = Field(default=None, description="Number of actions to skip before returning results.")
+
+
+class GetActionToolArgs(BaseModel):
+    action_id: int = Field(description="ID of the action to retrieve.")
+
+
+class CreateActionToolArgs(BaseModel):
+    name: str = Field(description="Name of the action (must be unique within the project).")
+    description: Optional[str] = Field(default=None, description="Human-readable description of the action.")
+    steps: Optional[list[ActionStepInput]] = Field(
+        default=None,
+        description="Trigger conditions. Multiple steps are OR-ed together. Omit for an empty action you'll fill in later.",
+    )
+
+
+class UpdateActionToolArgs(BaseModel):
+    action_id: int = Field(description="ID of the action to update.")
+    name: Optional[str] = Field(default=None, description="New name. Omit to leave unchanged.")
+    description: Optional[str] = Field(default=None, description="New description. Omit to leave unchanged.")
+    steps: Optional[list[ActionStepInput]] = Field(
+        default=None,
+        description="Replacement trigger conditions. When provided, REPLACES all existing steps. Omit to leave steps unchanged.",
+    )
+
+
+class DeleteActionToolArgs(BaseModel):
+    action_id: int = Field(description="ID of the action to delete.")
+
+
+class ActionToolError(ValueError):
+    """Raised for user-fixable problems (not found, duplicate name, invalid step). Surfaced as a retryable error."""
+
+
+@contextmanager
+def _acting_user(user: User) -> Iterator[None]:
+    """Attribute activity-log entries from a direct ORM save to `user` (no request middleware here)."""
+    previous = activity_storage.get_user()
+    activity_storage.set_user(user)
+    try:
+        yield
+    finally:
+        activity_storage.set_user(previous)
+
+
+def _format_step(step: ActionStepJSON) -> str:
+    parts: list[str] = []
+    if step.event is not None:
+        parts.append(f"event={step.event}")
+    if step.url:
+        parts.append(f"url {step.url_matching or 'contains'} {step.url!r}")
+    if step.selector:
+        parts.append(f"selector={step.selector!r}")
+    if step.tag_name:
+        parts.append(f"tag={step.tag_name}")
+    if step.text:
+        parts.append(f"text {step.text_matching or 'exact'} {step.text!r}")
+    if step.href:
+        parts.append(f"href {step.href_matching or 'exact'} {step.href!r}")
+    if step.properties:
+        parts.append(f"{len(step.properties)} property filter(s)")
+    return ", ".join(parts) or "matches all events"
+
+
+def _format_action(action: Action, *, detailed: bool = False) -> str:
+    lines = [f"#{action.id} {action.name or '(unnamed)'}"]
+    if action.description:
+        lines.append(f"  description: {action.description}")
+    steps = action.steps
+    if steps:
+        if detailed:
+            for i, step in enumerate(steps, 1):
+                lines.append(f"  step {i}: {_format_step(step)}")
+        else:
+            lines.append(f"  steps: {len(steps)} ({'; '.join(_format_step(s) for s in steps)})")
+    else:
+        lines.append("  steps: none")
+    if action.bytecode_error:
+        lines.append(f"  ⚠ bytecode error: {action.bytecode_error}")
+    return "\n".join(lines)
+
+
+def list_actions(team: Team, search: Optional[str], limit: Optional[int], offset: Optional[int]) -> str:
+    qs = Action.objects.filter(team=team, deleted=False)
+    if search:
+        qs = qs.filter(name__icontains=search)
+    total = qs.count()
+    qs = qs.order_by("name")
+    start = offset or 0
+    capped_limit = min(limit or DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT)
+    actions = list(qs[start : start + capped_limit])
+
+    if not actions:
+        return f"No actions found (project has {total} action(s) matching the filter)."
+
+    header = f"Showing {len(actions)} of {total} action(s)"
+    if start:
+        header += f", starting at offset {start}"
+    body = "\n".join(_format_action(a) for a in actions)
+    footer = ""
+    if start + len(actions) < total:
+        footer = (
+            f"\n\n{total - start - len(actions)} more — increase offset to {start + len(actions)} for the next page."
+        )
+    return f"{header}:\n{body}{footer}"
+
+
+def _get_action_or_raise(team: Team, action_id: int) -> Action:
+    try:
+        return Action.objects.get(team=team, pk=action_id, deleted=False)
+    except Action.DoesNotExist:
+        raise ActionToolError(f"No action with ID {action_id} exists in this project.")
+
+
+def get_action(team: Team, action_id: int) -> str:
+    return _format_action(_get_action_or_raise(team, action_id), detailed=True)
+
+
+def _check_name_available(team: Team, name: str, *, exclude_id: Optional[int] = None) -> None:
+    if not name.strip():
+        raise ActionToolError("Action name may not be blank.")
+    clash = Action.objects.filter(team=team, name=name, deleted=False)
+    if exclude_id is not None:
+        clash = clash.exclude(pk=exclude_id)
+    existing_id = clash.values_list("id", flat=True).first()
+    if existing_id:
+        raise ActionToolError(f"This project already has an action named {name!r} (ID {existing_id}).")
+
+
+def create_action(
+    team: Team, user: User, name: str, description: Optional[str], steps: Optional[list[ActionStepInput]]
+) -> str:
+    _check_name_available(team, name)
+    action = Action(team=team, name=name, description=description or "", created_by=user)
+    if steps:
+        action.steps = [s.to_step_dict() for s in steps]
+    with _acting_user(user):
+        action.save()
+    return f"Created action:\n{_format_action(action, detailed=True)}"
+
+
+def update_action(
+    team: Team,
+    user: User,
+    action_id: int,
+    name: Optional[str],
+    description: Optional[str],
+    steps: Optional[list[ActionStepInput]],
+) -> str:
+    action = _get_action_or_raise(team, action_id)
+    if name is not None:
+        _check_name_available(team, name, exclude_id=action.pk)
+        action.name = name
+    if description is not None:
+        action.description = description
+    if steps is not None:
+        action.steps = [s.to_step_dict() for s in steps]
+    with _acting_user(user):
+        action.save()
+    return f"Updated action:\n{_format_action(action, detailed=True)}"
+
+
+def delete_action(team: Team, user: User, action_id: int) -> str:
+    action = _get_action_or_raise(team, action_id)
+    action.deleted = True
+    with _acting_user(user):
+        action.save()
+    return f"Deleted action #{action.id} {action.name or '(unnamed)'}."

--- a/ee/hogai/tools/actions/core.py
+++ b/ee/hogai/tools/actions/core.py
@@ -149,7 +149,9 @@ def list_actions(team: Team, search: Optional[str], limit: Optional[int], offset
     actions = list(qs[start : start + capped_limit])
 
     if not actions:
-        return f"No actions found (project has {total} action(s) matching the filter)."
+        if total == 0:
+            return "No actions found matching the filter."
+        return f"No actions at offset {start} (project has {total} matching the filter) — try a lower offset."
 
     header = f"Showing {len(actions)} of {total} action(s)"
     if start:
@@ -163,7 +165,7 @@ def list_actions(team: Team, search: Optional[str], limit: Optional[int], offset
     return f"{header}:\n{body}{footer}"
 
 
-def _get_action_or_raise(team: Team, action_id: int) -> Action:
+def get_action_object(team: Team, action_id: int) -> Action:
     try:
         return Action.objects.get(team=team, pk=action_id, deleted=False)
     except Action.DoesNotExist:
@@ -171,7 +173,7 @@ def _get_action_or_raise(team: Team, action_id: int) -> Action:
 
 
 def get_action(team: Team, action_id: int) -> str:
-    return _format_action(_get_action_or_raise(team, action_id), detailed=True)
+    return _format_action(get_action_object(team, action_id), detailed=True)
 
 
 def _check_name_available(team: Team, name: str, *, exclude_id: Optional[int] = None) -> None:
@@ -205,7 +207,9 @@ def update_action(
     description: Optional[str],
     steps: Optional[list[ActionStepInput]],
 ) -> str:
-    action = _get_action_or_raise(team, action_id)
+    action = get_action_object(team, action_id)
+    if name is None and description is None and steps is None:
+        return f"Nothing to update — action #{action.id} left unchanged:\n{_format_action(action, detailed=True)}"
     if name is not None:
         _check_name_available(team, name, exclude_id=action.pk)
         action.name = name
@@ -219,7 +223,7 @@ def update_action(
 
 
 def delete_action(team: Team, user: User, action_id: int) -> str:
-    action = _get_action_or_raise(team, action_id)
+    action = get_action_object(team, action_id)
     action.deleted = True
     with _acting_user(user):
         action.save()

--- a/ee/hogai/tools/actions/core.py
+++ b/ee/hogai/tools/actions/core.py
@@ -6,8 +6,9 @@ from pydantic import BaseModel, Field
 
 from posthog.models import Team, User
 from posthog.models.activity_logging.utils import activity_storage
+from posthog.resource_limits import LimitKey, check_count_limit
 
-from products.actions.backend.models.action import Action, ActionStepJSON
+from products.actions.backend.models.action import Action, ActionStepJSON, ActionStepMatching
 
 # Cap how many actions a single list call can return, so the tool can never blow up
 # the agent's context window the way the unbounded REST default could.
@@ -35,12 +36,12 @@ class ActionStepInput(BaseModel):
     )
     tag_name: Optional[str] = Field(default=None, description='HTML tag name to match (e.g. "button", "a").')
     text: Optional[str] = Field(default=None, description="Element text content to match.")
-    text_matching: Optional[str] = Field(default=None, description="How to match text: contains, regex, or exact.")
+    text_matching: Optional[ActionStepMatching] = Field(default=None, description="How to match text.")
     href: Optional[str] = Field(default=None, description="Link href attribute to match.")
-    href_matching: Optional[str] = Field(default=None, description="How to match href: contains, regex, or exact.")
+    href_matching: Optional[ActionStepMatching] = Field(default=None, description="How to match href.")
     url: Optional[str] = Field(default=None, description="Page URL to match.")
-    url_matching: Optional[str] = Field(
-        default=None, description="How to match the URL: contains (default), regex, or exact."
+    url_matching: Optional[ActionStepMatching] = Field(
+        default=None, description="How to match the URL (default: contains)."
     )
 
     def to_step_dict(self) -> dict:
@@ -192,6 +193,10 @@ def create_action(
     team: Team, user: User, name: str, description: Optional[str], steps: Optional[list[ActionStepInput]]
 ) -> str:
     _check_name_available(team.id, name)
+    # Emit the same "resource limit hit" telemetry the REST create path does. This is
+    # notification-only — check_count_limit never raises or blocks.
+    current_count = Action.objects.filter(team=team, deleted=False).count()
+    check_count_limit(team=team, key=LimitKey.MAX_ACTIONS_PER_TEAM, current_count=current_count, user=user)
     action = Action(team=team, name=name, description=description or "", created_by=user)
     if steps:
         action.steps = [s.to_step_dict() for s in steps]

--- a/ee/hogai/tools/actions/core.py
+++ b/ee/hogai/tools/actions/core.py
@@ -172,14 +172,15 @@ def get_action_object(team: Team, action_id: int) -> Action:
         raise ActionToolError(f"No action with ID {action_id} exists in this project.")
 
 
-def get_action(team: Team, action_id: int) -> str:
-    return _format_action(get_action_object(team, action_id), detailed=True)
+def format_action_detail(action: Action) -> str:
+    """Detailed, human-readable rendering of a single (already-fetched) action for tool output."""
+    return _format_action(action, detailed=True)
 
 
-def _check_name_available(team: Team, name: str, *, exclude_id: Optional[int] = None) -> None:
+def _check_name_available(team_id: int, name: str, *, exclude_id: Optional[int] = None) -> None:
     if not name.strip():
         raise ActionToolError("Action name may not be blank.")
-    clash = Action.objects.filter(team=team, name=name, deleted=False)
+    clash = Action.objects.filter(team_id=team_id, name=name, deleted=False)
     if exclude_id is not None:
         clash = clash.exclude(pk=exclude_id)
     existing_id = clash.values_list("id", flat=True).first()
@@ -190,7 +191,7 @@ def _check_name_available(team: Team, name: str, *, exclude_id: Optional[int] = 
 def create_action(
     team: Team, user: User, name: str, description: Optional[str], steps: Optional[list[ActionStepInput]]
 ) -> str:
-    _check_name_available(team, name)
+    _check_name_available(team.id, name)
     action = Action(team=team, name=name, description=description or "", created_by=user)
     if steps:
         action.steps = [s.to_step_dict() for s in steps]
@@ -200,18 +201,16 @@ def create_action(
 
 
 def update_action(
-    team: Team,
     user: User,
-    action_id: int,
+    action: Action,
     name: Optional[str],
     description: Optional[str],
     steps: Optional[list[ActionStepInput]],
 ) -> str:
-    action = get_action_object(team, action_id)
     if name is None and description is None and steps is None:
         return f"Nothing to update — action #{action.id} left unchanged:\n{_format_action(action, detailed=True)}"
     if name is not None:
-        _check_name_available(team, name, exclude_id=action.pk)
+        _check_name_available(action.team_id, name, exclude_id=action.pk)
         action.name = name
     if description is not None:
         action.description = description
@@ -222,8 +221,7 @@ def update_action(
     return f"Updated action:\n{_format_action(action, detailed=True)}"
 
 
-def delete_action(team: Team, user: User, action_id: int) -> str:
-    action = get_action_object(team, action_id)
+def delete_action(user: User, action: Action) -> str:
     action.deleted = True
     with _acting_user(user):
         action.save()

--- a/ee/hogai/tools/actions/test/test_action_tools.py
+++ b/ee/hogai/tools/actions/test/test_action_tools.py
@@ -1,6 +1,7 @@
 import uuid
 
 from posthog.test.base import NonAtomicBaseTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -8,7 +9,7 @@ from posthog.models import Project, Team
 
 from products.actions.backend.models.action import Action
 
-from ee.hogai.tool_errors import MaxToolRetryableError
+from ee.hogai.tool_errors import MaxToolAccessDeniedError, MaxToolRetryableError
 from ee.hogai.tools.actions.core import MAX_LIST_LIMIT, ActionStepInput
 from ee.hogai.tools.actions.tool import (
     CreateActionTool,
@@ -65,7 +66,6 @@ class TestActionTools(NonAtomicBaseTest):
     async def test_list_offset_paginates_without_overlap(self):
         page1, _ = await self._list_tool()._arun_impl(limit=2, offset=0)
         page2, _ = await self._list_tool()._arun_impl(limit=2, offset=2)
-        # Ordered by name; pages must be disjoint.
         self.assertIn("Checkout completed", page1)
         self.assertIn("Checkout started", page1)
         self.assertIn("Pricing viewed", page2)
@@ -100,7 +100,6 @@ class TestActionTools(NonAtomicBaseTest):
         self.assertEqual(step["url"], "/x")
         self.assertEqual(step["url_matching"], "contains")
         self.assertEqual(action.created_by_id, self.user.id)
-        # Saving computes bytecode.
         self.assertIsNotNone(action.bytecode)
 
     @parameterized.expand([("blank", "   "), ("empty", "")])
@@ -153,7 +152,6 @@ class TestActionTools(NonAtomicBaseTest):
         self.assertIn("Deleted", content)
         refreshed = await Action.objects.aget(pk=action.id)
         self.assertTrue(refreshed.deleted)
-        # Deleted actions are excluded from listing and lookups.
         with self.assertRaises(MaxToolRetryableError):
             await GetActionTool(team=self.team, user=self.user)._arun_impl(action_id=action.id)
 
@@ -165,6 +163,15 @@ class TestActionTools(NonAtomicBaseTest):
         self.assertIn("Signup", preview)
 
     async def test_team_isolation(self):
-        # A tool scoped to self.team must not reach an action in another team.
         with self.assertRaises(MaxToolRetryableError):
             await GetActionTool(team=self.team, user=self.user)._arun_impl(action_id=self.foreign_action.id)
+
+    async def test_update_denied_by_object_level_access(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        # Object-level access control denying editor must block the write, even though
+        # the user has team/resource-level access (the team filter would let it through).
+        with patch("ee.hogai.tool.UserAccessControl.check_access_level_for_object", return_value=False):
+            with self.assertRaises(MaxToolAccessDeniedError):
+                await UpdateActionTool(team=self.team, user=self.user)._arun_impl(action_id=action.id, name="Blocked")
+        refreshed = await Action.objects.aget(pk=action.id)
+        self.assertEqual(refreshed.name, "Signup")

--- a/ee/hogai/tools/actions/test/test_action_tools.py
+++ b/ee/hogai/tools/actions/test/test_action_tools.py
@@ -9,7 +9,7 @@ from posthog.models import Project, Team
 from products.actions.backend.models.action import Action
 
 from ee.hogai.tool_errors import MaxToolRetryableError
-from ee.hogai.tools.actions.core import DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT, ActionStepInput
+from ee.hogai.tools.actions.core import MAX_LIST_LIMIT, ActionStepInput
 from ee.hogai.tools.actions.tool import (
     CreateActionTool,
     DeleteActionTool,
@@ -72,10 +72,17 @@ class TestActionTools(NonAtomicBaseTest):
         self.assertIn("Signup", page2)
 
     async def test_list_limit_is_hard_capped(self):
+        # Seed beyond the cap (setUp already created 4) and confirm a huge limit still clamps.
+        await Action.objects.abulk_create(
+            [Action(team=self.team, name=f"Bulk {i:04d}", created_by=self.user) for i in range(MAX_LIST_LIMIT + 5)]
+        )
         content, _ = await self._list_tool()._arun_impl(limit=10_000)
-        # All 4 fit under the cap; the point is no error and the cap exists.
-        self.assertIn("Showing 4 of 4", content)
-        self.assertLessEqual(DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT)
+        self.assertIn(f"Showing {MAX_LIST_LIMIT} of {MAX_LIST_LIMIT + 9}", content)
+
+    async def test_list_offset_beyond_total_explains_offset(self):
+        content, _ = await self._list_tool()._arun_impl(offset=100)
+        self.assertIn("offset 100", content)
+        self.assertIn("lower offset", content)
 
     async def test_create_action_with_step(self):
         content, _ = await CreateActionTool(team=self.team, user=self.user)._arun_impl(
@@ -127,6 +134,11 @@ class TestActionTools(NonAtomicBaseTest):
         assert refreshed.steps_json is not None
         self.assertEqual(len(refreshed.steps_json), 1)
         self.assertEqual(refreshed.steps_json[0]["event"], "signed_up")
+
+    async def test_update_with_no_changes_is_noop(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        content, _ = await UpdateActionTool(team=self.team, user=self.user)._arun_impl(action_id=action.id)
+        self.assertIn("Nothing to update", content)
 
     async def test_update_to_duplicate_name_is_rejected(self):
         action = await Action.objects.aget(team=self.team, name="Signup")

--- a/ee/hogai/tools/actions/test/test_tool.py
+++ b/ee/hogai/tools/actions/test/test_tool.py
@@ -1,0 +1,158 @@
+import uuid
+
+from posthog.test.base import NonAtomicBaseTest
+
+from parameterized import parameterized
+
+from posthog.models import Project, Team
+
+from products.actions.backend.models.action import Action
+
+from ee.hogai.tool_errors import MaxToolRetryableError
+from ee.hogai.tools.actions.core import DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT, ActionStepInput
+from ee.hogai.tools.actions.tool import (
+    CreateActionTool,
+    DeleteActionTool,
+    GetActionTool,
+    ListActionsTool,
+    UpdateActionTool,
+)
+
+
+class TestActionTools(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        for name in ["Checkout started", "Checkout completed", "Signup", "Pricing viewed"]:
+            Action.objects.create(team=self.team, name=name, created_by=self.user)
+
+        # A separate team in the same org, with its own action, to assert isolation.
+        foreign_project = Project.objects.create(
+            id=Team.objects.increment_id_sequence(), organization=self.organization
+        )
+        foreign_team = Team.objects.create(
+            id=foreign_project.id,
+            project=foreign_project,
+            organization=self.organization,
+            api_token=str(uuid.uuid4()),
+        )
+        self.foreign_action = Action.objects.create(team=foreign_team, name="Foreign action", created_by=self.user)
+
+    def _list_tool(self):
+        return ListActionsTool(team=self.team, user=self.user)
+
+    async def test_list_returns_all_by_default(self):
+        content, _ = await self._list_tool()._arun_impl()
+        self.assertIn("Showing 4 of 4", content)
+        self.assertIn("Checkout started", content)
+
+    async def test_list_search_is_case_insensitive(self):
+        content, _ = await self._list_tool()._arun_impl(search="checkout")
+        self.assertIn("Showing 2 of 2", content)
+        self.assertIn("Checkout started", content)
+        self.assertIn("Checkout completed", content)
+        self.assertNotIn("Signup", content)
+
+    async def test_list_search_no_match(self):
+        content, _ = await self._list_tool()._arun_impl(search="nonexistent")
+        self.assertIn("No actions found", content)
+
+    async def test_list_limit_caps_results(self):
+        content, _ = await self._list_tool()._arun_impl(limit=2)
+        self.assertIn("Showing 2 of 4", content)
+
+    async def test_list_offset_paginates_without_overlap(self):
+        page1, _ = await self._list_tool()._arun_impl(limit=2, offset=0)
+        page2, _ = await self._list_tool()._arun_impl(limit=2, offset=2)
+        # Ordered by name; pages must be disjoint.
+        self.assertIn("Checkout completed", page1)
+        self.assertIn("Checkout started", page1)
+        self.assertIn("Pricing viewed", page2)
+        self.assertIn("Signup", page2)
+
+    async def test_list_limit_is_hard_capped(self):
+        content, _ = await self._list_tool()._arun_impl(limit=10_000)
+        # All 4 fit under the cap; the point is no error and the cap exists.
+        self.assertIn("Showing 4 of 4", content)
+        self.assertLessEqual(DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT)
+
+    async def test_create_action_with_step(self):
+        content, _ = await CreateActionTool(team=self.team, user=self.user)._arun_impl(
+            name="New action",
+            description="desc",
+            steps=[ActionStepInput(event="$pageview", url="/x", url_matching="contains")],
+        )
+        self.assertIn("Created action", content)
+        action = await Action.objects.aget(team=self.team, name="New action")
+        self.assertEqual(action.description, "desc")
+        assert action.steps_json is not None
+        self.assertEqual(len(action.steps_json), 1)
+        step = action.steps_json[0]
+        self.assertEqual(step["event"], "$pageview")
+        self.assertEqual(step["url"], "/x")
+        self.assertEqual(step["url_matching"], "contains")
+        self.assertEqual(action.created_by_id, self.user.id)
+        # Saving computes bytecode.
+        self.assertIsNotNone(action.bytecode)
+
+    @parameterized.expand([("blank", "   "), ("empty", "")])
+    async def test_create_action_rejects_blank_name(self, _name: str, value: str):
+        with self.assertRaises(MaxToolRetryableError):
+            await CreateActionTool(team=self.team, user=self.user)._arun_impl(name=value)
+
+    async def test_create_action_rejects_duplicate_name(self):
+        with self.assertRaises(MaxToolRetryableError) as cm:
+            await CreateActionTool(team=self.team, user=self.user)._arun_impl(name="Signup")
+        self.assertIn("already has an action", str(cm.exception))
+
+    async def test_get_action(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        content, _ = await GetActionTool(team=self.team, user=self.user)._arun_impl(action_id=action.id)
+        self.assertIn(f"#{action.id} Signup", content)
+
+    async def test_get_missing_action_is_retryable(self):
+        with self.assertRaises(MaxToolRetryableError):
+            await GetActionTool(team=self.team, user=self.user)._arun_impl(action_id=999_999)
+
+    async def test_update_action_name_and_steps(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        await UpdateActionTool(team=self.team, user=self.user)._arun_impl(
+            action_id=action.id,
+            name="Signup renamed",
+            steps=[ActionStepInput(event="signed_up")],
+        )
+        refreshed = await Action.objects.aget(pk=action.id)
+        self.assertEqual(refreshed.name, "Signup renamed")
+        assert refreshed.steps_json is not None
+        self.assertEqual(len(refreshed.steps_json), 1)
+        self.assertEqual(refreshed.steps_json[0]["event"], "signed_up")
+
+    async def test_update_to_duplicate_name_is_rejected(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        with self.assertRaises(MaxToolRetryableError):
+            await UpdateActionTool(team=self.team, user=self.user)._arun_impl(
+                action_id=action.id, name="Checkout started"
+            )
+
+    async def test_delete_soft_deletes(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        content, _ = await DeleteActionTool(team=self.team, user=self.user)._arun_impl(action_id=action.id)
+        self.assertIn("Deleted", content)
+        refreshed = await Action.objects.aget(pk=action.id)
+        self.assertTrue(refreshed.deleted)
+        # Deleted actions are excluded from listing and lookups.
+        with self.assertRaises(MaxToolRetryableError):
+            await GetActionTool(team=self.team, user=self.user)._arun_impl(action_id=action.id)
+
+    async def test_delete_is_marked_dangerous(self):
+        action = await Action.objects.aget(team=self.team, name="Signup")
+        tool = DeleteActionTool(team=self.team, user=self.user)
+        self.assertTrue(await tool.is_dangerous_operation(action_id=action.id))
+        preview = await tool.format_dangerous_operation_preview(action_id=action.id)
+        self.assertIn("Signup", preview)
+
+    async def test_team_isolation(self):
+        # A tool scoped to self.team must not reach an action in another team.
+        with self.assertRaises(MaxToolRetryableError):
+            await GetActionTool(team=self.team, user=self.user)._arun_impl(action_id=self.foreign_action.id)

--- a/ee/hogai/tools/actions/tool.py
+++ b/ee/hogai/tools/actions/tool.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 
 from posthog.sync import database_sync_to_async
 
+from products.actions.backend.models.action import Action
+
 from ee.hogai.tool import MaxTool
 from ee.hogai.tool_errors import MaxToolRetryableError
 
@@ -18,9 +20,19 @@ from .core import (
     create_action,
     delete_action,
     get_action,
+    get_action_object,
     list_actions,
     update_action,
 )
+
+
+async def _fetch_action(tool: MaxTool, action_id: int) -> Action:
+    """Fetch an action for a tool's team, mapping a missing action to a retryable error."""
+    try:
+        return await database_sync_to_async(get_action_object)(tool._team, action_id)
+    except ActionToolError as e:
+        raise MaxToolRetryableError(str(e))
+
 
 LIST_ACTIONS_DESCRIPTION = """
 List the project's actions (reusable event definitions used in insights and funnels).
@@ -70,11 +82,9 @@ class GetActionTool(MaxTool):
         return [("action", "viewer")]
 
     async def _arun_impl(self, action_id: int) -> tuple[str, None]:
-        try:
-            result = await database_sync_to_async(get_action)(self._team, action_id)
-        except ActionToolError as e:
-            raise MaxToolRetryableError(str(e))
-        return result, None
+        action = await _fetch_action(self, action_id)
+        await self.check_object_access(action, "viewer", action="read")
+        return await database_sync_to_async(get_action)(self._team, action_id), None
 
 
 class CreateActionTool(MaxTool):
@@ -110,6 +120,8 @@ class UpdateActionTool(MaxTool):
         description: Optional[str] = None,
         steps: Optional[list[ActionStepInput]] = None,
     ) -> tuple[str, None]:
+        action = await _fetch_action(self, action_id)
+        await self.check_object_access(action, "editor", action="edit")
         try:
             result = await database_sync_to_async(update_action)(
                 self._team, self._user, action_id, name, description, steps
@@ -131,13 +143,14 @@ class DeleteActionTool(MaxTool):
         return True
 
     async def format_dangerous_operation_preview(self, action_id: int) -> str:
-        try:
-            current = await database_sync_to_async(get_action)(self._team, action_id)
-        except ActionToolError:
-            return f"Delete action #{action_id}"
+        action = await _fetch_action(self, action_id)
+        await self.check_object_access(action, "editor", action="delete")
+        current = await database_sync_to_async(get_action)(self._team, action_id)
         return f"Delete this action — it will be removed from any insights and funnels that use it:\n{current}"
 
     async def _arun_impl(self, action_id: int) -> tuple[str, None]:
+        action = await _fetch_action(self, action_id)
+        await self.check_object_access(action, "editor", action="delete")
         try:
             result = await database_sync_to_async(delete_action)(self._team, self._user, action_id)
         except ActionToolError as e:

--- a/ee/hogai/tools/actions/tool.py
+++ b/ee/hogai/tools/actions/tool.py
@@ -42,7 +42,7 @@ looking for a specific action by name, and use `limit`/`offset` to page rather t
 Use this to discover an action's ID before reading its properties (read_taxonomy), updating, or deleting it.
 """.strip()
 
-GET_ACTION_DESCRIPTION = "Get a single action by ID, including its full step (trigger condition) definition.".strip()
+GET_ACTION_DESCRIPTION = "Get a single action by ID, including its full step (trigger condition) definition."
 
 CREATE_ACTION_DESCRIPTION = """
 Create a new action. An action unifies one or more trigger conditions ("steps", OR-ed together) into a single
@@ -55,7 +55,7 @@ Update an existing action's name, description, or steps. Providing `steps` REPLA
 the full desired set. Look up the current definition with get_action first if you only want to tweak part of it.
 """.strip()
 
-DELETE_ACTION_DESCRIPTION = "Delete an action by ID. This removes it from insights and funnels that use it.".strip()
+DELETE_ACTION_DESCRIPTION = "Delete an action by ID. This removes it from insights and funnels that use it."
 
 
 class ListActionsTool(MaxTool):

--- a/ee/hogai/tools/actions/tool.py
+++ b/ee/hogai/tools/actions/tool.py
@@ -19,7 +19,7 @@ from .core import (
     UpdateActionToolArgs,
     create_action,
     delete_action,
-    get_action,
+    format_action_detail,
     get_action_object,
     list_actions,
     update_action,
@@ -84,7 +84,7 @@ class GetActionTool(MaxTool):
     async def _arun_impl(self, action_id: int) -> tuple[str, None]:
         action = await _fetch_action(self, action_id)
         await self.check_object_access(action, "viewer", action="read")
-        return await database_sync_to_async(get_action)(self._team, action_id), None
+        return format_action_detail(action), None
 
 
 class CreateActionTool(MaxTool):
@@ -123,9 +123,7 @@ class UpdateActionTool(MaxTool):
         action = await _fetch_action(self, action_id)
         await self.check_object_access(action, "editor", action="edit")
         try:
-            result = await database_sync_to_async(update_action)(
-                self._team, self._user, action_id, name, description, steps
-            )
+            result = await database_sync_to_async(update_action)(self._user, action, name, description, steps)
         except ActionToolError as e:
             raise MaxToolRetryableError(str(e))
         return result, None
@@ -145,14 +143,13 @@ class DeleteActionTool(MaxTool):
     async def format_dangerous_operation_preview(self, action_id: int) -> str:
         action = await _fetch_action(self, action_id)
         await self.check_object_access(action, "editor", action="delete")
-        current = await database_sync_to_async(get_action)(self._team, action_id)
-        return f"Delete this action — it will be removed from any insights and funnels that use it:\n{current}"
+        return (
+            "Delete this action — it will be removed from any insights and funnels that use it:\n"
+            f"{format_action_detail(action)}"
+        )
 
     async def _arun_impl(self, action_id: int) -> tuple[str, None]:
         action = await _fetch_action(self, action_id)
         await self.check_object_access(action, "editor", action="delete")
-        try:
-            result = await database_sync_to_async(delete_action)(self._team, self._user, action_id)
-        except ActionToolError as e:
-            raise MaxToolRetryableError(str(e))
+        result = await database_sync_to_async(delete_action)(self._user, action)
         return result, None

--- a/ee/hogai/tools/actions/tool.py
+++ b/ee/hogai/tools/actions/tool.py
@@ -1,0 +1,145 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.tool import MaxTool
+from ee.hogai.tool_errors import MaxToolRetryableError
+
+from .core import (
+    ActionStepInput,
+    ActionToolError,
+    CreateActionToolArgs,
+    DeleteActionToolArgs,
+    GetActionToolArgs,
+    ListActionsToolArgs,
+    UpdateActionToolArgs,
+    create_action,
+    delete_action,
+    get_action,
+    list_actions,
+    update_action,
+)
+
+LIST_ACTIONS_DESCRIPTION = """
+List the project's actions (reusable event definitions used in insights and funnels).
+
+Projects can have thousands of actions, so this tool is paginated and capped — always pass `search` when you're
+looking for a specific action by name, and use `limit`/`offset` to page rather than trying to fetch everything.
+Use this to discover an action's ID before reading its properties (read_taxonomy), updating, or deleting it.
+""".strip()
+
+GET_ACTION_DESCRIPTION = "Get a single action by ID, including its full step (trigger condition) definition.".strip()
+
+CREATE_ACTION_DESCRIPTION = """
+Create a new action. An action unifies one or more trigger conditions ("steps", OR-ed together) into a single
+reusable event — e.g. a "Signup" action matching a $pageview on /signup OR an $autocapture click on a button.
+Steps can match by event name, URL, CSS selector, element text/tag, href, and property filters.
+""".strip()
+
+UPDATE_ACTION_DESCRIPTION = """
+Update an existing action's name, description, or steps. Providing `steps` REPLACES all existing steps, so include
+the full desired set. Look up the current definition with get_action first if you only want to tweak part of it.
+""".strip()
+
+DELETE_ACTION_DESCRIPTION = "Delete an action by ID. This removes it from insights and funnels that use it.".strip()
+
+
+class ListActionsTool(MaxTool):
+    name: Literal["list_actions"] = "list_actions"
+    description: str = LIST_ACTIONS_DESCRIPTION
+    args_schema: type[BaseModel] = ListActionsToolArgs
+
+    def get_required_resource_access(self):
+        return [("action", "viewer")]
+
+    async def _arun_impl(
+        self, search: Optional[str] = None, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> tuple[str, None]:
+        result = await database_sync_to_async(list_actions)(self._team, search, limit, offset)
+        return result, None
+
+
+class GetActionTool(MaxTool):
+    name: Literal["get_action"] = "get_action"
+    description: str = GET_ACTION_DESCRIPTION
+    args_schema: type[BaseModel] = GetActionToolArgs
+
+    def get_required_resource_access(self):
+        return [("action", "viewer")]
+
+    async def _arun_impl(self, action_id: int) -> tuple[str, None]:
+        try:
+            result = await database_sync_to_async(get_action)(self._team, action_id)
+        except ActionToolError as e:
+            raise MaxToolRetryableError(str(e))
+        return result, None
+
+
+class CreateActionTool(MaxTool):
+    name: Literal["create_action"] = "create_action"
+    description: str = CREATE_ACTION_DESCRIPTION
+    args_schema: type[BaseModel] = CreateActionToolArgs
+
+    def get_required_resource_access(self):
+        return [("action", "editor")]
+
+    async def _arun_impl(
+        self, name: str, description: Optional[str] = None, steps: Optional[list[ActionStepInput]] = None
+    ) -> tuple[str, None]:
+        try:
+            result = await database_sync_to_async(create_action)(self._team, self._user, name, description, steps)
+        except ActionToolError as e:
+            raise MaxToolRetryableError(str(e))
+        return result, None
+
+
+class UpdateActionTool(MaxTool):
+    name: Literal["update_action"] = "update_action"
+    description: str = UPDATE_ACTION_DESCRIPTION
+    args_schema: type[BaseModel] = UpdateActionToolArgs
+
+    def get_required_resource_access(self):
+        return [("action", "editor")]
+
+    async def _arun_impl(
+        self,
+        action_id: int,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        steps: Optional[list[ActionStepInput]] = None,
+    ) -> tuple[str, None]:
+        try:
+            result = await database_sync_to_async(update_action)(
+                self._team, self._user, action_id, name, description, steps
+            )
+        except ActionToolError as e:
+            raise MaxToolRetryableError(str(e))
+        return result, None
+
+
+class DeleteActionTool(MaxTool):
+    name: Literal["delete_action"] = "delete_action"
+    description: str = DELETE_ACTION_DESCRIPTION
+    args_schema: type[BaseModel] = DeleteActionToolArgs
+
+    def get_required_resource_access(self):
+        return [("action", "editor")]
+
+    async def is_dangerous_operation(self, action_id: int) -> bool:
+        return True
+
+    async def format_dangerous_operation_preview(self, action_id: int) -> str:
+        try:
+            current = await database_sync_to_async(get_action)(self._team, action_id)
+        except ActionToolError:
+            return f"Delete action #{action_id}"
+        return f"Delete this action — it will be removed from any insights and funnels that use it:\n{current}"
+
+    async def _arun_impl(self, action_id: int) -> tuple[str, None]:
+        try:
+            result = await database_sync_to_async(delete_action)(self._team, self._user, action_id)
+        except ActionToolError as e:
+            raise MaxToolRetryableError(str(e))
+        return result, None

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3882,7 +3882,12 @@
                 "search_replay_vision_observations",
                 "upsert_account",
                 "upsert_account_notebook",
-                "open_account"
+                "open_account",
+                "list_actions",
+                "get_action",
+                "create_action",
+                "update_action",
+                "delete_action"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -522,6 +522,11 @@ export type AssistantTool =
     | 'upsert_account'
     | 'upsert_account_notebook'
     | 'open_account'
+    | 'list_actions'
+    | 'get_action'
+    | 'create_action'
+    | 'update_action'
+    | 'delete_action'
 
 export enum AgentMode {
     ProductAnalytics = 'product_analytics',

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -6,14 +6,19 @@ import {
     IconCloud,
     IconCreditCard,
     IconDocument,
+    IconEye,
     IconGlobe,
+    IconList,
     IconMemory,
     IconNotebook,
     IconNotification,
     IconPeople,
+    IconPencil,
     IconPlug,
+    IconPlus,
     IconSearch,
     IconShuffle,
+    IconTrash,
 } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -168,6 +173,58 @@ function skillStatusFormatter(
 }
 
 export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
+    list_actions: {
+        name: 'List actions',
+        description: 'List actions in the project',
+        icon: <IconList />,
+        displayFormatter: (toolCall) =>
+            skillStatusFormatter(toolCall, {
+                completedLabel: 'Listed actions',
+                pendingLabel: 'Listing actions',
+            }),
+    },
+    get_action: {
+        name: 'Get action',
+        description: 'Get action details',
+        icon: <IconEye />,
+        displayFormatter: (toolCall) =>
+            skillStatusFormatter(toolCall, {
+                completedLabel: 'Got action',
+                pendingLabel: 'Getting action',
+            }),
+    },
+    create_action: {
+        name: 'Create action',
+        description: 'Create action from trigger conditions',
+        icon: <IconPlus />,
+        displayFormatter: (toolCall) =>
+            skillStatusFormatter(toolCall, {
+                completedLabel: 'Created action',
+                pendingLabel: 'Creating action',
+                nameArgKey: 'name',
+            }),
+    },
+    update_action: {
+        name: 'Update action',
+        description: 'Update action name, description, or steps',
+        icon: <IconPencil />,
+        displayFormatter: (toolCall) =>
+            skillStatusFormatter(toolCall, {
+                completedLabel: 'Updated action',
+                pendingLabel: 'Updating action',
+                nameArgKey: 'name',
+            }),
+    },
+    delete_action: {
+        name: 'Delete action',
+        description: 'Delete action by ID',
+        icon: <IconTrash />,
+        displayFormatter: (toolCall) =>
+            skillStatusFormatter(toolCall, {
+                completedLabel: 'Deleted action',
+                pendingLabel: 'Deleting action',
+            }),
+    },
     call_mcp_server: {
         name: 'Call an MCP server',
         description: 'Call an MCP server',

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -414,6 +414,11 @@ class AssistantTool(StrEnum):
     UPSERT_ACCOUNT = "upsert_account"
     UPSERT_ACCOUNT_NOTEBOOK = "upsert_account_notebook"
     OPEN_ACCOUNT = "open_account"
+    LIST_ACTIONS = "list_actions"
+    GET_ACTION = "get_action"
+    CREATE_ACTION = "create_action"
+    UPDATE_ACTION = "update_action"
+    DELETE_ACTION = "delete_action"
 
 
 class Compare(StrEnum):


### PR DESCRIPTION
## Problem

Can't use actions in posthog AI

<img width="438" height="420" alt="Screenshot 2026-06-08 at 18 24 00" src="https://github.com/user-attachments/assets/94874ce7-d96e-462d-9d04-4c58837a37d8" />

## Changes

Use actions in posthog AI
<img width="649" height="689" alt="Screenshot 2026-06-08 at 17 49 36" src="https://github.com/user-attachments/assets/b2733587-b335-4f3e-8170-72ceca4fd0f6" />


Adds five in-product `MaxTool`s under `ee/hogai/tools/actions/`, wired into `DEFAULT_TOOLS` so they're available across all agent modes:

| Tool | Purpose |
|------|---------|
| `list_actions` | Paginated, hard-capped (max 100, default 25) listing with case-insensitive name `search` |
| `get_action` | A single action with its full step definition |
| `create_action` | Create an action with steps (event / URL / selector / text / property filters) |
| `update_action` | Update name, description, or steps |
| `delete_action` | Soft-delete, gated behind the framework's dangerous-operation approval flow |

Design notes:

- **`list_actions` is bounded by construction** — it caps results and supports `search`, so discovery can never flood the agent's context the way an unbounded list would. Output is compact (no per-action `created_by` payload).
- **Writes go through the `Action` model**, so bytecode compilation and activity logging behave exactly as in the REST path. The acting user is set on the activity-log context so entries are attributed correctly (there's no request middleware in the tool path).
- New `AssistantTool` enum values were added in `schema-assistant-messages.ts` and `pnpm schema:build` regenerated `posthog/schema.py` (`MaxTool.__init_subclass__` enforces names against that enum).

## How did you test this code?

I'm an agent (Claude Code), so I did not click through Max in a live chat — true end-to-end (the LLM actually selecting these tools mid-conversation) needs the assistant graph plus a model, which is best covered by CI and manual QA in the app.

What I did run:

- **17 automated tests** in `ee/hogai/tools/actions/test/test_tool.py` — list/search/limit/offset, create/update/delete, blank- and duplicate-name rejection, soft-delete exclusion, dangerous-operation gating, and cross-team isolation. All pass.
- A **manual smoke run against a local instance** exercising each tool's `_arun_impl` (create → list → search → get → update → delete, including the retryable not-found path).
- `ruff check`/`format` clean; confirmed all five tools register and land in `DEFAULT_TOOLS`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code. This is the Max-side follow-up to #62071: that PR fixed the MCP/REST read path; this one gives Max's own toolset the action CRUD it was missing.

Key decisions:

- **Direct `Action` model ORM over reusing `ActionSerializer`.** The serializer is heavily coupled to a DRF request/view context; the model already compiles bytecode and emits activity on `save()`, so going through it is simpler and lower-risk than fabricating a request. Name-uniqueness and blank-name checks are replicated explicitly.
- **No MCPTool mirrors.** The MCP server already exposes action CRUD via the REST proxy, so mirroring these as MCP tools would be redundant — the gap was purely the in-product `MaxTool` surface.
- The Max tools do their own `limit`/`search` at the ORM level, so they don't depend on #62071's backend change; this branch is rebased on `master`.

Agent-authored — requires human review; do not self-merge.
