### PR TITLE
feat(property-vals): pass region and team_id to read-path flag

### DIFF
--- a/posthog/hogql_queries/property_values_query_runner.py
+++ b/posthog/hogql_queries/property_values_query_runner.py
@@ -29,7 +29,7 @@ from posthog.queries.property_values import (
     get_event_property_values_from_aggregated_table,
     get_person_property_values_for_key,
 )
-from posthog.utils import convert_property_value, flatten, relative_date_parse
+from posthog.utils import convert_property_value, flatten, get_instance_region, relative_date_parse
 
 from products.access_control.backend.property_access_control import get_restricted_property_names
 
@@ -86,7 +86,13 @@ class PropertyValuesQueryRunner(AnalyticsQueryRunner[PropertyValuesQueryResponse
         # event-agnostic value suggestions for event-scoped requests.
         if self.query.is_column or self.query.property_key.startswith("$virt_"):
             return False
-        if not posthoganalytics.feature_enabled(PROPERTY_VALUES_TABLE_FLAG, str(self.team.pk)):
+        team_id = str(self.team.pk)
+        if not posthoganalytics.feature_enabled(
+            PROPERTY_VALUES_TABLE_FLAG,
+            team_id,
+            person_properties={"region": get_instance_region() or "DEV", "team_id": team_id},
+            send_feature_flag_events=False,
+        ):
             return False
         # Restricted keys stay on the events scan: the table read bypasses HogQL
         # property resolution, which is where property access control is enforced.


### PR DESCRIPTION
## Problem

The `property-values-table` flag decides whether property-value autocomplete reads from the new aggregated `property_values` table instead of scanning events (read path added in https://github.com/PostHog/posthog/pull/61837). The gate passed only the team pk as the flag's `distinct_id` but i also want to be able to rollout per region. 

## Changes

Pass `region` and `team_id` as `person_properties` into the `feature_enabled` call. 

## How did you test this code?

ci

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change; this only adjusts internal rollout gating.
