### PR TITLE
fix(slack-app): match user email case-insensitively

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -450,7 +450,7 @@ def resolve_slack_user(
         # membership
         membership = (
             OrganizationMembership.objects.filter(
-                organization_id=integration.team.organization_id, user__email=slack_email
+                organization_id=integration.team.organization_id, user__email__iexact=slack_email
             )
             .select_related("user")
             .first()
@@ -1422,7 +1422,7 @@ def _resolve_posthog_user_from_event(
         if not org_ids:
             return None
         membership = (
-            OrganizationMembership.objects.filter(organization_id__in=org_ids, user__email=slack_email)
+            OrganizationMembership.objects.filter(organization_id__in=org_ids, user__email__iexact=slack_email)
             .select_related("user")
             .first()
         )

--- a/products/slack_app/backend/tests/test_resolve_slack_user.py
+++ b/products/slack_app/backend/tests/test_resolve_slack_user.py
@@ -42,6 +42,27 @@ class TestResolveSlackUser:
         assert result.user.email == "dev@example.com"
         assert result.slack_email == "dev@example.com"
 
+    @pytest.mark.parametrize(
+        "slack_email",
+        [
+            pytest.param("DEV@example.com", id="uppercase_local_part"),
+            pytest.param("dev@Example.com", id="mixed_case_domain"),
+            pytest.param("DEV@EXAMPLE.COM", id="all_uppercase"),
+        ],
+    )
+    @patch("posthog.models.integration.WebClient")
+    def test_matches_email_case_insensitively(self, mock_webclient_class, slack_email):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+        mock_client.users_info.return_value = {"user": {"profile": {"email": slack_email}}}
+
+        slack = SlackIntegration(self.integration)
+        result = resolve_slack_user(slack, self.integration, "U123", "C001", "1234.5678")
+
+        assert result is not None
+        assert result.user.email == "dev@example.com"
+        assert result.slack_email == slack_email
+
     @patch("posthog.models.integration.WebClient")
     def test_missing_email(self, mock_webclient_class):
         mock_client = MagicMock()


### PR DESCRIPTION
## Problem

Slack integration user matching does a strict case-sensitive email comparison against the PostHog account, so users whose Slack profile email differs only in case from their PostHog email fail to resolve.

[Zendesk ticket](https://posthoghelp.zendesk.com/agent/tickets/59778)

## Changes

Switch the two `OrganizationMembership` lookups in `products/slack_app/backend/api.py` from `user__email=` to `user__email__iexact=`, aligning with the pattern used across auth, invites, and signup.

## How did you test this code?

Added a parametrized regression test in `test_resolve_slack_user.py` covering uppercase local part, mixed-case domain, and all-uppercase variants. Tested locally — `hogli test products/slack_app/backend/tests/test_resolve_slack_user.py` passes 15/15.
