### PR TITLE
feat(pulse): add subscription and digest rest api

### DIFF
--- a/products/pulse/backend/api.py
+++ b/products/pulse/backend/api.py
@@ -1,0 +1,475 @@
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from django.conf import settings
+from django.db import IntegrityError
+from django.db.models import Count, QuerySet
+
+import structlog
+import posthoganalytics
+from asgiref.sync import async_to_sync
+from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
+from rest_framework import mixins, serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.schema import PulseScanConfig
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.temporal.common.client import async_connect
+
+from products.pulse.backend.constants import MAX_PULSE_FLAG
+from products.pulse.backend.models import (
+    DetectionMode,
+    PulseDigest,
+    PulseFinding,
+    PulseSubscription,
+    PulseSubscriptionFrequency,
+)
+from products.pulse.backend.temporal.detection import MIN_BASELINE_WEEKS
+from products.pulse.backend.temporal.period import period_bounds, period_key
+from products.pulse.backend.temporal.selection import select_candidates
+from products.pulse.backend.temporal.workflow import PulseScanInputs
+
+logger = structlog.get_logger(__name__)
+
+WATCHED_MAX_CANDIDATES = 50
+
+
+class MaxPulseFeatureFlagPermission(BasePermission):
+    """404 (not 403) the whole Pulse surface unless `max-pulse` is enabled for the team's org.
+
+    A 404 hides the feature's existence from teams that don't have it, rather than
+    advertising it with a 403.
+    """
+
+    def has_permission(self, request: Request, view: Any) -> bool:
+        team = view.team
+        org_id = str(team.organization_id)
+        project_id = str(team.id)
+        enabled = posthoganalytics.feature_enabled(
+            MAX_PULSE_FLAG,
+            str(request.user.distinct_id),
+            groups={"organization": org_id, "project": project_id},
+            group_properties={"organization": {"id": org_id}, "project": {"id": project_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+        if not enabled:
+            raise NotFound()
+        return True
+
+
+class PulseFindingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PulseFinding
+        fields = [
+            "id",
+            "digest",
+            "metric_label",
+            "metric_descriptor",
+            "current_value",
+            "baseline_value",
+            "change_pct",
+            "robust_z",
+            "impact",
+            "attribution_breakdown",
+            "evidence",
+            "narrative",
+            "chart_thumbnail_url",
+            "rank",
+            "created_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "metric_label": {"help_text": "Human-readable name of the metric this finding is about."},
+            "metric_descriptor": {"help_text": "Opaque descriptor (source, label, query) Pulse re-evaluates."},
+            "current_value": {"help_text": "Metric value for the current period."},
+            "baseline_value": {"help_text": "Baseline median over the configured baseline window."},
+            "change_pct": {"help_text": "Fractional change vs baseline median, e.g. 0.5 means +50%."},
+            "robust_z": {
+                "help_text": "Robust z-score (median/MAD based). Secondary signal only, never a sole trigger."
+            },
+            "impact": {"help_text": "Ranking score: abs(change_pct) * sqrt(baseline_median)."},
+            "attribution_breakdown": {
+                "help_text": "Breakdown segment that best explains the change, e.g. {'$browser': 'Safari'}, or null."
+            },
+            "evidence": {
+                "help_text": "Supporting evidence: {'series': [...]} recent weekly values, {'daily_series': "
+                "[...]} daily values across the period for the finding chart, {'session_ids': [...]} for example "
+                "replays, and/or {'references': [{type, label, timestamp, id?, change?}]} for the related changes "
+                "(feature flags, experiments, annotations) the narrative tied to this finding — each timestamped "
+                "so it can be placed on the finding's timeline, or null."
+            },
+            "narrative": {"help_text": "LLM-generated explanation of the change."},
+        }
+
+
+class PulseDigestSerializer(serializers.ModelSerializer):
+    findings = PulseFindingSerializer(many=True, read_only=True)
+    finding_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PulseDigest
+        fields = [
+            "id",
+            "period_start",
+            "period_end",
+            "status",
+            "workflow_run_id",
+            "error",
+            "summary",
+            "created_at",
+            "finding_count",
+            "findings",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "status": {"help_text": "Lifecycle of this scan run (pending, generating, delivered, failed)."},
+            "workflow_run_id": {"help_text": "Temporal workflow run id that produced this digest."},
+            "error": {"help_text": "Error payload if the scan run failed, otherwise null."},
+            "summary": {"help_text": "Digest-level big-picture synthesis across findings (LLM-written, may be empty)."},
+        }
+
+    def get_finding_count(self, obj: PulseDigest) -> int:
+        # Avoid extra query when prefetched, fall back to .count() otherwise.
+        if hasattr(obj, "_prefetched_objects_cache") and "findings" in obj._prefetched_objects_cache:
+            return len(obj._prefetched_objects_cache["findings"])
+        return obj.findings.count()
+
+
+class PulseDigestListSerializer(serializers.ModelSerializer):
+    finding_count = serializers.IntegerField(read_only=True, help_text="Number of findings in this digest.")
+
+    class Meta:
+        model = PulseDigest
+        fields = [
+            "id",
+            "period_start",
+            "period_end",
+            "status",
+            "error",
+            "created_at",
+            "finding_count",
+            "summary",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "status": {"help_text": "Lifecycle of this scan run (pending, generating, delivered, failed)."},
+            "error": {"help_text": "Error payload (with a `message`) if the scan run failed, otherwise null."},
+            "summary": {"help_text": "Digest-level big-picture synthesis across findings (LLM-written, may be empty)."},
+        }
+
+
+class PulseSubscriptionSerializer(serializers.ModelSerializer):
+    min_change_pct = serializers.FloatField(
+        required=False,
+        min_value=0.0,
+        max_value=1.0,
+        help_text="Primary gate: minimum absolute fractional change to flag (0.0-1.0).",
+    )
+    baseline_weeks = serializers.IntegerField(
+        required=False,
+        min_value=MIN_BASELINE_WEEKS,
+        max_value=52,
+        help_text="Number of completed weeks used to compute the baseline median.",
+    )
+    max_findings = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=50,
+        help_text="Maximum findings surfaced per digest.",
+    )
+    robust_z_threshold = serializers.FloatField(
+        required=False,
+        min_value=0.1,
+        max_value=10.0,
+        help_text="Secondary informational threshold for the robust z-score. Never a sole trigger.",
+    )
+
+    class Meta:
+        model = PulseSubscription
+        fields = [
+            "id",
+            "enabled",
+            "frequency",
+            "detection_mode",
+            "sensitivity",
+            "min_change_pct",
+            "baseline_weeks",
+            "max_findings",
+            "robust_z_threshold",
+            "last_scan_at",
+            "next_scan_at",
+            "created_at",
+        ]
+        read_only_fields = ["id", "last_scan_at", "next_scan_at", "created_at"]
+        extra_kwargs = {
+            "enabled": {"help_text": "Whether Pulse runs scans for this team."},
+            "frequency": {"help_text": "Scan cadence (weekly or daily)."},
+            "detection_mode": {"help_text": "Detection algorithm. Only 'change_v1' is available in v1."},
+            "sensitivity": {
+                "help_text": "Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only "
+                "the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds."
+            },
+            "last_scan_at": {"help_text": "When Pulse last completed a scan for this team."},
+            "next_scan_at": {"help_text": "When the next scan is scheduled."},
+        }
+
+    def validate_detection_mode(self, value: str) -> str:
+        if value == DetectionMode.DISCOVERY:
+            raise ValidationError("detection_mode 'discovery' is not available in v1.")
+        return value
+
+
+class PulseWatchedCandidateSerializer(serializers.Serializer):
+    """A single metric Pulse is currently watching (read-only transparency)."""
+
+    source = serializers.CharField(
+        help_text="Where the candidate came from (dashboard_tile, recent_insight, top_event)."
+    )
+    source_id = serializers.CharField(allow_null=True, help_text="Underlying insight/event id, if any.")
+    label = serializers.CharField(help_text="Human-readable metric name.")
+    query = serializers.JSONField(help_text="TrendsQuery-shaped dict Pulse re-evaluates.")
+
+
+class PulseScanConfigSerializer(serializers.Serializer):
+    """Per-run scan tuning knobs for a manual staff trigger.
+
+    Every field is optional; omitted knobs fall back to the built-in defaults (the production
+    constants), so a partial override is "defaults plus the knobs you set". Nothing is persisted —
+    the resolved config rides along with the one-off scan that started it.
+    """
+
+    # Selection — which metrics get scanned. A per-source limit of 0 turns that source off.
+    max_candidates = serializers.IntegerField(
+        required=False, min_value=1, max_value=1000, help_text="Cap on total metrics scanned per run."
+    )
+    recent_days = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=365,
+        help_text="Lookback window for recently-accessed dashboards and recently-viewed insights.",
+    )
+    min_viewers_for_recent_insight = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=100,
+        help_text="Minimum distinct viewers for the recently-viewed-insights source to include an insight.",
+    )
+    dashboard_tile_limit = serializers.IntegerField(
+        required=False, min_value=0, max_value=200, help_text="Max insights from pinned/recent dashboards (0 = off)."
+    )
+    recent_insight_limit = serializers.IntegerField(
+        required=False, min_value=0, max_value=500, help_text="Max recently-viewed insights (0 = off)."
+    )
+    saved_insight_limit = serializers.IntegerField(
+        required=False, min_value=0, max_value=200, help_text="Max recently-edited saved Trends insights (0 = off)."
+    )
+    top_event_limit = serializers.IntegerField(
+        required=False, min_value=0, max_value=500, help_text="Max highest-volume events (0 = off)."
+    )
+    # Detection — what counts as a notable change.
+    min_baseline_value = serializers.FloatField(
+        required=False,
+        min_value=0.0,
+        max_value=1_000_000.0,
+        help_text="Volume floor: skip metrics whose baseline median is below this (the top noise lever).",
+    )
+    min_change_pct = serializers.FloatField(
+        required=False,
+        min_value=0.01,
+        max_value=10.0,
+        help_text="Primary gate: minimum absolute fractional change to flag (0.25 = 25%).",
+    )
+    robust_z_threshold = serializers.FloatField(
+        required=False,
+        min_value=0.1,
+        max_value=10.0,
+        help_text="Secondary informational threshold for the robust z-score. Never a sole trigger.",
+    )
+    baseline_weeks = serializers.IntegerField(
+        required=False,
+        min_value=MIN_BASELINE_WEEKS,
+        max_value=12,
+        help_text="Completed weeks used to compute the baseline median.",
+    )
+    max_findings = serializers.IntegerField(
+        required=False, min_value=1, max_value=50, help_text="Maximum findings surfaced per digest."
+    )
+
+
+class PulseDigestViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated, MaxPulseFeatureFlagPermission]
+    queryset = PulseDigest.objects.unscoped()
+
+    def get_serializer_class(self) -> type[serializers.BaseSerializer]:
+        if self.action == "list":
+            return PulseDigestListSerializer
+        return PulseDigestSerializer
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        qs = queryset.filter(team_id=self.team_id).order_by("-created_at")
+        if self.action == "list":
+            qs = qs.annotate(finding_count=Count("findings"))
+        elif self.action == "retrieve":
+            qs = qs.prefetch_related("findings")
+        return qs
+
+    @extend_schema(
+        request=PulseScanConfigSerializer,
+        responses={
+            202: OpenApiResponse(
+                response=inline_serializer(
+                    name="TriggerScanResponse",
+                    fields={"workflow_id": serializers.CharField()},
+                ),
+                description="Scan triggered; returns the Temporal workflow id.",
+            )
+        },
+    )
+    @action(detail=False, methods=["post"])
+    def trigger_scan(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Kick off a one-off Pulse scan for this team now, without waiting for the schedule.
+
+        Staff-only for now (404 hides it from non-staff); the gate can be relaxed to expose it to users later.
+
+        An optional body of tuning knobs (PulseScanConfig) overrides the heuristics for this run only —
+        nothing is persisted. The override is staff-gated by the same 404 as the trigger itself. With no
+        body, the run resolves its detection thresholds from the team's PulseSubscription, as a scheduled
+        run would.
+        """
+        if not request.user.is_staff:
+            raise NotFound()
+
+        config_serializer = PulseScanConfigSerializer(data=request.data or {})
+        config_serializer.is_valid(raise_exception=True)
+        # An empty body means "use the team's saved settings" (config=None → resolved in the workflow);
+        # any provided knob produces a full override built over the built-in defaults.
+        override = PulseScanConfig(**config_serializer.validated_data) if config_serializer.validated_data else None
+
+        team = self.team
+        subscription = PulseSubscription.objects.unscoped().filter(team_id=team.id).first()
+        frequency = subscription.frequency if subscription else PulseSubscriptionFrequency.WEEKLY
+        now = datetime.now(UTC)
+        period_from, period_to = period_bounds(now, frequency)
+        inputs = PulseScanInputs(
+            team_id=team.id,
+            period_key=period_key(now, frequency),
+            period_start=period_from.isoformat(),
+            period_end=period_to.isoformat(),
+            user_id=request.user.id,
+            config=override,
+        )
+        # Unique id (vs the scheduler's deterministic id) so a manual run never collides with a scheduled one.
+        workflow_id = f"pulse-scan-manual-{team.id}-{uuid4()}"
+
+        async def _start() -> None:
+            client = await async_connect()
+            await client.start_workflow(
+                "pulse-scan",
+                inputs,
+                id=workflow_id,
+                task_queue=settings.MAX_AI_TASK_QUEUE,
+            )
+
+        try:
+            async_to_sync(_start)()
+        except Exception:
+            logger.exception("pulse_trigger_scan_failed", team_id=team.id, workflow_id=workflow_id)
+            return Response(
+                {"detail": "Could not start the scan right now. Please try again shortly."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        return Response({"workflow_id": workflow_id}, status=status.HTTP_202_ACCEPTED)
+
+
+class PulseFindingViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated, MaxPulseFeatureFlagPermission]
+    queryset = PulseFinding.objects.unscoped()
+    serializer_class = PulseFindingSerializer
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        qs = queryset.filter(digest__team_id=self.team_id)
+        digest_id = self.request.query_params.get("digest")
+        if digest_id:
+            qs = qs.filter(digest_id=digest_id)
+        return qs.order_by("rank", "-created_at")
+
+
+class PulseSubscriptionViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated, MaxPulseFeatureFlagPermission]
+    queryset = PulseSubscription.objects.unscoped()
+    serializer_class = PulseSubscriptionSerializer
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        return queryset.filter(team_id=self.team_id)
+
+    def perform_create(self, serializer: serializers.ModelSerializer) -> None:
+        # OneToOneField on team enforces singleton at DB level; the explicit pre-check
+        # gives a friendly 400 in the common path but we catch IntegrityError for the
+        # concurrent-POST race.
+        if PulseSubscription.objects.unscoped().filter(team_id=self.team_id).exists():
+            raise ValidationError("This team already has a Pulse subscription. Use PATCH to update it.")
+        try:
+            serializer.save(team_id=self.team_id, created_by=self.request.user)
+        except IntegrityError as exc:
+            raise ValidationError("This team already has a Pulse subscription. Use PATCH to update it.") from exc
+
+    @extend_schema(responses={200: OpenApiResponse(response=PulseSubscriptionSerializer)})
+    @action(detail=False, methods=["get"], url_path="current")
+    def current(self, request: Request, *args, **kwargs) -> Response:
+        sub = PulseSubscription.objects.unscoped().filter(team_id=self.team_id).first()
+        if sub:
+            return Response(self.get_serializer(sub).data)
+        # No subscription yet — serialize the model's own field defaults (single source of truth)
+        # via an unsaved instance, so this response can't drift from the model definition.
+        defaults = self.get_serializer(PulseSubscription()).data
+        defaults["id"] = None
+        return Response(defaults)
+
+    @extend_schema(
+        request=None,
+        responses={200: OpenApiResponse(response=PulseWatchedCandidateSerializer(many=True))},
+    )
+    @action(detail=False, methods=["get"], url_path="watched")
+    def watched(self, request: Request, *args, **kwargs) -> Response:
+        # Preview the default-config selection (every source at its default limit), capped to a small total for the panel.
+        candidates = async_to_sync(select_candidates)(
+            team_id=self.team_id, config=PulseScanConfig(max_candidates=WATCHED_MAX_CANDIDATES)
+        )
+        rows = [
+            {
+                "source": c.descriptor.source,
+                "source_id": None if c.descriptor.source_id is None else str(c.descriptor.source_id),
+                "label": c.descriptor.label,
+                "query": c.descriptor.query,
+            }
+            for c in candidates
+        ]
+        return Response({"results": rows})

--- a/products/pulse/backend/routes.py
+++ b/products/pulse/backend/routes.py
@@ -1,0 +1,13 @@
+from posthog.api.routing import RouterRegistry
+
+from products.pulse.backend.api import PulseDigestViewSet, PulseFindingViewSet, PulseSubscriptionViewSet
+
+
+def register_routes(routers: RouterRegistry) -> None:
+    routers.register_legacy_dual_route(r"pulse_digests", PulseDigestViewSet, "environment_pulse_digests", ["team_id"])
+    routers.register_legacy_dual_route(
+        r"pulse_findings", PulseFindingViewSet, "environment_pulse_findings", ["team_id"]
+    )
+    routers.register_legacy_dual_route(
+        r"pulse_subscriptions", PulseSubscriptionViewSet, "environment_pulse_subscriptions", ["team_id"]
+    )

--- a/products/pulse/backend/tests/test_api.py
+++ b/products/pulse/backend/tests/test_api.py
@@ -1,0 +1,375 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import Team
+from posthog.models.scoping import team_scope
+
+from products.pulse.backend.models import PulseDigest, PulseDigestStatus, PulseFinding, PulseSubscription
+from products.pulse.backend.temporal.types import CandidateMetric, MetricDescriptor
+
+FLAG_TARGET = "products.pulse.backend.api.posthoganalytics.feature_enabled"
+
+
+def _make_digest(team: Team, status: str = PulseDigestStatus.DELIVERED, error: dict | None = None) -> PulseDigest:
+    with team_scope(team.id):
+        now = datetime.now(UTC)
+        return PulseDigest.objects.create(
+            team=team,
+            period_start=now - timedelta(days=7),
+            period_end=now,
+            status=status,
+            error=error,
+        )
+
+
+def _make_finding(
+    digest: PulseDigest, team: Team, label: str = "Test metric", rank: int = 0, evidence: dict | None = None
+) -> PulseFinding:
+    with team_scope(team.id):
+        return PulseFinding.objects.create(
+            digest=digest,
+            team=team,
+            metric_descriptor={"source": "top_event", "label": label, "query": {}},
+            metric_label=label,
+            current_value=100.0,
+            baseline_value=80.0,
+            change_pct=0.25,
+            impact=2.24,
+            robust_z=2.5,
+            evidence=evidence,
+            narrative=f"{label} rose 25%.",
+            rank=rank,
+        )
+
+
+class TestPulseFindingSerializerFields(APIBaseTest):
+    @patch(FLAG_TARGET, return_value=True)
+    def test_finding_exposes_robust_z_and_impact_not_z_score(self, _mock) -> None:
+        digest = _make_digest(self.team)
+        finding = _make_finding(digest, self.team)
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/{finding.id}/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        data = resp.json()
+        self.assertIn("robust_z", data)
+        self.assertIn("impact", data)
+        self.assertNotIn("z_score", data)
+        self.assertEqual(data["robust_z"], 2.5)
+        self.assertEqual(data["impact"], 2.24)
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_finding_exposes_evidence(self, _mock) -> None:
+        digest = _make_digest(self.team)
+        finding = _make_finding(digest, self.team, evidence={"session_ids": ["abc", "def"]})
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/{finding.id}/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        self.assertEqual(resp.json()["evidence"], {"session_ids": ["abc", "def"]})
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_subscription_drops_channel_fields(self, _mock) -> None:
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_subscriptions/current/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        data = resp.json()
+        for removed in ("enabled_channels", "slack_channel_id", "email_recipients"):
+            self.assertNotIn(removed, data)
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_list_digest_exposes_error_message(self, _mock) -> None:
+        _make_digest(self.team, status=PulseDigestStatus.FAILED, error={"message": "ImportError: boom"})
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        results = resp.json()["results"]
+        self.assertEqual(results[0]["error"], {"message": "ImportError: boom"})
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_digest_drops_delivered_to(self, _mock) -> None:
+        digest = _make_digest(self.team)
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/{digest.id}/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        self.assertNotIn("delivered_to", resp.json())
+
+
+class TestPulseDigestAndFindingList(APIBaseTest):
+    @patch(FLAG_TARGET, return_value=True)
+    def test_list_digests_returns_only_current_team(self, _mock) -> None:
+        _make_digest(self.team)
+        other_team = self.organization.teams.create(name="other")
+        other_team_digest = _make_digest(other_team)
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        ids = [d["id"] for d in resp.json()["results"]]
+        self.assertNotIn(str(other_team_digest.id), ids)
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_list_digests_includes_finding_count(self, _mock) -> None:
+        digest = _make_digest(self.team)
+        _make_finding(digest, self.team)
+        _make_finding(digest, self.team, label="Metric B", rank=1)
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/")
+        self.assertEqual(resp.json()["results"][0]["finding_count"], 2)
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_retrieve_digest_returns_findings(self, _mock) -> None:
+        digest = _make_digest(self.team)
+        _make_finding(digest, self.team)
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/{digest.id}/")
+        body = resp.json()
+        self.assertEqual(body["finding_count"], 1)
+        self.assertEqual(len(body["findings"]), 1)
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_list_findings_filters_by_team_via_digest(self, _mock) -> None:
+        digest = _make_digest(self.team)
+        _make_finding(digest, self.team)
+        other_team = self.organization.teams.create(name="other")
+        other_digest = _make_digest(other_team)
+        _make_finding(other_digest, other_team, label="Other team finding")
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/")
+        labels = [f["metric_label"] for f in resp.json()["results"]]
+        self.assertEqual(labels, ["Test metric"])
+
+
+class TestPulseSubscriptionValidation(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = f"/api/environments/{self.team.id}/pulse_subscriptions/"
+
+    @parameterized.expand(
+        [
+            ("min_change_pct_low", {"min_change_pct": -0.1}),
+            ("min_change_pct_high", {"min_change_pct": 1.5}),
+            ("baseline_weeks_low", {"baseline_weeks": 0}),
+            (
+                "baseline_weeks_below_floor",
+                {"baseline_weeks": 2},
+            ),  # below MIN_BASELINE_WEEKS — must reject, not silently clamp
+            ("baseline_weeks_high", {"baseline_weeks": 53}),
+            ("max_findings_low", {"max_findings": 0}),
+            ("max_findings_high", {"max_findings": 51}),
+            ("robust_z_low", {"robust_z_threshold": 0.0}),
+            ("robust_z_high", {"robust_z_threshold": 11.0}),
+        ]
+    )
+    @patch(FLAG_TARGET, return_value=True)
+    def test_out_of_range_rejected(self, _name, overrides, _mock) -> None:
+        resp = self.client.post(self.url, {"enabled": True, **overrides}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.json())
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_discovery_detection_mode_rejected(self, _mock) -> None:
+        resp = self.client.post(self.url, {"enabled": True, "detection_mode": "discovery"}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.json())
+        self.assertIn("detection_mode", str(resp.json()).lower())
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_change_v1_accepted(self, _mock) -> None:
+        resp = self.client.post(
+            self.url, {"enabled": True, "detection_mode": "change_v1", "min_change_pct": 0.3}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.json())
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_create_then_update(self, _mock) -> None:
+        create_resp = self.client.post(self.url, {"enabled": True, "frequency": "weekly"}, format="json")
+        self.assertEqual(create_resp.status_code, status.HTTP_201_CREATED, create_resp.json())
+        sub_id = create_resp.json()["id"]
+        update_resp = self.client.patch(f"{self.url}{sub_id}/", {"frequency": "daily"}, format="json")
+        self.assertEqual(update_resp.status_code, status.HTTP_200_OK, update_resp.json())
+        self.assertEqual(update_resp.json()["frequency"], "daily")
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_singleton_enforced(self, _mock) -> None:
+        with team_scope(self.team.id):
+            PulseSubscription.objects.create(team=self.team)
+        resp = self.client.post(self.url, {"enabled": True, "frequency": "weekly"}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.json())
+
+
+class TestPulseSubscriptionCurrent(APIBaseTest):
+    @patch(FLAG_TARGET, return_value=True)
+    def test_current_returns_defaults_when_missing(self, _mock) -> None:
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_subscriptions/current/")
+        body = resp.json()
+        self.assertIsNone(body["id"])
+        self.assertFalse(body["enabled"])
+        self.assertEqual(body["frequency"], "weekly")
+        self.assertEqual(body["detection_mode"], "change_v1")
+        self.assertEqual(body["sensitivity"], "balanced")
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_current_returns_saved_subscription(self, _mock) -> None:
+        with team_scope(self.team.id):
+            sub = PulseSubscription.objects.create(team=self.team, enabled=True, frequency="daily", max_findings=7)
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_subscriptions/current/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.json())
+        body = resp.json()
+        self.assertEqual(body["id"], str(sub.id))
+        self.assertTrue(body["enabled"])
+        self.assertEqual(body["frequency"], "daily")
+        self.assertEqual(body["max_findings"], 7)
+
+
+class TestPulseFlagGate(APIBaseTest):
+    @patch(FLAG_TARGET, return_value=False)
+    def test_findings_list_404_when_flag_off(self, _mock) -> None:
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
+
+    @patch(FLAG_TARGET, return_value=False)
+    def test_digests_list_404_when_flag_off(self, _mock) -> None:
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_digests/")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
+
+    @patch(FLAG_TARGET, return_value=False)
+    def test_subscription_current_404_when_flag_off(self, _mock) -> None:
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_subscriptions/current/")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_findings_list_200_when_flag_on(self, _mock) -> None:
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+
+
+class TestPulseCrossTeamIsolation(APIBaseTest):
+    @patch(FLAG_TARGET, return_value=True)
+    def test_retrieve_other_teams_finding_404(self, _mock) -> None:
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_digest = _make_digest(other_team)
+        other_finding = _make_finding(other_digest, other_team, label="X")
+        resp = self.client.get(f"/api/environments/{self.team.id}/pulse_findings/{other_finding.id}/")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
+
+
+class TestPulseWatchedEndpoint(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = f"/api/environments/{self.team.id}/pulse_subscriptions/watched/"
+
+    @patch(FLAG_TARGET, return_value=True)
+    @patch("products.pulse.backend.api.select_candidates")
+    def test_watched_returns_candidates(self, mock_select, _mock_flag) -> None:
+        async def _fake(*_args, **_kwargs):
+            return [
+                CandidateMetric(
+                    descriptor=MetricDescriptor(
+                        source="top_event",
+                        source_id=42,
+                        label="Signups",
+                        query={"kind": "TrendsQuery"},
+                    )
+                )
+            ]
+
+        mock_select.side_effect = _fake
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.content)
+        data = resp.json()
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["label"], "Signups")
+        self.assertEqual(data["results"][0]["source"], "top_event")
+        self.assertEqual(data["results"][0]["source_id"], "42")
+
+    @patch(FLAG_TARGET, return_value=False)
+    def test_watched_404_when_flag_off(self, _mock_flag) -> None:
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
+
+
+class TestPulseTriggerScan(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = f"/api/environments/{self.team.id}/pulse_digests/trigger_scan/"
+
+    def _make_staff(self) -> None:
+        self.user.is_staff = True
+        self.user.save()
+
+    def _mock_temporal_client(self, captured: dict) -> MagicMock:
+        async def _start_workflow(_name: str, inputs, **kwargs) -> None:
+            captured["inputs"] = inputs
+            captured["kwargs"] = kwargs
+
+        client = MagicMock()
+        client.start_workflow = AsyncMock(side_effect=_start_workflow)
+        return client
+
+    @patch(FLAG_TARGET, return_value=True)
+    def test_non_staff_gets_404(self, _mock_flag) -> None:
+        resp = self.client.post(self.url, {}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND, resp.content)
+
+    @patch(FLAG_TARGET, return_value=True)
+    @patch("products.pulse.backend.api.async_connect", new_callable=AsyncMock)
+    def test_staff_empty_body_starts_scan_without_override(self, mock_connect, _mock_flag) -> None:
+        self._make_staff()
+        captured: dict = {}
+        mock_connect.return_value = self._mock_temporal_client(captured)
+
+        resp = self.client.post(self.url, {}, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED, resp.content)
+        self.assertIn("workflow_id", resp.json())
+        self.assertIsNone(captured["inputs"].config)
+
+    @patch(FLAG_TARGET, return_value=True)
+    @patch("products.pulse.backend.api.async_connect", new_callable=AsyncMock)
+    def test_temporal_unavailable_returns_503(self, mock_connect, _mock_flag) -> None:
+        self._make_staff()
+        mock_connect.side_effect = RuntimeError("temporal down")
+
+        resp = self.client.post(self.url, {}, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_503_SERVICE_UNAVAILABLE, resp.content)
+
+    @patch(FLAG_TARGET, return_value=True)
+    @patch("products.pulse.backend.api.async_connect", new_callable=AsyncMock)
+    def test_staff_override_threads_config_into_inputs(self, mock_connect, _mock_flag) -> None:
+        self._make_staff()
+        captured: dict = {}
+        mock_connect.return_value = self._mock_temporal_client(captured)
+
+        body = {"min_baseline_value": 12.0, "top_event_limit": 0, "max_findings": 3, "min_change_pct": 0.5}
+        resp = self.client.post(self.url, body, format="json")
+
+        self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED, resp.content)
+        config = captured["inputs"].config
+        self.assertIsNotNone(config)
+        self.assertEqual(config.min_baseline_value, 12.0)
+        self.assertEqual(config.top_event_limit, 0)
+        self.assertEqual(config.max_findings, 3)
+        self.assertEqual(config.min_change_pct, 0.5)
+        self.assertEqual(config.dashboard_tile_limit, 10)
+        self.assertEqual(config.max_candidates, 200)
+
+    @parameterized.expand(
+        [
+            ("min_change_pct_too_high", {"min_change_pct": 99}),
+            ("min_change_pct_negative", {"min_change_pct": -0.1}),
+            ("min_change_pct_zero", {"min_change_pct": 0.0}),
+            ("top_event_limit_negative", {"top_event_limit": -1}),
+            ("dashboard_tile_limit_over_max", {"dashboard_tile_limit": 201}),
+            ("recent_insight_limit_negative", {"recent_insight_limit": -1}),
+            ("saved_insight_limit_negative", {"saved_insight_limit": -1}),
+            ("max_findings_zero", {"max_findings": 0}),
+            ("max_findings_over_max", {"max_findings": 51}),
+            ("baseline_weeks_too_low", {"baseline_weeks": 1}),
+            ("baseline_weeks_too_high", {"baseline_weeks": 13}),
+            ("min_viewers_zero", {"min_viewers_for_recent_insight": 0}),
+            ("recent_days_zero", {"recent_days": 0}),
+            ("recent_days_over_max", {"recent_days": 366}),
+            ("robust_z_too_low", {"robust_z_threshold": 0.05}),
+            ("min_baseline_value_negative", {"min_baseline_value": -1}),
+            ("max_candidates_zero", {"max_candidates": 0}),
+            ("max_candidates_over_max", {"max_candidates": 1001}),
+        ]
+    )
+    @patch(FLAG_TARGET, return_value=True)
+    def test_invalid_override_rejected(self, _name: str, body: dict, _mock_flag) -> None:
+        self._make_staff()
+        resp = self.client.post(self.url, body, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST, resp.content)

--- a/products/pulse/frontend/generated/api.schemas.ts
+++ b/products/pulse/frontend/generated/api.schemas.ts
@@ -1,0 +1,419 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+/**
+ * * `pending` - Pending
+ * * `generating` - Generating
+ * * `delivered` - Delivered
+ * * `failed` - Failed
+ */
+export type PulseDigestStatusEnumApi = (typeof PulseDigestStatusEnumApi)[keyof typeof PulseDigestStatusEnumApi]
+
+export const PulseDigestStatusEnumApi = {
+    Pending: 'pending',
+    Generating: 'generating',
+    Delivered: 'delivered',
+    Failed: 'failed',
+} as const
+
+export interface PulseDigestListApi {
+    readonly id: string
+    readonly period_start: string
+    readonly period_end: string
+    /** Lifecycle of this scan run (pending, generating, delivered, failed).
+     *
+     * * `pending` - Pending
+     * * `generating` - Generating
+     * * `delivered` - Delivered
+     * * `failed` - Failed */
+    readonly status: PulseDigestStatusEnumApi
+    /** Error payload (with a `message`) if the scan run failed, otherwise null. */
+    readonly error: unknown
+    readonly created_at: string
+    /** Number of findings in this digest. */
+    readonly finding_count: number
+    /** Digest-level big-picture synthesis across findings (LLM-written, may be empty). */
+    readonly summary: string
+}
+
+export interface PaginatedPulseDigestListListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: PulseDigestListApi[]
+}
+
+export interface PulseFindingApi {
+    readonly id: string
+    readonly digest: string
+    /** Human-readable name of the metric this finding is about. */
+    readonly metric_label: string
+    /** Opaque descriptor (source, label, query) Pulse re-evaluates. */
+    readonly metric_descriptor: unknown
+    /** Metric value for the current period. */
+    readonly current_value: number
+    /** Baseline median over the configured baseline window. */
+    readonly baseline_value: number
+    /** Fractional change vs baseline median, e.g. 0.5 means +50%. */
+    readonly change_pct: number
+    /** Robust z-score (median/MAD based). Secondary signal only, never a sole trigger. */
+    readonly robust_z: number
+    /** Ranking score: abs(change_pct) * sqrt(baseline_median). */
+    readonly impact: number
+    /** Breakdown segment that best explains the change, e.g. {'$browser': 'Safari'}, or null. */
+    readonly attribution_breakdown: unknown
+    /** Supporting evidence: {'series': [...]} recent weekly values, {'daily_series': [...]} daily values across the period for the finding chart, {'session_ids': [...]} for example replays, and/or {'references': [{type, label, timestamp, id?, change?}]} for the related changes (feature flags, experiments, annotations) the narrative tied to this finding — each timestamped so it can be placed on the finding's timeline, or null. */
+    readonly evidence: unknown
+    /** LLM-generated explanation of the change. */
+    readonly narrative: string
+    readonly chart_thumbnail_url: string
+    readonly rank: number
+    readonly created_at: string
+}
+
+export interface PulseDigestApi {
+    readonly id: string
+    readonly period_start: string
+    readonly period_end: string
+    /** Lifecycle of this scan run (pending, generating, delivered, failed).
+     *
+     * * `pending` - Pending
+     * * `generating` - Generating
+     * * `delivered` - Delivered
+     * * `failed` - Failed */
+    readonly status: PulseDigestStatusEnumApi
+    /** Temporal workflow run id that produced this digest. */
+    readonly workflow_run_id: string
+    /** Error payload if the scan run failed, otherwise null. */
+    readonly error: unknown
+    /** Digest-level big-picture synthesis across findings (LLM-written, may be empty). */
+    readonly summary: string
+    readonly created_at: string
+    readonly finding_count: number
+    readonly findings: readonly PulseFindingApi[]
+}
+
+/**
+ * Per-run scan tuning knobs for a manual staff trigger.
+ *
+ * Every field is optional; omitted knobs fall back to the built-in defaults (the production
+ * constants), so a partial override is "defaults plus the knobs you set". Nothing is persisted —
+ * the resolved config rides along with the one-off scan that started it.
+ */
+export interface PulseScanConfigApi {
+    /**
+     * Cap on total metrics scanned per run.
+     * @minimum 1
+     * @maximum 1000
+     */
+    max_candidates?: number
+    /**
+     * Lookback window for recently-accessed dashboards and recently-viewed insights.
+     * @minimum 1
+     * @maximum 365
+     */
+    recent_days?: number
+    /**
+     * Minimum distinct viewers for the recently-viewed-insights source to include an insight.
+     * @minimum 1
+     * @maximum 100
+     */
+    min_viewers_for_recent_insight?: number
+    /**
+     * Max insights from pinned/recent dashboards (0 = off).
+     * @minimum 0
+     * @maximum 200
+     */
+    dashboard_tile_limit?: number
+    /**
+     * Max recently-viewed insights (0 = off).
+     * @minimum 0
+     * @maximum 500
+     */
+    recent_insight_limit?: number
+    /**
+     * Max recently-edited saved Trends insights (0 = off).
+     * @minimum 0
+     * @maximum 200
+     */
+    saved_insight_limit?: number
+    /**
+     * Max highest-volume events (0 = off).
+     * @minimum 0
+     * @maximum 500
+     */
+    top_event_limit?: number
+    /**
+     * Volume floor: skip metrics whose baseline median is below this (the top noise lever).
+     * @minimum 0
+     * @maximum 1000000
+     */
+    min_baseline_value?: number
+    /**
+     * Primary gate: minimum absolute fractional change to flag (0.25 = 25%).
+     * @minimum 0.01
+     * @maximum 10
+     */
+    min_change_pct?: number
+    /**
+     * Secondary informational threshold for the robust z-score. Never a sole trigger.
+     * @minimum 0.1
+     * @maximum 10
+     */
+    robust_z_threshold?: number
+    /**
+     * Completed weeks used to compute the baseline median.
+     * @minimum 3
+     * @maximum 12
+     */
+    baseline_weeks?: number
+    /**
+     * Maximum findings surfaced per digest.
+     * @minimum 1
+     * @maximum 50
+     */
+    max_findings?: number
+}
+
+export interface TriggerScanResponseApi {
+    workflow_id: string
+}
+
+export interface PaginatedPulseFindingListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: PulseFindingApi[]
+}
+
+/**
+ * * `weekly` - Weekly
+ * * `daily` - Daily
+ */
+export type PulseSubscriptionFrequencyEnumApi =
+    (typeof PulseSubscriptionFrequencyEnumApi)[keyof typeof PulseSubscriptionFrequencyEnumApi]
+
+export const PulseSubscriptionFrequencyEnumApi = {
+    Weekly: 'weekly',
+    Daily: 'daily',
+} as const
+
+/**
+ * * `change_v1` - Change V1
+ * * `discovery` - Discovery
+ */
+export type DetectionModeEnumApi = (typeof DetectionModeEnumApi)[keyof typeof DetectionModeEnumApi]
+
+export const DetectionModeEnumApi = {
+    ChangeV1: 'change_v1',
+    Discovery: 'discovery',
+} as const
+
+/**
+ * * `conservative` - Conservative
+ * * `balanced` - Balanced
+ * * `sensitive` - Sensitive
+ * * `custom` - Custom
+ */
+export type SensitivityEnumApi = (typeof SensitivityEnumApi)[keyof typeof SensitivityEnumApi]
+
+export const SensitivityEnumApi = {
+    Conservative: 'conservative',
+    Balanced: 'balanced',
+    Sensitive: 'sensitive',
+    Custom: 'custom',
+} as const
+
+export interface PulseSubscriptionApi {
+    readonly id: string
+    /** Whether Pulse runs scans for this team. */
+    enabled?: boolean
+    /** Scan cadence (weekly or daily).
+     *
+     * * `weekly` - Weekly
+     * * `daily` - Daily */
+    frequency?: PulseSubscriptionFrequencyEnumApi
+    /** Detection algorithm. Only 'change_v1' is available in v1.
+     *
+     * * `change_v1` - Change V1
+     * * `discovery` - Discovery */
+    detection_mode?: DetectionModeEnumApi
+    /** Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.
+     *
+     * * `conservative` - Conservative
+     * * `balanced` - Balanced
+     * * `sensitive` - Sensitive
+     * * `custom` - Custom */
+    sensitivity?: SensitivityEnumApi
+    /**
+     * Primary gate: minimum absolute fractional change to flag (0.0-1.0).
+     * @minimum 0
+     * @maximum 1
+     */
+    min_change_pct?: number
+    /**
+     * Number of completed weeks used to compute the baseline median.
+     * @minimum 3
+     * @maximum 52
+     */
+    baseline_weeks?: number
+    /**
+     * Maximum findings surfaced per digest.
+     * @minimum 1
+     * @maximum 50
+     */
+    max_findings?: number
+    /**
+     * Secondary informational threshold for the robust z-score. Never a sole trigger.
+     * @minimum 0.1
+     * @maximum 10
+     */
+    robust_z_threshold?: number
+    /**
+     * When Pulse last completed a scan for this team.
+     * @nullable
+     */
+    readonly last_scan_at: string | null
+    /**
+     * When the next scan is scheduled.
+     * @nullable
+     */
+    readonly next_scan_at: string | null
+    readonly created_at: string
+}
+
+export interface PaginatedPulseSubscriptionListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: PulseSubscriptionApi[]
+}
+
+export interface PatchedPulseSubscriptionApi {
+    readonly id?: string
+    /** Whether Pulse runs scans for this team. */
+    enabled?: boolean
+    /** Scan cadence (weekly or daily).
+     *
+     * * `weekly` - Weekly
+     * * `daily` - Daily */
+    frequency?: PulseSubscriptionFrequencyEnumApi
+    /** Detection algorithm. Only 'change_v1' is available in v1.
+     *
+     * * `change_v1` - Change V1
+     * * `discovery` - Discovery */
+    detection_mode?: DetectionModeEnumApi
+    /** Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.
+     *
+     * * `conservative` - Conservative
+     * * `balanced` - Balanced
+     * * `sensitive` - Sensitive
+     * * `custom` - Custom */
+    sensitivity?: SensitivityEnumApi
+    /**
+     * Primary gate: minimum absolute fractional change to flag (0.0-1.0).
+     * @minimum 0
+     * @maximum 1
+     */
+    min_change_pct?: number
+    /**
+     * Number of completed weeks used to compute the baseline median.
+     * @minimum 3
+     * @maximum 52
+     */
+    baseline_weeks?: number
+    /**
+     * Maximum findings surfaced per digest.
+     * @minimum 1
+     * @maximum 50
+     */
+    max_findings?: number
+    /**
+     * Secondary informational threshold for the robust z-score. Never a sole trigger.
+     * @minimum 0.1
+     * @maximum 10
+     */
+    robust_z_threshold?: number
+    /**
+     * When Pulse last completed a scan for this team.
+     * @nullable
+     */
+    readonly last_scan_at?: string | null
+    /**
+     * When the next scan is scheduled.
+     * @nullable
+     */
+    readonly next_scan_at?: string | null
+    readonly created_at?: string
+}
+
+/**
+ * A single metric Pulse is currently watching (read-only transparency).
+ */
+export interface PulseWatchedCandidateApi {
+    /** Where the candidate came from (dashboard_tile, recent_insight, top_event). */
+    source: string
+    /**
+     * Underlying insight/event id, if any.
+     * @nullable
+     */
+    source_id: string | null
+    /** Human-readable metric name. */
+    label: string
+    /** TrendsQuery-shaped dict Pulse re-evaluates. */
+    query: unknown
+}
+
+export interface PaginatedPulseWatchedCandidateListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: PulseWatchedCandidateApi[]
+}
+
+export type PulseDigestsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type PulseFindingsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type PulseSubscriptionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}

--- a/products/pulse/frontend/generated/api.ts
+++ b/products/pulse/frontend/generated/api.ts
@@ -1,0 +1,291 @@
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import type {
+    PaginatedPulseDigestListListApi,
+    PaginatedPulseFindingListApi,
+    PaginatedPulseSubscriptionListApi,
+    PaginatedPulseWatchedCandidateListApi,
+    PatchedPulseSubscriptionApi,
+    PulseDigestApi,
+    PulseDigestsListParams,
+    PulseFindingApi,
+    PulseFindingsListParams,
+    PulseScanConfigApi,
+    PulseSubscriptionApi,
+    PulseSubscriptionsListParams,
+    TriggerScanResponseApi,
+} from './api.schemas'
+
+// https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
+type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B
+
+type WritableKeys<T> = {
+    [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P>
+}[keyof T]
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never
+
+type Writable<T> = Pick<T, WritableKeys<T>>
+type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
+    ? {
+          [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
+      }
+    : DistributeReadOnlyOverUnions<T>
+
+export const getPulseDigestsListUrl = (projectId: string, params?: PulseDigestsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/pulse_digests/?${stringifiedParams}`
+        : `/api/projects/${projectId}/pulse_digests/`
+}
+
+export const pulseDigestsList = async (
+    projectId: string,
+    params?: PulseDigestsListParams,
+    options?: RequestInit
+): Promise<PaginatedPulseDigestListListApi> => {
+    return apiMutator<PaginatedPulseDigestListListApi>(getPulseDigestsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseDigestsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/pulse_digests/${id}/`
+}
+
+export const pulseDigestsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<PulseDigestApi> => {
+    return apiMutator<PulseDigestApi>(getPulseDigestsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseDigestsTriggerScanCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/pulse_digests/trigger_scan/`
+}
+
+/**
+ * Kick off a one-off Pulse scan for this team now, without waiting for the schedule.
+ *
+ * Staff-only for now (404 hides it from non-staff); the gate can be relaxed to expose it to users later.
+ *
+ * An optional body of tuning knobs (PulseScanConfig) overrides the heuristics for this run only —
+ * nothing is persisted. The override is staff-gated by the same 404 as the trigger itself. With no
+ * body, the run resolves its detection thresholds from the team's PulseSubscription, as a scheduled
+ * run would.
+ */
+export const pulseDigestsTriggerScanCreate = async (
+    projectId: string,
+    pulseScanConfigApi?: PulseScanConfigApi,
+    options?: RequestInit
+): Promise<TriggerScanResponseApi> => {
+    return apiMutator<TriggerScanResponseApi>(getPulseDigestsTriggerScanCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(pulseScanConfigApi),
+    })
+}
+
+export const getPulseFindingsListUrl = (projectId: string, params?: PulseFindingsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/pulse_findings/?${stringifiedParams}`
+        : `/api/projects/${projectId}/pulse_findings/`
+}
+
+export const pulseFindingsList = async (
+    projectId: string,
+    params?: PulseFindingsListParams,
+    options?: RequestInit
+): Promise<PaginatedPulseFindingListApi> => {
+    return apiMutator<PaginatedPulseFindingListApi>(getPulseFindingsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseFindingsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/pulse_findings/${id}/`
+}
+
+export const pulseFindingsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<PulseFindingApi> => {
+    return apiMutator<PulseFindingApi>(getPulseFindingsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseSubscriptionsListUrl = (projectId: string, params?: PulseSubscriptionsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/pulse_subscriptions/?${stringifiedParams}`
+        : `/api/projects/${projectId}/pulse_subscriptions/`
+}
+
+export const pulseSubscriptionsList = async (
+    projectId: string,
+    params?: PulseSubscriptionsListParams,
+    options?: RequestInit
+): Promise<PaginatedPulseSubscriptionListApi> => {
+    return apiMutator<PaginatedPulseSubscriptionListApi>(getPulseSubscriptionsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseSubscriptionsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/`
+}
+
+export const pulseSubscriptionsCreate = async (
+    projectId: string,
+    pulseSubscriptionApi?: NonReadonly<PulseSubscriptionApi>,
+    options?: RequestInit
+): Promise<PulseSubscriptionApi> => {
+    return apiMutator<PulseSubscriptionApi>(getPulseSubscriptionsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(pulseSubscriptionApi),
+    })
+}
+
+export const getPulseSubscriptionsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/${id}/`
+}
+
+export const pulseSubscriptionsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<PulseSubscriptionApi> => {
+    return apiMutator<PulseSubscriptionApi>(getPulseSubscriptionsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseSubscriptionsUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/${id}/`
+}
+
+export const pulseSubscriptionsUpdate = async (
+    projectId: string,
+    id: string,
+    pulseSubscriptionApi?: NonReadonly<PulseSubscriptionApi>,
+    options?: RequestInit
+): Promise<PulseSubscriptionApi> => {
+    return apiMutator<PulseSubscriptionApi>(getPulseSubscriptionsUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(pulseSubscriptionApi),
+    })
+}
+
+export const getPulseSubscriptionsPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/${id}/`
+}
+
+export const pulseSubscriptionsPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedPulseSubscriptionApi?: NonReadonly<PatchedPulseSubscriptionApi>,
+    options?: RequestInit
+): Promise<PulseSubscriptionApi> => {
+    return apiMutator<PulseSubscriptionApi>(getPulseSubscriptionsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedPulseSubscriptionApi),
+    })
+}
+
+export const getPulseSubscriptionsDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/${id}/`
+}
+
+export const pulseSubscriptionsDestroy = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getPulseSubscriptionsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getPulseSubscriptionsCurrentRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/current/`
+}
+
+export const pulseSubscriptionsCurrentRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<PulseSubscriptionApi> => {
+    return apiMutator<PulseSubscriptionApi>(getPulseSubscriptionsCurrentRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getPulseSubscriptionsWatchedRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/pulse_subscriptions/watched/`
+}
+
+export const pulseSubscriptionsWatchedRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<PaginatedPulseWatchedCandidateListApi> => {
+    return apiMutator<PaginatedPulseWatchedCandidateListApi>(getPulseSubscriptionsWatchedRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/products/pulse/frontend/generated/api.zod.ts
+++ b/products/pulse/frontend/generated/api.zod.ts
@@ -1,0 +1,311 @@
+/**
+ * Auto-generated Zod validation schemas from the Django backend OpenAPI schema.
+ * To modify these schemas, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * Kick off a one-off Pulse scan for this team now, without waiting for the schedule.
+ *
+ * Staff-only for now (404 hides it from non-staff); the gate can be relaxed to expose it to users later.
+ *
+ * An optional body of tuning knobs (PulseScanConfig) overrides the heuristics for this run only —
+ * nothing is persisted. The override is staff-gated by the same 404 as the trigger itself. With no
+ * body, the run resolves its detection thresholds from the team's PulseSubscription, as a scheduled
+ * run would.
+ */
+export const pulseDigestsTriggerScanCreateBodyMaxCandidatesMax = 1000
+
+export const pulseDigestsTriggerScanCreateBodyRecentDaysMax = 365
+
+export const pulseDigestsTriggerScanCreateBodyMinViewersForRecentInsightMax = 100
+
+export const pulseDigestsTriggerScanCreateBodyDashboardTileLimitMin = 0
+export const pulseDigestsTriggerScanCreateBodyDashboardTileLimitMax = 200
+
+export const pulseDigestsTriggerScanCreateBodyRecentInsightLimitMin = 0
+export const pulseDigestsTriggerScanCreateBodyRecentInsightLimitMax = 500
+
+export const pulseDigestsTriggerScanCreateBodySavedInsightLimitMin = 0
+export const pulseDigestsTriggerScanCreateBodySavedInsightLimitMax = 200
+
+export const pulseDigestsTriggerScanCreateBodyTopEventLimitMin = 0
+export const pulseDigestsTriggerScanCreateBodyTopEventLimitMax = 500
+
+export const pulseDigestsTriggerScanCreateBodyMinBaselineValueMin = 0
+export const pulseDigestsTriggerScanCreateBodyMinBaselineValueMax = 1000000
+
+export const pulseDigestsTriggerScanCreateBodyMinChangePctMin = 0.01
+export const pulseDigestsTriggerScanCreateBodyMinChangePctMax = 10
+
+export const pulseDigestsTriggerScanCreateBodyRobustZThresholdMin = 0.1
+export const pulseDigestsTriggerScanCreateBodyRobustZThresholdMax = 10
+
+export const pulseDigestsTriggerScanCreateBodyBaselineWeeksMin = 3
+export const pulseDigestsTriggerScanCreateBodyBaselineWeeksMax = 12
+
+export const pulseDigestsTriggerScanCreateBodyMaxFindingsMax = 50
+
+export const PulseDigestsTriggerScanCreateBody = /* @__PURE__ */ zod
+    .object({
+        max_candidates: zod
+            .number()
+            .min(1)
+            .max(pulseDigestsTriggerScanCreateBodyMaxCandidatesMax)
+            .optional()
+            .describe('Cap on total metrics scanned per run.'),
+        recent_days: zod
+            .number()
+            .min(1)
+            .max(pulseDigestsTriggerScanCreateBodyRecentDaysMax)
+            .optional()
+            .describe('Lookback window for recently-accessed dashboards and recently-viewed insights.'),
+        min_viewers_for_recent_insight: zod
+            .number()
+            .min(1)
+            .max(pulseDigestsTriggerScanCreateBodyMinViewersForRecentInsightMax)
+            .optional()
+            .describe('Minimum distinct viewers for the recently-viewed-insights source to include an insight.'),
+        dashboard_tile_limit: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyDashboardTileLimitMin)
+            .max(pulseDigestsTriggerScanCreateBodyDashboardTileLimitMax)
+            .optional()
+            .describe('Max insights from pinned\/recent dashboards (0 = off).'),
+        recent_insight_limit: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyRecentInsightLimitMin)
+            .max(pulseDigestsTriggerScanCreateBodyRecentInsightLimitMax)
+            .optional()
+            .describe('Max recently-viewed insights (0 = off).'),
+        saved_insight_limit: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodySavedInsightLimitMin)
+            .max(pulseDigestsTriggerScanCreateBodySavedInsightLimitMax)
+            .optional()
+            .describe('Max recently-edited saved Trends insights (0 = off).'),
+        top_event_limit: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyTopEventLimitMin)
+            .max(pulseDigestsTriggerScanCreateBodyTopEventLimitMax)
+            .optional()
+            .describe('Max highest-volume events (0 = off).'),
+        min_baseline_value: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyMinBaselineValueMin)
+            .max(pulseDigestsTriggerScanCreateBodyMinBaselineValueMax)
+            .optional()
+            .describe('Volume floor: skip metrics whose baseline median is below this (the top noise lever).'),
+        min_change_pct: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyMinChangePctMin)
+            .max(pulseDigestsTriggerScanCreateBodyMinChangePctMax)
+            .optional()
+            .describe('Primary gate: minimum absolute fractional change to flag (0.25 = 25%).'),
+        robust_z_threshold: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyRobustZThresholdMin)
+            .max(pulseDigestsTriggerScanCreateBodyRobustZThresholdMax)
+            .optional()
+            .describe('Secondary informational threshold for the robust z-score. Never a sole trigger.'),
+        baseline_weeks: zod
+            .number()
+            .min(pulseDigestsTriggerScanCreateBodyBaselineWeeksMin)
+            .max(pulseDigestsTriggerScanCreateBodyBaselineWeeksMax)
+            .optional()
+            .describe('Completed weeks used to compute the baseline median.'),
+        max_findings: zod
+            .number()
+            .min(1)
+            .max(pulseDigestsTriggerScanCreateBodyMaxFindingsMax)
+            .optional()
+            .describe('Maximum findings surfaced per digest.'),
+    })
+    .describe(
+        'Per-run scan tuning knobs for a manual staff trigger.\n\nEvery field is optional; omitted knobs fall back to the built-in defaults (the production\nconstants), so a partial override is \"defaults plus the knobs you set\". Nothing is persisted —\nthe resolved config rides along with the one-off scan that started it.'
+    )
+
+export const pulseSubscriptionsCreateBodyMinChangePctMin = 0
+export const pulseSubscriptionsCreateBodyMinChangePctMax = 1
+
+export const pulseSubscriptionsCreateBodyBaselineWeeksMin = 3
+export const pulseSubscriptionsCreateBodyBaselineWeeksMax = 52
+
+export const pulseSubscriptionsCreateBodyMaxFindingsMax = 50
+
+export const pulseSubscriptionsCreateBodyRobustZThresholdMin = 0.1
+export const pulseSubscriptionsCreateBodyRobustZThresholdMax = 10
+
+export const PulseSubscriptionsCreateBody = /* @__PURE__ */ zod.object({
+    enabled: zod.boolean().optional().describe('Whether Pulse runs scans for this team.'),
+    frequency: zod
+        .enum(['weekly', 'daily'])
+        .describe('\* `weekly` - Weekly\n\* `daily` - Daily')
+        .optional()
+        .describe('Scan cadence (weekly or daily).\n\n\* `weekly` - Weekly\n\* `daily` - Daily'),
+    detection_mode: zod
+        .enum(['change_v1', 'discovery'])
+        .describe('\* `change_v1` - Change V1\n\* `discovery` - Discovery')
+        .optional()
+        .describe(
+            "Detection algorithm. Only 'change_v1' is available in v1.\n\n\* `change_v1` - Change V1\n\* `discovery` - Discovery"
+        ),
+    sensitivity: zod
+        .enum(['conservative', 'balanced', 'sensitive', 'custom'])
+        .describe(
+            '\* `conservative` - Conservative\n\* `balanced` - Balanced\n\* `sensitive` - Sensitive\n\* `custom` - Custom'
+        )
+        .optional()
+        .describe(
+            "Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.\n\n\* `conservative` - Conservative\n\* `balanced` - Balanced\n\* `sensitive` - Sensitive\n\* `custom` - Custom"
+        ),
+    min_change_pct: zod
+        .number()
+        .min(pulseSubscriptionsCreateBodyMinChangePctMin)
+        .max(pulseSubscriptionsCreateBodyMinChangePctMax)
+        .optional()
+        .describe('Primary gate: minimum absolute fractional change to flag (0.0-1.0).'),
+    baseline_weeks: zod
+        .number()
+        .min(pulseSubscriptionsCreateBodyBaselineWeeksMin)
+        .max(pulseSubscriptionsCreateBodyBaselineWeeksMax)
+        .optional()
+        .describe('Number of completed weeks used to compute the baseline median.'),
+    max_findings: zod
+        .number()
+        .min(1)
+        .max(pulseSubscriptionsCreateBodyMaxFindingsMax)
+        .optional()
+        .describe('Maximum findings surfaced per digest.'),
+    robust_z_threshold: zod
+        .number()
+        .min(pulseSubscriptionsCreateBodyRobustZThresholdMin)
+        .max(pulseSubscriptionsCreateBodyRobustZThresholdMax)
+        .optional()
+        .describe('Secondary informational threshold for the robust z-score. Never a sole trigger.'),
+})
+
+export const pulseSubscriptionsUpdateBodyMinChangePctMin = 0
+export const pulseSubscriptionsUpdateBodyMinChangePctMax = 1
+
+export const pulseSubscriptionsUpdateBodyBaselineWeeksMin = 3
+export const pulseSubscriptionsUpdateBodyBaselineWeeksMax = 52
+
+export const pulseSubscriptionsUpdateBodyMaxFindingsMax = 50
+
+export const pulseSubscriptionsUpdateBodyRobustZThresholdMin = 0.1
+export const pulseSubscriptionsUpdateBodyRobustZThresholdMax = 10
+
+export const PulseSubscriptionsUpdateBody = /* @__PURE__ */ zod.object({
+    enabled: zod.boolean().optional().describe('Whether Pulse runs scans for this team.'),
+    frequency: zod
+        .enum(['weekly', 'daily'])
+        .describe('\* `weekly` - Weekly\n\* `daily` - Daily')
+        .optional()
+        .describe('Scan cadence (weekly or daily).\n\n\* `weekly` - Weekly\n\* `daily` - Daily'),
+    detection_mode: zod
+        .enum(['change_v1', 'discovery'])
+        .describe('\* `change_v1` - Change V1\n\* `discovery` - Discovery')
+        .optional()
+        .describe(
+            "Detection algorithm. Only 'change_v1' is available in v1.\n\n\* `change_v1` - Change V1\n\* `discovery` - Discovery"
+        ),
+    sensitivity: zod
+        .enum(['conservative', 'balanced', 'sensitive', 'custom'])
+        .describe(
+            '\* `conservative` - Conservative\n\* `balanced` - Balanced\n\* `sensitive` - Sensitive\n\* `custom` - Custom'
+        )
+        .optional()
+        .describe(
+            "Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.\n\n\* `conservative` - Conservative\n\* `balanced` - Balanced\n\* `sensitive` - Sensitive\n\* `custom` - Custom"
+        ),
+    min_change_pct: zod
+        .number()
+        .min(pulseSubscriptionsUpdateBodyMinChangePctMin)
+        .max(pulseSubscriptionsUpdateBodyMinChangePctMax)
+        .optional()
+        .describe('Primary gate: minimum absolute fractional change to flag (0.0-1.0).'),
+    baseline_weeks: zod
+        .number()
+        .min(pulseSubscriptionsUpdateBodyBaselineWeeksMin)
+        .max(pulseSubscriptionsUpdateBodyBaselineWeeksMax)
+        .optional()
+        .describe('Number of completed weeks used to compute the baseline median.'),
+    max_findings: zod
+        .number()
+        .min(1)
+        .max(pulseSubscriptionsUpdateBodyMaxFindingsMax)
+        .optional()
+        .describe('Maximum findings surfaced per digest.'),
+    robust_z_threshold: zod
+        .number()
+        .min(pulseSubscriptionsUpdateBodyRobustZThresholdMin)
+        .max(pulseSubscriptionsUpdateBodyRobustZThresholdMax)
+        .optional()
+        .describe('Secondary informational threshold for the robust z-score. Never a sole trigger.'),
+})
+
+export const pulseSubscriptionsPartialUpdateBodyMinChangePctMin = 0
+export const pulseSubscriptionsPartialUpdateBodyMinChangePctMax = 1
+
+export const pulseSubscriptionsPartialUpdateBodyBaselineWeeksMin = 3
+export const pulseSubscriptionsPartialUpdateBodyBaselineWeeksMax = 52
+
+export const pulseSubscriptionsPartialUpdateBodyMaxFindingsMax = 50
+
+export const pulseSubscriptionsPartialUpdateBodyRobustZThresholdMin = 0.1
+export const pulseSubscriptionsPartialUpdateBodyRobustZThresholdMax = 10
+
+export const PulseSubscriptionsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    enabled: zod.boolean().optional().describe('Whether Pulse runs scans for this team.'),
+    frequency: zod
+        .enum(['weekly', 'daily'])
+        .describe('\* `weekly` - Weekly\n\* `daily` - Daily')
+        .optional()
+        .describe('Scan cadence (weekly or daily).\n\n\* `weekly` - Weekly\n\* `daily` - Daily'),
+    detection_mode: zod
+        .enum(['change_v1', 'discovery'])
+        .describe('\* `change_v1` - Change V1\n\* `discovery` - Discovery')
+        .optional()
+        .describe(
+            "Detection algorithm. Only 'change_v1' is available in v1.\n\n\* `change_v1` - Change V1\n\* `discovery` - Discovery"
+        ),
+    sensitivity: zod
+        .enum(['conservative', 'balanced', 'sensitive', 'custom'])
+        .describe(
+            '\* `conservative` - Conservative\n\* `balanced` - Balanced\n\* `sensitive` - Sensitive\n\* `custom` - Custom'
+        )
+        .optional()
+        .describe(
+            "Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.\n\n\* `conservative` - Conservative\n\* `balanced` - Balanced\n\* `sensitive` - Sensitive\n\* `custom` - Custom"
+        ),
+    min_change_pct: zod
+        .number()
+        .min(pulseSubscriptionsPartialUpdateBodyMinChangePctMin)
+        .max(pulseSubscriptionsPartialUpdateBodyMinChangePctMax)
+        .optional()
+        .describe('Primary gate: minimum absolute fractional change to flag (0.0-1.0).'),
+    baseline_weeks: zod
+        .number()
+        .min(pulseSubscriptionsPartialUpdateBodyBaselineWeeksMin)
+        .max(pulseSubscriptionsPartialUpdateBodyBaselineWeeksMax)
+        .optional()
+        .describe('Number of completed weeks used to compute the baseline median.'),
+    max_findings: zod
+        .number()
+        .min(1)
+        .max(pulseSubscriptionsPartialUpdateBodyMaxFindingsMax)
+        .optional()
+        .describe('Maximum findings surfaced per digest.'),
+    robust_z_threshold: zod
+        .number()
+        .min(pulseSubscriptionsPartialUpdateBodyRobustZThresholdMin)
+        .max(pulseSubscriptionsPartialUpdateBodyRobustZThresholdMax)
+        .optional()
+        .describe('Secondary informational threshold for the robust z-score. Never a sole trigger.'),
+})

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17213,6 +17213,18 @@ export namespace Schemas {
     }
 
     /**
+     * * `change_v1` - Change V1
+     * * `discovery` - Discovery
+     */
+    export type DetectionModeEnum = typeof DetectionModeEnum[keyof typeof DetectionModeEnum];
+
+
+    export const DetectionModeEnum = {
+      ChangeV1: 'change_v1',
+      Discovery: 'discovery',
+    } as const;
+
+    /**
      * * `Desktop` - Desktop
      * * `Mobile` - Mobile
      * * `Tablet` - Tablet
@@ -30603,6 +30615,209 @@ export namespace Schemas {
       results: ProjectSecretAPIKey[];
     }
 
+    /**
+     * * `pending` - Pending
+     * * `generating` - Generating
+     * * `delivered` - Delivered
+     * * `failed` - Failed
+     */
+    export type PulseDigestStatusEnum = typeof PulseDigestStatusEnum[keyof typeof PulseDigestStatusEnum];
+
+
+    export const PulseDigestStatusEnum = {
+      Pending: 'pending',
+      Generating: 'generating',
+      Delivered: 'delivered',
+      Failed: 'failed',
+    } as const;
+
+    export interface PulseDigestList {
+      readonly id: string;
+      readonly period_start: string;
+      readonly period_end: string;
+      /** Lifecycle of this scan run (pending, generating, delivered, failed).
+       *
+       * * `pending` - Pending
+       * * `generating` - Generating
+       * * `delivered` - Delivered
+       * * `failed` - Failed */
+      readonly status: PulseDigestStatusEnum;
+      /** Error payload (with a `message`) if the scan run failed, otherwise null. */
+      readonly error: unknown;
+      readonly created_at: string;
+      /** Number of findings in this digest. */
+      readonly finding_count: number;
+      /** Digest-level big-picture synthesis across findings (LLM-written, may be empty). */
+      readonly summary: string;
+    }
+
+    export interface PaginatedPulseDigestListList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: PulseDigestList[];
+    }
+
+    export interface PulseFinding {
+      readonly id: string;
+      readonly digest: string;
+      /** Human-readable name of the metric this finding is about. */
+      readonly metric_label: string;
+      /** Opaque descriptor (source, label, query) Pulse re-evaluates. */
+      readonly metric_descriptor: unknown;
+      /** Metric value for the current period. */
+      readonly current_value: number;
+      /** Baseline median over the configured baseline window. */
+      readonly baseline_value: number;
+      /** Fractional change vs baseline median, e.g. 0.5 means +50%. */
+      readonly change_pct: number;
+      /** Robust z-score (median/MAD based). Secondary signal only, never a sole trigger. */
+      readonly robust_z: number;
+      /** Ranking score: abs(change_pct) * sqrt(baseline_median). */
+      readonly impact: number;
+      /** Breakdown segment that best explains the change, e.g. {'$browser': 'Safari'}, or null. */
+      readonly attribution_breakdown: unknown;
+      /** Supporting evidence: {'series': [...]} recent weekly values, {'daily_series': [...]} daily values across the period for the finding chart, {'session_ids': [...]} for example replays, and/or {'references': [{type, label, timestamp, id?, change?}]} for the related changes (feature flags, experiments, annotations) the narrative tied to this finding — each timestamped so it can be placed on the finding's timeline, or null. */
+      readonly evidence: unknown;
+      /** LLM-generated explanation of the change. */
+      readonly narrative: string;
+      readonly chart_thumbnail_url: string;
+      readonly rank: number;
+      readonly created_at: string;
+    }
+
+    export interface PaginatedPulseFindingList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: PulseFinding[];
+    }
+
+    /**
+     * * `weekly` - Weekly
+     * * `daily` - Daily
+     */
+    export type PulseSubscriptionFrequencyEnum = typeof PulseSubscriptionFrequencyEnum[keyof typeof PulseSubscriptionFrequencyEnum];
+
+
+    export const PulseSubscriptionFrequencyEnum = {
+      Weekly: 'weekly',
+      Daily: 'daily',
+    } as const;
+
+    /**
+     * * `conservative` - Conservative
+     * * `balanced` - Balanced
+     * * `sensitive` - Sensitive
+     * * `custom` - Custom
+     */
+    export type SensitivityEnum = typeof SensitivityEnum[keyof typeof SensitivityEnum];
+
+
+    export const SensitivityEnum = {
+      Conservative: 'conservative',
+      Balanced: 'balanced',
+      Sensitive: 'sensitive',
+      Custom: 'custom',
+    } as const;
+
+    export interface PulseSubscription {
+      readonly id: string;
+      /** Whether Pulse runs scans for this team. */
+      enabled?: boolean;
+      /** Scan cadence (weekly or daily).
+       *
+       * * `weekly` - Weekly
+       * * `daily` - Daily */
+      frequency?: PulseSubscriptionFrequencyEnum;
+      /** Detection algorithm. Only 'change_v1' is available in v1.
+       *
+       * * `change_v1` - Change V1
+       * * `discovery` - Discovery */
+      detection_mode?: DetectionModeEnum;
+      /** Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.
+       *
+       * * `conservative` - Conservative
+       * * `balanced` - Balanced
+       * * `sensitive` - Sensitive
+       * * `custom` - Custom */
+      sensitivity?: SensitivityEnum;
+      /**
+         * Primary gate: minimum absolute fractional change to flag (0.0-1.0).
+         * @minimum 0
+         * @maximum 1
+         */
+      min_change_pct?: number;
+      /**
+         * Number of completed weeks used to compute the baseline median.
+         * @minimum 3
+         * @maximum 52
+         */
+      baseline_weeks?: number;
+      /**
+         * Maximum findings surfaced per digest.
+         * @minimum 1
+         * @maximum 50
+         */
+      max_findings?: number;
+      /**
+         * Secondary informational threshold for the robust z-score. Never a sole trigger.
+         * @minimum 0.1
+         * @maximum 10
+         */
+      robust_z_threshold?: number;
+      /**
+         * When Pulse last completed a scan for this team.
+         * @nullable
+         */
+      readonly last_scan_at: string | null;
+      /**
+         * When the next scan is scheduled.
+         * @nullable
+         */
+      readonly next_scan_at: string | null;
+      readonly created_at: string;
+    }
+
+    export interface PaginatedPulseSubscriptionList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: PulseSubscription[];
+    }
+
+    /**
+     * A single metric Pulse is currently watching (read-only transparency).
+     */
+    export interface PulseWatchedCandidate {
+      /** Where the candidate came from (dashboard_tile, recent_insight, top_event). */
+      source: string;
+      /**
+         * Underlying insight/event id, if any.
+         * @nullable
+         */
+      source_id: string | null;
+      /** Human-readable metric name. */
+      label: string;
+      /** TrendsQuery-shaped dict Pulse re-evaluates. */
+      query: unknown;
+    }
+
+    export interface PaginatedPulseWatchedCandidateList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: PulseWatchedCandidate[];
+    }
+
     export interface QuarantinedIdentifierEntry {
       created_by?: UserBasicInfo | null;
       /** Run whose failing snapshot prompted this quarantine. Null when quarantine was created without run context. */
@@ -38221,6 +38436,64 @@ export namespace Schemas {
       scopes?: string[];
     }
 
+    export interface PatchedPulseSubscription {
+      readonly id?: string;
+      /** Whether Pulse runs scans for this team. */
+      enabled?: boolean;
+      /** Scan cadence (weekly or daily).
+       *
+       * * `weekly` - Weekly
+       * * `daily` - Daily */
+      frequency?: PulseSubscriptionFrequencyEnum;
+      /** Detection algorithm. Only 'change_v1' is available in v1.
+       *
+       * * `change_v1` - Change V1
+       * * `discovery` - Discovery */
+      detection_mode?: DetectionModeEnum;
+      /** Preset that derives thresholds, or 'custom' to use the raw knobs. Gates only the deterministic metric scan — anomalies surfaced by the AI scout bypass these thresholds.
+       *
+       * * `conservative` - Conservative
+       * * `balanced` - Balanced
+       * * `sensitive` - Sensitive
+       * * `custom` - Custom */
+      sensitivity?: SensitivityEnum;
+      /**
+         * Primary gate: minimum absolute fractional change to flag (0.0-1.0).
+         * @minimum 0
+         * @maximum 1
+         */
+      min_change_pct?: number;
+      /**
+         * Number of completed weeks used to compute the baseline median.
+         * @minimum 3
+         * @maximum 52
+         */
+      baseline_weeks?: number;
+      /**
+         * Maximum findings surfaced per digest.
+         * @minimum 1
+         * @maximum 50
+         */
+      max_findings?: number;
+      /**
+         * Secondary informational threshold for the robust z-score. Never a sole trigger.
+         * @minimum 0.1
+         * @maximum 10
+         */
+      robust_z_threshold?: number;
+      /**
+         * When Pulse last completed a scan for this team.
+         * @nullable
+         */
+      readonly last_scan_at?: string | null;
+      /**
+         * When the next scan is scheduled.
+         * @nullable
+         */
+      readonly next_scan_at?: string | null;
+      readonly created_at?: string;
+    }
+
     export interface PatchedQueryTabState {
       readonly id?: string;
       /**
@@ -42335,6 +42608,110 @@ export namespace Schemas {
       truncated: boolean;
       /** Maximum number of pull requests returned in `items`. */
       limit: number;
+    }
+
+    export interface PulseDigest {
+      readonly id: string;
+      readonly period_start: string;
+      readonly period_end: string;
+      /** Lifecycle of this scan run (pending, generating, delivered, failed).
+       *
+       * * `pending` - Pending
+       * * `generating` - Generating
+       * * `delivered` - Delivered
+       * * `failed` - Failed */
+      readonly status: PulseDigestStatusEnum;
+      /** Temporal workflow run id that produced this digest. */
+      readonly workflow_run_id: string;
+      /** Error payload if the scan run failed, otherwise null. */
+      readonly error: unknown;
+      /** Digest-level big-picture synthesis across findings (LLM-written, may be empty). */
+      readonly summary: string;
+      readonly created_at: string;
+      readonly finding_count: number;
+      readonly findings: readonly PulseFinding[];
+    }
+
+    /**
+     * Per-run scan tuning knobs for a manual staff trigger.
+     *
+     * Every field is optional; omitted knobs fall back to the built-in defaults (the production
+     * constants), so a partial override is "defaults plus the knobs you set". Nothing is persisted —
+     * the resolved config rides along with the one-off scan that started it.
+     */
+    export interface PulseScanConfig {
+      /**
+         * Cap on total metrics scanned per run.
+         * @minimum 1
+         * @maximum 1000
+         */
+      max_candidates?: number;
+      /**
+         * Lookback window for recently-accessed dashboards and recently-viewed insights.
+         * @minimum 1
+         * @maximum 365
+         */
+      recent_days?: number;
+      /**
+         * Minimum distinct viewers for the recently-viewed-insights source to include an insight.
+         * @minimum 1
+         * @maximum 100
+         */
+      min_viewers_for_recent_insight?: number;
+      /**
+         * Max insights from pinned/recent dashboards (0 = off).
+         * @minimum 0
+         * @maximum 200
+         */
+      dashboard_tile_limit?: number;
+      /**
+         * Max recently-viewed insights (0 = off).
+         * @minimum 0
+         * @maximum 500
+         */
+      recent_insight_limit?: number;
+      /**
+         * Max recently-edited saved Trends insights (0 = off).
+         * @minimum 0
+         * @maximum 200
+         */
+      saved_insight_limit?: number;
+      /**
+         * Max highest-volume events (0 = off).
+         * @minimum 0
+         * @maximum 500
+         */
+      top_event_limit?: number;
+      /**
+         * Volume floor: skip metrics whose baseline median is below this (the top noise lever).
+         * @minimum 0
+         * @maximum 1000000
+         */
+      min_baseline_value?: number;
+      /**
+         * Primary gate: minimum absolute fractional change to flag (0.25 = 25%).
+         * @minimum 0.01
+         * @maximum 10
+         */
+      min_change_pct?: number;
+      /**
+         * Secondary informational threshold for the robust z-score. Never a sole trigger.
+         * @minimum 0.1
+         * @maximum 10
+         */
+      robust_z_threshold?: number;
+      /**
+         * Completed weeks used to compute the baseline median.
+         * @minimum 3
+         * @maximum 12
+         */
+      baseline_weeks?: number;
+      /**
+         * Maximum findings surfaced per digest.
+         * @minimum 1
+         * @maximum 50
+         */
+      max_findings?: number;
     }
 
     /**
@@ -49486,6 +49863,10 @@ export namespace Schemas {
       target_language?: string;
     }
 
+    export interface TriggerScanResponse {
+      workflow_id: string;
+    }
+
     export interface UpdateTextTileRequest {
       /** ID of the dashboard tile to update. Use dashboard-get to look up tile IDs. */
       tile_id: number;
@@ -55022,6 +55403,39 @@ export namespace Schemas {
      * The role UUID whose override should be deleted.
      */
     role?: string;
+    };
+
+    export type EnvironmentsPulseDigestsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type EnvironmentsPulseFindingsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type EnvironmentsPulseSubscriptionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
     };
 
     export type EnvironmentsQueryLogRetrieve200 = { [key: string]: unknown };
@@ -61536,6 +61950,39 @@ export namespace Schemas {
       Group: 'group',
       Session: 'session',
     } as const;
+
+    export type PulseDigestsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type PulseFindingsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type PulseSubscriptionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
 
     export type QueryLogRetrieve200 = { [key: string]: unknown };
 


### PR DESCRIPTION
## Problem

The Pulse engine (#62117, #62118) needs a REST surface: the frontend has to read digests/findings, manage the team's subscription (cadence + sensitivity), and staff need a manual trigger with per-run tuning for iteration.

## Changes

Adds the Pulse API: subscription CRUD, digest/finding reads, a staff-only manual scan trigger, and the generated types that flow from the serializers.

```mermaid
flowchart LR
    subgraph API["/api/projects/:team_id/pulse/*"]
        sub["PulseSubscriptionSerializer<br/>cadence · sensitivity presets ·<br/>tuning knobs · baseline/max_findings"]
        digest["digest + finding reads<br/>(paginated, team-scoped)"]
        trigger["staff manual trigger<br/>PulseScanConfigSerializer per-run override"]
    end
    subgraph PIPE["type pipeline (drf-spectacular → orval)"]
        gen["products/pulse/frontend/generated/*<br/>api.schemas.ts · api.ts · api.zod.ts"]
        mcp["services/mcp generated tool schemas"]
    end
    sub --> gen
    sub --> mcp
    digest --> gen
    trigger --> gen
    gen --> fe["frontend scene (#62120)"]
```

Notes for review:

- The sensitivity preset/knobs gate **only the deterministic source** — anomalies surfaced by the AI scout bypass these thresholds by design (#62117). The `help_text` says so explicitly, and that wording flows into the generated TS and MCP schemas.
- Every field carries `help_text`; the manual-trigger body is a fully typed serializer, so the generated layer has no `unknown`s.
- The watched-candidates preview endpoint reuses the same selection code the scan uses, so staff see exactly what a scan would consider.

## How did you test this code?

I'm an agent; no manual testing claimed. Automated: API tests cover subscription validation (including knob ranges), digest/finding reads, permissions, and the manual trigger; generated types were produced by `hogli build:openapi` from these serializers (no hand edits). 275 backend tests green locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @vdekrijger. The scout-bypass clarification on the sensitivity help_text came out of a local review-swarm finding (a user picking "Conservative" shouldn't be surprised that scout findings still appear).
