### PR TITLE
chore(signals): correct last_run_at liveness in scout exploring skill

### DIFF
--- a/products/signals/skills/exploring-signals-scouts/SKILL.md
+++ b/products/signals/skills/exploring-signals-scouts/SKILL.md
@@ -83,13 +83,22 @@ The config list is unpaginated — it comes back as `{ results: [...] }` (a bare
   running. Tell the user which scouts exist and that they're all off.
 - **At least one `enabled: true`** — the fleet is registered and that scout is allowed to run. For
   each enabled scout note its `run_interval_minutes` (cadence), `emit` (false = **dry-run**, runs
-  but writes nothing to the inbox), and `last_run_at` (when it last fired — `null` means it has
-  never run). One caveat before reporting "it's live": runs are gated by the `signals-scout` feature
-  flag, not by `enabled`. A project that was enrolled and later drained from the flag keeps its
-  `enabled: true` rows, but the coordinator no longer plans runs for it — so a stale or `null`
-  `last_run_at` on an enabled scout usually means the project is no longer enrolled, not that the
-  scout is idle. When `last_run_at` is recent, the scout is genuinely running; proceed to the user's
-  actual question.
+  but writes nothing to the inbox), and `last_run_at`. One caveat before reporting "it's live": runs
+  are gated by the `signals-scout` feature flag, not by `enabled`. A project that was enrolled and
+  later drained from the flag keeps its `enabled: true` rows, but the coordinator no longer plans
+  runs for it — so a stale or `null` `last_run_at` on an enabled scout usually means the project is
+  no longer enrolled, not that the scout is idle.
+
+  **`last_run_at` is a _dispatch_ stamp, not proof a run executed.** The coordinator advances it the
+  moment it _enqueues_ a child workflow for a due scout — before any worker picks the run up. Child
+  dispatch is fire-and-forget, so if workers are saturated or down the children just queue and no
+  run ever materializes, yet `last_run_at` keeps marching forward each tick. So a recent
+  `last_run_at` means "dispatched this tick," **not** "a run is genuinely happening." The
+  authoritative liveness signal is the newest actual **run row** in `signals-scout-runs-list`, not
+  the config stamp. Cross-check them: if `last_run_at` is fresh (minutes ago) but no run row has
+  appeared for that scout in well over its `run_interval_minutes`, the fleet is **dispatching but
+  not running** — workers backed up / down, or runs stranded — a real reliability problem, not a
+  live scout. Don't report "it's running" off `last_run_at` alone.
 
 A scout that is `enabled: true` but `emit: false` is the most common source of "my scout isn't
 doing anything" confusion: it _is_ running and reasoning every tick, it just isn't allowed to post
@@ -262,7 +271,11 @@ below. The full playbook, including how to read each signal and the common failu
 [`references/assessing-performance.md`](references/assessing-performance.md).
 
 - **Cadence adherence** — are runs landing roughly every `run_interval_minutes`? Large gaps mean
-  the coordinator is skipping it (disabled, drained from the flag, or capped out on busy ticks).
+  the coordinator is skipping it (disabled, drained from the flag, or capped out on busy ticks) —
+  _or_ it's dispatching but the runs aren't materializing. Tell the two apart with `last_run_at`: if
+  the config's `last_run_at` is also stale, the coordinator stopped planning it; if `last_run_at` is
+  fresh but the newest run row is hours old, it's the dispatch-vs-execution divergence above (workers
+  backed up / down, or runs stranded), which `runs-list` alone hides.
 - **Success rate** — how many runs reach a clean `status` vs. error out? A run of errors is a
   broken scout, not a quiet one.
 - **Emit rate** — what fraction of runs emitted vs. closed out empty. Near-zero over a long window

