### PR TITLE
fix(intercom): follow companies/list pagination with POST

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -178,8 +178,9 @@ def _intercom_get(session: Session, path_or_url: str, params: dict[str, Any] | N
     return response.json()
 
 
-def _intercom_post(session: Session, path: str, body: dict[str, Any]) -> dict[str, Any]:
-    response = session.post(f"{INTERCOM_API_BASE}{path}", json=body, timeout=30)
+def _intercom_post(session: Session, path_or_url: str, body: dict[str, Any]) -> dict[str, Any]:
+    url = path_or_url if path_or_url.startswith("http") else f"{INTERCOM_API_BASE}{path_or_url}"
+    response = session.post(url, json=body, timeout=30)
     response.raise_for_status()
     return response.json()
 
@@ -229,11 +230,12 @@ def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
         if next_url is None:
             payload = _intercom_post(session, "/companies/list", body)
         else:
-            # `pages.next` is a full URL; the framework follows it as GET, but
-            # /companies/list is POST. Empirically Intercom honors GET on the
-            # `pages.next` URL too — same response shape — so we use GET to
-            # avoid having to re-build the body with the embedded cursor.
-            payload = _intercom_get(session, next_url)
+            # `pages.next` is a full URL carrying the page cursor in its query
+            # string. `/companies/list` is POST-only — a GET against it 404s —
+            # so we re-POST the same body to the next-page URL, mirroring how
+            # the REST next-URL paginator advances the other list endpoints
+            # (it preserves the POST method + body and only swaps the URL).
+            payload = _intercom_post(session, next_url, body)
         yield from (payload.get("data") or [])
         next_url = (payload.get("pages") or {}).get("next")
         if not next_url:

--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -171,16 +171,19 @@ def get_resource(
     }
 
 
+def _resolve_intercom_url(path_or_url: str) -> str:
+    """Accept either an API path or a full URL (e.g. a `pages.next` link)."""
+    return path_or_url if path_or_url.startswith("http") else f"{INTERCOM_API_BASE}{path_or_url}"
+
+
 def _intercom_get(session: Session, path_or_url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    url = path_or_url if path_or_url.startswith("http") else f"{INTERCOM_API_BASE}{path_or_url}"
-    response = session.get(url, params=params, timeout=30)
+    response = session.get(_resolve_intercom_url(path_or_url), params=params, timeout=30)
     response.raise_for_status()
     return response.json()
 
 
 def _intercom_post(session: Session, path_or_url: str, body: dict[str, Any]) -> dict[str, Any]:
-    url = path_or_url if path_or_url.startswith("http") else f"{INTERCOM_API_BASE}{path_or_url}"
-    response = session.post(url, json=body, timeout=30)
+    response = session.post(_resolve_intercom_url(path_or_url), json=body, timeout=30)
     response.raise_for_status()
     return response.json()
 

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -283,20 +283,28 @@ class TestSubstreamGenerators:
         assert segments[0]["company_id"] == "co1"
         assert segments[1]["company_id"] == "co2"
 
-    def test_iter_companies_follows_next_url(self):
-        next_url = f"{INTERCOM_API_BASE}/companies/list?cursor=2"
+    def test_iter_companies_follows_next_url_with_post(self):
+        # `/companies/list` is POST-only; its `pages.next` URL carries the page
+        # cursor in the query string. Following it with GET 404s in production,
+        # so every page — including subsequent ones — must be a POST carrying
+        # the same body.
+        next_url = f"{INTERCOM_API_BASE}/companies/list?per_page=60&page=2"
         mock_session = mock.MagicMock()
         mock_session.post.side_effect = [
             _make_response({"data": [{"id": "co1"}], "pages": {"next": next_url}}),
-        ]
-        mock_session.get.side_effect = [
             _make_response({"data": [{"id": "co2"}], "pages": {}}),
         ]
 
         companies = list(_iter_companies(mock_session))
 
         assert [c["id"] for c in companies] == ["co1", "co2"]
-        assert mock_session.get.call_args_list[0].args[0] == next_url
+        # Second page is POSTed to the next-page URL with the same body — not
+        # GET (the production 404 this guards against).
+        assert mock_session.post.call_args_list[1].args[0] == next_url
+        assert mock_session.post.call_args_list[1].kwargs["json"] == {
+            "per_page": INTERCOM_ENDPOINTS["companies"].page_size
+        }
+        assert mock_session.get.call_count == 0
 
 
 class TestIntercomSource:


### PR DESCRIPTION
## Problem

The Intercom data-warehouse import crashes when syncing companies across more than one page. Error tracking shows an `HTTPError`:

```
404 Client Error: Not Found for url: https://api.intercom.io/companies/list?per_page=60&page=2
```

The failure is reproducible and frequent (314 occurrences over the issue window), and it originates entirely in our source code — the stack ends at `_company_segments_generator → _iter_companies → _intercom_get` raising on `raise_for_status()`.

Root cause: `/companies/list` is **POST-only**. Intercom returns `pages.next` as a full URL carrying the page cursor in its query string (`?per_page=60&page=2`). The `_iter_companies` helper (used by the `company_segments` substream) followed that URL with **GET**, which Intercom 404s. An in-code comment claimed Intercom "honors GET on the `pages.next` URL too" — production proves that wrong. The standalone `companies` endpoint never hit this because the REST next-URL paginator (`BaseNextUrlPaginator`) follows `pages.next` by swapping only the URL while preserving the POST method and body.

## Changes

- `_iter_companies` now follows `pages.next` with POST (re-sending the same body), matching the REST paginator's behavior.
- `_intercom_post` accepts a full URL (like `_intercom_get` already does) so it can post to the next-page URL.
- Updated the regression test to assert subsequent pages are POSTed to the next-page URL with the body, and that GET is never used to advance company pages.

This is a fixable bug on our side (wrong HTTP method for pagination), not a user/upstream error, so it is **not** added to `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I did not perform manual testing against the live Intercom API. Automated tests run locally:

- `posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py` — 57 passed (includes the updated `test_iter_companies_follows_next_url_with_post` regression test).
- `posthog/temporal/data_imports/sources/intercom/tests/test_intercom_source.py` — 12 passed.
- `ruff check` and `ruff format --check` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (PostHog Code) while triaging an error-tracking issue for the Intercom import source. Used PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace, confirming the failure path lands inside `intercom.py` rather than only appearing in serialized log context.

Decision: classified as a fixable pagination bug, not a user/upstream credential/config error, because the request method is wrong on our side and the standalone `companies` endpoint (same `pages.next` shape, but POST-preserving paginator) does not fail. Scoped the fix to `_iter_companies` and its `_intercom_post` helper; left retry policy and `NonRetryableErrors` untouched.
