### PR TITLE
feat(exports): publish-image endpoint + MCP tool for AI-rendered charts

### DIFF
--- a/products/exports/backend/api/chart_images.py
+++ b/products/exports/backend/api/chart_images.py
@@ -51,7 +51,9 @@ class ChartImageSerializer(serializers.Serializer):
         except (binascii.Error, ValueError):
             raise serializers.ValidationError({"image_base64": "Must be valid base64."})
         if len(png) > MAX_IMAGE_BYTES:
-            raise serializers.ValidationError({"image_base64": f"Image exceeds the {MAX_IMAGE_BYTES} byte limit."})
+            raise serializers.ValidationError(
+                {"image_base64": f"Image exceeds the {MAX_IMAGE_BYTES // (1024 * 1024)} MiB limit."}
+            )
         if png[:8] != PNG_MAGIC:
             raise serializers.ValidationError({"image_base64": "Decoded bytes are not a PNG image."})
         data["image_bytes"] = png

--- a/products/exports/backend/api/chart_images.py
+++ b/products/exports/backend/api/chart_images.py
@@ -1,0 +1,88 @@
+import base64
+import binascii
+from datetime import timedelta
+from typing import Any
+
+from django.utils.timezone import now
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, extend_schema_field
+from rest_framework import mixins, serializers, viewsets
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+
+from products.exports.backend.models.exported_asset import ExportedAsset, save_content
+from products.product_analytics.backend.models.insight import Insight
+
+CHART_IMAGE_TTL_DAYS = 30
+MAX_IMAGE_BYTES = 5 * 1024 * 1024
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class ChartImageSerializer(serializers.Serializer):
+    image_base64 = serializers.CharField(
+        write_only=True,
+        help_text="Base64-encoded PNG image bytes to publish. Must decode to a PNG no larger than 5 MiB.",
+    )
+    title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="Optional title used to build a readable filename for the published image.",
+    )
+    insight_short_id = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Optional short id of the insight this image visualizes, recorded for provenance.",
+    )
+    id = serializers.IntegerField(read_only=True, help_text="Id of the published image asset.")
+    image_url = serializers.SerializerMethodField(
+        help_text="Durable signed URL of the published PNG, fetchable without authentication so it can be posted to Slack.",
+    )
+
+    @extend_schema_field(OpenApiTypes.URI)
+    def get_image_url(self, asset: ExportedAsset) -> str:
+        return asset.get_subscription_delivery_content_url()
+
+    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+        try:
+            png = base64.b64decode(data["image_base64"], validate=True)
+        except (binascii.Error, ValueError):
+            raise serializers.ValidationError({"image_base64": "Must be valid base64."})
+        if len(png) > MAX_IMAGE_BYTES:
+            raise serializers.ValidationError({"image_base64": f"Image exceeds the {MAX_IMAGE_BYTES} byte limit."})
+        if png[:8] != PNG_MAGIC:
+            raise serializers.ValidationError({"image_base64": "Decoded bytes are not a PNG image."})
+        data["image_bytes"] = png
+        return data
+
+    def create(self, validated_data: dict[str, Any]) -> ExportedAsset:
+        team = self.context["get_team"]()
+        asset = ExportedAsset.objects.create(
+            team=team,
+            insight=self._resolve_insight(team, validated_data.get("insight_short_id")),
+            export_format=ExportedAsset.ExportFormat.PNG,
+            export_context={"filename": validated_data.get("title") or "chart"},
+            expires_after=now() + timedelta(days=CHART_IMAGE_TTL_DAYS),
+        )
+        save_content(asset, validated_data["image_bytes"])
+        return asset
+
+    def _resolve_insight(self, team: Any, short_id: str | None) -> Insight | None:
+        if not short_id:
+            return None
+        insight = Insight.objects.filter(team=team, short_id=short_id).first()
+        if insight is None:
+            raise serializers.ValidationError({"insight_short_id": "No insight found with this short id."})
+        return insight
+
+
+@extend_schema(
+    extensions={"x-product": "exports"},
+    description="Publish a pre-rendered PNG image and get back a durable signed URL that can be posted to Slack.",
+)
+class ChartImageViewSet(TeamAndOrgViewSetMixin, mixins.CreateModelMixin, viewsets.GenericViewSet):
+    scope_object = "export"
+    queryset = ExportedAsset.objects.all()
+    serializer_class = ChartImageSerializer

