### PR TITLE
chore(endpoints): relieve the 50k limit on materialization queries

### DIFF
--- a/products/endpoints/backend/materialization.py
+++ b/products/endpoints/backend/materialization.py
@@ -6,12 +6,14 @@ from typing import Any, Optional
 from posthog.schema import HogQLQuery, HogQLQueryModifiers
 
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.functions.aggregations import COMBINATORS
 from posthog.hogql.functions.mapping import find_hogql_aggregation
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
-from posthog.hogql.printer import to_printed_hogql
+from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.timings import HogQLTimings
-from posthog.hogql.visitor import CloningVisitor, TraversingVisitor
+from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
 
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL, BREAKDOWN_OTHER_STRING_LABEL
@@ -50,6 +52,21 @@ def _add_series_index_to_select(query: ast.SelectQuery, index: int) -> None:
         query.group_by = [*list(query.group_by), ast.Field(chain=["__series_index"])]
 
 
+def _print_materialized_hogql(query: ast.Expr, team: Team, modifiers: HogQLQueryModifiers | None = None) -> str:
+    """Like to_printed_hogql, but without the implicit top-level row cap — a materialized table must hold every row."""
+    return prepare_and_print_ast(
+        clone_expr(query),
+        dialect="hogql",
+        context=HogQLContext(
+            team_id=team.pk,
+            enable_select_queries=True,
+            limit_top_select=False,
+            modifiers=create_default_modifiers_for_team(team, modifiers),
+        ),
+        pretty=True,
+    )[0]
+
+
 def convert_insight_query_to_hogql(query: dict[str, Any], team: Team) -> dict[str, Any]:
     query_kind = query.get("kind")
 
