### PR TITLE
chore(ci): nudge humans to self-assign on bot PRs

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -131,6 +131,54 @@ jobs:
                           assignees: [process.env.PR_AUTHOR],
                       });
 
+            # Bot PRs can't be auto-assigned to a human (the step above skips bots),
+            # so for our known automation accounts drop a one-time comment asking the
+            # human behind it to self-assign for clear ownership. Only when nobody is
+            # assigned yet. Default GITHUB_TOKEN is enough to comment; never fail the
+            # PR over it.
+            - name: Nudge human to self-assign on bot PRs
+              if: >-
+                  github.event.pull_request.assignees[0] == null && (
+                      github.event.pull_request.user.login == 'posthog' ||
+                      github.event.pull_request.user.login == 'posthog-bot' ||
+                      contains(github.event.pull_request.user.login, 'mendral-app')
+                  )
+              continue-on-error: true
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  BOT_LOGIN: ${{ github.event.pull_request.user.login }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              with:
+                  script: |
+                      const prNumber = parseInt(process.env.PR_NUMBER, 10);
+                      const marker = '<!-- bot-pr-assign-nudge -->';
+
+                      // Post at most once per PR.
+                      const existing = await github.paginate(github.rest.issues.listComments, {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                          per_page: 100,
+                      });
+                      if (existing.some((comment) => comment.body?.includes(marker))) {
+                          console.log('Bot-PR nudge already posted — skipping.');
+                          return;
+                      }
+
+                      const body = [
+                          marker,
+                          `👋 This PR was opened by an automated account (\`${process.env.BOT_LOGIN}\`), so it has no human owner assigned.`,
+                          '',
+                          "If you're the person behind it, please **assign yourself** (Assignees, in the right sidebar) so ownership is clear.",
+                      ].join('\n');
+
+                      await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                          body,
+                      });
+
             - name: Nudge if commits use a non-PostHog email
               if: steps.membership.outputs.is-member == 'true'
               # A non-critical nudge must never turn the PR red on a transient API error.

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -153,6 +153,21 @@ jobs:
                       const prNumber = parseInt(process.env.PR_NUMBER, 10);
                       const marker = '<!-- bot-pr-assign-nudge -->';
 
+                      // Skip automated dependency/version bump PRs — there's no human
+                      // "behind" them to claim ownership, so the nudge would be noise.
+                      const pr = context.payload.pull_request;
+                      const title = pr.title || '';
+                      const labels = (pr.labels || []).map((l) => l.name.toLowerCase());
+                      const isDependencyBump =
+                          labels.includes('dependencies') ||
+                          /^\s*(chore|build|fix)\(deps/i.test(title) ||
+                          /^\s*deps[(:]/i.test(title) ||
+                          /^\s*bump\s/i.test(title);
+                      if (isDependencyBump) {
+                          console.log('Dependency/bump PR — skipping self-assign nudge.');
+                          return;
+                      }
+
                       // Post at most once per PR.
                       const existing = await github.paginate(github.rest.issues.listComments, {
                           owner: context.repo.owner,


### PR DESCRIPTION
## Problem

When PRs are opened by automation accounts (like `posthog`, `posthog-bot`, or Mendrel), they can't be auto-assigned to a human reviewer since the bot account itself isn't a team member. This leaves PRs without clear ownership, making it unclear who is responsible for the changes.

## Changes

Added a new GitHub Actions workflow step that posts a one-time comment on bot-opened PRs asking the human behind the automation to self-assign for clear ownership. The step:

- Only runs when no assignee is already set
- Targets known automation accounts (`posthog`, `posthog-bot`, and accounts containing `mendral-app`)
- Skips dependency/version bump PRs (which have no human "behind" them) by checking for `dependencies` label or common dependency bump patterns in the title
- Uses a marker comment to ensure the nudge is posted at most once per PR
- Continues on error to avoid failing the workflow over a transient API issue

## How did you test this code?

This is a CI workflow configuration change. The logic is straightforward:
- Conditional checks on PR metadata (assignees, user login, labels, title patterns)
- GitHub API calls to list and create comments (standard operations)
- No new dependencies or complex logic

The workflow will be validated by GitHub Actions when PRs are opened by the targeted automation accounts.

## 🤖 Agent context

This change was generated based on a code diff showing the addition of a new workflow step to `.github/workflows/pr-opened.yml`. The implementation follows existing patterns in the workflow (using `actions/github-script`, environment variables, and `continue-on-error` for non-critical steps) and includes safeguards to avoid noise on automated dependency updates.

https://claude.ai/code/session_01A7XexgSMVdTM9WvUXcA4dj