### PR TITLE
fix(logs): close logs viewer modal when navigating away

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
@@ -1,5 +1,5 @@
-import { expectLogic } from 'kea-test-utils'
 import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 

--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
@@ -1,4 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
+import { router } from 'kea-router'
 
 import { initKeaTests } from '~/test/init'
 
@@ -111,6 +112,35 @@ describe('logsViewerModalLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.closeLogsViewerModal()
             }).toMatchValues({ initialFilters: null })
+        })
+    })
+
+    describe('closes on navigation', () => {
+        it('closes the modal when navigating to a new scene', async () => {
+            logic.actions.openLogsViewerModal()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                router.actions.push('/project/1/dashboard')
+            }).toMatchValues({ isOpen: false })
+        })
+
+        it('does not react to query/hash-only changes on the same pathname', async () => {
+            router.actions.push('/project/1/logs')
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.openLogsViewerModal()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                router.actions.push('/project/1/logs', { search: 'foo' })
+            }).toMatchValues({ isOpen: true })
+        })
+
+        it('stays closed when navigating while not open', async () => {
+            await expectLogic(logic, () => {
+                router.actions.push('/project/1/dashboard')
+            }).toMatchValues({ isOpen: false })
         })
     })
 

--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.test.ts
@@ -116,9 +116,14 @@ describe('logsViewerModalLogic', () => {
     })
 
     describe('closes on navigation', () => {
-        it('closes the modal when navigating to a new scene', async () => {
-            logic.actions.openLogsViewerModal()
-            await expectLogic(logic).toFinishAllListeners()
+        it.each([
+            { description: 'when open', openFirst: true },
+            { description: 'when already closed', openFirst: false },
+        ])('modal is closed after scene navigation ($description)', async ({ openFirst }) => {
+            if (openFirst) {
+                logic.actions.openLogsViewerModal()
+                await expectLogic(logic).toFinishAllListeners()
+            }
 
             await expectLogic(logic, () => {
                 router.actions.push('/project/1/dashboard')
@@ -135,12 +140,6 @@ describe('logsViewerModalLogic', () => {
             await expectLogic(logic, () => {
                 router.actions.push('/project/1/logs', { search: 'foo' })
             }).toMatchValues({ isOpen: true })
-        })
-
-        it('stays closed when navigating while not open', async () => {
-            await expectLogic(logic, () => {
-                router.actions.push('/project/1/dashboard')
-            }).toMatchValues({ isOpen: false })
         })
     })
 

--- a/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic.ts
@@ -1,4 +1,5 @@
-import { actions, kea, path, reducers } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { router } from 'kea-router'
 
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 
@@ -12,6 +13,9 @@ export interface OpenLogsViewerModalOptions {
 
 export const logsViewerModalLogic = kea<logsViewerModalLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'LogsViewerModal', 'logsViewerModalLogic']),
+    connect(() => ({
+        actions: [router, ['locationChanged']],
+    })),
     actions({
         openLogsViewerModal: (options?: OpenLogsViewerModalOptions) => ({
             id: options?.id ?? 'modal',
@@ -47,5 +51,22 @@ export const logsViewerModalLogic = kea<logsViewerModalLogicType>([
                 closeLogsViewerModal: () => null,
             },
         ],
+    }),
+    listeners(({ values, actions, cache }) => ({
+        locationChanged: ({ pathname }) => {
+            // close the (often full-screen) modal when navigating to a new scene, e.g. via cmd+k.
+            // query/hash-only changes fire locationChanged too (the viewer syncs filters to the
+            // URL), so only react to an actual pathname change.
+            if (pathname === cache.lastPathname) {
+                return
+            }
+            cache.lastPathname = pathname
+            if (values.isOpen) {
+                actions.closeLogsViewerModal()
+            }
+        },
+    })),
+    afterMount(({ cache }) => {
+        cache.lastPathname = router.values.location.pathname
     }),
 ])


### PR DESCRIPTION
## Problem

When in full-screen mode on Logs, opening the cmd+k command palette and navigating elsewhere (e.g. pressing Enter on a result) navigated the page underneath, but the full-screen Logs overlay stayed open on top — the user had to press Escape to reveal the page they'd navigated to.

The `LogsViewerModal` is mounted globally (`GlobalModals.tsx`) and its logic had no URL binding, so a route change never closed it.

## Changes

`logsViewerModalLogic` now connects to the router's `locationChanged` action and closes the modal on an actual scene change. Query/hash-only changes are ignored (the viewer syncs its filters to the URL, and those updates also fire `locationChanged`), matching the existing pattern used in `autofillReleaseLogic`.

## How did you test this code?

I'm an agent. Added Jest cases to `logsViewerModalLogic.test.ts` covering: closing on scene navigation, not reacting to query/hash-only changes on the same pathname, and staying closed when navigating while not open. I could not run the suite locally because this environment has no installed node modules — CI will exercise the tests.

## 🤖 Agent context

Authored by the PostHog Slack app (PostHog Code) from a Slack bug report. Located the full-screen state in `logsViewerModalLogic` (a pure in-memory toggle with no URL binding) and confirmed the modal is mounted globally, so it persists across navigation. Chose the `connect(router, ['locationChanged'])` + `listeners` approach (with a pathname guard) over a `urlToAction`/`bindModalToUrl` binding because the modal isn't represented in the URL — mirroring the established `autofillReleaseLogic` pattern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
