### PR TITLE
fix(recharge): stop sending sort_by to the 2021-11 /products endpoint

### DIFF
--- a/posthog/temporal/data_imports/sources/recharge/api_inventory.md
+++ b/posthog/temporal/data_imports/sources/recharge/api_inventory.md
@@ -30,7 +30,7 @@ Source: Recharge Payments — subscription management for e-commerce.
 | `addresses`       | `/addresses`       | `id`        | `created_at`  | ✅          |                                                                                   |
 | `discounts`       | `/discounts`       | `id`        | `created_at`  | ✅          |                                                                                   |
 | `onetimes`        | `/onetimes`        | `id`        | `created_at`  | ✅          |                                                                                   |
-| `products`        | `/products`        | `id`        | `created_at`  | ✅          |                                                                                   |
+| `products`        | `/products`        | `id`        | `created_at`  | ➖ full     | 2021-11 list endpoint takes only cursor + `limit`/`ids` — no `sort_by` or `*_min`. |
 | `payment_methods` | `/payment_methods` | `id`        | `created_at`  | ✅          | Requires Recharge Pro / Custom plan.                                              |
 | `collections`     | `/collections`     | `id`        | `created_at`  | ➖ full     | Server-side timestamp filter not reliably documented — full refresh.              |
 

--- a/posthog/temporal/data_imports/sources/recharge/api_inventory.md
+++ b/posthog/temporal/data_imports/sources/recharge/api_inventory.md
@@ -21,18 +21,18 @@ Source: Recharge Payments — subscription management for e-commerce.
 
 ## Endpoints
 
-| Schema            | Path               | Primary key | Partition key | Incremental | Notes                                                                             |
-| ----------------- | ------------------ | ----------- | ------------- | ----------- | --------------------------------------------------------------------------------- |
-| `customers`       | `/customers`       | `id`        | `created_at`  | ✅          |                                                                                   |
-| `subscriptions`   | `/subscriptions`   | `id`        | `created_at`  | ✅          |                                                                                   |
-| `orders`          | `/orders`          | `id`        | `created_at`  | ✅          |                                                                                   |
-| `charges`         | `/charges`         | `id`        | `created_at`  | ✅          | 90-day retention for `processed_at` filtering (we use `updated_at`/`created_at`). |
-| `addresses`       | `/addresses`       | `id`        | `created_at`  | ✅          |                                                                                   |
-| `discounts`       | `/discounts`       | `id`        | `created_at`  | ✅          |                                                                                   |
-| `onetimes`        | `/onetimes`        | `id`        | `created_at`  | ✅          |                                                                                   |
+| Schema            | Path               | Primary key | Partition key | Incremental | Notes                                                                              |
+| ----------------- | ------------------ | ----------- | ------------- | ----------- | ---------------------------------------------------------------------------------- |
+| `customers`       | `/customers`       | `id`        | `created_at`  | ✅          |                                                                                    |
+| `subscriptions`   | `/subscriptions`   | `id`        | `created_at`  | ✅          |                                                                                    |
+| `orders`          | `/orders`          | `id`        | `created_at`  | ✅          |                                                                                    |
+| `charges`         | `/charges`         | `id`        | `created_at`  | ✅          | 90-day retention for `processed_at` filtering (we use `updated_at`/`created_at`).  |
+| `addresses`       | `/addresses`       | `id`        | `created_at`  | ✅          |                                                                                    |
+| `discounts`       | `/discounts`       | `id`        | `created_at`  | ✅          |                                                                                    |
+| `onetimes`        | `/onetimes`        | `id`        | `created_at`  | ✅          |                                                                                    |
 | `products`        | `/products`        | `id`        | `created_at`  | ➖ full     | 2021-11 list endpoint takes only cursor + `limit`/`ids` — no `sort_by` or `*_min`. |
