### PR TITLE
fix(ai): close DB connections around PostHog Code Slack + task-processing activities

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -16,6 +16,7 @@ from posthog.models.repo_routing_rule import RepoRoutingRule
 from posthog.storage import object_storage
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.utils import close_db_connections
 
 from products.slack_app.backend.models import SlackThreadTaskMapping
 from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler
@@ -524,6 +525,7 @@ async def _execute_posthog_code_agent_activity(activity_fn: Any, *args: Any) -> 
 
 
 @activity.defn
+@close_db_connections
 def resolve_posthog_code_slack_user_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -541,6 +543,7 @@ def resolve_posthog_code_slack_user_activity(
 
 
 @activity.defn
+@close_db_connections
 def handle_posthog_code_rules_command_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -578,6 +581,7 @@ def handle_posthog_code_rules_command_activity(
 
 
 @activity.defn
+@close_db_connections
 def collect_posthog_code_thread_messages_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -597,6 +601,7 @@ def collect_posthog_code_thread_messages_activity(
 
 
 @activity.defn
+@close_db_connections
 def cascade_posthog_code_repository_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     event_text: str,
@@ -654,6 +659,7 @@ def cascade_posthog_code_repository_activity(
 
 
 @activity.defn
+@close_db_connections
 async def discover_posthog_code_repository_via_agent_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -777,6 +783,7 @@ def classify_posthog_code_task_needs_repo_activity(
 
 
 @activity.defn
+@close_db_connections
 def enforce_posthog_code_billing_quota_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -809,6 +816,7 @@ def enforce_posthog_code_billing_quota_activity(
 
 
 @activity.defn
+@close_db_connections
 def post_posthog_code_no_repos_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str
 ) -> None:
@@ -829,6 +837,7 @@ def post_posthog_code_no_repos_activity(
 
 
 @activity.defn
+@close_db_connections
 def post_posthog_code_repo_picker_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -884,6 +893,7 @@ def post_posthog_code_repo_picker_activity(
 
 
 @activity.defn
+@close_db_connections
 def block_posthog_code_task_if_no_personal_github_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -958,6 +968,7 @@ def block_posthog_code_task_if_no_personal_github_activity(
 
 
 @activity.defn
+@close_db_connections
 def create_posthog_code_task_for_repo_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -1106,6 +1117,7 @@ def create_posthog_code_task_for_repo_activity(
 
 
 @activity.defn
+@close_db_connections
 def create_posthog_code_routing_rule_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -1161,6 +1173,7 @@ def create_posthog_code_routing_rule_activity(
 
 
 @activity.defn
+@close_db_connections
 def forward_posthog_code_followup_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs,
     channel: str,
@@ -1626,6 +1639,7 @@ def _parse_iso_datetime(value: Any) -> datetime | None:
 
 
 @activity.defn
+@close_db_connections
 def post_posthog_code_picker_timeout_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str
 ) -> None:
@@ -1664,6 +1678,7 @@ def post_posthog_code_picker_timeout_activity(
 
 
 @activity.defn
+@close_db_connections
 def post_posthog_code_internal_error_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str
 ) -> None:

--- a/posthog/temporal/ai/posthog_code_slack_mention_command.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention_command.py
@@ -7,6 +7,7 @@ from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.utils import close_db_connections
 
 POSTHOG_CODE_SLACK_COMMAND_ACTIVITY_TIMEOUT_SECONDS = 60
 # Matches the mention workflow's picker wait window so the bot's behaviour is
@@ -191,6 +192,7 @@ class PostHogCodeSlackMentionCommandWorkflow(PostHogWorkflow):
 
 
 @activity.defn
+@close_db_connections
 def resolve_posthog_code_slack_command_user_activity(
     inputs: PostHogCodeSlackMentionCommandWorkflowInputs,
 ) -> int | None:
@@ -236,6 +238,7 @@ def resolve_posthog_code_slack_command_user_activity(
 
 
 @activity.defn
+@close_db_connections
 def handle_posthog_code_slack_mention_command_activity(
     inputs: PostHogCodeSlackMentionCommandWorkflowInputs,
     user_id: int,

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -7,6 +7,7 @@ from temporalio import activity
 
 from posthog.models.user import User
 from posthog.temporal.common.logger import get_logger
+from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.access import has_tasks_access
 
@@ -38,6 +39,7 @@ def _viewer_has_posthog_code_access(viewer: User | None) -> bool:
 
 
 @activity.defn
+@close_db_connections
 def post_slack_update(input: PostSlackUpdateInput) -> None:
     """Post Slack update based on current task run state. Idempotent."""
     from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -11,6 +11,8 @@ import structlog
 import temporalio.client
 from temporalio import activity
 
+from posthog.temporal.common.utils import close_db_connections
+
 from products.tasks.backend.models import TaskRun as TaskRunModel
 from products.tasks.backend.services.agent_command import validate_sandbox_url
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
@@ -46,6 +48,7 @@ class RelaySandboxEventsInput:
 
 
 @activity.defn
+@close_db_connections
 async def relay_sandbox_events(input: RelaySandboxEventsInput) -> None:
     """Long-running activity that relays SSE events from a sandbox agent to a Redis stream.
 

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -7,6 +7,7 @@ import structlog
 from django_redis import get_redis_connection
 from temporalio import activity
 
+from posthog.temporal.common.utils import close_db_connections
 from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.models import TaskRun
@@ -44,6 +45,7 @@ class SendFollowupToSandboxInput:
 
 
 @activity.defn
+@close_db_connections
 def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
     """Send a follow-up user message to the sandbox and write result markers to Redis.
 

--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -6,6 +6,7 @@ from markdown_to_mrkdwn import SlackMarkdownConverter
 from temporalio import activity
 
 from posthog.temporal.common.logger import get_logger
+from posthog.temporal.common.utils import close_db_connections
 
 logger = get_logger(__name__)
 
@@ -232,6 +233,7 @@ class RelaySlackMessageInput:
 
 
 @activity.defn
+@close_db_connections
 def relay_slack_message(input: RelaySlackMessageInput) -> None:
     from products.slack_app.backend.models import SlackThreadTaskMapping
     from products.slack_app.backend.slack_thread import SlackThreadContext, SlackThreadHandler


### PR DESCRIPTION
## Problem

Long-running Temporal workers don't go through Django's request cycle, so `close_old_connections()` never fires. Stale DB connections stay in the pool until the next query fails.

## Changes

Wrap DB-touching activities with `@close_db_connections` (same pattern as existing usages in `products/tasks/backend/temporal/process_task/activities/`).

**PostHog Code Slack workflows** (`posthog/temporal/ai/`):
- `posthog_code_slack_mention.py` — 13 activities. `classify_posthog_code_task_needs_repo_activity` left alone (pure heuristics + LLM, no ORM).
- `posthog_code_slack_mention_command.py` — 2 activities.

**Task-processing workflow** (audit follow-up — `@asyncify` already wraps `close_db_connections` internally, so only sync / non-asyncified ORM-touching activities needed it):
- `process_task/activities/post_slack_update.py`
- `process_task/activities/send_followup_to_sandbox.py`
- `process_task/activities/relay_sandbox_events.py` (long-running async SSE relay)
- `slack_relay/activities.py` — `relay_slack_message`

## How did you test this code?

Tested locally end-to-end against the dev stack — chatted with the bot from Slack, mention + command paths behaved correctly.

## 🤖 Agent context

Agent-assisted: decorator application + audit across the temporal activity surface.