### PR TITLE
fix(docker): build nginx unit from source, drop archived base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@
 #
 
 
+# Single source of truth for the runtime Python. Shared by the dependency build, the
+# Nginx Unit build, and the final runtime image so the interpreter can never drift.
+# Bumping Python is a one-line change here; keep it equal to pyproject.toml's requires-python.
+ARG PYTHON_RUNTIME_IMAGE=python:3.12.12-slim-bookworm@sha256:78e702aee4d693e769430f0d7b4f4858d8ea3f1118dc3f57fee3f757d0ca64b1
+
 #
 # ---------------------------------------------------------
 #
@@ -107,7 +112,7 @@ RUN --mount=type=cache,id=pnpm,target=/tmp/pnpm-store-v24 \
 FROM ghcr.io/astral-sh/uv:0.11.14 AS uv
 
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
-FROM python:3.12.12-slim-bookworm@sha256:78e702aee4d693e769430f0d7b4f4858d8ea3f1118dc3f57fee3f757d0ca64b1 AS posthog-build
+FROM ${PYTHON_RUNTIME_IMAGE} AS posthog-build
 COPY --from=uv /uv /uvx /bin/
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
@@ -183,11 +188,12 @@ RUN apt-get update && \
 #
 # ---------------------------------------------------------
 #
-# NOTE: v1.32 is running bullseye, v1.33+ is running bookworm
-FROM unit:1.34.2-python3.12
-WORKDIR /code
+# Build the Nginx Unit daemon and its Python language module from source against the exact
+# pinned interpreter. Upstream's unit:* images are archived and frozen to whatever python:3.x
+# patch nginx shipped at release time, so we own the build — the runtime Python is then always
+# the version we pin in PYTHON_RUNTIME_IMAGE, and bumping it is a single change there.
+FROM ${PYTHON_RUNTIME_IMAGE} AS unit-build
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
-ENV PYTHONUNBUFFERED 1
 ARG UNIT_GIT_TAG=1.35.0
 ARG UNIT_GIT_REF=28404105810f53c570523c3e70006ad0ca210e58
 
@@ -195,8 +201,11 @@ ARG UNIT_GIT_REF=28404105810f53c570523c3e70006ad0ca210e58
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "build-essential" \
+    "ca-certificates" \
     "git" \
     "libpcre2-dev" \
+    "libssl-dev" \
+    "pkg-config" \
     "zlib1g-dev" \
     && \
     git clone --depth 1 --branch "$UNIT_GIT_TAG" https://github.com/nginx/unit.git /tmp/unit && \
@@ -221,12 +230,32 @@ RUN apt-get update && \
     make -j "$NCPU" unitd && \
     install -pm755 build/sbin/unitd /usr/sbin/unitd && \
     make clean && \
+    mkdir -p /usr/lib/unit/modules && \
     ./configure $CONFIGURE_ARGS && \
     ./configure python --config=/usr/local/bin/python3-config && \
