### PR TITLE
fix(agent-migrations): enable SSL on migrate + reset connections

### DIFF
--- a/services/agent-migrations/src/lib.ts
+++ b/services/agent-migrations/src/lib.ts
@@ -21,6 +21,31 @@ const { Pool } = pg
 const HERE = dirname(fileURLToPath(import.meta.url))
 const MIGRATIONS_DIR = resolve(HERE, '../migrations')
 
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', ''])
+
+function isLocalHost(connectionString: string): boolean {
+    try {
+        return LOCAL_HOSTS.has(new URL(connectionString).hostname)
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Aurora's pg_hba requires SSL (`hostssl all all 0.0.0.0/0 md5`) and the
+ * chart helper builds DSNs without `?sslmode=require`, so we opt in
+ * client-side — same pattern as `createAgentPool` in `@posthog/agent-shared`.
+ * `rejectUnauthorized: false` matches the in-cluster pgbouncer behavior
+ * (Aurora uses the AWS RDS CA which Node doesn't trust out of the box).
+ */
+function dbClientOpts(connectionString: string): pg.ClientConfig {
+    return {
+        connectionString,
+        // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
+        ssl: isLocalHost(connectionString) ? false : { rejectUnauthorized: false },
+    }
+}
+
 export interface MigrateOpts {
     /** Postgres connection string. Falls back to AGENT_DB_URL env. */
     databaseUrl?: string
@@ -36,7 +61,7 @@ export async function migrate(opts: MigrateOpts = {}): Promise<void> {
         throw new Error('agent-migrations: databaseUrl or AGENT_DB_URL is required')
     }
     await runner({
-        databaseUrl,
+        databaseUrl: dbClientOpts(databaseUrl),
         dir: MIGRATIONS_DIR,
         direction: opts.direction ?? 'up',
         count: opts.count ?? Infinity,
@@ -64,7 +89,7 @@ export async function reset(opts: MigrateOpts = {}): Promise<void> {
     if (!databaseUrl) {
         throw new Error('agent-migrations.reset: databaseUrl or AGENT_DB_URL is required')
     }
-    const pool = new Pool({ connectionString: databaseUrl, max: 1 })
+    const pool = new Pool({ ...dbClientOpts(databaseUrl), max: 1 })
     try {
         await pool.query('DROP SCHEMA IF EXISTS public CASCADE')
         await pool.query('CREATE SCHEMA public')


### PR DESCRIPTION
## Summary

Unblocks dev: agent-runner + agent-janitor are CrashLoopBackOff'ing on
boot because the migrations runner connects to Aurora without SSL and
gets rejected.

```
no pg_hba.conf entry for host "10.20.9.50", user "agent-runner",
database "agent_platform", no encryption
```

agent-ingress doesn't call `migrate()` on boot (its first DB hit is
lazy via the first request), so it didn't surface the same failure.

## Root cause

Aurora's `pg_hba` requires `hostssl` for the agent-* DB users. The
chart's secret template builds DSNs without `?sslmode=require`, so
SSL has to be opted in client-side. `createAgentPool` in
`@posthog/agent-shared/src/persistence/create-pool.ts` already does
this with `ssl: { rejectUnauthorized: false }` for non-localhost
hosts — but `@posthog/agent-migrations`' `migrate()` and `reset()`
helpers construct their pg pool internally inside `node-pg-migrate`
and never saw that helper.

## Fix

Pass `node-pg-migrate` the full `ClientConfig` (connectionString + ssl)
instead of the raw URL. Same `rejectUnauthorized: false` rationale as
`createAgentPool` — Aurora uses the RDS CA which Node doesn't trust
out of the box and we don't bundle it. Local dev / vitest keep
`ssl: false` via the same `isLocalHost` check.

## Testing

- [ ] Typecheck clean: `pnpm --filter @posthog/agent-migrations typescript:check` (verified locally)
- [ ] Vitest still green: `pnpm --filter @posthog/agent-migrations test` — local Postgres connects without SSL as before.
- [ ] On dev after merge + image rebuild: `kubectl -n agent-runner get pods` flips from CrashLoopBackOff to Running, same for agent-janitor.

## 🤖 Agent context

Authored from a Claude (Opus 4.7) session driven by Ben. Diagnosed by
inspecting the pod logs after the Valkey allowlist + cert + DNS
fixes landed and pods stopped CrashLoopBackOff'ing on ioredis but
immediately died on the migration step.

The branch name `ben/agent-health-probes` is a misnomer — that work
got preempted by this fix and will land on a follow-up branch.
