### PR TITLE
fix(visual-review): move quarantined toggle to run panel bottom-left

### DIFF
--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -152,9 +152,9 @@ function QuarantinedThumbnailsToggle({
             onClick={onClick}
             aria-expanded={isExpanded}
             data-attr="visual-review-toggle-quarantined-thumbnails"
-            className="flex flex-col items-center justify-center shrink-0 rounded p-1.5 w-[100px] h-full text-warning-dark border border-dashed border-warning hover:bg-warning/10 transition-colors"
+            className="shrink-0 text-xs text-muted hover:text-default hover:underline underline-offset-2 transition-colors"
         >
-            <span className="text-[11px] font-semibold text-center leading-tight">{label}</span>
+            {label}
         </button>
     )
 }
@@ -254,6 +254,7 @@ export function VisualReviewRunScene(): JSX.Element {
         ? navSnapshots
         : navSnapshots.filter((s: SnapshotApi) => !isHiddenQuarantined(s))
     const hiddenQuarantinedCount = navSnapshots.length - visibleNavSnapshots.length
+    const showQuarantinedToggle = quarantinedNavCount > 0 && (hiddenQuarantinedCount > 0 || showQuarantinedThumbnails)
 
     const currentIndex = selectedSnapshot
         ? navSnapshots.findIndex((s: SnapshotApi) => s.id === selectedSnapshot.id)
@@ -512,44 +513,52 @@ export function VisualReviewRunScene(): JSX.Element {
                                     />
                                 )
                             })}
-                            {quarantinedNavCount > 0 && (hiddenQuarantinedCount > 0 || showQuarantinedThumbnails) && (
+                        </div>
+                    )}
+
+                    {/* Pagination — below thumbnails, right-aligned */}
+                    {(showQuarantinedToggle || navSnapshots.length > 1) && (
+                        <div
+                            className={`flex items-center gap-2 px-3 pb-2 ${
+                                showQuarantinedToggle ? 'justify-between' : 'justify-end'
+                            }`}
+                        >
+                            {showQuarantinedToggle && (
                                 <QuarantinedThumbnailsToggle
                                     hiddenCount={hiddenQuarantinedCount}
                                     isExpanded={showQuarantinedThumbnails}
                                     onClick={toggleQuarantinedThumbnails}
                                 />
                             )}
-                        </div>
-                    )}
-
-                    {/* Pagination — below thumbnails, right-aligned */}
-                    {navSnapshots.length > 1 && (
-                        <div className="flex items-center justify-end gap-2 px-3 pb-2">
-                            <LemonButton
-                                size="xsmall"
-                                icon={<IconChevronLeft />}
-                                sideIcon={<KeyboardShortcut p />}
-                                onClick={goToPrevious}
-                                disabledReason={!hasPrevious ? 'No previous snapshot' : undefined}
-                                data-attr="visual-review-snapshot-previous"
-                            >
-                                Previous
-                            </LemonButton>
-                            {currentIndex >= 0 && (
-                                <span className="text-xs text-muted">
-                                    {currentIndex + 1} of {navSnapshots.length}
-                                </span>
+                            {navSnapshots.length > 1 && (
+                                <div className="flex items-center gap-2">
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={<IconChevronLeft />}
+                                        sideIcon={<KeyboardShortcut p />}
+                                        onClick={goToPrevious}
+                                        disabledReason={!hasPrevious ? 'No previous snapshot' : undefined}
+                                        data-attr="visual-review-snapshot-previous"
+                                    >
+                                        Previous
+                                    </LemonButton>
+                                    {currentIndex >= 0 && (
+                                        <span className="text-xs text-muted">
+                                            {currentIndex + 1} of {navSnapshots.length}
+                                        </span>
+                                    )}
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={<KeyboardShortcut n />}
+                                        sideIcon={<IconChevronRight />}
+                                        onClick={goToNext}
+                                        disabledReason={!hasNext ? 'No next snapshot' : undefined}
+                                        data-attr="visual-review-snapshot-next"
+                                    >
+                                        Next
+                                    </LemonButton>
+                                </div>
                             )}
-                            <LemonButton
-                                size="xsmall"
-                                icon={<KeyboardShortcut n />}
-                                sideIcon={<IconChevronRight />}
-                                onClick={goToNext}
-                                disabledReason={!hasNext ? 'No next snapshot' : undefined}
-                                data-attr="visual-review-snapshot-next"
-                            >
-                                Next
-                            </LemonButton>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
## Problem

The "hide quarantined snapshots by default" feature (#61985) added a toggle to the Visual Review run panel. It rendered as a tall dashed box inline at the end of the thumbnail strip, where it sat awkwardly next to the image thumbnails.

## Changes

Moves the quarantined-items toggle out of the thumbnail strip and into the panel's bottom control row:

- The toggle is now a subtle muted text link on the **left** of the bottom row ("N quarantined items hidden" / "Hide quarantined"), dropping the dashed-box styling.
- The **Previous / N of M / Next** paging controls stay on the **right**.
- The row renders when there are hidden quarantined items _or_ more than one snapshot to page through. It uses `justify-between` when the toggle is present and `justify-end` otherwise, so paging stays right-aligned either way.
- Expand/collapse behaviour is unchanged — clicking the link still reveals the quarantined thumbnails in the strip above.

The visibility predicate was extracted to a single `showQuarantinedToggle` const so the strip and the new row share one source of truth.

Follow-up to #61985.

_Frontend change — a reviewer with a run containing quarantined snapshots can confirm the toggle now sits bottom-left with paging on the right._

## How did you test this code?

I'm an agent (PostHog Code) and did **not** run the app manually. Automated checks run against the changed file:

- `oxlint` — 0 warnings, 0 errors
- `oxfmt --check` — passes (file formatted)

There are no existing unit or Storybook tests for `VisualReviewRunScene`, so visual confirmation in a running instance is still recommended before merge.

## 🤖 Agent context

Authored by PostHog Code (agent), directed by @pauldambra. Pure layout/styling move in `VisualReviewRunScene.tsx`: `QuarantinedThumbnailsToggle` restyled from a thumbnail-sized dashed box to a text link, its visibility predicate extracted to a shared `showQuarantinedToggle` const, and the paging row turned into a two-slot control row (toggle left, paging right). The text-link treatment was chosen over a bordered button / LemonButton to give the toggle the lowest visual weight next to the paging controls. Agent-authored; requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
