### PR TITLE
feat(subscriptions): use RichMarkdownEditor for AI prompt input

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.tsx
+++ b/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.tsx
@@ -32,6 +32,8 @@ export type RichMarkdownEditorProps = {
     renderPreview?: (markdown: string) => JSX.Element
     /** When true, focuses the editor once the ProseMirror view is mounted (default false to avoid stealing focus). */
     autoFocus?: boolean
+    /** Show the image upload button (default true). Set false when the extension set has no image node. */
+    showImageUpload?: boolean
 }
 
 export function RichMarkdownEditor({
@@ -46,6 +48,7 @@ export function RichMarkdownEditor({
     docToMarkdown,
     renderPreview,
     autoFocus = false,
+    showImageUpload = true,
 }: RichMarkdownEditorProps): JSX.Element {
     const [activeTab, setActiveTab] = useState<'write' | 'preview' | 'markdown'>('write')
     const [linkUrl, setLinkUrl] = useState('')
@@ -155,6 +158,7 @@ export function RichMarkdownEditor({
                                         editor={editor}
                                         alternativeDropTargetRef={dropRef}
                                         emojiPopoverDataAttr="rich-markdown-editor-emoji-popover"
+                                        showImageUpload={showImageUpload}
                                     />
                                 </div>
                                 <div className="flex shrink-0 items-center border-l border-primary pl-2">

--- a/frontend/src/lib/components/Subscriptions/views/AiPromptMarkdownEditor.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/AiPromptMarkdownEditor.tsx
@@ -1,0 +1,74 @@
+import { JSONContent } from '@tiptap/core'
+import { Link } from '@tiptap/extension-link'
+import { Placeholder } from '@tiptap/extension-placeholder'
+import { MarkdownManager } from '@tiptap/markdown'
+import { Extensions } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+
+import { RichMarkdownEditor } from 'lib/components/MarkdownEditor/rich/RichMarkdownEditor'
+
+const AI_PROMPT_PLACEHOLDER = 'e.g. Which events grew the most week-over-week? Highlight any unusual spikes.'
+
+// A lean extension set — the prompt is free text fed to an LLM, so we skip images and task lists.
+const AI_PROMPT_MARKDOWN_EXTENSIONS: Extensions = [
+    StarterKit.configure({ heading: { levels: [1, 2, 3] }, link: false }),
+    Link.configure({ openOnClick: false }),
+]
+
+const AI_PROMPT_EDITOR_EXTENSIONS: Extensions = [
+    ...AI_PROMPT_MARKDOWN_EXTENSIONS,
+    Placeholder.configure({ placeholder: AI_PROMPT_PLACEHOLDER }),
+]
+
+const markdownManager = new MarkdownManager({ extensions: AI_PROMPT_MARKDOWN_EXTENSIONS })
+
+const EMPTY_DOC: JSONContent = { type: 'doc', content: [{ type: 'paragraph' }] }
+
+function markdownToDoc(markdown: string | null | undefined): JSONContent {
+    if (!markdown || markdown.trim() === '') {
+        return EMPTY_DOC
+    }
+
+    try {
+        const parsed = markdownManager.parse(markdown) as JSONContent
+        if (parsed.type === 'doc') {
+            return parsed
+        }
+    } catch {
+        // Fall through to a plain paragraph for markdown we can't parse.
+    }
+
+    return { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: markdown }] }] }
+}
+
+function docToMarkdown(doc: JSONContent): string {
+    try {
+        return markdownManager.serialize(doc).trimEnd()
+    } catch {
+        return ''
+    }
+}
+
+export function AiPromptMarkdownEditor({
+    value,
+    onChange,
+    maxLength,
+}: {
+    value?: string | null
+    onChange?: (value: string) => void
+    maxLength?: number
+}): JSX.Element {
+    return (
+        <RichMarkdownEditor
+            value={value ?? ''}
+            onChange={onChange}
+            minRows={4}
+            maxRows={16}
+            maxLength={maxLength}
+            dataAttr="ai-subscription-prompt-editor"
+            extensions={AI_PROMPT_EDITOR_EXTENSIONS}
+            markdownToDoc={markdownToDoc}
+            docToMarkdown={docToMarkdown}
+        />
+    )
+}

--- a/frontend/src/lib/components/Subscriptions/views/AiPromptMarkdownEditor.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/AiPromptMarkdownEditor.tsx
@@ -69,6 +69,7 @@ export function AiPromptMarkdownEditor({
             extensions={AI_PROMPT_EDITOR_EXTENSIONS}
             markdownToDoc={markdownToDoc}
             docToMarkdown={docToMarkdown}
+            showImageUpload={false}
         />
     )
 }

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -54,6 +54,7 @@ import {
     WEEKDAYS,
     AI_PROMPT_MAX_LENGTH,
 } from '../utils'
+import { AiPromptMarkdownEditor } from './AiPromptMarkdownEditor'
 
 // Shown wherever AI subscriptions are gated off (org hasn't approved AI data
 // processing). Mirrors the backend gate in `_ai_create_gate_reason`, which 403s
@@ -184,11 +185,7 @@ function AiPromptFields({
                 label="Prompt"
                 help="Describe what the AI should look for. The same prompt runs every time the subscription fires."
             >
-                <LemonTextArea
-                    placeholder="e.g. Which events grew the most week-over-week? Highlight any unusual spikes."
-                    minRows={4}
-                    maxLength={AI_PROMPT_MAX_LENGTH}
-                />
+                <AiPromptMarkdownEditor maxLength={AI_PROMPT_MAX_LENGTH} />
             </LemonField>
             {/* Starter chips replace the whole prompt, so only offer them while the field is empty — once the
                 user has typed anything, a stray click would wipe their prompt with no undo. */}


### PR DESCRIPTION
## Problem

In the edit subscription modal, the new AI subscription type captures its prompt through a plain `LemonTextArea`. The prompt is markdown the AI uses to generate its report, so a richer editing surface (formatting controls, live preview, raw-markdown view) is a better fit than a bare textarea.

## Changes

- Add `AiPromptMarkdownEditor` — a thin wrapper around the existing `RichMarkdownEditor` configured with a lean TipTap extension set (`StarterKit` + `Link` + `Placeholder`). It deliberately omits images and task lists, since the prompt is free text fed to an LLM.
- Swap the `LemonTextArea` in `AiPromptFields` (AI subscription form) for `AiPromptMarkdownEditor`. It exposes the same `value`/`onChange` contract the kea-forms `LemonField` already injects, so it's a drop-in replacement that preserves the existing `prompt` field name, validation, max-length, and starter-prompt chips.

The non-AI subscription textareas (welcome message, etc.) are untouched.

## How did you test this code?

I'm an agent. Node modules weren't installed in this environment, so I could not run the frontend formatter, the TypeScript check, or the app locally. The existing subscription logic tests operate at the kea-forms level (`setSubscriptionValues`) rather than rendering the widget, so they remain valid but do not exercise the new component. A reviewer should run `pnpm --filter=@posthog/frontend typescript:check`, format, and visually confirm the editor renders and round-trips a prompt in the modal.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code). The user asked to swap the AI subscription prompt textarea for the `RichMarkdownEditor`. I followed the established wrapper pattern (`TextCardMarkdownEditor`) rather than using `RichMarkdownEditor` directly, since it requires `extensions`/`markdownToDoc`/`docToMarkdown`. I chose a lean extension set over reusing the TextCard stack to avoid pulling image-resize/task-list support and a cross-product dependency into the subscriptions form.