--- a/products/signals/skills/exploring-signals-scouts/scripts/assess_health.py
+++ b/products/signals/skills/exploring-signals-scouts/scripts/assess_health.py
@@ -155,23 +155,38 @@ def assess_scout(name: str, runs: list[dict], interval: float | None, mem_count:
     adherence = pct(n, expected) if expected else "-"
 
     emit_like = sum(1 for r in runs if quiet_or_emit(r.get("summary")) == "maybe")
-    # staleness uses the config's authoritative last_run_at when available — the runs
-    # window can be truncated by the 100-row cap and miss the newest runs.
-    last_start = parse_ts(config_last_run) or (starts[-1] if starts else None)
-    stale_min = (now - last_start).total_seconds() / 60.0 if now and last_start else None
+    # Two different stalenesses — keep them apart. `last_run_at` is the coordinator's DISPATCH
+    # stamp (advanced the moment a child is enqueued, before any worker runs it); the newest
+    # observed run row's `started_at` is when a run actually EXECUTED. A fresh `last_run_at`
+    # with a much older newest run = "dispatching but not running" (workers backed up / down,
+    # or runs stranded), which a single staleness number that trusts `last_run_at` would hide.
+    dispatch_at = parse_ts(config_last_run)
+    last_start = starts[-1] if starts else None
+    dispatch_stale_min = (now - dispatch_at).total_seconds() / 60.0 if now and dispatch_at else None
+    run_stale_min = (now - last_start).total_seconds() / 60.0 if now and last_start else None
+    # How far the dispatch stamp has marched ahead of the newest run that materialized. Robust to
+    # the 100-row cap: `last_run_at` is authoritative, and runs-list is newest-first so a scout's
+    # true newest run is in the window whenever it ran recently.
+    dispatch_run_gap_min = (
+        (dispatch_at - last_start).total_seconds() / 60.0 if dispatch_at and last_start else None
+    )
+    # Back-compat single value (dispatch-preferred, as before) for any caller reading stale_min.
+    stale_min = dispatch_stale_min if dispatch_stale_min is not None else run_stale_min
 
     return {
         "name": name, "runs": n, "completed": completed, "failed": failed, "timeouts": timeouts,
         "success_pct": pct(completed, n), "median_dur": median_dur, "median_gap": median_gap,
         "interval": interval, "adherence": adherence, "stalls": stalls,
-        "emit_like": emit_like, "emit_pct": pct(emit_like, n), "mem_count": mem_count, "stale_min": stale_min,
+        "emit_like": emit_like, "emit_pct": pct(emit_like, n), "mem_count": mem_count,
+        "stale_min": stale_min, "dispatch_stale_min": dispatch_stale_min,
+        "run_stale_min": run_stale_min, "dispatch_run_gap_min": dispatch_run_gap_min,
     }
 
 
 def render(scouts: list[dict], window_note: str, has_mem: bool, *, art: bool = True) -> str:
     banner: list[str] = []
     if art:
-        banner = [HEDGEHOG.strip("\n"), "", " judge a scout over a window of runs, not on any single tick", ""]
+        banner = [HEDGEHOG.strip("\n"), ""]
 
     if not scouts:
         return "\n".join([*banner, "SCOUT HEALTH", "",
@@ -202,7 +217,14 @@ def render(scouts: list[dict], window_note: str, has_mem: bool, *, art: bool = T
             flags.append(f" * {s['name']}: {s['stalls']} cadence stall(s) (gap >{int(STALL_FACTOR)}x interval) — coordinator skipped it (paused / drained / capped).")
         if has_mem and s["runs"] >= 5 and s["mem_count"] == 0:
             flags.append(f" * {s['name']}: {s['runs']} runs but an EMPTY scratchpad — not learning.")
-        if s["stale_min"] is not None and s["interval"] and s["stale_min"] > STALL_FACTOR * s["interval"]:
+        # Dispatching but not running: the coordinator's last_run_at has marched a full interval+
+        # past the newest run that actually materialized — children are queuing without executing
+        # (workers backed up / down, or runs stranded). Distinct from a cadence stall (gap between
+        # observed runs) because the runs simply aren't there to leave a gap.
+        if s["dispatch_run_gap_min"] is not None and s["interval"] and s["dispatch_run_gap_min"] > s["interval"]:
+            disp = fmt_age(s["dispatch_stale_min"]) if s["dispatch_stale_min"] is not None else "recently"
+            flags.append(f" * {s['name']}: dispatched {disp} ago but newest run row {fmt_age(s['run_stale_min'])} ago — DISPATCHING BUT NOT RUNNING (workers backed up / down, or runs stranded); last_run_at hides this.")
+        elif s["stale_min"] is not None and s["interval"] and s["stale_min"] > STALL_FACTOR * s["interval"]:
             flags.append(f" * {s['name']}: last run {fmt_age(s['stale_min'])} ago vs a {int(s['interval'])}m cadence — may be drained from the flag.")
 
     L += ["-" * 78, " worth a look", "-" * 78]

--- a/products/signals/skills/exploring-signals-scouts/scripts/fleet_survey.py
+++ b/products/signals/skills/exploring-signals-scouts/scripts/fleet_survey.py
@@ -126,7 +126,7 @@ def render(config: Any, runs_payload: Any, now: datetime | None, *, art: bool = 
 
     banner: list[str] = []
     if art:
-        banner = [HEDGEHOG.strip("\n"), "", " an empty close-out is a healthy scout outcome", ""]
+        banner = [HEDGEHOG.strip("\n"), ""]
 
     if not scouts:
         return "\n".join([*banner,

--- a/products/signals/skills/exploring-signals-scouts/scripts/render_run_report.py
+++ b/products/signals/skills/exploring-signals-scouts/scripts/render_run_report.py
@@ -294,8 +294,6 @@ def render(run: dict, timeline: list[dict] | None, scratchpad: Any, posture: dic
     if art:
         L.append(HEDGEHOG.strip("\n"))
         L.append("")
-        L.append(" an empty close-out is a healthy scout outcome")
-        L.append("")
     render_header(L, run, posture, base_url)
 
     if mode != "summary" and timeline:


### PR DESCRIPTION
## Problem

The `exploring-signals-scouts` skill told readers that a recent `last_run_at` means a scout is "genuinely running." That's not accurate. `last_run_at` is the coordinator's **dispatch** stamp — it's advanced the moment a child workflow is enqueued for a due scout, before any worker picks the run up. Child dispatch is fire-and-forget, so if workers are saturated/down (or runs get stranded) the children just queue, no run rows materialize, yet `last_run_at` keeps marching forward every tick.

The result: a fleet that is dispatching-but-not-running reads as healthy. The bundled `assess_health.py` had the same blind spot — its staleness check preferred `last_run_at`, so it would report a fresh ~stamp and surface no flag even when no run had executed for hours.

## Changes

- **`SKILL.md`** — clarify that `last_run_at` is a dispatch stamp, not proof a run executed; the authoritative liveness signal is the newest actual run row in `signals-scout-runs-list`. Added the dispatch-vs-execution divergence to the cadence-adherence guidance (fresh `last_run_at` + stale run rows = dispatching but not running; both stale = drained from the flag).
- **`assess_health.py`** — track dispatch-staleness and run-staleness separately and add a `DISPATCHING BUT NOT RUNNING` flag, distinct from the existing "may be drained from the flag" flag. The single `stale_min` value is kept for backward compatibility. The divergence check keys off `last_run_at` vs the newest observed run, which is robust to the 100-row list cap.
- **Helper scripts** — removed decorative banner taglines from `fleet_survey.py`, `assess_health.py`, and `render_run_report.py`; the equivalent guidance already lives in each report's column-key footnotes. The `--art`-gated hedgehog header stays.

## How did you test this code?

I'm an agent (Claude Code). I did not do manual UI testing. What I actually ran:

- `python -m py_compile` on all three helper scripts — clean.
- Ran `assess_health.py` and `fleet_survey.py` against a live fleet snapshot and confirmed the new `DISPATCHING BUT NOT RUNNING` flag fires for scouts whose dispatch stamp had advanced past their newest run row, while a genuinely-disabled scout (both stamps stale) still flags as "may be drained from the flag."

There is no automated test suite covering these bundled skill scripts.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code while exercising the `exploring-signals-scouts` skill against a live scout fleet. The overclaim surfaced when a config showed a fresh `last_run_at` but no run rows had appeared for hours — tracing the coordinator confirmed `last_run_at` advances at dispatch (enqueue), not on execution.

Decisions: kept the skill edits at the concept level (dispatch stamp vs. executed run) so they generalize to any user's fleet rather than describing a specific operational state; kept `assess_health.py`'s `stale_min` field backward-compatible and added the new fields alongside it; gated the divergence flag on `dispatch_run_gap > interval` so it only fires when the stamp is genuinely a tick+ ahead of the newest run. Banner taglines were removed as fluff at the human author's request.

Agent-assisted, human-reviewed — not self-merged.
