### PR TITLE
chore(ci): add explicit repo parameter to workflow dispatch

### DIFF
--- a/.github/workflows/ci-e2e-playwright-audit.yml
+++ b/.github/workflows/ci-e2e-playwright-audit.yml
@@ -31,5 +31,6 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
               run: |
                   gh workflow run ci-e2e-playwright.yml \
+                      --repo ${{ github.repository }} \
                       --ref master \
                       --field playwright_retries=0


### PR DESCRIPTION
## Problem

The `ci-e2e-playwright-audit` workflow dispatches the `ci-e2e-playwright` workflow without explicitly specifying the repository. While this typically works in the default case, it's a best practice to be explicit about the target repository when using `gh workflow run`.

## Changes

Added the `--repo ${{ github.repository }}` parameter to the `gh workflow run` command in the audit workflow. This ensures the workflow dispatch explicitly targets the current repository.

## How did you test this code?

No testing needed — this is a configuration change that makes the workflow dispatch more explicit and robust. The CI workflow will validate the syntax when the change is deployed.

## 🤖 Agent context

This is a straightforward GitHub Actions configuration improvement to follow best practices for workflow dispatch commands.

https://claude.ai/code/session_01XF2sKKLwT5r3XDztcPoSsH