### PR TITLE
feat(pulse): add frontend scene and api client

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,6 +67,7 @@ import {
     Node,
     NodeKind,
     PersistedFolder,
+    PulseScanConfig,
     QueryLogTags,
     QuerySchema,
     QueryStatusResponse,
@@ -240,6 +241,13 @@ import type {
     ColumnConfigurationApi,
     PaginatedColumnConfigurationListApi,
 } from 'products/product_analytics/frontend/generated/api.schemas'
+import {
+    PulseDigestDetail,
+    PulseDigestSummary,
+    PulseFindingType,
+    PulseSubscriptionType,
+    PulseWatchedCandidate,
+} from 'products/pulse/frontend/pulseTypes'
 import type {
     SessionGroupSummaryListItemType,
     SessionGroupSummaryType,
@@ -697,6 +705,22 @@ export class ApiRequest {
         return this.comments(teamId).addPathComponent(id)
     }
 
+    // # Pulse
+    public pulseDigests(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('pulse_digests')
+    }
+    public pulseDigest(id: string, teamId?: TeamType['id']): ApiRequest {
+        return this.pulseDigests(teamId).addPathComponent(id)
+    }
+    public pulseFindings(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('pulse_findings')
+    }
+    public pulseSubscriptions(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('pulse_subscriptions')
+    }
+    public pulseSubscription(id: string, teamId?: TeamType['id']): ApiRequest {
+        return this.pulseSubscriptions(teamId).addPathComponent(id)
+    }
     // # Exports
     public exports(teamId?: TeamType['id']): ApiRequest {
         return this.environmentsDetail(teamId).addPathComponent('exports')
@@ -2839,6 +2863,40 @@ const api = {
             teamId: TeamType['id'] = ApiConfig.getCurrentTeamId()
         ): Promise<CommentType> {
             return new ApiRequest().comment(id, teamId).withAction('reopen').create()
+        },
+    },
+
+    pulse: {
+        async listDigests(
+            url?: string
+        ): Promise<{ results: PulseDigestSummary[]; count: number; next: string | null }> {
+            // `url` follows the DRF `next` cursor when paging through older digests.
+            return url ? await api.get(url) : new ApiRequest().pulseDigests().get()
+        },
+        async getDigest(id: string): Promise<PulseDigestDetail> {
+            return new ApiRequest().pulseDigest(id).get()
+        },
+        async triggerScan(config?: Partial<PulseScanConfig>): Promise<{ workflow_id: string }> {
+            return new ApiRequest()
+                .pulseDigests()
+                .withAction('trigger_scan')
+                .create({ data: config ?? {} })
+        },
+        async listFindings(digestId?: string): Promise<{ results: PulseFindingType[]; count: number }> {
+            const req = new ApiRequest().pulseFindings()
+            return digestId ? req.withQueryString({ digest: digestId }).get() : req.get()
+        },
+        async currentSubscription(): Promise<PulseSubscriptionType> {
+            return new ApiRequest().pulseSubscriptions().withAction('current').get()
+        },
+        async watchedCandidates(): Promise<{ results: PulseWatchedCandidate[] }> {
+            return new ApiRequest().pulseSubscriptions().withAction('watched').get()
+        },
+        async createSubscription(data: Partial<PulseSubscriptionType>): Promise<PulseSubscriptionType> {
+            return new ApiRequest().pulseSubscriptions().create({ data })
+        },
+        async updateSubscription(id: string, data: Partial<PulseSubscriptionType>): Promise<PulseSubscriptionType> {
+            return new ApiRequest().pulseSubscription(id).update({ data })
         },
     },
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -371,6 +371,7 @@ export const FEATURE_FLAGS = {
     MAX_DEEP_RESEARCH: 'max-deep-research', // owner: @kappa90 #team-posthog-ai
     MAX_HANDS_FREE: 'max-hands-free', // owner: #team-posthog-ai
     MAX_WEB_ANALYTICS_NUDGE: 'posthog-ai-web-analytics-nudge', // owner: @jordanm-posthog #team-web-analytics
+    MAX_PULSE: 'max-pulse', // owner: #team-posthog-ai — proactive Pulse insights
     MCP_ANALYTICS: 'mcp-analytics', // owner: #project-mcp-analytics
     MCP_ANALYTICS_INTENT_ROUTING: 'mcp-analytics-intent-routing', // owner: #project-mcp-analytics
     MCP_HINTS: 'mcp-hints', // owner: @rafaeelaudibert #team-growth multivariate=control,test

--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -199,6 +199,7 @@
             "type": "product_tour",
             "intents": ["product_tours"]
         },
+        { "path": "Pulse", "category": "Analytics", "iconType": "activity", "type": null, "intents": ["max"] },
         {
             "path": "Session replay",
             "category": "Behavior",

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -136,6 +136,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     MCPAnalytics: () => import('../../products/mcp_analytics/frontend/MCPAnalyticsScene'),
     MCPAnalyticsToolDetail: () => import('../../products/mcp_analytics/frontend/MCPAnalyticsToolDetail'),
     Metrics: () => import('../../products/metrics/frontend/MetricsScene'),
+    Pulse: () => import('../../products/pulse/frontend/Pulse'),
     ReplayVision: () => import('../../products/replay_vision/frontend/replay_scanners/ReplayScannersScene'),
     ReplayVisionScanner: () => import('../../products/replay_vision/frontend/replay_scanners/ReplayScanner'),
     ReplayVisionScannerEditor: () => import('../../products/replay_vision/frontend/replay_scanners/ScannerEditorScene'),
@@ -270,6 +271,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/mcp-analytics/tool-quality/:toolName': ['MCPAnalyticsToolDetail', 'mcpAnalyticsTool'],
     '/mcp-analytics/intent-clustering': ['MCPAnalytics', 'mcpAnalyticsIntentClustering'],
     '/metrics': ['Metrics', 'metrics'],
+    '/pulse': ['Pulse', 'pulse'],
     '/replay-vision': ['ReplayVision', 'replayVision'],
     '/replay-vision/observations/:observationId': ['ReplayVisionObservation', 'replayVisionObservation'],
     '/replay-vision/:id/template': ['ReplayVisionScannerEditor', 'replayVisionScannerTemplate'],
@@ -744,6 +746,11 @@ export const productConfiguration: Record<string, any> = {
         description: 'Monitor and analyze application metrics to understand system performance and health.',
         iconType: 'metrics',
     },
+    Pulse: {
+        name: 'Pulse',
+        projectBased: true,
+        description: "Proactive insights surfaced by Max from your team's key metrics.",
+    },
     ReplayVision: {
         name: 'Replay vision',
         projectBased: true,
@@ -1192,6 +1199,7 @@ export const productUrls = {
     insightQuickStart: (): string => '/insights/quick-start',
     productTours: (): string => '/product_tours',
     productTour: (id: string): string => `/product_tours/${id}`,
+    pulse: (): string => '/pulse',
     replay: (
         tab?: ReplayTabs,
         filters?: Partial<RecordingUniversalFilters>,
@@ -2033,6 +2041,17 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
             'AIObservabilityClusters',
             'AIObservabilityCluster',
         ],
+    },
+    {
+        path: 'Pulse',
+        intents: [ProductKey.MAX],
+        category: ProductItemCategory.ANALYTICS,
+        iconType: 'activity',
+        href: urls.pulse(),
+        flag: FEATURE_FLAGS.MAX_PULSE,
+        tags: ['beta'],
+        sceneKey: 'Pulse',
+        sceneKeys: ['Pulse'],
     },
     {
         path: 'Replay vision',

--- a/products/pulse/backend/tests/test_models.py
+++ b/products/pulse/backend/tests/test_models.py
@@ -1,4 +1,6 @@
+import re
 from datetime import timedelta
+from pathlib import Path
 
 import pytest
 from posthog.test.base import BaseTest
@@ -49,6 +51,19 @@ class TestPulseEnums:
 
     def test_custom_has_no_preset_entry(self):
         assert Sensitivity.CUSTOM not in SENSITIVITY_PRESETS
+
+    def test_frontend_sensitivity_presets_match_backend(self):
+        # Single cross-language drift guard: the frontend mirrors SENSITIVITY_PRESETS in utils.ts to
+        # apply thresholds locally. Assert the FE values equal the backend source of truth so the two
+        # can't silently diverge — independent literal tests on each side would not catch drift.
+        utils_ts = (Path(__file__).resolve().parents[2] / "frontend" / "utils.ts").read_text()
+        block = utils_ts.split("export const SENSITIVITY_PRESETS", 1)[1].split("\n}", 1)[0]
+        frontend = {}
+        for name, body in re.findall(r"(conservative|balanced|sensitive):\s*\{([^}]*)\}", block):
+            min_change = float(re.search(r"min_change_pct:\s*([\d.]+)", body).group(1))
+            robust_z = float(re.search(r"robust_z_threshold:\s*([\d.]+)", body).group(1))
+            frontend[name] = (min_change, robust_z)
+        assert frontend == {k.value: v for k, v in SENSITIVITY_PRESETS.items()}
 
 
 def _make_digest(test: BaseTest) -> PulseDigest:

--- a/products/pulse/frontend/Pulse.tsx
+++ b/products/pulse/frontend/Pulse.tsx
@@ -1,0 +1,824 @@
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import {
+    IconBell,
+    IconChevronRight,
+    IconCursorClick,
+    IconDashboard,
+    IconGraph,
+    IconList,
+    IconPlay,
+    IconPulse,
+    IconRefresh,
+    IconTrending,
+} from '@posthog/icons'
+import {
+    LemonBanner,
+    LemonCard,
+    LemonCollapse,
+    LemonDivider,
+    LemonInput,
+    LemonSegmentedButton,
+    LemonSkeleton,
+    LemonSwitch,
+    LemonTag,
+    Spinner,
+    Tooltip,
+} from '@posthog/lemon-ui'
+
+import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
+import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
+import { IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { LemonTagType } from 'lib/lemon-ui/LemonTag'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { humanFriendlyLargeNumber } from 'lib/utils'
+import { maxContextLogic } from 'scenes/max/maxContextLogic'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { SceneExport } from 'scenes/sceneTypes'
+import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { PulseScanConfig } from '~/queries/schema/schema-general'
+import { SidePanelTab } from '~/types'
+
+import { PulseFindingChart } from './PulseFindingChart'
+import { pulseLogic } from './pulseLogic'
+import { PulseDigestStatus, PulseDigestSummary, PulseFindingType, PulseSensitivity } from './pulseTypes'
+import {
+    SENSITIVITY_PRESETS,
+    buildFindingInsightContext,
+    buildFindingTimelineMarkers,
+    buildMaxSeedPrompt,
+    describeChange,
+    suggestedNextStep,
+} from './utils'
+
+export const scene: SceneExport = {
+    component: Pulse,
+    logic: pulseLogic,
+}
+
+const FREQUENCY_OPTIONS: { value: 'weekly' | 'daily'; label: string }[] = [
+    { value: 'weekly', label: 'Weekly' },
+    { value: 'daily', label: 'Daily' },
+]
+
+const SENSITIVITY_OPTIONS: { value: PulseSensitivity; label: string }[] = [
+    { value: 'conservative', label: 'Conservative' },
+    { value: 'balanced', label: 'Balanced' },
+    { value: 'sensitive', label: 'Sensitive' },
+    { value: 'custom', label: 'Custom' },
+]
+
+const STATUS_TONES: Record<PulseDigestStatus, LemonTagType> = {
+    delivered: 'success',
+    failed: 'danger',
+    generating: 'default',
+    pending: 'default',
+}
+
+function statusTone(status: PulseDigestStatus): LemonTagType {
+    return STATUS_TONES[status] ?? 'default'
+}
+
+// The digest synthesis is written as a "- " bullet list so it's skimmable; LemonMarkdown renders it (and
+// still renders older paragraph-style summaries fine).
+function DigestReadBanner({ summary, className }: { summary: string; className?: string }): JSX.Element {
+    // type="ai" gives the premium AI-styled banner + icon; the body stays normal weight (LemonBanner
+    // forces font-weight:500 on its content) while the "PostHog's read" header stays bold.
+    return (
+        <LemonBanner type="ai" className={className}>
+            <div className="font-semibold mb-1">PostHog's read</div>
+            <div className="font-normal">
+                <LemonMarkdown>{summary}</LemonMarkdown>
+            </div>
+        </LemonBanner>
+    )
+}
+
+// Skeleton mirroring the FindingCard layout (title / delta+sparkline / narrative) so loading reads as
+// "cards coming" rather than generic bars.
+function FindingCardSkeleton(): JSX.Element {
+    return (
+        <LemonCard className="border-l-4 border-muted">
+            <div className="flex items-center justify-between mb-2">
+                <LemonSkeleton className="h-5 w-48" />
+                <LemonSkeleton className="h-6 w-28" />
+            </div>
+            <div className="flex items-end justify-between gap-4 mb-2">
+                <LemonSkeleton className="h-8 w-32" />
+                <LemonSkeleton className="h-10 w-28" />
+            </div>
+            <LemonSkeleton className="h-4 w-full mb-1" />
+            <LemonSkeleton className="h-4 w-3/4" />
+        </LemonCard>
+    )
+}
+
+function FindingCard({
+    finding,
+    periodStart,
+    periodEnd,
+}: {
+    finding: PulseFindingType
+    periodStart: string
+    periodEnd: string
+}): JSX.Element {
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+    const { addOrUpdateContextInsight } = useActions(maxContextLogic)
+    const { dataProcessingAccepted, dataProcessingDismissed } = useValues(maxGlobalLogic)
+    const change = describeChange(finding.change_pct)
+    // Hand the AI the actual insight as structured context (so it can read_data on the real metric),
+    // then open the panel and auto-send the seed. Falls back to prompt-only for event-sourced findings.
+    const openExplore = (seed: string): void => {
+        const insight = buildFindingInsightContext(finding)
+        if (insight) {
+            addOrUpdateContextInsight(insight)
+        }
+        openSidePanel(SidePanelTab.Max, `!${seed}`)
+    }
+    // Surface the specific guided lead as the button itself when we have one (e.g. "Dive into Chrome",
+    // "Check the X experiment") so the suggested next step is proactive, not hidden behind a generic
+    // label; fall back to a generic "Explore with AI" + explain-seed otherwise.
+    const nextStep = suggestedNextStep(finding)
+    const exploreSeed = nextStep?.seed ?? buildMaxSeedPrompt(finding)
+    const exploreLabel = nextStep?.label ?? 'Explore with AI'
+
+    // Border accent + delta tag + the chart line all share the change's tone (danger=drop, success=rise).
+    const TrendIcon =
+        change.direction === 'up' ? IconTrending : change.direction === 'down' ? IconTrendingDown : IconTrendingFlat
+    // Prefer the daily series over the period (markers spread intra-day); fall back to the weekly series,
+    // whose axis then runs one week per point back from the period end.
+    const dailySeries = finding.evidence?.daily_series
+    const useDaily = !!dailySeries && dailySeries.length > 1
+    const chartSeries = useDaily ? dailySeries : (finding.evidence?.series ?? [])
+    const axisStart =
+        useDaily || chartSeries.length < 2
+            ? periodStart
+            : dayjs(periodEnd)
+                  .subtract(chartSeries.length - 1, 'week')
+                  .toISOString()
+    const breakdown = finding.attribution_breakdown
+    // The finding's referenced flag/experiment/annotation changes, placed on the same axis as the line.
+    const timelineMarkers = buildFindingTimelineMarkers(finding, axisStart, periodEnd)
+    const sessionIds = finding.evidence?.session_ids ?? []
+
+    return (
+        <LemonCard
+            className={clsx(
+                'border-l-4',
+                change.tone === 'danger' && 'border-danger',
+                change.tone === 'success' && 'border-success',
+                change.tone === 'muted' && 'border-muted'
+            )}
+        >
+            <div className="flex items-start gap-2 mb-2">
+                <div className="flex items-center gap-2 min-w-0">
+                    <h3 className="text-base font-semibold mb-0 truncate">{finding.metric_label}</h3>
+                </div>
+                <div className="ml-auto flex items-center gap-1 shrink-0">
+                    {finding.metric_descriptor?.url ? (
+                        <LemonButton
+                            type="tertiary"
+                            size="xsmall"
+                            to={finding.metric_descriptor.url as string}
+                            targetBlank
+                        >
+                            View insight
+                        </LemonButton>
+                    ) : null}
+                    <AIConsentPopoverWrapper onApprove={() => openExplore(exploreSeed)}>
+                        <LemonButton
+                            type="tertiary"
+                            size="xsmall"
+                            // While the consent popover is up, only its Approve should send the seed —
+                            // a live onClick would fire pre-consent and then onApprove would send it again.
+                            onClick={
+                                dataProcessingAccepted || dataProcessingDismissed
+                                    ? () => openExplore(exploreSeed)
+                                    : undefined
+                            }
+                            sideIcon={null}
+                        >
+                            {exploreLabel}
+                        </LemonButton>
+                    </AIConsentPopoverWrapper>
+                </div>
+            </div>
+            <div className="flex items-baseline gap-2 flex-wrap mb-2">
+                <span className="text-2xl font-bold leading-none">
+                    {humanFriendlyLargeNumber(finding.current_value)}
+                </span>
+                <LemonTag type={change.tone} icon={<TrendIcon />}>
+                    {change.label}
+                </LemonTag>
+                <span className="text-muted-alt text-xs">
+                    vs {humanFriendlyLargeNumber(finding.baseline_value)}/wk typical
+                </span>
+            </div>
+            <p className="text-sm mb-0">{finding.narrative}</p>
+            {breakdown?.value ? (
+                <div className="flex items-center gap-1 text-muted-alt text-xs mt-2">
+                    <span>Concentrated in</span>
+                    {/* PropertyIcon.WithLabel's className styles only the icon wrapper, so render the icon and
+                        the emphasized value separately — the icon is simply omitted for unmapped properties. */}
+                    <PropertyIcon property={breakdown.property as string} value={String(breakdown.value)} />
+                    <span className="font-medium text-default">{String(breakdown.value)}</span>
+                </div>
+            ) : null}
+            {chartSeries.length > 1 || sessionIds.length ? <LemonDivider className="my-3" /> : null}
+            {chartSeries.length > 1 ? (
+                <PulseFindingChart
+                    series={chartSeries}
+                    markers={timelineMarkers}
+                    axisStart={axisStart}
+                    axisEnd={periodEnd}
+                    tone={change.tone}
+                />
+            ) : null}
+            {sessionIds.length ? (
+                <div className="flex items-center flex-wrap gap-2 mt-2 text-xs">
+                    <span className="text-muted-alt">Sessions:</span>
+                    {sessionIds.map((sessionId, index) => (
+                        <LemonButton
+                            key={sessionId}
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconPlay />}
+                            to={urls.replaySingle(sessionId)}
+                            targetBlank
+                        >
+                            Session {index + 1}
+                        </LemonButton>
+                    ))}
+                </div>
+            ) : null}
+        </LemonCard>
+    )
+}
+
+function SubscriptionPanel(): JSX.Element {
+    const { subscriptionDraft, subscriptionLoading } = useValues(pulseLogic)
+    const { updateSubscriptionLocal, saveSubscription } = useActions(pulseLogic)
+
+    if (!subscriptionDraft) {
+        return <LemonSkeleton className="h-40 w-full mb-6" />
+    }
+
+    const setSensitivity = (sensitivity: PulseSensitivity): void => {
+        if (sensitivity === 'custom') {
+            updateSubscriptionLocal({ sensitivity })
+            return
+        }
+        updateSubscriptionLocal({ sensitivity, ...SENSITIVITY_PRESETS[sensitivity] })
+    }
+
+    return (
+        <LemonCard className="mb-6">
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="text-base font-semibold mb-0">Pulse settings</h3>
+                <LemonButton
+                    type="primary"
+                    size="small"
+                    onClick={() => saveSubscription()}
+                    loading={subscriptionLoading}
+                    disabledReason={subscriptionLoading ? 'Saving…' : undefined}
+                >
+                    Save settings
+                </LemonButton>
+            </div>
+            <div className="flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                    <span>Enable Pulse</span>
+                    <LemonSwitch
+                        checked={subscriptionDraft.enabled}
+                        onChange={(checked) => updateSubscriptionLocal({ enabled: checked })}
+                    />
+                </div>
+                <div className="flex items-center justify-between">
+                    <span>Frequency</span>
+                    <LemonSelect
+                        value={subscriptionDraft.frequency}
+                        onChange={(v) => v && updateSubscriptionLocal({ frequency: v })}
+                        options={FREQUENCY_OPTIONS}
+                    />
+                </div>
+                <div className="flex items-center justify-between">
+                    <Tooltip title="Controls the always-on metric scan. Anomalies surfaced by the AI scout aren't filtered by these thresholds.">
+                        <span>Sensitivity</span>
+                    </Tooltip>
+                    <LemonSegmentedButton
+                        value={subscriptionDraft.sensitivity}
+                        onChange={(v) => setSensitivity(v)}
+                        options={SENSITIVITY_OPTIONS}
+                        size="small"
+                    />
+                </div>
+                <LemonCollapse
+                    panels={[
+                        {
+                            key: 'advanced',
+                            header: 'Advanced',
+                            content: (
+                                <div className="flex flex-col gap-3">
+                                    <div className="flex items-center justify-between">
+                                        <span>Minimum change %</span>
+                                        <LemonInput
+                                            type="number"
+                                            step={0.05}
+                                            value={subscriptionDraft.min_change_pct}
+                                            onChange={(v) =>
+                                                updateSubscriptionLocal({
+                                                    min_change_pct: v ?? 0,
+                                                    sensitivity: 'custom',
+                                                })
+                                            }
+                                        />
+                                    </div>
+                                    <div className="flex items-center justify-between">
+                                        <span>Baseline weeks</span>
+                                        <LemonInput
+                                            type="number"
+                                            value={subscriptionDraft.baseline_weeks}
+                                            onChange={(v) => updateSubscriptionLocal({ baseline_weeks: v ?? 4 })}
+                                        />
+                                    </div>
+                                    <div className="flex items-center justify-between">
+                                        <span>Maximum findings</span>
+                                        <LemonInput
+                                            type="number"
+                                            value={subscriptionDraft.max_findings}
+                                            onChange={(v) => updateSubscriptionLocal({ max_findings: v ?? 5 })}
+                                        />
+                                    </div>
+                                    <div className="flex items-center justify-between">
+                                        <span>Robust z threshold</span>
+                                        <LemonInput
+                                            type="number"
+                                            step={0.5}
+                                            value={subscriptionDraft.robust_z_threshold}
+                                            onChange={(v) =>
+                                                updateSubscriptionLocal({
+                                                    robust_z_threshold: v ?? 3.5,
+                                                    sensitivity: 'custom',
+                                                })
+                                            }
+                                        />
+                                    </div>
+                                </div>
+                            ),
+                        },
+                    ]}
+                />
+            </div>
+        </LemonCard>
+    )
+}
+
+// Icon + readable label per watched-metric source, so a glance tells dashboard vs insight vs event.
+const WATCHED_META: Record<string, { icon: JSX.Element; label: string }> = {
+    dashboard_tile: { icon: <IconDashboard />, label: 'Dashboard tile' },
+    recent_insight: { icon: <IconGraph />, label: 'Insight' },
+    saved_insight: { icon: <IconGraph />, label: 'Insight' },
+    top_event: { icon: <IconCursorClick />, label: 'Event' },
+}
+
+function WatchedPanel(): JSX.Element | null {
+    const { watchedCandidates, watchedCandidatesLoading } = useValues(pulseLogic)
+
+    if (watchedCandidatesLoading) {
+        return <LemonSkeleton className="h-24 w-full mb-6" />
+    }
+    if (!watchedCandidates.length) {
+        return null
+    }
+
+    return (
+        <LemonCard className="mb-6">
+            <div className="flex items-center gap-2 mb-2">
+                <h3 className="text-base font-semibold mb-0">What PostHog is watching</h3>
+                <LemonTag type="warning">Staff debug</LemonTag>
+            </div>
+            <p className="text-muted-alt text-sm mb-3">
+                Internal: the metric set scanned each cycle. Hidden from non-staff while we tune it.
+            </p>
+            <div className="flex flex-wrap gap-2">
+                {watchedCandidates.map((c, i) => {
+                    const meta = WATCHED_META[c.source] ?? { icon: <IconList />, label: 'Metric' }
+                    return (
+                        <Tooltip key={c.source_id ?? `${c.source}-${i}`} title={meta.label}>
+                            <LemonTag type="muted" icon={meta.icon}>
+                                {c.label}
+                            </LemonTag>
+                        </Tooltip>
+                    )
+                })}
+            </div>
+        </LemonCard>
+    )
+}
+
+// Knob definitions for the staff scan-tuning panel — kept module-level so they aren't rebuilt each render.
+type ScanKnob = { key: keyof PulseScanConfig; label: string; step?: number; hint?: string }
+const SELECTION_KNOBS: ScanKnob[] = [
+    { key: 'max_candidates', label: 'Max candidates' },
+    { key: 'recent_days', label: 'Recent window (days)' },
+    { key: 'min_viewers_for_recent_insight', label: 'Min viewers (recent insights)' },
+    { key: 'dashboard_tile_limit', label: 'Dashboard tiles', hint: '0 = off' },
+    { key: 'recent_insight_limit', label: 'Recently-viewed insights', hint: '0 = off' },
+    { key: 'saved_insight_limit', label: 'Saved insights', hint: '0 = off' },
+    { key: 'top_event_limit', label: 'Top events', hint: '0 = off' },
+]
+const DETECTION_KNOBS: ScanKnob[] = [
+    { key: 'min_baseline_value', label: 'Volume floor (min baseline)', step: 1 },
+    { key: 'min_change_pct', label: 'Min change %', step: 0.05 },
+    { key: 'robust_z_threshold', label: 'Robust z threshold', step: 0.5 },
+    { key: 'baseline_weeks', label: 'Baseline weeks' },
+    { key: 'max_findings', label: 'Max findings' },
+]
+
+// Staff-only knobs for one-off, no-deploy tuning of what Pulse considers interesting. The draft is local
+// (persisted to localStorage); "Run scan with these settings" sends it as a per-run override — nothing is
+// saved to the team. A plain "Run scan now" (no config) still uses the team's saved subscription settings.
+function ScanTuningPanel(): JSX.Element {
+    const { scanConfigDraft, scanTriggerLoading } = useValues(pulseLogic)
+    const { updateScanConfigLocal, resetScanConfig, triggerScan } = useActions(pulseLogic)
+
+    const renderKnob = (knob: ScanKnob): JSX.Element => (
+        <div key={knob.key} className="flex items-center justify-between gap-2">
+            <span className="text-sm">
+                {knob.label}
+                {knob.hint ? <span className="text-muted-alt ml-1">({knob.hint})</span> : null}
+            </span>
+            <LemonInput
+                type="number"
+                size="small"
+                className="w-24"
+                step={knob.step}
+                value={scanConfigDraft[knob.key]}
+                onChange={(v) =>
+                    // LemonInput type="number" emits NaN (not undefined) for an empty field, and NaN ?? x
+                    // doesn't catch it — so guard on finiteness to keep NaN out of the draft and the request.
+                    Number.isFinite(v) && updateScanConfigLocal({ [knob.key]: v as number } as Partial<PulseScanConfig>)
+                }
+            />
+        </div>
+    )
+
+    return (
+        <LemonCard className="mb-6">
+            <div className="flex items-center gap-2 mb-2">
+                <h3 className="text-base font-semibold mb-0">Scan tuning</h3>
+                <LemonTag type="warning">Staff debug</LemonTag>
+            </div>
+            <p className="text-muted-alt text-sm mb-3">
+                Internal: override the heuristics for a single one-off scan to calibrate what's interesting — nothing
+                here is saved to the team.
+            </p>
+            <LemonCollapse
+                panels={[
+                    {
+                        key: 'knobs',
+                        header: 'Knobs',
+                        content: (
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+                                <div className="flex flex-col gap-3">
+                                    <h4 className="text-xs uppercase font-semibold text-muted mb-0">Selection</h4>
+                                    {SELECTION_KNOBS.map(renderKnob)}
+                                </div>
+                                <div className="flex flex-col gap-3">
+                                    <h4 className="text-xs uppercase font-semibold text-muted mb-0">Detection</h4>
+                                    {DETECTION_KNOBS.map(renderKnob)}
+                                </div>
+                            </div>
+                        ),
+                    },
+                ]}
+            />
+            <div className="flex items-center gap-2 mt-3">
+                <LemonButton
+                    type="primary"
+                    size="small"
+                    icon={<IconPulse />}
+                    onClick={() => triggerScan(scanConfigDraft)}
+                    loading={scanTriggerLoading}
+                    disabledReason={scanTriggerLoading ? 'Scan starting…' : undefined}
+                >
+                    Run scan with these settings
+                </LemonButton>
+                <LemonButton type="secondary" size="small" onClick={() => resetScanConfig()}>
+                    Reset to defaults
+                </LemonButton>
+            </div>
+        </LemonCard>
+    )
+}
+
+function DigestRow({ digest }: { digest: PulseDigestSummary }): JSX.Element {
+    const { expandedDigestId, expandedDigest, expandedDigestLoading } = useValues(pulseLogic)
+    const { setExpandedDigestId, getDigest } = useActions(pulseLogic)
+    const isExpanded = expandedDigestId === digest.id
+
+    const onToggle = (): void => {
+        if (isExpanded) {
+            setExpandedDigestId(null)
+            return
+        }
+        setExpandedDigestId(digest.id)
+        if (expandedDigest?.id !== digest.id) {
+            getDigest(digest.id)
+        }
+    }
+
+    return (
+        <li className="border rounded bg-surface-primary">
+            <button
+                type="button"
+                className="w-full flex items-center justify-between p-3 cursor-pointer bg-transparent border-none text-left"
+                onClick={onToggle}
+                aria-expanded={isExpanded}
+            >
+                <span className="flex items-center gap-2 font-medium">
+                    <IconChevronRight
+                        className={isExpanded ? 'rotate-90 transition-transform' : 'transition-transform'}
+                    />
+                    <TZLabel time={digest.created_at} />
+                    <LemonTag type={statusTone(digest.status)}>{digest.status}</LemonTag>
+                </span>
+                <span className="text-muted-alt text-sm">
+                    {digest.finding_count} finding{digest.finding_count === 1 ? '' : 's'}
+                </span>
+            </button>
+            {isExpanded && (
+                <div className="p-3 pt-0 space-y-3">
+                    {digest.status === 'failed' ? (
+                        <LemonBanner type="error">
+                            <span className="font-semibold">Scan failed: </span>
+                            {digest.error?.message ?? 'Unknown error'}
+                        </LemonBanner>
+                    ) : null}
+                    {expandedDigestLoading || expandedDigest?.id !== digest.id ? (
+                        <LemonSkeleton className="h-24 w-full" />
+                    ) : expandedDigest.findings.length === 0 ? (
+                        <p className="text-muted mb-0">No findings in this digest.</p>
+                    ) : (
+                        <>
+                            {expandedDigest.summary ? <DigestReadBanner summary={expandedDigest.summary} /> : null}
+                            {expandedDigest.findings.map((finding) => (
+                                <FindingCard
+                                    key={finding.id}
+                                    finding={finding}
+                                    periodStart={expandedDigest.period_start}
+                                    periodEnd={expandedDigest.period_end}
+                                />
+                            ))}
+                        </>
+                    )}
+                </div>
+            )}
+        </li>
+    )
+}
+
+export function Pulse(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const {
+        digests,
+        digestsLoading,
+        findingsLoading,
+        shouldShowEmptyState,
+        latestDigest,
+        findingsForLatest,
+        digestsError,
+        findingsError,
+        subscriptionError,
+        watchedError,
+        scanTriggerLoading,
+        isScanInProgress,
+        digestsNext,
+        loadingMore,
+    } = useValues(pulseLogic)
+    const { loadDigests, loadMoreDigests, loadFindings, loadSubscription, loadWatched, triggerScan, setUpPulseAlerts } =
+        useActions(pulseLogic)
+    const { user } = useValues(userLogic)
+
+    const flagEnabled = !!featureFlags[FEATURE_FLAGS.MAX_PULSE]
+
+    useEffect(() => {
+        if (!flagEnabled) {
+            return
+        }
+        loadDigests()
+        loadFindings()
+        loadSubscription()
+        if (user?.is_staff) {
+            loadWatched() // staff-only debug panel; don't fetch the watched set for non-staff
+        }
+    }, [flagEnabled, user?.is_staff, loadDigests, loadFindings, loadSubscription, loadWatched])
+
+    if (!flagEnabled) {
+        return (
+            <SceneContent>
+                <SceneTitleSection
+                    name="Pulse"
+                    description="PostHog scans your metrics and surfaces changes worth investigating."
+                    resourceType={{ type: 'project', forceIcon: <IconPulse /> }}
+                />
+                <ProductIntroduction
+                    productName="Pulse"
+                    thingName="finding"
+                    description="PostHog scans your metrics each cycle and surfaces notable changes worth investigating. Pulse is rolling out gradually."
+                    isEmpty
+                    docsURL="https://posthog.com/docs"
+                />
+            </SceneContent>
+        )
+    }
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Pulse"
+                description="PostHog scans your metrics and surfaces changes worth investigating."
+                resourceType={{ type: 'project', forceIcon: <IconPulse /> }}
+                actions={
+                    <>
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconBell />}
+                            onClick={() => setUpPulseAlerts()}
+                            tooltip="Get notified in Slack when Pulse surfaces a finding (routes the pulse_finding_surfaced event to a destination)"
+                        >
+                            Set up alerts
+                        </LemonButton>
+                        {user?.is_staff && (
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                icon={<IconPulse />}
+                                onClick={() => triggerScan()}
+                                loading={scanTriggerLoading}
+                                tooltip="Staff only: run a Pulse scan for this project now"
+                            >
+                                Run scan now
+                            </LemonButton>
+                        )}
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconRefresh />}
+                            onClick={() => {
+                                loadDigests()
+                                loadFindings()
+                            }}
+                            loading={digestsLoading || findingsLoading}
+                        >
+                            Refresh
+                        </LemonButton>
+                    </>
+                }
+            />
+
+            <SubscriptionPanel />
+            {/* The watched-metric set and the scan-tuning knobs are internal "magic sauce" we'll keep tuning —
+                staff-only debug while we calibrate on production data. */}
+            {user?.is_staff && <WatchedPanel />}
+            {user?.is_staff && <ScanTuningPanel />}
+
+            {digestsError && (
+                <LemonBanner type="error" action={{ children: 'Retry', onClick: () => loadDigests() }} className="mb-4">
+                    Failed to load Pulse digests.
+                </LemonBanner>
+            )}
+            {findingsError && (
+                <LemonBanner
+                    type="error"
+                    action={{ children: 'Retry', onClick: () => loadFindings() }}
+                    className="mb-4"
+                >
+                    Failed to load findings.
+                </LemonBanner>
+            )}
+            {subscriptionError && (
+                <LemonBanner
+                    type="error"
+                    action={{ children: 'Retry', onClick: () => loadSubscription() }}
+                    className="mb-4"
+                >
+                    Failed to load Pulse settings.
+                </LemonBanner>
+            )}
+            {watchedError && (
+                <LemonBanner type="error" action={{ children: 'Retry', onClick: () => loadWatched() }} className="mb-4">
+                    Failed to load the watched metrics.
+                </LemonBanner>
+            )}
+
+            {isScanInProgress && (
+                <LemonBanner type="info" className="mb-4">
+                    <span className="flex items-center gap-2">
+                        <Spinner />
+                        Scan in progress — findings will appear here as soon as it finishes…
+                    </span>
+                </LemonBanner>
+            )}
+
+            {digestsLoading && digests.length === 0 ? (
+                <div className="space-y-4">
+                    <LemonSkeleton className="h-8 w-48" />
+                    <FindingCardSkeleton />
+                    <FindingCardSkeleton />
+                </div>
+            ) : (
+                <>
+                    <ProductIntroduction
+                        productName="Pulse"
+                        thingName="finding"
+                        description="Once Pulse runs its first scan, findings will appear here."
+                        isEmpty={shouldShowEmptyState}
+                        docsURL="https://posthog.com/docs"
+                    />
+                    {!shouldShowEmptyState && (
+                        <div className="space-y-6">
+                            {latestDigest && (
+                                <div>
+                                    <div className="flex items-center gap-2 mb-3">
+                                        <h2 className="text-lg font-semibold mb-0">Latest digest</h2>
+                                        <LemonTag type={statusTone(latestDigest.status)}>
+                                            {latestDigest.status}
+                                        </LemonTag>
+                                        <span className="text-muted-alt text-xs">
+                                            <TZLabel time={latestDigest.created_at} />
+                                        </span>
+                                    </div>
+                                    {latestDigest.status === 'failed' ? (
+                                        <LemonBanner type="error" className="mb-3">
+                                            <span className="font-semibold">Scan failed: </span>
+                                            {latestDigest.error?.message ?? 'Unknown error'}
+                                        </LemonBanner>
+                                    ) : null}
+                                    {latestDigest.summary ? (
+                                        <DigestReadBanner summary={latestDigest.summary} className="mb-3" />
+                                    ) : null}
+                                    {findingsForLatest.length === 0 ? (
+                                        <p className="text-muted">No findings in the latest digest.</p>
+                                    ) : (
+                                        <div className="grid grid-cols-1 gap-4">
+                                            {findingsForLatest.map((finding) => (
+                                                <FindingCard
+                                                    key={finding.id}
+                                                    finding={finding}
+                                                    periodStart={latestDigest.period_start}
+                                                    periodEnd={latestDigest.period_end}
+                                                />
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {digests.length > 1 && (
+                                <div>
+                                    <h2 className="text-lg font-semibold mb-3">Previous digests</h2>
+                                    <ul className="space-y-2">
+                                        {digests.slice(1).map((digest) => (
+                                            <DigestRow key={digest.id} digest={digest} />
+                                        ))}
+                                    </ul>
+                                    {digestsNext && (
+                                        <div className="flex justify-center mt-3">
+                                            <LemonButton
+                                                type="secondary"
+                                                size="small"
+                                                onClick={() => loadMoreDigests()}
+                                                loading={loadingMore}
+                                                disabledReason={loadingMore ? 'Loading…' : undefined}
+                                            >
+                                                Load more previous digests
+                                            </LemonButton>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </>
+            )}
+        </SceneContent>
+    )
+}
+
+export default Pulse

--- a/products/pulse/frontend/PulseFindingChart.tsx
+++ b/products/pulse/frontend/PulseFindingChart.tsx
@@ -1,0 +1,221 @@
+import clsx from 'clsx'
+import { useState } from 'react'
+
+import { IconFlag, IconFlask, IconNotebook } from '@posthog/icons'
+import { LemonTag, Link, Popover } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTagType } from 'lib/lemon-ui/LemonTag'
+
+import { PulseTimelineMarker } from './pulseTypes'
+
+interface SignalMeta {
+    icon: JSX.Element
+    tagType: LemonTagType
+    label: string
+}
+
+// Distinct colour + icon per change type, kept apart from the red/green the line uses for metric direction.
+const SIGNAL_META: Record<string, SignalMeta> = {
+    feature_flag: { icon: <IconFlag />, tagType: 'warning', label: 'Feature flag' },
+    experiment: { icon: <IconFlask />, tagType: 'highlight', label: 'Experiment' },
+    annotation: { icon: <IconNotebook />, tagType: 'primary', label: 'Annotation' },
+}
+const FALLBACK_META: SignalMeta = { icon: <IconNotebook />, tagType: 'default', label: 'Change' }
+
+const TONE_TEXT: Record<string, string> = {
+    danger: 'text-danger',
+    success: 'text-success',
+    muted: 'text-muted',
+}
+
+// Markers closer than this (fraction of the axis width) would overlap, so they collapse into one cluster
+// chip you click through to the individual changes.
+const MIN_MARKER_GAP = 0.05
+
+function metaFor(type: string): SignalMeta {
+    return SIGNAL_META[type] ?? FALLBACK_META
+}
+
+type ChartItem =
+    | { kind: 'marker'; key: string; position: number; marker: PulseTimelineMarker }
+    | { kind: 'cluster'; key: string; position: number; markers: PulseTimelineMarker[] }
+
+function MarkerDetails({ marker }: { marker: PulseTimelineMarker }): JSX.Element {
+    const meta = metaFor(marker.type)
+    return (
+        <div className="flex flex-col gap-1 p-2 max-w-xs">
+            <span className="text-xs uppercase font-medium text-muted">
+                {meta.label}
+                {marker.change ? ` · ${marker.change}` : ''}
+            </span>
+            <span className="font-semibold">{marker.label}</span>
+            <span className="text-xs text-muted">{dayjs(marker.timestamp).format('ddd, MMM D')}</span>
+            {marker.to ? (
+                <LemonButton type="secondary" size="xsmall" to={marker.to} targetBlank className="mt-1 self-start">
+                    Open {meta.label.toLowerCase()}
+                </LemonButton>
+            ) : null}
+        </div>
+    )
+}
+
+function ClusterDetails({ markers }: { markers: PulseTimelineMarker[] }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1.5 p-2 max-w-sm">
+            <span className="text-xs uppercase font-medium text-muted">
+                {markers.length} changes on {dayjs(markers[0].timestamp).format('MMM D')}
+            </span>
+            {markers.map((marker) => {
+                const meta = metaFor(marker.type)
+                return (
+                    <div key={marker.key} className="flex items-start gap-1.5 text-sm">
+                        {/* items-start + a nudge keeps the icon aligned to the first line of a wrapped label */}
+                        <span className="shrink-0 mt-0.5">{meta.icon}</span>
+                        <span className="min-w-0">
+                            {marker.to ? (
+                                <Link to={marker.to} target="_blank">
+                                    {marker.label}
+                                </Link>
+                            ) : (
+                                marker.label
+                            )}
+                            {/* the action verb — e.g. "turned on" / "launched" — so a toggle is visible here too */}
+                            {marker.change ? <span className="text-muted"> · {marker.change}</span> : null}
+                        </span>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+// One marker pinned to the bottom bar with a guide line rising to the time it happened. Click opens a
+// popover (not a hover tooltip — that was unreadable/unclickable) with the details and a deep link.
+function ChartMarker({ item }: { item: ChartItem }): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const tag =
+        item.kind === 'cluster' ? (
+            <LemonTag type="muted" size="small">
+                {item.markers.length}
+            </LemonTag>
+        ) : (
+            <LemonTag type={metaFor(item.marker.type).tagType} size="small" icon={metaFor(item.marker.type).icon}>
+                {null}
+            </LemonTag>
+        )
+    return (
+        <div
+            className="absolute inset-y-0 -translate-x-1/2 flex flex-col items-center"
+            style={{ left: `${item.position * 100}%` }}
+        >
+            <div className="w-px flex-1 bg-border" />
+            <Popover
+                visible={open}
+                onClickOutside={() => setOpen(false)}
+                placement="top"
+                overlay={
+                    item.kind === 'cluster' ? (
+                        <ClusterDetails markers={item.markers} />
+                    ) : (
+                        <MarkerDetails marker={item.marker} />
+                    )
+                }
+            >
+                <span role="button" tabIndex={0} className="cursor-pointer shrink-0" onClick={() => setOpen((v) => !v)}>
+                    {tag}
+                </span>
+            </Popover>
+        </div>
+    )
+}
+
+// The finding's metric trend as a line, with its referenced flag / experiment / annotation changes overlaid
+// as vertical guide lines dropping from when they happened to an icon on the bottom bar — so the move and
+// the changes that might explain it (a coincidence to check, never proven cause) read together. Same-day
+// markers beyond MAX_MARKERS_PER_DAY converge into one chip. The line renders whenever there are >= 2 points.
+export function PulseFindingChart({
+    series,
+    markers,
+    axisStart,
+    axisEnd,
+    tone,
+}: {
+    series: number[]
+    markers: PulseTimelineMarker[]
+    axisStart: string
+    axisEnd: string
+    tone: 'danger' | 'success' | 'muted'
+}): JSX.Element | null {
+    if (series.length < 2) {
+        return null
+    }
+
+    const min = Math.min(...series)
+    const max = Math.max(...series)
+    const range = max - min || 1
+    // viewBox is 0..100 in both axes with preserveAspectRatio="none", so points map straight to the box.
+    const linePoints = series
+        .map((value, index) => {
+            const x = (index / (series.length - 1)) * 100
+            const y = 100 - ((value - min) / range) * 100
+            return `${x.toFixed(2)},${y.toFixed(2)}`
+        })
+        .join(' ')
+
+    // Collapse markers that sit closer than MIN_MARKER_GAP (they'd overlap) into one cluster. markers
+    // arrive sorted by position, so a greedy left-to-right sweep groups each run of near-adjacent ones.
+    const items: ChartItem[] = []
+    let group: PulseTimelineMarker[] = []
+    const flush = (): void => {
+        if (group.length === 1) {
+            items.push({ kind: 'marker', key: group[0].key, position: group[0].position, marker: group[0] })
+        } else if (group.length > 1) {
+            const position = group.reduce((sum, m) => sum + m.position, 0) / group.length
+            items.push({ kind: 'cluster', key: `cluster-${group[0].key}`, position, markers: [...group] })
+        }
+        group = []
+    }
+    for (const marker of markers) {
+        if (group.length && marker.position - group[group.length - 1].position > MIN_MARKER_GAP) {
+            flush()
+        }
+        group.push(marker)
+    }
+    flush()
+
+    return (
+        <div className="mt-1">
+            <div className="text-muted-alt text-xs mb-1">
+                {markers.length ? 'Trend & related changes' : 'Recent trend'}
+            </div>
+            {/* Dynamic left% / SVG point coords are data-driven, so inline positioning is unavoidable here.
+                The line lives in the top band; markers sit in the strip below it so they never cross the line. */}
+            <div className="relative h-20 w-full">
+                <svg
+                    viewBox="0 0 100 100"
+                    preserveAspectRatio="none"
+                    className={clsx('absolute inset-x-0 top-0 h-12 w-full overflow-visible', TONE_TEXT[tone])}
+                >
+                    <polyline
+                        points={linePoints}
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                        strokeLinejoin="round"
+                        strokeLinecap="round"
+                        vectorEffect="non-scaling-stroke"
+                    />
+                </svg>
+                {items.map((item) => (
+                    <ChartMarker key={item.key} item={item} />
+                ))}
+            </div>
+            <div className="flex justify-between text-muted-alt text-[10px] mt-0.5">
+                <span>{dayjs(axisStart).format('MMM D')}</span>
+                <span>{dayjs(axisEnd).format('MMM D')}</span>
+            </div>
+        </div>
+    )
+}

--- a/products/pulse/frontend/index.ts
+++ b/products/pulse/frontend/index.ts
@@ -1,0 +1,1 @@
+export { Pulse } from './Pulse'

--- a/products/pulse/frontend/pulseLogic.test.ts
+++ b/products/pulse/frontend/pulseLogic.test.ts
@@ -1,0 +1,256 @@
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { userLogic } from 'scenes/userLogic'
+
+import { useMocks } from '~/mocks/jest'
+import schemaJson from '~/queries/schema.json'
+import { initKeaTests } from '~/test/init'
+
+import { PULSE_SCAN_CONFIG_DEFAULTS, pulseLogic } from './pulseLogic'
+
+const DIGEST = {
+    id: 'd1',
+    period_start: '2026-05-19',
+    period_end: '2026-05-26',
+    status: 'delivered',
+    created_at: '2026-05-26T00:00:00Z',
+    finding_count: 1,
+}
+
+const FINDING = {
+    id: 'f1',
+    digest: 'd1',
+    metric_label: 'Pageviews',
+    metric_descriptor: {},
+    current_value: 100,
+    baseline_value: 50,
+    change_pct: 1.0,
+    robust_z: 4.2,
+    impact: 7.07,
+    attribution_breakdown: null,
+    narrative: 'Pageviews doubled.',
+    chart_thumbnail_url: '',
+    rank: 0,
+    created_at: '2026-05-26T00:00:00Z',
+}
+
+const SUBSCRIPTION = {
+    id: 's1',
+    enabled: true,
+    frequency: 'weekly',
+    detection_mode: 'change_v1',
+    sensitivity: 'balanced',
+    min_change_pct: 0.25,
+    baseline_weeks: 4,
+    max_findings: 5,
+    robust_z_threshold: 3.5,
+    last_scan_at: null,
+    next_scan_at: null,
+    created_at: '2026-05-26T00:00:00Z',
+}
+
+const WATCHED = { source: 'recent_insight', source_id: '7', label: 'Signups', query: { kind: 'TrendsQuery' } }
+
+describe('pulseLogic', () => {
+    let logic: ReturnType<typeof pulseLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/pulse_digests/': () => [200, { count: 1, results: [DIGEST] }],
+                '/api/environments/:team_id/pulse_digests/d1/': () => [200, { ...DIGEST, findings: [FINDING] }],
+                '/api/environments/:team_id/pulse_findings/': () => [200, { count: 1, results: [FINDING] }],
+                '/api/environments/:team_id/pulse_subscriptions/current/': () => [200, SUBSCRIPTION],
+                '/api/environments/:team_id/pulse_subscriptions/watched/': () => [200, { results: [WATCHED] }],
+            },
+            patch: {
+                '/api/environments/:team_id/pulse_subscriptions/:id/': () => [
+                    200,
+                    { ...SUBSCRIPTION, sensitivity: 'sensitive' },
+                ],
+            },
+        })
+        initKeaTests()
+        userLogic.mount()
+        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        logic = pulseLogic()
+        logic.mount()
+    })
+
+    it('loads digests, findings and subscription into typed values', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadDigests()
+            logic.actions.loadFindings(DIGEST.id)
+            logic.actions.loadSubscription()
+        })
+            .toDispatchActions(['loadDigestsSuccess', 'loadFindingsSuccess', 'loadSubscriptionSuccess'])
+            .toMatchValues({
+                digests: [DIGEST],
+                findings: [FINDING],
+                subscription: SUBSCRIPTION,
+            })
+    })
+
+    it('follows the next cursor and appends older digests on loadMoreDigests', async () => {
+        let page = 0
+        useMocks({
+            get: {
+                '/api/environments/:team_id/pulse_digests/': () => {
+                    page += 1
+                    return page === 1
+                        ? [200, { count: 2, next: '/api/environments/997/pulse_digests/?offset=1', results: [DIGEST] }]
+                        : [200, { count: 2, next: null, results: [{ ...DIGEST, id: 'd2' }] }]
+                },
+            },
+        })
+
+        await expectLogic(logic, () => logic.actions.loadDigests())
+            .toDispatchActions(['loadDigestsSuccess', 'setDigestsNext'])
+            .toMatchValues({ digestsNext: '/api/environments/997/pulse_digests/?offset=1' })
+
+        await expectLogic(logic, () => logic.actions.loadMoreDigests())
+            .toDispatchActions(['loadMoreDigestsSuccess', 'setDigestsNext'])
+            .toMatchValues({
+                digests: [DIGEST, { ...DIGEST, id: 'd2' }],
+                digestsNext: null,
+            })
+    })
+
+    it('seeds subscriptionDraft from loaded subscription and patches locally', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSubscription()
+        }).toDispatchActions(['loadSubscriptionSuccess'])
+
+        await expectLogic(logic, () => {
+            logic.actions.updateSubscriptionLocal({ frequency: 'daily', enabled: false })
+        }).toMatchValues({
+            subscriptionDraft: expect.objectContaining({
+                frequency: 'daily',
+                enabled: false,
+                sensitivity: 'balanced',
+            }),
+        })
+    })
+
+    it('tracks expandedDigestId', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setExpandedDigestId('d9')
+        }).toMatchValues({ expandedDigestId: 'd9' })
+    })
+
+    it('sets digestsError on loadDigestsFailure', async () => {
+        useMocks({ get: { '/api/environments/:team_id/pulse_digests/': () => [500, {}] } })
+        await expectLogic(logic, () => logic.actions.loadDigests()).toDispatchActions(['loadDigestsFailure'])
+        expect(logic.values.digestsError).toBeTruthy()
+    })
+
+    it('sets findingsError on loadFindingsFailure', async () => {
+        useMocks({ get: { '/api/environments/:team_id/pulse_findings/': () => [500, {}] } })
+        await expectLogic(logic, () => logic.actions.loadFindings(DIGEST.id)).toDispatchActions(['loadFindingsFailure'])
+        expect(logic.values.findingsError).toBeTruthy()
+    })
+
+    it('skips the findings fetch when no digest id is available yet', async () => {
+        // On mount the digests have not loaded; the loader must return [] without hitting the API
+        // (loadDigestsSuccess re-issues with the latest digest id).
+        await expectLogic(logic, () => logic.actions.loadFindings()).toDispatchActions(['loadFindingsSuccess'])
+        expect(logic.values.findings).toEqual([])
+    })
+
+    it('exposes subscriptionLoading while saving and applies preset locally', async () => {
+        await expectLogic(logic, () => logic.actions.loadSubscription()).toDispatchActions(['loadSubscriptionSuccess'])
+
+        logic.actions.updateSubscriptionLocal({
+            sensitivity: 'sensitive',
+            min_change_pct: 0.15,
+            robust_z_threshold: 3.0,
+        })
+        expect(logic.values.subscriptionDraft?.min_change_pct).toBe(0.15)
+        expect(logic.values.subscriptionDraft?.robust_z_threshold).toBe(3.0)
+
+        await expectLogic(logic, () => logic.actions.saveSubscription())
+            .toMatchValues({ subscriptionLoading: true })
+            .toDispatchActions(['saveSubscriptionSuccess'])
+            .toMatchValues({ subscriptionLoading: false })
+    })
+
+    it('creates a subscription via POST when the draft has no id', async () => {
+        useMocks({
+            post: {
+                '/api/environments/:team_id/pulse_subscriptions/': () => [201, { ...SUBSCRIPTION, id: 's2' }],
+            },
+        })
+
+        // No loadSubscription → the draft seeds from DEFAULT_SUBSCRIPTION (id: null), so save must POST,
+        // not PATCH. The distinct response id ('s2' vs the patch mock's 's1') proves which path ran.
+        logic.actions.updateSubscriptionLocal({ enabled: true })
+        expect(logic.values.subscriptionDraft?.id).toBeNull()
+
+        await expectLogic(logic, () => logic.actions.saveSubscription())
+            .toDispatchActions(['saveSubscriptionSuccess'])
+            .toMatchValues({ subscription: expect.objectContaining({ id: 's2' }) })
+    })
+
+    it('loads watched candidates', async () => {
+        await expectLogic(logic, () => logic.actions.loadWatched())
+            .toDispatchActions(['loadWatchedSuccess'])
+            .toMatchValues({ watchedCandidates: [WATCHED] })
+    })
+
+    it('reflects an in-progress scan and polls while the latest digest is generating', async () => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/pulse_digests/': () => [
+                    200,
+                    { count: 1, results: [{ ...DIGEST, status: 'generating' }] },
+                ],
+            },
+        })
+        await expectLogic(logic, () => logic.actions.loadDigests()).toDispatchActions([
+            'loadDigestsSuccess',
+            'markScanInProgress',
+            'pollScan',
+        ])
+        expect(logic.values.isScanInProgress).toBe(true)
+    })
+
+    it('does not flag scan in progress for a delivered digest', async () => {
+        await expectLogic(logic, () => logic.actions.loadDigests()).toDispatchActions(['loadDigestsSuccess'])
+        expect(logic.values.isScanInProgress).toBe(false)
+    })
+
+    it('starts polling and shows progress immediately after a manual scan trigger', async () => {
+        useMocks({
+            post: {
+                '/api/environments/:team_id/pulse_digests/trigger_scan/': () => [202, { workflow_id: 'wf-1' }],
+            },
+        })
+        await expectLogic(logic, () => logic.actions.triggerScan()).toDispatchActions([
+            'triggerScanSuccess',
+            'pollScan',
+        ])
+        expect(logic.values.isScanInProgress).toBe(true)
+    })
+
+    it('loads a past digest on getDigest', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.setExpandedDigestId('d1')
+            logic.actions.getDigest('d1')
+        })
+            .toDispatchActions(['getDigestSuccess'])
+            .toMatchValues({
+                expandedDigestId: 'd1',
+                expandedDigest: expect.objectContaining({ id: 'd1' }),
+            })
+    })
+
+    it('PULSE_SCAN_CONFIG_DEFAULTS matches the schema defaults', () => {
+        const props = (schemaJson as any).definitions.PulseScanConfig.properties
+        const schemaDefaults = Object.fromEntries(
+            Object.keys(PULSE_SCAN_CONFIG_DEFAULTS).map((k) => [k, props[k].default])
+        )
+        expect(PULSE_SCAN_CONFIG_DEFAULTS).toEqual(schemaDefaults)
+    })
+})

