### PR TITLE
feat(pulse): add anomaly sources: change detection and signals scout

### DIFF
--- a/docs/superpowers/plans/2026-06-09-pulse-v2-sensemaking-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-pulse-v2-sensemaking-implementation.md
@@ -1,0 +1,790 @@
+# Pulse v2: Sense-making on scout anomalies — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Pulse consume the Signals anomaly-detection scout's findings (behind a pluggable `AnomalySource` interface, scout-only in v1) instead of running its own detection, then run Pulse's existing causal-enrichment + Max handoff on top.
+
+**Architecture:** Introduce `AnomalySource.get_findings(...) -> list[Finding]` at the `Finding` boundary in `products/pulse/backend/temporal/workflow.py`, replacing `select_candidate_metrics_activity → detect_changes_activity`. The one v1 implementation, `ScoutAnomalySource`, calls a new `get_team_anomalies` read method on the Signals facade (reads raw anomaly signals from ClickHouse `document_embeddings`), then adapts each into a `Finding` by best-effort-extracting the flagged insight `short_id` from `evidence[].entity_id`, loading the insight, and re-scoring it (numbers only, no re-gate). Everything downstream of `Finding` (enrich/narrative/synthesis/Max) is unchanged.
+
+**Tech Stack:** Django, Temporal (pydantic activities), HogQL/ClickHouse (`execute_hogql_query_with_retry`), `products/signals` facade, pulse `detection.py`/`types.py`, kea + Max side panel (Phase 2).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-pulse-sensemaking-on-scout-anomalies-design.md`
+
+**Stacking note:** this branch (`vdekrijger-pulse-v2-sensemaking`) is off the round-1 extraction stack tip (`vdekrijger-pulse-frontend`), because `products/pulse` only exists there, not on master. Rebase onto master once round-1 (#62116–62120) merges. Phase 1 = backend source-swap (PR1); Phase 2 = proactive surfacing (PR2).
+
+**Verify commands** (this repo): backend `flox activate -- bash -c "python -m pytest <path> -q --no-header -p no:cacheprovider --reuse-db"`; ruff `flox activate -- bash -c "ruff check <path> && ruff format <path>"`; FE jest `flox activate -- bash -c "pnpm --filter=@posthog/frontend exec jest <path>"`.
+
+---
+
+## File Structure
+
+**Phase 1 (PR1 — backend source-swap):**
+- Modify `products/pulse/backend/temporal/detection.py` — extract `score_series()` + `_build_finding()` (no-gate scoring), keep `_evaluate_candidate` gating.
+- Create `products/pulse/backend/temporal/sources.py` — `AnomalySource` protocol + `ScoutAnomalySource` + the scout-signal→`Finding` adapter.
+- Modify `products/pulse/backend/temporal/types.py` — add `FetchScoutFindingsInputs`; `AnomalyFinding` DTO lives in the signals facade contract (imported), `Finding` reused.
+- Modify `products/pulse/backend/temporal/metrics.py` — add `increment_scout_anomaly_outcome()` counter (resolved / unresolvable_insight / no_series).
+- Modify `products/pulse/backend/temporal/workflow.py` — replace `select_candidate_metrics_activity`+`detect_changes_activity` calls with one `fetch_scout_findings_activity`.
+- Modify `products/pulse/backend/temporal/__init__.py` + `posthog/temporal/ai/__init__.py` — register `fetch_scout_findings_activity`, drop the two removed activities from registration.
+- Create `products/signals/backend/facade/api.py` addition — `get_team_anomalies()` read method (+ `AnomalyFinding` DTO in `products/signals/backend/facade/contracts.py` or inline dataclass).
+- Create `products/signals/backend/temporal/signal_queries.py` addition — `fetch_team_anomaly_signals()` ClickHouse read (or co-locate in facade if no Temporal-activity wrapper needed).
+- Tests: `products/pulse/backend/tests/temporal/test_sources.py`, `test_pulse_detectors.py` (score_series), `test_pulse_workflow.py` (scout-source path); `products/signals/backend/tests/test_get_team_anomalies.py`.
+
+**Phase 2 (PR2 — proactive surfacing, frontend):**
+- Modify `frontend/src/scenes/max/maxContextLogic.ts` — accept a `PulseFindingContext` (full `EnrichedFinding`) alongside the insight context.
+- Modify `products/pulse/frontend/Pulse.tsx` + `products/pulse/frontend/utils.ts` — pass full finding context to Max; proactive `suggestedNextStep`; one-click "make this insight" (Max `create_insight`).
+- Tests: `products/pulse/frontend/utils.test.ts`, `pulseLogic.test.ts`.
+
+---
+
+## Phase 1 — PR1: Backend source-swap
+
+### Task 1: Extract no-gate scoring in detection.py
+
+**Files:**
+- Modify: `products/pulse/backend/temporal/detection.py`
+- Test: `products/pulse/backend/tests/temporal/test_pulse_detectors.py`
+
+- [ ] **Step 1: Write the failing test** (append to `test_pulse_detectors.py`)
+
+```python
+class TestScoreSeries:
+    def test_scores_without_gating(self):
+        # A change BELOW min_change_pct: _evaluate_candidate would drop it (gate),
+        # but score_series must still return the computed numbers (no gate).
+        from products.pulse.backend.temporal.detection import score_series
+
+        config = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+        # 4 baseline weeks ~100, current ~105 (+5%, below the 25% gate), + a trailing partial week
+        scored = score_series([100.0, 101.0, 99.0, 100.0, 105.0, 0.0], config)
+        assert scored is not None
+        result, current, series = scored
+        assert current == 105.0
+        assert result.triggered is False  # below gate, but still returned
+        assert round(result.change_pct, 3) == 0.05
+        assert len(series) == config.baseline_weeks + 1
+
+    def test_returns_none_on_insufficient_data(self):
+        from products.pulse.backend.temporal.detection import score_series
+
+        config = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+        assert score_series([1.0, 2.0], config) is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_pulse_detectors.py::TestScoreSeries -q --no-header -p no:cacheprovider"`
+Expected: FAIL — `ImportError: cannot import name 'score_series'`.
+
+- [ ] **Step 3: Refactor `_evaluate_candidate` to use the extracted helpers**
+
+In `detection.py`, replace the body of `_evaluate_candidate` and add the two helpers above it:
+
+```python
+def score_series(
+    weekly_values: list[float], config: PulseScanConfig, detection_mode: str = "change_v1"
+) -> tuple[DetectionResult, float, list[float]] | None:
+    """Compute the change-detection result for a weekly series WITHOUT applying the trigger gate.
+
+    Returns (result, current_value, sparkline_series) or None when there's too little data. Callers
+    that want the detection gate check `result.triggered`; callers that already know the metric is
+    anomalous (the scout source) ignore it and use the numbers for display.
+    """
+    assert config.baseline_weeks is not None
+    assert config.min_change_pct is not None
+    assert config.robust_z_threshold is not None
+    assert config.min_baseline_value is not None
+    if len(weekly_values) < MIN_BASELINE_WEEKS + 2:
+        return None
+    completed = weekly_values[:-1]  # drop the in-progress (partial) week
+    current = completed[-1]
+    baseline = completed[:-1][-config.baseline_weeks :]
+    if len(baseline) < MIN_BASELINE_WEEKS:
+        return None
+    result = get_detector(detection_mode).detect(
+        current, baseline, config.min_change_pct, config.robust_z_threshold, config.min_baseline_value
+    )
+    series = [float(v) for v in completed[-(config.baseline_weeks + 1) :]]
+    return result, current, series
+
+
+def _build_finding(descriptor: MetricDescriptor, result: DetectionResult, current: float, series: list[float]) -> Finding:
+    return Finding(
+        descriptor=descriptor,
+        current_value=current,
+        baseline_value=result.baseline_median,
+        change_pct=result.change_pct,
+        impact=result.impact,
+        robust_z=result.robust_z,
+        series=series,
+    )
+```
+
+Then rewrite `_evaluate_candidate`:
+
+```python
+def _evaluate_candidate(
+    candidate: CandidateMetric,
+    weekly_values: list[float],
+    config: PulseScanConfig,
+    detection_mode: str = "change_v1",
+) -> Finding | None:
+    scored = score_series(weekly_values, config, detection_mode)
+    if scored is None:
+        return None
+    result, current, series = scored
+    if not result.triggered:
+        return None
+    return _build_finding(candidate.descriptor, result, current, series)
+```
+
+Add `MetricDescriptor` to the existing `from products.pulse.backend.temporal.types import ...` import if not already present.
+
+- [ ] **Step 4: Run to verify it passes** (new test + the existing detector suite, to prove the refactor is behavior-preserving)
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_pulse_detectors.py -q --no-header -p no:cacheprovider"`
+Expected: PASS (all existing tests + `TestScoreSeries`).
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+flox activate -- bash -c "ruff check --fix products/pulse/backend/temporal/detection.py products/pulse/backend/tests/temporal/test_pulse_detectors.py && ruff format products/pulse/backend/temporal/detection.py products/pulse/backend/tests/temporal/test_pulse_detectors.py"
+git add products/pulse/backend/temporal/detection.py products/pulse/backend/tests/temporal/test_pulse_detectors.py
+git commit -m "refactor(pulse): extract no-gate score_series from _evaluate_candidate"
+```
+
+---
+
+### Task 2: `get_team_anomalies` read method on the Signals facade
+
+**Files:**
+- Modify: `products/signals/backend/facade/api.py` (add `get_team_anomalies` + `AnomalyFinding` dataclass)
+- Modify: `products/signals/backend/temporal/signal_queries.py` (add `fetch_team_anomaly_signal_rows`)
+- Test: `products/signals/backend/tests/test_get_team_anomalies.py`
+
+**Contract recap (verified):** raw signals live in ClickHouse `document_embeddings` (`product='signals'`, `document_type='signal'`), deduped by `argMax(metadata, inserted_at) GROUP BY document_id`. `metadata` is a JSON string with `source_product`, `source_type`, `weight`, `deleted`, and `extra` (a `SignalsScoutSignalExtra`: `skill_name`, `confidence`, `evidence: [{source_product, summary, entity_id?}]`, `hypothesis?`, `severity?`, `time_range? {date_from,date_to}`, `finding_id`, `scout_run_id`). Scope = `source_product='signals_scout' AND source_type='cross_source_issue'` (ClickHouse) then `extra.skill_name == 'signals-scout-anomaly-detection'` (Python). The flagged insight `short_id` is best-effort: the `entity_id` of the `evidence` entry whose `source_product == 'query_runs'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# products/signals/backend/tests/test_get_team_anomalies.py
+import json
+from unittest.mock import patch
+
+from posthog.test.base import BaseTest
+
+from products.signals.backend.facade.api import AnomalyFinding, get_team_anomalies
+
+ANOMALY_SKILL = "signals-scout-anomaly-detection"
+
+
+def _signal_row(skill_name=ANOMALY_SKILL, short_id="abc123", with_short_id=True):
+    evidence = [{"source_product": "query_runs", "summary": "spike", **({"entity_id": short_id} if with_short_id else {})}]
+    metadata = {
+        "source_product": "signals_scout",
+        "source_type": "cross_source_issue",
+        "weight": 0.86,
+        "deleted": False,
+        "extra": {
+            "skill_name": skill_name,
+            "skill_version": 1.0,
+            "confidence": 0.9,
+            "finding_id": "f1",
+            "scout_run_id": "r1",
+            "task_run_id": "t1",
+            "evidence": evidence,
+            "hypothesis": "Likely a deploy regression.",
+            "severity": "P1",
+            "time_range": {"date_from": "2026-06-01T00:00:00Z", "date_to": "2026-06-08T00:00:00Z"},
+        },
+    }
+    return ("doc-1", "Signups dropped 60%.", json.dumps(metadata), "2026-06-07T00:00:00Z")
+
+
+class TestGetTeamAnomalies(BaseTest):
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows")
+    def test_parses_and_scopes_to_anomaly_scout(self, mock_rows):
+        mock_rows.return_value = [
+            _signal_row(),
+            _signal_row(skill_name="signals-scout-logs"),  # other scout — must be filtered out
+        ]
+        out = get_team_anomalies(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert len(out) == 1
+        a = out[0]
+        assert isinstance(a, AnomalyFinding)
+        assert a.insight_short_id == "abc123"
+        assert a.weight == 0.86
+        assert a.hypothesis == "Likely a deploy regression."
+        assert a.severity == "P1"
+        assert a.time_range == ("2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows")
+    def test_short_id_none_when_no_query_runs_evidence(self, mock_rows):
+        mock_rows.return_value = [_signal_row(with_short_id=False)]
+        out = get_team_anomalies(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert len(out) == 1
+        assert out[0].insight_short_id is None  # adapter will count + skip these
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flox activate -- bash -c "python -m pytest products/signals/backend/tests/test_get_team_anomalies.py -q --no-header -p no:cacheprovider"`
+Expected: FAIL — `ImportError: cannot import name 'AnomalyFinding'`.
+
+- [ ] **Step 3: Add the ClickHouse read** in `signal_queries.py`
+
+Mirror the existing deduped-read helpers. Add:
+
+```python
+def fetch_team_anomaly_signal_rows(team: "Team", date_from: str, date_to: str) -> list[tuple]:
+    """Raw scout signals for a team in [date_from, date_to], deduped, not deleted.
+
+    Scoped to source_product='signals_scout'; skill-level scoping (anomaly-detection only) is applied
+    by the caller against the parsed `extra.skill_name`. Returns (document_id, content, metadata_json, timestamp).
+    """
+    query = f"""
+        SELECT document_id, content, metadata, timestamp
+        FROM ({_deduped_signals_subquery(extra_where="team_id = {team_id} AND timestamp >= {date_from} AND timestamp <= {date_to}")})
+        WHERE JSONExtractString(metadata, 'source_product') = 'signals_scout'
+          AND JSONExtractString(metadata, 'source_type') = 'cross_source_issue'
+          AND NOT JSONExtractBool(metadata, 'deleted')
+        ORDER BY timestamp ASC
+    """
+    result = execute_hogql_query_with_retry(
+        query_type="SignalsFetchTeamAnomalies",
+        query=query,
+        team=team,
+        placeholders={
+            "team_id": ast.Constant(value=team.id),
+            "date_from": ast.Constant(value=date_from),
+            "date_to": ast.Constant(value=date_to),
+        },
+    )
+    return list(result.results or [])
+```
+
+> NOTE for implementer: confirm the exact name/signature of `_deduped_signals_subquery` and the `model_name` placeholder requirement by reading `signal_queries.py:44-66` — the existing read helpers show whether `model_name` must be passed. Match them verbatim; adjust the subquery call to the real helper name.
+
+- [ ] **Step 4: Add `AnomalyFinding` + `get_team_anomalies`** in `facade/api.py`
+
+```python
+from dataclasses import dataclass
+
+from products.signals.backend.temporal.signal_queries import fetch_team_anomaly_signal_rows
+
+ANOMALY_DETECTION_SKILL = "signals-scout-anomaly-detection"
+
+
+@dataclass(frozen=True)
+class AnomalyFinding:
+    """A single anomaly the scout surfaced, flattened for cross-product (Pulse) consumption.
+
+    insight_short_id is best-effort: the scout is instructed (emit-contract) to put it in the
+    evidence entry whose source_product == 'query_runs', but the field is LLM-authored and optional,
+    so it can be None — the consumer counts + skips those.
+    """
+
+    insight_short_id: str | None
+    weight: float
+    confidence: float
+    hypothesis: str | None
+    severity: str | None
+    description: str
+    time_range: tuple[str, str] | None
+    finding_id: str
+    scout_run_id: str
+
+
+def _short_id_from_evidence(evidence: list[dict]) -> str | None:
+    for entry in evidence:
+        if entry.get("source_product") == "query_runs" and entry.get("entity_id"):
+            return str(entry["entity_id"])
+    return None
+
+
+def get_team_anomalies(team: "Team", period_start: str, period_end: str) -> list[AnomalyFinding]:
+    """The team's anomaly-detection scout findings in [period_start, period_end].
+
+    Reads raw signals from ClickHouse (NOT grouped reports), scopes to the anomaly-detection scout,
+    and flattens each into an AnomalyFinding. Returns [] when the org hasn't approved AI data
+    processing (mirrors emit_signal's gate)."""
+    organization = team.organization
+    if not organization.is_ai_data_processing_approved:
+        return []
+
+    rows = fetch_team_anomaly_signal_rows(team, period_start, period_end)
+    out: list[AnomalyFinding] = []
+    for _document_id, content, metadata_json, _timestamp in rows:
+        metadata = json.loads(metadata_json) if isinstance(metadata_json, str) else metadata_json
+        extra = metadata.get("extra") or {}
+        if extra.get("skill_name") != ANOMALY_DETECTION_SKILL:
+            continue
+        time_range = extra.get("time_range")
+        out.append(
+            AnomalyFinding(
+                insight_short_id=_short_id_from_evidence(extra.get("evidence") or []),
+                weight=float(metadata.get("weight") or 0.0),
+                confidence=float(extra.get("confidence") or 0.0),
+                hypothesis=extra.get("hypothesis"),
+                severity=extra.get("severity"),
+                description=content or "",
+                time_range=(time_range["date_from"], time_range["date_to"]) if time_range else None,
+                finding_id=extra.get("finding_id") or "",
+                scout_run_id=extra.get("scout_run_id") or "",
+            )
+        )
+    return out
+```
+
+Add `import json` at module top if absent.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `flox activate -- bash -c "python -m pytest products/signals/backend/tests/test_get_team_anomalies.py -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: ruff + tach + commit**
+
+```bash
+flox activate -- bash -c "ruff check --fix products/signals/backend/facade/api.py products/signals/backend/temporal/signal_queries.py products/signals/backend/tests/test_get_team_anomalies.py && ruff format products/signals/backend/facade/api.py products/signals/backend/temporal/signal_queries.py products/signals/backend/tests/test_get_team_anomalies.py && tach check"
+git add products/signals/backend/facade/api.py products/signals/backend/temporal/signal_queries.py products/signals/backend/tests/test_get_team_anomalies.py
+git commit -m "feat(signals): add get_team_anomalies facade read for cross-product consumption"
+```
+
+---
+
+### Task 3: Scout-anomaly → `Finding` adapter
+
+**Files:**
+- Create: `products/pulse/backend/temporal/sources.py`
+- Modify: `products/pulse/backend/temporal/metrics.py` (counter)
+- Test: `products/pulse/backend/tests/temporal/test_sources.py`
+
+- [ ] **Step 1: Add the counter** in `metrics.py` (mirror existing `increment_detection_outcome`)
+
+```python
+def increment_scout_anomaly_outcome(outcome: str, *, count: int = 1) -> None:
+    """Per-anomaly adapter outcomes: resolved / unresolvable_insight / no_series.
+
+    `unresolvable_insight` measures how often the scout's best-effort short_id is missing or doesn't
+    load — the signal that the scout emit contract should be hardened (spec D5/O-followup)."""
+    meter = _meter({"outcome": outcome})
+    if meter is None:
+        return
+    meter.create_counter("pulse_scout_anomaly_outcome", "Pulse scout-anomaly adapter outcomes").add(count)
+```
+
+- [ ] **Step 2: Write the failing test** for the adapter
+
+```python
+# products/pulse/backend/tests/temporal/test_sources.py
+import pytest
+from unittest.mock import patch
+
+from posthog.test.base import BaseTest
+from posthog.schema import PulseScanConfig
+
+from products.pulse.backend.temporal.sources import _adapt_anomaly_to_finding
+from products.signals.backend.facade.api import AnomalyFinding
+
+SOURCES = "products.pulse.backend.temporal.sources"
+RESOLVED_CONFIG = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+
+
+def _anomaly(short_id="abc123"):
+    return AnomalyFinding(
+        insight_short_id=short_id, weight=0.86, confidence=0.9, hypothesis="deploy regression",
+        severity="P1", description="Signups dropped.", time_range=("2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z"),
+        finding_id="f1", scout_run_id="r1",
+    )
+
+
+class TestAdaptAnomalyToFinding(BaseTest):
+    @pytest.mark.asyncio
+    async def test_none_when_no_short_id(self):
+        with patch(f"{SOURCES}.increment_scout_anomaly_outcome") as counter:
+            result = await _adapt_anomaly_to_finding(self.team, _anomaly(short_id=None), RESOLVED_CONFIG)
+        assert result is None
+        counter.assert_called_once_with("unresolvable_insight")
+
+    @pytest.mark.asyncio
+    async def test_none_when_insight_missing(self):
+        with patch(f"{SOURCES}.increment_scout_anomaly_outcome") as counter:
+            result = await _adapt_anomaly_to_finding(self.team, _anomaly(short_id="missing"), RESOLVED_CONFIG)
+        assert result is None
+        counter.assert_called_once_with("unresolvable_insight")
+
+    @pytest.mark.asyncio
+    async def test_builds_finding_without_regating(self):
+        # Insight whose weekly series moves only +5% (below the 25% gate) must STILL yield a Finding
+        # (the scout already decided it's anomalous; Pulse re-scores for display only).
+        from products.product_analytics.backend.models.insight import Insight
+        from posthog.models.scoping import team_scope
+
+        with team_scope(self.team.id):
+            insight = Insight.objects.create(
+                team=self.team, name="Signups",
+                query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "signup", "math": "total"}]},
+            )
+        with (
+            patch(f"{SOURCES}.run_trends_query_sync", return_value={"results": [{"data": [100.0, 101.0, 99.0, 100.0, 105.0, 0.0]}]}),
+            patch(f"{SOURCES}.increment_scout_anomaly_outcome") as counter,
+        ):
+            result = await _adapt_anomaly_to_finding(self.team, _anomaly(short_id=insight.short_id), RESOLVED_CONFIG)
+        assert result is not None
+        assert result.descriptor.source == "scout_anomaly"
+        assert result.current_value == 105.0
+        assert round(result.change_pct, 3) == 0.05  # below gate, but produced anyway
+        counter.assert_called_once_with("resolved")
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_sources.py -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: FAIL — `ModuleNotFoundError: products.pulse.backend.temporal.sources`.
+
+- [ ] **Step 4: Implement the adapter** in `sources.py`
+
+```python
+"""Anomaly sources for Pulse: where the findings to enrich come from.
+
+v1 ships exactly one source — ScoutAnomalySource — which consumes the Signals anomaly-detection
+scout (behind the AnomalySource protocol so a deterministic source can be added later without
+touching anything downstream of Finding).
+"""
+
+from typing import Protocol
+
+import structlog
+
+from posthog.schema import PulseScanConfig
+
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+
+from products.pulse.backend.temporal.detection import _build_finding, score_series
+from products.pulse.backend.temporal.metrics import increment_scout_anomaly_outcome
+from products.pulse.backend.temporal.types import CandidateMetric, Finding, MetricDescriptor, run_trends_query_sync
+
+logger = structlog.get_logger(__name__)
+
+
+class AnomalySource(Protocol):
+    async def get_findings(self, team_id: int, period_start: str, period_end: str, config: PulseScanConfig) -> list[Finding]:
+        ...
+
+
+def _to_trends_query(query: object) -> dict | None:
+    """Unwrap an insight's query down to a TrendsQuery dict, or None if it isn't one."""
+    while isinstance(query, dict) and query.get("source"):
+        query = query["source"]
+    if isinstance(query, dict) and query.get("kind") == "TrendsQuery":
+        return query
+    return None
+
+
+async def _adapt_anomaly_to_finding(team: Team, anomaly: "AnomalyFinding", config: PulseScanConfig) -> Finding | None:
+    """Best-effort: load the scout-flagged insight by short_id and re-score it for display numbers.
+
+    Does NOT re-gate — the scout already decided this is anomalous, so we always build a Finding when
+    the insight + series resolve. Increments a counter so the unresolvable rate is measurable."""
+    # Lazy import: pulse is eagerly preloaded via posthog.api; importing product_analytics models at
+    # module scope risks an app-init import cycle (matches selection.py / delivery.py).
+    from products.product_analytics.backend.models.insight import Insight  # noqa: PLC0415
+
+    if not anomaly.insight_short_id:
+        increment_scout_anomaly_outcome("unresolvable_insight")
+        return None
+
+    @database_sync_to_async
+    def _load() -> "Insight | None":
+        return Insight.objects.filter(team=team, short_id=anomaly.insight_short_id, deleted=False).first()
+
+    insight = await _load()
+    query = _to_trends_query(insight.query) if insight else None
+    if insight is None or query is None:
+        increment_scout_anomaly_outcome("unresolvable_insight")
+        logger.warning("pulse_scout_anomaly_unresolvable", team_id=team.id, short_id=anomaly.insight_short_id)
+        return None
+
+    # detection._build_detection_query mutates dateRange/interval and strips breakdowns.
+    from products.pulse.backend.temporal.detection import _build_detection_query, _extract_weekly_series  # noqa: PLC0415
+
+    assert config.baseline_weeks is not None
+    try:
+        result = await run_trends_query_sync(team, _build_detection_query(query, config.baseline_weeks))
+    except Exception as exc:
+        increment_scout_anomaly_outcome("no_series")
+        logger.warning("pulse_scout_anomaly_query_failed", team_id=team.id, short_id=anomaly.insight_short_id, error=str(exc))
+        return None
+
+    series = _extract_weekly_series(result)
+    scored = score_series(series, config)
+    if scored is None:
+        increment_scout_anomaly_outcome("no_series")
+        return None
+
+    detection_result, current, sparkline = scored
+    descriptor = MetricDescriptor(
+        source="scout_anomaly",
+        source_id=insight.id,
+        label=insight.name or insight.derived_name or f"Insight {insight.short_id}",
+        query=query,
+        url=f"/insights/{insight.short_id}",
+    )
+    increment_scout_anomaly_outcome("resolved")
+    # Build unconditionally — trust the scout's anomaly decision; re-score only for the numbers.
+    return _build_finding(descriptor, detection_result, current, sparkline)
+```
+
+(`AnomalyFinding` is type-only here; add `from products.signals.backend.facade.api import AnomalyFinding` under `TYPE_CHECKING` to avoid an import cycle, and quote the annotation as `"AnomalyFinding"`.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_sources.py -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: ruff + commit**
+
+```bash
+flox activate -- bash -c "ruff check --fix products/pulse/backend/temporal/sources.py products/pulse/backend/temporal/metrics.py products/pulse/backend/tests/temporal/test_sources.py && ruff format products/pulse/backend/temporal/sources.py products/pulse/backend/temporal/metrics.py products/pulse/backend/tests/temporal/test_sources.py"
+git add products/pulse/backend/temporal/sources.py products/pulse/backend/temporal/metrics.py products/pulse/backend/tests/temporal/test_sources.py
+git commit -m "feat(pulse): scout-anomaly to Finding adapter (best-effort short_id, no re-gate)"
+```
+
+---
+
+### Task 4: `ScoutAnomalySource` + `fetch_scout_findings_activity`
+
+**Files:**
+- Modify: `products/pulse/backend/temporal/sources.py` (add `ScoutAnomalySource`)
+- Modify: `products/pulse/backend/temporal/types.py` (add `FetchScoutFindingsInputs`)
+- Modify: `products/pulse/backend/temporal/workflow.py` (add `fetch_scout_findings_activity`)
+- Test: `products/pulse/backend/tests/temporal/test_sources.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestScoutAnomalySource(BaseTest):
+    @pytest.mark.asyncio
+    async def test_maps_anomalies_to_findings_dropping_unresolvable(self):
+        from products.pulse.backend.temporal.sources import ScoutAnomalySource
+
+        anomalies = [_anomaly(short_id="resolves"), _anomaly(short_id=None)]
+        with (
+            patch(f"{SOURCES}.get_team_anomalies", return_value=anomalies),
+            patch(f"{SOURCES}._adapt_anomaly_to_finding", side_effect=[object(), None]) as adapt,
+        ):
+            findings = await ScoutAnomalySource().get_findings(self.team.id, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z", RESOLVED_CONFIG)
+        assert len(findings) == 1  # the None (unresolvable) is dropped
+        assert adapt.call_count == 2
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_sources.py::TestScoutAnomalySource -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: FAIL — `ImportError: cannot import name 'ScoutAnomalySource'`.
+
+- [ ] **Step 3: Implement `ScoutAnomalySource`** in `sources.py`
+
+```python
+class ScoutAnomalySource:
+    """v1 AnomalySource: consume the Signals anomaly-detection scout's findings."""
+
+    async def get_findings(self, team_id: int, period_start: str, period_end: str, config: PulseScanConfig) -> list[Finding]:
+        from products.signals.backend.facade.api import get_team_anomalies  # noqa: PLC0415 — facade, avoid app-init cycle
+
+        @database_sync_to_async
+        def _fetch() -> tuple[Team, list]:
+            team = Team.objects.get(id=team_id)
+            return team, get_team_anomalies(team, period_start, period_end)
+
+        team, anomalies = await _fetch()
+        findings: list[Finding] = []
+        for anomaly in anomalies:
+            finding = await _adapt_anomaly_to_finding(team, anomaly, config)
+            if finding is not None:
+                findings.append(finding)
+        return findings
+```
+
+- [ ] **Step 4: Add the activity** in `workflow.py` and the input type in `types.py`
+
+`types.py`:
+
+```python
+class FetchScoutFindingsInputs(BaseModel):
+    team_id: int
+    period_start: str
+    period_end: str
+    config: PulseScanConfig = Field(default_factory=PulseScanConfig)
+```
+
+`workflow.py` (new activity near the other `@activity.defn`s):
+
+```python
+@activity.defn
+async def fetch_scout_findings_activity(inputs: FetchScoutFindingsInputs) -> list[Finding]:
+    """v1 anomaly source: consume the Signals anomaly-detection scout, adapt to Findings."""
+    return await ScoutAnomalySource().get_findings(
+        inputs.team_id, inputs.period_start, inputs.period_end, inputs.config
+    )
+```
+
+Add imports to `workflow.py`: `from products.pulse.backend.temporal.sources import ScoutAnomalySource` and `FetchScoutFindingsInputs` to the `types` import.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_sources.py -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: PASS.
+
+- [ ] **Step 6: ruff + commit**
+
+```bash
+flox activate -- bash -c "ruff check --fix products/pulse/backend/temporal/sources.py products/pulse/backend/temporal/types.py products/pulse/backend/temporal/workflow.py products/pulse/backend/tests/temporal/test_sources.py && ruff format products/pulse/backend/temporal/sources.py products/pulse/backend/temporal/types.py products/pulse/backend/temporal/workflow.py products/pulse/backend/tests/temporal/test_sources.py"
+git add products/pulse/backend/temporal/sources.py products/pulse/backend/temporal/types.py products/pulse/backend/temporal/workflow.py products/pulse/backend/tests/temporal/test_sources.py
+git commit -m "feat(pulse): ScoutAnomalySource + fetch_scout_findings_activity"
+```
+
+---
+
+### Task 5: Wire the source into the workflow (replace select+detect)
+
+**Files:**
+- Modify: `products/pulse/backend/temporal/workflow.py` (the `run` method)
+- Modify: `products/pulse/backend/temporal/__init__.py` + `posthog/temporal/ai/__init__.py` (registration)
+- Test: `products/pulse/backend/tests/temporal/test_pulse_workflow.py`
+
+- [ ] **Step 1: Update the workflow test's `_run_scan` helper** — replace the `select_candidate_metrics_activity` + `detect_changes_activity` mocks with one `fetch_scout_findings_activity` mock (returns `findings`). Mirror the existing helper exactly; the activity-name string is `"fetch_scout_findings_activity"`. Keep the no-findings, failure, and with-findings tests; they now drive findings through the new activity.
+
+```python
+    @activity.defn(name="fetch_scout_findings_activity")
+    async def m_fetch(inputs: object) -> list[Finding]:
+        if detect_raises:
+            raise RuntimeError("fetch boom")
+        return detected
+```
+
+Remove the `m_select` / `m_detect` stubs and drop them from the `activities=[...]` list; add `m_fetch`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_pulse_workflow.py -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: FAIL — the workflow still calls `select_candidate_metrics_activity`, which is no longer registered → activity-not-registered error.
+
+- [ ] **Step 3: Replace the select+detect block** in `workflow.py` `run`
+
+Replace the `select_candidate_metrics_activity` + `detect_changes_activity` calls (the block that produces `findings`) with:
+
+```python
+            findings = await workflow.execute_activity(
+                fetch_scout_findings_activity,
+                FetchScoutFindingsInputs(
+                    team_id=inputs.team_id,
+                    period_start=inputs.period_start,
+                    period_end=inputs.period_end,
+                    config=config,
+                ),
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=retry_policy,
+            )
+```
+
+Leave the `if not findings:` no-findings branch and everything after (enrich/persist/synthesize/notify/emit) unchanged.
+
+- [ ] **Step 4: Update activity registration**
+
+In `products/pulse/backend/temporal/__init__.py` and `posthog/temporal/ai/__init__.py`: add `fetch_scout_findings_activity`, remove `select_candidate_metrics_activity` and `detect_changes_activity` from the registered activity lists and `__all__`. (Leave `selection.py`/`detection.py` modules in place — they remain the future `DeterministicSource` impl + the adapter uses detection's scoring.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `flox activate -- bash -c "python -m pytest products/pulse/backend/tests/temporal/test_pulse_workflow.py -q --no-header -p no:cacheprovider --reuse-db"`
+Expected: PASS (no-findings → DELIVERED finding_count 0; failure → FAILED; with-findings → DELIVERED finding_count > 0).
+
+- [ ] **Step 6: ruff + commit**
+
+```bash
+flox activate -- bash -c "ruff check --fix products/pulse/backend/temporal/workflow.py products/pulse/backend/temporal/__init__.py posthog/temporal/ai/__init__.py products/pulse/backend/tests/temporal/test_pulse_workflow.py && ruff format products/pulse/backend/temporal/workflow.py products/pulse/backend/temporal/__init__.py posthog/temporal/ai/__init__.py products/pulse/backend/tests/temporal/test_pulse_workflow.py"
+git add products/pulse/backend/temporal/workflow.py products/pulse/backend/temporal/__init__.py posthog/temporal/ai/__init__.py products/pulse/backend/tests/temporal/test_pulse_workflow.py
+git commit -m "feat(pulse): drive scans from the scout anomaly source (v1)"
+```
+
+---
+
+### Task 6: Empty-state + sensitivity-config neutralization (D3) + full backend gauntlet
+
+**Files:**
+- Modify: `products/pulse/backend/api.py` (the `trigger_scan` config + the `current`/subscription surface — neutralize detection-tuning knobs that the scout now owns; keep the model)
+- Modify: `products/pulse/frontend/pulseLogic.ts` / `Pulse.tsx` empty state copy → "Enable the anomaly scout to get a Pulse digest" when the team has no scout enrollment / no anomalies
+- Test: `products/pulse/backend/tests/test_api.py`
+
+- [ ] **Step 1:** Decide D3 with the reviewer — for v1, hide the sensitivity/threshold inputs from the subscription UI (they no longer affect detection) but keep the model + serializer fields (no migration). Add a test asserting `trigger_scan`/subscription still works with the knobs ignored. (Full code depends on the D3 choice confirmed in review; if "keep as-is," this task is a no-op + a doc comment on `PulseScanConfig` noting the knobs are display-only in v1.)
+
+- [ ] **Step 2: Full backend gauntlet** (run before opening PR1)
+
+```bash
+flox activate -- bash -c "python -m pytest products/pulse/backend/tests/ products/signals/backend/tests/test_get_team_anomalies.py -q --no-header -p no:cacheprovider --create-db && ruff check products/pulse products/signals/backend/facade products/signals/backend/temporal/signal_queries.py && DEBUG=1 python manage.py makemigrations --check --dry-run pulse signals && tach check"
+```
+
+Expected: all green, `No changes detected` for migrations (no model changes in PR1), tach validated.
+
+---
+
+## Phase 2 — PR2: Proactive surfacing (frontend)
+
+> Builds on PR1. The causal narrative + chips + `suggestedNextStep` already exist; this phase makes Pulse *drive* the exploration (full Max context + one-click insight) rather than wait for a click.
+
+### Task 7: Pass the full finding context to Max
+
+**Files:**
+- Modify: `frontend/src/scenes/max/maxContextLogic.ts` (accept a finding-context payload alongside the insight)
+- Modify: `products/pulse/frontend/utils.ts` (`buildMaxSeedPrompt` already exists — extend the context builder to attach narrative + attribution + references)
+- Modify: `products/pulse/frontend/Pulse.tsx` (the "Explore with AI" handoff calls the extended context setter)
+- Test: `products/pulse/frontend/utils.test.ts`
+
+- [ ] Add a `buildFindingMaxContext(finding)` in `utils.ts` returning `{ insight: InsightWithQuery | null, narrative: string, attribution, references }`; test it returns the narrative + attribution from an `EnrichedFinding`-shaped `PulseFindingType`. Wire `Pulse.tsx`'s handoff to pass it via `maxContextLogic`. Seed prompt references the context so Max continues rather than re-derives. (Jest, mirror `pulseLogic.test.ts` patterns.)
+
+### Task 8: One-click "make this insight" + proactive next-step
+
+**Files:**
+- Modify: `products/pulse/frontend/Pulse.tsx` (+ `pulseLogic.ts` if a listener is needed)
+- Test: `products/pulse/frontend/pulseLogic.test.ts`
+
+- [ ] Surface `suggestedNextStep(finding)` as a primary action on each finding card (it already exists, deterministic). Add a "Build this insight" action that opens Max seeded to use its `create_insight` tool on the finding's metric. Guard the button against double-submit (`disabledReason`/loading). Test the listener/seed via kea-test, mirroring the existing scan-trigger test.
+
+### Task 9: FE gauntlet
+
+```bash
+flox activate -- bash -c "pnpm --filter=@posthog/frontend typegen:write:no-cache && pnpm --filter=@posthog/frontend exec jest products/pulse/frontend && NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter=@posthog/frontend exec tsc --noEmit 2>&1 | grep -ciE 'products/pulse' "
+```
+
+Expected: jest green; `0` pulse tsc errors.
+
+---
+
+## Self-review (run after writing; fixes folded in)
+
+**Spec coverage:**
+- AnomalySource interface @ Finding boundary → Tasks 4–5. ✅
+- v1 scout-only source → Task 4 (`ScoutAnomalySource`), Task 5 (workflow wiring drops select/detect). ✅
+- O1 (raw ClickHouse signals) → Task 2 `fetch_team_anomaly_signal_rows`. ✅
+- O2 (scope to anomaly-detection scout) → Task 2 (`source_product`/`source_type` in CH + `skill_name` in Python). ✅
+- D1 (re-score, no parse) + the no-re-gate refinement → Task 1 (`score_series`), Task 3 (adapter builds unconditionally). ✅
+- best-effort short_id (decided) + counter → Task 2 (`_short_id_from_evidence`), Task 3 (`increment_scout_anomaly_outcome`). ✅
+- D3 (sensitivity config vestigial) → Task 6. ⚠️ depends on review confirmation — flagged, not silently assumed.
+- Reused untouched (narrative/Max) → confirmed: no task modifies `narrative.py`. ✅
+- Pillar-4 proactive → Phase 2 (Tasks 7–8). ✅
+- Non-goals respected: no Pulse detection in v1 path (selection/detect dropped from activities); no observability-gaps rebuild; no scout emit-contract change (best-effort instead). ✅
+
+**Placeholder scan:** one explicit implementer NOTE in Task 2 Step 3 (confirm the real `_deduped_signals_subquery` name/signature against `signal_queries.py:44-66`) — intentional, because that helper's exact name wasn't verified first-hand; it is a "read X and match verbatim" instruction, not a code placeholder. Task 6 Step 1 is gated on the D3 review decision (called out). No `TBD`/`add error handling`-style gaps.
+
+**Type consistency:** `score_series` returns `(DetectionResult, float, list[float])` used identically in Task 1 and Task 3; `AnomalyFinding` fields defined in Task 2 match the adapter's reads in Task 3; `fetch_scout_findings_activity` name matches the workflow test mock and registration in Task 5.
+
+---
+
+## Execution Handoff
+
+Plan complete. Two execution options:
+1. **Subagent-Driven (recommended)** — a fresh subagent per task, review between tasks.
+2. **Inline Execution** — execute here with checkpoints.
+
+**Before executing:** the `get_team_anomalies` facade method (Task 2) is the cross-team touch — loop in the Signals team. And confirm the D3 choice (Task 6) and the `_deduped_signals_subquery` helper name (Task 2 NOTE).

--- a/docs/superpowers/specs/2026-06-09-pulse-sensemaking-on-scout-anomalies-design.md
+++ b/docs/superpowers/specs/2026-06-09-pulse-sensemaking-on-scout-anomalies-design.md
@@ -1,0 +1,220 @@
+# Pulse v2: Sense-making layer on top of scout anomalies — design
+
+**Goal:** Re-center Pulse from "a deterministic anomaly detector that happens to narrate"
+to "the analytics co-pilot that takes an anomaly someone else detected and turns it into
+understanding + next steps" — proactively driven by Pulse, with Max as the engine underneath.
+
+**Architecture:** Pulse stops discovering anomalies. It consumes anomalies the Signals
+anomaly scout already detects (behind a pluggable `AnomalySource` interface), adapts each into
+Pulse's existing `Finding` shape, and runs its existing — and genuinely differentiated —
+causal-enrichment + guided-exploration pipeline on top, surfaced proactively.
+
+**Tech stack:** Django/Temporal (Pulse backend), `products/signals` facade (read), the existing
+Pulse `narrative.py` enrichment + `MaxChatOpenAI`, the Max side panel handoff (`utils.ts`).
+
+---
+
+## Problem / why
+
+Two products were independently doing anomaly detection on the same candidate set (most-viewed
+insights) with the same MAD z-score. The Signals anomaly scout is the more capable detector
+(seasonality-matched baselines, durable watchlist, explore/exploit memory) and is the system of
+record — anomalies it emits flow into the Signals pipeline (group → research → optionally
+auto-fix), which is an **engineering-issue-resolution** surface.
+
+Pulse's genuine, non-duplicated value is a different downstream job: **analytics sense-making.**
+Given "metric X moved," Pulse answers *why* (the flag flipped / experiment started / segment that
+explains it), cross-references what the user isn't tracking yet, and drives a guided exploration
+that helps them build the analytics they're missing. That engine already exists in Pulse
+(`narrative.py` + the Max handoff) and nothing else in the codebase does it.
+
+So the move is: **demote detection to a consumed input, keep and deepen the sense-making engine.**
+
+## Product positioning (the seat this takes)
+
+- Signals anomaly scout → *detects* anomalies. (engine)
+- observability-gaps scout → *finds coverage holes*. (engine)
+- **Pulse → "your metric moved: here's why, here's what you're not tracking yet, let's explore it
+  and build it together."** Consumes the engines; owns causal correlation + guided exploration.
+
+## v1 scope (decided)
+
+- **`AnomalySource` is the only anomaly entry point**, and v1 ships exactly one implementation:
+  `ScoutAnomalySource`. No deterministic detection in the v1 path. The interface exists from day
+  one so a `DeterministicSource` (or any other source) can be added later without touching
+  anything downstream of `Finding`.
+- Pulse v1 only produces digests for teams where the anomaly scout is enrolled and has run.
+  Coverage is intentionally bounded — see Risks.
+
+## Architecture
+
+The interface boundary is the existing `Finding` type. Everything downstream of it
+(attribution, flag/experiment/annotation correlation, replay evidence, narrative, synthesis,
+the Max handoff) already operates on `Finding` / `EnrichedFinding` and does not care where the
+anomaly came from — so swapping the source leaves the entire sense-making engine untouched.
+
+```
+Signals anomaly scout (detects) ─→ emit_signal ─→ ClickHouse document_embeddings (product='signals')
+                                                              │
+            products/signals facade: get_team_anomalies(team, time_range)   ← NEW read (raw anomaly signals, O1)
+                                                              │
+                                              ScoutAnomalySource.get_findings(...)         ← NEW (the only v1 source)
+                                                  │  adapt: short_id → insight query,
+                                                  │         re-score → Finding numbers,
+                                                  │         carry scout hypothesis/severity/weight
+                                                  ▼
+                                               list[Finding]
+                                                  │
+   ┌──────────────────────────── UNCHANGED Pulse engine ────────────────────────────┐
+   │  enrich_findings: _attribute_finding · correlate flags/experiments/annotations  │
+   │  /errors (CoincidentSignal) · replay evidence · _generate_narrative ·           │
+   │  synthesize_digest                                                              │
+   └─────────────────────────────────────────────────────────────────────────────────┘
+                                                  │
+                          proactive surface: digest + notify + one-click "make this insight"
+                                            + Max-driven suggestedNextStep (full finding context)
+```
+
+## Components
+
+### 1. `AnomalySource` interface (NEW)
+A small protocol slotted into `workflow.py` where `select_candidate_metrics_activity →
+detect_changes_activity` sits today:
+
+```
+class AnomalySource(Protocol):
+    async def get_findings(self, team_id: int, period_start: str, period_end: str,
+                           config: PulseScanConfig) -> list[Finding]: ...
+```
+
+v1 wires exactly one implementation. The workflow no longer calls `select` + `detect`; it calls
+`source.get_findings(...)` and feeds the result straight into `enrich_findings_activity`.
+
+### 2. `ScoutAnomalySource` (NEW — the only v1 source)
+Reads the team's recent raw anomaly signals for the digest period (via the new facade method),
+then adapts each into a `Finding`.
+
+### 3. `get_team_anomalies` signals facade read method (NEW)
+`products/signals/backend/facade/api.py` is write-only today (`emit_signal` +
+`dismiss_report_from_slack`). Add a read method that returns the team's raw anomaly-detection
+signals (read from ClickHouse `document_embeddings`, `product='signals'` — O1, NOT grouped
+`SignalReport`s) for a time window, as a stable DTO:
+
+```
+async def get_team_anomalies(team: Team, period_start: datetime, period_end: datetime
+                             ) -> list[AnomalyFinding]
+# AnomalyFinding DTO: insight_short_id, time_range, weight, confidence, severity,
+#                     hypothesis, description, dedupe_keys, source_run_id
+```
+
+Scoped to the anomaly-detection scout's signals (see O2 for the exact key), gated by the same org
+`is_ai_data_processing_approved` check `emit_signal` uses. Built as a facade method, **not** a new
+REST/HTTP surface, so the boundary stays clean and the signal shape can change without breaking Pulse.
+
+### 4. Anomaly signal → `Finding` adapter (NEW)
+For each raw anomaly signal (as an `AnomalyFinding` DTO):
+- `insight_short_id` → load the `Insight` → build `MetricDescriptor` (source=`scout_anomaly`,
+  label=insight name, query=the saved TrendsQuery, url=`/insights/<short_id>`).
+- **Re-score the single flagged insight** with the existing `detection._evaluate_candidate` /
+  `_compute_robust_z` to populate `current_value` / `baseline_value` / `change_pct` / `robust_z` /
+  `series`. (We re-derive rather than parse the scout's prose numbers — see Decision D1.)
+- Carry the scout's `hypothesis` / `severity` / `weight` / `description` along so the narrative LLM
+  can build on the scout's prior instead of starting cold.
+
+### 5. Proactive surfacing (NEW behavior on existing surfaces)
+Pulse drives the sense-making rather than waiting for a click:
+- The digest/notification carries the *why* (already computed), the `suggestedNextStep`, and a
+  one-click **"make this insight"** action.
+- The Max handoff passes the **full `EnrichedFinding`** (narrative + attribution + coincident
+  signals + evidence) as structured context, not just the insight query — so Max continues the
+  thread instead of re-reasoning. Max's `create_insight` tool does the actual creation.
+
+### 6. Reused, untouched
+The whole `narrative.py` engine and the `utils.ts` / `Pulse.tsx` Max handoff. This is the
+differentiator and it does not change shape.
+
+### 7. Deferred (interface-ready, not built in v1)
+`DeterministicSource` (today's `selection.py` + `detection.py` discovery path) as a second
+`AnomalySource` impl — the path to universal coverage post-v1.
+
+## Key design decisions (recommendations — confirm in review)
+
+- **D1 — Adapter re-scores rather than parses prose.** The scout emits its numbers in prose;
+  only the `short_id`, `time_range`, weight/confidence/severity/hypothesis are structured.
+  Recommendation: re-score the flagged insight (reuse Pulse's scoring math on one insight). Pros:
+  no cross-team emit-contract change; Pulse shows numbers consistent with its own charts. Con:
+  Pulse's re-derived z may differ slightly from the scout's (different granularity). Alternative
+  (post-v1): ask Signals to emit structured anomaly detail in `extra` for pure projection.
+- **D2 — Detection code split.** Keep `detection.py`'s *scoring* (`_evaluate_candidate`,
+  `_compute_robust_z`) — the adapter uses it. Drop `selection.py`'s *discovery* from the v1 path
+  (the scout owns "which insights are anomalous"). Both stay in-tree as the dormant
+  `DeterministicSource` impl.
+- **D3 — Sensitivity config becomes vestigial in v1.** `PulseSubscription`'s sensitivity presets /
+  thresholds and the staff scan-config UI tune *detection* — which the scout now owns. v1 should
+  hide/neutralize them (or repurpose to "which scout findings to surface"); do not delete the
+  model yet. Open for review.
+- **D4 — Proactive depth.** v1 = digest carries why + next-step + one-click insight (Max under the
+  hood). Auto-running the next-step exploration in the background (no click at all) is post-v1.
+
+## Non-goals (v1)
+
+- No anomaly discovery/detection in Pulse (scout-only source).
+- Do **not** rebuild the observability-gaps scout's "you're missing an insight" detection —
+  surfacing/consuming its recommendations is a separate, later step (Pillar 2).
+- No auto-fix / coding tasks — that is Signals' job.
+- No changes to the scout's emit contract.
+- No new REST surface on Signals (facade method only).
+
+## Open questions (resolve in review / implementation research)
+
+- **O1 — Read grain (DECIDED ✅): raw anomaly signals, not grouped reports.** A `SignalReport`
+  groups signals across sources, so it is a fuzzy unit for "one metric anomaly." Pulse reads the
+  **raw anomaly signal** (one anomaly → one finding, each with its `short_id` + `time_range`):
+  `get_team_anomalies` queries ClickHouse `document_embeddings` (`product='signals'`, filtered to
+  the anomaly-detection scout), not Postgres `SignalReport`s.
+- **O2 — Scoping to the anomaly-detection scout.** All scouts emit `source_product='signals_scout'`,
+  `source_type='cross_source_issue'`, so `source_product` alone is too broad. Scope via the scout
+  `skill_name` (`signals-scout-anomaly-detection`, reachable through `SignalScoutRun` / the signal's
+  `extra.scout_run_id`) or the `dedupe_keys` pattern (`metric_anomaly:` / `insight:`). Confirm the
+  reliable key with the Signals team.
+- **O3 — Sensitivity config fate (D3):** hide, repurpose to "which scout findings to surface," or
+  keep `PulseSubscription`'s detection knobs? They tune detection, which the scout now owns.
+- **O4 — Slicing:** this is plausibly two PRs — (a) `AnomalySource` interface + `ScoutAnomalySource`
+  + facade read method + adapter (the source swap), and (b) proactive surfacing (full-context Max
+  handoff + one-click insight). Confirm split before planning.
+
+## Success criteria
+
+- A team with the anomaly scout enrolled gets a Pulse digest whose findings are sourced entirely
+  through `ScoutAnomalySource` (zero calls into `selection.py`/`detect_changes` in the v1 path).
+- Each finding shows: the scout's anomaly, Pulse's re-scored numbers + chart, the causal narrative
+  (flag/experiment/annotation/segment), and a working one-click "make this insight" + Max handoff
+  carrying full finding context.
+- Swapping in a stub second `AnomalySource` requires no change downstream of `Finding` (proves the
+  boundary is real).
+- A team without the scout enrolled gets a clear "enable the anomaly scout" empty state, not a
+  broken/empty digest.
+
+## Risks & mitigations
+
+- **Coverage dependency (accepted):** Pulse v1 only works where the scout is enrolled
+  (flag-gated, AI-data-processing-approved, has run on schedule). Mitigation: explicit empty state;
+  the interface makes adding `DeterministicSource` for universal coverage a contained follow-up.
+- **Numbers-in-prose / granularity (D1):** Pulse's re-scored numbers may differ from the scout's
+  prose figures. Mitigation: Pulse presents its own consistent numbers; the scout's prose rides
+  along as hypothesis context, not as the displayed figure.
+- **New facade surface on Signals:** `get_team_anomalies` is new cross-product API. Mitigation:
+  DTO-shaped (decoupled from row shape), facade-only, AI-approval gated, owned with the Signals team.
+- **Empty/duplicate findings:** ensure the read method returns de-duplicated, anomaly-scoped
+  signals for the period only (dedupe on `document_id`, per the ReplacingMergeTree pattern in
+  `signal_queries.py`).
+
+## Migration path
+
+1. v1: `AnomalySource` interface + `ScoutAnomalySource` only (this doc).
+2. Universal coverage: add `DeterministicSource` impl behind the same interface; prefer scout where
+   enrolled, fall back to the built-in detector elsewhere.
+3. Richer adapter: Signals emits structured anomaly detail → adapter becomes pure projection (drop
+   re-scoring).
+4. Pillar 2: consume observability-gaps recommendations to power "make this insight."
+5. Deeper proactivity (D4): background-run the suggested next step via Max.

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -30846,6 +30846,61 @@
             },
             "type": "object"
         },
+        "PulseScanConfig": {
+            "additionalProperties": false,
+            "description": "Per-run tuning knobs for one Pulse scan. Defaults mirror the production constants and are resolved per-run (staff override → team subscription → these defaults); nothing is persisted. Every field is optional so its `@default` flows into the generated pydantic — a resolved config is always fully populated at runtime.",
+            "properties": {
+                "baseline_weeks": {
+                    "$ref": "#/definitions/integer",
+                    "default": 4
+                },
+                "dashboard_tile_limit": {
+                    "$ref": "#/definitions/integer",
+                    "default": 10
+                },
+                "max_candidates": {
+                    "$ref": "#/definitions/integer",
+                    "default": 200
+                },
+                "max_findings": {
+                    "$ref": "#/definitions/integer",
+                    "default": 5
+                },
+                "min_baseline_value": {
+                    "default": 5,
+                    "type": "number"
+                },
+                "min_change_pct": {
+                    "default": 0.25,
+                    "type": "number"
+                },
+                "min_viewers_for_recent_insight": {
+                    "$ref": "#/definitions/integer",
+                    "default": 3
+                },
+                "recent_days": {
+                    "$ref": "#/definitions/integer",
+                    "default": 30
+                },
+                "recent_insight_limit": {
+                    "$ref": "#/definitions/integer",
+                    "default": 100
+                },
+                "robust_z_threshold": {
+                    "default": 3.5,
+                    "type": "number"
+                },
+                "saved_insight_limit": {
+                    "$ref": "#/definitions/integer",
+                    "default": 15
+                },
+                "top_event_limit": {
+                    "$ref": "#/definitions/integer",
+                    "default": 25
+                }
+            },
+            "type": "object"
+        },
         "QueryIndexUsage": {
             "enum": ["undecisive", "no", "partial", "yes"],
             "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4856,6 +4856,40 @@ export interface HogQLAlertConfig {
     label_column?: string | null
 }
 
+/**
+ * Per-run tuning knobs for one Pulse scan. Defaults mirror the production constants and are resolved per-run
+ * (staff override → team subscription → these defaults); nothing is persisted. Every field is optional so its
+ * `@default` flows into the generated pydantic — a resolved config is always fully populated at runtime.
+ */
+export interface PulseScanConfig {
+    // Selection — which metrics get scanned. A per-source limit of 0 disables that source.
+    /** @default 200 */
+    max_candidates?: integer
+    /** @default 30 */
+    recent_days?: integer
+    /** @default 3 */
+    min_viewers_for_recent_insight?: integer
+    /** @default 10 */
+    dashboard_tile_limit?: integer
+    /** @default 100 */
+    recent_insight_limit?: integer
+    /** @default 15 */
+    saved_insight_limit?: integer
+    /** @default 25 */
+    top_event_limit?: integer
+    // Detection — what counts as a notable change.
+    /** @default 5 */
+    min_baseline_value?: number
+    /** @default 0.25 */
+    min_change_pct?: number
+    /** @default 3.5 */
+    robust_z_threshold?: number
+    /** @default 4 */
+    baseline_weeks?: integer
+    /** @default 5 */
+    max_findings?: integer
+}
+
 /** One blocked period for quiet hours: 24-hour HH:MM in the project timezone; interval is half-open [start, end). */
 export interface AlertScheduleRestrictionWindow {
     start: string

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5925,6 +5925,24 @@ class PropertyValueItem(BaseModel):
     name: str | float | bool | None = None
 
 
+class PulseScanConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    baseline_weeks: int | None = 4
+    dashboard_tile_limit: int | None = 10
+    max_candidates: int | None = 200
+    max_findings: int | None = 5
+    min_baseline_value: float | None = 5
+    min_change_pct: float | None = 0.25
+    min_viewers_for_recent_insight: int | None = 3
+    recent_days: int | None = 30
+    recent_insight_limit: int | None = 100
+    robust_z_threshold: float | None = 3.5
+    saved_insight_limit: int | None = 15
+    top_event_limit: int | None = 25
+
+
 class QueryResponseAlternative9(BaseModel):
     model_config = ConfigDict(
         extra="forbid",

--- a/products/pulse/backend/temporal/detection.py
+++ b/products/pulse/backend/temporal/detection.py
@@ -1,0 +1,213 @@
+"""Change detection for Pulse candidate metrics (the `change_v1` strategy)."""
+
+import math
+import asyncio
+import statistics
+from typing import Any
+
+import structlog
+
+from posthog.schema import PulseScanConfig
+
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+
+from products.pulse.backend.temporal.detectors.base import DetectionResult, PulseDetector
+from products.pulse.backend.temporal.detectors.registry import get_detector, register_detector
+from products.pulse.backend.temporal.metrics import increment_detection_outcome
+from products.pulse.backend.temporal.types import CandidateMetric, Finding, MetricDescriptor, run_trends_query_sync
+
+logger = structlog.get_logger(__name__)
+
+
+DETECTION_CONCURRENCY = 8
+MIN_BASELINE_WEEKS = 3  # hard floor: fewer completed weeks than this and a baseline median is too noisy to trust
+MAX_BASELINE_WEEKS = 4  # default baseline window, also narrative.py's attribution window when none is configured
+
+
+def _build_detection_query(base_query: dict, baseline_weeks: int) -> dict:
+    query = {**base_query}
+    # Fetch the configured baseline window plus the current and the in-progress (dropped) week.
+    fetch_days = (baseline_weeks + 2) * 7
+    query["dateRange"] = {"date_from": f"-{fetch_days}d", "date_to": None}
+    query["interval"] = "week"
+    # Strip breakdowns for the initial detection scan — we want the headline metric.
+    if "breakdownFilter" in query:
+        query["breakdownFilter"] = None
+    return query
+
+
+def _extract_weekly_series(result: Any) -> list[float]:
+    if not isinstance(result, dict):
+        return []
+    results = result.get("results") or []
+    if not results:
+        return []
+    first_series = results[0]
+    if not isinstance(first_series, dict):
+        return []
+    data = first_series.get("data") or []
+    return [float(v) for v in data if isinstance(v, int | float) and not isinstance(v, bool)]
+
+
+def _compute_robust_z(current: float, baseline: list[float]) -> float:
+    """Modified z-score: 0.6745 * |x - median| / MAD. Floors to 0.0 when MAD == 0.
+
+    Secondary/informational only — never a sole trigger (the primary gate is change_pct).
+    Mirrors posthog/tasks/alerts/detectors/statistical/mad.py's modified-z formula.
+    """
+    if len(baseline) < 2:
+        return 0.0
+    median = statistics.median(baseline)
+    mad = statistics.median([abs(v - median) for v in baseline])
+    if mad == 0:
+        return 0.0
+    return 0.6745 * abs(current - median) / mad
+
+
+def _compute_impact(change_pct: float, baseline_median: float) -> float:
+    """Rank weight: relative change scaled by sqrt(volume) so high-traffic moves rank higher."""
+    return abs(change_pct) * math.sqrt(baseline_median)
+
+
+@register_detector("change_v1")
+class ChangeV1Detector(PulseDetector):
+    """v1 deterministic change detection: median baseline + change_pct primary gate."""
+
+    def detect(
+        self,
+        current: float,
+        baseline: list[float],
+        min_change_pct: float,
+        robust_z_threshold: float,
+        min_baseline_value: float,
+    ) -> DetectionResult:
+        baseline_median = statistics.median(baseline)
+        robust_z = _compute_robust_z(current, baseline)
+        # Guard the division: a zero baseline_median has no defined percentage change, and the volume floor
+        # (min_baseline_value) suppresses low-volume metrics for the deterministic gate. Either short-circuits.
+        if baseline_median == 0 or baseline_median < min_baseline_value:
+            return DetectionResult(
+                triggered=False,
+                baseline_median=baseline_median,
+                change_pct=0.0,
+                impact=0.0,
+                robust_z=robust_z,
+            )
+        change_pct = (current - baseline_median) / baseline_median
+        impact = _compute_impact(change_pct, baseline_median)
+        # Primary gate: change_pct only. robust_z is intentionally NOT a gate — it is undefined for a
+        # flat baseline (MAD=0 → robust_z=0), where a change is actually the clearest possible signal, so
+        # gating on it would suppress exactly those. robust_z stays a surfaced secondary signal and
+        # ranking aid (robust_z_threshold is the reserved sensitivity knob), never a sole or co-trigger.
+        triggered = abs(change_pct) >= min_change_pct
+        return DetectionResult(
+            triggered=triggered,
+            baseline_median=baseline_median,
+            change_pct=change_pct,
+            impact=impact,
+            robust_z=robust_z,
+        )
+
+
+def score_series(
+    weekly_values: list[float], config: PulseScanConfig, detection_mode: str = "change_v1"
+) -> tuple[DetectionResult, float, list[float]] | None:
+    """Compute the change-detection result for a weekly series WITHOUT applying the trigger gate.
+
+    Returns (result, current_value, sparkline_series) or None when there's too little data. Callers
+    that want the detection gate check `result.triggered`; callers that already know the metric is
+    anomalous (the scout source) ignore it and use the numbers for display.
+    """
+    assert config.baseline_weeks is not None
+    assert config.min_change_pct is not None
+    assert config.robust_z_threshold is not None
+    assert config.min_baseline_value is not None
+    if len(weekly_values) < MIN_BASELINE_WEEKS + 2:
+        return None
+    completed = weekly_values[:-1]  # drop the in-progress (partial) week
+    current = completed[-1]
+    baseline = completed[:-1][-config.baseline_weeks :]
+    if len(baseline) < MIN_BASELINE_WEEKS:
+        return None
+    result = get_detector(detection_mode).detect(
+        current, baseline, config.min_change_pct, config.robust_z_threshold, config.min_baseline_value
+    )
+    # The recent completed weeks (baseline window + current) drive the card's trend sparkline; kept
+    # unrounded so the last point equals current_value exactly (matters for avg/median/p90 metrics).
+    series = [float(v) for v in completed[-(config.baseline_weeks + 1) :]]
+    return result, current, series
+
+
+def _build_finding(
+    descriptor: MetricDescriptor, result: DetectionResult, current: float, series: list[float]
+) -> Finding:
+    return Finding(
+        descriptor=descriptor,
+        current_value=current,
+        baseline_value=result.baseline_median,
+        change_pct=result.change_pct,
+        impact=result.impact,
+        robust_z=result.robust_z,
+        series=series,
+    )
+
+
+def _evaluate_candidate(
+    candidate: CandidateMetric,
+    weekly_values: list[float],
+    config: PulseScanConfig,
+    detection_mode: str = "change_v1",
+) -> Finding | None:
+    scored = score_series(weekly_values, config, detection_mode)
+    if scored is None:
+        return None
+    result, current, series = scored
+    if not result.triggered:
+        return None
+    return _build_finding(candidate.descriptor, result, current, series)
+
+
+async def _evaluate_one(
+    team: Team,
+    candidate: CandidateMetric,
+    config: PulseScanConfig,
+    semaphore: asyncio.Semaphore,
+) -> Finding | None:
+    # Validate the resolved config BEFORE the try: an AssertionError inside it would be swallowed as a
+    # per-candidate "failed" tick, disguising a config bug as N transient query failures.
+    assert config.baseline_weeks is not None  # Optional in the generated schema; always set on a resolved config
+    assert config.min_change_pct is not None
+    assert config.robust_z_threshold is not None
+    assert config.min_baseline_value is not None
+    async with semaphore:
+        try:
+            query = _build_detection_query(candidate.descriptor.query, config.baseline_weeks)
+            result = await run_trends_query_sync(team, query)
+            series = _extract_weekly_series(result)
+            return _evaluate_candidate(candidate, series, config)
+        except Exception as exc:
+            logger.exception(
+                "pulse_detection_candidate_failed",
+                team_id=team.id,
+                metric=candidate.descriptor.label,
+                error=str(exc),
+            )
+            increment_detection_outcome("failed")
+            return None
+
+
+async def detect_changes(team_id: int, candidates: list[CandidateMetric], config: PulseScanConfig) -> list[Finding]:
+    """The deterministic AnomalySource's scoring pass: score every selected candidate, keep the triggered
+    ones. Wrapped by sources.DeterministicSource and run alongside the scout each scan. Its scoring helpers
+    (score_series, _build_detection_query, _extract_weekly_series, _build_finding) are also reused by the
+    scout adapter."""
+
+    @database_sync_to_async
+    def _get_team() -> Team:
+        return Team.objects.get(id=team_id)
+
+    team = await _get_team()
+    semaphore = asyncio.Semaphore(DETECTION_CONCURRENCY)
+    results = await asyncio.gather(*[_evaluate_one(team, c, config, semaphore) for c in candidates])
+    return [f for f in results if f is not None]

--- a/products/pulse/backend/temporal/detectors/__init__.py
+++ b/products/pulse/backend/temporal/detectors/__init__.py
@@ -1,0 +1,4 @@
+from products.pulse.backend.temporal.detectors.base import DetectionResult, PulseDetector
+from products.pulse.backend.temporal.detectors.registry import get_detector, register_detector
+
+__all__ = ["DetectionResult", "PulseDetector", "get_detector", "register_detector"]

--- a/products/pulse/backend/temporal/detectors/base.py
+++ b/products/pulse/backend/temporal/detectors/base.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    """Outcome of evaluating one candidate weekly series for a notable change."""
+
+    triggered: bool
+    baseline_median: float
+    change_pct: float
+    impact: float
+    robust_z: float
+
+
+class PulseDetector(ABC):
+    """Strategy for deciding whether a candidate metric changed notably.
+
+    Mirrors the alert detector seam (posthog/tasks/alerts/detectors/base.py)
+    but operates on a pre-extracted weekly series, not a numpy training window —
+    the alert DETECTOR_MIN_SAMPLES=31 floor rejects short weekly baselines.
+    """
+
+    @abstractmethod
+    def detect(
+        self,
+        current: float,
+        baseline: list[float],
+        min_change_pct: float,
+        robust_z_threshold: float,
+        min_baseline_value: float,
+    ) -> DetectionResult:
+        """Evaluate one candidate. robust_z is informational; the gate is in the strategy.
+
+        `min_baseline_value` is the volume floor — metrics with a quieter baseline are skipped to
+        avoid noisy percentage swings on near-zero traffic.
+        """
+        ...

--- a/products/pulse/backend/temporal/detectors/registry.py
+++ b/products/pulse/backend/temporal/detectors/registry.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from products.pulse.backend.temporal.detectors.base import PulseDetector
+
+_DETECTOR_REGISTRY: dict[str, type["PulseDetector"]] = {}
+
+
+def register_detector(detection_mode: str) -> Callable[[type["PulseDetector"]], type["PulseDetector"]]:
+    def decorator(cls: type["PulseDetector"]) -> type["PulseDetector"]:
+        _DETECTOR_REGISTRY[detection_mode] = cls
+        return cls
+
+    return decorator
+
+
+_REGISTERED = False
+
+
+def _ensure_registered() -> None:
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    # change_v1 registers itself on import.
+    from products.pulse.backend.temporal import detection  # noqa: F401, PLC0415
+
+    _REGISTERED = True
+
+
+def get_detector(detection_mode: str) -> "PulseDetector":
+    _ensure_registered()
+    detector_cls = _DETECTOR_REGISTRY.get(detection_mode)
+    if detector_cls is None:
+        raise ValueError(f"Unknown detection mode: {detection_mode}. Available: {sorted(_DETECTOR_REGISTRY)}")
+    return detector_cls()

--- a/products/pulse/backend/temporal/metrics.py
+++ b/products/pulse/backend/temporal/metrics.py
@@ -1,0 +1,79 @@
+"""Prometheus counters for the Pulse pipeline. No-op outside Temporal context."""
+
+from temporalio import activity, workflow
+from temporalio.common import MetricMeter
+
+Attributes = dict[str, str | int | float | bool]
+
+
+def _meter(attributes: Attributes | None = None) -> MetricMeter | None:
+    """Return the active meter, or None when called outside a workflow/activity."""
+    if activity.in_activity():
+        meter = activity.metric_meter()
+    elif workflow.in_workflow():
+        meter = workflow.metric_meter()
+    else:
+        return None
+    return meter.with_additional_attributes(attributes) if attributes else meter
+
+
+def increment_dispatch_outcome(outcome: str, *, count: int = 1) -> None:
+    """Dispatcher counters: eligible / dispatched / deduped / failed."""
+    meter = _meter({"outcome": outcome})
+    if meter is None:
+        return
+    meter.create_counter("pulse_dispatch_outcome", "Pulse dispatcher team outcomes").add(count)
+
+
+def increment_scan_outcome(outcome: str, *, count: int = 1) -> None:
+    """Per-team scan counters: delivered / failed."""
+    meter = _meter({"outcome": outcome})
+    if meter is None:
+        return
+    meter.create_counter("pulse_scan_outcome", "Pulse scan delivery outcomes").add(count)
+
+
+def increment_detection_outcome(outcome: str, *, count: int = 1) -> None:
+    """Per-candidate detection counters: failed (a candidate's query or evaluation raised).
+
+    Lets an all-candidates-errored scan be told apart from a genuinely quiet one — both surface
+    zero findings, but only the former increments here.
+    """
+    meter = _meter({"outcome": outcome})
+    if meter is None:
+        return
+    meter.create_counter("pulse_detection_outcome", "Pulse per-candidate detection outcomes").add(count)
+
+
+def increment_scout_anomaly_outcome(outcome: str, *, count: int = 1) -> None:
+    """Per-anomaly adapter outcomes.
+
+    resolved — built a Finding. unresolvable_insight — best-effort short_id missing or doesn't load (the
+    signal that the scout emit contract should be hardened later). unsupported_query_kind — insight loaded
+    but isn't a TrendsQuery, so it can't be re-scored. query_failed — the trends re-score raised. no_series —
+    insufficient data. zero_baseline — the re-scored baseline median is 0, so a percentage change is
+    undefined. adapter_error — an unexpected per-anomaly failure the loop caught so the scan could
+    continue."""
+    meter = _meter({"outcome": outcome})
+    if meter is None:
+        return
+    meter.create_counter("pulse_scout_anomaly_outcome", "Pulse scout-anomaly adapter outcomes").add(count)
+
+
+def increment_anomaly_source_failure(source: str, *, count: int = 1) -> None:
+    """A whole AnomalySource failed and the scan degraded to the remaining sources' findings.
+
+    Without this, a half-degraded digest (e.g. the scout source threw but deterministic findings still
+    delivered) is metrically indistinguishable from a healthy scan — scan_outcome stays "delivered"."""
+    meter = _meter({"source": source})
+    if meter is None:
+        return
+    meter.create_counter("pulse_anomaly_source_failure", "Pulse whole-source failures (scan degraded)").add(count)
+
+
+def record_finding_count(count: int) -> None:
+    """Number of findings persisted in a delivered digest."""
+    meter = _meter()
+    if meter is None:
+        return
+    meter.create_counter("pulse_finding_count", "Findings persisted per delivered digest").add(count)

--- a/products/pulse/backend/temporal/period.py
+++ b/products/pulse/backend/temporal/period.py
@@ -1,0 +1,36 @@
+"""Deterministic period keys for Pulse scans — find-or-create digests per (team, period)."""
+
+import datetime as dt
+
+from products.pulse.backend.models import PulseSubscriptionFrequency
+
+
+def period_key(now: dt.datetime, frequency: PulseSubscriptionFrequency | str) -> str:
+    """Stable identifier for the scan period containing `now`.
+
+    Weekly -> ISO week ("2026-W22"); daily -> date ("2026-05-29"). Used as the
+    idempotency key so re-runs and Temporal retries reuse one digest per period.
+    Caller passes a deterministic clock (`workflow.now()`) inside workflows.
+    """
+    if frequency == PulseSubscriptionFrequency.DAILY:
+        return now.date().isoformat()
+    iso_year, iso_week, _ = now.isocalendar()
+    return f"{iso_year}-W{iso_week:02d}"
+
+
+def period_bounds(now: dt.datetime, frequency: PulseSubscriptionFrequency | str) -> tuple[dt.datetime, dt.datetime]:
+    """(`period_start`, `period_end`) for the digest, snapped to the period boundary — the last
+    completed period. Daily -> the prior calendar day [00:00, 00:00); weekly -> the prior ISO week
+    [Mon 00:00, Mon 00:00).
+
+    Snapping makes the bounds a pure function of the period rather than of the exact `now`, so every
+    run within one `period_key` yields identical bounds. `create_or_get_digest_activity` matches its
+    find-or-create on these bounds, so they must not vary with the calling instant — otherwise a
+    manual run overlapping a scheduled one in the same period would create a duplicate digest.
+    """
+    if frequency == PulseSubscriptionFrequency.DAILY:
+        anchor = dt.datetime(now.year, now.month, now.day, tzinfo=now.tzinfo)
+        return anchor - dt.timedelta(days=1), anchor
+    monday = now - dt.timedelta(days=now.weekday())
+    anchor = dt.datetime(monday.year, monday.month, monday.day, tzinfo=now.tzinfo)
+    return anchor - dt.timedelta(days=7), anchor

--- a/products/pulse/backend/temporal/selection.py
+++ b/products/pulse/backend/temporal/selection.py
@@ -1,0 +1,226 @@
+"""Pure-SQL candidate metric selection for Pulse.
+
+v1 strategy: top-N popular insights and high-volume events. No LLM.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from django.db.models import Count, Q
+
+from posthog.schema import NodeKind, PulseScanConfig
+
+from posthog.sync import database_sync_to_async
+
+from products.pulse.backend.temporal.types import CandidateMetric, MetricDescriptor
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+    from products.product_analytics.backend.models.insight import Insight
+
+
+def _trends_query_from_insight(insight: Insight) -> dict | None:
+    """Extract a re-executable TrendsQuery from a saved Insight, or None if unsupported."""
+    query = insight.query
+    if not query:
+        return None
+    while isinstance(query, dict) and query.get("source"):
+        query = query["source"]
+    if not isinstance(query, dict) or query.get("kind") != NodeKind.TRENDS_QUERY:
+        return None
+    return query
+
+
+def _build_event_volume_query(event_name: str) -> dict:
+    return {
+        "kind": NodeKind.TRENDS_QUERY,
+        "series": [{"kind": "EventsNode", "event": event_name, "name": event_name, "math": "total"}],
+        "dateRange": {"date_from": "-30d", "date_to": None},
+        "interval": "day",
+    }
+
+
+def insight_to_descriptor(insight: Insight, source: str) -> MetricDescriptor | None:
+    """Build a re-scoreable MetricDescriptor from a saved Insight, or None if it isn't a TrendsQuery.
+
+    Shared by selection (candidate discovery) and the scout adapter (sources.py) so both resolve insights
+    to a descriptor identically — one place to change the query unwrap, label fallback, and deep-link.
+    """
+    query = _trends_query_from_insight(insight)
+    if not query:
+        return None
+    return MetricDescriptor(
+        source=source,
+        source_id=str(insight.id),
+        label=insight.name or insight.derived_name or f"Insight {insight.short_id}",
+        query=query,
+        url=f"/insights/{insight.short_id}",
+    )
+
+
+def _insight_to_candidate(insight: Insight, source: str) -> CandidateMetric | None:
+    descriptor = insight_to_descriptor(insight, source)
+    return CandidateMetric(descriptor=descriptor) if descriptor else None
+
+
+def _select_dashboard_tile_candidates(team: Team, limit: int, recent_days: int) -> list[CandidateMetric]:
+    """Pick Trends insights on the team's most-pinned/visible dashboards."""
+    # Lazy import: importing product models at module level triggers an app-init circular import
+    # (the pulse package is eagerly preloaded via posthog.api). They resolve fine at activity-call time.
+    from products.dashboards.backend.models.dashboard import Dashboard  # noqa: PLC0415
+    from products.dashboards.backend.models.dashboard_tile import DashboardTile  # noqa: PLC0415
+
+    dashboards = (
+        Dashboard.objects.filter(team=team, deleted=False)
+        .filter(Q(pinned=True) | Q(last_accessed_at__gte=datetime.now(UTC) - timedelta(days=recent_days)))
+        .order_by("-pinned", "-last_accessed_at")[:limit]
+    )
+    tiles = (
+        DashboardTile.objects.filter(dashboard__in=dashboards, deleted=False, insight__isnull=False)
+        .select_related("insight")
+        .order_by("dashboard_id", "id")
+    )
+    candidates: list[CandidateMetric] = []
+    seen_insight_ids: set[str] = set()
+    for tile in tiles:
+        insight = tile.insight
+        if insight is None or str(insight.id) in seen_insight_ids:
+            continue
+        seen_insight_ids.add(str(insight.id))
+        candidate = _insight_to_candidate(insight, source="dashboard_tile")
+        if candidate:
+            candidates.append(candidate)
+    return candidates
+
+
+def _select_recent_viewed_insight_candidates(
+    team: Team, limit: int, existing_ids: set[str], recent_days: int, min_viewers: int
+) -> list[CandidateMetric]:
+    """Pick Trends insights recently viewed by multiple team members."""
+    # lazy: avoid app-init circular import
+    from products.product_analytics.backend.models.insight import Insight, InsightViewed  # noqa: PLC0415
+
+    since = datetime.now(UTC) - timedelta(days=recent_days)
+    viewed = (
+        InsightViewed.objects.filter(team=team, last_viewed_at__gte=since)
+        .values("insight_id")
+        .annotate(viewer_count=Count("user_id", distinct=True))
+        .filter(viewer_count__gte=min_viewers)
+        .order_by("-viewer_count")
+    )
+    insight_ids = [v["insight_id"] for v in viewed if str(v["insight_id"]) not in existing_ids]
+    # `viewed` is ranked by -viewer_count, but a SQL `id__in` fetch imposes no ordering. Bound the fetch
+    # (many insights aren't Trends-shaped and get dropped, so over-fetch a multiple of `limit`) and re-sort
+    # the rows back into viewer-count order so the cap keeps the most-viewed insights, not an arbitrary subset.
+    ranked_ids = insight_ids[: limit * 4]
+    position = {insight_id: i for i, insight_id in enumerate(ranked_ids)}
+    insights = sorted(
+        Insight.objects.filter(id__in=ranked_ids, deleted=False),
+        key=lambda insight: position[insight.id],
+    )
+
+    candidates: list[CandidateMetric] = []
+    for insight in insights:
+        candidate = _insight_to_candidate(insight, source="recent_insight")
+        if candidate:
+            candidates.append(candidate)
+            if len(candidates) >= limit:
+                break
+    return candidates
+
+
+def _select_saved_insight_candidates(team: Team, limit: int, existing_ids: set[str]) -> list[CandidateMetric]:
+    """Pick the team's most recently edited saved Trends insights, independent of dashboards or views.
+
+    The broad "watch our saved insights" net — surfaces insights even on small teams that never hit
+    the multi-viewer bar or pin a dashboard.
+    """
+    # lazy: avoid app-init circular import
+    from products.product_analytics.backend.models.insight import Insight  # noqa: PLC0415
+
+    # Over-fetch: many saved insights aren't Trends-shaped and get dropped by _insight_to_candidate.
+    insights = Insight.objects.filter(team=team, deleted=False, saved=True).order_by("-last_modified_at")[: limit * 4]
+    candidates: list[CandidateMetric] = []
+    for insight in insights:
+        if str(insight.id) in existing_ids:
+            continue
+        candidate = _insight_to_candidate(insight, source="saved_insight")
+        if candidate:
+            candidates.append(candidate)
+            if len(candidates) >= limit:
+                break
+    return candidates
+
+
+def _select_top_event_candidates(team: Team, limit: int) -> list[CandidateMetric]:
+    """Pick the team's highest-volume events as candidate metrics."""
+    from posthog.models import EventDefinition  # noqa: PLC0415
+
+    base_qs = EventDefinition.objects.filter(team=team).exclude(name__startswith="$")
+    # Prefer events with computed 30-day usage stats.
+    events = list(base_qs.exclude(query_usage_30_day__isnull=True).order_by("-query_usage_30_day")[:limit])
+    if len(events) < limit:
+        seen = {e.id for e in events}
+        backfill = base_qs.exclude(id__in=seen).order_by("-last_seen_at")[: limit - len(events)]
+        events.extend(backfill)
+
+    return [
+        CandidateMetric(
+            descriptor=MetricDescriptor(
+                source="top_event",
+                source_id=str(event.id),
+                label=event.name,
+                query=_build_event_volume_query(event.name),
+            )
+        )
+        for event in events
+    ]
+
+
+def _candidate_source_ids(candidates: list[CandidateMetric]) -> set[str]:
+    return {str(c.descriptor.source_id) for c in candidates if c.descriptor.source_id is not None}
+
+
+@database_sync_to_async
+def _select_sync(team_id: int, config: PulseScanConfig) -> list[CandidateMetric]:
+    from posthog.models import Team  # lazy: avoid app-init circular import  # noqa: PLC0415
+
+    team = Team.objects.get(id=team_id)
+    # Every PulseScanConfig field is Optional in the generated schema (so its @default can flow); a
+    # resolved config is always fully populated at runtime. Narrow the fields used below.
+    assert config.dashboard_tile_limit is not None
+    assert config.recent_insight_limit is not None
+    assert config.saved_insight_limit is not None
+    assert config.top_event_limit is not None
+    assert config.recent_days is not None
+    assert config.min_viewers_for_recent_insight is not None
+    assert config.max_candidates is not None
+    # Each source contributes only when its limit is positive — a limit of 0 turns it off, the per-run
+    # on/off lever. Order matters: earlier sources win the dedup, so dashboard tiles take priority.
+    candidates: list[CandidateMetric] = []
+    if config.dashboard_tile_limit > 0:
+        candidates.extend(_select_dashboard_tile_candidates(team, config.dashboard_tile_limit, config.recent_days))
+    if config.recent_insight_limit > 0:
+        candidates.extend(
+            _select_recent_viewed_insight_candidates(
+                team,
+                config.recent_insight_limit,
+                _candidate_source_ids(candidates),
+                config.recent_days,
+                config.min_viewers_for_recent_insight,
+            )
+        )
+    if config.saved_insight_limit > 0:
+        candidates.extend(
+            _select_saved_insight_candidates(team, config.saved_insight_limit, _candidate_source_ids(candidates))
+        )
+    if config.top_event_limit > 0:
+        candidates.extend(_select_top_event_candidates(team, config.top_event_limit))
+    return candidates[: config.max_candidates]
+
+
+async def select_candidates(team_id: int, config: PulseScanConfig) -> list[CandidateMetric]:
+    return await _select_sync(team_id, config)

--- a/products/pulse/backend/temporal/sources.py
+++ b/products/pulse/backend/temporal/sources.py
@@ -1,0 +1,213 @@
+"""Anomaly sources for Pulse: where the findings to enrich come from.
+
+Each source implements the AnomalySource protocol (get_findings -> list[Finding]). A scan runs every
+source via gather_findings and merges the results, so sources compose without anything downstream of
+Finding caring where a finding came from. Two ship today:
+  - DeterministicSource: selects popular candidates and scores them with the change detector.
+  - ScoutAnomalySource: consumes the Signals anomaly-detection scout (no-ops where it isn't enrolled).
+"""
+
+import asyncio
+from typing import TYPE_CHECKING, Protocol
+
+import structlog
+
+from posthog.schema import PulseScanConfig
+
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+
+from products.pulse.backend.temporal.detection import (
+    DETECTION_CONCURRENCY,
+    _build_detection_query,
+    _build_finding,
+    _extract_weekly_series,
+    detect_changes,
+    score_series,
+)
+from products.pulse.backend.temporal.metrics import increment_anomaly_source_failure, increment_scout_anomaly_outcome
+from products.pulse.backend.temporal.selection import insight_to_descriptor, select_candidates
+from products.pulse.backend.temporal.types import Finding, run_trends_query_sync
+
+if TYPE_CHECKING:
+    from products.signals.backend.facade.api import AnomalyFinding
+
+logger = structlog.get_logger(__name__)
+
+# Bound the re-scoring fan-out so a runaway scout emission can't blow the activity timeout. The scout
+# only watches viewed insights, so real counts are a handful; if it ever floods, keep the highest-weight
+# anomalies (the survivors are re-ranked by impact downstream) and log the truncation.
+MAX_ANOMALIES_PER_SCAN = 50
+
+
+class AnomalySource(Protocol):
+    async def get_findings(
+        self, team_id: int, period_start: str, period_end: str, config: PulseScanConfig
+    ) -> list[Finding]: ...
+
+
+class DeterministicSource:
+    """Selects popular candidates (insights, dashboards, top events) and scores them with the change
+    detector — the always-on baseline source, available for every team."""
+
+    async def get_findings(
+        self, team_id: int, period_start: str, period_end: str, config: PulseScanConfig
+    ) -> list[Finding]:
+        candidates = await select_candidates(team_id, config)
+        return await detect_changes(team_id, candidates, config)
+
+
+async def _adapt_anomaly_to_finding(team: Team, anomaly: "AnomalyFinding", config: PulseScanConfig) -> Finding | None:
+    """Best-effort: load the scout-flagged insight by short_id and re-score it for display numbers.
+
+    Does NOT re-gate — the scout already decided this is anomalous, so we always build a Finding when the
+    insight + series resolve. That includes neutralizing the volume floor (min_baseline_value): it's a
+    detection gate that would zero out change_pct/impact for low-volume metrics, dropping anomalies the
+    scout deliberately surfaced. impact already damps low volume via sqrt(baseline), so ranking still works.
+    Increments a counter so the unresolvable rate is measurable.
+
+    Re-scoring math (score_series, _build_detection_query, ...) is reused from detection.py."""
+    from products.product_analytics.backend.models.insight import Insight  # noqa: PLC0415 — app-init cycle
+
+    if not anomaly.insight_short_id:
+        increment_scout_anomaly_outcome("unresolvable_insight")
+        return None
+
+    @database_sync_to_async
+    def _load() -> "Insight | None":
+        return Insight.objects.filter(team=team, short_id=anomaly.insight_short_id, deleted=False).first()
+
+    insight = await _load()
+    if insight is None:
+        increment_scout_anomaly_outcome("unresolvable_insight")
+        logger.warning("pulse_scout_anomaly_unresolvable", team_id=team.id, short_id=anomaly.insight_short_id)
+        return None
+
+    descriptor = insight_to_descriptor(insight, "scout_anomaly")
+    if descriptor is None:  # insight resolved but isn't a TrendsQuery — can't re-score
+        increment_scout_anomaly_outcome("unsupported_query_kind")
+        logger.warning("pulse_scout_anomaly_unsupported_query", team_id=team.id, short_id=anomaly.insight_short_id)
+        return None
+
+    assert config.baseline_weeks is not None
+    try:
+        # Re-score over the recent baseline window (now), not the scout's original anomaly window — these
+        # are display numbers; the scout already made the trigger decision.
+        result = await run_trends_query_sync(team, _build_detection_query(descriptor.query, config.baseline_weeks))
+    except Exception as exc:
+        increment_scout_anomaly_outcome("query_failed")
+        logger.warning(
+            "pulse_scout_anomaly_query_failed",
+            team_id=team.id,
+            short_id=anomaly.insight_short_id,
+            error=str(exc),
+        )
+        return None
+
+    series = _extract_weekly_series(result)
+    # min_baseline_value=0: the scout owns the surface decision, so don't let the volume floor suppress it.
+    scored = score_series(series, config.model_copy(update={"min_baseline_value": 0.0}))
+    if scored is None:
+        increment_scout_anomaly_outcome("no_series")
+        logger.warning("pulse_scout_anomaly_no_series", team_id=team.id, short_id=anomaly.insight_short_id)
+        return None
+
+    detection_result, current, sparkline = scored
+    if detection_result.baseline_median == 0:  # 0→N rise has no defined % change; skip cleanly, don't show +0%
+        increment_scout_anomaly_outcome("zero_baseline")
+        logger.warning("pulse_scout_anomaly_zero_baseline", team_id=team.id, short_id=anomaly.insight_short_id)
+        return None
+    increment_scout_anomaly_outcome("resolved")
+    return _build_finding(descriptor, detection_result, current, sparkline)
+
+
+async def _adapt_guarded(
+    team: Team, anomaly: "AnomalyFinding", config: PulseScanConfig, semaphore: asyncio.Semaphore
+) -> Finding | None:
+    """Re-score one anomaly under the concurrency limit, isolating failures so one can't abort the scan."""
+    async with semaphore:
+        try:
+            return await _adapt_anomaly_to_finding(team, anomaly, config)
+        except Exception:
+            increment_scout_anomaly_outcome("adapter_error")
+            logger.exception("pulse_scout_anomaly_adapter_error", team_id=team.id, short_id=anomaly.insight_short_id)
+            return None
+
+
+class ScoutAnomalySource:
+    """v1 AnomalySource: consume the Signals anomaly-detection scout's findings."""
+
+    async def get_findings(
+        self, team_id: int, period_start: str, period_end: str, config: PulseScanConfig
+    ) -> list[Finding]:
+        # Lazy import: the pulse package is eagerly preloaded via posthog.api; importing the signals
+        # facade at module level risks an app-init cycle (matches the pattern in delivery.py).
+        from products.signals.backend.facade.api import get_team_anomalies  # noqa: PLC0415 — app-init cycle
+
+        team = await database_sync_to_async(lambda: Team.objects.get(id=team_id))()
+        anomalies = await get_team_anomalies(team, period_start, period_end)  # async — await directly
+        if len(anomalies) > MAX_ANOMALIES_PER_SCAN:
+            logger.warning(
+                "pulse_scout_anomalies_truncated",
+                team_id=team_id,
+                count=len(anomalies),
+                cap=MAX_ANOMALIES_PER_SCAN,
+            )
+            anomalies = sorted(anomalies, key=lambda a: a.weight, reverse=True)[:MAX_ANOMALIES_PER_SCAN]
+
+        # Re-score concurrently under a bounded semaphore (mirrors the prior detect_changes path) so a
+        # batch of cache-cold insights doesn't serialize into the activity timeout. gather preserves order.
+        semaphore = asyncio.Semaphore(DETECTION_CONCURRENCY)
+        results = await asyncio.gather(*(_adapt_guarded(team, a, config, semaphore) for a in anomalies))
+        return [f for f in results if f is not None]
+
+
+# The sources a scan runs. The scout no-ops where it isn't enrolled, so non-scout teams transparently
+# get just the deterministic findings — "additional source", not a replacement.
+ALL_SOURCES: list[AnomalySource] = [DeterministicSource(), ScoutAnomalySource()]
+
+
+async def _safe_get_findings(
+    source: AnomalySource, team_id: int, period_start: str, period_end: str, config: PulseScanConfig
+) -> list[Finding]:
+    """Isolate a source: one failing source degrades to the others' findings rather than failing the scan."""
+    try:
+        return await source.get_findings(team_id, period_start, period_end, config)
+    except Exception:
+        increment_anomaly_source_failure(type(source).__name__)
+        logger.exception("pulse_anomaly_source_failed", source=type(source).__name__, team_id=team_id)
+        return []
+
+
+def _dedup_findings(findings: list[Finding]) -> list[Finding]:
+    """One finding per insight (keyed by descriptor.url = /insights/<short_id>); a scout finding wins over
+    a deterministic one for the same insight (richer hypothesis/severity). Findings with no url (e.g.
+    top-event metrics) are all kept."""
+    chosen: dict[str, Finding] = {}
+    unkeyed: list[Finding] = []
+    for f in findings:
+        key = f.descriptor.url
+        if not key:
+            unkeyed.append(f)
+            continue
+        current = chosen.get(key)
+        if current is None:
+            chosen[key] = f
+        elif current.descriptor.source != "scout_anomaly" and f.descriptor.source == "scout_anomaly":
+            chosen[key] = f  # upgrade a deterministic finding to the scout's for the same insight
+    return list(chosen.values()) + unkeyed
+
+
+async def gather_findings(
+    team_id: int,
+    period_start: str,
+    period_end: str,
+    config: PulseScanConfig,
+    sources: list[AnomalySource] | None = None,
+) -> list[Finding]:
+    """Run every anomaly source concurrently and merge their findings, deduped by insight."""
+    sources = ALL_SOURCES if sources is None else sources
+    per_source = await asyncio.gather(
+        *(_safe_get_findings(s, team_id, period_start, period_end, config) for s in sources)
+    )
+    return _dedup_findings([f for findings in per_source for f in findings])

--- a/products/pulse/backend/temporal/types.py
+++ b/products/pulse/backend/temporal/types.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from posthog.schema import PulseScanConfig
+
+# PulseScanConfig is the single source of truth in the query schema
+# (frontend/src/queries/schema/schema-general.ts → generated into posthog/schema.py), so the TS type and the
+# pydantic model are one definition. Imported here for the activity-input defaults below.
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+
+
+@database_sync_to_async
+def run_trends_query_sync(team: Team, query_json: dict) -> Any:
+    """Execute an opaque TrendsQuery against ClickHouse and return the result dict.
+
+    Shared by detection (headline metric) and narrative (breakdown attribution).
+    """
+    from posthog.api.services.query import process_query_dict  # noqa: PLC0415
+
+    response = process_query_dict(
+        team=team,
+        query_json=query_json,
+        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+    )
+    return response.model_dump() if hasattr(response, "model_dump") else response
+
+
+class MetricDescriptor(BaseModel):
+    """Opaque descriptor of a metric Pulse can re-evaluate.
+
+    `source` traces where the candidate came from (for debugging).
+    `query` is a TrendsQuery-shaped dict, executable against the existing query runner.
+    """
+
+    source: str  # "dashboard_tile" | "recent_insight" | "saved_insight" | "top_event" | "scout_anomaly"
+    source_id: str | int | None = None
+    label: str
+    query: dict[str, Any]
+    url: str | None = None  # deep-link to the source (e.g. /insights/<short_id>), surfaced as "View insight"
+
+
+class CandidateMetric(BaseModel):
+    descriptor: MetricDescriptor
+
+
+class Finding(BaseModel):
+    descriptor: MetricDescriptor
+    current_value: float
+    baseline_value: float
+    change_pct: float
+    impact: float
+    robust_z: float
+    # Recent completed-week values (oldest→newest, current week last) for the card's trend sparkline.
+    series: list[float] | None = None
+
+
+class EnrichedFinding(BaseModel):
+    descriptor: MetricDescriptor
+    current_value: float
+    baseline_value: float
+    change_pct: float
+    impact: float
+    robust_z: float
+    attribution_breakdown: dict[str, Any] | None = None
+    # Supporting evidence, e.g. {"session_ids": [...]} for example replays. None when none found.
+    evidence: dict[str, Any] | None = None
+    narrative: str
+
+
+class FetchFindingsInputs(BaseModel):
+    team_id: int
+    period_start: str
+    period_end: str
+    config: PulseScanConfig = Field(default_factory=PulseScanConfig)
+
+
+class EnrichFindingsInputs(BaseModel):
+    team_id: int
+    user_id: int | None = None
+    findings: list[Finding]
+    max_findings: int = 5
+    # Period bounds (ISO) used to scope the replay-evidence window. Empty disables evidence collection.
+    period_start: str = ""
+    period_end: str = ""
+
+
+class DeliverDigestInputs(BaseModel):
+    team_id: int
+    digest_id: str
+    findings: list[EnrichedFinding]
+
+
+class SynthesizeDigestInputs(BaseModel):
+    team_id: int
+    digest_id: str
+    user_id: int | None = None
+    findings: list[EnrichedFinding]
+    period_start: str = ""
+    period_end: str = ""

--- a/products/pulse/backend/tests/temporal/conftest.py
+++ b/products/pulse/backend/tests/temporal/conftest.py
@@ -1,0 +1,48 @@
+import random
+
+import pytest
+
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+
+from posthog.models import Organization, Team
+from posthog.temporal.common.logger import configure_logger
+
+
+@pytest_asyncio.fixture(autouse=True, scope="module", loop_scope="module")
+async def configure_logger_auto() -> None:
+    configure_logger(cache_logger_on_first_use=False)
+
+
+@pytest.fixture
+def organization():
+    org = Organization.objects.create(
+        name=f"PulseTestOrg-{random.randint(1, 99999)}", is_ai_data_processing_approved=True
+    )
+    yield org
+    org.delete()
+
+
+@pytest.fixture
+def team(organization):
+    team = Team.objects.create(organization=organization, name=f"PulseTestTeam-{random.randint(1, 99999)}")
+    yield team
+    team.delete()
+
+
+@pytest_asyncio.fixture
+async def aorganization():
+    org = await sync_to_async(Organization.objects.create)(
+        name=f"PulseTestOrg-{random.randint(1, 99999)}", is_ai_data_processing_approved=True
+    )
+    yield org
+    await sync_to_async(org.delete)()
+
+
+@pytest_asyncio.fixture
+async def ateam(aorganization):
+    team = await sync_to_async(Team.objects.create)(
+        organization=aorganization, name=f"PulseTestTeam-{random.randint(1, 99999)}"
+    )
+    yield team
+    await sync_to_async(team.delete)()

--- a/products/pulse/backend/tests/temporal/test_pulse_detectors.py
+++ b/products/pulse/backend/tests/temporal/test_pulse_detectors.py
@@ -1,0 +1,121 @@
+import asyncio
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.schema import PulseScanConfig
+
+from products.pulse.backend.temporal.detection import _evaluate_one, score_series
+from products.pulse.backend.temporal.detectors import DetectionResult, PulseDetector, get_detector, register_detector
+from products.pulse.backend.temporal.types import CandidateMetric, EnrichedFinding, Finding, MetricDescriptor
+
+DETECTION = "products.pulse.backend.temporal.detection"
+
+
+class TestDetectorRegistry:
+    def test_get_detector_unknown_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown detection mode: nope"):
+            get_detector("nope")
+
+    def test_get_detector_returns_change_v1(self):
+        detector = get_detector("change_v1")
+        assert isinstance(detector, PulseDetector)
+
+    def test_register_detector_adds_to_registry(self):
+        @register_detector("test_only_mode")
+        class _Dummy(PulseDetector):
+            def detect(self, current, baseline, min_change_pct, robust_z_threshold, min_baseline_value):
+                return DetectionResult(
+                    triggered=False,
+                    baseline_median=0.0,
+                    change_pct=0.0,
+                    impact=0.0,
+                    robust_z=0.0,
+                )
+
+        assert isinstance(get_detector("test_only_mode"), _Dummy)
+
+    def test_detection_result_fields(self):
+        result = DetectionResult(
+            triggered=True,
+            baseline_median=100.0,
+            change_pct=-0.5,
+            impact=5.0,
+            robust_z=3.2,
+        )
+        assert result.triggered is True
+        assert result.baseline_median == 100.0
+        assert result.impact == 5.0
+        assert result.robust_z == 3.2
+
+
+class TestNoStaleZScoreReferences:
+    def test_finding_has_no_z_score_field(self):
+        assert "z_score" not in Finding.model_fields
+        assert "robust_z" in Finding.model_fields
+        assert "impact" in Finding.model_fields
+        assert "z_score" not in EnrichedFinding.model_fields
+        assert "robust_z" in EnrichedFinding.model_fields
+        assert "impact" in EnrichedFinding.model_fields
+
+
+class TestChangeV1Gating:
+    def _detect(self, current, baseline, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0):
+        return get_detector("change_v1").detect(
+            current, baseline, min_change_pct, robust_z_threshold, min_baseline_value
+        )
+
+    @pytest.mark.parametrize(
+        "name,current,baseline,kwargs,expected_triggered",
+        [
+            ("large_change_triggers", 200.0, [100.0, 101.0, 99.0, 100.0], {}, True),
+            ("below_min_change_does_not", 105.0, [100.0, 101.0, 99.0, 100.0], {"min_change_pct": 0.25}, False),
+            # A change against a zero-variance baseline (MAD=0 → robust_z=0) is the clearest signal and must
+            # still fire — robust_z is deliberately not a gate.
+            ("flat_baseline_still_triggers", 50.0, [100.0, 100.0, 100.0, 100.0], {}, True),
+            ("below_volume_floor_does_not", 5.0, [1.0, 1.0, 1.0, 1.0], {"min_baseline_value": 100.0}, False),
+        ],
+    )
+    def test_gating(self, name, current, baseline, kwargs, expected_triggered):
+        result = self._detect(current, baseline, **kwargs)
+        assert result.triggered is expected_triggered
+
+    def test_flat_baseline_robust_z_is_zero_but_not_a_gate(self):
+        result = self._detect(50.0, [100.0, 100.0, 100.0, 100.0])
+        assert result.robust_z == 0.0
+        assert result.triggered is True
+
+
+class TestDetectionFailureMetric:
+    @pytest.mark.asyncio
+    async def test_evaluate_one_counts_candidate_failures(self):
+        # A candidate whose query raises must be counted, so an all-errored scan is distinguishable
+        # from a quiet one (both yield zero findings).
+        candidate = CandidateMetric(descriptor=MetricDescriptor(source="top_event", label="Boom", query={}))
+        config = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+        with (
+            patch(f"{DETECTION}.run_trends_query_sync", side_effect=RuntimeError("query boom")),
+            patch(f"{DETECTION}.increment_detection_outcome") as mock_counter,
+        ):
+            result = await _evaluate_one(MagicMock(id=1), candidate, config, asyncio.Semaphore(1))
+        assert result is None
+        mock_counter.assert_called_once_with("failed")
+
+
+class TestScoreSeries:
+    def test_scores_without_gating(self):
+        # A change BELOW min_change_pct: _evaluate_candidate would drop it (gate),
+        # but score_series must still return the computed numbers (no gate).
+        config = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+        # 4 baseline weeks ~100, current 105 (+5%, below the 25% gate), + a trailing partial week
+        scored = score_series([100.0, 101.0, 99.0, 100.0, 105.0, 0.0], config)
+        assert scored is not None
+        result, current, series = scored
+        assert current == 105.0
+        assert result.triggered is False  # below gate, but still returned
+        assert round(result.change_pct, 3) == 0.05
+        assert len(series) == config.baseline_weeks + 1
+
+    def test_returns_none_on_insufficient_data(self):
+        config = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+        assert score_series([1.0, 2.0], config) is None

--- a/products/pulse/backend/tests/temporal/test_pulse_metrics.py
+++ b/products/pulse/backend/tests/temporal/test_pulse_metrics.py
@@ -1,0 +1,16 @@
+from products.pulse.backend.temporal import metrics
+
+
+class TestPulseMetricsNoOpOutsideContext:
+    """Counters must be safe to call outside a Temporal worker (e.g. unit tests)."""
+
+    def test_dispatcher_counters_noop(self):
+        # No assertion target — just must not raise when no activity/workflow context exists.
+        metrics.increment_dispatch_outcome("eligible", count=3)
+        metrics.increment_dispatch_outcome("dispatched")
+        metrics.increment_dispatch_outcome("failed")
+
+    def test_scan_counters_noop(self):
+        metrics.increment_scan_outcome("delivered")
+        metrics.increment_scan_outcome("failed")
+        metrics.record_finding_count(5)

--- a/products/pulse/backend/tests/temporal/test_pulse_period.py
+++ b/products/pulse/backend/tests/temporal/test_pulse_period.py
@@ -1,0 +1,52 @@
+import datetime as dt
+
+from parameterized import parameterized
+
+from products.pulse.backend.models import PulseSubscriptionFrequency
+from products.pulse.backend.temporal.period import period_bounds, period_key
+
+
+class TestPeriodKey:
+    @parameterized.expand(
+        [
+            # 2026-05-29 is a Friday in ISO week 22 of 2026
+            ("weekly", PulseSubscriptionFrequency.WEEKLY, dt.datetime(2026, 5, 29, 14, 3, tzinfo=dt.UTC), "2026-W22"),
+            ("daily", PulseSubscriptionFrequency.DAILY, dt.datetime(2026, 5, 29, 14, 3, tzinfo=dt.UTC), "2026-05-29"),
+        ]
+    )
+    def test_period_key(self, _name, frequency, now, expected):
+        assert period_key(now, frequency) == expected
+
+    def test_weekly_key_is_stable_within_week(self):
+        mon = dt.datetime(2026, 5, 25, 0, 0, tzinfo=dt.UTC)
+        sun = dt.datetime(2026, 5, 31, 23, 59, tzinfo=dt.UTC)
+        assert period_key(mon, PulseSubscriptionFrequency.WEEKLY) == period_key(sun, PulseSubscriptionFrequency.WEEKLY)
+
+    def test_weekly_bounds_are_the_prior_iso_week(self):
+        # 2026-05-29 is a Friday in ISO week 22; bounds snap to the prior completed week.
+        now = dt.datetime(2026, 5, 29, 14, 3, tzinfo=dt.UTC)
+        start, end = period_bounds(now, PulseSubscriptionFrequency.WEEKLY)
+        assert start == dt.datetime(2026, 5, 18, tzinfo=dt.UTC)  # Monday of the prior week
+        assert end == dt.datetime(2026, 5, 25, tzinfo=dt.UTC)  # Monday of this week
+        assert (end - start) == dt.timedelta(days=7)
+
+    def test_daily_bounds_are_the_prior_day(self):
+        now = dt.datetime(2026, 5, 29, 14, 3, tzinfo=dt.UTC)
+        start, end = period_bounds(now, PulseSubscriptionFrequency.DAILY)
+        assert start == dt.datetime(2026, 5, 28, tzinfo=dt.UTC)
+        assert end == dt.datetime(2026, 5, 29, tzinfo=dt.UTC)
+        assert (end - start) == dt.timedelta(days=1)
+
+    def test_bounds_are_stable_within_period(self):
+        # Two instants in the same period must yield identical bounds, so the digest find-or-create
+        # (which matches on these bounds) can't be fooled into a duplicate by the exact run time.
+        mon = dt.datetime(2026, 5, 25, 8, 0, tzinfo=dt.UTC)
+        fri = dt.datetime(2026, 5, 29, 14, 3, tzinfo=dt.UTC)
+        assert period_bounds(mon, PulseSubscriptionFrequency.WEEKLY) == period_bounds(
+            fri, PulseSubscriptionFrequency.WEEKLY
+        )
+        morning = dt.datetime(2026, 5, 29, 8, 0, tzinfo=dt.UTC)
+        evening = dt.datetime(2026, 5, 29, 20, 30, tzinfo=dt.UTC)
+        assert period_bounds(morning, PulseSubscriptionFrequency.DAILY) == period_bounds(
+            evening, PulseSubscriptionFrequency.DAILY
+        )

--- a/products/pulse/backend/tests/temporal/test_pulse_selection.py
+++ b/products/pulse/backend/tests/temporal/test_pulse_selection.py
@@ -1,0 +1,104 @@
+import pytest
+from unittest.mock import patch
+
+from posthog.schema import PulseScanConfig
+
+from products.product_analytics.backend.models.insight import Insight
+from products.pulse.backend.temporal.selection import _select_saved_insight_candidates, _select_sync
+from products.pulse.backend.temporal.types import CandidateMetric, MetricDescriptor
+
+_SELECTION = "products.pulse.backend.temporal.selection."
+
+
+def _candidate(source: str, source_id: str) -> CandidateMetric:
+    return CandidateMetric(
+        descriptor=MetricDescriptor(source=source, source_id=source_id, label=f"{source}-{source_id}", query={})
+    )
+
+
+@pytest.mark.django_db
+class TestSelectSavedInsightCandidates:
+    def _insight(self, team, name, kind="TrendsQuery", saved=True, deleted=False):
+        return Insight.objects.create(
+            team=team,
+            name=name,
+            saved=saved,
+            deleted=deleted,
+            query={"kind": kind, "series": [{"kind": "EventsNode", "event": "x"}]},
+        )
+
+    def test_picks_trends_insights_only(self, team):
+        self._insight(team, "Weekly signups", "TrendsQuery")
+        self._insight(team, "Onboarding funnel", "FunnelsQuery")
+
+        out = _select_saved_insight_candidates(team, limit=10, existing_ids=set())
+
+        labels = [c.descriptor.label for c in out]
+        assert "Weekly signups" in labels
+        assert "Onboarding funnel" not in labels  # non-Trends dropped
+        assert all(c.descriptor.source == "saved_insight" for c in out)
+
+    def test_respects_existing_ids(self, team):
+        insight = self._insight(team, "Weekly signups")
+        out = _select_saved_insight_candidates(team, limit=10, existing_ids={str(insight.id)})
+        assert out == []
+
+    def test_skips_deleted_and_unsaved(self, team):
+        self._insight(team, "Deleted", deleted=True)
+        self._insight(team, "Unsaved", saved=False)
+        assert _select_saved_insight_candidates(team, limit=10, existing_ids=set()) == []
+
+
+@pytest.mark.django_db
+class TestSelectSyncConfig:
+    """_select_sync is database_sync_to_async-wrapped; .func is the raw sync callable we exercise directly.
+
+    The per-source helpers are mocked so only the config-driven orchestration (per-source on/off + the
+    overall cap) is under test, not the underlying product-model queries.
+    """
+
+    def _patched_sources(self):
+        return (
+            patch(_SELECTION + "_select_dashboard_tile_candidates", return_value=[_candidate("dashboard_tile", "d1")]),
+            patch(
+                _SELECTION + "_select_recent_viewed_insight_candidates",
+                return_value=[_candidate("recent_insight", "r1")],
+            ),
+            patch(_SELECTION + "_select_saved_insight_candidates", return_value=[_candidate("saved_insight", "s1")]),
+            patch(_SELECTION + "_select_top_event_candidates", return_value=[_candidate("top_event", "e1")]),
+        )
+
+    def test_all_sources_contribute_at_defaults(self, team):
+        dash, recent, saved, top = self._patched_sources()
+        with dash, recent, saved, top:
+            out = _select_sync.func(team.id, PulseScanConfig())
+        assert {c.descriptor.source for c in out} == {"dashboard_tile", "recent_insight", "saved_insight", "top_event"}
+
+    def test_limit_zero_disables_each_source(self, team):
+        dash, recent, saved, top = self._patched_sources()
+        with dash as m_dash, recent as m_recent, saved as m_saved, top as m_top:
+            config = PulseScanConfig(
+                dashboard_tile_limit=0, recent_insight_limit=0, saved_insight_limit=0, top_event_limit=25
+            )
+            out = _select_sync.func(team.id, config)
+        assert {c.descriptor.source for c in out} == {"top_event"}
+        m_dash.assert_not_called()
+        m_recent.assert_not_called()
+        m_saved.assert_not_called()
+        m_top.assert_called_once()
+
+    def test_max_candidates_caps_total(self, team):
+        dash, recent, saved, top = self._patched_sources()
+        with dash, recent, saved, top:
+            out = _select_sync.func(team.id, PulseScanConfig(max_candidates=2))
+        assert len(out) == 2
+
+    def test_scalar_knobs_forwarded_to_sources(self, team):
+        dash, recent, saved, top = self._patched_sources()
+        with dash as m_dash, recent as m_recent, saved, top:
+            _select_sync.func(team.id, PulseScanConfig(recent_days=14, min_viewers_for_recent_insight=7))
+        # dashboard helper: (team, limit, recent_days)
+        assert m_dash.call_args.args[2] == 14
+        # recent-viewed helper: (team, limit, existing_ids, recent_days, min_viewers)
+        assert m_recent.call_args.args[3] == 14
+        assert m_recent.call_args.args[4] == 7

--- a/products/pulse/backend/tests/temporal/test_pulse_types.py
+++ b/products/pulse/backend/tests/temporal/test_pulse_types.py
@@ -1,0 +1,33 @@
+from products.pulse.backend.temporal.types import EnrichedFinding, Finding, MetricDescriptor
+
+
+def _descriptor() -> MetricDescriptor:
+    return MetricDescriptor(source="top_event", source_id=1, label="$pageview", query={"kind": "TrendsQuery"})
+
+
+class TestPulseDTOFields:
+    def test_finding_carries_impact_and_robust_z(self):
+        f = Finding(
+            descriptor=_descriptor(),
+            current_value=50.0,
+            baseline_value=100.0,
+            change_pct=-0.5,
+            impact=5.0,
+            robust_z=4.2,
+        )
+        assert f.impact == 5.0
+        assert f.robust_z == 4.2
+        assert not hasattr(f, "z_score")
+
+    def test_enriched_finding_carries_impact_and_robust_z(self):
+        ef = EnrichedFinding(
+            descriptor=_descriptor(),
+            current_value=50.0,
+            baseline_value=100.0,
+            change_pct=-0.5,
+            impact=5.0,
+            robust_z=4.2,
+            narrative="x",
+        )
+        assert ef.impact == 5.0
+        assert ef.robust_z == 4.2

--- a/products/pulse/backend/tests/temporal/test_sources.py
+++ b/products/pulse/backend/tests/temporal/test_sources.py
@@ -1,0 +1,304 @@
+from types import SimpleNamespace
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+
+from posthog.schema import PulseScanConfig
+
+from products.pulse.backend.temporal.sources import (
+    DeterministicSource,
+    _adapt_anomaly_to_finding,
+    _dedup_findings,
+    gather_findings,
+)
+from products.pulse.backend.temporal.types import Finding, MetricDescriptor
+from products.signals.backend.facade.api import AnomalyFinding
+
+SOURCES = "products.pulse.backend.temporal.sources"
+INSIGHT_OBJECTS = "products.product_analytics.backend.models.insight.Insight.objects"
+RESOLVED_CONFIG = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=0.0)
+
+
+def _anomaly(short_id="abc123", weight=0.86):
+    return AnomalyFinding(
+        insight_short_id=short_id,
+        weight=weight,
+        confidence=0.9,
+        hypothesis="deploy regression",
+        severity="P1",
+        description="Signups dropped.",
+        time_range=("2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z"),
+        finding_id="f1",
+        scout_run_id="r1",
+    )
+
+
+class TestAdaptAnomalyToFinding:
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    def test_none_when_no_short_id(self, mock_counter):
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly(short_id=None), RESOLVED_CONFIG)
+        assert result is None
+        mock_counter.assert_called_once_with("unresolvable_insight")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(INSIGHT_OBJECTS)
+    def test_none_when_insight_missing(self, mock_objects, mock_counter):
+        mock_objects.filter.return_value.first.return_value = None
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("missing"), RESOLVED_CONFIG)
+        assert result is None
+        mock_counter.assert_called_once_with("unresolvable_insight")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(INSIGHT_OBJECTS)
+    def test_none_when_insight_not_trends_query(self, mock_objects, mock_counter):
+        # A non-TrendsQuery insight (e.g. a funnel) can't be re-scored — count + skip, don't build.
+        fake_insight = SimpleNamespace(
+            id=1, name="Funnel", derived_name=None, short_id="abc123", query={"kind": "FunnelsQuery"}
+        )
+        mock_objects.filter.return_value.first.return_value = fake_insight
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("abc123"), RESOLVED_CONFIG)
+        assert result is None
+        mock_counter.assert_called_once_with("unsupported_query_kind")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(f"{SOURCES}.run_trends_query_sync", new_callable=AsyncMock)
+    @patch(INSIGHT_OBJECTS)
+    def test_none_when_trends_query_raises(self, mock_objects, mock_trends, mock_counter):
+        # The most likely production failure: the re-score query itself raises (timeout, transient CH error).
+        fake_insight = SimpleNamespace(
+            id=1,
+            name="Signups",
+            derived_name=None,
+            short_id="abc123",
+            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "signup", "math": "total"}]},
+        )
+        mock_objects.filter.return_value.first.return_value = fake_insight
+        mock_trends.side_effect = RuntimeError("clickhouse timeout")
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("abc123"), RESOLVED_CONFIG)
+        assert result is None
+        mock_counter.assert_called_once_with("query_failed")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(f"{SOURCES}.run_trends_query_sync", new_callable=AsyncMock)
+    @patch(INSIGHT_OBJECTS)
+    def test_unwraps_nested_source_query(self, mock_objects, mock_trends, mock_counter):
+        # An InsightVizNode-wrapped query must unwrap to the inner TrendsQuery and still resolve.
+        fake_insight = SimpleNamespace(
+            id=1,
+            name="Signups",
+            derived_name=None,
+            short_id="abc123",
+            query={
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "signup", "math": "total"}],
+                },
+            },
+        )
+        mock_objects.filter.return_value.first.return_value = fake_insight
+        mock_trends.return_value = {"results": [{"data": [100.0, 100.0, 100.0, 100.0, 100.0, 110.0]}]}
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("abc123"), RESOLVED_CONFIG)
+        assert result is not None
+        assert result.descriptor.query["kind"] == "TrendsQuery"  # unwrapped, not the InsightVizNode wrapper
+        mock_counter.assert_called_once_with("resolved")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(f"{SOURCES}.run_trends_query_sync", new_callable=AsyncMock)
+    @patch(INSIGHT_OBJECTS)
+    def test_builds_finding_without_regating(self, mock_objects, mock_trends, mock_counter):
+        # +5% move — BELOW the 25% gate — must STILL produce a Finding (scout already decided; no re-gate).
+        fake_insight = SimpleNamespace(
+            id=1,
+            name="Signups",
+            derived_name=None,
+            short_id="abc123",
+            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "signup", "math": "total"}]},
+        )
+        mock_objects.filter.return_value.first.return_value = fake_insight
+        mock_trends.return_value = {"results": [{"data": [100.0, 101.0, 99.0, 100.0, 105.0, 0.0]}]}
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("abc123"), RESOLVED_CONFIG)
+        assert result is not None
+        assert result.descriptor.source == "scout_anomaly"
+        assert result.descriptor.url == "/insights/abc123"
+        assert result.current_value == 105.0
+        assert round(result.change_pct, 3) == 0.05
+        mock_counter.assert_called_once_with("resolved")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(f"{SOURCES}.run_trends_query_sync", new_callable=AsyncMock)
+    @patch(INSIGHT_OBJECTS)
+    def test_volume_floor_does_not_suppress_low_volume_anomaly(self, mock_objects, mock_trends, mock_counter):
+        # baseline median 3 is below the config's min_baseline_value=5 — the deterministic gate would zero
+        # this out, but the scout owns the surface decision so the adapter must still report the +100% move.
+        config = PulseScanConfig(baseline_weeks=4, min_change_pct=0.25, robust_z_threshold=3.0, min_baseline_value=5.0)
+        fake_insight = SimpleNamespace(
+            id=1,
+            name="Niche",
+            derived_name=None,
+            short_id="abc123",
+            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "x", "math": "total"}]},
+        )
+        mock_objects.filter.return_value.first.return_value = fake_insight
+        mock_trends.return_value = {"results": [{"data": [3.0, 3.0, 3.0, 3.0, 6.0, 0.0]}]}
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("abc123"), config)
+        assert result is not None
+        assert round(result.change_pct, 3) == 1.0  # +100%, not suppressed to 0 by the volume floor
+        mock_counter.assert_called_once_with("resolved")
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch(f"{SOURCES}.run_trends_query_sync", new_callable=AsyncMock)
+    @patch(INSIGHT_OBJECTS)
+    def test_zero_baseline_skipped_without_dividing(self, mock_objects, mock_trends, mock_counter):
+        # A flat-zero baseline (0→N rise) has no defined % change — must skip cleanly, not raise ZeroDivisionError.
+        fake_insight = SimpleNamespace(
+            id=1,
+            name="New metric",
+            derived_name=None,
+            short_id="abc123",
+            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "x", "math": "total"}]},
+        )
+        mock_objects.filter.return_value.first.return_value = fake_insight
+        mock_trends.return_value = {"results": [{"data": [0.0, 0.0, 0.0, 0.0, 10.0, 0.0]}]}
+        result = async_to_sync(_adapt_anomaly_to_finding)(MagicMock(id=1), _anomaly("abc123"), RESOLVED_CONFIG)
+        assert result is None  # skipped, not crashed
+        mock_counter.assert_called_once_with("zero_baseline")
+
+
+class TestScoutAnomalySource:
+    @patch("posthog.models.Team.objects")
+    @patch(f"{SOURCES}._adapt_anomaly_to_finding", new_callable=AsyncMock)
+    @patch("products.signals.backend.facade.api.get_team_anomalies", new_callable=AsyncMock)
+    def test_maps_anomalies_dropping_unresolvable(self, mock_get_anomalies, mock_adapt, mock_team_objects):
+        from products.pulse.backend.temporal.sources import (  # noqa: PLC0415 — imported after patches are installed
+            ScoutAnomalySource,
+        )
+
+        team = MagicMock(id=7)
+        mock_team_objects.get.return_value = team
+        mock_get_anomalies.return_value = [_anomaly("resolves"), _anomaly(None)]
+        sentinel = MagicMock()
+        mock_adapt.side_effect = [sentinel, None]  # first anomaly resolves, second doesn't
+
+        findings = async_to_sync(ScoutAnomalySource().get_findings)(
+            7, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z", RESOLVED_CONFIG
+        )
+        assert findings == [sentinel]  # the None is dropped
+        assert mock_adapt.call_count == 2
+        mock_get_anomalies.assert_awaited_once_with(team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert all(call.args[0] is team for call in mock_adapt.await_args_list)  # team threaded to each adapt
+
+    @patch(f"{SOURCES}.increment_scout_anomaly_outcome")
+    @patch("posthog.models.Team.objects")
+    @patch(f"{SOURCES}._adapt_anomaly_to_finding", new_callable=AsyncMock)
+    @patch("products.signals.backend.facade.api.get_team_anomalies", new_callable=AsyncMock)
+    def test_one_raising_anomaly_does_not_abort_the_scan(
+        self, mock_get_anomalies, mock_adapt, mock_team_objects, mock_counter
+    ):
+        from products.pulse.backend.temporal.sources import (  # noqa: PLC0415 — imported after patches are installed
+            ScoutAnomalySource,
+        )
+
+        mock_team_objects.get.return_value = MagicMock(id=7)
+        mock_get_anomalies.return_value = [_anomaly("boom"), _anomaly("ok")]
+        sentinel = MagicMock()
+        mock_adapt.side_effect = [RuntimeError("db down"), sentinel]  # first raises, second resolves
+
+        findings = async_to_sync(ScoutAnomalySource().get_findings)(
+            7, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z", RESOLVED_CONFIG
+        )
+        assert findings == [sentinel]  # the raising anomaly is skipped, not fatal
+        mock_counter.assert_called_once_with("adapter_error")
+
+    @patch("posthog.models.Team.objects")
+    @patch(f"{SOURCES}._adapt_anomaly_to_finding", new_callable=AsyncMock)
+    @patch("products.signals.backend.facade.api.get_team_anomalies", new_callable=AsyncMock)
+    def test_truncates_to_cap_keeping_highest_weight(self, mock_get_anomalies, mock_adapt, mock_team_objects):
+        from products.pulse.backend.temporal.sources import (  # noqa: PLC0415 — imported after patches are installed
+            MAX_ANOMALIES_PER_SCAN,
+            ScoutAnomalySource,
+        )
+
+        mock_team_objects.get.return_value = MagicMock(id=7)
+        # Ascending weights; only the top MAX_ANOMALIES_PER_SCAN should be re-scored, lowest dropped.
+        mock_get_anomalies.return_value = [
+            _anomaly(f"i{i}", weight=float(i)) for i in range(MAX_ANOMALIES_PER_SCAN + 5)
+        ]
+        mock_adapt.return_value = None
+
+        async_to_sync(ScoutAnomalySource().get_findings)(
+            7, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z", RESOLVED_CONFIG
+        )
+        assert mock_adapt.await_count == MAX_ANOMALIES_PER_SCAN
+        scored_weights = {call.args[1].weight for call in mock_adapt.await_args_list}
+        assert min(scored_weights) == 5.0  # weights 0..4 (the 5 lowest) were dropped
+
+
+def _finding(url: str | None, source: str) -> Finding:
+    return Finding(
+        descriptor=MetricDescriptor(source=source, source_id="1", label="x", query={"kind": "TrendsQuery"}, url=url),
+        current_value=1.0,
+        baseline_value=1.0,
+        change_pct=0.0,
+        impact=0.0,
+        robust_z=0.0,
+        series=[1.0],
+    )
+
+
+class TestDeterministicSource:
+    @patch(f"{SOURCES}.detect_changes", new_callable=AsyncMock)
+    @patch(f"{SOURCES}.select_candidates", new_callable=AsyncMock)
+    def test_selects_then_detects(self, mock_select, mock_detect):
+        candidates = [MagicMock()]
+        findings = [_finding("/insights/a", "recent_insight")]
+        mock_select.return_value = candidates
+        mock_detect.return_value = findings
+        result = async_to_sync(DeterministicSource().get_findings)(7, "s", "e", RESOLVED_CONFIG)
+        assert result == findings
+        mock_select.assert_awaited_once_with(7, RESOLVED_CONFIG)
+        mock_detect.assert_awaited_once_with(7, candidates, RESOLVED_CONFIG)
+
+
+class TestDedupFindings:
+    def test_scout_wins_over_deterministic_for_same_insight(self):
+        det = _finding("/insights/abc", "recent_insight")
+        scout = _finding("/insights/abc", "scout_anomaly")
+        for ordering in ([det, scout], [scout, det]):  # scout wins regardless of order
+            out = _dedup_findings(ordering)
+            assert len(out) == 1
+            assert out[0].descriptor.source == "scout_anomaly"
+
+    def test_distinct_insights_both_kept(self):
+        out = _dedup_findings([_finding("/insights/a", "recent_insight"), _finding("/insights/b", "scout_anomaly")])
+        assert {f.descriptor.url for f in out} == {"/insights/a", "/insights/b"}
+
+    def test_urlless_findings_all_kept(self):
+        # top-event metrics have no insight url — they can't collide, so none are deduped
+        out = _dedup_findings([_finding(None, "top_event"), _finding(None, "top_event")])
+        assert len(out) == 2
+
+
+class TestGatherFindings:
+    @staticmethod
+    def _source(findings=None, raises=None):
+        src = MagicMock()
+        src.get_findings = AsyncMock(side_effect=raises) if raises else AsyncMock(return_value=findings or [])
+        return src
+
+    def test_merges_and_dedups_across_sources(self):
+        det = self._source([_finding("/insights/abc", "recent_insight")])
+        scout = self._source([_finding("/insights/abc", "scout_anomaly")])
+        out = async_to_sync(gather_findings)(7, "s", "e", RESOLVED_CONFIG, sources=[det, scout])
+        assert len(out) == 1
+        assert out[0].descriptor.source == "scout_anomaly"  # same insight, scout preferred
+        # args (incl. config) must thread through to every source intact
+        det.get_findings.assert_awaited_once_with(7, "s", "e", RESOLVED_CONFIG)
+        scout.get_findings.assert_awaited_once_with(7, "s", "e", RESOLVED_CONFIG)
+
+    def test_one_failing_source_degrades_to_the_others(self):
+        bad = self._source(raises=RuntimeError("boom"))
+        good = self._source([_finding("/insights/a", "scout_anomaly")])
+        out = async_to_sync(gather_findings)(7, "s", "e", RESOLVED_CONFIG, sources=[bad, good])
+        assert [f.descriptor.url for f in out] == ["/insights/a"]  # bad source isolated, good survives

--- a/tach.toml
+++ b/tach.toml
@@ -538,6 +538,7 @@ depends_on = [
     "products.error_tracking",
     "products.notifications",
     "products.product_analytics",
+    "products.signals",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem

Pulse needs to know *which metrics moved* before it can explain why. No single detector covers everyone: a deterministic statistical scan works for every team but only sees popular metrics, while the Signals anomaly-detection scout produces richer, hypothesis-bearing findings but only for teams enrolled in it.

## Changes

Adds the finding-production layer of Pulse: two anomaly sources behind one protocol, composed per scan.

```mermaid
flowchart TB
    subgraph SOURCES["AnomalySource implementations (sources.py)"]
        det["DeterministicSource<br/>select_candidates: popular insights,<br/>dashboards, top events<br/>→ detect_changes: change_v1 detector,<br/>gated by tuning knobs"]
        scout["ScoutAnomalySource<br/>get_team_anomalies (signals facade, PR #62648)<br/>→ re-score each flagged insight for display<br/>NO re-gate — the scout already decided"]
    end
    gather["gather_findings<br/>runs all sources concurrently ·<br/>per-source + per-anomaly fault isolation ·<br/>counters for every failure mode"]
    dedup["_dedup_findings<br/>one finding per insight (descriptor.url) ·<br/>scout wins (richer hypothesis/severity)"]
    finding["list[Finding] — everything downstream<br/>(narrative, delivery, Max) is source-agnostic"]

    det --> gather
    scout --> gather
    gather --> dedup --> finding
```

Key decisions:

- **The seam is the `Finding` type.** Sources are swappable; nothing downstream knows where a finding came from. The scout no-ops where it isn't enrolled, so non-scout teams transparently get deterministic findings only.
- **The scout path never re-gates.** The scout already made the trigger decision, so the adapter re-scores only for display numbers: the volume floor is neutralized (low-volume anomalies the scout surfaced aren't zeroed out) and a flat-zero baseline is skipped with its own counter outcome rather than shown as a misleading "+0%".
- **Shared insight resolution.** Both sources resolve insights through one `insight_to_descriptor` helper, so the dedup key (`/insights/<short_id>`) is identical across sources by construction.
- **Fault isolation at three levels**: per-anomaly (`adapter_error` counter), per-candidate (existing), and per-source (`pulse_anomaly_source_failure` counter — a half-degraded digest is alertable, not just log-diagnosable).
- Known watch item before broad enrollment: each source bounds its own trends-query concurrency (semaphore of 8), so an enrolled team can peak at ~16 concurrent queries during a scan. Acceptable at current scale; revisit with a shared bound if burst load warrants it.

## How did you test this code?

I'm an agent; no manual testing claimed. Automated coverage in `test_sources.py` and `test_pulse_detectors.py`: the no-re-gate contract (a +5% move below the gate still produces a finding), volume-floor neutralization, zero-baseline skip, query-failure and unresolvable paths (each pinned to its counter outcome), nested `InsightVizNode` unwrapping, truncation-by-weight, dedup (scout-wins both orderings, url-less findings kept), per-source failure isolation, and config threading into both sources. 275 backend tests, ruff, and tach green locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @vdekrijger. The additive two-source design (rather than the scout replacing the deterministic detector) was an explicit product decision: scouts aren't rolled out everywhere yet, so the scout is an additional source and the deterministic scan remains the always-on baseline. Hardened across several local multi-reviewer swarm rounds — the per-source failure counter, the zero-baseline division guard, and the dead-input-type removal came out of those reviews.