--- a/products/exports/backend/api/test/test_chart_images.py
+++ b/products/exports/backend/api/test/test_chart_images.py
@@ -4,6 +4,7 @@ import base64
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from PIL import Image
 
 from products.exports.backend.models.exported_asset import ExportedAsset
@@ -43,12 +44,14 @@ class TestChartImagesAPI(APIBaseTest):
         response = self._publish(image_base64=self._png_base64(), insight_short_id="nope99")
         assert response.status_code == 400
 
-    def test_publish_rejects_non_png(self):
-        response = self._publish(image_base64=base64.b64encode(b"this is definitely not a png file").decode())
-        assert response.status_code == 400
-
-    def test_publish_rejects_invalid_base64(self):
-        response = self._publish(image_base64="!!!not-base64!!!")
+    @parameterized.expand(
+        [
+            ("non_png", base64.b64encode(b"this is definitely not a png file").decode()),
+            ("invalid_base64", "!!!not-base64!!!"),
+        ]
+    )
+    def test_publish_rejects_invalid_image_base64(self, _name, image_base64):
+        response = self._publish(image_base64=image_base64)
         assert response.status_code == 400
 
     def test_publish_rejects_oversized_image(self):

--- a/products/exports/backend/api/test/test_chart_images.py
+++ b/products/exports/backend/api/test/test_chart_images.py
@@ -1,0 +1,57 @@
+import io
+import base64
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from PIL import Image
+
+from products.exports.backend.models.exported_asset import ExportedAsset
+from products.product_analytics.backend.models.insight import Insight
+
+
+class TestChartImagesAPI(APIBaseTest):
+    def _png_base64(self, color: str = "blue", size: tuple[int, int] = (8, 8)) -> str:
+        buffer = io.BytesIO()
+        Image.new("RGB", size, color).save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode()
+
+    def _publish(self, **payload):
+        return self.client.post(f"/api/projects/{self.team.id}/chart_images/", payload)
+
+    def test_publish_returns_durable_image_url(self):
+        response = self._publish(image_base64=self._png_base64(), title="Weekly signups")
+        assert response.status_code == 201, response.content
+        body = response.json()
+        assert "/exporter/" in body["image_url"]
+        assert ".png" in body["image_url"]
+        assert "token=" in body["image_url"]
+        asset = ExportedAsset.objects.get(pk=body["id"])
+        assert asset.team == self.team
+        assert asset.export_format == ExportedAsset.ExportFormat.PNG
+        assert asset.has_content
+
+    def test_publish_links_insight_for_provenance(self):
+        insight = Insight.objects.create(
+            team=self.team, short_id="abc123", name="Signups", query={"kind": "TrendsQuery"}, created_by=self.user
+        )
+        response = self._publish(image_base64=self._png_base64(), insight_short_id="abc123")
+        assert response.status_code == 201, response.content
+        assert ExportedAsset.objects.get(pk=response.json()["id"]).insight_id == insight.id
+
+    def test_publish_rejects_unknown_insight(self):
+        response = self._publish(image_base64=self._png_base64(), insight_short_id="nope99")
+        assert response.status_code == 400
+
+    def test_publish_rejects_non_png(self):
+        response = self._publish(image_base64=base64.b64encode(b"this is definitely not a png file").decode())
+        assert response.status_code == 400
+
+    def test_publish_rejects_invalid_base64(self):
+        response = self._publish(image_base64="!!!not-base64!!!")
+        assert response.status_code == 400
+
+    def test_publish_rejects_oversized_image(self):
+        with patch("products.exports.backend.api.chart_images.MAX_IMAGE_BYTES", 10):
+            response = self._publish(image_base64=self._png_base64())
+        assert response.status_code == 400

--- a/products/exports/backend/routes.py
+++ b/products/exports/backend/routes.py
@@ -1,7 +1,8 @@
 from posthog.api.routing import RouterRegistry
 
