### PR TITLE
fix(brevo): handle empty collections that omit the array key

### DIFF
--- a/posthog/temporal/data_imports/sources/brevo/brevo.py
+++ b/posthog/temporal/data_imports/sources/brevo/brevo.py
@@ -134,9 +134,10 @@ def get_rows(
                 params["offset"] = offset
 
             data = fetch_page(params)
-            # Fail loudly if the expected envelope key is missing (e.g. an API-shape change),
-            # rather than silently reporting a successful sync of zero rows.
-            items = data[config.data_key]
+            # Brevo omits the array key entirely (or sets it to null) for an empty collection,
+            # e.g. {"count": 0} with no "campaigns"/"segments" key. Treat that as an empty page
+            # rather than crashing the sync.
+            items = data.get(config.data_key) or []
 
             if items:
                 yield items

--- a/posthog/temporal/data_imports/sources/brevo/tests/test_brevo.py
+++ b/posthog/temporal/data_imports/sources/brevo/tests/test_brevo.py
@@ -208,14 +208,25 @@ class TestGetRowsErrors:
         with pytest.raises(HTTPError):
             _drive_get_rows("contacts", manager, responses)
 
-    def test_missing_envelope_key_raises(self) -> None:
+    @pytest.mark.parametrize(
+        ("endpoint", "body"),
+        [
+            # Brevo omits the array key entirely for an empty collection (just {"count": 0}).
+            ("email_campaigns", {"count": 0}),
+            ("sms_campaigns", {"count": 0}),
+            ("contact_segments", {"count": 0}),
+            # Some responses set the key to null instead of omitting it.
+            ("email_campaigns", {"campaigns": None, "count": 0}),
+        ],
+    )
+    def test_missing_or_null_envelope_key_yields_nothing(self, endpoint: str, body: dict[str, Any]) -> None:
         manager = MagicMock(spec=ResumableSourceManager)
         manager.can_resume.return_value = False
 
-        # 200 OK with an unexpected body shape must fail loudly, not sync zero rows.
-        responses = [_make_response({"unexpected": []})]
-        with pytest.raises(KeyError):
-            _drive_get_rows("contacts", manager, responses)
+        _, rows = _drive_get_rows(endpoint, manager, [_make_response(body)])
+
+        assert rows == []
+        manager.save_state.assert_not_called()
 
 
 class TestGetRowsSession:


### PR DESCRIPTION
## Problem

The Brevo data-warehouse import crashes with a `KeyError` for accounts that have empty collections on certain endpoints. Brevo omits the array envelope key entirely (returning just `{"count": 0}`, and sometimes `{"<key>": null}`) when a list endpoint has no rows — this is [documented behavior](https://developers.brevo.com/reference/get-email-campaigns), not an error.

`get_rows` indexed the envelope key directly (`items = data[config.data_key]`), so an empty collection raised `KeyError` and failed the whole sync. Observed in error tracking on `'campaigns'` (`/emailCampaigns`, `/smsCampaigns`) and `'segments'` (`/contacts/segments`), with hundreds of failed runs.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019e9485-5d54-7981-9fee-e93e5ec0ffb8

## Changes

- `get_rows` now defaults a missing or `null` envelope key to an empty page (`data.get(config.data_key) or []`) rather than crashing.

This is a genuine code bug rather than a user/upstream error: Brevo's documented response for an empty collection is to omit the key, and we cannot distinguish that from a shape change at the response level — so failing loudly was incorrect for this API and broke syncs on the common empty case.

## How did you test this code?

I'm an agent. I ran the source's unit tests (`posthog/temporal/data_imports/sources/brevo/tests/test_brevo.py`) — 38 passed, including a new parametrized regression test asserting that a missing/`null` array key on `email_campaigns`, `sms_campaigns`, and `contact_segments` yields no rows instead of raising. `ruff check` and `ruff format --check` pass on the changed files.

## 🤖 Agent context

Triaged from an error tracking issue. Pulled the stack trace and sampled events via the PostHog MCP error-tracking tools, confirming the in-app failure chain `import_data_activity_sync → pipeline.run → get_rows:139` and the `KeyError` values `'campaigns'`/`'segments'`. Cross-checked Brevo's API docs to confirm the empty-collection response omits the key.

Decision: fixable bug, not a `NonRetryableErrors` case. The previous code intentionally failed loudly on a missing key to avoid masking an API shape change; that protection is unsound here because Brevo returns the same shape for a legitimately empty collection, so the existing "raises" test was replaced with one asserting graceful empty handling. Scoped strictly to this code path — no retry-policy changes.