-| `payment_methods` | `/payment_methods` | `id`        | `created_at`  | ✅          | Requires Recharge Pro / Custom plan.                                              |
-| `collections`     | `/collections`     | `id`        | `created_at`  | ➖ full     | Server-side timestamp filter not reliably documented — full refresh.              |
+| `payment_methods` | `/payment_methods` | `id`        | `created_at`  | ✅          | Requires Recharge Pro / Custom plan.                                               |
+| `collections`     | `/collections`     | `id`        | `created_at`  | ➖ full     | Server-side timestamp filter not reliably documented — full refresh.               |
 
 ## Possible future work
 

--- a/posthog/temporal/data_imports/sources/recharge/recharge.py
+++ b/posthog/temporal/data_imports/sources/recharge/recharge.py
@@ -100,9 +100,14 @@ def _build_initial_params(
         # created_at). Filter server-side on `<field>_min` and sort ascending on
         # the same field so the pipeline watermark advances monotonically.
         params[f"{incremental_field}_min"] = _format_incremental_value(db_incremental_field_last_value)
-        params["sort_by"] = f"{incremental_field}-asc"
+        sort_field = incremental_field
     else:
-        params["sort_by"] = f"{config.default_sort_field}-asc"
+        sort_field = config.default_sort_field
+
+    # Some endpoints (e.g. `/products` on the 2021-11 API) reject `sort_by`
+    # outright with a 422 — they rely on cursor pagination for stable ordering.
+    if config.supports_sort:
+        params["sort_by"] = f"{sort_field}-asc"
 
     return params
 

--- a/posthog/temporal/data_imports/sources/recharge/settings.py
+++ b/posthog/temporal/data_imports/sources/recharge/settings.py
@@ -24,6 +24,11 @@ class RechargeEndpointConfig:
     incremental_fields: list[IncrementalField] = field(default_factory=list)
     partition_key: Optional[str] = "created_at"
     supports_incremental: bool = True
+    # Whether the list endpoint accepts a `sort_by` query param. The 2021-11 API
+    # dropped `sort_by` for `/products` (it isn't in the sorting reference for
+    # this version), so sending it returns a 422. Endpoints without sort support
+    # rely on cursor pagination for ordering instead.
+    supports_sort: bool = True
     # Default sort field used when not syncing incrementally. Recharge accepts
     # `<field>-asc` / `<field>-desc`; `id-asc` is a stable monotonic order that
     # avoids page-boundary skips/dupes when rows are inserted mid-sync.
@@ -81,10 +86,15 @@ RECHARGE_ENDPOINTS: dict[str, RechargeEndpointConfig] = {
         path="/onetimes",
         incremental_fields=_UPDATED_AND_CREATED,
     ),
+    # `/products` on the 2021-11 API only accepts cursor pagination + `limit`/
+    # `ids` — unlike 2021-01 it exposes neither `sort_by` nor a `*_min` timestamp
+    # filter, so sending either returns a 422. Full-refresh, cursor-ordered only.
     "products": RechargeEndpointConfig(
         name="products",
         path="/products",
-        incremental_fields=_UPDATED_AND_CREATED,
+        incremental_fields=[],
+        supports_incremental=False,
+        supports_sort=False,
     ),
     "payment_methods": RechargeEndpointConfig(
         name="payment_methods",

--- a/posthog/temporal/data_imports/sources/recharge/tests/test_recharge.py
+++ b/posthog/temporal/data_imports/sources/recharge/tests/test_recharge.py
@@ -77,6 +77,19 @@ class TestBuildInitialParams:
         assert params["sort_by"] == "id-asc"
         assert not any(k.endswith("_min") for k in params)
 
+    def test_products_omits_sort_by_and_filters(self) -> None:
+        # `/products` on the 2021-11 API rejects `sort_by` (and exposes no
+        # `*_min` filter), so even with incremental inputs we send only `limit`.
+        params = _build_initial_params(
+            RECHARGE_ENDPOINTS["products"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            incremental_field="updated_at",
+        )
+        assert params == {"limit": 250}
+        assert "sort_by" not in params
+        assert not any(k.endswith("_min") for k in params)
+
     def test_non_incremental_endpoint_never_filters(self) -> None:
         # `collections` ships full-refresh only; even with incremental inputs set
         # it must not emit a server-side timestamp filter.
@@ -179,6 +192,24 @@ class TestGetRows:
         )
 
         assert mock_session.call_args.kwargs["redact_values"] == ("secret-token",)
+
+    @patch("posthog.temporal.data_imports.sources.recharge.recharge.make_tracked_session")
+    def test_products_request_omits_sort_by(self, mock_session: MagicMock) -> None:
+        # Regression: the 2021-11 `/products` endpoint 422s on `sort_by`, so the
+        # initial request must send only `limit` (no sort, no timestamp filter).
+        mock_session.return_value.get.return_value = _mock_response(
+            json_body={"products": [{"id": 1}], "next_cursor": None}
+        )
+
+        manager = MagicMock()
+        manager.can_resume.return_value = False
+
+        list(get_rows(api_key="t", endpoint="products", logger=MagicMock(), resumable_source_manager=manager))
+
+        requested_url = mock_session.return_value.get.call_args.args[0]
+        assert "products?limit=250" in requested_url
+        assert "sort_by" not in requested_url
+        assert "_min" not in requested_url
 
     @patch("posthog.temporal.data_imports.sources.recharge.recharge.make_tracked_session")
     def test_resumes_from_saved_cursor_when_endpoint_matches(self, mock_session: MagicMock) -> None:

--- a/posthog/temporal/data_imports/sources/recharge/tests/test_recharge.py
+++ b/posthog/temporal/data_imports/sources/recharge/tests/test_recharge.py
@@ -77,29 +77,24 @@ class TestBuildInitialParams:
         assert params["sort_by"] == "id-asc"
         assert not any(k.endswith("_min") for k in params)
 
-    def test_products_omits_sort_by_and_filters(self) -> None:
-        # `/products` on the 2021-11 API rejects `sort_by` (and exposes no
-        # `*_min` filter), so even with incremental inputs we send only `limit`.
+    @parameterized.expand(
+        [
+            # `collections` is full-refresh but still sortable -> keeps `id-asc`.
+            ("collections", {"limit": 250, "sort_by": "id-asc"}),
+            # `/products` on the 2021-11 API rejects `sort_by` outright -> limit only.
+            ("products", {"limit": 250}),
+        ]
+    )
+    def test_full_refresh_endpoint_ignores_incremental_inputs(self, endpoint: str, expected: dict) -> None:
+        # Full-refresh endpoints must never emit a `*_min` filter even when the
+        # user supplies incremental inputs; products additionally omits `sort_by`.
         params = _build_initial_params(
-            RECHARGE_ENDPOINTS["products"],
+            RECHARGE_ENDPOINTS[endpoint],
             should_use_incremental_field=True,
             db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
             incremental_field="updated_at",
         )
-        assert params == {"limit": 250}
-        assert "sort_by" not in params
-        assert not any(k.endswith("_min") for k in params)
-
-    def test_non_incremental_endpoint_never_filters(self) -> None:
-        # `collections` ships full-refresh only; even with incremental inputs set
-        # it must not emit a server-side timestamp filter.
-        params = _build_initial_params(
-            RECHARGE_ENDPOINTS["collections"],
-            should_use_incremental_field=True,
-            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
-            incremental_field="updated_at",
-        )
-        assert params["sort_by"] == "id-asc"
+        assert params == expected
         assert not any(k.endswith("_min") for k in params)
 
 

--- a/posthog/temporal/data_imports/sources/recharge/tests/test_recharge_source.py
+++ b/posthog/temporal/data_imports/sources/recharge/tests/test_recharge_source.py
@@ -52,6 +52,14 @@ class TestRechargeSourceGetSchemas:
         assert collections.supports_incremental is False
         assert collections.incremental_fields == []
 
+    def test_products_is_full_refresh_only(self) -> None:
+        # The 2021-11 `/products` endpoint has no `sort_by` or `*_min` filter, so
+        # it can't sync incrementally — it must be advertised as full-refresh.
+        schemas = RechargeSource().get_schemas(_config(), team_id=1)
+        products = next(s for s in schemas if s.name == "products")
+        assert products.supports_incremental is False
+        assert products.incremental_fields == []
+
     def test_filters_by_names(self) -> None:
         schemas = RechargeSource().get_schemas(_config(), team_id=1, names=["customers", "orders"])
         assert {s.name for s in schemas} == {"customers", "orders"}


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` on the Recharge data-warehouse import source:

```
422 Client Error: unknown for url: https://api.rechargeapps.com/products?limit=250&sort_by=id-asc
```

The Recharge client pins `X-Recharge-Version: 2021-11`, but our pagination code appended a `sort_by` query param to **every** list request. Under the 2021-11 API the `/products` list endpoint no longer accepts `sort_by` — Products was removed from the [2021-11 sorting reference](https://developer.rechargepayments.com/2021-11/sorting) (it is still listed in [2021-01](https://developer.rechargepayments.com/2021-01/products/products_list)) and now supports only cursor pagination plus `limit`/`ids`. So `GET /products?limit=250&sort_by=id-asc` is rejected with a 422 and the products sync fails for every store.

This is our bug (a request param invalid for the API version we pin), not a customer/credentials/upstream issue — so the fix is to correct the request rather than mark the error non-retryable.

The failure originates in this source's code: `get_rows` → `fetch_page` → `response.raise_for_status()` in `posthog/temporal/data_imports/sources/recharge/recharge.py`.

## Changes

- Added a per-endpoint `supports_sort` capability flag to `RechargeEndpointConfig` (mirrors the existing `supports_incremental`).
- `_build_initial_params` now only emits `sort_by` for endpoints that support it; the request for `/products` carries just `limit` (+ cursor on follow-up pages).
- Marked `/products` as **full-refresh only** (`supports_incremental=False`, `supports_sort=False`): the 2021-11 list endpoint exposes neither `sort_by` nor an `*_min` timestamp filter, and the incremental design relies on `sort_by=<field>-asc` to advance the watermark — so incremental sync of products cannot work and would 422 on the same root cause.
- Updated the in-source `api_inventory.md` to reflect products being full-refresh.
- All other endpoints (customers, subscriptions, orders, etc.) are unchanged — they remain in the 2021-11 sorting reference and continue to sort/sync incrementally.

Scope was deliberately limited to the confirmed endpoint. `payment_methods` and `collections` are also absent from the 2021-11 sorting table, but there is no observed error for them, so they were left untouched.

## How did you test this code?

I'm an agent; I did not perform manual testing against a live Recharge store. I ran the source's automated test suite locally:

```
uv run pytest posthog/temporal/data_imports/sources/recharge/tests/  # 47 passed
```

Added regression tests:
- `test_products_omits_sort_by_and_filters` — `_build_initial_params` for `/products` returns only `{limit: 250}`, even when incremental inputs are supplied.
- `test_products_request_omits_sort_by` — the emitted `/products` request URL contains no `sort_by` or `*_min` (asserts at the request layer where the 422 occurred).
- `test_products_is_full_refresh_only` — the advertised schema for products is full-refresh.

Also ran `ruff check` and `ruff format --check` on the source directory (clean).

## 🤖 Agent context

Authored by an agent (Claude Code) triaging a specific error-tracking issue for the Recharge source. The error-tracking issue's error signature (`422` on `GET /products?...&sort_by=id-asc`) was given; the live issue couldn't be opened from this environment, so the root cause was verified against the Recharge API docs and the source code.

Decision path: the working hypothesis was a products API migration. Confirmed via the Recharge docs that `sort_by` for Products exists in the 2021-01 sorting reference but was dropped in 2021-11 (the version we pin) — so this is a fixable request bug, not a user/upstream error to add to `NonRetryableErrors`. Considered fixing only the `sort_by` param, but since the 2021-11 products list also lacks a timestamp filter and incremental sync depends on sorting, products was marked full-refresh to fully resolve the same root cause. Kept the change scoped to `/products`.