-from products.exports.backend.api import exports
+from products.exports.backend.api import chart_images, exports
 
 
 def register_routes(routers: RouterRegistry) -> None:
     routers.register_legacy_dual_route(r"exports", exports.ExportedAssetViewSet, "environment_exports", ["team_id"])
+    routers.projects.register(r"chart_images", chart_images.ChartImageViewSet, "project_chart_images", ["team_id"])

--- a/products/exports/frontend/generated/api.schemas.ts
+++ b/products/exports/frontend/generated/api.schemas.ts
@@ -7,66 +7,18 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-/**
- * * `image/png` - image/png
- * `application/pdf` - application/pdf
- * `text/csv` - text/csv
- * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
- * `video/webm` - video/webm
- * `video/mp4` - video/mp4
- * `image/gif` - image/gif
- * `application/json` - application/json
- */
-export type ExportFormatEnumApi = (typeof ExportFormatEnumApi)[keyof typeof ExportFormatEnumApi]
-
-export const ExportFormatEnumApi = {
-    ImagePng: 'image/png',
-    ApplicationPdf: 'application/pdf',
-    TextCsv: 'text/csv',
-    ApplicationVndopenxmlformatsOfficedocumentspreadsheetmlsheet:
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    VideoWebm: 'video/webm',
-    VideoMp4: 'video/mp4',
-    ImageGif: 'image/gif',
-    ApplicationJson: 'application/json',
-} as const
-
-/**
- * Standard ExportedAsset serializer that doesn't return content.
- */
-export interface ExportedAssetApi {
+export interface ChartImageApi {
+    /** Base64-encoded PNG image bytes to publish. Must decode to a PNG no larger than 5 MiB. */
+    image_base64: string
+    /** Optional title used to build a readable filename for the published image. */
+    title?: string
+    /**
+     * Optional short id of the insight this image visualizes, recorded for provenance.
+     * @nullable
+     */
+    insight_short_id?: string | null
+    /** Id of the published image asset. */
     readonly id: number
-    /** @nullable */
-    dashboard?: number | null
-    /** @nullable */
-    insight?: number | null
-    export_format: ExportFormatEnumApi
-    readonly created_at: string
-    readonly has_content: boolean
-    export_context?: unknown
-    readonly filename: string
-    /** @nullable */
-    readonly expires_after: string | null
-    /** @nullable */
-    readonly exception: string | null
-}
-
-export interface PaginatedExportedAssetListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: ExportedAssetApi[]
-}
-
-export type ExportsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number
+    /** Durable signed URL of the published PNG, fetchable without authentication so it can be posted to Slack. */
+    readonly image_url: string
 }

--- a/products/exports/frontend/generated/api.ts
+++ b/products/exports/frontend/generated/api.ts
@@ -8,7 +8,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
-import type { ExportedAssetApi, ExportsListParams, PaginatedExportedAssetListApi } from './api.schemas'
+import type { ChartImageApi } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
 type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B
@@ -27,72 +27,22 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
       }
     : DistributeReadOnlyOverUnions<T>
 
-export const getExportsListUrl = (projectId: string, params?: ExportsListParams) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/exports/?${stringifiedParams}`
-        : `/api/projects/${projectId}/exports/`
+export const getChartImagesCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/chart_images/`
 }
 
