### PR TITLE
feat(replay-vision): UI updates for estimate UI

### DIFF
--- a/products/replay_vision/backend/quota.py
+++ b/products/replay_vision/backend/quota.py
@@ -8,7 +8,7 @@ from posthog.date_util import start_of_month
 
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
 
-MONTHLY_OBSERVATION_QUOTA = 3000
+MONTHLY_OBSERVATION_QUOTA = 10  # ⚠️ TEMP — revert to 3000 before committing.
 
 # In-flight rows count against the quota so concurrent on-demand triggers can't all race past the gate before any complete.
 _COUNTED_STATUSES = (ObservationStatus.SUCCEEDED, ObservationStatus.PENDING, ObservationStatus.RUNNING)

--- a/products/replay_vision/backend/quota.py
+++ b/products/replay_vision/backend/quota.py
@@ -8,7 +8,7 @@ from posthog.date_util import start_of_month
 
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
 
-MONTHLY_OBSERVATION_QUOTA = 10  # ⚠️ TEMP — revert to 3000 before committing.
+MONTHLY_OBSERVATION_QUOTA = 3000
 
 # In-flight rows count against the quota so concurrent on-demand triggers can't all race past the gate before any complete.
 _COUNTED_STATUSES = (ObservationStatus.SUCCEEDED, ObservationStatus.PENDING, ObservationStatus.RUNNING)

