### PR TITLE
feat(dags): verify queued deletion requests via job + admin button

### DIFF
--- a/posthog/admin/admins/data_deletion_request_admin.py
+++ b/posthog/admin/admins/data_deletion_request_admin.py
@@ -20,6 +20,7 @@ from posthog.models.data_deletion_request import (
     event_match_params,
     event_match_sql_fragment,
     jsonhas_expr,
+    verify_queued_request,
 )
 
 CRITERIA_FIELDS = {
@@ -629,6 +630,10 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
                 obj.status == RequestStatus.FAILED and request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
             )
             extra_context["retry_url"] = reverse("admin:posthog_datadeletionrequest_retry", args=[obj.pk])
+            extra_context["can_verify"] = (
+                obj.status == RequestStatus.QUEUED and request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
+            )
+            extra_context["verify_url"] = reverse("admin:posthog_datadeletionrequest_verify", args=[obj.pk])
 
             # ClickHouse stats are calculated from this page (works for any status).
             extra_context["fetch_stats_url"] = reverse("admin:posthog_datadeletionrequest_fetch_stats", args=[obj.pk])
@@ -681,6 +686,11 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
                 "<path:object_id>/retry/",
                 self.admin_site.admin_view(self.retry_view),
                 name="posthog_datadeletionrequest_retry",
+            ),
+            path(
+                "<path:object_id>/verify/",
+                self.admin_site.admin_view(self.verify_view),
+                name="posthog_datadeletionrequest_verify",
             ),
         ]
         return custom_urls + urls
@@ -966,4 +976,33 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             request,
             "Request requeued. The pickup sensor will launch a new run on its next tick.",
         )
+        return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
+
+    def verify_view(self, request, object_id):
+        obj = self.get_object(request, object_id)
+        if not obj:
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_changelist"))
+
+        if request.method != "POST":
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
+
+        if not request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists():
+            messages.error(request, "Only ClickHouse Team members can verify deletion requests.")
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
+
+        if obj.status != RequestStatus.QUEUED:
+            messages.error(request, "Only queued requests can be verified.")
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
+
+        outcome = verify_queued_request(obj)
+        if outcome.promoted:
+            obj.refresh_from_db()
+            self.log_change(request, obj, "Verified: 0 matching events remain, status queued → completed.")
+            messages.success(request, "Verified — no matching events remain. Marked completed.")
+        else:
+            messages.warning(
+                request,
+                f"{outcome.remaining} matching event(s) still present in ClickHouse. "
+                "Left queued — re-run after the next scheduled deletion.",
+            )
         return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))

--- a/posthog/admin/test_data_deletion_request_admin.py
+++ b/posthog/admin/test_data_deletion_request_admin.py
@@ -707,3 +707,66 @@ class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
         response = self._call(self.admin.preview_stats_view, request)
         self.assertEqual(response.status_code, 302)
         self.assertIn("posthog_datadeletionrequest_change", response.url)
+
+
+@override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})
+class TestDataDeletionRequestAdminVerify(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        clickhouse_team, _ = Group.objects.get_or_create(name="ClickHouse Team")
+        self.user.groups.add(clickhouse_team)
+
+        self.factory = RequestFactory()
+        self.admin = DataDeletionRequestAdmin(DataDeletionRequest, AdminSite())
+
+    def _queued_request(self):
+        return DataDeletionRequest.objects.create(
+            team_id=self.team.id,
+            request_type=RequestType.EVENT_REMOVAL,
+            events=["$pageview"],
+            start_time=datetime.now() - timedelta(days=7),
+            end_time=datetime.now(),
+            status=RequestStatus.QUEUED,
+            execution_mode=ExecutionMode.DEFERRED,
+        )
+
+    def _call_verify(self, request, user=None):
+        path = f"/admin/posthog/datadeletionrequest/{request.pk}/verify/"
+        http_request = self.factory.post(path)
+        http_request.user = user or self.user
+        _attach_messages(http_request)
+        with patch("posthog.admin.admins.data_deletion_request_admin.reverse", side_effect=_fake_reverse):
+            return self.admin.verify_view(http_request, str(request.pk))
+
+    def test_verify_view_promotes_when_events_gone(self):
+        request = self._queued_request()
+        with patch("posthog.models.data_deletion_request.count_remaining_matching_events", return_value=0):
+            response = self._call_verify(request)
+        self.assertEqual(response.status_code, 302)
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.COMPLETED)
+
+    def test_verify_view_keeps_queued_when_events_remain(self):
+        request = self._queued_request()
+        with patch("posthog.models.data_deletion_request.count_remaining_matching_events", return_value=5):
+            response = self._call_verify(request)
+        self.assertEqual(response.status_code, 302)
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.QUEUED)
+
+    def test_verify_view_rejects_non_queued(self):
+        request = self._queued_request()
+        request.status = RequestStatus.APPROVED
+        request.save(update_fields=["status"])
+        self._call_verify(request)
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.APPROVED)
+
+    def test_verify_view_rejects_non_clickhouse_team(self):
+        request = self._queued_request()
+        self.user.groups.clear()
+        self._call_verify(request)
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.QUEUED)

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -1,7 +1,7 @@
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.conf import settings as django_settings
 
