### PR TITLE
fix(data-warehouse): isolate postgres metadata probes in savepoints

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -997,9 +997,12 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
     logger.debug(f"Running EXPLAIN on {query.as_string()}")
 
     try:
-        query_with_explain = sql.SQL("EXPLAIN {}").format(query)
-        cursor.execute(query_with_explain)
-        rows = cursor.fetchall()
+        # Debug-only and best-effort: a query may use syntax the source DB rejects (e.g.
+        # TABLESAMPLE on CockroachDB). Savepoint so a failure doesn't poison the transaction.
+        with cursor.connection.transaction(savepoint_name="explain_query"):
+            query_with_explain = sql.SQL("EXPLAIN {}").format(query)
+            cursor.execute(query_with_explain)
+            rows = cursor.fetchall()
         explain_result: str = ""
         # Build up a single string of the EXPLAIN output
         for row in rows:
@@ -1007,7 +1010,6 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
                 explain_result += f"\n{col}"
         logger.debug(f"EXPLAIN result: {explain_result}")
     except Exception as e:
-        capture_exception(e)
         logger.debug(f"EXPLAIN raised an exception: {e}")
 
 
@@ -1146,10 +1148,13 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
             ) as subquery
         """).format(inner_query)
 
-        _explain_query(cursor, query, logger)
-        logger.debug(f"Running query: {query.as_string()}")
-        cursor.execute(query)
-        row = cursor.fetchone()
+        # Best-effort: the sampled query can fail (e.g. TABLESAMPLE on CockroachDB). Savepoint
+        # so a failure falls back to DEFAULT_CHUNK_SIZE without poisoning the transaction.
+        with cursor.connection.transaction(savepoint_name="table_chunk_size"):
+            _explain_query(cursor, query, logger)
+            logger.debug(f"Running query: {query.as_string()}")
+            cursor.execute(query)
+            row = cursor.fetchone()
 
         if row is None:
             logger.debug(f"_get_table_chunk_size: No results returned. Using DEFAULT_CHUNK_SIZE={DEFAULT_CHUNK_SIZE}")

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -14,6 +14,7 @@ import structlog
 from psycopg import sql
 
 import posthog.temporal.data_imports.sources.postgres.partitioned_tables as partitioned_tables_pkg
+from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE
 from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     DEFAULT_NUMERIC_SCALE,
     MAX_NUMERIC_SCALE,
@@ -49,6 +50,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _get_primary_keys,
     _get_sslmode,
     _get_table,
+    _get_table_chunk_size,
     _has_duplicate_primary_keys,
     _is_connection_dropped_error,
     _is_partitioned_table,
@@ -1077,6 +1079,21 @@ class TestIsPartitionedTable:
             for stmt in setup_ddl:
                 dj_cursor.execute(stmt)
             assert _is_partitioned_table(cast(Any, dj_cursor), "public", table_name) is expected
+
+
+class TestGetTableChunkSize:
+    @pytest.mark.django_db
+    def test_failing_probe_falls_back_without_poisoning_transaction(self):
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            inner_query = sql.SQL("SELECT * FROM does_not_exist_chunk_probe").format()
+
+            chunk_size = _get_table_chunk_size(cast(Any, dj_cursor), inner_query, logger)
+            assert chunk_size == DEFAULT_CHUNK_SIZE
+
+            dj_cursor.execute("SELECT 1")
+            assert dj_cursor.fetchone()[0] == 1
 
 
 class TestPartitionedTableChunkSizing:


### PR DESCRIPTION
## Problem

Postgres imports from a Postgres-wire-compatible source that doesn't support `TABLESAMPLE` (e.g. CockroachDB) were failing. The chunk-size estimator probes a sampled query with `TABLESAMPLE SYSTEM (1)`; on such sources the query is rejected with a syntax error.

The probe — and the debug-only `EXPLAIN` that runs ahead of it — executed without a savepoint inside the non-autocommit metadata transaction. So the failure put the transaction into an aborted state, and every subsequent metadata query (`_get_rows_to_sync`, `_get_partition_settings`, …) then died with `InFailedSqlTransaction`. The `EXPLAIN` helper additionally reported these expected failures to error tracking as noise.

## Changes

- Wrap the chunk-size sampling probe and the `EXPLAIN` debug helper in savepoints, matching the existing numeric-scale probe pattern in the same file. A probe failure now rolls back to its savepoint and degrades gracefully to `DEFAULT_CHUNK_SIZE` with the transaction intact.
- Drop `capture_exception` from the debug-only `EXPLAIN` helper — a query using syntax the source rejects is expected, not an error worth reporting (it's already debug-logged).

No source-specific branching: the savepoint isolation makes the probes degrade gracefully on any source that rejects the sampling syntax. Note the actual data fetch never uses `TABLESAMPLE` (sampling only feeds chunk-size estimation), so affected syncs now proceed with the default chunk size instead of breaking.

## How did you test this code?

I'm an agent. Automated tests only:

- Added `TestGetTableChunkSize::test_failing_probe_falls_back_without_poisoning_transaction` — a failing probe returns `DEFAULT_CHUNK_SIZE` and leaves the cursor usable (would raise `InFailedSqlTransaction` without the fix).
- Ran the full `posthog/temporal/data_imports/sources/postgres/test_postgres.py` suite: 241 passed.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Root-caused from an error-tracking stack trace: the `HINT: try \h <SOURCE>` format and `at or near "system"` pointed at a CockroachDB instance connected via the Postgres connector rejecting `TABLESAMPLE`. Considered a CockroachDB-specific branch but rejected it in favor of generic savepoint isolation, reusing the convention already documented in this file for the numeric-scale probe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
