### PR TITLE
feat(tasks): gate cloud task creation on posthog_code usage limit

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -123,6 +123,7 @@ from .serializers import (
     build_task_run_artifact_size_error,
     get_task_run_artifact_max_size_bytes,
 )
+from .services.code_usage_gate import cloud_usage_limit_response
 from .services.connection_token import create_sandbox_connection_token
 from .services.staged_artifacts import (
     RUN_ARTIFACT_TTL_DAYS,
@@ -974,6 +975,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             200: OpenApiResponse(response=TaskSerializer, description="Task with updated latest run"),
             400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid task run payload"),
             404: OpenApiResponse(description="Task not found"),
+            429: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
+            ),
         },
         summary="Run task",
         description="Create a new task run and kick off the workflow.",
@@ -981,6 +985,11 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], url_path="run", required_scopes=["task:write"])
     def run(self, request, pk=None, **kwargs):
         task = cast(Task, self.get_object())
+
+        # Always cloud: gate before creating the run.
+        if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+            return limit_response
+
         mode = request.validated_data.get("mode", "background")
         branch = request.validated_data.get("branch")
         resume_from_run_id = request.validated_data.get("resume_from_run_id")
@@ -1294,6 +1303,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         responses={
             201: OpenApiResponse(response=TaskRunDetailSerializer, description="Created task run"),
             400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid task run payload"),
+            429: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
+            ),
         },
         summary="Create task run",
         description="Create a new run for a specific task without starting execution.",
@@ -1311,6 +1323,12 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if task is None:
             raise NotFound("Task not found")
         environment = request.validated_data.get("environment", TaskRun.Environment.LOCAL)
+
+        # Gate cloud runs before the run row is created; local runs aren't limited.
+        if environment == TaskRun.Environment.CLOUD:
+            if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+                return limit_response
+
         mode = request.validated_data.get("mode", "background")
         branch = request.validated_data.get("branch")
         sandbox_environment_id = request.validated_data.get("sandbox_environment_id")
@@ -1422,6 +1440,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             200: OpenApiResponse(response=TaskSerializer, description="Task with updated latest run"),
             400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid start payload"),
             404: OpenApiResponse(description="Task run not found"),
+            429: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
+            ),
         },
         summary="Start task run",
         description="Start an existing cloud run after any initial run-scoped attachments have been uploaded.",
@@ -1448,6 +1469,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 ).data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # Backstop: don't launch the cloud workflow for an over-limit team.
+        if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+            return limit_response
 
         if pending_user_artifact_ids:
             _, missing_artifact_ids = get_task_run_artifacts_by_id(task_run, pending_user_artifact_ids)
@@ -2623,6 +2648,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             400: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer, description="Run already active or workflow failed"
             ),
+            429: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
+            ),
         },
         summary="Resume task run in cloud",
         description="Resume an existing task run in a cloud sandbox. Terminates any existing workflow and starts a new one.",