@@ -22,6 +22,7 @@ from posthog.models.data_deletion_request import (
     count_remaining_matching_events,
     event_removal_where,
     jsonhas_expr,
+    verify_queued_request,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.person.bulk_delete import (
@@ -1127,7 +1128,57 @@ def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext
 
 
 # ---------------------------------------------------------------------------
-# Verifier sensor: promotes QUEUED → COMPLETED once events are gone
+# Verify-queued sweep job: promotes recently-QUEUED requests once events are gone
+# ---------------------------------------------------------------------------
+
+
+class VerifyQueuedConfig(dagster.Config):
+    lookback_days: int = pydantic.Field(
+        default=28,
+        description="Only verify QUEUED requests created within this many days. Bounds the sweep so a "
+        "permanently stuck request isn't re-checked forever.",
+    )
+
+
+@dagster.op(tags=OWNER_TAG)
+def verify_queued_deletion_requests_op(context: dagster.OpExecutionContext, config: VerifyQueuedConfig) -> None:
+    """Verify recently-QUEUED deletion requests and promote those whose events are gone."""
+    from django.utils import timezone
+
+    cutoff = timezone.now() - timedelta(days=config.lookback_days)
+    queued = DataDeletionRequest.objects.filter(status=RequestStatus.QUEUED, created_at__gte=cutoff)
+    promoted = 0
+    still_queued = 0
+    for request in queued:
+        try:
+            outcome = verify_queued_request(request)
+        except Exception as exc:
+            context.log.warning(f"Could not verify deletion request {request.pk}: {exc}")
+            still_queued += 1
+            continue
+        if outcome.promoted:
+            promoted += 1
+            context.log.info(f"Deletion request {request.pk} promoted QUEUED → COMPLETED.")
+        else:
+            still_queued += 1
+            context.log.info(f"Deletion request {request.pk}: {outcome.remaining} matching events remain, kept QUEUED.")
+    context.add_output_metadata(
+        {
+            "promoted": dagster.MetadataValue.int(promoted),
+            "still_queued": dagster.MetadataValue.int(still_queued),
+            "lookback_days": dagster.MetadataValue.int(config.lookback_days),
+        }
+    )
+    context.log.info(f"verify_queued_deletion_requests: {promoted} promoted, {still_queued} kept queued.")
+
+
+@dagster.job(tags=OWNER_TAG)
+def verify_queued_deletion_requests_job():
+    verify_queued_deletion_requests_op()
+
+
+# ---------------------------------------------------------------------------
+# Verifier sensor: launches the sweep job after each deletes_job SUCCESS
 # ---------------------------------------------------------------------------
 
 

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -19,7 +19,6 @@ from posthog.models.data_deletion_request import (
     RequestStatus,
     RequestType,
     compile_hogql_predicate,
-    count_remaining_matching_events,
     event_removal_where,
     jsonhas_expr,
     verify_queued_request,
@@ -1185,36 +1184,14 @@ def verify_queued_deletion_requests_job():
 @dagster.run_status_sensor(
     run_status=dagster.DagsterRunStatus.SUCCESS,
     monitored_jobs=[deletes_job],
+    request_job=verify_queued_deletion_requests_job,
     default_status=dagster.DefaultSensorStatus.STOPPED,
     minimum_interval_seconds=60,
 )
 def verify_queued_deletion_requests(context: dagster.RunStatusSensorContext):
-    """Promote QUEUED deletion requests to COMPLETED once their events are gone.
+    """Launch the verify-queued sweep after each deletes_job SUCCESS (the weekend drain).
 
-    Fires after each deletes_job SUCCESS.
+    deletes_job runs after the Saturday-night squash, so this fires once the adhoc-event
+    deletion drain has completed. The sweep logic lives in verify_queued_deletion_requests_job.
     """
-    from django.utils import timezone
-
-    queued = DataDeletionRequest.objects.filter(status=RequestStatus.QUEUED)
-    promoted = 0
-    for request in queued:
-        try:
-            remaining = count_remaining_matching_events(request)
-        except Exception as exc:
-            context.log.warning(f"Could not verify deletion request {request.pk}: {exc}")
-            continue
-
-        if remaining > 0:
-            context.log.info(
-                f"Deletion request {request.pk}: {remaining} matching events remain, keeping status QUEUED."
-            )
-            continue
-
-        updated = DataDeletionRequest.objects.filter(pk=request.pk, status=RequestStatus.QUEUED).update(
-            status=RequestStatus.COMPLETED, updated_at=timezone.now()
-        )
-        if updated:
-            promoted += 1
-            context.log.info(f"Deletion request {request.pk} promoted QUEUED → COMPLETED.")
-
-    context.log.info(f"verify_queued_deletion_requests: {promoted} request(s) promoted this cycle.")
+    return dagster.RunRequest(run_key=context.dagster_run.run_id)

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -19,8 +19,8 @@ from posthog.models.data_deletion_request import (
     RequestStatus,
     RequestType,
     compile_hogql_predicate,
-    event_match_params,
-    event_match_sql_fragment,
+    count_remaining_matching_events,
+    event_removal_where,
     jsonhas_expr,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
@@ -125,27 +125,6 @@ def _base_params(ctx: DeletionRequestContext) -> dict:
     if ctx.person_properties:
         params.update(_property_filter_params(ctx.person_properties, prefix="pp_"))
     return params
-
-
-_EVENT_REMOVAL_TIME_PREDICATE = "team_id = %(team_id)s AND timestamp >= %(start_time)s AND timestamp < %(end_time)s"
-
-
-def _event_removal_where(obj) -> tuple[str, dict]:
-    """Full WHERE predicate + params for event-removal queries.
-
-    Combines the mandatory team/timestamp bounds, the events filter (skipped
-    when ``delete_all_events`` is set), and any compiled HogQL predicate. The
-    compiled HogQL fragment uses unqualified column references, so the result
-    is safe to splice into queries against either the Distributed ``events``
-    proxy or the local ``sharded_events`` MergeTree.
-    """
-    parts = [_EVENT_REMOVAL_TIME_PREDICATE, event_match_sql_fragment(obj)]
-    params = event_match_params(obj)
-    hogql_sql, hogql_values = compile_hogql_predicate(obj)
-    if hogql_sql:
-        parts.append(f"AND ({hogql_sql})")
-        params.update(hogql_values)
-    return " ".join(p for p in parts if p), params
 
 
 def _mat_col_presence_clauses(mat_cols: list[tuple[str, bool]]) -> list[str]:
@@ -395,7 +374,7 @@ def _run_immediate_event_deletion(
         context.log.info(f"Processing shard {shard_num} ({idx}/{len(shards)})")
         shard_start = time.monotonic()
 
-        predicate, parameters = _event_removal_where(deletion_request)
+        predicate, parameters = event_removal_where(deletion_request)
         runner = LightweightDeleteMutationRunner(
             table=table,
             predicate=predicate,
@@ -423,7 +402,7 @@ def _queue_events_for_deferred_deletion(
     source_table = EVENTS_DATA_TABLE()
     db = django_settings.CLICKHOUSE_DATABASE
     shards = sorted(cluster.shards)
-    predicate, params = _event_removal_where(deletion_request)
+    predicate, params = event_removal_where(deletion_request)
     # nosemgrep: clickhouse-fstring-param-audit (all interpolated values are internal constants/settings)
     insert_sql = (
         f"INSERT INTO {db}.{ADHOC_EVENTS_DELETION_TABLE} (team_id, uuid) "
@@ -1152,32 +1131,6 @@ def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext
 # ---------------------------------------------------------------------------
 
 
-def _count_remaining_matching_events(request: DataDeletionRequest) -> int:
-    from posthog.clickhouse.client import sync_execute
-    from posthog.clickhouse.client.connection import ClickHouseUser
-    from posthog.clickhouse.query_tagging import Feature, Product, tags_context
-    from posthog.clickhouse.workload import Workload
-
-    predicate, params = _event_removal_where(request)
-    with tags_context(
-        product=Product.INTERNAL,
-        feature=Feature.DATA_DELETION,
-        team_id=request.team_id,
-        workload=Workload.OFFLINE,
-        query_type="data_deletion_request_verify_queued",
-    ):
-        # nosemgrep: clickhouse-fstring-param-audit (predicate built from internal helper, not user input)
-        result = sync_execute(
-            f"SELECT count() FROM events WHERE {predicate} AND _row_exists = 1",
-            params,
-            team_id=request.team_id,
-            readonly=True,
-            workload=Workload.OFFLINE,
-            ch_user=ClickHouseUser.META,
-        )
-    return int(result[0][0]) if result else 0
-
-
 @dagster.run_status_sensor(
     run_status=dagster.DagsterRunStatus.SUCCESS,
     monitored_jobs=[deletes_job],
@@ -1195,7 +1148,7 @@ def verify_queued_deletion_requests(context: dagster.RunStatusSensorContext):
     promoted = 0
     for request in queued:
         try:
-            remaining = _count_remaining_matching_events(request)
+            remaining = count_remaining_matching_events(request)
         except Exception as exc:
             context.log.warning(f"Could not verify deletion request {request.pk}: {exc}")
             continue

--- a/posthog/dags/locations/clickhouse.py
+++ b/posthog/dags/locations/clickhouse.py
@@ -47,6 +47,7 @@ defs = dagster.Definitions(
         backups.non_sharded_backup,
         data_deletion_requests.data_deletion_request_event_removal,
         data_deletion_requests.data_deletion_request_property_removal,
+        data_deletion_requests.verify_queued_deletion_requests_job,
         part_breaker.break_oversized_parts,
     ],
     schedules=[

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -33,7 +33,6 @@ from posthog.models.data_deletion_request import DataDeletionRequest, ExecutionM
 from posthog.models.person import Person
 
 TEAM_ID = 99999
-VERIFY_TEAM_ID = 77777
 
 
 def _insert_events(events: list[tuple], client: Client) -> None:
@@ -514,11 +513,11 @@ def test_verify_queued_request_keeps_status_when_events_remain(cluster: Clickhou
 
     now = datetime.now()
     cluster.any_host(_truncate_writable_events).result()
-    remaining_events = [(VERIFY_TEAM_ID, "$pageview", uuid4(), now - timedelta(hours=i)) for i in range(3)]
+    remaining_events = [(DEFERRED_TEAM_ID, "$pageview", uuid4(), now - timedelta(hours=i)) for i in range(3)]
     cluster.any_host(partial(_insert_events, remaining_events)).result()
 
     request = DataDeletionRequest.objects.create(
-        team_id=VERIFY_TEAM_ID,
+        team_id=DEFERRED_TEAM_ID,
         request_type=RequestType.EVENT_REMOVAL,
         events=["$pageview"],
         start_time=now - timedelta(days=7),
@@ -545,7 +544,7 @@ def test_verify_queued_job_promotes_in_window_and_skips_old(cluster: ClickhouseC
 
     now = datetime.now()
     common = {
-        "team_id": VERIFY_TEAM_ID,
+        "team_id": DEFERRED_TEAM_ID,
         "request_type": RequestType.EVENT_REMOVAL,
         "events": ["$pageview"],
         "start_time": now - timedelta(days=7),

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -569,6 +569,12 @@ def test_verify_queued_job_promotes_in_window_and_skips_old(cluster: ClickhouseC
     assert old.status == RequestStatus.QUEUED
 
 
+def test_verify_queued_job_registered_in_clickhouse_location():
+    from posthog.dags.locations.clickhouse import defs
+
+    assert defs.get_job_def("verify_queued_deletion_requests_job") is not None
+
+
 # ---------------------------------------------------------------------------
 # Property removal tests
 # ---------------------------------------------------------------------------

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -33,6 +33,7 @@ from posthog.models.data_deletion_request import DataDeletionRequest, ExecutionM
 from posthog.models.person import Person
 
 TEAM_ID = 99999
+VERIFY_TEAM_ID = 77777
 
 
 def _insert_events(events: list[tuple], client: Client) -> None:
@@ -485,8 +486,8 @@ def test_full_job_event_deletion_deferred(cluster: ClickhouseCluster):
 
 
 @pytest.mark.django_db
-def test_verify_queued_promotes_when_events_gone():
-    from posthog.models.data_deletion_request import count_remaining_matching_events
+def test_verify_queued_request_promotes_when_events_gone():
+    from posthog.models.data_deletion_request import verify_queued_request
 
     now = datetime.now()
     request = DataDeletionRequest.objects.create(
@@ -499,16 +500,41 @@ def test_verify_queued_promotes_when_events_gone():
         execution_mode=ExecutionMode.DEFERRED,
     )
 
-    assert count_remaining_matching_events(request) == 0
+    outcome = verify_queued_request(request)
 
-    from django.utils import timezone
-
-    DataDeletionRequest.objects.filter(pk=request.pk, status=RequestStatus.QUEUED).update(
-        status=RequestStatus.COMPLETED, updated_at=timezone.now()
-    )
-
+    assert outcome.remaining == 0
+    assert outcome.promoted is True
     request.refresh_from_db()
     assert request.status == RequestStatus.COMPLETED
+
+
+@pytest.mark.django_db
+def test_verify_queued_request_keeps_status_when_events_remain(cluster: ClickhouseCluster):
+    from posthog.models.data_deletion_request import verify_queued_request
+
+    now = datetime.now()
+    cluster.any_host(_truncate_writable_events).result()
+    remaining_events = [(VERIFY_TEAM_ID, "$pageview", uuid4(), now - timedelta(hours=i)) for i in range(3)]
+    cluster.any_host(partial(_insert_events, remaining_events)).result()
+
+    request = DataDeletionRequest.objects.create(
+        team_id=VERIFY_TEAM_ID,
+        request_type=RequestType.EVENT_REMOVAL,
+        events=["$pageview"],
+        start_time=now - timedelta(days=7),
+        end_time=now + timedelta(minutes=1),
+        status=RequestStatus.QUEUED,
+        execution_mode=ExecutionMode.DEFERRED,
+    )
+
+    outcome = verify_queued_request(request)
+
+    assert outcome.remaining == 3
+    assert outcome.promoted is False
+    request.refresh_from_db()
+    assert request.status == RequestStatus.QUEUED
+
+    cluster.any_host(_truncate_writable_events).result()
 
 
 # ---------------------------------------------------------------------------

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -486,7 +486,7 @@ def test_full_job_event_deletion_deferred(cluster: ClickhouseCluster):
 
 @pytest.mark.django_db
 def test_verify_queued_promotes_when_events_gone():
-    from posthog.dags.data_deletion_requests import _count_remaining_matching_events
+    from posthog.models.data_deletion_request import count_remaining_matching_events
 
     now = datetime.now()
     request = DataDeletionRequest.objects.create(
@@ -499,7 +499,7 @@ def test_verify_queued_promotes_when_events_gone():
         execution_mode=ExecutionMode.DEFERRED,
     )
 
-    assert _count_remaining_matching_events(request) == 0
+    assert count_remaining_matching_events(request) == 0
 
     from django.utils import timezone
 

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -537,6 +537,38 @@ def test_verify_queued_request_keeps_status_when_events_remain(cluster: Clickhou
     cluster.any_host(_truncate_writable_events).result()
 
 
+@pytest.mark.django_db
+def test_verify_queued_job_promotes_in_window_and_skips_old(cluster: ClickhouseCluster):
+    from django.utils import timezone
+
+    from posthog.dags.data_deletion_requests import verify_queued_deletion_requests_job
+
+    now = datetime.now()
+    common = {
+        "team_id": VERIFY_TEAM_ID,
+        "request_type": RequestType.EVENT_REMOVAL,
+        "events": ["$pageview"],
+        "start_time": now - timedelta(days=7),
+        "end_time": now + timedelta(minutes=1),
+        "status": RequestStatus.QUEUED,
+        "execution_mode": ExecutionMode.DEFERRED,
+    }
+    cluster.any_host(_truncate_writable_events).result()  # no matching events → remaining 0
+
+    recent = DataDeletionRequest.objects.create(**common)
+    old = DataDeletionRequest.objects.create(**common)
+    # created_at uses auto_now_add, so push `old` outside the default 28-day window via update().
+    DataDeletionRequest.objects.filter(pk=old.pk).update(created_at=timezone.now() - timedelta(days=60))
+
+    result = verify_queued_deletion_requests_job.execute_in_process()
+    assert result.success
+
+    recent.refresh_from_db()
+    old.refresh_from_db()
+    assert recent.status == RequestStatus.COMPLETED
+    assert old.status == RequestStatus.QUEUED
+
+
 # ---------------------------------------------------------------------------
 # Property removal tests
 # ---------------------------------------------------------------------------

--- a/posthog/models/data_deletion_request.py
+++ b/posthog/models/data_deletion_request.py
@@ -92,6 +92,27 @@ def event_match_params(obj) -> dict:
     return params
 
 
+_EVENT_REMOVAL_TIME_PREDICATE = "team_id = %(team_id)s AND timestamp >= %(start_time)s AND timestamp < %(end_time)s"
+
+
+def event_removal_where(obj) -> tuple[str, dict]:
+    """Full WHERE predicate + params for event-removal queries.
+
+    Combines the mandatory team/timestamp bounds, the events filter (skipped
+    when ``delete_all_events`` is set), and any compiled HogQL predicate. The
+    compiled HogQL fragment uses unqualified column references, so the result
+    is safe to splice into queries against either the Distributed ``events``
+    proxy or the local ``sharded_events`` MergeTree.
+    """
+    parts = [_EVENT_REMOVAL_TIME_PREDICATE, event_match_sql_fragment(obj)]
+    params = event_match_params(obj)
+    hogql_sql, hogql_values = compile_hogql_predicate(obj)
+    if hogql_sql:
+        parts.append(f"AND ({hogql_sql})")
+        params.update(hogql_values)
+    return " ".join(p for p in parts if p), params
+
+
 class RequestType(models.TextChoices):
     PROPERTY_REMOVAL = "property_removal"
     EVENT_REMOVAL = "event_removal"
@@ -340,3 +361,30 @@ class DataDeletionRequest(UUIDModel):
             )
         if self.person_drop_profiles or self.person_drop_events or self.person_drop_recordings:
             raise ValidationError({"person_drop_profiles": "person_drop_* flags are only valid for person_removal."})
+
+
+def count_remaining_matching_events(request: "DataDeletionRequest") -> int:
+    """Count events still matching an event-removal request's criteria in ClickHouse."""
+    from posthog.clickhouse.client import sync_execute
+    from posthog.clickhouse.client.connection import ClickHouseUser
+    from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+    from posthog.clickhouse.workload import Workload
+
+    predicate, params = event_removal_where(request)
+    with tags_context(
+        product=Product.INTERNAL,
+        feature=Feature.DATA_DELETION,
+        team_id=request.team_id,
+        workload=Workload.OFFLINE,
+        query_type="data_deletion_request_verify_queued",
+    ):
+        # nosemgrep: clickhouse-fstring-param-audit (predicate built from internal helper, not user input)
+        result = sync_execute(
+            f"SELECT count() FROM events WHERE {predicate} AND _row_exists = 1",
+            params,
+            team_id=request.team_id,
+            readonly=True,
+            workload=Workload.OFFLINE,
+            ch_user=ClickHouseUser.META,
+        )
+    return int(result[0][0]) if result else 0

--- a/posthog/models/data_deletion_request.py
+++ b/posthog/models/data_deletion_request.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -388,3 +390,25 @@ def count_remaining_matching_events(request: "DataDeletionRequest") -> int:
             ch_user=ClickHouseUser.META,
         )
     return int(result[0][0]) if result else 0
+
+
+@dataclass
+class VerifyOutcome:
+    remaining: int
+    promoted: bool
+
+
+def verify_queued_request(request: "DataDeletionRequest") -> VerifyOutcome:
+    """Verify a QUEUED event-removal request and promote it to COMPLETED when its events are gone.
+
+    Counts events still matching the request in ClickHouse. When zero remain and the request is
+    still QUEUED, atomically promotes QUEUED → COMPLETED via a status-guarded update. Idempotent;
+    safe to call from both the Dagster sweep job and the Django admin button.
+    """
+    remaining = count_remaining_matching_events(request)
+    if remaining > 0 or request.status != RequestStatus.QUEUED:
+        return VerifyOutcome(remaining=remaining, promoted=False)
+    promoted = DataDeletionRequest.objects.filter(pk=request.pk, status=RequestStatus.QUEUED).update(
+        status=RequestStatus.COMPLETED, updated_at=timezone.now()
+    )
+    return VerifyOutcome(remaining=remaining, promoted=bool(promoted))

--- a/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
+++ b/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
@@ -60,10 +60,12 @@
     </fieldset>
     {% endif %}
 
-    {# Stats are calculated from this page (works for any status). These buttons use
+    {% comment %}
+       Stats are calculated from this page (works for any status). These buttons use
        formaction= to post the surrounding admin <form> to the stats views.
        Guarded on `original` — the stats URLs only exist for a saved object, and on the
-       add view an empty formaction would post back and create a record. #}
+       add view an empty formaction would post back and create a record.
+    {% endcomment %}
     {% if original %}
     <fieldset style="margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 4px;">
         <h2>ClickHouse stats</h2>

--- a/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
+++ b/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
@@ -139,4 +139,14 @@
         <button type="submit" formaction="{{ retry_url }}" formmethod="post" formnovalidate class="button" style="padding: 10px 15px; background: #d9534f; color: white;" onclick="return confirm('Retry this failed request? It will be re-queued for execution.');">Retry execution</button>
     </div>
     {% endif %}
+
+    {% if can_verify %}
+    <div class="submit-row" style="margin-top: 20px; padding: 20px; border-radius: 5px; border: 1px solid #417690; display: flex; align-items: center; gap: 10px;">
+        <div class="info">
+            This request is <strong>queued</strong> for deferred deletion. Verify to re-check ClickHouse now —
+            if no matching events remain, it will be marked completed.
+        </div>
+        <button type="submit" formaction="{{ verify_url }}" formmethod="post" formnovalidate class="button" style="padding: 10px 15px; background: #417690; color: white;" onclick="return confirm('Verify this queued request against ClickHouse now?');">Verify deletion</button>
+    </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Problem

Event-removal `DataDeletionRequest`s approved in **deferred** mode don't delete immediately — they queue event UUIDs into the `adhoc_events_deletion` ClickHouse table and move to status **queued**. The scheduled `deletes_job` drains that table after the Saturday-night squash, and only then are the events actually gone. A queued request therefore has to be *verified* (confirm no matching events remain) before it can be marked **completed**.

That verification existed only as inline logic inside the `verify_queued_deletion_requests` run-status sensor, with two gaps:

- No way for an operator to verify a single request on demand — they had to wait for the next weekend run.
- The logic was a sensor (not a reusable job) and swept every queued request forever, with no bound on how far back it looked.

## Changes

- Extract the verify-then-complete logic into a single reusable helper, `verify_queued_request`, in the dagster-free model module `posthog/models/data_deletion_request.py` (alongside the existing predicate builders it depends on). `event_removal_where` and `count_remaining_matching_events` move there too; the delete path imports them back, unchanged.
- Add `verify_queued_deletion_requests_job` — a windowed Dagster sweep (configurable `lookback_days`, default 28) that verifies recently-queued requests and promotes those whose events are gone. Per-request errors are caught so one bad row doesn't fail the run.
- Rewire the existing `verify_queued_deletion_requests` run-status sensor into a thin trigger that launches the new job after each `deletes_job` success — same weekend timing, logic now lives in the job.
- Add a Django admin **Verify deletion** button (ClickHouse Team only) on queued requests that runs the same helper inline and reports the result immediately.

Window is keyed on `created_at` (not `updated_at`, which is rewritten on every status transition). The admin button and the job share one verification code path.

## How did you test this code?

I'm an agent. I ran the affected suites locally against a live Postgres + ClickHouse dev stack — all green (151 tests):

```
pytest posthog/dags/tests/test_data_deletion_requests.py \
       posthog/admin/test_data_deletion_request_admin.py \
       posthog/models/test/test_data_deletion_request.py
# 151 passed
```

New coverage: helper promotes at zero remaining / stays queued when events remain; the job promotes an in-window request and skips one outside the window; the admin view promotes when events are gone, leaves queued when they remain, and rejects non-queued requests and non-ClickHouse-Team users. `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