--- a/products/pulse/frontend/pulseLogic.ts
+++ b/products/pulse/frontend/pulseLogic.ts
@@ -1,0 +1,384 @@
+import { actions, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { urls } from 'scenes/urls'
+
+import { PulseScanConfig } from '~/queries/schema/schema-general'
+
+import type { pulseLogicType } from './pulseLogicType'
+import {
+    PulseDigestDetail,
+    PulseDigestSummary,
+    PulseFindingType,
+    PulseSubscriptionType,
+    PulseWatchedCandidate,
+} from './pulseTypes'
+
+const SCAN_POLL_INTERVAL_MS = 3000
+const SCAN_POLL_ATTEMPTS = 40 // ~2 minutes — covers a slow scan plus digest synthesis
+
+// The event Pulse emits per finding into the team's own project — the trigger a CDP destination filters on.
+const PULSE_FINDING_EVENT = 'pulse_finding_surfaced'
+
+// A Pulse-shaped Slack message prefilled into the destination. The generic template assumes a person
+// triggered the event, but Pulse's distinct_id is the digest, not a user — so we lead with the metric +
+// the human-readable narrative (the raw numeric props aren't formatted) and link back to the digest.
+// {project.url}/{event.properties.*} are resolved by the CDP destination at send time; source_url is a
+// relative path so it's prefixed with {project.url} for an absolute link.
+const PULSE_SLACK_BLOCKS = [
+    {
+        type: 'header',
+        text: { type: 'plain_text', text: '📈 Pulse: {event.properties.metric}' },
+    },
+    {
+        type: 'section',
+        text: { type: 'mrkdwn', text: '{event.properties.narrative}' },
+    },
+    {
+        type: 'context',
+        elements: [{ type: 'mrkdwn', text: 'Flagged by PostHog Pulse · <{project.url}|{project.name}>' }],
+    },
+    {
+        type: 'actions',
+        elements: [
+            {
+                type: 'button',
+                url: '{project.url}{event.properties.source_url}',
+                text: { type: 'plain_text', text: 'Open in Pulse' },
+            },
+        ],
+    },
+]
+const PULSE_SLACK_TEXT = 'Pulse flagged {event.properties.metric}: {event.properties.narrative}'
+
+const DEFAULT_SUBSCRIPTION: PulseSubscriptionType = {
+    id: null,
+    enabled: false,
+    frequency: 'weekly',
+    detection_mode: 'change_v1',
+    sensitivity: 'balanced',
+    min_change_pct: 0.25,
+    baseline_weeks: 4,
+    max_findings: 5,
+    robust_z_threshold: 3.5,
+    last_scan_at: null,
+    next_scan_at: null,
+    created_at: null,
+}
+
+// Defaults mirror the backend PulseScanConfig (the production constants). The staff tuning draft starts
+// here and is persisted to localStorage so tweaks survive a reload while iterating.
+export const PULSE_SCAN_CONFIG_DEFAULTS: PulseScanConfig = {
+    max_candidates: 200,
+    recent_days: 30,
+    min_viewers_for_recent_insight: 3,
+    dashboard_tile_limit: 10,
+    recent_insight_limit: 100,
+    saved_insight_limit: 15,
+    top_event_limit: 25,
+    min_baseline_value: 5,
+    min_change_pct: 0.25,
+    robust_z_threshold: 3.5,
+    baseline_weeks: 4,
+    max_findings: 5,
+}
+
+export const pulseLogic = kea<pulseLogicType>([
+    path(['scenes', 'pulse', 'pulseLogic']),
+    actions({
+        loadDigests: true,
+        loadMoreDigests: true,
+        loadFindings: (digestId?: string) => ({ digestId }),
+        loadSubscription: true,
+        loadWatched: true,
+        getDigest: (id: string) => ({ id }),
+        setExpandedDigestId: (id: string | null) => ({ id }),
+        setDigestsNext: (next: string | null) => ({ next }),
+        updateSubscriptionLocal: (patch: Partial<PulseSubscriptionType>) => ({ patch }),
+        saveSubscription: true,
+        pollScan: true,
+        markScanInProgress: true,
+        scanResolved: true,
+        setUpPulseAlerts: true,
+        updateScanConfigLocal: (patch: Partial<PulseScanConfig>) => ({ patch }),
+        resetScanConfig: true,
+    }),
+    loaders(({ values, cache }) => ({
+        digests: [
+            [] as PulseDigestSummary[],
+            {
+                loadDigests: async () => {
+                    const response = await api.pulse.listDigests()
+                    // Stash the cursor in cache; the success listener moves it into the reducer, keeping
+                    // loaders free of action dispatches (a kea anti-pattern that can race).
+                    cache.digestsNext = response.next ?? null
+                    return response.results || []
+                },
+                loadMoreDigests: async () => {
+                    const next = values.digestsNext
+                    if (!next) {
+                        return values.digests
+                    }
+                    const response = await api.pulse.listDigests(next)
+                    cache.digestsNext = response.next ?? null
+                    return [...values.digests, ...(response.results || [])]
+                },
+            },
+        ],
+        expandedDigest: [
+            null as PulseDigestDetail | null,
+            {
+                getDigest: async ({ id }) => await api.pulse.getDigest(id),
+            },
+        ],
+        findings: [
+            [] as PulseFindingType[],
+            {
+                loadFindings: async ({ digestId }) => {
+                    // Default to the latest digest so its findings are never truncated by older digests'
+                    // findings under the shared rank-ordered pagination. On mount the digests haven't
+                    // loaded yet — skip the unfiltered all-digests fetch; loadDigestsSuccess re-issues
+                    // this with the latest digest id.
+                    const id = digestId ?? values.latestDigest?.id
+                    if (!id) {
+                        return []
+                    }
+                    const response = await api.pulse.listFindings(id)
+                    return response.results || []
+                },
+            },
+        ],
+        subscription: [
+            null as PulseSubscriptionType | null,
+            {
+                loadSubscription: async () => await api.pulse.currentSubscription(),
+                saveSubscription: async () => {
+                    const draft = values.subscriptionDraft
+                    if (!draft) {
+                        return null
+                    }
+                    const payload: Partial<PulseSubscriptionType> = {
+                        enabled: draft.enabled,
+                        frequency: draft.frequency,
+                        detection_mode: draft.detection_mode,
+                        sensitivity: draft.sensitivity,
+                        min_change_pct: draft.min_change_pct,
+                        baseline_weeks: draft.baseline_weeks,
+                        max_findings: draft.max_findings,
+                        robust_z_threshold: draft.robust_z_threshold,
+                    }
+                    if (draft.id) {
+                        return await api.pulse.updateSubscription(draft.id, payload)
+                    }
+                    return await api.pulse.createSubscription(payload)
+                },
+            },
+        ],
+        watchedCandidates: [
+            [] as PulseWatchedCandidate[],
+            {
+                loadWatched: async () => {
+                    const response = await api.pulse.watchedCandidates()
+                    return response.results || []
+                },
+            },
+        ],
+        scanTrigger: [
+            null as { workflow_id: string } | null,
+            {
+                triggerScan: async (config?: Partial<PulseScanConfig>) => await api.pulse.triggerScan(config),
+            },
+        ],
+    })),
+    reducers({
+        expandedDigestId: [
+            null as string | null,
+            {
+                setExpandedDigestId: (_, { id }) => id,
+            },
+        ],
+        // DRF `next` cursor for older digests — drives the "Load more" button when there are more pages.
+        digestsNext: [
+            null as string | null,
+            {
+                setDigestsNext: (_, { next }) => next,
+            },
+        ],
+        // Separate from `digestsLoading` so appending a page never blanks the list into a skeleton.
+        loadingMore: [
+            false,
+            {
+                loadMoreDigests: () => true,
+                loadMoreDigestsSuccess: () => false,
+                loadMoreDigestsFailure: () => false,
+            },
+        ],
+        subscriptionDraft: [
+            null as PulseSubscriptionType | null,
+            {
+                loadSubscriptionSuccess: (_, { subscription }) => subscription,
+                saveSubscriptionSuccess: (_, { subscription }) => subscription,
+                updateSubscriptionLocal: (state, { patch }) =>
+                    state ? { ...state, ...patch } : { ...DEFAULT_SUBSCRIPTION, ...patch },
+            },
+        ],
+        digestsError: [
+            false,
+            {
+                loadDigests: () => false,
+                loadDigestsSuccess: () => false,
+                loadDigestsFailure: () => true,
+            },
+        ],
+        findingsError: [
+            false,
+            {
+                loadFindings: () => false,
+                loadFindingsSuccess: () => false,
+                loadFindingsFailure: () => true,
+            },
+        ],
+        subscriptionError: [
+            false,
+            {
+                loadSubscription: () => false,
+                loadSubscriptionSuccess: () => false,
+                loadSubscriptionFailure: () => true,
+            },
+        ],
+        watchedError: [
+            false,
+            {
+                loadWatched: () => false,
+                loadWatchedSuccess: () => false,
+                loadWatchedFailure: () => true,
+            },
+        ],
+        isScanInProgress: [
+            false,
+            {
+                triggerScanSuccess: () => true,
+                triggerScanFailure: () => false,
+                markScanInProgress: () => true,
+                scanResolved: () => false,
+                // A poll-time digests failure breaks the loadDigestsSuccess poll loop, so clear the
+                // spinner here — the digestsError banner surfaces the error and a retry separately.
+                loadDigestsFailure: () => false,
+            },
+        ],
+        // Staff scan-tuning draft. Persisted to localStorage so iterating on the knobs survives reloads;
+        // never sent anywhere until a "Run scan with these settings" trigger fires.
+        scanConfigDraft: [
+            PULSE_SCAN_CONFIG_DEFAULTS,
+            { persist: true },
+            {
+                updateScanConfigLocal: (state, { patch }) => ({ ...state, ...patch }),
+                resetScanConfig: () => PULSE_SCAN_CONFIG_DEFAULTS,
+            },
+        ],
+    }),
+    listeners(({ actions, values, cache }) => ({
+        saveSubscriptionSuccess: () => {
+            lemonToast.success('Pulse settings saved')
+        },
+        saveSubscriptionFailure: () => {
+            lemonToast.error('Failed to save Pulse settings')
+        },
+        setUpPulseAlerts: () => {
+            // Deep-link into the CDP destination form pre-filtered to Pulse finding events, so the user only
+            // has to pick a Slack channel and save. hogFunctionConfigurationLogic reads `configuration` from
+            // the URL hash and merges it into the form (same seam the "duplicate destination" flow uses).
+            router.actions.push(
+                urls.hogFunctionNew('template-slack'),
+                {},
+                {
+                    configuration: {
+                        name: 'Pulse findings → Slack',
+                        filters: {
+                            events: [{ id: PULSE_FINDING_EVENT, name: PULSE_FINDING_EVENT, type: 'events' }],
+                        },
+                        // The form's input schema comes from the template; these prefill the message (the merge
+                        // is shallow, so we include icon/username too). The user still picks workspace + channel.
+                        inputs: {
+                            icon_emoji: { value: ':chart_with_upwards_trend:' },
+                            username: { value: 'PostHog Pulse' },
+                            blocks: { value: PULSE_SLACK_BLOCKS },
+                            text: { value: PULSE_SLACK_TEXT },
+                        },
+                    },
+                }
+            )
+        },
+        triggerScan: () => {
+            // Remember the current digest so we can tell when a *new* one finishes (the scan creates a
+            // fresh digest), and budget a bounded number of polls so we don't loop forever.
+            cache.preScanDigestId = values.latestDigest?.id ?? null
+            cache.scanPollsLeft = SCAN_POLL_ATTEMPTS
+        },
+        triggerScanSuccess: () => {
+            lemonToast.success('Pulse scan started — findings will appear here shortly.')
+            actions.pollScan()
+        },
+        triggerScanFailure: () => {
+            lemonToast.error('Failed to start Pulse scan.')
+        },
+        pollScan: async (_, breakpoint) => {
+            await breakpoint(SCAN_POLL_INTERVAL_MS)
+            // Refetches page 1 (where a new digest lands). If the user had paged into older digests via
+            // "Load more", that resets to the newest page — acceptable: a scan finishing should surface
+            // its fresh result at the top, and digests accrue weekly so paging is rarely in flight.
+            // loadDigestsSuccess re-loads the findings for the (possibly new) latest digest.
+            actions.loadDigests()
+        },
+        loadMoreDigestsSuccess: () => {
+            actions.setDigestsNext(cache.digestsNext ?? null)
+        },
+        loadDigestsSuccess: ({ digests }) => {
+            actions.setDigestsNext(cache.digestsNext ?? null)
+            const latest = digests[0]
+            if (latest) {
+                // Refresh findings scoped to the new latest digest (a poll may have produced one).
+                actions.loadFindings(latest.id)
+            }
+            const isGenerating = !!latest && (latest.status === 'pending' || latest.status === 'generating')
+            if (values.isScanInProgress) {
+                cache.scanPollsLeft = (cache.scanPollsLeft ?? 0) - 1
+                // Done once a *new* digest (different from the one present at trigger time) has settled,
+                // i.e. findings AND the summary are ready — or once the poll budget runs out.
+                const newDigestSettled =
+                    !!latest &&
+                    latest.id !== cache.preScanDigestId &&
+                    (latest.status === 'delivered' || latest.status === 'failed')
+                if (newDigestSettled || cache.scanPollsLeft <= 0) {
+                    actions.scanResolved()
+                } else {
+                    actions.pollScan()
+                }
+            } else if (isGenerating) {
+                // A scan we didn't trigger here (e.g. scheduled) is mid-flight — reflect it and poll.
+                cache.preScanDigestId = null
+                cache.scanPollsLeft = SCAN_POLL_ATTEMPTS
+                actions.markScanInProgress()
+                actions.pollScan()
+            }
+        },
+    })),
+    selectors({
+        latestDigest: [
+            (s) => [s.digests],
+            (digests): PulseDigestSummary | null => (digests.length ? digests[0] : null),
+        ],
+        shouldShowEmptyState: [
+            (s) => [s.digests, s.digestsLoading],
+            (digests, digestsLoading): boolean => !digestsLoading && digests.length === 0,
+        ],
+        findingsForLatest: [
+            (s) => [s.findings, s.latestDigest],
+            (findings, latestDigest): PulseFindingType[] =>
+                latestDigest ? findings.filter((f) => f.digest === latestDigest.id) : [],
+        ],
+    }),
+])

--- a/products/pulse/frontend/pulseTypes.ts
+++ b/products/pulse/frontend/pulseTypes.ts
@@ -1,0 +1,87 @@
+export type PulseDigestStatus = 'pending' | 'generating' | 'delivered' | 'failed'
+export type PulseSubscriptionFrequency = 'weekly' | 'daily'
+export type PulseDetectionMode = 'change_v1' | 'discovery'
+export type PulseSensitivity = 'conservative' | 'balanced' | 'sensitive' | 'custom'
+
+export interface PulseDigestSummary {
+    id: string
+    period_start: string
+    period_end: string
+    status: PulseDigestStatus
+    error: Record<string, any> | null
+    created_at: string
+    finding_count: number
+    summary: string
+}
+
+// A same-period change (feature flag, experiment, annotation) the finding's narrative tied to it. Carries
+// its own ISO timestamp so it can be placed on the finding's timeline; the deep link is built from (type, id).
+export interface PulseReference {
+    type: 'feature_flag' | 'experiment' | 'annotation' | string
+    label: string
+    timestamp?: string // full ISO instant
+    id?: string
+    change?: string // 'turned on', 'launched', etc. (flags/experiments; absent for annotations)
+}
+
+export interface PulseFindingType {
+    id: string
+    digest: string
+    metric_label: string
+    metric_descriptor: Record<string, any>
+    current_value: number
+    baseline_value: number
+    change_pct: number
+    robust_z: number
+    impact: number
+    attribution_breakdown: Record<string, any> | null
+    evidence: {
+        series?: number[] // weekly values (detection baseline window + current)
+        daily_series?: number[] // daily values over the digest period — drives the finding chart when present
+        session_ids?: string[]
+        references?: PulseReference[]
+    } | null
+    narrative: string
+    chart_thumbnail_url: string
+    rank: number
+    created_at: string
+}
+
+export interface PulseDigestDetail extends PulseDigestSummary {
+    workflow_run_id: string
+    findings: PulseFindingType[]
+}
+
+// A positioned marker on a finding's timeline: one change the finding's narrative referenced, placed by
+// time along the digest period (0..1) with a deep link to the flag / experiment / annotation.
+export interface PulseTimelineMarker {
+    key: string
+    type: PulseReference['type']
+    label: string
+    change?: string
+    timestamp: string // full ISO
+    position: number // 0..1 along period_start..period_end
+    to?: string // deep link to the flag / experiment / annotation
+}
+
+export interface PulseSubscriptionType {
+    id: string | null
+    enabled: boolean
+    frequency: PulseSubscriptionFrequency
+    detection_mode: PulseDetectionMode
+    sensitivity: PulseSensitivity
+    min_change_pct: number
+    baseline_weeks: number
+    max_findings: number
+    robust_z_threshold: number
+    last_scan_at: string | null
+    next_scan_at: string | null
+    created_at: string | null
+}
+
+export interface PulseWatchedCandidate {
+    source: string
+    source_id: string | null
+    label: string
+    query: Record<string, any>
+}

--- a/products/pulse/frontend/utils.test.ts
+++ b/products/pulse/frontend/utils.test.ts
@@ -1,0 +1,195 @@
+import { urls } from 'scenes/urls'
+
+import { PulseFindingType } from './pulseTypes'
+import {
+    SENSITIVITY_PRESETS,
+    buildFindingInsightContext,
+    buildFindingTimelineMarkers,
+    buildMaxSeedPrompt,
+    describeChange,
+    describeReference,
+    findingShortId,
+    formatSignedPct,
+    suggestedNextStep,
+} from './utils'
+
+const PERIOD_START = '2026-05-19T00:00:00+00:00'
+const PERIOD_END = '2026-05-26T00:00:00+00:00'
+
+const FINDING: PulseFindingType = {
+    id: 'f1',
+    digest: 'd1',
+    metric_label: 'purchase_completed',
+    metric_descriptor: {},
+    current_value: 64,
+    baseline_value: 125,
+    change_pct: -0.49,
+    robust_z: 4.2,
+    impact: 5.5,
+    attribution_breakdown: { property: '$browser', value: 'Safari' },
+    evidence: null,
+    narrative: 'purchase_completed is down 49% this week.',
+    chart_thumbnail_url: '',
+    rank: 0,
+    created_at: '2026-05-26T00:00:00Z',
+}
+
+describe('pulse utils', () => {
+    it('formats signed percent', () => {
+        expect(formatSignedPct(0.42)).toBe('+42%')
+        expect(formatSignedPct(-0.1)).toBe('-10%')
+    })
+
+    it.each([
+        [0, { direction: 'flat' as const, tone: 'muted' as const, label: 'flat' }],
+        [0.42, { direction: 'up' as const, tone: 'success' as const, label: '+42%' }],
+        [-0.1, { direction: 'down' as const, tone: 'danger' as const, label: '-10%' }],
+    ])('describeChange(%s)', (pct, expected) => {
+        expect(describeChange(pct)).toEqual(expected)
+    })
+
+    it('describes references as labelled deep links', () => {
+        expect(describeReference({ type: 'feature_flag', label: 'new-onboarding', id: '7' })).toEqual({
+            label: 'Flag: new-onboarding',
+            to: '/feature_flags/7',
+        })
+        expect(describeReference({ type: 'experiment', label: 'checkout-v2', id: '3' })).toEqual({
+            label: 'Experiment: checkout-v2',
+            to: urls.experiment('3'),
+        })
+        // Annotations are linkable too (the user's "pricing promo" / "deploy note" examples).
+        expect(describeReference({ type: 'annotation', label: 'pricing v2 promo', id: '9' })).toEqual({
+            label: 'Note: pricing v2 promo',
+            to: urls.annotation(9),
+        })
+        // No id -> a label-only chip, no link.
+        expect(describeReference({ type: 'feature_flag', label: 'mystery' })).toEqual({ label: 'Flag: mystery' })
+    })
+
+    it('maps sensitivity presets to thresholds', () => {
+        expect(SENSITIVITY_PRESETS.conservative).toEqual({ min_change_pct: 0.4, robust_z_threshold: 3.5 })
+        expect(SENSITIVITY_PRESETS.balanced).toEqual({ min_change_pct: 0.25, robust_z_threshold: 3.5 })
+        expect(SENSITIVITY_PRESETS.sensitive).toEqual({ min_change_pct: 0.15, robust_z_threshold: 3.0 })
+    })
+
+    it('buildMaxSeedPrompt includes the metric, signed change, breakdown, and narrative', () => {
+        const seed = buildMaxSeedPrompt(FINDING)
+        expect(seed).toContain('purchase_completed')
+        expect(seed).toContain('-49%')
+        expect(seed).toContain('Safari')
+        expect(seed).toContain('$browser')
+        expect(seed).toContain('down 49%') // the narrative is echoed verbatim
+    })
+
+    it('buildMaxSeedPrompt omits the breakdown clause when there is no attribution', () => {
+        const seed = buildMaxSeedPrompt({ ...FINDING, attribution_breakdown: null })
+        expect(seed).not.toContain('concentrated')
+        expect(seed).toContain('purchase_completed')
+    })
+
+    it('extracts the insight short id from the descriptor url, or null', () => {
+        expect(findingShortId({ ...FINDING, metric_descriptor: { url: '/insights/abc123' } })).toBe('abc123')
+        expect(findingShortId({ ...FINDING, metric_descriptor: { url: '/insights/abc123?foo=1' } })).toBe('abc123')
+        expect(findingShortId({ ...FINDING, metric_descriptor: {} })).toBeNull()
+        expect(findingShortId({ ...FINDING, metric_descriptor: { url: '/feature_flags/7' } })).toBeNull()
+    })
+
+    it('builds structured Max context only for insight-backed findings', () => {
+        const insightFinding = {
+            ...FINDING,
+            metric_descriptor: { url: '/insights/abc123', query: { kind: 'TrendsQuery' } },
+        }
+        expect(buildFindingInsightContext(insightFinding)).toEqual({
+            short_id: 'abc123',
+            name: 'purchase_completed',
+            query: { kind: 'TrendsQuery' },
+        })
+        // No short id (event-sourced) -> null, handoff degrades to prompt-only.
+        expect(
+            buildFindingInsightContext({ ...FINDING, metric_descriptor: { query: { kind: 'TrendsQuery' } } })
+        ).toBeNull()
+    })
+
+    it('suggests diving into the segment when a finding is concentrated', () => {
+        const step = suggestedNextStep(FINDING) // attribution_breakdown = $browser/Safari
+        expect(step?.label).toBe('Dive into Safari')
+        expect(step?.seed).toContain('purchase_completed')
+        expect(step?.seed).toContain('Safari')
+    })
+
+    it('suggests checking a coincident experiment, then a flag, then nothing', () => {
+        const base = { ...FINDING, attribution_breakdown: null }
+        const withExperiment = {
+            ...base,
+            evidence: { references: [{ type: 'experiment', label: 'checkout-v2', id: '3' }] },
+        }
+        expect(suggestedNextStep(withExperiment)?.label).toBe('Check the checkout-v2 experiment')
+
+        const withFlag = {
+            ...base,
+            evidence: { references: [{ type: 'feature_flag', label: 'new-onboarding', id: '7' }] },
+        }
+        expect(suggestedNextStep(withFlag)?.label).toBe('Check the new-onboarding flag')
+
+        // No segment and no references -> no specific lead (generic "Explore with AI" covers it).
+        expect(suggestedNextStep({ ...base, evidence: null })).toBeNull()
+    })
+
+    it('buildFindingTimelineMarkers returns [] without references or a valid axis', () => {
+        const finding = {
+            ...FINDING,
+            evidence: {
+                references: [{ type: 'feature_flag', label: 'f', timestamp: '2026-05-22T10:00:00+00:00', id: '7' }],
+            },
+        }
+        expect(buildFindingTimelineMarkers({ ...FINDING, evidence: null }, PERIOD_START, PERIOD_END)).toEqual([])
+        expect(buildFindingTimelineMarkers(finding, undefined, PERIOD_END)).toEqual([])
+        expect(buildFindingTimelineMarkers(finding, PERIOD_END, PERIOD_START)).toEqual([]) // span <= 0
+    })
+
+    it('buildFindingTimelineMarkers places the finding-referenced changes chronologically over the axis', () => {
+        // References carry their own ISO timestamps (self-contained), so positions are exact regardless of tz.
+        const finding = {
+            ...FINDING,
+            evidence: {
+                references: [
+                    {
+                        type: 'feature_flag',
+                        label: 'new-onboarding',
+                        id: '7',
+                        timestamp: '2026-05-25T00:00:00+00:00',
+                        change: 'turned on',
+                    },
+                    {
+                        type: 'experiment',
+                        label: 'checkout-v2',
+                        id: '3',
+                        timestamp: '2026-05-22T00:00:00+00:00',
+                        change: 'launched',
+                    },
+                ],
+            },
+        }
+        const markers = buildFindingTimelineMarkers(finding, PERIOD_START, PERIOD_END)
+        // Sorted chronologically: experiment (day 3) before flag (day 6).
+        expect(markers.map((m) => m.type)).toEqual(['experiment', 'feature_flag'])
+        expect(markers[0].position).toBeCloseTo(3 / 7, 5)
+        expect(markers[1].position).toBeCloseTo(6 / 7, 5)
+        expect(markers[0].change).toBe('launched')
+        expect(markers[0].to).toBe(urls.experiment('3'))
+    })
+
+    it('buildFindingTimelineMarkers skips references without a timestamp', () => {
+        const finding = {
+            ...FINDING,
+            evidence: {
+                references: [
+                    { type: 'feature_flag', label: 'dated', id: '7', timestamp: '2026-05-22T00:00:00+00:00' },
+                    { type: 'annotation', label: 'undated', id: '9' }, // no timestamp -> nothing to place
+                ],
+            },
+        }
+        const markers = buildFindingTimelineMarkers(finding, PERIOD_START, PERIOD_END)
+        expect(markers.map((m) => m.label)).toEqual(['dated'])
+    })
+})

--- a/products/pulse/frontend/utils.ts
+++ b/products/pulse/frontend/utils.ts
@@ -1,0 +1,190 @@
+import { dayjs } from 'lib/dayjs'
+import { percentage } from 'lib/utils'
+import { InsightWithQuery } from 'scenes/max/maxTypes'
+import { urls } from 'scenes/urls'
+
+import { InsightShortId } from '~/types'
+
+import { PulseFindingType, PulseReference, PulseSensitivity, PulseTimelineMarker } from './pulseTypes'
+
+export function formatSignedPct(pct: number): string {
+    return `${pct >= 0 ? '+' : ''}${percentage(pct, 0)}`
+}
+
+export type ChangeDirection = 'up' | 'down' | 'flat'
+
+export interface ChangeDescriptor {
+    direction: ChangeDirection
+    tone: 'success' | 'danger' | 'muted'
+    label: string
+}
+
+// Tone is DIRECTIONAL, not sentiment: up=success/down=danger matches PostHog's web-analytics default. Pulse
+// doesn't model per-metric polarity, so a rising error_rate reads "success" and a falling one "danger" — read
+// the colour as "rose/fell", not "good/bad". Per-metric polarity (cf. web-analytics' reverseColors) is a
+// tracked follow-up; the signed % label + arrow always state the literal direction regardless of colour.
+export function describeChange(pct: number): ChangeDescriptor {
+    if (pct === 0) {
+        return { direction: 'flat', tone: 'muted', label: 'flat' }
+    }
+    if (pct > 0) {
+        return { direction: 'up', tone: 'success', label: formatSignedPct(pct) }
+    }
+    return { direction: 'down', tone: 'danger', label: formatSignedPct(pct) }
+}
+
+// Seed question handed to the AI ("Explore with AI") — investigative, never asserts a cause.
+export function buildMaxSeedPrompt(finding: PulseFindingType): string {
+    const breakdown = finding.attribution_breakdown
+    const breakdownClause =
+        breakdown && breakdown.value
+            ? ` The shift looks concentrated in ${breakdown.value}${breakdown.property ? ` (${breakdown.property})` : ''}.`
+            : ''
+    return (
+        `Why did "${finding.metric_label}" change by ${formatSignedPct(finding.change_pct)} this week?` +
+        breakdownClause +
+        ` PostHog Pulse flagged it with this note: "${finding.narrative}". Help me dig into the likely causes.`
+    )
+}
+
+const REFERENCE_TYPE_PREFIXES: Record<string, string> = {
+    feature_flag: 'Flag',
+    experiment: 'Experiment',
+    annotation: 'Note',
+}
+
+// Turns a coincident-change reference into a labelled chip with an optional deep link, so the user can
+// jump straight to the flag / experiment / annotation the narrative tied to this finding (the same idea
+// as the replay links). A reference with no id renders as a label-only chip.
+export function describeReference(ref: PulseReference): { label: string; to?: string } {
+    const prefix = REFERENCE_TYPE_PREFIXES[ref.type]
+    const label = prefix ? `${prefix}: ${ref.label}` : ref.label
+    if (ref.id && ref.type === 'feature_flag') {
+        return { label, to: urls.featureFlag(ref.id) }
+    }
+    if (ref.id && ref.type === 'experiment') {
+        return { label, to: urls.experiment(ref.id) }
+    }
+    if (ref.id && ref.type === 'annotation') {
+        return { label, to: urls.annotation(Number(ref.id)) }
+    }
+    return { label }
+}
+
+// Pull the saved-insight short id out of a finding's "View insight" deep link (/insights/<short_id>),
+// so we can hand the AI the actual insight as structured context. Event-sourced findings have no saved
+// insight and return null (the handoff then degrades to prompt-only).
+export function findingShortId(finding: PulseFindingType): InsightShortId | null {
+    const url = finding.metric_descriptor?.url
+    if (typeof url !== 'string') {
+        return null
+    }
+    // Short ids are nanoid-style (alphanumeric + - _); the strict class also rejects anything odd in
+    // a malformed url before we cast to the branded type.
+    const match = url.match(/\/insights\/([A-Za-z0-9_-]+)/)
+    return match ? (match[1] as InsightShortId) : null
+}
+
+// Structured AI context for a finding: the actual insight (query + name) so the AI can read_data on the
+// real metric instead of re-deriving it from a prompt. Null when the finding isn't backed by a saved insight.
+export function buildFindingInsightContext(finding: PulseFindingType): InsightWithQuery | null {
+    const shortId = findingShortId(finding)
+    const query = finding.metric_descriptor?.query
+    if (!shortId || !query) {
+        return null
+    }
+    return { short_id: shortId, name: finding.metric_label, query }
+}
+
+// A guided, finding-specific "next step" that hands the AI a concrete investigative task. Deterministic
+// (no LLM), and only for high-confidence shapes — a concentrated segment, or a coincident experiment/flag.
+// Returns null when there's no specific lead (the generic "Explore with AI" covers that). Stays investigative:
+// it proposes WHAT to look at next, never asserts a cause.
+//
+// Priority is segment first, then references: a concentrated segment is a direct statistical attribution
+// for THIS metric, whereas a referenced experiment/flag is a coincidence the narrative tied to this finding
+// — a strong but softer lead — so it's the fallback when no segment stands out. One step, not an accumulation.
+export function suggestedNextStep(finding: PulseFindingType): { label: string; seed: string } | null {
+    const metric = finding.metric_label
+    const signed = formatSignedPct(finding.change_pct)
+    const breakdown = finding.attribution_breakdown
+    if (breakdown && breakdown.value) {
+        const segment = String(breakdown.value)
+        const prop = breakdown.property ? ` (${breakdown.property})` : ''
+        return {
+            label: `Dive into ${segment}`,
+            seed:
+                `"${metric}" changed by ${signed} this week, concentrated in ${segment}${prop}. ` +
+                `Break this metric down within ${segment} and help me find what's driving the shift — ` +
+                `a specific event, page, or cohort.`,
+        }
+    }
+    const references = finding.evidence?.references ?? []
+    const experiment = references.find((ref) => ref.type === 'experiment')
+    if (experiment) {
+        return {
+            label: `Check the ${experiment.label} experiment`,
+            seed:
+                `"${metric}" changed by ${signed} this week while the "${experiment.label}" experiment was active. ` +
+                `Help me check whether the experiment is driving this — compare exposed vs unexposed users.`,
+        }
+    }
+    const flag = references.find((ref) => ref.type === 'feature_flag')
+    if (flag) {
+        return {
+            label: `Check the ${flag.label} flag`,
+            seed:
+                `"${metric}" changed by ${signed} this week, coinciding with a change to the "${flag.label}" ` +
+                `feature flag. Help me check whether the rollout is linked to this change.`,
+        }
+    }
+    return null
+}
+
+// Build a finding's own timeline from the changes its narrative referenced (evidence.references), each
+// carrying its own ISO timestamp — so it's self-contained and never depends on a digest-wide cap. Markers
+// are positioned by time along axisStart..axisEnd (0..1, clamped) and sorted chronologically. Pure +
+// deterministic. Returns [] when the finding cites nothing (with a timestamp) or the axis is missing.
+export function buildFindingTimelineMarkers(
+    finding: PulseFindingType,
+    axisStart?: string,
+    axisEnd?: string
+): PulseTimelineMarker[] {
+    const references = finding.evidence?.references ?? []
+    if (!references.length || !axisStart || !axisEnd) {
+        return []
+    }
+    const start = dayjs(axisStart)
+    const span = dayjs(axisEnd).diff(start)
+    if (span <= 0) {
+        return []
+    }
+    const markers: PulseTimelineMarker[] = []
+    references.forEach((ref, index) => {
+        if (!ref.timestamp) {
+            return // older findings may lack timestamps on their references — nothing to place
+        }
+        const fraction = dayjs(ref.timestamp).diff(start) / span
+        const position = Number.isFinite(fraction) ? Math.min(1, Math.max(0, fraction)) : 0
+        markers.push({
+            key: `${ref.type}-${ref.id || index}-${ref.timestamp}`,
+            type: ref.type,
+            label: ref.label,
+            change: ref.change,
+            timestamp: ref.timestamp,
+            position,
+            to: describeReference(ref).to,
+        })
+    })
+    return markers.sort((a, b) => a.position - b.position)
+}
+
+// Frontend mirror of the backend SENSITIVITY_PRESETS. Selecting a preset applies these thresholds locally.
+export const SENSITIVITY_PRESETS: Record<
+    Exclude<PulseSensitivity, 'custom'>,
+    { min_change_pct: number; robust_z_threshold: number }
+> = {
+    conservative: { min_change_pct: 0.4, robust_z_threshold: 3.5 },
+    balanced: { min_change_pct: 0.25, robust_z_threshold: 3.5 },
+    sensitive: { min_change_pct: 0.15, robust_z_threshold: 3.0 },
+}

--- a/products/pulse/manifest.tsx
+++ b/products/pulse/manifest.tsx
@@ -1,0 +1,40 @@
+import { FEATURE_FLAGS } from 'lib/constants'
+import { urls } from 'scenes/urls'
+
+import { ProductItemCategory, ProductKey } from '~/queries/schema/schema-general'
+
+import { ProductManifest } from '../../frontend/src/types'
+
+export const manifest: ProductManifest = {
+    name: 'Pulse',
+    scenes: {
+        Pulse: {
+            name: 'Pulse',
+            import: () => import('./frontend/Pulse'),
+            projectBased: true,
+            description: "Proactive insights surfaced by Max from your team's key metrics.",
+        },
+    },
+    routes: {
+        '/pulse': ['Pulse', 'pulse'],
+    },
+    redirects: {},
+    urls: {
+        pulse: (): string => '/pulse',
+    },
+    fileSystemTypes: {},
+    treeItemsNew: [],
+    treeItemsProducts: [
+        {
+            path: 'Pulse',
+            intents: [ProductKey.MAX],
+            category: ProductItemCategory.ANALYTICS,
+            iconType: 'activity',
+            href: urls.pulse(),
+            flag: FEATURE_FLAGS.MAX_PULSE,
+            tags: ['beta'],
+            sceneKey: 'Pulse',
+            sceneKeys: ['Pulse'],
+        },
+    ],
+}


### PR DESCRIPTION
## Problem

Pulse's digests need a home in the app: a scene where users read explained findings, tune their subscription, and — the differentiator — get handed to PostHog AI with full context to dig deeper.

## Changes

Adds the Pulse frontend scene and API client wiring.

```mermaid
flowchart TB
    scene["Pulse scene<br/>digest list · finding cards"] --> card["FindingCard<br/>sparkline chart · change tag ·<br/>narrative · attribution chips"]
    card --> next["suggestedNextStep<br/>deterministic guided lead from the finding<br/>(segment dive, experiment check, ...)"]
    next -->|"label + seed prompt"| max["PostHog AI side panel<br/>full finding context: insight, narrative,<br/>timeline markers, guided task"]
    settings["Subscription settings<br/>frequency · sensitivity presets · advanced knobs<br/>(tooltip: scout findings bypass these)"] --> api["generated API client (#62119)"]
    scene --> api
```

Notes for review:

- **The explore button is the suggested next step.** When a finding has a high-confidence guided lead (e.g. "Dive into Chrome"), that label *is* the button — proactive, not hidden behind a generic "Explore with AI" (which remains the fallback).
- The sensitivity control carries a tooltip clarifying it governs the always-on metric scan only; scout-surfaced anomalies aren't filtered by it (mirrors the serializer help_text in #62119).
- Business logic lives in `pulseLogic` (kea); the scene components stay presentational.
- A cross-language drift test pins the frontend sensitivity presets to the backend's.

## How did you test this code?

I'm an agent; no manual testing claimed. Automated: 29 jest tests across `pulseLogic` and utils (seed-prompt building, next-step derivation, change description, preset drift guard); tsc clean for the product. Screenshots are best taken from the running scene — happy to add them on request before marking ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @vdekrijger. The proactive next-step-as-button-label and the sensitivity tooltip both came out of local review rounds.