-    make -j "$NCPU" python3-install && \
-    rm -rf /tmp/unit && \
-    apt-get purge -y --auto-remove "build-essential" "git" "libpcre2-dev" "zlib1g-dev" && \
-    rm -rf /var/lib/apt/lists/*
+    make -j "$NCPU" python3-install
+
+
+#
+# ---------------------------------------------------------
+#
+FROM ${PYTHON_RUNTIME_IMAGE}
+WORKDIR /code
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+ENV PYTHONUNBUFFERED 1
+
+# Install the Unit daemon + Python module built above, and recreate the scaffolding the
+# upstream unit image used to provide: the `unit` user, the config drop-in dir, and the
+# docker-entrypoint.sh (vendored from nginx/unit, Apache-2.0, since upstream is archived).
+# bin/docker-server-unit invokes /usr/local/bin/docker-entrypoint.sh on the non-preload path.
+COPY --from=unit-build /usr/sbin/unitd /usr/sbin/unitd
+COPY --from=unit-build /usr/lib/unit/modules/ /usr/lib/unit/modules/
+COPY bin/unit-docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN groupadd --gid 999 unit && \
+    useradd --uid 999 --gid unit --no-create-home --home /nonexistent --comment "unit user" --shell /bin/false unit && \
+    mkdir -p /var/lib/unit /docker-entrypoint.d /usr/lib/unit/modules && \
+    ln -sf /dev/stderr /var/log/unit.log && \
+    chmod 755 /usr/local/bin/docker-entrypoint.sh
 
 # Install OS runtime dependencies.
 # Note: please add in this stage runtime dependences only!
@@ -234,7 +263,10 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
     "chromium" \
     "chromium-driver" \
+    "curl" \
+    "dirmngr" \
     "gettext-base" \
+    "gnupg" \
     "libpq-dev" \
     "libxmlsec1=1.2.37-2" \
     "libxmlsec1-dev=1.2.37-2" \
@@ -242,6 +274,8 @@ RUN apt-get update && \
     "libssl-dev=3.0.19-1~deb12u2" \
     "libssl3=3.0.19-1~deb12u2" \
     "libjemalloc2" \
+    "libpcre2-8-0" \
+    "xz-utils" \
     && \
     rm -rf /var/lib/apt/lists/*
 

--- a/bin/unit-docker-entrypoint.sh
+++ b/bin/unit-docker-entrypoint.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+#
+# Vendored verbatim from nginx/unit v1.34.2 (pkg/docker/docker-entrypoint.sh),
+# licensed under the Apache License 2.0. We build Unit from source in the
+# Dockerfile (see the unit-build stage) and supply this entrypoint ourselves
+# because the upstream unit:* Docker images are archived and unmaintained.
+# Upstream: https://github.com/nginx/unit/blob/1.34.2/pkg/docker/docker-entrypoint.sh
+
+set -e
+
+WAITLOOPS=5
+SLEEPSEC=1
+
+curl_put()
+{
+    RET=$(/usr/bin/curl -s -w '%{http_code}' -X PUT --data-binary @$1 --unix-socket /var/run/control.unit.sock http://localhost/$2)
+    RET_BODY=$(echo $RET | /bin/sed '$ s/...$//')
+    RET_STATUS=$(echo $RET | /usr/bin/tail -c 4)
+    if [ "$RET_STATUS" -ne "200" ]; then
+        echo "$0: Error: HTTP response status code is '$RET_STATUS'"
+        echo "$RET_BODY"
+        return 1
+    else
+        echo "$0: OK: HTTP response status code is '$RET_STATUS'"
+        echo "$RET_BODY"
+    fi
+    return 0
+}
+
+if [ "$1" = "unitd" ] || [ "$1" = "unitd-debug" ]; then
+    if /usr/bin/find "/var/lib/unit/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
+        echo "$0: /var/lib/unit/ is not empty, skipping initial configuration..."
+    else
+        echo "$0: Launching Unit daemon to perform initial configuration..."
+        /usr/sbin/$1 --control unix:/var/run/control.unit.sock
+
+        for i in $(/usr/bin/seq $WAITLOOPS); do
+            if [ ! -S /var/run/control.unit.sock ]; then
+                echo "$0: Waiting for control socket to be created..."
+                /bin/sleep $SLEEPSEC
+            else
+                break
+            fi
+        done
+        # even when the control socket exists, it does not mean unit has finished initialisation
+        # this curl call will get a reply once unit is fully launched
+        /usr/bin/curl -s -X GET --unix-socket /var/run/control.unit.sock http://localhost/
+
+        if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
+            echo "$0: /docker-entrypoint.d/ is not empty, applying initial configuration..."
+
+            echo "$0: Looking for certificate bundles in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.pem"); do
+                echo "$0: Uploading certificates bundle: $f"
+                curl_put $f "certificates/$(basename $f .pem)"
+            done
+
+            echo "$0: Looking for JavaScript modules in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.js"); do
+                echo "$0: Uploading JavaScript module: $f"
+                curl_put $f "js_modules/$(basename $f .js)"
+            done
+
+            echo "$0: Looking for configuration snippets in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.json"); do
+                echo "$0: Applying configuration $f";
+                curl_put $f "config"
+            done
+
+            echo "$0: Looking for shell scripts in /docker-entrypoint.d/..."
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -name "*.sh"); do
+                echo "$0: Launching $f";
+                "$f"
+            done
+
+            # warn on filetypes we don't know what to do with
+            for f in $(/usr/bin/find /docker-entrypoint.d/ -type f -not -name "*.sh" -not -name "*.json" -not -name "*.pem" -not -name "*.js"); do
+                echo "$0: Ignoring $f";
+            done
+        else
+            echo "$0: /docker-entrypoint.d/ is empty, creating 'welcome' configuration..."
+            curl_put /usr/share/unit/welcome/welcome.json "config"
+        fi
+
+        echo "$0: Stopping Unit daemon after initial configuration..."
+        kill -TERM $(/bin/cat /var/run/unit.pid)
+
+        for i in $(/usr/bin/seq $WAITLOOPS); do
+            if [ -S /var/run/control.unit.sock ]; then
+                echo "$0: Waiting for control socket to be removed..."
+                /bin/sleep $SLEEPSEC
+            else
+                break
+            fi
+        done
+        if [ -S /var/run/control.unit.sock ]; then
+            kill -KILL $(/bin/cat /var/run/unit.pid)
+            rm -f /var/run/control.unit.sock
+        fi
+
+        echo
+        echo "$0: Unit initial configuration complete; ready for start up..."
+        echo
+    fi
+fi
+
+exec "$@"

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -13,6 +13,8 @@ config:
         - mprocs-test.yaml
         - sandbox-entrypoint.py
         - lint-feature-flag-sorting.mjs
+        # Vendored nginx/unit entrypoint COPY'd into the Docker image, not a hogli command.
+        - unit-docker-entrypoint.sh
         # Locally-built, gitignored binary (tools/phrocs). Referenced via cmd:/process
         # name, not bin_script:, so exclude it from auto-discovery to stop the manifest
         # regenerating a stub entry on every hogli run.

--- a/unit.json.tpl
+++ b/unit.json.tpl
@@ -39,7 +39,7 @@
     },
     "applications": {
         "posthog": {
-            "type": "python 3.12",
+            "type": "python 3",
             "processes": $NGINX_UNIT_APP_PROCESSES,
             "working_directory": "/code",
             "path": ".",
@@ -51,7 +51,7 @@
             }
         },
         "metrics": {
-            "type": "python 3.12",
+            "type": "python 3",
             "processes": 1,
             "working_directory": "/code/bin",
             "path": ".",


### PR DESCRIPTION
## Problem

The runtime image was based on `unit:1.34.2-python3.12`, an upstream image that is **archived/unmaintained** and frozen to whatever `python:3.12` patch nginx shipped at release time. Unit's *embedded* interpreter — the one that actually runs the app — therefore came from that stale base, not the version pinned in `pyproject.toml`/`uv`. The shared `python3.12` ABI path hid the divergence (e.g. the app ran a different patch than `/python-runtime`). The archived base also cannot follow Python patch bumps at all, so bumping the runtime Python required hacks.

We already compiled `unitd` + the Python module from source in the Dockerfile — the archived base only supplied a Python we don't want, the `unit` user, the config drop-in dir, and `docker-entrypoint.sh`. So we can own the whole thing.

## Changes

- **New `unit-build` stage** compiles `unitd` and the `python3` language module from the upstream 1.35.0 source against the *exact pinned interpreter*; the runtime stage copies the artifacts in.
- **Single source of truth for Python:** a shared `ARG PYTHON_RUNTIME_IMAGE` drives the dependency build, the Unit build, and the final runtime image, so the interpreter can't drift across stages and **bumping Python is a one-line change**.
- **Vendor `docker-entrypoint.sh`** from nginx/unit (Apache-2.0) at `bin/unit-docker-entrypoint.sh`, and recreate the `unit` user (uid/gid 999), `/docker-entrypoint.d`, and state dirs that the upstream image provided.
- **Add the packages the slim base lacks** but the existing MS SQL + Node steps (and `unitd`) need: `curl`, `gnupg`, `dirmngr`, `xz-utils`, `libpcre2-8-0`.
- `unit.json.tpl` stays version-agnostic (`"python 3"`) so Unit auto-selects the compiled module and the file never needs touching on a Python bump.

This is the in-monorepo build option that was already under consideration as the successor to depending on the archived image; it does not preclude later moving the Unit build to a separately-published image or migrating off Unit entirely.

## How did you test this code?

Agent-authored; **no local Docker build** was possible in the agent environment. Relying on CI's *Build Docker image* job to validate the from-source build (compile + apt deps). The build job does **not** exercise `unitd` actually starting and binding `:8000` — recommend a `dev-two` smoke (deploy this branch's image) to confirm runtime boot before merge, as was done for the 3.13 cutover.

## 🤖 Agent context

Rebuilds the Nginx Unit runtime stage to compile Unit from source on the pinned `python:*-slim` base instead of consuming the archived `unit:*` image, eliminating the silent embedded-interpreter mismatch and the previous `/usr/local` overlay workaround. Independent of the Python 3.13 cutover PR — this is the runtime-build mechanism; the version bump remains a one-line `PYTHON_RUNTIME_IMAGE` change.

https://claude.ai/code/session_01UBpimaBiGDa3zYxybapexx