### PR TITLE
fix(hogql): rust parser handles paren-led non-first CTE expressions

### DIFF
--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -2823,6 +2823,35 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ),
             )
 
+        @parameterized.expand(
+            [
+                # A non-first CTE whose column-form expression begins with a paren group
+                # followed by an operator tail. The CTE-list disambiguation must look past
+                # the paren group to the top-level `AS <ident>` alias; an early version of
+                # the rust parser stopped at the matching `)` and mis-parsed the remainder
+                # as the enclosing SELECT's paren.
+                ("operator_tail_after_paren_group", "WITH 5 AS a, 2 AS b, (a - b) * 10 AS c SELECT c", ["a", "b", "c"]),
+                ("single_paren_then_operator", "WITH 1 AS a, (a) + 1 AS c SELECT c", ["a", "c"]),
+                ("both_ctes_paren_led", "WITH (a - b) AS c, (c) * 2 AS d SELECT d", ["c", "d"]),
+                ("scalar_subquery_in_expression", "WITH 1 AS a, (SELECT 2) + 1 AS c SELECT c", ["a", "c"]),
+                (
+                    "paren_then_property_access",
+                    "WITH x AS (SELECT 1 AS n), (x.n) * 2 AS y SELECT y FROM x",
+                    ["x", "y"],
+                ),
+                # Disambiguation that must be preserved: an alias directly after the paren
+                # group is still a CTE, and a trailing-comma paren main query (no alias)
+                # must terminate the CTE list rather than be swallowed as a CTE.
+                ("immediate_alias_after_paren", "WITH 1 AS a, (a) AS c SELECT c", ["a", "c"]),
+                ("immediate_alias_after_subquery", "WITH 1 AS a, (SELECT 2) AS c SELECT c", ["a", "c"]),
+                ("trailing_comma_paren_main_query", "WITH 1 AS a, (SELECT 2)", ["a"]),
+            ]
+        )
+        def test_paren_led_cte_disambiguation(self, _name: str, query: str, expected_ctes: list[str]):
+            node = cast(ast.SelectQuery, self._select(query))
+            assert isinstance(node.ctes, dict)
+            self.assertEqual(sorted(node.ctes.keys()), sorted(expected_ctes))
+
         def test_grammar_quirk_invalid_join_type_rejected_on_all_backends(self):
             # `LEFT OUTER SEMI JOIN` passes the rust grammar's per-keyword checks (no rule forbids the combination) but isn't in `VALID_JOIN_TYPES`, so `JoinExpr.__post_init__` raises `ValueError` on every backend. rust-py writes `join_type` post-construction (via `chain_join`), so `PyEmitter::set_field` re-fires `__post_init__` and restores the original exception — surfacing the same `ValueError` the json backends raise from `cls(**kwargs)`.
             q = "SELECT 1 FROM a LEFT OUTER SEMI JOIN b ON a.x = b.x"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.69",