@@ -2635,6 +2663,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     )
     def resume_in_cloud(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
+
+        # Resume also runs in cloud: gate before handoff.
+        if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+            return limit_response
 
         logger.info(
             "resume_in_cloud_called",

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -519,6 +519,19 @@ class TaskRunErrorResponseSerializer(serializers.Serializer):
         required=False,
         help_text="Artifact ids that could not be resolved for the run",
     )
+    limit_type = serializers.ChoiceField(
+        choices=[("burst", "burst"), ("sustained", "sustained")],
+        required=False,
+        help_text="Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)",
+    )
+    reset_at = serializers.CharField(
+        required=False,
+        help_text="ISO 8601 timestamp when the hit usage limit resets, when known",
+    )
+    is_pro = serializers.BooleanField(
+        required=False,
+        help_text="Whether the team is on a Pro plan (drives the upgrade-prompt copy)",
+    )
 
 
 class AgentListResponseSerializer(serializers.Serializer):

--- a/products/tasks/backend/services/code_usage_gate.py
+++ b/products/tasks/backend/services/code_usage_gate.py
@@ -1,0 +1,149 @@
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from django.conf import settings
+
+import requests
+from rest_framework import status
+from rest_framework.response import Response
+
+from posthog.models import OAuthAccessToken
+from posthog.temporal.oauth import create_oauth_access_token_for_user
+from posthog.utils import get_instance_region
+
+from products.tasks.backend.serializers import TaskRunErrorResponseSerializer
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_PRODUCT = "posthog_code"
+
+# Short timeout: this runs on the creation hot path; on failure we fail open.
+GATEWAY_USAGE_TIMEOUT_SECONDS = 2.5
+
+
+@dataclass(frozen=True)
+class CodeUsageStatus:
+    is_rate_limited: bool
+    limit_type: str | None  # "burst" (daily) | "sustained" (monthly) | None
+    reset_at: str | None  # ISO 8601 string from the gateway, when known
+    is_pro: bool
+
+
+def _gateway_usage_url() -> str | None:
+    """Resolve the LLM gateway usage endpoint for this deployment.
+
+    Region-based in cloud, the local gateway (localhost:3308, matching the
+    desktop client) under DEBUG. Returns None when no gateway applies, so
+    callers fail open.
+    """
+    region = get_instance_region()
+    if region == "US":
+        base = "https://gateway.us.posthog.com"
+    elif region == "EU":
+        base = "https://gateway.eu.posthog.com"
+    elif settings.DEBUG:
+        base = "http://localhost:3308"
+    else:
+        return None
+    return f"{base}/v1/usage/{GATEWAY_PRODUCT}"
+
+
+def _parse_usage(data: dict[str, Any]) -> CodeUsageStatus:
+    sustained = data.get("sustained") or {}
+    burst = data.get("burst") or {}
+    sustained_exceeded = bool(sustained.get("exceeded"))
+    burst_exceeded = bool(burst.get("exceeded"))
+    is_limited = bool(data.get("is_rate_limited")) or sustained_exceeded or burst_exceeded
+
+    # Surface the bucket that's actually over for the reset hint; burst (daily) takes priority.
+    if burst_exceeded:
+        limit_type, reset_at = "burst", burst.get("reset_at")
+    elif sustained_exceeded:
+        limit_type, reset_at = "sustained", sustained.get("reset_at")
+    else:
+        limit_type, reset_at = None, None
+
+    return CodeUsageStatus(
+        is_rate_limited=is_limited,
+        limit_type=limit_type,
+        reset_at=reset_at,
+        is_pro=bool(data.get("is_pro")),
+    )
+
+
+def get_posthog_code_usage(user, team_id: int) -> CodeUsageStatus | None:
+    """Fetch the team's posthog_code usage from the LLM gateway.
+
+    Returns None (fail open) on any failure — gateway hiccups must never block
+    task creation. Mints a short-lived, least-privilege `llm_gateway:read` token
+    the same way the sandbox agent authenticates to the gateway.
+    """
+    url = _gateway_usage_url()
+    if not url:
+        return None
+
+    try:
+        token = create_oauth_access_token_for_user(
+            user, team_id, scopes=["llm_gateway:read"], include_internal_scopes=False
+        )
+    except Exception:
+        logger.warning("code_usage_gate: failed to mint gateway token", exc_info=True)
+        return None
+
+    try:
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=GATEWAY_USAGE_TIMEOUT_SECONDS,
+        )
+        if response.status_code != 200:
+            logger.warning("code_usage_gate: gateway usage returned %s", response.status_code)
+            return None
+        return _parse_usage(response.json())
+    except requests.RequestException:
+        logger.warning("code_usage_gate: gateway usage request failed", exc_info=True)
+        return None
+    except (ValueError, AttributeError):
+        logger.warning("code_usage_gate: could not parse gateway usage response", exc_info=True)
+        return None
+    finally:
+        # Short-lived token: delete it so repeated gate checks don't pile up OAuthAccessToken rows.
+        # Swallow cleanup errors so a DB hiccup here can't break the fail-open guarantee.
+        try:
+            OAuthAccessToken.objects.filter(token=token).delete()
+        except Exception:
+            logger.warning("code_usage_gate: failed to delete gateway token", exc_info=True)
+
+
+def rate_limit_error_payload(usage: CodeUsageStatus) -> dict[str, Any]:
+    """Structured 429 body the PostHog Code client parses into its upgrade prompt.
+
+    Omits unknown bucket/reset fields so they don't render as null in the shared
+    error serializer (which other error responses reuse).
+    """
+    payload: dict[str, Any] = {
+        "type": "rate_limited",
+        "code": "usage_limit_exceeded",
+        "error": "You've reached your PostHog Code usage limit.",
+        "is_pro": usage.is_pro,
+    }
+    if usage.limit_type is not None:
+        payload["limit_type"] = usage.limit_type
+    if usage.reset_at is not None:
+        payload["reset_at"] = usage.reset_at
+    return payload
+
+
+def cloud_usage_limit_response(user, team_id: int) -> Response | None:
+    """Return a structured 429 Response when the team is over its posthog_code usage limit, else None.
+
+    Fails open: if the gateway can't be reached, returns None and the run proceeds.
+    """
+    usage = get_posthog_code_usage(user, team_id)
+    if usage is None or not usage.is_rate_limited:
+        return None
+    return Response(
+        TaskRunErrorResponseSerializer(rate_limit_error_payload(usage)).data,
+        status=status.HTTP_429_TOO_MANY_REQUESTS,
+    )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -16,6 +16,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone as django_timezone
 
 import jwt