-export const exportsList = async (
+/**
+ * Publish a pre-rendered PNG image and get back a durable signed URL that can be posted to Slack.
+ */
+export const chartImagesCreate = async (
     projectId: string,
-    params?: ExportsListParams,
+    chartImageApi: NonReadonly<ChartImageApi>,
     options?: RequestInit
-): Promise<PaginatedExportedAssetListApi> => {
-    return apiMutator<PaginatedExportedAssetListApi>(getExportsListUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getExportsCreateUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/exports/`
-}
-
-export const exportsCreate = async (
-    projectId: string,
-    exportedAssetApi: NonReadonly<ExportedAssetApi>,
-    options?: RequestInit
-): Promise<ExportedAssetApi> => {
-    return apiMutator<ExportedAssetApi>(getExportsCreateUrl(projectId), {
+): Promise<ChartImageApi> => {
+    return apiMutator<ChartImageApi>(getChartImagesCreateUrl(projectId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(exportedAssetApi),
-    })
-}
-
-export const getExportsRetrieveUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/exports/${id}/`
-}
-
-export const exportsRetrieve = async (
-    projectId: string,
-    id: number,
-    options?: RequestInit
-): Promise<ExportedAssetApi> => {
-    return apiMutator<ExportedAssetApi>(getExportsRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getExportsContentRetrieveUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/exports/${id}/content/`
-}
-
-export const exportsContentRetrieve = async (projectId: string, id: number, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getExportsContentRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
+        body: JSON.stringify(chartImageApi),
     })
 }

--- a/products/exports/mcp/tools.yaml
+++ b/products/exports/mcp/tools.yaml
@@ -1,0 +1,23 @@
+category: Exports
+feature: exports
+url_prefix: /exports
+tools:
+    chart-image-publish:
+        operation: chart_images_create
+        enabled: true
+        scopes:
+            - export:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Publish chart image
+        description: >
+            Publish a PNG image you have already rendered (for example a chart you generated
+            with Python in your sandbox) and get back a durable, publicly fetchable URL.
+            Include the returned image_url on its own line in your Slack reply so Slack renders
+            the chart inline. Pass the PNG as base64 in image_base64; optionally set title for a
+            readable filename and insight_short_id to link the image to an existing insight.
+        param_overrides:
+            image_base64:
+                description: Base64-encoded PNG bytes of the image you rendered.

--- a/products/exports/mcp/tools.yaml
+++ b/products/exports/mcp/tools.yaml
@@ -1,6 +1,13 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
 category: Exports
 feature: exports
 url_prefix: /exports
+ui_apps: {}
 tools:
     chart-image-publish:
         operation: chart_images_create
@@ -13,11 +20,22 @@ tools:
             idempotent: false
         title: Publish chart image
         description: >
-            Publish a PNG image you have already rendered (for example a chart you generated
-            with Python in your sandbox) and get back a durable, publicly fetchable URL.
-            Include the returned image_url on its own line in your Slack reply so Slack renders
-            the chart inline. Pass the PNG as base64 in image_base64; optionally set title for a
-            readable filename and insight_short_id to link the image to an existing insight.
+            Publish a PNG image you have already rendered (for example a chart you generated with Python in your
+            sandbox) and get back a durable, publicly fetchable URL. Include the returned image_url on its own line in
+            your Slack reply so Slack renders the chart inline. Pass the PNG as base64 in image_base64; optionally set
+            title for a readable filename and insight_short_id to link the image to an existing insight.
         param_overrides:
             image_base64:
                 description: Base64-encoded PNG bytes of the image you rendered.
+    exports-content-retrieve:
+        operation: exports_content_retrieve
+        enabled: false
+    exports-create:
+        operation: exports_create
+        enabled: false
+    exports-list:
+        operation: exports_list
+        enabled: false
+    exports-retrieve:
+        operation: exports_retrieve
+        enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -785,6 +785,20 @@
             "readOnlyHint": true
         }
     },
+    "chart-image-publish": {
+        "description": "Publish a PNG image you have already rendered (for example a chart you generated with Python in your sandbox) and get back a durable, publicly fetchable URL. Include the returned image_url on its own line in your Slack reply so Slack renders the chart inline. Pass the PNG as base64 in image_base64; optionally set title for a readable filename and insight_short_id to link the image to an existing insight.",
+        "category": "Exports",
+        "feature": "exports",
+        "summary": "Publish chart image",
+        "title": "Publish chart image",
+        "required_scopes": ["export:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "cohorts-add-persons-to-static-cohort-partial-update": {
         "description": "Add persons to a static cohort by their UUIDs. Only works for static cohorts (is_static: true).\n\nIntended for small, ad-hoc additions — pass at most ~20 person UUIDs per call. To build or grow a static cohort from a larger set, do NOT loop this tool over many UUIDs; instead create the cohort from a query ('cohorts-create' with 'is_static: true' and a 'query'), or add to an existing static cohort by setting a 'query' on it via 'cohorts-partial-update'. The server then runs the query and inserts every matching person in a single call, with no row limit.",
         "category": "Cohorts",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -801,6 +801,20 @@
             "readOnlyHint": true
         }
     },
+    "chart-image-publish": {
+        "description": "Publish a PNG image you have already rendered (for example a chart you generated with Python in your sandbox) and get back a durable, publicly fetchable URL. Include the returned image_url on its own line in your Slack reply so Slack renders the chart inline. Pass the PNG as base64 in image_base64; optionally set title for a readable filename and insight_short_id to link the image to an existing insight.",
+        "category": "Exports",
+        "feature": "exports",
+        "summary": "Publish chart image",
+        "title": "Publish chart image",
+        "required_scopes": ["export:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "cohorts-add-persons-to-static-cohort-partial-update": {
         "description": "Add persons to a static cohort by their UUIDs. Only works for static cohorts (is_static: true).\n\nIntended for small, ad-hoc additions — pass at most ~20 person UUIDs per call. To build or grow a static cohort from a larger set, do NOT loop this tool over many UUIDs; instead create the cohort from a query ('cohorts-create' with 'is_static: true' and a 'query'), or add to an existing static cohort by setting a 'query' on it via 'cohorts-partial-update'. The server then runs the query and inserts every matching person in a single call, with no row limit.",
         "category": "Cohorts",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -10747,6 +10747,22 @@ export namespace Schemas {
       Github: 'github',
     } as const;
 
+    export interface ChartImage {
+      /** Base64-encoded PNG image bytes to publish. Must decode to a PNG no larger than 5 MiB. */
+      image_base64: string;
+      /** Optional title used to build a readable filename for the published image. */
+      title?: string;
+      /**
+         * Optional short id of the insight this image visualizes, recorded for provenance.
+         * @nullable
+         */
+      insight_short_id?: string | null;
+      /** Id of the published image asset. */
+      readonly id: number;
+      /** Durable signed URL of the published PNG, fetchable without authentication so it can be posted to Slack. */
+      readonly image_url: string;
+    }
+
     export interface CheckDatabaseNameResponse {
       name: string;
       available: boolean;

--- a/services/mcp/src/generated/exports/api.ts
+++ b/services/mcp/src/generated/exports/api.ts
@@ -1,10 +1,9 @@
 /**
- * Auto-generated Zod validation schemas from the Django backend OpenAPI schema.
- * To modify these schemas, update the Django serializers or views, then run:
- *   hogli build:openapi
- * Questions or issues? #team-devex on Slack
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
  *
- * PostHog API - generated
+ * PostHog API - MCP 1 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -12,6 +11,14 @@ import * as zod from 'zod'
 /**
  * Publish a pre-rendered PNG image and get back a durable signed URL that can be posted to Slack.
  */
+export const ChartImagesCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
 export const chartImagesCreateBodyTitleDefault = ``
 
 export const ChartImagesCreateBody = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/exports.ts
+++ b/services/mcp/src/tools/generated/exports.ts
@@ -1,0 +1,40 @@
+// AUTO-GENERATED from products/exports/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import { ChartImagesCreateBody } from '@/generated/exports/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const ChartImagePublishSchema = ChartImagesCreateBody.extend({
+    image_base64: ChartImagesCreateBody.shape['image_base64'].describe(
+        'Base64-encoded PNG bytes of the image you rendered.'
+    ),
+})
+
+const chartImagePublish = (): ToolBase<typeof ChartImagePublishSchema, Schemas.ChartImage> => ({
+    name: 'chart-image-publish',
+    schema: ChartImagePublishSchema,
+    handler: async (context: Context, params: z.infer<typeof ChartImagePublishSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.image_base64 !== undefined) {
+            body['image_base64'] = params.image_base64
+        }
+        if (params.title !== undefined) {
+            body['title'] = params.title
+        }
+        if (params.insight_short_id !== undefined) {
+            body['insight_short_id'] = params.insight_short_id
+        }
+        const result = await context.api.request<Schemas.ChartImage>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/chart_images/`,
+            body,
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'chart-image-publish': chartImagePublish,
+}

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -19,6 +19,7 @@ import { GENERATED_TOOLS as early_access_features } from './early_access_feature
 import { GENERATED_TOOLS as endpoints } from './endpoints'
 import { GENERATED_TOOLS as error_tracking } from './error_tracking'
 import { GENERATED_TOOLS as experiments } from './experiments'
+import { GENERATED_TOOLS as exports } from './exports'
 import { GENERATED_TOOLS as feature_flags } from './feature_flags'
 import { GENERATED_TOOLS as integrations } from './integrations'
 import { GENERATED_TOOLS as logs } from './logs'
@@ -61,6 +62,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...endpoints,
     ...error_tracking,
     ...experiments,
+    ...exports,
     ...feature_flags,
     ...integrations,
     ...logs,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/chart-image-publish.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/chart-image-publish.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "image_base64": {
+            "description": "Base64-encoded PNG bytes of the image you rendered.",
+            "type": "string"
+        },
+        "insight_short_id": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional short id of the insight this image visualizes, recorded for provenance."
+        },
+        "title": {
+            "default": "",
+            "description": "Optional title used to build a readable filename for the published image.",
+            "type": "string"
+        }
+    },
+    "required": ["image_base64"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

PostHog can answer questions in Slack through the app, but only with text. Getting a chart back today means the headless-browser exporter, which is slow, infra-heavy, and only works for a saved insight. We want the agent to return an ad hoc visual from any data, not just a saved PostHog insight.

## Changes

This takes the data-provider-agnostic route: instead of PostHog owning a fixed renderer, the AI renders the chart itself in its sandbox (using whatever data it can reach and any charting library), and the backend provides one primitive to publish that image and hand back a URL it can post to Slack.

- New `POST /api/projects/:team_id/chart_images/` endpoint (`ChartImageViewSet`). It accepts a base64 PNG, validates it (PNG magic bytes, 5 MiB cap), stores it as an `ExportedAsset`, and returns a durable signed `image_url`.
- The URL reuses the existing subscription-delivery mechanism (`/exporter/<file>.png?token=...`), which Slack fetches anonymously and unfurls inline. No new storage, no Slack file-upload scope.
- New `chart-image-publish` MCP tool (`products/exports/mcp/tools.yaml`) mapped to the endpoint, so the sandbox agent (or any MCP client) can publish an image and get a URL.
- Optional `insight_short_id` links the published image to an insight for provenance.

Remaining steps before the flow works end to end:

- Run `hogli build:openapi` to generate the MCP tool TypeScript and frontend types from the new endpoint (not run here, needs the JS toolchain).
- Add guidance to the Slack run's agent prompt so it renders a chart and calls `chart-image-publish`, embedding the returned URL in its reply.
- Optional: pre-install a charting library in the sandbox image, and a dedicated token purpose for cleaner audit semantics.

## How did you test this code?

I am an agent (Claude Code) and did not do any manual testing. Automated tests I ran in this branch:

- `products/exports/backend/api/test/test_chart_images.py` (6 tests, passing): publishes a real PNG and asserts a durable `/exporter` signed URL is returned; links an insight for provenance; and rejects non-PNG bytes, invalid base64, oversized images, and unknown insight ids.
- Verified the endpoint produces a correct OpenAPI schema (operation `chart_images_create`, write-only `image_base64`, read-only `id` and `image_url`) by running the schema generation step that the MCP tool definition references.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change yet.

## 🤖 Agent context

Authored by Claude Code (Opus) in an agent session. The work began as a fixed server-side renderer (a normalized chart spec plus a Vega-Lite renderer and a PostHog query adapter). Midway the human redirected the goal: rather than PostHog rendering a fixed set of chart types, the AI should write its own rendering code against any data source and only needs a way to get the image into Slack. We verified that the existing Slack coding-agent sandbox can run rendering code (Modal container, full bash and network on Slack runs) and that the Slack reply path unfurls a bare image URL, then pivoted: dropped the fixed renderer and built this publish primitive plus MCP tool, reusing the `ExportedAsset` signed-URL delivery that subscriptions already use. The branch was squashed to a single commit containing only the final approach.

This is agent-authored and requires human review; please do not self-merge.
