### PR TITLE
chore(ci): spike pytest-xdist on visual_review product tests

### DIFF
--- a/products/visual_review/package.json
+++ b/products/visual_review/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-visual-review",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short -n 2 --dist worksteal",
         "backend:test:unit": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v -m 'not integration' --tb=short",
         "backend:test:integration": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v -m 'integration' --tb=short",
         "backend:lint": "ruff check --config ../../pyproject.toml backend && ruff format --config ../../pyproject.toml --check backend",

--- a/products/visual_review/turbo.json
+++ b/products/visual_review/turbo.json
@@ -1,6 +1,17 @@
 {
     "extends": ["//"],
     "tasks": {
+        "backend:test": {
+            "inputs": [
+                "**/*.py",
+                "!**/__pycache__/**",
+                "!frontend/**",
+                "../../pyproject.toml",
+                "../../uv.lock",
+                "../../common/**/*.py",
+                "package.json"
+            ]
+        },
         "backend:contract-check": {
             "inputs": ["backend/facade/**", "backend/presentation/**"],
             "outputs": [],


### PR DESCRIPTION
## Problem

Product backend tests run **serially within a runner** (`turbo run backend:test --concurrency=1`). Each product's pytest process uses every core for one test at a time, leaving the rest idle. We want to know whether **in-process parallelism** (`pytest-xdist`) is a viable, careful opt-in for product tests — scoped to one product at a time rather than the shared Django suite.

Prior art: an xdist-on-Django-shards attempt reached a "22% faster" state but was self-closed unmerged (ClickHouse cross-worker contention + per-test isolation maintenance on the big shared suite). The org went the other way — horizontal bin-packed sharding. No one has tried xdist scoped to a **single isolated product**, which is a much more favorable environment (small suite, few ClickHouse tables, tiny blast radius).

This is a **viability spike, not a merge candidate.** `visual_review` is the largest isolated product (`backend:contract-check` present, ~2.5 min suite) so only its own product-test job runs — CI stays cheap.

## Changes

- `products/visual_review/package.json`: add `-n 2 --dist worksteal` to `backend:test`.

Open questions this run should answer:
1. **Collision-safety** — do the tests pass under 2 workers, or do shared singletons (object storage bucket, GitHub-integration fixtures, Kafka topics) collide? The xdist per-worker DB/ClickHouse/Redis suffixing already exists in settings; this tests whether anything *outside* that is unscoped.
2. **Setup wall** — the PR schema-cache primes only `posthog_test`; xdist workers use `posthog_test_gw0/gw1` and re-migrate. The job timing quantifies that per-worker cost, which determines whether xdist can ever be net-faster here without per-worker DB priming (e.g. `CREATE DATABASE ... TEMPLATE posthog_test`).

## How did you test this code?

I'm an agent. No manual testing. The point of the draft is to observe the `Product tests (visual_review)` CI job: pass/fail and wall-time vs. the serial baseline. Labeled `run-ci-backend` so the matrix runs on the draft.

## 🤖 Agent context

Authored by Claude (via Claude Code) at the user's request to investigate intra-runner product-test parallelism. We first ruled out existing work (searched open/closed PRs — found the closed Django-shard xdist attempt and confirmed it never targeted the product `turbo-tests` job), then scoped the spike to the largest *isolated* product to keep the CI blast radius to a single job. Chose `-n 2 --dist worksteal` (over `-n auto`) deliberately: it mirrors the least-bad config from the prior attempt and bounds the per-worker migration storm while still proving the concept. Expectation going in is that collisions are likely fine but the per-worker DB-priming gap may dominate wall-time — the run is to confirm or refute that with real numbers before investing in priming.
