### PR TITLE
feat(cymbal): add rust error tracking frame type

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -493,6 +493,7 @@ mod test {
         match frame {
             RawFrame::Rust(frame) => {
                 let resolved: Frame = (&frame).into();
+                let resolved_frame_id = frame.frame_id();
                 assert_eq!(resolved.lang, "rust");
                 assert_eq!(resolved.mangled_name, "checkout::payment::charge");
                 assert_eq!(
@@ -502,6 +503,14 @@ mod test {
                 assert_eq!(resolved.source.as_deref(), Some("src/main.rs"));
                 assert_eq!(resolved.module.as_deref(), Some("checkout::payment"));
                 assert_eq!(resolved.line, Some(42));
+                assert_eq!(resolved.context, None);
+
+                let unresolved_data = data.replace("\"resolved\": true,", "\"resolved\": false,");
+                let unresolved_frame: RawFrame = serde_json::from_str(&unresolved_data).unwrap();
+                match unresolved_frame {
+                    RawFrame::Rust(frame) => assert_eq!(frame.frame_id(), resolved_frame_id),
+                    _ => panic!("Expected a rust frame"),
+                }
             }
             _ => panic!("Expected a rust frame"),
         }

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -511,6 +511,21 @@ mod test {
                     RawFrame::Rust(frame) => assert_eq!(frame.frame_id(), resolved_frame_id),
                     _ => panic!("Expected a rust frame"),
                 }
+
+                let missing_function_data =
+                    data.replace("\"function\": \"checkout::payment::charge\",\n", "");
+                let missing_function_frame: RawFrame =
+                    serde_json::from_str(&missing_function_data).unwrap();
+                match missing_function_frame {
+                    RawFrame::Rust(frame) => {
+                        let resolved: Frame = (&frame).into();
+                        assert_eq!(resolved.mangled_name, "");
+                        assert_eq!(resolved.resolved_name, None);
+                        assert_eq!(resolved.source.as_deref(), Some("src/main.rs"));
+                        assert_eq!(resolved.line, Some(42));
+                    }
+                    _ => panic!("Expected a rust frame"),
+                }
             }
             _ => panic!("Expected a rust frame"),
         }

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         php::RawPHPFrame,
         python::RawPythonFrame,
         ruby::RawRubyFrame,
+        rust::RawRustFrame,
     },
     metric_consts::{FRAME_NOT_RESOLVED, FRAME_RESOLVED, LEGACY_JS_FRAME_RESOLVED, PER_FRAME_TIME},
     sanitize_source_line,
