### PR TITLE
ci: reuse skills build artifact in release job

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -141,6 +141,15 @@ jobs:
                   DEBUG: 1
               run: ./bin/hogli build:skills
 
+            - name: Upload skills artifact
+              if: github.ref == 'refs/heads/master'
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: skills-zip
+                  path: products/posthog_ai/dist/skills.zip
+                  retention-days: 1
+                  if-no-files-found: error
+
     release-skills:
         name: Release agent skills
         runs-on: ubuntu-latest
@@ -153,82 +162,11 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-            - name: Log in to Docker Hub
-              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+            - name: Download skills artifact
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-            - name: Start Docker services
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-              run: |
-                  bin/ci-wait-for-docker launch --down
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version-file: 'pyproject.toml'
-                  token: ${{ github.token }}
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-              with:
-                  version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: false
-
-            - name: Install python dependencies
-              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
-
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: stable
-                  components: cargo
-
-            - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-              with:
-                  shared-key: 'v2-rust-skills'
-                  workspaces: rust
-                  save-if: false
-
-            - name: Install sqlx-cli
-              uses: ./.github/actions/setup-sqlx-cli
-
-            - name: Wait for Docker services
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-              run: bin/ci-wait-for-docker wait
-
-            - name: Run migrations and create test data
-              env:
-                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
-                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
-                  REDIS_URL: 'redis://localhost'
-                  OBJECT_STORAGE_ENABLED: 'False'
-                  TEST: 1
-                  DEBUG: 1
-              run: |
-                  DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
-                    sqlx database create
-                  DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
-                    sqlx migrate run --source rust/persons_migrations/
-                  python manage.py migrate --noinput
-                  python manage.py setup_dev --no-data
-
-            - name: Build skills ZIP
-              env:
-                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
-                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
-                  REDIS_URL: 'redis://localhost'
-                  OBJECT_STORAGE_ENABLED: 'False'
-                  TEST: 1
-                  DEBUG: 1
-              run: ./bin/hogli build:skills
+                  name: skills-zip
+                  path: products/posthog_ai/dist/
 
             - name: Determine next version
               id: version


### PR DESCRIPTION
## Problem

The `release-skills` job in `ci-agent-skills.yml` rebuilt `skills.zip` from scratch on every qualifying master push — spinning up Postgres/Redis/Kafka/ClickHouse, running the full Django migration set + `setup_dev`, installing Rust/sqlx, and re-rendering all skills — even though `check-skills` (which gates the same push) had just produced the byte-identical artifact minutes earlier. ~3-6 min of duplicated runner time and a full Postgres-cluster spin-up per master push, for nothing.

## Changes

- `check-skills`: upload `products/posthog_ai/dist/skills.zip` as an artifact (master only, 1-day retention) after the build step.
- `release-skills`: download that artifact instead of rebuilding it. Removes 11 setup steps (Docker login, compose up, Python/uv, Rust/sqlx, migrations, `setup_dev`, build).

The build is deterministic for a given SHA — ZIP entry timestamps (`_ZIP_FIXED_TIME`) and the HogQL evaluation time (`FROZEN_TIME`) are pinned — so the reused artifact is identical to what `release-skills` would have produced. Release semantics (versioned tag + `agent-skills-latest`) are untouched.

Net: +13/-75 lines, one workflow file.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally:
- `actionlint .github/workflows/ci-agent-skills.yml` — passes.
- YAML parse + pre-commit yaml formatter — clean.

Not exercised end-to-end on a live master push (requires merge to master). The artifact upload/download names and download path (`products/posthog_ai/dist/`) match the path the release steps consume.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — CI-only change. Add `skip-inkeep-docs`.

## 🤖 Agent context

Authored by Claude Code from a DevEx intel finding. Verified the report's core claims before implementing (build determinism, artifact path, no existing upload/download-artifact usage, no in-flight PRs on this file) and rejected one part of the proposed diff: the report suggested adding `fetch-depth: 0` to the release checkout, but `git ls-remote origin` reads the remote, not local history, and works on the default shallow checkout — so it was omitted.

Suggested reviewer: skoob13 (original author of the release-skills job).
