### PR TITLE
feat(property-vals-rs): raise max property value length to 10000

### DIFF
--- a/rust/property-vals-rs/src/config.rs
+++ b/rust/property-vals-rs/src/config.rs
@@ -86,7 +86,7 @@ pub struct LengthCaps {
     #[envconfig(default = "400")]
     pub max_property_key_len: usize,
 
-    #[envconfig(default = "255")]
+    #[envconfig(default = "10000")]
     pub max_property_value_len: usize,
 }
 
@@ -204,7 +204,7 @@ mod tests {
     fn length_caps_default_when_env_unset() {
         let caps = LengthCaps::init_from_hashmap(&std::collections::HashMap::new()).unwrap();
         assert_eq!(caps.max_property_key_len, 400);
-        assert_eq!(caps.max_property_value_len, 255);
+        assert_eq!(caps.max_property_value_len, 10000);
     }
 
     #[test]

--- a/rust/property-vals-rs/src/fan_out.rs
+++ b/rust/property-vals-rs/src/fan_out.rs
@@ -142,8 +142,6 @@ mod tests {
     use proptest::prelude::*;
     use serde_json::{Map, Value};
 
-    // Mirrors the production envconfig defaults; the arb generators below
-    // straddle these boundaries on purpose.
     const TEST_CAPS: LengthCaps = LengthCaps {
         max_property_key_len: 400,
         max_property_value_len: 255,


### PR DESCRIPTION
## Problem

The property-values aggregator drops any property value longer than `MAX_PROPERTY_VALUE_LEN` at fan-out. The default was 255 characters, which silently discarded legitimate long values such as URLs, stringified JSON payloads, and long identifiers, so they never showed up in property-value autocomplete.

## Changes

Raise the `max_property_value_len` envconfig default from 255 to 10000 in the Rust service. No chart sets `MAX_PROPERTY_VALUE_LEN`, so this default is the effective value in every environment once deployed.


## How did you test this code?

I am an agent (Claude Code). Ran the crate's unit and property tests:

```
cargo test -p property-vals-rs --lib
# 52 passed
```

This covers the updated default assertion (`length_caps_default_when_env_unset`), the env-override test, and the fan-out proptests that exercise the length caps. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

Authored with Claude Code at the PR owner's request: raise `MAX_PROPERTY_VALUE_LEN` to 10000.

Notes for review:
- Confirmed via grep that no chart or config overrides `MAX_PROPERTY_VALUE_LEN`, so the envconfig default is the effective production value.
- Kept the fan-out test cap at 255 rather than mirroring the new default, because the proptest generators top out near 500 characters; raising the test cap to 10000 would make the value-too-long drop path unreachable in tests. Removed the now-inaccurate comment that claimed the test caps mirror production.
