### PR TITLE
fix(session-replay): allow mp4 export during read-only mode

### DIFF
--- a/frontend/src/lib/readOnlyGuard.test.ts
+++ b/frontend/src/lib/readOnlyGuard.test.ts
@@ -100,6 +100,9 @@ describe('readOnlyGuard', () => {
                 ['AI conversation queue clear', 'POST', '/api/environments/2/conversations/abc-123/queue/clear'],
                 ['AI conversation append message', 'POST', '/api/environments/2/conversations/abc-123/append_message'],
                 ['AI conversation cancel', 'PATCH', '/api/environments/2/conversations/abc-123/cancel/'],
+                ['session replay export create', 'POST', '/api/environments/2/exports/'],
+                ['session replay export create (projects)', 'POST', '/api/projects/2/exports/'],
+                ['export create with query string', 'POST', '/api/environments/2/exports/?export_format=video/mp4'],
             ] as const)('lets %s through (%s %s)', (_label, method, url) => {
                 const notifier = jest.fn()
                 setReadOnlyNotifier(notifier)
@@ -130,6 +133,8 @@ describe('readOnlyGuard', () => {
                     '/api/environments/2/conversations/tickets/',
                 ],
                 ['conversations-like prefix blocked', 'POST', '/api/environments/2/conversationsfoo/'],
+                ['export detail write blocked', 'DELETE', '/api/environments/2/exports/123/'],
+                ['exports-like prefix blocked', 'POST', '/api/environments/2/exportsfoo/'],
             ] as const)('still blocks %s (%s %s) — only allowlisted paths pass', (_l, method, url) => {
                 expect(() => assertNotReadOnly(method, url)).toThrow(ReadOnlyModeError)
             })

--- a/frontend/src/lib/readOnlyGuard.ts
+++ b/frontend/src/lib/readOnlyGuard.ts
@@ -71,6 +71,8 @@ export function isReadOnly(): boolean {
 //      Matches /conversations except the two ticket sub-features (`views` and
 //      `tickets`). Mount-path-agnostic — works under /environments/ or
 //      /projects/ — so the discriminator is the sub-feature, not the prefix.
+//   4. Exports — POST creates a render job (session replay MP4, insight PNG, etc.)
+//      but does not mutate product data; blocking it breaks download workflows.
 const READ_ONLY_ALLOWED_PATTERNS = [
     /\/query(?:\/|$|\?)/, // /api/environments/:team_id/query, /api/environments/:team_id/query/:queryId/log, etc.
     /\/file_system\/log_view(?:\/|$|\?)/, // /api/environments/:team_id/file_system/log_view
@@ -78,6 +80,7 @@ const READ_ONLY_ALLOWED_PATTERNS = [
     /\/insights\/timing(?:\/|$|\?)/, // /api/projects/:team_id/insights/timing — time-to-see-data telemetry fired after every dashboard/insight load
     /\/metalytics(?:\/|$|\?)/, // /api/projects/:team_id/metalytics — side-panel scene view tracking (only accepts metric_name=viewed)
     /\/conversations(?!\/(?:views|tickets))(?:\/|$|\?)/, // /api/.../conversations[/:id[/queue|/append_message|/cancel|...]] — PostHog AI (Max), excluding /conversations/views and /conversations/tickets
+    /\/exports\/?(?:\?|$)/, // /api/.../exports[/] — create export jobs only; detail paths like /exports/:id/ stay blocked
 ]
 
 function isReadDisguisedAsWrite(url: string): boolean {

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1189,6 +1189,8 @@ READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
     # for a data warehouse schema. Validates external credentials and lists schemas
     # against the customer's source — no PostHog-side mutations.
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/external_data_schemas/[^/]+/incremental_fields/?$"),
+    # POST but read-only: kicks off insight/dashboard/session replay export renders (e.g. MP4)
+    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/exports/?$"),
     # Allow upgrading from read-only to read-write impersonation
     "/admin/impersonation/upgrade/",
     # Logout is POST in Django 5; the frontend submits to `/logout` (no trailing slash),

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -790,6 +790,11 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
                 "external_data_schemas/00000000-0000-0000-0000-000000000000/incremental_fields/",
                 {},
             ),
+            (
+                "exports",
+                "exports/",
+                {"export_format": "video/mp4", "export_context": {"session_recording_id": "test-session"}},
+            ),
         ]
     )
     def test_read_only_impersonation_allows_allowlisted_post(self, _name, path_suffix, body):


### PR DESCRIPTION
## Problem

Session replay MP4 export fails in read-only mode because creating an export job POSTs to `/api/.../exports/`, which the read-only guard treats as a blocked mutation.

Reported in [Zendesk #59864](https://posthoghelp.zendesk.com/agent/tickets/59864) (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61305).

## Changes

- Allowlist the exports collection endpoint in the frontend `readOnlyGuard` (create-only; `/exports/:id/` paths stay blocked)
- Allowlist the same endpoint in `ImpersonationReadOnlyMiddleware` for read-only impersonation sessions
- Add unit tests for both layers

## How did you test this code?

Ran `pnpm --filter=@posthog/frontend exec jest frontend/src/lib/readOnlyGuard.test.ts --no-coverage` (65 tests passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Cursor agent implemented this after a report that session replay MP4 export showed a read-only mode error. The fix follows the existing pattern for read-disguised-as-write endpoints (`/query`, `/insights/viewed`, etc.): exports kick off a render/download job without mutating product analytics data. Frontend and backend allowlists were updated together so both the `read-only-mode` feature flag and read-only impersonation behave consistently.