@@ -74,6 +75,8 @@ pub enum RawFrame {
     Dart(RawDartFrame),
     #[serde(rename = "apple")]
     Apple(RawAppleFrame),
+    #[serde(rename = "rust")]
+    Rust(RawRustFrame),
     #[serde(rename = "custom")]
     Custom(CustomFrame),
     // TODO - remove once we're happy no clients are using this anymore
@@ -109,6 +112,7 @@ impl RawFrame {
             RawFrame::Php(frame) => (to_vec(Ok(frame.into())), "php"),
             RawFrame::Python(frame) => (to_vec(Ok(frame.into())), "python"),
             RawFrame::Ruby(frame) => (to_vec(Ok(frame.into())), "ruby"),
+            RawFrame::Rust(frame) => (to_vec(Ok(frame.into())), "rust"),
             RawFrame::Custom(frame) => (to_vec(Ok(frame.into())), "custom"),
             RawFrame::Go(frame) => (to_vec(Ok(frame.into())), "go"),
             RawFrame::Hermes(frame) => (to_vec(frame.resolve(team_id, catalog).await), "hermes"),
@@ -161,6 +165,7 @@ impl RawFrame {
             | RawFrame::Go(_)
             | RawFrame::Dart(_)
             | RawFrame::Apple(_)
+            | RawFrame::Rust(_)
             | RawFrame::Custom(_) => None,
         }
     }
@@ -173,6 +178,7 @@ impl RawFrame {
             RawFrame::Python(raw) => raw.frame_id(),
             RawFrame::Ruby(raw) => raw.frame_id(),
             RawFrame::Go(raw) => raw.frame_id(),
+            RawFrame::Rust(raw) => raw.frame_id(),
             RawFrame::Custom(raw) => raw.frame_id(),
             RawFrame::Hermes(raw) => raw.frame_id(),
             RawFrame::Java(raw) => raw.frame_id(),
@@ -445,7 +451,7 @@ fn to_vec<T, E>(item: Result<T, E>) -> Result<Vec<T>, E> {
 
 #[cfg(test)]
 mod test {
-    use crate::frames::RawFrame;
+    use crate::frames::{Frame, RawFrame};
 
     #[test]
     fn ensure_custom_frames_work() {
@@ -466,6 +472,38 @@ mod test {
         match frame {
             RawFrame::Custom(_) => {}
             _ => panic!("Expected a custom frame"),
+        }
+    }
+
+    #[test]
+    fn ensure_rust_frames_work() {
+        let data = r#"
+            {
+            "function": "checkout::payment::charge",
+            "module": "checkout::payment",
+            "filename": "src/main.rs",
+            "resolved": true,
+            "in_app": true,
+            "lineno": 42,
+            "platform": "rust"
+            }
+            "#;
+
+        let frame: RawFrame = serde_json::from_str(data).unwrap();
+        match frame {
+            RawFrame::Rust(frame) => {
+                let resolved: Frame = (&frame).into();
+                assert_eq!(resolved.lang, "rust");
+                assert_eq!(resolved.mangled_name, "checkout::payment::charge");
+                assert_eq!(
+                    resolved.resolved_name.as_deref(),
+                    Some("checkout::payment::charge")
+                );
+                assert_eq!(resolved.source.as_deref(), Some("src/main.rs"));
+                assert_eq!(resolved.module.as_deref(), Some("checkout::payment"));
+                assert_eq!(resolved.line, Some(42));
+            }
+            _ => panic!("Expected a rust frame"),
         }
     }
 }

--- a/rust/cymbal/src/langs/mod.rs
+++ b/rust/cymbal/src/langs/mod.rs
@@ -11,6 +11,7 @@ pub mod node;
 pub mod php;
 pub mod python;
 pub mod ruby;
+pub mod rust;
 pub mod utils;
 
 // Some metadata is common across all languages, so we define it here. In some

--- a/rust/cymbal/src/langs/rust.rs
+++ b/rust/cymbal/src/langs/rust.rs
@@ -1,0 +1,106 @@
+use common_types::error_tracking::FrameId;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+use crate::{
+    frames::{Context, ContextLine, Frame},
+    langs::CommonFrameMetadata,
+};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RawRustFrame {
+    pub function: String,
+    pub filename: Option<String>,
+    pub lineno: Option<u32>,
+    pub colno: Option<u32>,
+    pub module: Option<String>,
+    pub context_line: Option<String>,
+    #[serde(default)]
+    pub pre_context: Vec<String>,
+    #[serde(default)]
+    pub post_context: Vec<String>,
+    #[serde(default)]
+    pub resolved: bool,
+    #[serde(flatten)]
+    meta: CommonFrameMetadata,
+}
+
+impl RawRustFrame {
+    pub fn frame_id(&self) -> String {
+        let mut hasher = Sha512::new();
+
+        self.context_line
+            .as_ref()
+            .inspect(|c| hasher.update(c.as_bytes()));
+        self.filename
+            .as_ref()
+            .inspect(|f| hasher.update(f.as_bytes()));
+        hasher.update(self.function.as_bytes());
+        hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
+        hasher.update(self.colno.unwrap_or_default().to_be_bytes());
+        hasher.update(b"rust");
+        hasher.update(self.resolved.to_string().as_bytes());
+        self.module
+            .as_ref()
+            .inspect(|m| hasher.update(m.as_bytes()));
+        self.pre_context
+            .iter()
+            .chain(self.post_context.iter())
+            .for_each(|line| {
+                hasher.update(line.as_bytes());
+            });
+        format!("{:x}", hasher.finalize())
+    }
+
+    pub fn get_context(&self) -> Option<Context> {
+        let context_line = self.context_line.as_ref()?;
+        let lineno = self.lineno?;
+
+        let line = ContextLine::new(lineno, context_line);
+
+        let before = self
+            .pre_context
+            .iter()
+            .take(10)
+            .enumerate()
+            .map(|(i, line)| ContextLine::new_rel(lineno, -(i as i32) - 1, line.clone()))
+            .collect();
+        let after = self
+            .post_context
+            .iter()
+            .take(10)
+            .enumerate()
+            .map(|(i, line)| ContextLine::new_rel(lineno, i as i32 + 1, line.clone()))
+            .collect();
+        Some(Context {
+            before,
+            line,
+            after,
+        })
+    }
+}
+
+impl From<&RawRustFrame> for Frame {
+    fn from(value: &RawRustFrame) -> Self {
+        Frame {
+            frame_id: FrameId::placeholder(),
+            mangled_name: value.function.clone(),
+            line: value.lineno,
+            column: value.colno,
+            source: value.filename.clone(),
+            in_app: value.meta.in_app,
+            resolved_name: Some(value.function.clone()),
+            lang: "rust".to_string(),
+            resolved: value.resolved,
+            resolve_failure: None,
+
+            junk_drawer: None,
+            context: value.get_context(),
+            release: None,
+            synthetic: value.meta.synthetic,
+            suspicious: false,
+            module: value.module.clone(),
+            code_variables: None,
+        }
+    }
+}

--- a/rust/cymbal/src/langs/rust.rs
+++ b/rust/cymbal/src/langs/rust.rs
@@ -2,10 +2,7 @@ use common_types::error_tracking::FrameId;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
 
-use crate::{
-    frames::{Context, ContextLine, Frame},
-    langs::CommonFrameMetadata,
-};
+use crate::{frames::Frame, langs::CommonFrameMetadata};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RawRustFrame {
@@ -14,11 +11,6 @@ pub struct RawRustFrame {
     pub lineno: Option<u32>,
     pub colno: Option<u32>,
     pub module: Option<String>,
-    pub context_line: Option<String>,
-    #[serde(default)]
-    pub pre_context: Vec<String>,
-    #[serde(default)]
-    pub post_context: Vec<String>,
     #[serde(default)]
     pub resolved: bool,
     #[serde(flatten)]
@@ -29,9 +21,6 @@ impl RawRustFrame {
     pub fn frame_id(&self) -> String {
         let mut hasher = Sha512::new();
 
-        self.context_line
-            .as_ref()
-            .inspect(|c| hasher.update(c.as_bytes()));
         self.filename
             .as_ref()
             .inspect(|f| hasher.update(f.as_bytes()));
@@ -39,44 +28,10 @@ impl RawRustFrame {
         hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
         hasher.update(self.colno.unwrap_or_default().to_be_bytes());
         hasher.update(b"rust");
-        hasher.update(self.resolved.to_string().as_bytes());
         self.module
             .as_ref()
             .inspect(|m| hasher.update(m.as_bytes()));
-        self.pre_context
-            .iter()
-            .chain(self.post_context.iter())
-            .for_each(|line| {
-                hasher.update(line.as_bytes());
-            });
         format!("{:x}", hasher.finalize())
-    }
-
-    pub fn get_context(&self) -> Option<Context> {
-        let context_line = self.context_line.as_ref()?;
-        let lineno = self.lineno?;
-
-        let line = ContextLine::new(lineno, context_line);
-
-        let before = self
-            .pre_context
-            .iter()
-            .take(10)
-            .enumerate()
-            .map(|(i, line)| ContextLine::new_rel(lineno, -(i as i32) - 1, line.clone()))
-            .collect();
-        let after = self
-            .post_context
-            .iter()
-            .take(10)
-            .enumerate()
-            .map(|(i, line)| ContextLine::new_rel(lineno, i as i32 + 1, line.clone()))
-            .collect();
-        Some(Context {
-            before,
-            line,
-            after,
-        })
     }
 }
 
@@ -95,7 +50,7 @@ impl From<&RawRustFrame> for Frame {
             resolve_failure: None,
 
             junk_drawer: None,
-            context: value.get_context(),
+            context: None,
             release: None,
             synthetic: value.meta.synthetic,
             suspicious: false,

--- a/rust/cymbal/src/langs/rust.rs
+++ b/rust/cymbal/src/langs/rust.rs
@@ -6,7 +6,7 @@ use crate::{frames::Frame, langs::CommonFrameMetadata};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RawRustFrame {
-    pub function: String,
+    pub function: Option<String>,
     pub filename: Option<String>,
     pub lineno: Option<u32>,
     pub colno: Option<u32>,
@@ -24,7 +24,7 @@ impl RawRustFrame {
         self.filename
             .as_ref()
             .inspect(|f| hasher.update(f.as_bytes()));
-        hasher.update(self.function.as_bytes());
+        hasher.update(self.function.as_deref().unwrap_or_default().as_bytes());
         hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
         hasher.update(self.colno.unwrap_or_default().to_be_bytes());
         hasher.update(b"rust");
@@ -37,14 +37,16 @@ impl RawRustFrame {
 
 impl From<&RawRustFrame> for Frame {
     fn from(value: &RawRustFrame) -> Self {
+        let function = value.function.clone().unwrap_or_default();
+
         Frame {
             frame_id: FrameId::placeholder(),
-            mangled_name: value.function.clone(),
+            mangled_name: function,
             line: value.lineno,
             column: value.colno,
             source: value.filename.clone(),
             in_app: value.meta.in_app,
-            resolved_name: Some(value.function.clone()),
+            resolved_name: value.function.clone(),
             lang: "rust".to_string(),
             resolved: value.resolved,
             resolve_failure: None,


### PR DESCRIPTION
## Problem

Rust SDK error tracking frames now use a native Rust platform. Cymbal needs to accept Rust frames as first-class input so future symbolication and debug-symbol handling can be added behind Rust-specific frame logic instead of treating these frames as generic custom frames.

## Changes

- Add a `RawRustFrame` type that normalizes into Cymbal frames with `lang: "rust"`.
- Register `platform: "rust"` in raw frame deserialization and resolution.
- Add unit coverage for Rust frame deserialization and normalized frame fields.

## How did you test this code?

As an agent, I ran:

- `cargo fmt --all -- --check`
- `cargo test -p cymbal ensure_rust_frames_work`
- `cargo test -p cymbal`
- `cargo clippy -p cymbal --all-targets -- -D warnings`

I also replayed a local Rust-frame exception through the local Cymbal stack and confirmed the processed event had `lang: "rust"` plus persisted issue and stack-frame rows.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update; this is internal frame-type support for Error tracking ingestion.

## 🤖 Agent context

Authored by Codex in a local agent session, using shell, Cargo, curl, psql, and gh CLI. The implementation keeps Rust frames separate from `custom` so later Rust symbolication and debug-symbol support can build on a native frame type without reclassifying stored data.