@@ -70,7 +87,7 @@ def convert_insight_query_to_hogql(query: dict[str, Any], team: Team) -> dict[st
     if query_kind in SERIES_INDEX_QUERY_TYPES:
         inject_series_index(combined_query_ast)
 
-    hogql_string = to_printed_hogql(combined_query_ast, team=team, modifiers=query_runner.modifiers)
+    hogql_string = _print_materialized_hogql(combined_query_ast, team, query_runner.modifiers)
 
     result = HogQLQuery(query=hogql_string, modifiers=query_runner.modifiers).model_dump()
     if "variables" in query:
@@ -1102,7 +1119,7 @@ def transform_query_for_materialization(
     transformer = MaterializationTransformer(variable_infos)
     transformed_ast = transformer.visit(parsed_ast)
 
-    transformed_query_str = to_printed_hogql(transformed_ast, team=team)
+    transformed_query_str = _print_materialized_hogql(transformed_ast, team)
 
     return {
         **hogql_query,

--- a/products/endpoints/backend/tests/__snapshots__/test_variable_materialization.ambr
+++ b/products/endpoints/backend/tests/__snapshots__/test_variable_materialization.ambr
@@ -14,7 +14,6 @@
       os_name
   FROM
       cte
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_cte_range_variable_deduped_group_by
@@ -34,7 +33,6 @@
       end_hour
   FROM
       cte
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_cte_two_variables_same_cte
@@ -55,7 +53,6 @@
       user_id
   FROM
       cte
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_cte_variable_preserves_non_variable_where
@@ -75,7 +72,6 @@
       event_name
   FROM
       cte
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_cte_variable_top_level_no_group_by_passthrough
@@ -96,7 +92,6 @@
       cte
   GROUP BY
       event_name
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_cte_variable_with_group_by
@@ -117,7 +112,6 @@
       event_name
   FROM
       cte
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_cte_variable_without_group_by
@@ -134,7 +128,6 @@
       cte
   GROUP BY
       event_name
-  LIMIT 50000
   '''
 # ---
 # name: TestCTETransformSnapshots.test_top_level_variable_with_cte_present
@@ -153,7 +146,6 @@
       event AS event_name
   FROM
       cte
-  LIMIT 50000
   '''
 # ---
 # name: TestDownstreamTransformSnapshots.test_transform_downstream_aggregation_propagation
@@ -180,7 +172,6 @@
       event_name
   FROM
       agg
-  LIMIT 50000
   '''
 # ---
 # name: TestDownstreamTransformSnapshots.test_transform_downstream_cross_join_propagation
@@ -217,7 +208,6 @@
       event_name
   FROM
       combined
-  LIMIT 50000
   '''
 # ---
 # name: TestDownstreamTransformSnapshots.test_transform_downstream_distinct_propagation
@@ -239,7 +229,6 @@
       event_name
   FROM
       u
-  LIMIT 50000
   '''
 # ---
 # name: TestDownstreamTransformSnapshots.test_transform_downstream_projection_propagation
@@ -261,7 +250,6 @@
       event_name
   FROM
       proj
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_all_where_conditions_are_variables
@@ -275,7 +263,6 @@
   GROUP BY
       event,
       distinct_id
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_duplicate_placeholder_produces_single_alias
@@ -287,7 +274,6 @@
       events
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_existing_group_by_preserved
@@ -301,7 +287,6 @@
   GROUP BY
       day,
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_function_call_toDate
@@ -313,7 +298,6 @@
       events
   GROUP BY
       toDate(timestamp)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_hard_cap_timestamp_with_variable_range
@@ -328,7 +312,6 @@
       greater(timestamp, minus(today(), toIntervalDay(90)))
   GROUP BY
       toStartOfDay(timestamp)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_like_operator
@@ -340,7 +323,6 @@
       events
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_mixed_equality_and_range
@@ -354,7 +336,6 @@
   GROUP BY
       event,
       toStartOfDay(hour)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_mixed_field_and_function_call
@@ -368,7 +349,6 @@
   GROUP BY
       event,
       toDate(timestamp)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_nested_and_variable_removed
@@ -382,7 +362,6 @@
       equals(distinct_id, 'u1')
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_order_by_having_limit_preserved
@@ -411,7 +390,6 @@
       events
   GROUP BY
       person.properties.city
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_preserves_non_variable_where
@@ -425,7 +403,6 @@
       and(greater(timestamp, '2024-01-01'), equals(distinct_id, 'user1'))
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_property_variable_json_extract
@@ -437,7 +414,6 @@
       events
   GROUP BY
       properties.os
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_range_on_same_function_call_deduped
@@ -450,7 +426,6 @@
       events
   GROUP BY
       toDate(timestamp)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_range_same_column_deduped
@@ -463,7 +438,6 @@
       events
   GROUP BY
       toStartOfDay(hour)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_single_equality
@@ -475,7 +449,6 @@
       events
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_single_equality_with_alias
@@ -487,7 +460,6 @@
       events
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_three_variables_range_deduped
@@ -502,7 +474,6 @@
   GROUP BY
       event,
       toStartOfDay(hour)
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_two_equality_different_columns
@@ -516,7 +487,6 @@
   GROUP BY
       event,
       distinct_id
-  LIMIT 50000
   '''
 # ---
 # name: TestTransformQuerySnapshots.test_variable_on_left_side
@@ -528,6 +498,5 @@
       events
   GROUP BY
       event
-  LIMIT 50000
   '''
 # ---


### PR DESCRIPTION
## Problem

Materializing an endpoint serialized its query through the default top-level row cap (50k), so the materialized table silently dropped everything past 50k rows. For endpoints whose result is larger — or just ordered so the rows you query for fall past the cap — reads returned incomplete results that didn't match the live query.

## Changes

Materialization now serializes the query without the implicit top-level row cap, so the materialized table holds every row. This is done with a small materialization-local printer (`_print_materialized_hogql`) that calls `prepare_and_print_ast` with `limit_top_select=False`. `to_printed_hogql` and the inline `/run` path are untouched — inline execution still applies its row limit at query time.

The 50k cap was deliberate originally; this lifts it for the materialization path only.

## How did you test this code?

Regenerated the `test_variable_materialization` snapshot (the diff is purely the removed `LIMIT 50000` lines).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

no

## 🤖 Agent context

Agent-assisted. Traced wrong materialized-endpoint results to the 50k cap injected when printing the query for materialization. Considered a `limit_top_select` kwarg on `to_printed_hogql` and a feature-flagged rollout, but settled on the simplest shape: a materialization-local print helper, since "no row cap" is intrinsic to materializing rather than a caller option.