+import requests
 from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -39,6 +40,7 @@ from products.tasks.backend.serializers import (
     TASK_RUN_PDF_ARTIFACT_MAX_SIZE_BYTES,
     TaskAutomationSerializer,
 )
+from products.tasks.backend.services.code_usage_gate import CodeUsageStatus, _gateway_usage_url, get_posthog_code_usage
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key, reset_sandbox_jwt_key_cache
 from products.tasks.backend.services.staged_artifacts import (
     RUN_ARTIFACT_TTL_DAYS,
@@ -6569,3 +6571,202 @@ class TestSandboxEnvironmentAPI(BaseTaskAPITest):
 
         task_run = TaskRun.objects.filter(task=task).latest("created_at")
         self.assertNotIn("sandbox_environment_id", task_run.state)
+
+
+class TestCloudUsageGate(BaseTaskAPITest):
+    OVER_LIMIT: ClassVar[CodeUsageStatus] = CodeUsageStatus(
+        is_rate_limited=True,
+        limit_type="burst",
+        reset_at="2026-06-09T00:00:00Z",
+        is_pro=False,
+    )
+
+    def _cloud_run(self, task, status_value=TaskRun.Status.QUEUED):
+        return TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            environment=TaskRun.Environment.CLOUD,
+            status=status_value,
+        )
+
+    @patch("products.tasks.backend.services.code_usage_gate.get_posthog_code_usage")
+    def test_run_over_limit_returns_429_and_creates_no_run(self, mock_gate):
+        mock_gate.return_value = self.OVER_LIMIT
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"mode": "background"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(response.json()["code"], "usage_limit_exceeded")
+        self.assertEqual(response.json()["limit_type"], "burst")
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
+
+    @patch("products.tasks.backend.services.code_usage_gate.get_posthog_code_usage")
+    def test_create_cloud_run_over_limit_returns_429_and_creates_no_run(self, mock_gate):
+        mock_gate.return_value = self.OVER_LIMIT
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {"environment": "cloud"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(response.json()["code"], "usage_limit_exceeded")
+        self.assertFalse(TaskRun.objects.filter(task=task).exists())
+
+    @patch("products.tasks.backend.services.code_usage_gate.get_posthog_code_usage")
+    def test_create_local_run_is_not_gated(self, mock_gate):
+        mock_gate.return_value = self.OVER_LIMIT
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {"environment": "local"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_gate.assert_not_called()
+        self.assertTrue(TaskRun.objects.filter(task=task).exists())
+
+    @patch("products.tasks.backend.services.code_usage_gate.get_posthog_code_usage")
+    def test_start_over_limit_returns_429(self, mock_gate):
+        mock_gate.return_value = self.OVER_LIMIT
+        task = self.create_task()
+        run = self._cloud_run(task)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/start/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(response.json()["code"], "usage_limit_exceeded")
+        run.refresh_from_db()
+        self.assertEqual(run.status, TaskRun.Status.QUEUED)
+
+    @patch("products.tasks.backend.services.code_usage_gate.get_posthog_code_usage")
+    def test_resume_in_cloud_over_limit_returns_429(self, mock_gate):
+        mock_gate.return_value = self.OVER_LIMIT
+        task = self.create_task()
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            environment=TaskRun.Environment.LOCAL,
+            status=TaskRun.Status.COMPLETED,
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/resume_in_cloud/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(response.json()["code"], "usage_limit_exceeded")
+
+    @parameterized.expand(
+        [
+            ("fail_open", None),
+            ("under_limit", CodeUsageStatus(is_rate_limited=False, limit_type=None, reset_at=None, is_pro=False)),
+        ]
+    )
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    @patch("products.tasks.backend.services.code_usage_gate.get_posthog_code_usage")
+    def test_run_proceeds_when_not_blocked(self, _name, gate_return, mock_gate, mock_workflow):
+        mock_gate.return_value = gate_return
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"mode": "background"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_gate.assert_called_once()
+        self.assertTrue(TaskRun.objects.filter(task=task).exists())
+        mock_workflow.assert_called_once()
+
+
+class TestGetPosthogCodeUsage(TestCase):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("products.tasks.backend.services.code_usage_gate.requests.get")
+    @patch("products.tasks.backend.services.code_usage_gate.create_oauth_access_token_for_user")
+    def test_parses_rate_limited_usage(self, mock_token, mock_get):
+        mock_token.return_value = "tok"
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "is_rate_limited": True,
+                "burst": {"exceeded": True, "reset_at": "2026-06-09T00:00:00Z"},
+                "sustained": {"exceeded": False, "reset_at": "2026-07-01T00:00:00Z"},
+                "is_pro": True,
+            },
+        )
+
+        usage = get_posthog_code_usage(MagicMock(), 1)
+
+        assert usage is not None
+        self.assertTrue(usage.is_rate_limited)
+        self.assertEqual(usage.limit_type, "burst")
+        self.assertEqual(usage.reset_at, "2026-06-09T00:00:00Z")
+        self.assertTrue(usage.is_pro)
+        self.assertEqual(mock_get.call_args.args[0], "https://gateway.us.posthog.com/v1/usage/posthog_code")
+
+    @override_settings(DEBUG=True, CLOUD_DEPLOYMENT=None)
+    def test_local_uses_localhost_gateway(self):
+        self.assertEqual(_gateway_usage_url(), "http://localhost:3308/v1/usage/posthog_code")
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("products.tasks.backend.services.code_usage_gate.OAuthAccessToken")
+    @patch("products.tasks.backend.services.code_usage_gate.requests.get")
+    @patch("products.tasks.backend.services.code_usage_gate.create_oauth_access_token_for_user")
+    def test_token_cleanup_error_does_not_break_fail_open(self, mock_token, mock_get, mock_oauth_model):
+        mock_token.return_value = "tok"
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "is_rate_limited": True,
+                "burst": {"exceeded": True, "reset_at": "2026-06-09T00:00:00Z"},
+                "sustained": {"exceeded": False, "reset_at": "2026-07-01T00:00:00Z"},
+                "is_pro": False,
+            },
+        )
+        mock_oauth_model.objects.filter.return_value.delete.side_effect = Exception("db down")
+
+        usage = get_posthog_code_usage(MagicMock(), 1)
+
+        assert usage is not None
+        self.assertTrue(usage.is_rate_limited)
+
+    @parameterized.expand(
+        [
+            ("non_200", 500, None),
+            ("network_error", None, None),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("products.tasks.backend.services.code_usage_gate.requests.get")
+    @patch("products.tasks.backend.services.code_usage_gate.create_oauth_access_token_for_user")
+    def test_fails_open_on_gateway_error(self, _name, status_code, _unused, mock_token, mock_get):
+        mock_token.return_value = "tok"
+        if status_code is None:
+            mock_get.side_effect = requests.RequestException("boom")
+        else:
+            mock_get.return_value = MagicMock(status_code=status_code)
+
+        self.assertIsNone(get_posthog_code_usage(MagicMock(), 1))
+
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="DEV")
+    @patch("products.tasks.backend.services.code_usage_gate.create_oauth_access_token_for_user")
+    def test_fails_open_when_no_gateway_url(self, mock_token):
+        self.assertIsNone(get_posthog_code_usage(MagicMock(), 1))
+        mock_token.assert_not_called()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -12,6 +12,17 @@ export interface CodeInviteRedeemRequestApi {
     code: string
 }
 
+/**
+ * * `burst` - burst
+ * `sustained` - sustained
+ */
+export type LimitTypeEnumApi = (typeof LimitTypeEnumApi)[keyof typeof LimitTypeEnumApi]
+
+export const LimitTypeEnumApi = {
+    Burst: 'burst',
+    Sustained: 'sustained',
+} as const
+
 export interface TaskRunErrorResponseApi {
     /** Human-readable validation error */
     detail?: string
@@ -25,6 +36,15 @@ export interface TaskRunErrorResponseApi {
     attr?: string
     /** Artifact ids that could not be resolved for the run */
     missing_artifact_ids?: string[]
+    /** Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)
+
+  * `burst` - burst
+  * `sustained` - sustained */
+    limit_type?: LimitTypeEnumApi
+    /** ISO 8601 timestamp when the hit usage limit resets, when known */
+    reset_at?: string
+    /** Whether the team is on a Pro plan (drives the upgrade-prompt copy) */
+    is_pro?: boolean
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21703,6 +21703,18 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `burst` - burst
+    * `sustained` - sustained
+     */
+    export type LimitTypeEnum = typeof LimitTypeEnum[keyof typeof LimitTypeEnum];
+
+
+    export const LimitTypeEnum = {
+      Burst: 'burst',
+      Sustained: 'sustained',
+    } as const;
+
+    /**
      * Typed output for view set `list`.
      */
     export interface ListOutput {
@@ -40097,6 +40109,15 @@ export namespace Schemas {
       attr?: string;
       /** Artifact ids that could not be resolved for the run */
       missing_artifact_ids?: string[];
+      /** Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)
+
+      * `burst` - burst
+      * `sustained` - sustained */
+      limit_type?: LimitTypeEnum;
+      /** ISO 8601 timestamp when the hit usage limit resets, when known */
+      reset_at?: string;
+      /** Whether the team is on a Pro plan (drives the upgrade-prompt copy) */
+      is_pro?: boolean;
     }
 
     export interface TaskRunRelayMessageRequest {


### PR DESCRIPTION
## Problem

When a team is over its PostHog Code usage limit, creating a cloud task previously let the run start and then fail on its first model call with a raw rate-limit error. There was no signal at creation time for clients to react to, so users hit a confusing error instead of a path forward (upgrade).

This adds a pre-creation check so clients can show an upgrade prompt and no run is created when over limit
