### PR TITLE
fix(workos): build valid directory_groups/directory_users list requests

### DIFF
--- a/posthog/temporal/data_imports/sources/workos/tests/test_workos.py
+++ b/posthog/temporal/data_imports/sources/workos/tests/test_workos.py
@@ -13,6 +13,7 @@ from posthog.temporal.data_imports.sources.workos.settings import ENDPOINTS, WOR
 from posthog.temporal.data_imports.sources.workos.workos import (
     WorkOSPaginator,
     WorkOSResumeConfig,
+    get_resource,
     validate_credentials,
     workos_source,
 )
@@ -136,6 +137,16 @@ class TestWorkOSEndpoints:
         assert set(ENDPOINTS) == set(WORKOS_ENDPOINTS)
         # Every endpoint partitions on the immutable created_at field.
         assert all(cfg.partition_key == "created_at" for cfg in WORKOS_ENDPOINTS.values())
+
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_resource_request_params_are_valid(self, endpoint: str) -> None:
+        # directory_users and directory_groups reject ``order=asc`` with a 422; every
+        # WorkOS list endpoint accepts ``order=desc`` (the WorkOS SDK default). Guard
+        # against regressing back to the rejected value on any endpoint.
+        params = get_resource(endpoint)["endpoint"]["params"]
+        assert params["order"] == "desc"
+        assert params["order"] != "asc"
+        assert params["limit"] == WORKOS_ENDPOINTS[endpoint].page_size
 
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_source_response_shape(self, endpoint: str) -> None:

--- a/posthog/temporal/data_imports/sources/workos/tests/test_workos.py
+++ b/posthog/temporal/data_imports/sources/workos/tests/test_workos.py
@@ -143,9 +143,9 @@ class TestWorkOSEndpoints:
         # directory_users and directory_groups reject ``order=asc`` with a 422; every
         # WorkOS list endpoint accepts ``order=desc`` (the WorkOS SDK default). Guard
         # against regressing back to the rejected value on any endpoint.
-        params = get_resource(endpoint)["endpoint"]["params"]
+        endpoint_config = cast(dict[str, Any], get_resource(endpoint)["endpoint"])
+        params = cast(dict[str, Any], endpoint_config["params"])
         assert params["order"] == "desc"
-        assert params["order"] != "asc"
         assert params["limit"] == WORKOS_ENDPOINTS[endpoint].page_size
 
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))

--- a/posthog/temporal/data_imports/sources/workos/workos.py
+++ b/posthog/temporal/data_imports/sources/workos/workos.py
@@ -98,7 +98,10 @@ def get_resource(name: str) -> EndpointResource:
         "params": {
             "limit": config.page_size,
             # Stable creation-ordered pagination so the cursor walks deterministically.
-            "order": "asc",
+            # Must be "desc" (the WorkOS SDK default): the high-volume directory_users
+            # and directory_groups list endpoints reject "order=asc" with a 422, while
+            # "desc" is accepted on every WorkOS list endpoint.
+            "order": "desc",
         },
     }
 


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a steady stream of `422 Unprocessable Entity` errors from the WorkOS data-warehouse import source, on two endpoints:

- `GET https://api.workos.com/directory_groups?limit=100&order=asc`
- `GET https://api.workos.com/directory_users?limit=100&order=asc`

Because the WorkOS source is built on the shared declarative `rest_source` client, these failures have no WorkOS-specific stack frame — they surface from `common/rest_source/rest_client.py` and are identifiable only by the `api.workos.com` URL in the exception value. Every page request for these two endpoints failed, so directory user/group sync never produced data.

The four other WorkOS endpoints (`organizations`, `users`, `connections`, `directories`) send the **identical** `limit=100&order=asc` and produced zero errors — which rules out a global problem and points at something specific to the two directory-sync endpoints.

## Changes

Root cause: `get_resource` hardcoded `order=asc` for every endpoint. The high-volume `directory_users` and `directory_groups` list endpoints reject `order=asc` with a 422 (WorkOS re-architected these two around a newer cursor-pagination model and no longer accept ascending order), whereas the other list endpoints still accept it.

The WorkOS SDK, auto-generated from their OpenAPI spec, always sends `order` and defaults it to `desc` for the directory list endpoints — and `desc` is accepted on every WorkOS list endpoint. If `desc` were rejected here, the official SDK's default listing would be broken for everyone, which it is not.

Fix: send `order=desc` instead of `order=asc`. This is a one-line change to the WorkOS source's endpoint config — the shared `rest_source` client and global retry policy are untouched. Pagination remains a deterministic, creation-ordered cursor walk (now newest-first); the source is full-refresh `replace`, so traversal direction does not affect correctness.

This is a request-construction bug, not a per-customer/credential issue: both endpoints failed identically and consistently, and the 422 is not silenced via `NonRetryableErrors` (that would just mask broken directory sync).

## How did you test this code?

I'm an agent. I did not perform manual testing against the live WorkOS API (it requires real credentials). I verified the root cause against the WorkOS API reference and the official auto-generated WorkOS SDK source (which always sends `order=desc` for these endpoints), and confirmed via error-tracking data that only the two directory endpoints fail while the other four send identical params successfully.

Automated tests I ran (all passing):

- Added a parametrized regression test (`test_resource_request_params_are_valid`) asserting that every WorkOS endpoint builds `order=desc` (never `order=asc`) and the expected `limit`.
- `posthog/temporal/data_imports/sources/workos/tests/test_workos.py` — 34 passed
- `posthog/temporal/data_imports/sources/workos/tests/test_workos_source.py` — 13 passed
- `ruff check` / `ruff format` — clean

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) via the PostHog Code agent.

Investigation: read the WorkOS source end to end; confirmed the failing requests and their onset via error-tracking `$exception` events; cross-referenced the WorkOS API reference and the official WorkOS Python SDK source (generated from their OpenAPI) to establish that `order=desc` is the proven-valid value on these endpoints.

Decisions:

- Rejected the "drop `order` entirely" option in favor of `desc` to match the WorkOS SDK default and preserve deterministic cursor pagination.
- Rejected adding the 422 to `NonRetryableErrors` — a consistently malformed request should be fixed, not silenced.
- Kept the change scoped to the WorkOS source's endpoint config; did not touch the shared `rest_source` client or retry policy.
