### PR TITLE
fix(dashboards): black tile titles on builtin-placement dashboards

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -666,7 +666,7 @@ export function InsightMetaContent({
 }): JSX.Element {
     const titleContent = (
         <>
-            <span className={clsx(infoPopover && 'truncate text-primary')}>
+            <span className={clsx('text-primary', infoPopover && 'truncate')}>
                 {title || <i>{fallbackTitle || 'Untitled'}</i>}
             </span>
             {(loading || loadingQueued) && (


### PR DESCRIPTION
## Problem

Insight tile titles render as **orange links** instead of black on dashboards using `DashboardPlacement.Builtin` — most visibly the AI observability dashboard (`/project/:id/ai-observability/dashboard`). Normal dashboards show black titles, so these embedded dashboards look inconsistent.

Root cause: the tile title is always wrapped in a `<Link>` (accent/orange color). The `text-primary` override that restores black text was added in #54213 but gated on `infoPopover`, which is only set for compact-tile placements (`Dashboard`/`ProjectHomepage`/`Public`). `Builtin` (and `Person`/`Group`/`FeatureFlag`) placements never get it, so the link's accent color shows through.

This traces back to #54197 inverting the `<Link>`/`<h4>` nesting (to free the info popover from the link's context menu), which exposed the accent color; #54213 was the follow-up fix but only covered compact tiles.

## Changes

Apply `text-primary` to the title `<span>` unconditionally, keeping `truncate` gated on `infoPopover` as before. This makes titles black across all placements, completing the intent of #54213.

```diff
-            <span className={clsx(infoPopover && 'truncate text-primary')}>
+            <span className={clsx('text-primary', infoPopover && 'truncate')}>
```

The title remains a `<Link>`, so hover/active states still use the accent color — only the resting color changes to match normal dashboards.

## How did you test this code?

I'm an agent (PostHog Slack app) and have **not** manually run the UI. I verified the change by tracing the render path and CSS: `.Link { color: var(--color-accent) }` (orange) is overridden by `text-primary` on the inner span, matching the behavior already in place for `Dashboard`-placement tiles. I did not add an automated test or run the existing suite. Recommend a quick visual check on the AI observability dashboard before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) at Carlos Marchal's request, investigating why AI observability dashboard tile titles render orange.

- Tools used: git history/blame analysis, `gh` PR inspection, codebase exploration.
- Investigation: titles were always inside a `<Link>`; black came from the `<h4>` wrapping the link until #54197 (2026-04-13) inverted the nesting and the accent color leaked through. #54213 fixed it for compact tiles only via an `infoPopover`-gated `text-primary`.
- Decision: chose to make `text-primary` unconditional (rather than adding `Builtin` to `showCompactTile`) — it's the minimal, faithful completion of #54213 and avoids pulling the full compact-tile treatment (info popover, etc.) into embedded dashboards.

Requires human review and a visual check; do not auto-merge.