-    "hogql-parser-rs==1.3.82",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.83",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.69",
-    "hogql-parser-rs==1.3.83",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.84",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.83"
+version = "1.3.84"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.82"
+version = "1.3.83"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.82); each ships as its own PyPI wheel.
-version = "1.3.82"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.83); each ships as its own PyPI wheel.
+version = "1.3.83"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.83); each ships as its own PyPI wheel.
-version = "1.3.83"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.84); each ships as its own PyPI wheel.
+version = "1.3.84"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.83).
-version = "1.3.83"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.84).
+version = "1.3.84"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.82).
-version = "1.3.82"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.69, this is 1.3.83).
+version = "1.3.83"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/src/parse/cte.rs
+++ b/rust/hogql/parser/src/parse/cte.rs
@@ -61,9 +61,8 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
         // and are skipped; only a depth-0 `AS` is the CTE alias.
         let mut depth: i32 = 1;
         loop {
-            let tok = match probe.next_token() {
-                Ok(t) => t,
-                Err(_) => return false,
+            let Ok(tok) = probe.next_token() else {
+                return false;
             };
             match tok.kind {
                 TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => depth += 1,
@@ -80,9 +79,8 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
                 // alias: it is not a column-form CTE.
                 TokenKind::Comma if depth == 0 => return false,
                 TokenKind::Keyword(Kw::As) if depth == 0 => {
-                    let ident = match probe.next_token() {
-                        Ok(t) => t,
-                        Err(_) => return false,
+                    let Ok(ident) = probe.next_token() else {
+                        return false;
                     };
                     return matches!(
                         ident.kind,
@@ -291,6 +289,10 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
 mod tests {
     use crate::parse::parse_select;
 
+    fn assert_parses(src: &str) {
+        parse_select(src).unwrap_or_else(|e| panic!("expected ok for {src:?}: {e:?}"));
+    }
+
     /// A non-first CTE whose column-form expression begins with a paren
     /// group followed by an operator tail (`(a - b) * 10 AS c`) must
     /// parse. Regression: the CTE-list loop terminated early because the
@@ -308,7 +310,7 @@ mod tests {
             // paren group followed by a postfix property access then operator
             "WITH x AS (SELECT 1 AS n), (x.n) * 2 AS y SELECT y FROM x",
         ] {
-            parse_select(src).unwrap_or_else(|e| panic!("expected ok for {src:?}: {e:?}"));
+            assert_parses(src);
         }
     }
 
@@ -323,7 +325,7 @@ mod tests {
             "WITH 1 AS a, (SELECT 2) AS c SELECT c",
             "WITH 1 AS a, (SELECT 2)",
         ] {
-            parse_select(src).unwrap_or_else(|e| panic!("expected ok for {src:?}: {e:?}"));
+            assert_parses(src);
         }
     }
 }

--- a/rust/hogql/parser/src/parse/cte.rs
+++ b/rust/hogql/parser/src/parse/cte.rs
@@ -22,8 +22,8 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
         // that terminates the CTE list; mirror that. A bare `LPAREN`
         // following the comma can ALSO be the leading `(` of the next
         // CTE element (column-form `(SELECT 1) AS x` / `(a + b) AS y`),
-        // so peek past the matching `)` to see if an `AS identifier`
-        // pattern follows before terminating the loop.
+        // so peek past the paren group's expression to see if an
+        // `AS identifier` alias follows before terminating the loop.
         let mut out = Vec::new();
         loop {
             out.push(self.parse_with_expr()?);
@@ -33,48 +33,65 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
             if matches!(self.peek(), TokenKind::Keyword(Kw::Select)) {
                 break;
             }
-            if self.peek() == TokenKind::LParen && !self.paren_group_followed_by_as_identifier() {
+            if self.peek() == TokenKind::LParen && !self.paren_led_column_cte_follows() {
                 break;
             }
         }
         Ok(out)
     }
 
-    /// `self.peek()` is `(`. Probe whether the matching `)` is followed
-    /// by an `AS identifier` pattern — the shape that marks the paren
-    /// group as the head of the next column-form CTE
-    /// (`(SELECT 1) AS x`, `(a + b) AS y`) rather than the leading
-    /// paren of the enclosing SELECT statement.
-    fn paren_group_followed_by_as_identifier(&self) -> bool {
+    /// `self.peek()` is `(`. Probe whether this paren group heads a
+    /// column-form CTE — i.e. a top-level `AS identifier` alias
+    /// terminates the expression it begins — rather than being the
+    /// leading paren of the enclosing SELECT statement.
+    ///
+    /// The paren group can be the whole expression (`(a + b) AS y`,
+    /// `(SELECT 1) AS x`) or just its head, with an operator tail
+    /// before the alias (`(a - b) * 10 AS y`, `(SELECT n) + 1 AS y`).
+    /// Either way the distinguishing mark is a depth-0 `AS <ident>`:
+    /// the alias of a column-form CTE. A trailing-comma main query
+    /// (`WITH a AS 1, (SELECT 2)`) has no such alias, so we stop at
+    /// EOF, a depth-0 comma, or a `)` that closes past the leading
+    /// paren (the enclosing query's own paren).
+    fn paren_led_column_cte_follows(&self) -> bool {
         let mut probe = Lexer::with_pos(self.src, self.peek0.end);
+        // Depth starts at 1: the leading `(` has been consumed by the
+        // caller's `peek`. `AS`/`,` inside the paren group (tuple
+        // commas, `CAST(x AS t)`, nested subqueries) sit at depth >= 1
+        // and are skipped; only a depth-0 `AS` is the CTE alias.
         let mut depth: i32 = 1;
-        while depth > 0 {
+        loop {
             let tok = match probe.next_token() {
                 Ok(t) => t,
                 Err(_) => return false,
             };
             match tok.kind {
                 TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => depth += 1,
-                TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => depth -= 1,
+                TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
+                    depth -= 1;
+                    // Closed past the leading paren group's container —
+                    // the enclosing query's `)`. Not a CTE head.
+                    if depth < 0 {
+                        return false;
+                    }
+                }
                 TokenKind::Eof => return false,
+                // A depth-0 comma ends this list element without an
+                // alias: it is not a column-form CTE.
+                TokenKind::Comma if depth == 0 => return false,
+                TokenKind::Keyword(Kw::As) if depth == 0 => {
+                    let ident = match probe.next_token() {
+                        Ok(t) => t,
+                        Err(_) => return false,
+                    };
+                    return matches!(
+                        ident.kind,
+                        TokenKind::Ident | TokenKind::QuotedIdent | TokenKind::Keyword(_)
+                    );
+                }
                 _ => {}
             }
         }
-        let after = match probe.next_token() {
-            Ok(t) => t,
-            Err(_) => return false,
-        };
-        if after.kind != TokenKind::Keyword(Kw::As) {
-            return false;
-        }
-        let ident = match probe.next_token() {
-            Ok(t) => t,
-            Err(_) => return false,
-        };
-        matches!(
-            ident.kind,
-            TokenKind::Ident | TokenKind::QuotedIdent | TokenKind::Keyword(_)
-        )
     }
 
     fn parse_with_expr(&mut self) -> Result<E::Value, ParseError> {
@@ -267,5 +284,46 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
         Ok(self
             .emit
             .cte_subquery(&name, sub, columns, using_key, materialized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse::parse_select;
+
+    /// A non-first CTE whose column-form expression begins with a paren
+    /// group followed by an operator tail (`(a - b) * 10 AS c`) must
+    /// parse. Regression: the CTE-list loop terminated early because the
+    /// paren-group probe only accepted `(...)` immediately followed by
+    /// `AS`, so the trailing operator chain sent the leftover into the
+    /// SELECT parser ("mismatched input ... expecting {SELECT, WITH, ...}").
+    #[test]
+    fn paren_led_non_first_cte_with_operator_tail() {
+        for src in [
+            "WITH 5 AS a, 2 AS b, (a - b) * 10 AS c SELECT c",
+            "WITH 1 AS a, (a) + 1 AS c SELECT c",
+            "WITH (a - b) AS c, (c) * 2 AS d SELECT d",
+            // scalar subquery as the head of a larger CTE expression
+            "WITH 1 AS a, (SELECT 2) + 1 AS c SELECT c",
+            // paren group followed by a postfix property access then operator
+            "WITH x AS (SELECT 1 AS n), (x.n) * 2 AS y SELECT y FROM x",
+        ] {
+            parse_select(src).unwrap_or_else(|e| panic!("expected ok for {src:?}: {e:?}"));
+        }
+    }
+
+    /// The fix must not over-eat: a paren group with the alias directly
+    /// after `)` is still a CTE, and a trailing-comma main query
+    /// (`WITH a AS 1, (SELECT 2)`) — a paren group with no alias — must
+    /// still terminate the CTE list and parse as the enclosing select.
+    #[test]
+    fn paren_led_cte_disambiguation_preserved() {
+        for src in [
+            "WITH 1 AS a, (a) AS c SELECT c",
+            "WITH 1 AS a, (SELECT 2) AS c SELECT c",
+            "WITH 1 AS a, (SELECT 2)",
+        ] {
+            parse_select(src).unwrap_or_else(|e| panic!("expected ok for {src:?}: {e:?}"));
+        }
     }
 }

--- a/rust/hogql/parser/src/parse/cte.rs
+++ b/rust/hogql/parser/src/parse/cte.rs
@@ -41,15 +41,16 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
     }
 
     /// `self.peek()` is `(`. Probe whether this paren group heads a
-    /// column-form CTE — i.e. a top-level `AS identifier` alias
-    /// terminates the expression it begins — rather than being the
-    /// leading paren of the enclosing SELECT statement.
+    /// column-form CTE — i.e. a top-level `AS identifier` alias follows
+    /// the expression it begins — rather than being the leading paren of
+    /// the enclosing SELECT statement.
     ///
     /// The paren group can be the whole expression (`(a + b) AS y`,
     /// `(SELECT 1) AS x`) or just its head, with an operator tail
     /// before the alias (`(a - b) * 10 AS y`, `(SELECT n) + 1 AS y`).
     /// Either way the distinguishing mark is a depth-0 `AS <ident>`:
-    /// the alias of a column-form CTE. A trailing-comma main query
+    /// the alias of a column-form CTE. We scan forward and return true
+    /// on the first depth-0 `AS <ident>`. A trailing-comma main query
     /// (`WITH a AS 1, (SELECT 2)`) has no such alias, so we stop at
     /// EOF, a depth-0 comma, or a `)` that closes past the leading
     /// paren (the enclosing query's own paren).
@@ -282,50 +283,5 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
         Ok(self
             .emit
             .cte_subquery(&name, sub, columns, using_key, materialized))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::parse::parse_select;
-
-    fn assert_parses(src: &str) {
-        parse_select(src).unwrap_or_else(|e| panic!("expected ok for {src:?}: {e:?}"));
-    }
-
-    /// A non-first CTE whose column-form expression begins with a paren
-    /// group followed by an operator tail (`(a - b) * 10 AS c`) must
-    /// parse. Regression: the CTE-list loop terminated early because the
-    /// paren-group probe only accepted `(...)` immediately followed by
-    /// `AS`, so the trailing operator chain sent the leftover into the
-    /// SELECT parser ("mismatched input ... expecting {SELECT, WITH, ...}").
-    #[test]
-    fn paren_led_non_first_cte_with_operator_tail() {
-        for src in [
-            "WITH 5 AS a, 2 AS b, (a - b) * 10 AS c SELECT c",
-            "WITH 1 AS a, (a) + 1 AS c SELECT c",
-            "WITH (a - b) AS c, (c) * 2 AS d SELECT d",
-            // scalar subquery as the head of a larger CTE expression
-            "WITH 1 AS a, (SELECT 2) + 1 AS c SELECT c",
-            // paren group followed by a postfix property access then operator
-            "WITH x AS (SELECT 1 AS n), (x.n) * 2 AS y SELECT y FROM x",
-        ] {
-            assert_parses(src);
-        }
-    }
-
-    /// The fix must not over-eat: a paren group with the alias directly
-    /// after `)` is still a CTE, and a trailing-comma main query
-    /// (`WITH a AS 1, (SELECT 2)`) — a paren group with no alias — must
-    /// still terminate the CTE list and parse as the enclosing select.
-    #[test]
-    fn paren_led_cte_disambiguation_preserved() {
-        for src in [
-            "WITH 1 AS a, (a) AS c SELECT c",
-            "WITH 1 AS a, (SELECT 2) AS c SELECT c",
-            "WITH 1 AS a, (SELECT 2)",
-        ] {
-            assert_parses(src);
-        }
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -3025,16 +3025,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.83"
+version = "1.3.84"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/b5/5e9e8357404953bb51cb0d23c50cd3cfbdeb605834fb6110db476e59e05d/hogql_parser_rs-1.3.83.tar.gz", hash = "sha256:8d77dc906a96008b149ae8163fcd5afe6f9185a6a7ea9be320beb2cf54bde574", size = 301922, upload-time = "2026-05-30T08:58:51.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/8c/03d5335d3d98bff386f0497a4624e761a6ea283e802bc01a77ac8cc8d221/hogql_parser_rs-1.3.84.tar.gz", hash = "sha256:7db5389fcb36e52624d5c6c8733f3d50477a06439a82ad3e027a3ed19e5514c7", size = 282589, upload-time = "2026-06-08T18:03:21.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/73/9fa7b31759c15b12c6c593bc2a96daa90f0abdf194824e652fda3e001ee5/hogql_parser_rs-1.3.83-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:da2f895cf6786260bce9e43566ffa8787aca6b3bba3d7d650ace813b20a5a8c2", size = 731433, upload-time = "2026-05-30T08:58:40.489Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/0e/fbd477f4115f58da0dd30ed64d6553778185b1b42c68b4e2b8e2dcb307e5/hogql_parser_rs-1.3.83-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:ee0beeafc0c29a87253c6b44760b0bcdabfea917d17b1a466efbbd4809af56b7", size = 689487, upload-time = "2026-05-30T08:58:42.464Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/2f/0048876d0f13e935ff49e84c9f959cae101f907a36d76df78deec7875594/hogql_parser_rs-1.3.83-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fe3178919d5834c548f17855378e9611c69108b3864099fc3365395455b53f69", size = 2479962, upload-time = "2026-05-30T08:58:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/28/45/8bbef42d791448529f8ed8187c8687e836fb872c7a165fc73ce84941501a/hogql_parser_rs-1.3.83-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:72fa5c141bda552e8df3c45aed661c286412eab27a213b9cbe81a92e8e78ba2b", size = 2738862, upload-time = "2026-05-30T08:58:46.164Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/99/95f47a6d04cd2bd9d4f42ec709eddfb70926465d5ce72dc579f51fea2605/hogql_parser_rs-1.3.83-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fe24c20028ec49b77b1145158c7c8ccee5608a4c825fd5ed73d8c662ef7ba718", size = 2651283, upload-time = "2026-05-30T08:58:47.926Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/55/f25ae07ffb46a754a9576389ab26b4e5beff55f683b23a6486f5c2d85640/hogql_parser_rs-1.3.83-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a290a741df88cfb742fde506394c072a7b4f80e9dfbc8ec0b44a7cecb86464b", size = 2701269, upload-time = "2026-05-30T08:58:49.688Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8e/ad99eff56a05ca6b2f1bd592efde1aa81a7a52b3fc7fcd4c7519c9ce5515/hogql_parser_rs-1.3.84-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fc32c43413bd2692798faedc65e2687ba52630d9f232b167fc745f9113e0621c", size = 727303, upload-time = "2026-06-08T18:03:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/89/c94866d0ab46d8bbd2a45c741a2ff5c1dd7b977083ba3f3b6e2f01690f6e/hogql_parser_rs-1.3.84-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:44aaae7a57a29762d3598284183443e16098a5a65d5cba430f11ea5727fee16b", size = 685009, upload-time = "2026-06-08T18:03:13.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a7/68e64caf41f9e8606cf21c126371b75d401259655ce88f4fd35501d32825/hogql_parser_rs-1.3.84-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ef3dfb8a520e17a9315c18be59dda9e81c37be2b30d3f8a0fca14c118ade452f", size = 2474527, upload-time = "2026-06-08T18:03:15.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/d2894e3ae4e2c4197cfc36c6735af0ed48b2ad6cbe97f5b267b6c0d6c5a6/hogql_parser_rs-1.3.84-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:097551f2733d2dabe7b419f08199d30f6e2970f442dc8a87fa3228fa7be82b15", size = 2733806, upload-time = "2026-06-08T18:03:17.2Z" },
+    { url = "https://files.pythonhosted.org/packages/99/f1/56857dea8c90b4f5b5731327bf3977c90737bd32c21ef3a6fb487b62a769/hogql_parser_rs-1.3.84-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bf77c7067610833aae1292ed995619445d44f7cbf2cb7790a9d3ec26653b335b", size = 2647471, upload-time = "2026-06-08T18:03:18.568Z" },
+    { url = "https://files.pythonhosted.org/packages/78/34/411d1e5c8c08474d0c49c9e03b734895867a2b3eaff8730da2c8550445bc/hogql_parser_rs-1.3.84-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:497c7d435f6bcbc839372f12026176fbccf6b419714673edda61a4fd2d05913d", size = 2696957, upload-time = "2026-06-08T18:03:20.124Z" },
 ]
 
 [[package]]
@@ -5568,7 +5568,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.69" },
-    { name = "hogql-parser-rs", specifier = "==1.3.83" },
+    { name = "hogql-parser-rs", specifier = "==1.3.84" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3025,16 +3025,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.82"
+version = "1.3.83"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/3f/d9bea06219775097b1dbde1885c6089ce9c9c7c6e6f0c1e30aed6cc3f3d7/hogql_parser_rs-1.3.82.tar.gz", hash = "sha256:b5e13d1467060ffd4a26430177a9abfeb760fd2cabef19641960f3c5d9191296", size = 280827, upload-time = "2026-05-29T14:42:51.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/b5/5e9e8357404953bb51cb0d23c50cd3cfbdeb605834fb6110db476e59e05d/hogql_parser_rs-1.3.83.tar.gz", hash = "sha256:8d77dc906a96008b149ae8163fcd5afe6f9185a6a7ea9be320beb2cf54bde574", size = 301922, upload-time = "2026-05-30T08:58:51.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/92/1b03ed83090b947046978bee27e4cd9e34419a5f3eb6024d82f8a685e3f4/hogql_parser_rs-1.3.82-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7d1417a6d4714d92e691a2e20d5a1486d61a34dddc45265fd0fd3fb9a1400397", size = 727516, upload-time = "2026-05-29T14:42:42.372Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a2/3a04eba078a02aacf9351825b837e64b68449fcde0568ae3b05e0156b885/hogql_parser_rs-1.3.82-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:1d21ad7cefb74cfadbafd8daa1de72cd774704100e20ec2253fd5aeb24b7d7ba", size = 685383, upload-time = "2026-05-29T14:42:43.941Z" },
-    { url = "https://files.pythonhosted.org/packages/01/46/64b408c7e1021a73656b335983836d45e2e5ad9a072fbaa4fba863d7336f/hogql_parser_rs-1.3.82-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dbe6d6680ee528d27f0f6a1374973f7ae9ddd10cab4972f1e9aede68460501e5", size = 2475166, upload-time = "2026-05-29T14:42:45.701Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/ec/42df4f4e9fefbd1dbe8874fb3df9e7328e3bf4e2beb0f3d05a82bf5cb1a7/hogql_parser_rs-1.3.82-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:63f571fa4a7629133e84e4e5ff22b7f02e85f830cf5520b6f9cdb743410c49f9", size = 2734482, upload-time = "2026-05-29T14:42:47.215Z" },
-    { url = "https://files.pythonhosted.org/packages/80/50/7a4c2dd611414c7fe17e1b6c77bc31bee1583d852c25594906141cc91527/hogql_parser_rs-1.3.82-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68298628f3bcccb1ef5557f455af0005f7f6628677f17c9cf23c950acd1264fa", size = 2647339, upload-time = "2026-05-29T14:42:48.965Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f3/39f0e6ea25221780371fb5a452c7e1a53f4e959e5d997819b4c1bc8ad907/hogql_parser_rs-1.3.82-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f62790bb62b0846a0ea421c772f69759d71e4480f1965144f202aaccbd302b62", size = 2696915, upload-time = "2026-05-29T14:42:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/46/73/9fa7b31759c15b12c6c593bc2a96daa90f0abdf194824e652fda3e001ee5/hogql_parser_rs-1.3.83-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:da2f895cf6786260bce9e43566ffa8787aca6b3bba3d7d650ace813b20a5a8c2", size = 731433, upload-time = "2026-05-30T08:58:40.489Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/fbd477f4115f58da0dd30ed64d6553778185b1b42c68b4e2b8e2dcb307e5/hogql_parser_rs-1.3.83-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:ee0beeafc0c29a87253c6b44760b0bcdabfea917d17b1a466efbbd4809af56b7", size = 689487, upload-time = "2026-05-30T08:58:42.464Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2f/0048876d0f13e935ff49e84c9f959cae101f907a36d76df78deec7875594/hogql_parser_rs-1.3.83-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fe3178919d5834c548f17855378e9611c69108b3864099fc3365395455b53f69", size = 2479962, upload-time = "2026-05-30T08:58:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/28/45/8bbef42d791448529f8ed8187c8687e836fb872c7a165fc73ce84941501a/hogql_parser_rs-1.3.83-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:72fa5c141bda552e8df3c45aed661c286412eab27a213b9cbe81a92e8e78ba2b", size = 2738862, upload-time = "2026-05-30T08:58:46.164Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/99/95f47a6d04cd2bd9d4f42ec709eddfb70926465d5ce72dc579f51fea2605/hogql_parser_rs-1.3.83-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fe24c20028ec49b77b1145158c7c8ccee5608a4c825fd5ed73d8c662ef7ba718", size = 2651283, upload-time = "2026-05-30T08:58:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/55/f25ae07ffb46a754a9576389ab26b4e5beff55f683b23a6486f5c2d85640/hogql_parser_rs-1.3.83-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a290a741df88cfb742fde506394c072a7b4f80e9dfbc8ec0b44a7cecb86464b", size = 2701269, upload-time = "2026-05-30T08:58:49.688Z" },
 ]
 
 [[package]]
@@ -5568,7 +5568,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.69" },
-    { name = "hogql-parser-rs", specifier = "==1.3.82" },
+    { name = "hogql-parser-rs", specifier = "==1.3.83" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },


### PR DESCRIPTION
## Problem

The native Rust HogQL parser (`rust-json` / `rust-py` backends, the default since the parser was introduced) rejects a class of valid `WITH` clauses that the C++ ANTLR parser — the source of truth — accepts. A non-first CTE whose column-form expression *begins* with a parenthesised group followed by an operator fails to parse:

```sql
WITH 5 AS a, 2 AS b, (a - b) * 10 AS c SELECT c
```

errors with `mismatched input 'a' expecting {SELECT, WITH, '{', '(', '<'}`, while the equivalent shape without the trailing operator (`(a - b) AS c`) parses fine. Because the default backend is the Rust parser, real saved queries that use this pattern (multi-CTE `WITH` blocks where a later CTE derives a value via parenthesised arithmetic, scalar subqueries used inside expressions, etc.) started failing even though they parse correctly under the C++ oracle.

## Root cause

The CTE-list loop in `rust/hogql/parser/src/parse/cte.rs` decides, after each comma, whether a leading `(` starts another column-form CTE or is the opening paren of the enclosing SELECT. The probe that made this call only treated the paren group as a CTE head when `AS <identifier>` came **immediately** after the matching `)`. When the paren group is merely the *head* of a larger expression (`(a - b) * 10 AS c`, `(SELECT n) + 1 AS c`, `(x.n) * 2 AS y`), the token after `)` is an operator, so the probe returned false, the CTE list terminated early, and the leftover `( ... ) <op> ... AS c SELECT ...` was handed to the SELECT parser — which consumed the `(` as a parenthesised sub-select and failed on the first inner token.

## Changes

Rewrite the probe (`paren_group_followed_by_as_identifier` → `paren_led_column_cte_follows`) to scan the token stream with bracket-depth tracking and look for a **top-level (`depth == 0`) `AS <identifier>`** that terminates the expression — the unambiguous mark of a column-form CTE. It still bails out (treating `(` as the enclosing query) at EOF, a depth-0 comma, or a `)` that closes past the leading paren, so a trailing-comma main query like `WITH a AS 1, (SELECT 2)` keeps terminating the list correctly.

This is a Rust-parser-only fix: the grammar and the C++ parser were already correct, so no grammar change is involved. The fix lives entirely in the CTE-list control flow (before any AST emission), so it applies identically to both the `rust-json` and `rust-py` emitters.

Also bumps the crate version (`1.3.82` → `1.3.83`) in `Cargo.toml` / `pyproject.toml` / `rust/Cargo.lock` per the crate's per-change versioning convention.

> Note: the repo-root `pyproject.toml` pin and `uv.lock` still reference `1.3.82` — they should be bumped to `1.3.83` once the wheel is published by the `build-hogql-parser-rs` workflow, following the normal publish flow.

## How did you test this code?

I'm an agent; I did not perform manual UI testing. Automated tests I actually ran:

- Added two regression tests in `cte.rs` driven through the real `parse_select` entry point:
  - `paren_led_non_first_cte_with_operator_tail` — the previously-failing shapes (arithmetic tail, scalar-subquery head, postfix property-access head) now parse.
  - `paren_led_cte_disambiguation_preserved` — immediate-`AS` CTEs and the no-alias trailing-comma main query still parse correctly.
- `cargo test` — full crate suite passes (17/17, including the two new tests).
- `cargo fmt --check` and `cargo clippy --all-targets` — clean.

Cross-backend parity (rebuilding the wheel and asserting `rust-*` matches `cpp-json`) runs in CI; I confirmed against the C++ parser that every query asserted as OK in the new tests is accepted by the source-of-truth parser.

## 🤖 Agent context

Authored by Claude Code (Opus) driving the investigation and fix.

The starting symptom was a parse error on saved queries that previously worked. I bisected by running the same query through each parser backend (`cpp-json`, `rust-json`, `rust-py`) and found the C++ ANTLR parser accepted it while both Rust backends rejected it — narrowing the regression to the hand-rolled Rust parser rather than the grammar. I then reduced the trigger to a minimal repro and traced it to the CTE-list continuation probe, confirming the boundary (first vs. non-first CTE; presence of an operator tail after the paren group).

Rejected approaches: enumerating an allowlist of expression-continuation operators after `)` (fragile — easy to miss an operator, and would need updating with the grammar). Chose the depth-tracking "find the top-level `AS` alias" scan instead, since a column-form CTE is *defined* by having that alias and a main-query paren never carries one — which makes the disambiguation robust without tracking the operator set.

Requires human review; agent-authored.
