### PR TITLE
fix(cdp): Wake parked workflow waits regardless of cyclotron queue

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.test.ts
@@ -195,6 +195,17 @@ describe('CdpHogflowSubscriptionMatcherConsumer', () => {
             expect(lookup.params[4]).toEqual(['flow-1']) // functionIds
         })
 
+        it('does not constrain the lookup by queue_name so waits parked on any queue are found', async () => {
+            // A wait that follows an email step parks on the email queue, not hogflow. The lookup
+            // must not filter queue_name or it would silently miss those parked jobs; function_id
+            // already scopes the results to hogflow jobs.
+            matcher.setHogFlows({ 'flow-1': makeHogFlow({ id: 'flow-1' }) })
+            await matcher.runWake([makeGlobals({})])
+            const lookup = matcher.calls.find((c) => c.sql.includes('SELECT id, team_id, function_id'))!
+            expect(lookup).not.toBeUndefined()
+            expect(lookup.sql).not.toContain('queue_name')
+        })
+
         it('correlates team_id with distinct_id so a cross-team pairing is never queried or woken', async () => {
             // Bug scenario: event A is (team 1, alice), event B is (team 2, bob). A naive
             // `team_id = ANY([1,2]) AND distinct_id = ANY([alice,bob])` query would also match

--- a/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.ts
@@ -264,6 +264,12 @@ export class CdpHogflowSubscriptionMatcherConsumer<
         // ANY/ANY would match a job whose team and distinct_id came from two different
         // events in the batch (a cross-team false-positive candidate). The function_id
         // filter further scopes to flows the matcher can act on.
+        //
+        // We deliberately do NOT filter by queue_name: a parked wait can sit on a queue
+        // other than 'hogflow'. When a step (e.g. email) routes the invocation to a
+        // dedicated queue, the following wait parks on that queue, so a queue_name='hogflow'
+        // filter would silently miss it. function_id already scopes to hogflow jobs, and
+        // waking the job (scheduled = NOW()) lets whichever worker owns that queue resume it.
         const stopTimer = histogramHogflowMatcherFindParkedJobs.startTimer()
         let result
         try {
@@ -271,7 +277,6 @@ export class CdpHogflowSubscriptionMatcherConsumer<
                 `SELECT id, team_id, function_id, action_id, distinct_id, person_id
              FROM cyclotron_jobs
              WHERE status = 'available'
-               AND queue_name = 'hogflow'
                AND scheduled > NOW()
                AND function_id = ANY($5::uuid[])
                AND (team_id, distinct_id) IN (SELECT * FROM unnest($1::int[], $2::text[]))
@@ -279,7 +284,6 @@ export class CdpHogflowSubscriptionMatcherConsumer<
              SELECT id, team_id, function_id, action_id, distinct_id, person_id
              FROM cyclotron_jobs
              WHERE status = 'available'
-               AND queue_name = 'hogflow'
                AND scheduled > NOW()
                AND function_id = ANY($5::uuid[])
                AND (team_id, person_id) IN (SELECT * FROM unnest($3::int[], $4::text[]))`,

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -1452,7 +1452,8 @@ describe('Workflows E2E (email queue)', () => {
         const parked = (await queryCyclotronJobs()).find(
             (j: any) => j.status === 'available' && new Date(j.scheduled) > new Date()
         )
-        expect(parked.queue_name).toBe('email')
+        expect(parked).toBeDefined()
+        expect(parked?.queue_name).toBe('email')
         expect(emailsSent()).toBe(1)
 
         // The subscribed event fires for this person — the matcher wakes the parked job even though

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -1038,12 +1038,14 @@ describe('Workflows E2E (email queue)', () => {
     let eventsConsumer: CdpEventsConsumer
     let hogflowWorker: CdpCyclotronWorkerHogFlow
     let emailWorker: CdpCyclotronWorkerEmail
+    let matcher: CdpHogflowSubscriptionMatcherConsumer | undefined
 
     let hub: Hub
     let kafkaProducer: KafkaProducerWrapper
     let mockProducerObserver: KafkaProducerObserver
     let team: Team
     let cyclotronPool: Pool
+    let deps: ReturnType<typeof createCdpConsumerDeps>
 
     beforeAll(() => {
         cyclotronPool = new Pool({ connectionString: CYCLOTRON_NODE_DB_URL })
@@ -1112,7 +1114,8 @@ describe('Workflows E2E (email queue)', () => {
             ],
         })
 
-        const deps = createCdpConsumerDeps(hub, kafkaProducer)
+        matcher = undefined
+        deps = createCdpConsumerDeps(hub, kafkaProducer)
         const kafkaQueue = new CyclotronJobQueueKafka(hub.KAFKA_CLIENT_RACK, hub, hub.CONSUMER_BATCH_SIZE)
         // Each consumer gets a dedicated CyclotronJobQueuePostgresV2 — sharing one
         // across two consumers collides on `this.worker` and the shared pg pool.
@@ -1143,6 +1146,7 @@ describe('Workflows E2E (email queue)', () => {
             eventsConsumer?.stop() ?? Promise.resolve(),
             hogflowWorker?.stop() ?? Promise.resolve(),
             emailWorker?.stop() ?? Promise.resolve(),
+            matcher?.stop().catch(() => {}) ?? Promise.resolve(),
         ])
         await kafkaProducer.disconnect()
         await closeHub(hub)
@@ -1154,7 +1158,9 @@ describe('Workflows E2E (email queue)', () => {
         return result.rows
     }
 
-    function createGlobals(): HogFunctionInvocationGlobals {
+    function createGlobals(
+        overrides: Partial<HogFunctionInvocationGlobals['event']> = {}
+    ): HogFunctionInvocationGlobals {
         return createHogExecutionGlobals({
             project: { id: team.id } as any,
             event: {
@@ -1165,9 +1171,16 @@ describe('Workflows E2E (email queue)', () => {
                     $lib_version: '1.0.0',
                 },
                 timestamp: '2024-09-03T09:00:00Z',
+                ...overrides,
             } as any,
         })
     }
+
+    // Mirrors what HogFlowSerializer compiles for {events: [{id: <name>}]}: a single
+    // equality check on the `event` global. The matcher fails closed without bytecode.
+    const eventNameFilter = (eventName: string) => ({
+        filters: { events: [{ id: eventName }], bytecode: ['_H', 1, 32, eventName, 32, 'event', 1, 1, 11] as any[] },
+    })
 
     it('routes the email through the dedicated queue and continues the workflow', async () => {
         const hogFlow = new FixtureHogFlowBuilder()
@@ -1355,5 +1368,101 @@ describe('Workflows E2E (email queue)', () => {
             )
             expect(terminal.length).toBeGreaterThanOrEqual(1)
         }, 10000)
+    })
+
+    it('wakes a wait_until_condition parked on the email queue after an email step', async () => {
+        // Reproduces the prod bug: an email step routes the invocation to the email queue, so the
+        // following wait_until_condition parks on the email queue (not hogflow). The matcher must
+        // still find and wake it there — otherwise a matching event never wakes the job and the
+        // post-wait email is never sent.
+        const emailAction = (label: string) => ({
+            type: 'function_email' as const,
+            config: {
+                template_id: 'template-workflows-e2e-email',
+                inputs: {
+                    email: {
+                        value: {
+                            to: { email: 'recipient@example.com', name: 'Recipient' },
+                            from: { integrationId: 1, email: 'sender@posthog.com' },
+                            subject: label,
+                            text: label,
+                            html: `<p>${label}</p>`,
+                        },
+                    },
+                },
+            },
+        })
+
+        const hogFlow = new FixtureHogFlowBuilder()
+            .withTeamId(team.id)
+            .withStatus('active')
+            .withExitCondition('exit_only_at_end')
+            .withWorkflow({
+                actions: {
+                    trigger: {
+                        type: 'trigger',
+                        config: { type: 'event', filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {} },
+                    },
+                    email_1: emailAction('First email'),
+                    wait_condition: {
+                        type: 'wait_until_condition',
+                        config: {
+                            // Property condition never matches, so only the event can wake the job.
+                            condition: { filters: HOG_FILTERS_EXAMPLES.elements_text_filter.filters },
+                            events: [eventNameFilter('wakeup_event')],
+                            // Long enough that the job stays parked for the whole test — the only way
+                            // the second email sends is the matcher waking it, never a timeout.
+                            max_wait_duration: '5m',
+                        },
+                    },
+                    email_2: emailAction('Second email'),
+                    exit: { type: 'exit', config: {} },
+                },
+                edges: [
+                    { from: 'trigger', to: 'email_1', type: 'continue' },
+                    { from: 'email_1', to: 'wait_condition', type: 'continue' },
+                    { from: 'wait_condition', to: 'email_2', type: 'branch', index: 0 },
+                    { from: 'wait_condition', to: 'exit', type: 'continue' },
+                    { from: 'email_2', to: 'exit', type: 'continue' },
+                ],
+            })
+            .build()
+        await insertHogFlow(hub.postgres, hogFlow)
+
+        const emailsSent = () =>
+            mockProducerObserver
+                .getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                .filter((m: any) => m.value.metric_name === 'email_sent')
+                .reduce((sum: number, m: any) => sum + m.value.count, 0)
+
+        // Trigger: email_1 routes to the email queue, the email worker sends it and continues the
+        // flow to the wait step, which parks.
+        const { backgroundTask } = await eventsConsumer.processBatch([createGlobals()])
+        await backgroundTask
+
+        // The first email is sent and the job parks waiting for the event.
+        await waitForExpect(async () => {
+            expect(emailsSent()).toBe(1)
+            const jobs = await queryCyclotronJobs()
+            expect(jobs.some((j: any) => j.status === 'available' && new Date(j.scheduled) > new Date())).toBe(true)
+        }, 15000)
+
+        // The wait parks on the email queue (carried over from email_1). The matcher has to find
+        // it there regardless of queue — that's exactly the scenario that was broken.
+        const parked = (await queryCyclotronJobs()).find(
+            (j: any) => j.status === 'available' && new Date(j.scheduled) > new Date()
+        )
+        expect(parked.queue_name).toBe('email')
+        expect(emailsSent()).toBe(1)
+
+        // The subscribed event fires for this person — the matcher wakes the parked job even though
+        // it sits on the email queue, the email worker resumes it down the matched branch, and the
+        // second email is sent. This is the end-to-end "the job wakes and the next step runs" check.
+        matcher = new CdpHogflowSubscriptionMatcherConsumer({ ...hub }, deps)
+        await matcher.processBatch([createGlobals({ event: 'wakeup_event' })])
+
+        await waitForExpect(() => {
+            expect(emailsSent()).toBe(2)
+        }, 15000)
     })
 })


### PR DESCRIPTION
## Problem

A workflow `wait until` step that waits on an event is woken by the hogflow subscription matcher, which looks up parked jobs in cyclotron. When the wait follows an email step and email queue routing is enabled (`CDP_EMAIL_QUEUE_ROUTING`), the email step routes the invocation onto the dedicated `email` queue, and the queue is preserved across subsequent actions — so the wait parks with `queue_name='email'`. The matcher's lookup filtered `queue_name='hogflow'`, so it never found these jobs: the workflow never advanced past the wait on a matching event and only ever resumed via the timeout branch.

## Changes

Drop the `queue_name` filter from the matcher's `findParkedJobs`. `function_id` already scopes the lookup to hogflow jobs, so the matcher now finds a parked wait regardless of which queue it sits on. Waking the job (`scheduled = NOW()`) lets whichever worker owns that queue resume it — consistent with the email queue's "continue on the worker that has the job" model (#54418).

No executor changes — where a job parks is left as-is; only the matcher's lookup is broadened. This is also future-proof: a wait following any routed step (not just email) is now found.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only:

- Matcher unit test asserting the lookup does not constrain `queue_name`.
- E2E (`workflows-e2e.test.ts`, real postgres-v2 + email worker, `CDP_EMAIL_QUEUE_ROUTING='*'`): an `email → wait_until_condition → email` workflow whose wait parks on the `email` queue is woken by a matching event, resumes the matched branch, and sends the second email. Verified it **fails** with the old `queue_name='hogflow'` filter (second email never sends) and **passes** with the filter removed.
- E2E for `email → delay → webhook` continuing to completion.
- Existing matcher E2E (hogflow-parked wakes) and the email-queue regression tests still pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with Claude Code. First attempt fixed this in the executor (reset the invocation's queue back to `hogflow` when a wait parks), but that reversed the deliberate inline-continue design introduced in #54418, so it was discarded. Switched to a matcher-only fix — broaden the lookup rather than relocate the job — which is smaller, future-proof, and leaves the email-queue design untouched.

Separate, out-of-scope observation worth a follow-up: a `delay` parked on the `email` queue is resumed by the email worker via polling, so if that worker scales toward zero with pending scheduled jobs they could be delayed. Not addressed here.
