### PR TITLE
fix(batch-exports): move compression reset out of render-prop effect

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -39,7 +39,6 @@ export function BatchExportConfiguration(): JSX.Element {
         batchExportConfigTest,
         batchExportConfigTestLoading,
         configuration,
-        configurationChanged,
         tables,
         batchExportConfig,
         selectedModel,
@@ -360,7 +359,6 @@ export function BatchExportConfiguration(): JSX.Element {
                         <BatchExportConfigurationFields
                             isNew={isNew}
                             formValues={configuration as BatchExportConfigurationForm}
-                            configurationChanged={configurationChanged}
                         />
                     </div>
                     {batchExportConfigTest && (
@@ -387,20 +385,14 @@ export function BatchExportConfiguration(): JSX.Element {
 function BatchExportConfigurationFields({
     isNew,
     formValues,
-    configurationChanged,
 }: {
     isNew: boolean
     formValues: BatchExportConfigurationForm
-    configurationChanged: boolean
 }): JSX.Element {
     return (
         <>
             <BatchExportGeneralEditFields isNew={isNew} isPipeline batchExportConfigForm={formValues} />
-            <BatchExportsEditFields
-                isNew={isNew}
-                batchExportConfigForm={formValues}
-                configurationChanged={configurationChanged}
-            />
+            <BatchExportsEditFields isNew={isNew} batchExportConfigForm={formValues} />
         </>
     )
 }

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -79,24 +79,16 @@ export function BatchExportGeneralEditFields({
 export function BatchExportsEditFields({
     isNew,
     batchExportConfigForm,
-    configurationChanged,
 }: {
     isNew: boolean
     batchExportConfigForm: BatchExportConfigurationForm
-    configurationChanged: boolean
 }): JSX.Element {
     const destination = batchExportConfigForm.destination
     const definition = destination ? DESTINATIONS[destination] : undefined
 
     return (
         <div className="flex flex-col gap-y-4 max-w-200">
-            {definition && (
-                <definition.Fields
-                    isNew={isNew}
-                    formValues={batchExportConfigForm}
-                    configurationChanged={configurationChanged}
-                />
-            )}
+            {definition && <definition.Fields isNew={isNew} formValues={batchExportConfigForm} />}
         </div>
     )
 }

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -545,6 +545,37 @@ describe('batchExportConfigFormLogic', () => {
         })
     })
 
+    describe('compression resets when file_format changes', () => {
+        it.each([
+            { newFormat: 'JSONLines', expected: null },
+            { newFormat: 'Parquet', expected: 'zstd' },
+        ])('new export: switching to $newFormat sets compression to $expected', async ({ newFormat, expected }) => {
+            await initLogic({ service: 'S3', id: null })
+
+            logic.actions.setConfigurationValue('file_format', newFormat)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.configuration.compression).toBe(expected)
+        })
+
+        it.each([
+            { startCompression: 'snappy', expected: null },
+            { startCompression: 'gzip', expected: 'gzip' },
+        ])(
+            'existing export: Parquet/$startCompression -> JSONLines yields $expected',
+            async ({ startCompression, expected }) => {
+                await initLogic({ service: null, id: S3_BATCH_EXPORT.id })
+                logic.actions.setConfigurationValues({ compression: startCompression })
+                await expectLogic(logic).toFinishAllListeners()
+
+                logic.actions.setConfigurationValue('file_format', 'JSONLines')
+                await expectLogic(logic).toFinishAllListeners()
+
+                expect(logic.values.configuration.compression).toBe(expected)
+            }
+        )
+    })
+
     describe('Redshift bucket validation only runs in COPY mode', () => {
         // Validates that Redshift's mode-conditional validation only kicks in for COPY mode.
         // INSERT mode shouldn't validate the (irrelevant) bucket name field.

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -574,6 +574,35 @@ describe('batchExportConfigFormLogic', () => {
                 expect(logic.values.configuration.compression).toBe(expected)
             }
         )
+
+        it('existing export: Parquet/zstd -> JSONLines -> Parquet restores the saved zstd codec', async () => {
+            // AWS_S3_BATCH_EXPORT is saved with Parquet/zstd; zstd is invalid for JSONLines, so it's
+            // cleared on the way out and must come back from the saved config — not default to zstd by
+            // coincidence.
+            await initLogic({ service: null, id: AWS_S3_BATCH_EXPORT.id })
+            expect(logic.values.configuration.compression).toBe('zstd')
+
+            logic.actions.setConfigurationValue('file_format', 'JSONLines')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.configuration.compression).toBeNull()
+
+            logic.actions.setConfigurationValue('file_format', 'Parquet')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.configuration.compression).toBe('zstd')
+        })
+
+        it('existing export: Parquet/gzip survives a JSONLines round-trip (valid for both formats)', async () => {
+            await initLogic({ service: null, id: S3_BATCH_EXPORT.id })
+            expect(logic.values.configuration.compression).toBe('gzip')
+
+            logic.actions.setConfigurationValue('file_format', 'JSONLines')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.configuration.compression).toBe('gzip')
+
+            logic.actions.setConfigurationValue('file_format', 'Parquet')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.configuration.compression).toBe('gzip')
+        })
     })
 
     describe('invalid persisted compression is dropped on save', () => {

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -576,6 +576,27 @@ describe('batchExportConfigFormLogic', () => {
         )
     })
 
+    describe('invalid persisted compression is dropped on save', () => {
+        it('clears a JSONLines+zstd combination when saving an unrelated edit', async () => {
+            await initLogic({ service: null, id: S3_BATCH_EXPORT.id })
+
+            logic.actions.setConfigurationValues({
+                ...logic.values.configuration,
+                file_format: 'JSONLines',
+                compression: 'zstd',
+                prefix: 'updated-prefix/',
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.submitConfiguration()
+            }).toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
+
+            expect(lastPatchBody!.destination.config.file_format).toBe('JSONLines')
+            expect(lastPatchBody!.destination.config.compression).toBeNull()
+            expect(lastPatchBody!.destination.config.prefix).toBe('updated-prefix/')
+        })
+    })
+
     describe('Redshift bucket validation only runs in COPY mode', () => {
         // Validates that Redshift's mode-conditional validation only kicks in for COPY mode.
         // INSERT mode shouldn't validate the (irrelevant) bucket name field.

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -848,12 +848,24 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
             const fieldName = Array.isArray(name) ? name[0] : name
 
             if (fieldName === 'file_format') {
-                if (values.isNew && value === 'JSONLines') {
-                    actions.setConfigurationValue('compression', null)
-                } else if (values.isNew && value === 'Parquet') {
-                    actions.setConfigurationValue('compression', 'zstd')
-                } else if (!isSelectedCompressionOptionValid(value, values.configuration.compression)) {
-                    actions.setConfigurationValue('compression', null)
+                // Pick a compression that's valid for the newly-selected format, in priority order:
+                //   1. keep the current codec if it still fits (e.g. gzip works for both formats);
+                //   2. otherwise, when returning to the format the export was saved with, restore the
+                //      persisted codec — so a Parquet→JSONLines→Parquet round-trip recovers the saved
+                //      compression rather than stranding the export on a default;
+                //   3. otherwise fall back to the format's default (zstd for Parquet, none for JSONLines).
+                const current = values.configuration.compression
+                const saved = values.savedConfiguration
+                let next: string | null
+                if (current !== null && isSelectedCompressionOptionValid(value, current)) {
+                    next = current
+                } else if (value === saved.file_format && isSelectedCompressionOptionValid(value, saved.compression)) {
+                    next = saved.compression
+                } else {
+                    next = value === 'Parquet' ? 'zstd' : null
+                }
+                if (next !== current) {
+                    actions.setConfigurationValue('compression', next)
                 }
             }
 

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -21,7 +21,7 @@ import {
 import type { batchExportConfigFormLogicType } from './batchExportConfigFormLogicType'
 import { batchExportDataLogic } from './batchExportDataLogic'
 import { DESTINATIONS } from './destinations'
-import { genericPersonEventFields } from './destinations/common'
+import { genericPersonEventFields, isSelectedCompressionOptionValid } from './destinations/common'
 import { humanizeBatchExportName } from './utils'
 
 export interface BatchExportConfigFormLogicProps {
@@ -840,6 +840,16 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
         },
         setConfigurationValue: ({ name, value }) => {
             const fieldName = Array.isArray(name) ? name[0] : name
+
+            if (fieldName === 'file_format') {
+                if (values.isNew && value === 'JSONLines') {
+                    actions.setConfigurationValue('compression', null)
+                } else if (values.isNew && value === 'Parquet') {
+                    actions.setConfigurationValue('compression', 'zstd')
+                } else if (!isSelectedCompressionOptionValid(value, values.configuration.compression)) {
+                    actions.setConfigurationValue('compression', null)
+                }
+            }
 
             if (fieldName === 'interval') {
                 // if changing to day or week, set the timezone to the team's timezone if not already set

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -73,6 +73,12 @@ function buildDestinationPayload(formValues: Record<string, any>): {
         }
         config[key] = value
     }
+    // A persisted compression value can be invalid for the selected file_format (e.g. an
+    // externally-created JSONLines export still carrying a Parquet-only codec). Drop it on save so
+    // editing an unrelated field doesn't resubmit a combination the backend rejects.
+    if ('compression' in config && !isSelectedCompressionOptionValid(config.file_format, config.compression)) {
+        config.compression = null
+    }
     const result: { type: string; config: Record<string, any>; integration?: any } = {
         type: destinationType,
         config,

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/awss3.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/awss3.tsx
@@ -27,12 +27,11 @@ export const awsS3Definition: DestinationDefinition = {
     }),
     eventTableExtraFields: S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS,
     eventTableOverrides: { includeGenericPersonFields: false },
-    Fields: function AwsS3Fields({ isNew, formValues, configurationChanged }) {
+    Fields: function AwsS3Fields({ isNew, formValues }) {
         return (
             <S3FamilyFields
                 isNew={isNew}
                 formValues={formValues}
-                configurationChanged={configurationChanged}
                 regionOptions={AWS_ONLY_REGION_OPTIONS}
                 awsBranded
                 showEncryption

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/azureblob.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/azureblob.tsx
@@ -19,7 +19,7 @@ export const azureBlobDefinition: DestinationDefinition = {
         container_name: validateAzureContainerName(formValues.container_name),
     }),
     eventTableOverrides: { teamIdHogql: 'team_id' },
-    Fields: function AzureBlobFields({ isNew, formValues, configurationChanged }) {
+    Fields: function AzureBlobFields({ formValues }) {
         return (
             <>
                 <LemonField name="integration_id" label="Azure connection">
@@ -60,11 +60,7 @@ export const azureBlobDefinition: DestinationDefinition = {
                     <MaxFileSizeField />
                 </div>
 
-                <CompressionField
-                    fileFormat={formValues.file_format}
-                    isNew={isNew}
-                    configurationChanged={configurationChanged}
-                />
+                <CompressionField fileFormat={formValues.file_format} />
             </>
         )
     },

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/common.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/common.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 
 import { LemonCheckbox, LemonInput, LemonSelect, Link } from '@posthog/lemon-ui'
 
@@ -203,58 +203,32 @@ const JSONLINES_COMPRESSION_OPTIONS = [
     { value: null, label: 'No compression' },
 ]
 
-// Compression select that adapts its options to the currently-selected file format and self-corrects
-// invalid combinations. Used by S3 and AzureBlob, which share file_format/compression semantics.
-export function CompressionField({
-    fileFormat,
-    isNew,
-    configurationChanged,
-}: {
-    fileFormat: string | undefined
-    isNew: boolean
-    configurationChanged: boolean
-}): JSX.Element {
+export function isSelectedCompressionOptionValid(fileFormat: string | undefined, value: string | null): boolean {
+    if (fileFormat === 'Parquet') {
+        return PARQUET_COMPRESSION_OPTIONS.some((option) => option.value === value)
+    } else if (fileFormat === 'JSONLines') {
+        return JSONLINES_COMPRESSION_OPTIONS.some((option) => option.value === value)
+    }
+    return false
+}
+
+// Compression select whose options adapt to the currently-selected file format. Used by S3 and
+// AzureBlob, which share file_format/compression semantics. The form logic resets compression to a
+// valid value when file_format changes (see batchExportConfigFormLogic's setConfigurationValue).
+export function CompressionField({ fileFormat }: { fileFormat: string | undefined }): JSX.Element {
+    const compressionOptions =
+        fileFormat === 'Parquet'
+            ? PARQUET_COMPRESSION_OPTIONS
+            : fileFormat === 'JSONLines'
+              ? JSONLINES_COMPRESSION_OPTIONS
+              : []
+
     return (
         <LemonField name="compression" label="Compression" className="flex-1">
-            {({ value, onChange }) => {
-                const compressionOptions =
-                    fileFormat === 'Parquet'
-                        ? PARQUET_COMPRESSION_OPTIONS
-                        : fileFormat === 'JSONLines'
-                          ? JSONLINES_COMPRESSION_OPTIONS
-                          : []
-
-                const isSelectedCompressionOptionValid = (val: string | null): boolean => {
-                    if (fileFormat === 'Parquet') {
-                        return PARQUET_COMPRESSION_OPTIONS.some((option) => option.value === val)
-                    } else if (fileFormat === 'JSONLines') {
-                        return JSONLINES_COMPRESSION_OPTIONS.some((option) => option.value === val)
-                    }
-                    return false
-                }
-
-                React.useEffect(() => {
-                    if (!configurationChanged) {
-                        return
-                    }
-                    if (isNew && fileFormat === 'JSONLines') {
-                        onChange(null)
-                    } else if (isNew && fileFormat === 'Parquet') {
-                        onChange('zstd')
-                    } else if (!isSelectedCompressionOptionValid(value)) {
-                        onChange(null)
-                    }
-                }, [configurationChanged, fileFormat, isNew]) // oxlint-disable-line react-hooks/exhaustive-deps
-
-                return (
-                    <LemonSelect
-                        options={compressionOptions}
-                        value={value}
-                        onChange={onChange}
-                        placeholder={!fileFormat ? 'Select file format first' : undefined}
-                    />
-                )
-            }}
+            <LemonSelect
+                options={compressionOptions}
+                placeholder={!fileFormat ? 'Select file format first' : undefined}
+            />
         </LemonField>
     )
 }
@@ -314,7 +288,6 @@ export const S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS: Record<string, DatabaseSchemaFi
 export function S3FamilyFields({
     isNew,
     formValues,
-    configurationChanged,
     regionOptions,
     awsBranded,
     allowCustomRegion = false,
@@ -326,7 +299,6 @@ export function S3FamilyFields({
 }: {
     isNew: boolean
     formValues: Record<string, any>
-    configurationChanged: boolean
     regionOptions: { value: string; label: string }[]
     // Prefix the credential labels with "AWS" — only true for AWS S3, not the S3-compatible catch-all.
     awsBranded: boolean
@@ -388,11 +360,7 @@ export function S3FamilyFields({
             </div>
 
             <div className="flex gap-4">
-                <CompressionField
-                    fileFormat={formValues.file_format}
-                    isNew={isNew}
-                    configurationChanged={configurationChanged}
-                />
+                <CompressionField fileFormat={formValues.file_format} />
 
                 {showEncryption && (
                     <LemonField name="encryption" label="Encryption" className="flex-1">

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3.tsx
@@ -23,12 +23,11 @@ export const s3Definition: DestinationDefinition = {
     }),
     eventTableExtraFields: S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS,
     eventTableOverrides: { includeGenericPersonFields: false },
-    Fields: function S3Fields({ isNew, formValues, configurationChanged }) {
+    Fields: function S3Fields({ isNew, formValues }) {
         return (
             <S3FamilyFields
                 isNew={isNew}
                 formValues={formValues}
-                configurationChanged={configurationChanged}
                 regionOptions={S3_REGION_OPTIONS}
                 awsBranded
                 allowCustomRegion

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3compatible.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3compatible.tsx
@@ -23,12 +23,11 @@ export const s3CompatibleDefinition: DestinationDefinition = {
     }),
     eventTableExtraFields: S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS,
     eventTableOverrides: { includeGenericPersonFields: false },
-    Fields: function S3CompatibleFields({ isNew, formValues, configurationChanged }) {
+    Fields: function S3CompatibleFields({ isNew, formValues }) {
         return (
             <S3FamilyFields
                 isNew={isNew}
                 formValues={formValues}
-                configurationChanged={configurationChanged}
                 regionOptions={S3_REGION_OPTIONS}
                 awsBranded={false}
                 allowCustomRegion

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/types.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/types.ts
@@ -40,5 +40,5 @@ export interface DestinationDefinition {
     eventTableOverrides?: EventTableOverrides
     // Lift integration_id from destination.integration during deserialize and push it back during save.
     usesIntegration?: boolean
-    Fields: React.FC<{ isNew: boolean; formValues: Record<string, any>; configurationChanged: boolean }>
+    Fields: React.FC<{ isNew: boolean; formValues: Record<string, any> }>
 }


### PR DESCRIPTION
## Problem

The compression `<LemonSelect>` shared by the S3 and Azure Blob batch-export forms called `React.useEffect` **inside a `<LemonField>` render-prop callback**. That callback is not a real React component — it is a child render function `LemonField` invokes — so calling a hook there violates the Rules of Hooks (hook ordering is not guaranteed stable across renders).

The effect was also being used to fake an event handler: it watched `file_format` and called `onChange` to reset `compression` to a valid value. Per [react.dev — You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect#sharing-logic-between-event-handlers), that logic belongs in the handler that changes `file_format`, not in an effect that watches it.

## Changes

- Moved the compression self-correction into `batchExportConfigFormLogic`'s existing `setConfigurationValue` listener, next to the `interval` cross-field handling. It now runs when `file_format` changes (new exports get a sensible default; existing exports keep a valid compression or have an invalid one cleared).
- `CompressionField` is now a thin presentational component — no effect, no hook in a render-prop.
- Removed the now-dead `isNew` / `configurationChanged` plumbing that only existed to feed the effect (`Fields` type, `BatchExportEditForm`, `BatchExportConfiguration`).
- Exported `isSelectedCompressionOptionValid` so the logic and the component share one definition.

### react-doctor finding

This work was driven by [react-doctor](https://react.doctor). After lifting the hook out of the render-prop, react-doctor still flagged the effect itself under its **`no-event-handler`** rule ("Faking an event handler with a prop plus a `useEffect` costs an extra render & runs late"). Moving the reset into the form-logic listener resolves that finding. react-doctor's other finding on the file — `no-jsx-element-type` (prefer `React.ReactNode` over `JSX.Element`) — was intentionally **not** actioned: `: JSX.Element` is the established convention across the frontend (~2.3k files), so changing one file would break local consistency.

## How did you test this code?

I'm an agent. I did not perform manual UI testing. Automated checks I actually ran:

- `oxlint` + `oxfmt` on all changed files — clean.
- `batchExportConfigFormLogic.test.ts` — all tests pass, including a new parameterized test covering the compression reset (new vs existing export; valid compression kept, invalid cleared). This behaviour was previously untestable while it lived in a component `useEffect`.

## 🤖 Agent context

Authored with PostHog Code (Claude). The task was a specific bug report — a `useEffect` inside a `LemonField` render-prop — plus a request to run react-doctor on the file.

Decisions:
- Two-stage fix. First lifted the hook into a real named component (minimal, behaviour-preserving). react-doctor then surfaced that the effect was itself an anti-pattern (`no-event-handler`), so — with the author's go-ahead — moved the logic into the kea form-logic listener and deleted the effect entirely, which also let the now-orphaned props be removed.
- Considered coupling `CompressionField` directly to the keyed form logic, but the listener approach keeps the field presentational and reuses the existing `setConfigurationValue` cross-field pattern.
- Did not change `JSX.Element` -> `React.ReactNode` despite react-doctor flagging it, to stay consistent with the rest of the codebase.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
