### PR TITLE
chore(slack_app): drain and deprecate posthog-code workflow.patched markers

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -285,14 +285,6 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             if not user_id:
                 return
 
-            # Commands (including `rules add` and its repo picker) are dispatched
-            # by PostHogCodeSlackMentionCommandWorkflow. The patch marker is
-            # preserved via `deprecate_patch` so any straggler workflow that
-            # recorded the pre-patch path on its first task can still replay
-            # deterministically. Drop the `deprecate_patch` call once the next
-            # drain completes.
-            workflow.deprecate_patch("posthog-code-mention-skip-rules-command")
-
             thread_messages = await _execute_posthog_code_activity(
                 collect_posthog_code_thread_messages_activity,
                 inputs,
@@ -301,13 +293,6 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             )
             if not thread_messages:
                 return
-
-            # Cascade fast-path before the discovery agent. The patch marker is
-            # preserved via `deprecate_patch` so any straggler workflow that
-            # recorded the pre-patch (`select_posthog_code_repository_activity`)
-            # path on its first task can still replay deterministically. Drop the
-            # `deprecate_patch` call once the next drain completes.
-            workflow.deprecate_patch("posthog-code-repo-discovery-agent-2026-05")
 
             repository: str | None
             # Set only on the ambiguous path that runs the discovery sandbox
@@ -483,13 +468,7 @@ async def _gate_on_personal_github(
     thread_ts: str,
     user_id: int,
 ) -> bool:
-    """Return True when the workflow must abort because the mentioner has no personal GitHub.
-
-    The patch marker is preserved via `deprecate_patch` so any straggler workflow
-    that recorded the pre-patch path on its first task can still replay
-    deterministically. Drop the `deprecate_patch` call once the next drain completes.
-    """
-    workflow.deprecate_patch("posthog-code-block-no-personal-github-2026-05")
+    """Return True when the workflow must abort because the mentioner has no personal GitHub."""
     return await _execute_posthog_code_activity(
         block_posthog_code_task_if_no_personal_github_activity,
         inputs,

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -299,23 +299,13 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             repo_research_task_id: str | None = None
             repo_research_run_id: str | None = None
 
-            # The cascade activity gained `user_id` and a new `needs_user_github`
-            # outcome. Gate the new shape so in-flight workflows that recorded
-            # the 2-arg cascade command keep matching history on replay; new
-            # workflows record the 3-arg shape and can take the new branch.
-            if workflow.patched("posthog-code-slack-user-github-2026-06"):
-                cascade = await _execute_posthog_code_activity(
-                    cascade_posthog_code_repository_activity,
-                    inputs,
-                    event.get("text", ""),
-                    user_id,
-                )
-            else:
-                cascade = await _execute_posthog_code_activity(
-                    cascade_posthog_code_repository_activity,
-                    inputs,
-                    event.get("text", ""),
-                )
+            workflow.deprecate_patch("posthog-code-slack-user-github-2026-06")
+            cascade = await _execute_posthog_code_activity(
+                cascade_posthog_code_repository_activity,
+                inputs,
+                event.get("text", ""),
+                user_id,
+            )
 
             if cascade.mode == "auto":
                 repository = cascade.repository
@@ -326,29 +316,26 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                 # answer with no repo; coding asks surface the connect-personal-
                 # GitHub prompt instead of silently no-op'ing.
                 repository = None
-                if workflow.patched("posthog-code-classify-before-gate-2026-06"):
-                    needs_repo = await _execute_posthog_code_activity(
-                        classify_posthog_code_task_needs_repo_activity,
-                        event.get("text", ""),
-                        thread_messages,
+                workflow.deprecate_patch("posthog-code-classify-before-gate-2026-06")
+                needs_repo = await _execute_posthog_code_activity(
+                    classify_posthog_code_task_needs_repo_activity,
+                    event.get("text", ""),
+                    thread_messages,
+                )
+                if needs_repo:
+                    blocked = await _execute_posthog_code_activity(
+                        block_posthog_code_task_if_no_personal_github_activity,
+                        inputs,
+                        channel,
+                        thread_ts,
+                        user_id,
                     )
-                    if needs_repo:
-                        blocked = await _execute_posthog_code_activity(
-                            block_posthog_code_task_if_no_personal_github_activity,
-                            inputs,
-                            channel,
-                            thread_ts,
-                            user_id,
-                        )
-                        if blocked:
-                            return
+                    if blocked:
+                        return
             elif cascade.mode == "needs_user_github":
                 # Team has GitHub, but the mentioning user hasn't connected their
                 # personal install. Fire the gate so they get the Connect button
-                # instead of a silently no-repo task. Only reachable on the patched
-                # path — the cascade activity never emits this outcome when called
-                # without `user_id`, so pre-patch workflows on replay don't see a
-                # new activity command appear in history.
+                # instead of a silently no-repo task.
                 await _execute_posthog_code_activity(
                     block_posthog_code_task_if_no_personal_github_activity,
                     inputs,
@@ -388,31 +375,18 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                         # Agent crashed/timed out/hallucinated — italicize its reason
                         # above the picker guidance so the user sees why.
                         picker_guidance = f"_{outcome.reason}_\n\n{POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE}"
-                        if workflow.patched("posthog-code-slack-user-github-2026-06"):
-                            await _execute_posthog_code_activity(
-                                post_posthog_code_repo_picker_activity,
-                                inputs,
-                                channel,
-                                thread_ts,
-                                slack_user_id,
-                                event,
-                                workflow.info().workflow_id,
-                                picker_guidance,
-                                True,
-                                user_id,
-                            )
-                        else:
-                            await _execute_posthog_code_activity(
-                                post_posthog_code_repo_picker_activity,
-                                inputs,
-                                channel,
-                                thread_ts,
-                                slack_user_id,
-                                event,
-                                workflow.info().workflow_id,
-                                picker_guidance,
-                                True,
-                            )
+                        await _execute_posthog_code_activity(
+                            post_posthog_code_repo_picker_activity,
+                            inputs,
+                            channel,
+                            thread_ts,
+                            slack_user_id,
+                            event,
+                            workflow.info().workflow_id,
+                            picker_guidance,
+                            True,
+                            user_id,
+                        )
                         try:
                             await workflow.wait_condition(
                                 lambda: self._repo_selection_resolved,

--- a/posthog/temporal/ai/posthog_code_slack_mention_command.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention_command.py
@@ -117,54 +117,33 @@ class PostHogCodeSlackMentionCommandWorkflow(PostHogWorkflow):
             slack_team_id=inputs.slack_team_id,
         )
 
-        # Pre-patch command workflows skip the gate entirely and behave as before,
-        # so in-flight replays don't trip nondeterminism on the new activity command.
-        if workflow.patched("posthog-code-command-block-no-personal-github-2026-06"):
-            blocked = await workflow.execute_activity(
-                block_posthog_code_task_if_no_personal_github_activity,
-                args=[picker_inputs, channel, thread_ts, user_id],
-                start_to_close_timeout=timedelta(seconds=POSTHOG_CODE_SLACK_COMMAND_ACTIVITY_TIMEOUT_SECONDS),
-                retry_policy=RetryPolicy(maximum_attempts=3),
-            )
-            if blocked:
-                return
+        workflow.deprecate_patch("posthog-code-command-block-no-personal-github-2026-06")
+        blocked = await workflow.execute_activity(
+            block_posthog_code_task_if_no_personal_github_activity,
+            args=[picker_inputs, channel, thread_ts, user_id],
+            start_to_close_timeout=timedelta(seconds=POSTHOG_CODE_SLACK_COMMAND_ACTIVITY_TIMEOUT_SECONDS),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+        if blocked:
+            return
 
-        # Pre-patch command workflows replay through the 8-arg call shape so the
-        # recorded picker command matches history; new workflows append `user_id`
-        # as the final positional arg, matching the picker activity's signature.
-        if workflow.patched("posthog-code-command-user-id-2026-06"):
-            await workflow.execute_activity(
-                post_posthog_code_repo_picker_activity,
-                args=[
-                    picker_inputs,
-                    channel,
-                    thread_ts,
-                    slack_user_id,
-                    inputs.event,
-                    workflow.info().workflow_id,
-                    POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE,
-                    False,
-                    user_id,
-                ],
-                start_to_close_timeout=timedelta(seconds=POSTHOG_CODE_SLACK_COMMAND_ACTIVITY_TIMEOUT_SECONDS),
-                retry_policy=RetryPolicy(maximum_attempts=3),
-            )
-        else:
-            await workflow.execute_activity(
-                post_posthog_code_repo_picker_activity,
-                args=[
-                    picker_inputs,
-                    channel,
-                    thread_ts,
-                    slack_user_id,
-                    inputs.event,
-                    workflow.info().workflow_id,
-                    POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE,
-                    False,
-                ],
-                start_to_close_timeout=timedelta(seconds=POSTHOG_CODE_SLACK_COMMAND_ACTIVITY_TIMEOUT_SECONDS),
-                retry_policy=RetryPolicy(maximum_attempts=3),
-            )
+        workflow.deprecate_patch("posthog-code-command-user-id-2026-06")
+        await workflow.execute_activity(
+            post_posthog_code_repo_picker_activity,
+            args=[
+                picker_inputs,
+                channel,
+                thread_ts,
+                slack_user_id,
+                inputs.event,
+                workflow.info().workflow_id,
+                POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE,
+                False,
+                user_id,
+            ],
+            start_to_close_timeout=timedelta(seconds=POSTHOG_CODE_SLACK_COMMAND_ACTIVITY_TIMEOUT_SECONDS),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
 
         try:
             await workflow.wait_condition(


### PR DESCRIPTION
## Problem

The posthog-code Slack workflows in `posthog/temporal/ai/` carry several `workflow.patched` markers from earlier rollouts. Mention workflows are short-lived (capped at ~45 min by activity + picker timeouts), so anything older than a day or two has drained. This PR mows the lawn in two phases.

## Changes

Two commits:

**1. `chore(slack_app): drop drained workflow.patched markers from May 2026`** — deletes three already-deprecated markers whose drain window closed weeks ago:

| Marker | Shipped | Deprecated |
|---|---|---|
| `posthog-code-block-no-personal-github-2026-05` | 2026-05-26 (#59890) | drop |
| `posthog-code-mention-skip-rules-command` | 2026-05-29 (#60249) | drop |
| `posthog-code-repo-discovery-agent-2026-05` | 2026-05-26 (#57655), deprecated 2026-06-03 | drop |

**2. `chore(slack_app): deprecate June 2026 workflow.patched markers`** — downgrades four still-`patched` markers shipped on 2026-06-02 (~6 days ago, well past the 45-min workflow lifetime) to `deprecate_patch`, collapsing each `if patched: A else: B` to the new-code arm. The follow-up PR will delete these once another drain window passes.

| Marker | Location |
|---|---|
| `posthog-code-command-block-no-personal-github-2026-06` | `posthog_code_slack_mention_command.py` |
| `posthog-code-command-user-id-2026-06` | `posthog_code_slack_mention_command.py` |
| `posthog-code-slack-user-github-2026-06` | `posthog_code_slack_mention.py` (was used at two call sites; one `deprecate_patch` covers the path) |
| `posthog-code-classify-before-gate-2026-06` | `posthog_code_slack_mention.py` |

Mirrors the convention from #61333 and #57655's follow-up.

## How did you test this code?

Tested locally: ran `posthog/temporal/tests/ai/test_module_integrity.py` (13 passed) and `posthog/temporal/tests/ai/test_block_missing_user_github.py` (4 passed). No behavior change for new workflows — purely marker management.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Claude (Opus 4.7) inventoried the patch markers, cross-checked introduction dates via `git log -S`, and applied the two-step delete/deprecate pattern from `0fa597d26c5`/#61333.