--- a/products/replay_vision/frontend/components/ObservationsDock.tsx
+++ b/products/replay_vision/frontend/components/ObservationsDock.tsx
@@ -27,7 +27,7 @@ function quotaUx(quota: VisionQuotaApi | null): { disabledReason?: string; toolt
     if (!quota || quota.monthly_quota <= 0) {
         return {}
     }
-    const resetsOn = dayjs(quota.period_end).format('MMM D')
+    const resetsOn = dayjs(quota.period_end).format('MMMM D')
     if (quota.exhausted) {
         return { disabledReason: `Monthly observation quota reached. Resets ${resetsOn}.` }
     }

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -268,7 +268,7 @@ function QuotaBanner(): JSX.Element | null {
     if (!quota || quota.monthly_quota <= 0) {
         return null
     }
-    const resetsOn = dayjs(quota.period_end).format('MMM D')
+    const resetsOn = dayjs(quota.period_end).format('MMMM D')
     if (quota.exhausted) {
         return (
             <LemonBanner type="warning">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
@@ -11,13 +11,15 @@ interface Props {
 }
 
 const STATUS_STYLES: Record<QuotaStatus, { bar: string; text: string }> = {
-    safe: { bar: 'bg-primary', text: 'text-muted' },
+    safe: { bar: 'bg-success', text: 'text-success' },
     warning: { bar: 'bg-warning', text: 'text-warning' },
     danger: { bar: 'bg-danger', text: 'text-danger' },
 }
 
 export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
-    const { scanner, scannerEstimate, scannerEstimateLoading, isNew } = useValues(replayScannerLogic({ id: scannerId }))
+    const { scanner, scannerEstimate, scannerEstimateLoading, scannerEstimateError } = useValues(
+        replayScannerLogic({ id: scannerId })
+    )
     const { quota } = useValues(visionQuotaLogic)
 
     if (!scanner) {
@@ -30,10 +32,10 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
     const used = quota?.usage_this_month ?? 0
     const cap = quota?.monthly_quota ?? 0
 
-    // On edit, this scanner's existing contribution is already inside `usage_this_month`, so adding
-    // its projection on top of historical burn would double-count. Skip the addition; the headline
-    // number still reads the new projection so the user can compare it to current burn.
-    const projection = projectQuota(quota, isNew ? projected : null)
+    // Always include the scanner's projection — on edit we slightly double-count the scanner's existing
+    // contribution to `usage_this_month`, but that's a small over-report. Missing an over-cap config
+    // (e.g., 15 obs/month projected against a 10 cap) is the bigger UX hazard.
+    const projection = projectQuota(quota, projected)
     const {
         status,
         capReachDate,
@@ -51,8 +53,6 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
     const usedPct = hasCap ? Math.min((used / cap) * 100, 100) : 0
     const additionalUsagePct =
         hasCap && projected !== null ? Math.min((combinedDailyRate * daysRemaining * 100) / cap, 100 - usedPct) : 0
-    const projectedPeriodEndUsage = used + (projected !== null ? combinedDailyRate * daysRemaining : 0)
-    const overflowPct = hasCap && projectedPeriodEndUsage > cap ? ((projectedPeriodEndUsage - cap) / cap) * 100 : 0
 
     const renderBreakdown = (): JSX.Element => (
         <div className="text-xs space-y-0.5">
@@ -74,17 +74,11 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
             if (capReachDate && projectionConfident) {
                 return (
                     <span className="text-danger">
-                        Cap reached on <strong>{capReachDate.format('MMM D')}</strong> at this rate.
+                        You'll run out of observations on <strong>{capReachDate.format('MMMM D')}</strong> at this rate.
                     </span>
                 )
             }
             return <span className="text-danger">Projected to exceed your monthly cap.</span>
-        }
-        if (effectiveStatus === 'warning') {
-            return <span className="text-warning">Approaching cap by {resetsOn ?? 'period end'} at this rate.</span>
-        }
-        if (hasCap) {
-            return <>Should last the month at this rate.</>
         }
         return (
             <>
@@ -110,7 +104,7 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
 
             <div className="flex items-baseline justify-between gap-3">
                 {projected !== null ? (
-                    <div className="text-base font-semibold tabular-nums flex items-baseline gap-2">
+                    <div className="text-base font-semibold tabular-nums flex items-center gap-2">
                         <span>
                             {projected.toLocaleString()}{' '}
                             <span className="text-sm font-normal text-muted">observations/month</span>
@@ -134,7 +128,7 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
             {hasCap && projected !== null && (
                 <Tooltip title={renderBreakdown()}>
                     <div
-                        className="flex h-1.5 rounded overflow-hidden bg-border-light"
+                        className="flex h-3 rounded overflow-hidden bg-fill-tertiary"
                         role="meter"
                         aria-valuemin={0}
                         aria-valuemax={100}
@@ -144,10 +138,14 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
                         }`}
                     >
                         <div className="bg-muted" style={{ width: `${usedPct}%` }} />
-                        <div className={styles.bar} style={{ width: `${additionalUsagePct}%` }} />
-                        {overflowPct > 0 && (
-                            <div className="bg-danger opacity-60" style={{ width: `${Math.min(overflowPct, 100)}%` }} />
-                        )}
+                        <div
+                            className={styles.bar}
+                            style={{
+                                width: `${additionalUsagePct}%`,
+                                backgroundImage:
+                                    'repeating-linear-gradient(135deg, rgba(255,255,255,0.25) 0, rgba(255,255,255,0.25) 4px, transparent 4px, transparent 8px)',
+                            }}
+                        />
                     </div>
                 </Tooltip>
             )}
@@ -162,6 +160,8 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
                 </div>
             ) : scannerEstimate ? (
                 <div className="text-xs text-muted">{renderStatusLine()}</div>
+            ) : scannerEstimateError ? (
+                <div className="text-xs text-danger">Couldn't estimate impact: {scannerEstimateError}</div>
             ) : (
                 <div className="text-xs text-muted">Estimate unavailable. Try adjusting your filters.</div>
             )}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
@@ -63,7 +63,7 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
                 Projected from this scanner: <strong>~{(projected ?? 0).toLocaleString()}/month</strong>
             </div>
             <div>
-                Monthly cap: <strong>{cap.toLocaleString()}</strong>
+                Monthly quota: <strong>{cap.toLocaleString()}</strong>
             </div>
             {resetsOn && <div className="text-muted">Resets {resetsOn}</div>}
         </div>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
@@ -22,8 +22,7 @@ export function VisionMetrics(): JSX.Element {
     const { quota } = useValues(visionQuotaLogic)
 
     const projection = projectQuota(quota)
-    const { status, capReachDate, capReachInPeriod, projectionConfident, resetsOn, daysRemaining, combinedDailyRate } =
-        projection
+    const { resetsOn, status, daysRemaining, combinedDailyRate } = projection
     const used = quota?.usage_this_month ?? 0
     const cap = quota?.monthly_quota ?? 0
     const hasCap = cap > 0
@@ -115,7 +114,7 @@ export function VisionMetrics(): JSX.Element {
                                             Used this month: <strong>{quota.usage_this_month.toLocaleString()}</strong>
                                         </div>
                                         <div>
-                                            Monthly cap: <strong>{quota.monthly_quota.toLocaleString()}</strong>
+                                            Monthly quota: <strong>{quota.monthly_quota.toLocaleString()}</strong>
                                         </div>
                                         {resetsOn && <div className="text-muted">Resets {resetsOn}</div>}
                                     </div>
@@ -142,21 +141,9 @@ export function VisionMetrics(): JSX.Element {
                             </Tooltip>
                             <div className="text-muted text-sm mt-1">
                                 {quota.exhausted ? (
-                                    <span className="text-danger">Quota reached.</span>
-                                ) : capReachInPeriod && projectionConfident && capReachDate ? (
-                                    <span className="text-danger">
-                                        {quota.remaining.toLocaleString()} remaining. You'll run out on{' '}
-                                        <strong>{capReachDate.format('MMMM D')}</strong> at this rate.
-                                    </span>
-                                ) : status === 'warning' && projectionConfident ? (
-                                    <span className="text-warning">
-                                        {quota.remaining.toLocaleString()} remaining. You'll use most of your cap by{' '}
-                                        {resetsOn ?? 'period end'} at this rate.
-                                    </span>
+                                    <span className="text-danger">Quota exhausted</span>
                                 ) : (
-                                    `${quota.remaining.toLocaleString()} observations left${
-                                        resetsOn ? ` until ${resetsOn}.` : '.'
-                                    }`
+                                    `${quota.remaining.toLocaleString()} observations remaining.`
                                 )}
                             </div>
                         </>

--- a/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
@@ -1,9 +1,8 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonTag } from '@posthog/lemon-ui'
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { Query } from '~/queries/Query/Query'
 import { InsightVizNode, NodeKind, ProductKey, TrendsQuery } from '~/queries/schema/schema-general'
@@ -22,11 +21,15 @@ export function VisionMetrics(): JSX.Element {
     const { setChartDateRange } = useActions(replayScannersLogic)
     const { quota } = useValues(visionQuotaLogic)
 
-    const ratio = quota && quota.monthly_quota > 0 ? Math.min(quota.usage_this_month / quota.monthly_quota, 1) : 0
     const projection = projectQuota(quota)
-    const { status, capReachDate, capReachInPeriod, projectionConfident, resetsOn } = projection
-    const quotaStroke =
-        status === 'danger' ? 'var(--danger)' : status === 'warning' ? 'var(--warning)' : 'var(--success)'
+    const { status, capReachDate, capReachInPeriod, projectionConfident, resetsOn, daysRemaining, combinedDailyRate } =
+        projection
+    const used = quota?.usage_this_month ?? 0
+    const cap = quota?.monthly_quota ?? 0
+    const hasCap = cap > 0
+    const usedPct = hasCap ? Math.min((used / cap) * 100, 100) : 0
+    const additionalUsagePct = hasCap ? Math.min((combinedDailyRate * daysRemaining * 100) / cap, 100 - usedPct) : 0
+    const projectedBarColor = status === 'danger' ? 'bg-danger' : status === 'warning' ? 'bg-warning' : 'bg-success'
 
     // `tags.productKey` is required for ClickHouse query tagging; without it the runner aborts.
     const chartSource: TrendsQuery = {
@@ -105,27 +108,54 @@ export function VisionMetrics(): JSX.Element {
                                     {quota.monthly_quota.toLocaleString()}
                                 </span>
                             </div>
-                            <LemonProgress
-                                className="mt-2"
-                                percent={Math.round(ratio * 100)}
-                                strokeColor={quotaStroke}
-                            />
+                            <Tooltip
+                                title={
+                                    <div className="text-xs space-y-0.5">
+                                        <div>
+                                            Used this month: <strong>{quota.usage_this_month.toLocaleString()}</strong>
+                                        </div>
+                                        <div>
+                                            Monthly cap: <strong>{quota.monthly_quota.toLocaleString()}</strong>
+                                        </div>
+                                        {resetsOn && <div className="text-muted">Resets {resetsOn}</div>}
+                                    </div>
+                                }
+                            >
+                                <div
+                                    className="flex h-3 rounded overflow-hidden bg-fill-tertiary mt-2"
+                                    role="meter"
+                                    aria-valuemin={0}
+                                    aria-valuemax={100}
+                                    aria-valuenow={Math.round(usedPct + additionalUsagePct)}
+                                    aria-label={`${Math.round(usedPct + additionalUsagePct)}% of monthly observation quota`}
+                                >
+                                    <div className="bg-muted" style={{ width: `${usedPct}%` }} />
+                                    <div
+                                        className={projectedBarColor}
+                                        style={{
+                                            width: `${additionalUsagePct}%`,
+                                            backgroundImage:
+                                                'repeating-linear-gradient(135deg, rgba(255,255,255,0.25) 0, rgba(255,255,255,0.25) 4px, transparent 4px, transparent 8px)',
+                                        }}
+                                    />
+                                </div>
+                            </Tooltip>
                             <div className="text-muted text-sm mt-1">
                                 {quota.exhausted ? (
                                     <span className="text-danger">Quota reached.</span>
                                 ) : capReachInPeriod && projectionConfident && capReachDate ? (
                                     <span className="text-danger">
-                                        {quota.remaining.toLocaleString()} remaining. Cap reached on{' '}
-                                        <strong>{capReachDate.format('MMM D')}</strong> at this rate.
+                                        {quota.remaining.toLocaleString()} remaining. You'll run out on{' '}
+                                        <strong>{capReachDate.format('MMMM D')}</strong> at this rate.
                                     </span>
                                 ) : status === 'warning' && projectionConfident ? (
                                     <span className="text-warning">
-                                        {quota.remaining.toLocaleString()} remaining. Approaching cap by{' '}
+                                        {quota.remaining.toLocaleString()} remaining. You'll use most of your cap by{' '}
                                         {resetsOn ?? 'period end'} at this rate.
                                     </span>
                                 ) : (
-                                    `${quota.remaining.toLocaleString()} remaining${
-                                        resetsOn ? `. Resets ${resetsOn}.` : '.'
+                                    `${quota.remaining.toLocaleString()} observations left${
+                                        resetsOn ? ` until ${resetsOn}.` : '.'
                                     }`
                                 )}
                             </div>

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -212,7 +212,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         requestScannerEstimate: true,
         loadScannerEstimate: true,
         loadScannerEstimateSuccess: (estimate: EstimateResponseApi) => ({ estimate }),
-        loadScannerEstimateFailure: true,
+        loadScannerEstimateFailure: (error: string | null = null) => ({ error }),
     }),
 
     forms(({ props }) => ({
@@ -354,6 +354,14 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
             {
                 loadScannerEstimateSuccess: (_, { estimate }) => estimate,
                 loadScannerEstimateFailure: () => null,
+            },
+        ],
+        scannerEstimateError: [
+            null as string | null,
+            {
+                requestScannerEstimate: () => null,
+                loadScannerEstimateSuccess: () => null,
+                loadScannerEstimateFailure: (_, { error }) => error,
             },
         ],
         scannerEstimateLoading: [
@@ -608,7 +616,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         return
                     }
                     actions.loadScannerEstimateSuccess(response)
-                } catch (error) {
+                } catch (error: any) {
                     if (error instanceof Error && isBreakpoint(error)) {
                         throw error
                     }
@@ -617,7 +625,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     if (values.estimateRequestVersion !== version) {
                         return
                     }
-                    actions.loadScannerEstimateFailure()
+                    actions.loadScannerEstimateFailure(error?.detail ?? null)
                 }
             },
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -625,7 +625,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     if (values.estimateRequestVersion !== version) {
                         return
                     }
-                    actions.loadScannerEstimateFailure(error?.detail ?? null)
+                    const detail = typeof error?.detail === 'string' ? error.detail : null
+                    const message = typeof error?.message === 'string' ? error.message : null
+                    actions.loadScannerEstimateFailure(detail ?? message)
                 }
             },
 

--- a/products/replay_vision/frontend/utils/quotaProjection.ts
+++ b/products/replay_vision/frontend/utils/quotaProjection.ts
@@ -2,7 +2,7 @@ import { dayjs } from 'lib/dayjs'
 
 import type { VisionQuotaApi } from '../generated/api.schemas'
 
-export const QUOTA_WARN_THRESHOLD = 0.8
+export const QUOTA_WARN_THRESHOLD = 0.85
 
 const MIN_DAYS_FOR_PROJECTED_DATE = 3
 
@@ -45,7 +45,7 @@ export function projectQuota(
     const periodLengthDays = periodStart && periodEnd ? Math.max(periodEnd.diff(periodStart, 'day', true), 1) : 30
     const daysElapsed = periodStart ? Math.max(now.diff(periodStart, 'day', true), 0) : 0
     const daysRemaining = periodEnd ? Math.max(periodEnd.diff(now, 'day', true), 0) : 0
-    const resetsOn = periodEnd ? periodEnd.format('MMM D') : null
+    const resetsOn = periodEnd ? periodEnd.format('MMMM D') : null
     const projectionConfident = daysElapsed >= MIN_DAYS_FOR_PROJECTED_DATE
 
     const historicalDailyBurn = daysElapsed > 0 ? used / daysElapsed : 0


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Some UI updates to estimate UI to make things more straightforward

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- progress bar is taller
- estimation color block has dashes for better clarity
- copy changes on estimation to make it more clear when the quota will be reached and changed copy for how we calculated the estimate when quota will not be reached.
- Fixed a bug where on edit page the progress bar was not updating per sampling edit
- Shows an error to users when estimate API returned non 2XX 

main page:
<img width="818" height="175" alt="Screenshot 2026-06-08 at 10 20 43" src="https://github.com/user-attachments/assets/3201f76a-d713-4d83-8305-dd1a1d414822" />


config page:
<img width="827" height="206" alt="Screenshot 2026-06-08 at 09 44 52" src="https://github.com/user-attachments/assets/16eb453b-21fd-4d5b-af58-6a298ac7e809" />
<img width="827" height="206" alt="Screenshot 2026-06-08 at 10 15 05" src="https://github.com/user-attachments/assets/e9c63d9f-4658-4fe9-8b5d-9ab5b1737530" />
<img width="827" height="206" alt="Screenshot 2026-06-08 at 09 40 29" src="https://github.com/user-attachments/assets/67c0d4bc-0b0b-4176-a41b-d1ba90c24e49" />

error:
<img width="818" height="175" alt="Screenshot 2026-06-08 at 10 43 19" src="https://github.com/user-attachments/assets/2cd13f38-888c-4941-9e4b-05882d87bc0e" />

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
