### PR TITLE
fix(cdp): make update_hog_function_code skip uncompilable destinations

### DIFF
--- a/posthog/management/commands/test/test_update_hog_function_code.py
+++ b/posthog/management/commands/test/test_update_hog_function_code.py
@@ -152,6 +152,44 @@ class TestUpdateHogFunctionCode(BaseTest):
         self.assertIn("Updated: 1", output)
         self.assertIn("Update completed", output)
 
+    @patch("posthog.management.commands.update_hog_function_code.compile_hog")
+    def test_update_skips_destinations_that_fail_to_compile(self, mock_compile_hog):
+        """A destination with uncompilable hog is skipped and logged, not fatal to the whole run."""
+        with patch("products.cdp.backend.models.hog_functions.hog_function.reload_hog_functions_on_workers"):
+            bad_function = HogFunction.objects.create(
+                team=self.team,
+                name="Meta Ads Broken",
+                type="destination",
+                template_id="template-meta-ads",
+                description="Broken hog",
+                hog="let res := fetch(f'https://graph.facebook.com/v21.0/{inputs.pixelId}/events BROKEN', {}); return event;",
+                enabled=True,
+            )
+
+        def fake_compile(hog, hog_type):
+            if "BROKEN" in hog:
+                raise Exception("unexpected character '&'")
+            return "compiled_bytecode"
+
+        mock_compile_hog.side_effect = fake_compile
+
+        out = StringIO()
+        call_command("update_hog_function_code", replace_key="meta-ads-api-version-update", stdout=out)
+
+        # The healthy function is still migrated
+        self.meta_ads_function1.refresh_from_db()
+        assert "graph.facebook.com/v25.0/" in self.meta_ads_function1.hog
+
+        # The uncompilable one is left untouched, not partially written
+        bad_function.refresh_from_db()
+        assert "graph.facebook.com/v21.0/" in bad_function.hog
+
+        output = out.getvalue()
+        self.assertIn("Found 3 destinations to process", output)
+        self.assertIn("Updated: 1", output)
+        self.assertIn("Failed: 1", output)
+        self.assertIn(str(bad_function.id), output)
+
     @patch("posthog.cdp.validation.compile_hog")
     def test_invalid_replace_key(self, mock_compile_hog):
         """Test handling of invalid replace key."""

--- a/posthog/management/commands/update_hog_function_code.py
+++ b/posthog/management/commands/update_hog_function_code.py
@@ -55,6 +55,7 @@ class Command(BaseCommand):
         )
 
         updated_count = 0
+        failed: list[tuple[str, int, bool, str]] = []
         total_found = queryset.count()
         paginator = Paginator(queryset.order_by("id"), 1000)
 
@@ -71,15 +72,32 @@ class Command(BaseCommand):
             )
 
             for destination in page.object_list:
-                if destination.hog and replaceOption["from_string"] in destination.hog:
-                    destination.hog = destination.hog.replace(replaceOption["from_string"], replaceOption["to_string"])
-                    destination.bytecode = compile_hog(destination.hog, destination.type)
-                    updated_count += 1
-                    if not dry_run:
-                        destination.save(update_fields=["hog", "bytecode"])
+                if not destination.hog or replaceOption["from_string"] not in destination.hog:
+                    continue
+
+                new_hog = destination.hog.replace(replaceOption["from_string"], replaceOption["to_string"])
+                # A single destination with uncompilable (e.g. hand-edited) hog must not abort the whole run.
+                try:
+                    new_bytecode = compile_hog(new_hog, destination.type)
+                except Exception as e:
+                    failed.append((str(destination.id), destination.team_id, destination.enabled, str(e)))
+                    continue
+
+                updated_count += 1
+                if not dry_run:
+                    destination.hog = new_hog
+                    destination.bytecode = new_bytecode
+                    destination.save(update_fields=["hog", "bytecode"])
 
         # Output summary
         duration = time.time() - start_time
         self.stdout.write(
-            self.style.SUCCESS(f"Update completed in {duration:.2f}s. Found: {total_found}, Updated: {updated_count}, ")
+            self.style.SUCCESS(
+                f"Update completed in {duration:.2f}s. Found: {total_found}, Updated: {updated_count}, Failed: {len(failed)}"
+            )
         )
+
+        if failed:
+            self.stdout.write(self.style.WARNING(f"{len(failed)} destination(s) failed to compile and were skipped:"))
+            for fn_id, team_id, enabled, error in failed:
+                self.stdout.write(f"  id={fn_id} team={team_id} enabled={enabled} error={error}")


### PR DESCRIPTION
## Problem

`update_hog_function_code` recompiles bytecode for every matched destination, but had no error handling around `compile_hog`. A single destination with hand-edited, uncompilable hog (e.g. invalid HogQL that the current parser rejects) raised and aborted the entire run.

Because the command saves per row with no surrounding transaction, a real run would persist every row up to the failing one and then crash — leaving a partially migrated, hard-to-reason-about state. This blocked the in-flight Meta Ads `v21.0 → v25.0` migration (PR #61413) on one region, where a customized destination tripped a `SyntaxError: unexpected character '&'`.

## Changes

- Wrap each destination's `compile_hog` in `try/except`. A row that fails to compile is recorded and **skipped**, never aborting the run and never partially written.
- Report skipped rows: the summary now includes `Failed: <n>` plus a per-row list (`id`, `team`, `enabled`, `error`) so the uncompilable destinations can be triaged afterwards.
- Convert the match check to a guard clause so the compile/save path only runs for matched rows.

The skipped rows are left exactly as-is (still on the old version) — they have pre-existing invalid syntax that cannot be recompiled through this path and need a manual hog fix, which is now surfaced rather than silently fatal.

## How did you test this code?

I'm an agent (Claude). Automated checks I actually ran:

- `hogli test posthog/management/commands/test/test_update_hog_function_code.py` → 7 passed, including a new `test_update_skips_destinations_that_fail_to_compile` (one healthy + one uncompilable Meta destination; asserts the healthy one migrates, the broken one is left untouched on the old version, and the output reports `Updated: 1 / Failed: 1` with the skipped id).
- `ruff check` + `ruff format --check` on both files → clean.
- Manual end-to-end run against a local dev database with the real `compile_hog` (no mocks): created fixtures covering migrate / already-new / wrong-template / deleted / broken-syntax, ran the command, and confirmed only the valid old-version row migrated, the broken row was skipped and reported, scoping excluded deleted/wrong-template rows, and the fixtures were cleaned up afterwards.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal management command, no user-facing docs.

## 🤖 Agent context

Authored by Claude (Opus 4.8) at the user's request, as a follow-up to the brittleness found while running the Meta Ads `v21.0 → v25.0` migration (PR #61413) in production. A dry-run aborted on one customized destination whose hog no longer compiles. We considered fixing the offending rows by hand or running an ad-hoc resilient shell loop, but chose to harden the command itself since it's reusable across version-bump migrations (LinkedIn, future Meta bumps) and the same failure mode would otherwise recur. The skip-and-report approach was preferred over wrapping the whole run in a transaction, so the bulk migration completes and only the genuinely broken rows are surfaced for manual follow-up.
