### PR TITLE
chore(temporal): register posthog-code slack workflows on tasks queue

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -349,7 +349,7 @@ jobs:
             - name: Check for changes that affect Tasks Agent Temporal worker
               id: check_changes_tasks_agent_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^products/tasks/backend|^posthog/tasks/|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/ai/posthog_code_slack_|^posthog/temporal/ai/slack_app/|^products/slack_app/backend|^products/tasks/backend|^posthog/tasks/|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -20,7 +20,7 @@ with workflow.unsafe.imports_passed_through():
     from django.core.management.base import BaseCommand
 
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.temporal.ai import AI_ACTIVITIES, AI_WORKFLOWS
+from posthog.temporal.ai import AI_ACTIVITIES, AI_WORKFLOWS, POSTHOG_CODE_SLACK_ACTIVITIES, POSTHOG_CODE_SLACK_WORKFLOWS
 from posthog.temporal.ai_observability import (
     ACTIVITIES as LLM_ANALYTICS_ACTIVITIES,
     EVAL_ACTIVITIES as LLM_ANALYTICS_EVAL_ACTIVITIES,
@@ -287,8 +287,13 @@ _task_queue_specs = [
     ),
     (
         settings.TASKS_TASK_QUEUE,
-        TASKS_WORKFLOWS,
-        TASKS_ACTIVITIES,
+        # PostHog Code Slack workflows are also registered on MAX_AI_TASK_QUEUE.
+        # First step of merging them onto this queue — once master traffic has
+        # cut over and any in-flight runs have drained, drop them from
+        # AI_WORKFLOWS / AI_ACTIVITIES and flip the start_workflow callers in
+        # products/slack_app to settings.TASKS_TASK_QUEUE.
+        TASKS_WORKFLOWS + POSTHOG_CODE_SLACK_WORKFLOWS,
+        TASKS_ACTIVITIES + POSTHOG_CODE_SLACK_ACTIVITIES,
     ),
     (
         settings.MAX_AI_TASK_QUEUE,

--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -32,6 +32,21 @@ from .sync_vectors import (
     get_approximate_actions_count,
 )
 
+# The PostHog Code Slack workflows handed off to ProcessTaskWorkflow on the tasks
+# queue once a repo was picked, so the two queues were already paired. Exposing
+# them as a subset lets the tasks-agent worker register them alongside the AI
+# worker during the migration to a single queue.
+POSTHOG_CODE_SLACK_WORKFLOWS = [
+    PostHogCodeSlackMentionWorkflow,
+    PostHogCodeSlackMentionCommandWorkflow,
+    PostHogCodeSlackTerminateTaskWorkflow,
+]
+
+POSTHOG_CODE_SLACK_ACTIVITIES = [
+    *SLACK_APP_ACTIVITIES,
+    process_posthog_code_terminate_task_activity,
+]
+
 AI_WORKFLOWS = [
     SyncVectorsWorkflow,
     AssistantConversationRunnerWorkflow,
@@ -39,9 +54,7 @@ AI_WORKFLOWS = [
     ResearchAgentWorkflow,
     SummarizeLLMTracesWorkflow,
     SlackConversationRunnerWorkflow,
-    PostHogCodeSlackMentionWorkflow,
-    PostHogCodeSlackMentionCommandWorkflow,
-    PostHogCodeSlackTerminateTaskWorkflow,
+    *POSTHOG_CODE_SLACK_WORKFLOWS,
     AnomalyInvestigationWorkflow,
 ]
 
@@ -54,8 +67,7 @@ AI_ACTIVITIES = [
     process_research_agent_activity,
     summarize_llm_traces_activity,
     process_slack_conversation_activity,
-    *SLACK_APP_ACTIVITIES,
-    process_posthog_code_terminate_task_activity,
+    *POSTHOG_CODE_SLACK_ACTIVITIES,
     investigate_anomaly_activity,
 ]
 


### PR DESCRIPTION
## Problem

The PostHog Code Slack workflows (`PostHogCodeSlackMentionWorkflow`, `PostHogCodeSlackMentionCommandWorkflow`, `PostHogCodeSlackTerminateTaskWorkflow`) run on `MAX_AI_TASK_QUEUE`, then hand off to `ProcessTaskWorkflow` on `TASKS_TASK_QUEUE` once a repo is picked. The two queues are already paired — splitting them across workers adds operational surface area without isolation benefit.

This PR is step 1 of merging them onto the tasks-agent worker. It's a no-op for traffic: workflows are still _started_ on `MAX_AI_TASK_QUEUE`. The change just makes the tasks-agent worker capable of serving them, so a follow-up can flip the start_workflow callers without dropping in-flight runs.

## Changes

- Extract `POSTHOG_CODE_SLACK_WORKFLOWS` / `POSTHOG_CODE_SLACK_ACTIVITIES` subsets in `posthog/temporal/ai/__init__.py`. `AI_WORKFLOWS` / `AI_ACTIVITIES` retain identical contents.
- Register those subsets on the `TASKS_TASK_QUEUE` spec in `start_temporal_worker.py`. They remain registered on `MAX_AI_TASK_QUEUE` via `AI_WORKFLOWS` / `AI_ACTIVITIES`.
- Add `posthog/temporal/ai/posthog_code_slack_` and `posthog/temporal/ai/slack_app/` to the tasks-agent CI watcher in `container-images-cd.yml` so edits to those modules redeploy the tasks-agent image (they already redeploy max-ai via the catch-all `.py` watcher).

Follow-up PR will:

1. Flip the `task_queue=settings.MAX_AI_TASK_QUEUE` call sites in `products/slack_app/backend/api.py` to `TASKS_TASK_QUEUE`.
2. Drop the slack workflows/activities from `AI_WORKFLOWS` / `AI_ACTIVITIES`.
3. Extend the OTel force-enable condition in `start_temporal_worker.py` (currently only fires for `MAX_AI_TASK_QUEUE`) so Slack-agent traces keep connecting to the upstream Django spans.

## How did you test this code?

- Ran `posthog/temporal/tests/ai/test_module_integrity.py` — 13/13 pass; `AI_WORKFLOWS` / `AI_ACTIVITIES` contents unchanged.
- Verified locally end-to-end against a local PostHog stack: dispatched a Slack mention, confirmed both workers boot with the new registration and the workflow still runs on `max-ai` (callers haven't flipped yet on this PR).

## 🤖 Agent context

Model: Claude Opus 4.7