### PR TITLE
fix(logs): populate _bytes_uncompressed per row to fix volume preview

### DIFF
--- a/bin/clickhouse-logs.sql
+++ b/bin/clickhouse-logs.sql
@@ -126,7 +126,8 @@ CREATE OR REPLACE TABLE kafka_logs_avro
     `resource_attributes` Map(LowCardinality(String), String),
     `instrumentation_scope` String,
     `event_name` String,
-    `attributes` Map(LowCardinality(String), String)
+    `attributes` Map(LowCardinality(String), String),
+    `bytes_uncompressed` Nullable(Int64)
 )
 ENGINE = Kafka('kafka:9092', 'clickhouse_logs', 'clickhouse-logs-avro', 'Avro')
 SETTINGS
@@ -155,15 +156,21 @@ CREATE MATERIALIZED VIEW kafka_logs_avro_mv TO logs32
     `resource_attributes` Map(LowCardinality(String), String),
     `instrumentation_scope` String,
     `event_name` String,
-    `attributes` Map(LowCardinality(String), String)
+    `attributes` Map(LowCardinality(String), String),
+    `_bytes_uncompressed` UInt64
 )
 AS SELECT
-* except (attributes, resource_attributes),
+* except (attributes, resource_attributes, bytes_uncompressed),
 mapSort(mapApply((k,v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) as attributes_map_str,
 -- mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__float'), toFloat64OrNull(JSONExtract(v, 'String'))), attributes))) as attributes_map_float,
 -- mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__datetime'), parseDateTimeBestEffortOrNull(JSONExtract(v, 'String'), 6)), attributes))) as attributes_map_datetime,
 mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
-toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id
+toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id,
+-- per-row content size from the Avro payload. Must NOT come from the per-batch
+-- `bytes_uncompressed` Kafka header, which is the whole HTTP body size and would be
+-- replicated onto every row in the batch (inflating sum(_bytes_uncompressed) by the
+-- batch row count in the volume preview).
+toUInt64(ifNull(bytes_uncompressed, 0)) as _bytes_uncompressed
 FROM kafka_logs_avro settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;
 
 create or replace table logs_kafka_metrics


### PR DESCRIPTION
## Problem

The drop-rule volume preview sums `_bytes_uncompressed`, but in production that column was fed the **per-batch** Kafka header `bytes_uncompressed` (the whole HTTP body size), stamped onto every row in the batch. So `sum(_bytes_uncompressed)` was inflated by the batch row count — measured at **~772×** for one service (it reported ~1.5 TB/hour where the real content was ~2 GB/hour). The column "isn't really used by anything" except this preview, so blast radius is low, but the preview is unusable.

## Changes

Single change to the logs ingest materialized view (`bin/clickhouse-logs.sql`):
- Read the per-row Avro `bytes_uncompressed` field on the `kafka_logs_avro` Kafka table.
- Map it into `_bytes_uncompressed` in `kafka_logs_avro_mv` instead of the per-batch header.

**No new table and no migration.** Earlier iterations of this fix cut over to a fresh `logs34` table via a ClickHouse migration, but that's unnecessary:
- The logs table has a **25-hour TTL**, so inflated rows age out within a day once the MV is fixed — no clean table needed.
- Recent logs-cluster schema changes ship via the SQL definition (local dev) with prod applied out-of-band, **not** via Django ClickHouse migrations (no `NodeRole.LOGS` migration has landed since `0223`). Prod already runs `logs34`; this stays on `logs32` in-repo, matching that drift.

The production ingest MV is deploy-managed (not in this repo) and gets the same per-row mapping out-of-band; this PR is the local-dev parity half.

## How did you test this code?

I'm an agent. This is a local-dev SQL definition change; I confirmed the diff is limited to the `kafka_logs_avro` Kafka table column + the `kafka_logs_avro_mv` mapping (no table/migration churn) and that the per-row Avro field (`bytes_uncompressed`, added in #59480) is the correct source. End-to-end byte accounting against real production data showed the 772× inflation that this remap removes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). Originally root-caused alongside a separate rate-limit bug; this PR is the byte-preview half. The first version created a `logs34` table + migration to "land corrected semantics on a clean table," but on review we dropped that: the 25h TTL self-heals inflated data, prod already runs `logs34`, and recent precedent evolves the logs cluster via the SQL def + out-of-band prod application rather than Django CH migrations. Scoped the PR down to the MV remap only.

Agent-authored; requires human review. Reviewer note: the prod deploy-managed ingest MV must get the same per-row mapping for the prod preview to be corrected — this repo change is local parity.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
