### PR TITLE
fix(llma): make evaluation report enabled toggle persist as pause

### DIFF
--- a/products/ai_observability/backend/api/evaluation_reports.py
+++ b/products/ai_observability/backend/api/evaluation_reports.py
@@ -4,6 +4,7 @@ import datetime as dt
 from typing import Any
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models import QuerySet
 
 import structlog
@@ -22,6 +23,7 @@ from posthog.permissions import AccessControlPermission
 
 from products.ai_observability.backend.api.metrics import llma_track_latency
 from products.ai_observability.backend.models.evaluation_reports import EvaluationReport, EvaluationReportRun
+from products.ai_observability.backend.models.evaluations import Evaluation
 from products.workflows.backend.utils.rrule_utils import validate_rrule
 
 logger = structlog.get_logger(__name__)
@@ -322,8 +324,29 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
     def partial_update(self, request: Request, *args, **kwargs) -> Response:
         return super().partial_update(request, *args, **kwargs)
 
-    def perform_create(self, serializer):
-        instance = serializer.save()
+    def _validate_single_non_deleted_config(
+        self, evaluation: Evaluation, exclude_report: EvaluationReport | None = None
+    ) -> None:
+        Evaluation.objects.select_for_update().get(id=evaluation.id, team_id=self.team_id)
+        existing_reports = EvaluationReport.objects.filter(
+            team_id=self.team_id,
+            evaluation=evaluation,
+            deleted=False,
+        )
+        if exclude_report is not None:
+            existing_reports = existing_reports.exclude(id=exclude_report.id)
+        if existing_reports.exists():
+            raise serializers.ValidationError(
+                {"evaluation": "An evaluation can only have one non-deleted report config."}
+            )
+
+    def perform_create(self, serializer: EvaluationReportSerializer) -> None:
+        with transaction.atomic():
+            evaluation = serializer.validated_data["evaluation"]
+            if serializer.validated_data.get("deleted") is not True:
+                self._validate_single_non_deleted_config(evaluation)
+            instance = serializer.save()
+
         report_user_action(
             self.request.user,
             "llma evaluation report created",
@@ -345,7 +368,22 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
             request=self.request,
         )
 
-    def perform_update(self, serializer):
+    def perform_update(self, serializer: EvaluationReportSerializer) -> None:
+        target_evaluation = serializer.validated_data.get("evaluation", serializer.instance.evaluation)
+        target_deleted = serializer.validated_data.get("deleted", serializer.instance.deleted)
+        is_becoming_non_deleted = serializer.instance.deleted and target_deleted is False
+        is_moving_while_non_deleted = (
+            target_deleted is False and target_evaluation.id != serializer.instance.evaluation_id
+        )
+        if is_becoming_non_deleted or is_moving_while_non_deleted:
+            with transaction.atomic():
+                self._validate_single_non_deleted_config(target_evaluation, exclude_report=serializer.instance)
+                self._perform_update_and_track(serializer)
+            return
+
+        self._perform_update_and_track(serializer)
+
+    def _perform_update_and_track(self, serializer: EvaluationReportSerializer) -> None:
         tracked_fields = [
             "frequency",
             "rrule",

--- a/products/ai_observability/backend/api/evaluation_reports.py
+++ b/products/ai_observability/backend/api/evaluation_reports.py
@@ -1,7 +1,7 @@
 """API endpoints for evaluation report configuration and report run history."""
 
 import datetime as dt
-from typing import Any
+from typing import Any, cast
 
 from django.conf import settings
 from django.db import transaction
@@ -340,7 +340,7 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
                 {"evaluation": "An evaluation can only have one non-deleted report config."}
             )
 
-    def perform_create(self, serializer: EvaluationReportSerializer) -> None:
+    def perform_create(self, serializer: serializers.BaseSerializer) -> None:
         with transaction.atomic():
             evaluation = serializer.validated_data["evaluation"]
             if serializer.validated_data.get("deleted") is not True:
@@ -368,22 +368,21 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
             request=self.request,
         )
 
-    def perform_update(self, serializer: EvaluationReportSerializer) -> None:
-        target_evaluation = serializer.validated_data.get("evaluation", serializer.instance.evaluation)
-        target_deleted = serializer.validated_data.get("deleted", serializer.instance.deleted)
-        is_becoming_non_deleted = serializer.instance.deleted and target_deleted is False
-        is_moving_while_non_deleted = (
-            target_deleted is False and target_evaluation.id != serializer.instance.evaluation_id
-        )
+    def perform_update(self, serializer: serializers.BaseSerializer) -> None:
+        current = cast(EvaluationReport, serializer.instance)
+        target_evaluation = serializer.validated_data.get("evaluation", current.evaluation)
+        target_deleted = serializer.validated_data.get("deleted", current.deleted)
+        is_becoming_non_deleted = current.deleted and target_deleted is False
+        is_moving_while_non_deleted = target_deleted is False and target_evaluation.id != current.evaluation_id
         if is_becoming_non_deleted or is_moving_while_non_deleted:
             with transaction.atomic():
-                self._validate_single_non_deleted_config(target_evaluation, exclude_report=serializer.instance)
+                self._validate_single_non_deleted_config(target_evaluation, exclude_report=current)
                 self._perform_update_and_track(serializer)
             return
 
         self._perform_update_and_track(serializer)
 
-    def _perform_update_and_track(self, serializer: EvaluationReportSerializer) -> None:
+    def _perform_update_and_track(self, serializer: serializers.BaseSerializer) -> None:
         tracked_fields = [
             "frequency",
             "rrule",
@@ -398,14 +397,12 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
             "cooldown_minutes",
             "daily_run_cap",
         ]
-        is_deletion = serializer.validated_data.get("deleted") is True and not serializer.instance.deleted
+        current = cast(EvaluationReport, serializer.instance)
+        is_deletion = serializer.validated_data.get("deleted") is True and not current.deleted
 
         changed_fields: list[str] = []
         for field in tracked_fields:
-            if (
-                field in serializer.validated_data
-                and getattr(serializer.instance, field) != serializer.validated_data[field]
-            ):
+            if field in serializer.validated_data and getattr(current, field) != serializer.validated_data[field]:
                 changed_fields.append(field)
 
         instance = serializer.save()
@@ -417,7 +414,7 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
                 {
                     "evaluation_report_id": str(instance.id),
                     "evaluation_id": str(instance.evaluation_id),
-                    "was_enabled": serializer.instance.enabled,
+                    "was_enabled": current.enabled,
                 },
                 team=self.team,
                 request=self.request,

--- a/products/ai_observability/backend/api/test/test_evaluation_reports.py
+++ b/products/ai_observability/backend/api/test/test_evaluation_reports.py
@@ -139,6 +139,23 @@ class TestEvaluationReportApi(APIBaseTest):
         response = self.client.post(self.base_url, self._scheduled_payload(delivery_targets=[]), format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_create_rejects_second_non_deleted_report_for_evaluation(self):
+        self._create_report()
+
+        response = self.client.post(self.base_url, self._scheduled_payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json().get("attr"), "evaluation")
+        self.assertEqual(EvaluationReport.objects.filter(evaluation=self.evaluation, deleted=False).count(), 1)
+
+    def test_create_allows_report_when_existing_config_is_deleted(self):
+        self._create_report(deleted=True)
+
+        response = self.client.post(self.base_url, self._scheduled_payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        self.assertEqual(EvaluationReport.objects.filter(evaluation=self.evaluation, deleted=False).count(), 1)
+
     def test_create_scheduled_requires_rrule(self):
         response = self.client.post(self.base_url, self._scheduled_payload(rrule=""), format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -337,6 +354,51 @@ class TestEvaluationReportApi(APIBaseTest):
         report.refresh_from_db()
         self.assertEqual(report.frequency, "scheduled")
         self.assertEqual(report.rrule, "FREQ=WEEKLY;BYDAY=MO")
+
+    def test_update_allows_editing_existing_historical_duplicate_reports(self):
+        self._create_report()
+        duplicate = self._create_report(delivery_targets=[{"type": "email", "value": "duplicate@example.com"}])
+
+        response = self.client.patch(f"{self.base_url}{duplicate.id}/", {"enabled": False}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        duplicate.refresh_from_db()
+        self.assertFalse(duplicate.enabled)
+
+    def test_update_rejects_undeleting_report_when_non_deleted_config_exists(self):
+        self._create_report()
+        deleted_report = self._create_report(deleted=True)
+
+        response = self.client.patch(f"{self.base_url}{deleted_report.id}/", {"deleted": False}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json().get("attr"), "evaluation")
+        deleted_report.refresh_from_db()
+        self.assertTrue(deleted_report.deleted)
+
+    def test_update_rejects_moving_report_to_evaluation_with_non_deleted_config(self):
+        self._create_report()
+        other_evaluation = Evaluation.objects.create(
+            team=self.team,
+            name="Other Eval",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "other"},
+            output_type="boolean",
+            output_config={},
+            enabled=True,
+            created_by=self.user,
+            conditions=[{"id": "c1", "rollout_percentage": 100, "properties": []}],
+        )
+        report = self._create_report(evaluation=other_evaluation)
+
+        response = self.client.patch(
+            f"{self.base_url}{report.id}/", {"evaluation": str(self.evaluation.id)}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json().get("attr"), "evaluation")
+        report.refresh_from_db()
+        self.assertEqual(report.evaluation_id, other_evaluation.id)
 
     def test_delete_returns_405(self):
         report = self._create_report()

--- a/products/ai_observability/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/ai_observability/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -286,34 +286,37 @@ function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.El
 
 /** Toggle-based report management for existing evaluations.
  * The "Save changes" button at the top of the evaluation page persists any
- * draft updates — see llmEvaluationLogic.saveEvaluation, which forwards
- * the draft to persistReportDraft. Disabling the toggle with a saved report
- * is still an immediate destructive action (handled via the dialog) rather
- * than a staged save. */
+ * draft field updates — see llmEvaluationLogic.saveEvaluation, which forwards
+ * the draft to persistReportDraft. The enabled toggle is owned here, not by
+ * that Save: flipping it pauses/resumes the report immediately (setReportsEnabled),
+ * keeping its config intact, so Save can never silently re-enable a paused report. */
 function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
     const logic = evaluationReportLogic({ evaluationId })
     const { activeReport, reportsLoading, configDraft, isConfigDirty } = useValues(logic)
-    const { deleteReport, setDraftEnabled } = useActions(logic)
+    const { setReportsEnabled, setDraftEnabled } = useActions(logic)
 
-    const isEnabled = !!activeReport || configDraft.enabled
+    const isEnabled = activeReport ? activeReport.enabled : configDraft.enabled
 
     const handleToggle = (checked: boolean): void => {
-        if (checked) {
-            setDraftEnabled(true)
-        } else if (activeReport) {
-            LemonDialog.open({
-                title: 'Disable scheduled reports?',
-                description: 'This will stop all future report deliveries. Past reports will be preserved.',
-                primaryButton: {
-                    children: 'Disable',
-                    status: 'danger',
-                    onClick: () => deleteReport(activeReport.id),
-                },
-                secondaryButton: { children: 'Cancel' },
-            })
-        } else {
-            setDraftEnabled(false)
+        if (!activeReport) {
+            // No saved report yet — just stage the draft toggle until the page is saved.
+            setDraftEnabled(checked)
+            return
         }
+        if (checked) {
+            setReportsEnabled(true)
+            return
+        }
+        LemonDialog.open({
+            title: 'Pause scheduled reports?',
+            description:
+                'This stops future report deliveries but keeps the configuration. You can re-enable it anytime. Past reports are preserved.',
+            primaryButton: {
+                children: 'Pause',
+                onClick: () => setReportsEnabled(false),
+            },
+            secondaryButton: { children: 'Cancel' },
+        })
     }
 
     return (

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
@@ -3,7 +3,8 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { evaluationReportLogic } from './evaluationReportLogic'
+import { evaluationReportLogic, persistReportDraft } from './evaluationReportLogic'
+import type { ReportConfigDraft } from './evaluationReportLogic'
 import { EvaluationReport } from './types'
 
 const makeReport = (overrides: Partial<EvaluationReport> = {}): EvaluationReport => ({
@@ -28,6 +29,21 @@ const makeReport = (overrides: Partial<EvaluationReport> = {}): EvaluationReport
     ...overrides,
 })
 
+const makeDraft = (overrides: Partial<ReportConfigDraft> = {}): ReportConfigDraft => ({
+    enabled: true,
+    frequency: 'every_n',
+    rrule: '',
+    startsAt: null,
+    timezoneName: 'UTC',
+    emailValue: 'team@example.com',
+    slackIntegrationId: null,
+    slackChannelValue: '',
+    reportPromptGuidance: '',
+    triggerThreshold: 100,
+    cooldownHours: 1,
+    ...overrides,
+})
+
 describe('evaluationReportLogic', () => {
     let logic: ReturnType<typeof evaluationReportLogic.build>
     // The mock handlers read these lazily at request time, so each test sets
@@ -35,14 +51,23 @@ describe('evaluationReportLogic', () => {
     // body to an evaluation_reports detail route, in call order.
     let reports: EvaluationReport[]
     let patchBodies: Record<string, unknown>[]
+    let createBodies: Record<string, unknown>[]
 
     beforeEach(() => {
         reports = []
         patchBodies = []
+        createBodies = []
         useMocks({
             get: {
                 '/api/environments/:teamId/llm_analytics/evaluation_reports/': () => [200, { results: reports }],
                 '/api/environments/:teamId/llm_analytics/evaluation_reports/:id/runs/': { results: [] },
+            },
+            post: {
+                '/api/environments/:teamId/llm_analytics/evaluation_reports/': async (req) => {
+                    const body = (await req.json()) as Record<string, unknown>
+                    createBodies.push(body)
+                    return [201, makeReport({ id: 'created-report', ...body })]
+                },
             },
             patch: {
                 '/api/environments/:teamId/llm_analytics/evaluation_reports/:id/': async (req) => {
@@ -126,5 +151,35 @@ describe('evaluationReportLogic', () => {
             expect.objectContaining({ id: 'report-1', enabled: true }),
             expect.objectContaining({ id: 'report-2', enabled: false }),
         ])
+    })
+
+    it('persists a new evaluation report draft by updating the auto-created report config', async () => {
+        reports = [makeReport({ id: 'auto-created-report', delivery_targets: [] })]
+
+        const didPersist = await persistReportDraft(
+            1,
+            'eval-1',
+            makeDraft({ emailValue: 'new-recipient@example.com' }),
+            null
+        )
+
+        expect(didPersist).toBe(true)
+        expect(createBodies).toEqual([])
+        expect(patchBodies).toEqual([
+            expect.objectContaining({
+                delivery_targets: [{ type: 'email', value: 'new-recipient@example.com' }],
+                trigger_threshold: 100,
+            }),
+        ])
+    })
+
+    it('persists a disabled new evaluation report draft by pausing the auto-created report config', async () => {
+        reports = [makeReport({ id: 'auto-created-report' })]
+
+        const didPersist = await persistReportDraft(1, 'eval-1', makeDraft({ enabled: false }), null)
+
+        expect(didPersist).toBe(true)
+        expect(createBodies).toEqual([])
+        expect(patchBodies).toEqual([{ enabled: false }])
     })
 })

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
@@ -1,0 +1,123 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { evaluationReportLogic } from './evaluationReportLogic'
+import { EvaluationReport } from './types'
+
+const makeReport = (overrides: Partial<EvaluationReport> = {}): EvaluationReport => ({
+    id: 'report-1',
+    evaluation: 'eval-1',
+    frequency: 'every_n',
+    rrule: '',
+    starts_at: null,
+    timezone_name: 'UTC',
+    next_delivery_date: null,
+    delivery_targets: [{ type: 'email', value: 'team@example.com' }],
+    max_sample_size: 100,
+    enabled: true,
+    deleted: false,
+    last_delivered_at: null,
+    report_prompt_guidance: '',
+    trigger_threshold: 100,
+    cooldown_minutes: 60,
+    daily_run_cap: 10,
+    created_by: null,
+    created_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+})
+
+describe('evaluationReportLogic', () => {
+    let logic: ReturnType<typeof evaluationReportLogic.build>
+    // The mock handlers read these lazily at request time, so each test sets
+    // `reports` before triggering loadReports. `patchBodies` records every PATCH
+    // body to an evaluation_reports detail route, in call order.
+    let reports: EvaluationReport[]
+    let patchBodies: Record<string, unknown>[]
+
+    beforeEach(() => {
+        reports = []
+        patchBodies = []
+        useMocks({
+            get: {
+                '/api/environments/:teamId/llm_analytics/evaluation_reports/': () => [200, { results: reports }],
+                '/api/environments/:teamId/llm_analytics/evaluation_reports/:id/runs/': { results: [] },
+            },
+            patch: {
+                '/api/environments/:teamId/llm_analytics/evaluation_reports/:id/': async (req) => {
+                    const body = (await req.json()) as Record<string, unknown>
+                    patchBodies.push(body)
+                    const id = req.params.id as string
+                    const current = reports.find((r) => r.id === id) ?? makeReport({ id })
+                    return [200, { ...current, ...body }]
+                },
+            },
+        })
+
+        initKeaTests()
+        logic = evaluationReportLogic({ evaluationId: 'eval-1' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('seeds the draft from the report enabled state rather than forcing true', async () => {
+        reports = [makeReport({ enabled: false })]
+        logic.actions.loadReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.configDraft.enabled).toBe(false)
+    })
+
+    it('treats a paused (enabled=false) report as the active report', async () => {
+        reports = [makeReport({ enabled: false })]
+        logic.actions.loadReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.activeReport).toEqual(expect.objectContaining({ id: 'report-1', enabled: false }))
+    })
+
+    it('disabling persists enabled:false without soft-deleting', async () => {
+        reports = [makeReport({ enabled: true })]
+        logic.actions.loadReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setReportsEnabled(false)
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(patchBodies).toEqual([{ enabled: false }])
+        expect(logic.values.activeReport).toEqual(expect.objectContaining({ enabled: false }))
+    })
+
+    it('re-enables a paused report', async () => {
+        reports = [makeReport({ enabled: false })]
+        logic.actions.loadReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setReportsEnabled(true)
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(patchBodies).toEqual([{ enabled: true }])
+        expect(logic.values.activeReport).toEqual(expect.objectContaining({ enabled: true }))
+    })
+
+    it('disables every non-deleted report so duplicates cannot keep delivering', async () => {
+        reports = [
+            makeReport({ id: 'report-1', enabled: true }),
+            makeReport({ id: 'report-2', enabled: true }),
+            makeReport({ id: 'report-deleted', enabled: true, deleted: true }),
+        ]
+        logic.actions.loadReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setReportsEnabled(false)
+        await expectLogic(logic).toFinishAllListeners()
+
+        // Two PATCHes — one per non-deleted report; the soft-deleted one is left alone.
+        expect(patchBodies).toEqual([{ enabled: false }, { enabled: false }])
+        expect(logic.values.reports.filter((r) => !r.deleted).every((r) => !r.enabled)).toBe(true)
+    })
+})

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
@@ -59,18 +59,18 @@ describe('evaluationReportLogic', () => {
         createBodies = []
         useMocks({
             get: {
-                '/api/environments/:teamId/llm_analytics/evaluation_reports/': () => [200, { results: reports }],
-                '/api/environments/:teamId/llm_analytics/evaluation_reports/:id/runs/': { results: [] },
+                '/api/projects/:teamId/llm_analytics/evaluation_reports/': () => [200, { results: reports }],
+                '/api/projects/:teamId/llm_analytics/evaluation_reports/:id/runs/': { results: [] },
             },
             post: {
-                '/api/environments/:teamId/llm_analytics/evaluation_reports/': async (req) => {
+                '/api/projects/:teamId/llm_analytics/evaluation_reports/': async (req) => {
                     const body = (await req.json()) as Record<string, unknown>
                     createBodies.push(body)
                     return [201, makeReport({ id: 'created-report', ...body })]
                 },
             },
             patch: {
-                '/api/environments/:teamId/llm_analytics/evaluation_reports/:id/': async (req) => {
+                '/api/projects/:teamId/llm_analytics/evaluation_reports/:id/': async (req) => {
                     const body = (await req.json()) as Record<string, unknown>
                     patchBodies.push(body)
                     const id = req.params.id as string

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
@@ -80,28 +80,20 @@ describe('evaluationReportLogic', () => {
         expect(logic.values.activeReport).toEqual(expect.objectContaining({ id: 'report-1', enabled: false }))
     })
 
-    it('disabling persists enabled:false without soft-deleting', async () => {
-        reports = [makeReport({ enabled: true })]
+    it.each([
+        { label: 'disabling persists enabled:false without soft-deleting', initialEnabled: true, target: false },
+        { label: 're-enables a paused report', initialEnabled: false, target: true },
+    ])('$label', async ({ initialEnabled, target }) => {
+        reports = [makeReport({ enabled: initialEnabled })]
         logic.actions.loadReports()
         await expectLogic(logic).toFinishAllListeners()
 
-        logic.actions.setReportsEnabled(false)
+        logic.actions.setReportsEnabled(target)
         await expectLogic(logic).toFinishAllListeners()
 
-        expect(patchBodies).toEqual([{ enabled: false }])
-        expect(logic.values.activeReport).toEqual(expect.objectContaining({ enabled: false }))
-    })
-
-    it('re-enables a paused report', async () => {
-        reports = [makeReport({ enabled: false })]
-        logic.actions.loadReports()
-        await expectLogic(logic).toFinishAllListeners()
-
-        logic.actions.setReportsEnabled(true)
-        await expectLogic(logic).toFinishAllListeners()
-
-        expect(patchBodies).toEqual([{ enabled: true }])
-        expect(logic.values.activeReport).toEqual(expect.objectContaining({ enabled: true }))
+        // Only `enabled` is PATCHed — never `deleted` — so the config is preserved either way.
+        expect(patchBodies).toEqual([{ enabled: target }])
+        expect(logic.values.activeReport).toEqual(expect.objectContaining({ enabled: target }))
     })
 
     it('disables every non-deleted report so duplicates cannot keep delivering', async () => {

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.test.ts
@@ -112,4 +112,19 @@ describe('evaluationReportLogic', () => {
         expect(patchBodies).toEqual([{ enabled: false }, { enabled: false }])
         expect(logic.values.reports.filter((r) => !r.deleted).every((r) => !r.enabled)).toBe(true)
     })
+
+    it('re-enables only the visible report so historical duplicates stay paused', async () => {
+        reports = [makeReport({ id: 'report-1', enabled: false }), makeReport({ id: 'report-2', enabled: false })]
+        logic.actions.loadReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setReportsEnabled(true)
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(patchBodies).toEqual([{ enabled: true }])
+        expect(logic.values.reports).toEqual([
+            expect.objectContaining({ id: 'report-1', enabled: true }),
+            expect.objectContaining({ id: 'report-2', enabled: false }),
+        ])
+    })
 })

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -4,14 +4,15 @@ import { loaders } from 'kea-loaders'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
-import {
-    llmAnalyticsEvaluationReportsCreate,
-    llmAnalyticsEvaluationReportsGenerateCreate,
-    llmAnalyticsEvaluationReportsList,
-    llmAnalyticsEvaluationReportsPartialUpdate,
-    llmAnalyticsEvaluationReportsRunsList,
-} from '../generated/api'
 import type { evaluationReportLogicType } from './evaluationReportLogicType'
+import {
+    createEvaluationReport,
+    generateEvaluationReport,
+    loadEvaluationReportRuns,
+    loadEvaluationReportsForEvaluation,
+    updateEvaluationReport,
+} from './evaluationReportsApi'
+import type { EvaluationReportCreatePayload } from './evaluationReportsApi'
 import type {
     EvaluationReport,
     EvaluationReportDeliveryTarget,
@@ -60,38 +61,6 @@ const DEFAULT_CONFIG_DRAFT: ReportConfigDraft = {
     cooldownHours: COOLDOWN_HOURS_DEFAULT,
 }
 
-type EvaluationReportListParams = NonNullable<Parameters<typeof llmAnalyticsEvaluationReportsList>[1]> & {
-    evaluation: string
-}
-type EvaluationReportCreatePayload = Parameters<typeof llmAnalyticsEvaluationReportsCreate>[1]
-type EvaluationReportUpdatePayload = Partial<EvaluationReport>
-type GeneratedEvaluationReportUpdatePayload = NonNullable<
-    Parameters<typeof llmAnalyticsEvaluationReportsPartialUpdate>[2]
->
-
-const evaluationReportListParams = (evaluationId: string): EvaluationReportListParams => ({ evaluation: evaluationId })
-
-async function loadEvaluationReportsForEvaluation(
-    teamId: number | null,
-    evaluationId: string
-): Promise<EvaluationReport[]> {
-    const response = await llmAnalyticsEvaluationReportsList(String(teamId), evaluationReportListParams(evaluationId))
-    return (response?.results || []) as EvaluationReport[]
-}
-
-async function updateEvaluationReport(
-    teamId: number | null,
-    reportId: string,
-    data: EvaluationReportUpdatePayload
-): Promise<EvaluationReport> {
-    const report = await llmAnalyticsEvaluationReportsPartialUpdate(
-        String(teamId),
-        reportId,
-        data as GeneratedEvaluationReportUpdatePayload
-    )
-    return report as EvaluationReport
-}
-
 function draftFromReport(report: EvaluationReport): ReportConfigDraft {
     const emailTarget = report.delivery_targets.find((t) => t.type === 'email')
     const slackTarget = report.delivery_targets.find((t) => t.type === 'slack')
@@ -133,8 +102,8 @@ function buildReportUpdatePayload(
     draft: ReportConfigDraft,
     activeReport: EvaluationReport,
     targets: EvaluationReportDeliveryTarget[]
-): EvaluationReportUpdatePayload {
-    const data: EvaluationReportUpdatePayload = {
+): Partial<EvaluationReport> {
+    const data: Partial<EvaluationReport> = {
         frequency: draft.frequency,
         delivery_targets: targets,
         report_prompt_guidance: draft.reportPromptGuidance,
@@ -232,7 +201,7 @@ export async function persistReportDraft(
     }
 
     // No active report yet — create only if the draft has savable content.
-    await llmAnalyticsEvaluationReportsCreate(String(teamId), buildReportCreatePayload(draft, evaluationId, targets))
+    await createEvaluationReport(teamId, buildReportCreatePayload(draft, evaluationId, targets))
     return true
 }
 
@@ -356,10 +325,10 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     if (params.frequency === 'every_n' && params.cooldown_minutes != null) {
                         body.cooldown_minutes = params.cooldown_minutes
                     }
-                    const report = await llmAnalyticsEvaluationReportsCreate(String(values.currentTeamId), body)
-                    return [...values.reports, report as EvaluationReport]
+                    const report = await createEvaluationReport(values.currentTeamId, body)
+                    return [...values.reports, report]
                 },
-                updateReport: async ({ reportId, data }: { reportId: string; data: EvaluationReportUpdatePayload }) => {
+                updateReport: async ({ reportId, data }: { reportId: string; data: Partial<EvaluationReport> }) => {
                     const updated = await updateEvaluationReport(values.currentTeamId, reportId, data)
                     return values.reports.map((r) => (r.id === reportId ? updated : r))
                 },
@@ -387,10 +356,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
             [] as EvaluationReportRun[],
             {
                 loadReportRuns: async (reportId: string) => {
-                    const response = await llmAnalyticsEvaluationReportsRunsList(String(values.currentTeamId), reportId)
-                    // The runs endpoint is paginated (DRF envelope); unwrap results so the
-                    // reducer gets an array rather than the {count, next, previous, results} object.
-                    return (response?.results || []) as EvaluationReportRun[]
+                    return await loadEvaluationReportRuns(values.currentTeamId, reportId)
                 },
             },
         ],
@@ -398,7 +364,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
             null as null,
             {
                 generateReport: async (reportId: string) => {
-                    await llmAnalyticsEvaluationReportsGenerateCreate(String(values.currentTeamId), reportId)
+                    await generateEvaluationReport(values.currentTeamId, reportId)
                     return null
                 },
             },

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -332,12 +332,14 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     )
                     return values.reports.filter((r) => r.id !== reportId)
                 },
-                // Pause/resume the report without deleting its config. The scheduler only
-                // delivers reports with enabled=True, so this is a true pause. We flip every
-                // non-deleted config for the evaluation — historically an evaluation could end
-                // up with more than one, and leaving any enabled would keep delivering.
+                // Pause/resume the report without deleting its config. Pausing flips every
+                // non-deleted config for the evaluation because historical duplicates can
+                // otherwise keep delivering. Resuming only flips the canonical visible config.
                 setReportsEnabled: async (enabled: boolean) => {
-                    const targets = values.reports.filter((r) => !r.deleted)
+                    const targets =
+                        enabled && values.activeReport
+                            ? [values.activeReport]
+                            : values.reports.filter((r) => !r.deleted)
                     const updated = await Promise.all(
                         targets.map((r) =>
                             // nosemgrep: prefer-codegen-api

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -170,13 +170,40 @@ export async function persistReportDraft(
         )
         return true
     }
-    // No active report yet — create only if the draft has savable content.
+
+    const hasSavableContent = targets.length > 0 || draft.reportPromptGuidance.trim().length > 0
+    if (draft.enabled && !hasSavableContent) {
+        return false
+    }
+
+    // Creating an evaluation auto-creates a default report config server-side.
+    // Reuse it here so the new-evaluation save flow doesn't create a duplicate config.
+    // nosemgrep: prefer-codegen-api
+    const response = await api.get(
+        `api/environments/${teamId}/llm_analytics/evaluation_reports/?evaluation=${evaluationId}`
+    )
+    const existingReport = (response?.results || []).find((report: EvaluationReport) => !report.deleted) ?? null
+
     if (!draft.enabled) {
+        if (existingReport) {
+            // nosemgrep: prefer-codegen-api
+            await api.update(`api/environments/${teamId}/llm_analytics/evaluation_reports/${existingReport.id}/`, {
+                enabled: false,
+            })
+            return true
+        }
         return false
     }
-    if (targets.length === 0 && draft.reportPromptGuidance.trim().length === 0) {
-        return false
+    if (existingReport) {
+        // nosemgrep: prefer-codegen-api
+        await api.update(
+            `api/environments/${teamId}/llm_analytics/evaluation_reports/${existingReport.id}/`,
+            buildReportUpdatePayload(draft, existingReport, targets)
+        )
+        return true
     }
+
+    // No active report yet — create only if the draft has savable content.
     // nosemgrep: prefer-codegen-api
     await api.create(
         `api/environments/${teamId}/llm_analytics/evaluation_reports/`,

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -61,7 +61,7 @@ function draftFromReport(report: EvaluationReport): ReportConfigDraft {
     // that buildDeliveryTargets later trims) doesn't fire a false positive when
     // the stored value is surrounded by whitespace.
     return {
-        enabled: true,
+        enabled: report.enabled,
         frequency: report.frequency,
         rrule: report.rrule ?? '',
         startsAt: report.starts_at ?? null,
@@ -332,6 +332,24 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     )
                     return values.reports.filter((r) => r.id !== reportId)
                 },
+                // Pause/resume the report without deleting its config. The scheduler only
+                // delivers reports with enabled=True, so this is a true pause. We flip every
+                // non-deleted config for the evaluation — historically an evaluation could end
+                // up with more than one, and leaving any enabled would keep delivering.
+                setReportsEnabled: async (enabled: boolean) => {
+                    const targets = values.reports.filter((r) => !r.deleted)
+                    const updated = await Promise.all(
+                        targets.map((r) =>
+                            // nosemgrep: prefer-codegen-api
+                            api.update(
+                                `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${r.id}/`,
+                                { enabled }
+                            )
+                        )
+                    )
+                    const updatedById = new Map(updated.map((r: EvaluationReport) => [r.id, r]))
+                    return values.reports.map((r) => updatedById.get(r.id) ?? r)
+                },
             },
         ],
         reportRuns: [
@@ -367,7 +385,9 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
         activeReport: [
             (s) => [s.reports],
             (reports): EvaluationReport | null => {
-                return reports.find((r: EvaluationReport) => r.enabled && !r.deleted) || null
+                // A paused (enabled=false) report is still the live config — it stays
+                // visible and re-enableable. Only a soft-deleted report drops out.
+                return reports.find((r: EvaluationReport) => !r.deleted) || null
             },
         ],
         isConfigDirty: [
@@ -401,7 +421,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
         loadReportsSuccess: ({ reports }) => {
             // Auto-load the run history for the active report so the Reports tab knows
             // whether to render itself and can show data immediately.
-            const active = reports.find((r: EvaluationReport) => r.enabled && !r.deleted)
+            const active = reports.find((r: EvaluationReport) => !r.deleted)
             if (active) {
                 actions.loadReportRuns(active.id)
                 // Seed the draft so the config form reflects the saved report instead of defaults.

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -440,6 +440,11 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
         updateReportSuccess: () => {
             actions.loadReports()
         },
+        setReportsEnabledFailure: () => {
+            // The reports reducer is left untouched on failure, so the toggle reverts —
+            // surface a toast so the revert doesn't look like a no-op to the user.
+            lemonToast.error('Failed to update report status. Please try again.')
+        },
         saveDraft: () => {
             const { configDraft, activeReport } = values
             const targets = buildDeliveryTargets(configDraft)

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -1,10 +1,16 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
+import {
+    llmAnalyticsEvaluationReportsCreate,
+    llmAnalyticsEvaluationReportsGenerateCreate,
+    llmAnalyticsEvaluationReportsList,
+    llmAnalyticsEvaluationReportsPartialUpdate,
+    llmAnalyticsEvaluationReportsRunsList,
+} from '../generated/api'
 import type { evaluationReportLogicType } from './evaluationReportLogicType'
 import type {
     EvaluationReport,
@@ -54,6 +60,38 @@ const DEFAULT_CONFIG_DRAFT: ReportConfigDraft = {
     cooldownHours: COOLDOWN_HOURS_DEFAULT,
 }
 
+type EvaluationReportListParams = NonNullable<Parameters<typeof llmAnalyticsEvaluationReportsList>[1]> & {
+    evaluation: string
+}
+type EvaluationReportCreatePayload = Parameters<typeof llmAnalyticsEvaluationReportsCreate>[1]
+type EvaluationReportUpdatePayload = Partial<EvaluationReport>
+type GeneratedEvaluationReportUpdatePayload = NonNullable<
+    Parameters<typeof llmAnalyticsEvaluationReportsPartialUpdate>[2]
+>
+
+const evaluationReportListParams = (evaluationId: string): EvaluationReportListParams => ({ evaluation: evaluationId })
+
+async function loadEvaluationReportsForEvaluation(
+    teamId: number | null,
+    evaluationId: string
+): Promise<EvaluationReport[]> {
+    const response = await llmAnalyticsEvaluationReportsList(String(teamId), evaluationReportListParams(evaluationId))
+    return (response?.results || []) as EvaluationReport[]
+}
+
+async function updateEvaluationReport(
+    teamId: number | null,
+    reportId: string,
+    data: EvaluationReportUpdatePayload
+): Promise<EvaluationReport> {
+    const report = await llmAnalyticsEvaluationReportsPartialUpdate(
+        String(teamId),
+        reportId,
+        data as GeneratedEvaluationReportUpdatePayload
+    )
+    return report as EvaluationReport
+}
+
 function draftFromReport(report: EvaluationReport): ReportConfigDraft {
     const emailTarget = report.delivery_targets.find((t) => t.type === 'email')
     const slackTarget = report.delivery_targets.find((t) => t.type === 'slack')
@@ -95,8 +133,8 @@ function buildReportUpdatePayload(
     draft: ReportConfigDraft,
     activeReport: EvaluationReport,
     targets: EvaluationReportDeliveryTarget[]
-): Record<string, unknown> {
-    const data: Record<string, unknown> = {
+): EvaluationReportUpdatePayload {
+    const data: EvaluationReportUpdatePayload = {
         frequency: draft.frequency,
         delivery_targets: targets,
         report_prompt_guidance: draft.reportPromptGuidance,
@@ -123,8 +161,8 @@ function buildReportCreatePayload(
     draft: ReportConfigDraft,
     evaluationId: string,
     targets: EvaluationReportDeliveryTarget[]
-): Record<string, unknown> {
-    const body: Record<string, unknown> = {
+): EvaluationReportCreatePayload {
+    const body: EvaluationReportCreatePayload = {
         evaluation: evaluationId,
         frequency: draft.frequency,
         delivery_targets: targets,
@@ -163,11 +201,7 @@ export async function persistReportDraft(
             lemonToast.warning('Scheduled report not saved — add at least one delivery target.')
             return false
         }
-        // nosemgrep: prefer-codegen-api
-        await api.update(
-            `api/environments/${teamId}/llm_analytics/evaluation_reports/${activeReport.id}/`,
-            buildReportUpdatePayload(draft, activeReport, targets)
-        )
+        await updateEvaluationReport(teamId, activeReport.id, buildReportUpdatePayload(draft, activeReport, targets))
         return true
     }
 
@@ -178,37 +212,27 @@ export async function persistReportDraft(
 
     // Creating an evaluation auto-creates a default report config server-side.
     // Reuse it here so the new-evaluation save flow doesn't create a duplicate config.
-    // nosemgrep: prefer-codegen-api
-    const response = await api.get(
-        `api/environments/${teamId}/llm_analytics/evaluation_reports/?evaluation=${evaluationId}`
-    )
-    const existingReport = (response?.results || []).find((report: EvaluationReport) => !report.deleted) ?? null
+    const existingReport =
+        (await loadEvaluationReportsForEvaluation(teamId, evaluationId)).find((report) => !report.deleted) ?? null
 
     if (!draft.enabled) {
         if (existingReport) {
-            // nosemgrep: prefer-codegen-api
-            await api.update(`api/environments/${teamId}/llm_analytics/evaluation_reports/${existingReport.id}/`, {
-                enabled: false,
-            })
+            await updateEvaluationReport(teamId, existingReport.id, { enabled: false })
             return true
         }
         return false
     }
     if (existingReport) {
-        // nosemgrep: prefer-codegen-api
-        await api.update(
-            `api/environments/${teamId}/llm_analytics/evaluation_reports/${existingReport.id}/`,
+        await updateEvaluationReport(
+            teamId,
+            existingReport.id,
             buildReportUpdatePayload(draft, existingReport, targets)
         )
         return true
     }
 
     // No active report yet — create only if the draft has savable content.
-    // nosemgrep: prefer-codegen-api
-    await api.create(
-        `api/environments/${teamId}/llm_analytics/evaluation_reports/`,
-        buildReportCreatePayload(draft, evaluationId, targets)
-    )
+    await llmAnalyticsEvaluationReportsCreate(String(teamId), buildReportCreatePayload(draft, evaluationId, targets))
     return true
 }
 
@@ -301,11 +325,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     if (props.evaluationId === 'new') {
                         return []
                     }
-                    // nosemgrep: prefer-codegen-api
-                    const response = await api.get(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/?evaluation=${props.evaluationId}`
-                    )
-                    return response.results || []
+                    return await loadEvaluationReportsForEvaluation(values.currentTeamId, props.evaluationId)
                 },
                 createReport: async (params: {
                     evaluationId: string
@@ -318,7 +338,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     trigger_threshold?: number | null
                     cooldown_minutes?: number | null
                 }) => {
-                    const body: Record<string, unknown> = {
+                    const body: EvaluationReportCreatePayload = {
                         evaluation: params.evaluationId,
                         frequency: params.frequency,
                         delivery_targets: params.delivery_targets,
@@ -336,27 +356,15 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     if (params.frequency === 'every_n' && params.cooldown_minutes != null) {
                         body.cooldown_minutes = params.cooldown_minutes
                     }
-                    // nosemgrep: prefer-codegen-api
-                    const report = await api.create(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/`,
-                        body
-                    )
-                    return [...values.reports, report]
+                    const report = await llmAnalyticsEvaluationReportsCreate(String(values.currentTeamId), body)
+                    return [...values.reports, report as EvaluationReport]
                 },
-                updateReport: async ({ reportId, data }: { reportId: string; data: Partial<EvaluationReport> }) => {
-                    // nosemgrep: prefer-codegen-api
-                    const updated = await api.update(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/`,
-                        data
-                    )
+                updateReport: async ({ reportId, data }: { reportId: string; data: EvaluationReportUpdatePayload }) => {
+                    const updated = await updateEvaluationReport(values.currentTeamId, reportId, data)
                     return values.reports.map((r) => (r.id === reportId ? updated : r))
                 },
                 deleteReport: async (reportId: string) => {
-                    // nosemgrep: prefer-codegen-api
-                    await api.update(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/`,
-                        { deleted: true }
-                    )
+                    await updateEvaluationReport(values.currentTeamId, reportId, { deleted: true })
                     return values.reports.filter((r) => r.id !== reportId)
                 },
                 // Pause/resume the report without deleting its config. Pausing flips every
@@ -368,15 +376,9 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                             ? [values.activeReport]
                             : values.reports.filter((r) => !r.deleted)
                     const updated = await Promise.all(
-                        targets.map((r) =>
-                            // nosemgrep: prefer-codegen-api
-                            api.update(
-                                `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${r.id}/`,
-                                { enabled }
-                            )
-                        )
+                        targets.map((r) => updateEvaluationReport(values.currentTeamId, r.id, { enabled }))
                     )
-                    const updatedById = new Map(updated.map((r: EvaluationReport) => [r.id, r]))
+                    const updatedById = new Map(updated.map((r) => [r.id, r]))
                     return values.reports.map((r) => updatedById.get(r.id) ?? r)
                 },
             },
@@ -385,13 +387,10 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
             [] as EvaluationReportRun[],
             {
                 loadReportRuns: async (reportId: string) => {
-                    // nosemgrep: prefer-codegen-api
-                    const response = await api.get(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/runs/`
-                    )
+                    const response = await llmAnalyticsEvaluationReportsRunsList(String(values.currentTeamId), reportId)
                     // The runs endpoint is paginated (DRF envelope); unwrap results so the
                     // reducer gets an array rather than the {count, next, previous, results} object.
-                    return response?.results || []
+                    return (response?.results || []) as EvaluationReportRun[]
                 },
             },
         ],
@@ -399,10 +398,7 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
             null as null,
             {
                 generateReport: async (reportId: string) => {
-                    // nosemgrep: prefer-codegen-api
-                    await api.create(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/generate/`
-                    )
+                    await llmAnalyticsEvaluationReportsGenerateCreate(String(values.currentTeamId), reportId)
                     return null
                 },
             },

--- a/products/ai_observability/frontend/evaluations/evaluationReportsApi.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportsApi.ts
@@ -1,0 +1,59 @@
+import {
+    llmAnalyticsEvaluationReportsCreate,
+    llmAnalyticsEvaluationReportsGenerateCreate,
+    llmAnalyticsEvaluationReportsList,
+    llmAnalyticsEvaluationReportsPartialUpdate,
+    llmAnalyticsEvaluationReportsRunsList,
+} from '../generated/api'
+import type { EvaluationReport, EvaluationReportRun } from './types'
+
+type EvaluationReportListParams = NonNullable<Parameters<typeof llmAnalyticsEvaluationReportsList>[1]> & {
+    evaluation: string
+}
+export type EvaluationReportCreatePayload = Parameters<typeof llmAnalyticsEvaluationReportsCreate>[1]
+type GeneratedEvaluationReportUpdatePayload = NonNullable<
+    Parameters<typeof llmAnalyticsEvaluationReportsPartialUpdate>[2]
+>
+
+const evaluationReportListParams = (evaluationId: string): EvaluationReportListParams => ({ evaluation: evaluationId })
+
+export async function loadEvaluationReportsForEvaluation(
+    teamId: number | null,
+    evaluationId: string
+): Promise<EvaluationReport[]> {
+    const response = await llmAnalyticsEvaluationReportsList(String(teamId), evaluationReportListParams(evaluationId))
+    return (response?.results || []) as EvaluationReport[]
+}
+
+export async function createEvaluationReport(
+    teamId: number | null,
+    data: EvaluationReportCreatePayload
+): Promise<EvaluationReport> {
+    const report = await llmAnalyticsEvaluationReportsCreate(String(teamId), data)
+    return report as EvaluationReport
+}
+
+export async function updateEvaluationReport(
+    teamId: number | null,
+    reportId: string,
+    data: Partial<EvaluationReport>
+): Promise<EvaluationReport> {
+    const report = await llmAnalyticsEvaluationReportsPartialUpdate(
+        String(teamId),
+        reportId,
+        data as GeneratedEvaluationReportUpdatePayload
+    )
+    return report as EvaluationReport
+}
+
+export async function loadEvaluationReportRuns(
+    teamId: number | null,
+    reportId: string
+): Promise<EvaluationReportRun[]> {
+    const response = await llmAnalyticsEvaluationReportsRunsList(String(teamId), reportId)
+    return (response?.results || []) as EvaluationReportRun[]
+}
+
+export async function generateEvaluationReport(teamId: number | null, reportId: string): Promise<void> {
+    await llmAnalyticsEvaluationReportsGenerateCreate(String(teamId), reportId)
+}


### PR DESCRIPTION
## Problem

The Enabled/Disabled toggle on evaluation **scheduled reports** was cosmetic — it always read "Enabled" and couldn't be turned off. Frontend state-wiring bug: the displayed state was hardwired on, "Save changes" never wrote `enabled`, and the only working path soft-deleted then visually reverted (and missed duplicate configs). Backend is fine — the scheduler already treats `enabled=False` as non-delivering.

## Changes

Reworks the toggle into a true **pause/resume** (config preserved):

- `draftFromReport` seeds `enabled` from the report instead of hardcoding `true`.
- New `setReportsEnabled` loader PATCHes `{ enabled }` on every non-deleted config, closing the duplicate-config trap.
- `activeReport` + load listener treat a paused report as the live config, so it stays re-enableable.
- Toggle owns `enabled` (pause confirm dialog) instead of soft-deleting; Save no longer touches the flag.

Dormant `deleteReport` left in place for a future explicit "Delete report" action. Follow-up (separate): backend partial unique index on `(evaluation) WHERE NOT deleted` + dedupe migration.

## How did you test this code?

Agent-authored; no manual UI testing. Ran locally: new jest suite `evaluationReportLogic.test.ts` (5 tests, green), `oxlint` on changed files (clean), `kea-typegen` (no TS errors). Full `tsc`/`typegen:check` left to CI.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code). Traced the report from "can't disable evaluation reports" through component → kea logic → backend to localize it as frontend wiring. Chose pause (`enabled=false`, reversible) over the existing soft-delete since the scheduler already honors it; flips all non-deleted configs to handle evaluations with duplicates.
