### PR TITLE
fix(intercom): skip 404 on per-conversation detail fetch

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -1,7 +1,9 @@
 from collections.abc import AsyncIterable, Callable, Iterable, Iterator
 from typing import Any, Optional
 
+import structlog
 from requests import Request, Response, Session
+from requests.exceptions import HTTPError
 from urllib3.util.retry import Retry
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -18,6 +20,15 @@ from posthog.temporal.data_imports.sources.intercom.settings import INTERCOM_END
 
 INTERCOM_API_BASE = "https://api.intercom.io"
 INTERCOM_API_VERSION = "2.13"
+
+logger = structlog.get_logger(__name__)
+
+
+def _is_not_found(exc: HTTPError) -> bool:
+    """A child row referenced by a parent can vanish (deleted/merged) between
+    the parent listing and the per-row detail fetch — Intercom then returns
+    404. Skip that single row instead of failing the whole sync."""
+    return exc.response is not None and exc.response.status_code == 404
 
 
 def _default_headers() -> dict[str, str]:
@@ -235,7 +246,13 @@ def _conversation_parts_generator(
     so the pipeline's cursor watermark advances per-part. `conversation_id`
     is injected onto each row for joinability."""
     for conv in _iter_conversations(session, incremental_field, db_incremental_field_last_value):
-        full = _intercom_get(session, f"/conversations/{conv['id']}")
+        try:
+            full = _intercom_get(session, f"/conversations/{conv['id']}")
+        except HTTPError as exc:
+            if _is_not_found(exc):
+                logger.warning("intercom_conversation_not_found", conversation_id=conv["id"])
+                continue
+            raise
         parts = (full.get("conversation_parts") or {}).get("conversation_parts") or []
         for part in parts:
             part["conversation_id"] = conv["id"]
@@ -268,7 +285,13 @@ def _company_segments_generator(session: Session) -> Iterator[dict[str, Any]]:
     injected. Full refresh — Intercom has no server-side timestamp filter on
     either parent or child."""
     for company in _iter_companies(session):
-        payload = _intercom_get(session, f"/companies/{company['id']}/segments")
+        try:
+            payload = _intercom_get(session, f"/companies/{company['id']}/segments")
+        except HTTPError as exc:
+            if _is_not_found(exc):
+                logger.warning("intercom_company_not_found", company_id=company["id"])
+                continue
+            raise
         for seg in payload.get("data", []) or []:
             seg["company_id"] = company["id"]
             yield seg

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from requests import Request, Response
 from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError
 
 from posthog.temporal.data_imports.sources.common.rest_source.paginators import (
     JSONResponseCursorPaginator,
@@ -268,6 +269,50 @@ class TestSubstreamGenerators:
 
         assert [p["id"] for p in parts] == ["p1", "p2", "p3"]
         assert {p["conversation_id"] for p in parts} == {"c1", "c2"}
+
+    def test_conversation_parts_skips_404_parent(self):
+        # A conversation listed by search can be deleted/merged before we fetch
+        # its detail — Intercom 404s. Skip it instead of failing the whole sync.
+        mock_session = mock.MagicMock()
+        mock_session.post.side_effect = [
+            _make_response({"conversations": [{"id": "c1"}, {"id": "c2"}], "pages": {}}),
+        ]
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=404, text="Not Found"),
+            _make_response({"conversation_parts": {"conversation_parts": [{"id": "p3"}]}}),
+        ]
+
+        parts = list(_conversation_parts_generator(mock_session, "updated_at", None))
+
+        assert [p["id"] for p in parts] == ["p3"]
+        assert {p["conversation_id"] for p in parts} == {"c2"}
+
+    def test_conversation_parts_reraises_non_404(self):
+        mock_session = mock.MagicMock()
+        mock_session.post.side_effect = [
+            _make_response({"conversations": [{"id": "c1"}], "pages": {}}),
+        ]
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=500, text="Server Error"),
+        ]
+
+        with pytest.raises(HTTPError):
+            list(_conversation_parts_generator(mock_session, "updated_at", None))
+
+    def test_company_segments_skips_404_parent(self):
+        mock_session = mock.MagicMock()
+        mock_session.post.side_effect = [
+            _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "pages": {}}),
+        ]
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=404, text="Not Found"),
+            _make_response({"data": [{"id": "s2"}]}),
+        ]
+
+        segments = list(_company_segments_generator(mock_session))
+
+        assert [s["id"] for s in segments] == ["s2"]
+        assert segments[0]["company_id"] == "co2"
 
     def test_company_segments_injects_company_id(self):
         mock_session = mock.MagicMock()

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -314,6 +314,18 @@ class TestSubstreamGenerators:
         assert [s["id"] for s in segments] == ["s2"]
         assert segments[0]["company_id"] == "co2"
 
+    def test_company_segments_reraises_non_404(self):
+        mock_session = mock.MagicMock()
+        mock_session.post.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "pages": {}}),
+        ]
+        mock_session.get.side_effect = [
+            _make_response(None, status_code=500, text="Server Error"),
+        ]
+
+        with pytest.raises(HTTPError):
+            list(_company_segments_generator(mock_session))
+
     def test_company_segments_injects_company_id(self):
         mock_session = mock.MagicMock()
         mock_session.post.side_effect = [


### PR DESCRIPTION
## Problem

The Intercom data-warehouse import for `conversation_parts` crashes the entire sync when a single conversation 404s.

The substream lists conversations via `POST /conversations/search`, then fetches each one's detail at `GET /conversations/{id}` to pull its parts. A conversation can be deleted or merged in the window between being listed and being fetched, so the detail request returns `404 Not Found`. `_intercom_get` calls `raise_for_status()`, the `HTTPError` propagates up through the substream generator, and the whole import activity fails — one missing conversation takes down the entire table sync.

Surfaced by PostHog error tracking: `HTTPError: 404 Client Error: Not Found for url: https://api.intercom.io/conversations/<id>`, raised in `posthog/temporal/data_imports/sources/intercom/intercom.py` at `_intercom_get` (called from `_conversation_parts_generator`).

## Changes

- Catch a `404` on the per-row child detail fetch in `_conversation_parts_generator`, log a warning with the conversation id, and skip that conversation instead of failing the sync. Non-404 HTTP errors still propagate.
- Apply the same guard to `_company_segments_generator`, which shares the identical list-then-detail-fetch pattern (a company can vanish between listing and the `/companies/{id}/segments` fetch).
- Small shared `_is_not_found` helper to keep the two skip sites consistent.

This is treated as a fixable bug (graceful per-row skip), not a non-retryable credential/config error — the sync should drop the missing row and carry on, and a subsequent sync stays healthy. The global retry policy is untouched.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests at the same layer as the fix:

- `test_conversation_parts_skips_404_parent` — a 404 on one conversation is skipped; remaining conversations' parts still yield.
- `test_conversation_parts_reraises_non_404` — a 500 still propagates.
- `test_company_segments_skips_404_parent` — same skip behavior for the company segments substream.

Ran the full source test file locally: `pytest posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py` — 60 passed. `ruff check` and `ruff format --check` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code triaging a specific error-tracking issue for the Intercom warehouse source. I confirmed the stack trace originates in `intercom.py` (`_conversation_parts_generator` → `_intercom_get` → `raise_for_status`), matching a deleted/merged-conversation 404. Considered adding `404` to the source's `NonRetryableErrors` but rejected it: a single vanished child row shouldn't permanently fail the job — the right behavior is a graceful per-row skip so the rest of the table syncs and future runs recover. Extended the same guard to the company-segments substream since it has the same failure mode.
