### PR TITLE
fix(admin): sync-refresh policy cache on AI Gateway clicks; collapse fieldset

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -237,6 +237,7 @@ class TeamAdmin(admin.ModelAdmin):
         (
             "AI Gateway",
             {
+                "classes": ["collapse"],
                 "fields": [
                     "llm_gateway_enabled_at",
                     "llm_gateway_revoked_at",
@@ -367,6 +368,13 @@ class TeamAdmin(admin.ModelAdmin):
             raise PermissionDenied
         return team, None
 
+    def _refresh_ai_gateway_policy_cache(self, team: Team) -> None:
+        # Sync write: the post_save signal's Celery task races the redirect,
+        # and idempotent clicks skip team.save() so the signal never fires.
+        from posthog.storage.team_llm_gateway_policy_cache import update_team_llm_gateway_policy_cache
+
+        update_team_llm_gateway_policy_cache(team)
+
     def enable_ai_gateway_view(self, request, object_id):
         team, response = self._resolve_ai_gateway_team(request, object_id)
         if response is not None:
@@ -390,6 +398,7 @@ class TeamAdmin(admin.ModelAdmin):
                 f"Team '{team.name}' was already enabled (since {team.llm_gateway_enabled_at.isoformat()}).",
                 level=messages.INFO,
             )
+        self._refresh_ai_gateway_policy_cache(team)
         return redirect(reverse("admin:posthog_team_change", args=[object_id]))
 
     def revoke_ai_gateway_view(self, request, object_id):
@@ -415,6 +424,7 @@ class TeamAdmin(admin.ModelAdmin):
                 f"Team '{team.name}' was already revoked (since {team.llm_gateway_revoked_at.isoformat()}).",
                 level=messages.INFO,
             )
+        self._refresh_ai_gateway_policy_cache(team)
         return redirect(reverse("admin:posthog_team_change", args=[object_id]))
 
     def clear_ai_gateway_revoke_view(self, request, object_id):
@@ -440,6 +450,7 @@ class TeamAdmin(admin.ModelAdmin):
                 f"Team '{team.name}' was not revoked.",
                 level=messages.INFO,
             )
+        self._refresh_ai_gateway_policy_cache(team)
         return redirect(reverse("admin:posthog_team_change", args=[object_id]))
 
     @admin.display(description="Actions")

--- a/posthog/admin/test_team_admin.py
+++ b/posthog/admin/test_team_admin.py
@@ -217,6 +217,33 @@ class TestTeamAdminLLMGateway(BaseTest):
 
     @parameterized.expand(
         [
+            ("enable_first_time", "enable_ai_gateway_view", "llm_gateway_enabled_at", False),
+            ("enable_already_enabled", "enable_ai_gateway_view", "llm_gateway_enabled_at", True),
+            ("revoke_first_time", "revoke_ai_gateway_view", "llm_gateway_revoked_at", False),
+            ("revoke_already_revoked", "revoke_ai_gateway_view", "llm_gateway_revoked_at", True),
+            ("clear_revoke_with_revoke", "clear_ai_gateway_revoke_view", "llm_gateway_revoked_at", True),
+            ("clear_revoke_no_op", "clear_ai_gateway_revoke_view", "llm_gateway_revoked_at", False),
+        ]
+    )
+    def test_views_refresh_policy_cache(self, _name: str, view_name: str, field: str, preset_already: bool) -> None:
+        from django.utils import timezone
+
+        if preset_already:
+            setattr(self.team, field, timezone.now() - timedelta(days=1))
+            self.team.save()
+
+        with patch("posthog.storage.team_llm_gateway_policy_cache.update_team_llm_gateway_policy_cache") as mock_update:
+            response = getattr(self.admin, view_name)(self._post(), str(self.team.pk))
+
+        assert response.status_code == 302
+        assert response["Location"] == self.team_change_url
+        # Refresh fires on every click, including no-op clicks where team.save()
+        # is skipped and the Team.save signal therefore never runs.
+        assert mock_update.call_count == 1
+        assert mock_update.call_args.args[0].pk == self.team.pk
+
+    @parameterized.expand(
+        [
             ("enable", "enable_ai_gateway_view"),
             ("revoke", "revoke_ai_gateway_view"),
             ("clear_revoke", "clear_ai_gateway_revoke_view"),


### PR DESCRIPTION
## Problem

The AI Gateway admin section's Enable / Revoke / Clear-revoke buttons leave the policy cache blob stale in two cases:

- An idempotent click (field already in target state) early-returns without `team.save()`, so the `post_save` signal that refreshes the cache never fires.
- On first click the signal's refresh is async (Celery) and races the page render, so the redirected admin shows "(no entry in Redis…)" until something else refreshes.

The only reliable trigger today is clicking the form's Save button, which always calls `obj.save()`.

## Changes

`posthog/admin/admins/team_admin.py`:

- New `_refresh_ai_gateway_policy_cache(team)` helper synchronously calls `update_team_llm_gateway_policy_cache`. Each view (enable / revoke / clear-revoke) invokes it before the redirect, regardless of whether the field changed.
- AI Gateway fieldset gets `classes: ["collapse"]` to match General, Onboarding, Settings, Surveys, Filters.

`posthog/admin/test_team_admin.py`:

- New `test_views_refresh_policy_cache` parameterized across 6 cases (3 views × first-time and already-in-target-state) asserts `update_team_llm_gateway_policy_cache` fires exactly once per click, including the previously broken no-op paths.

## How did you test this code?

Tested locally
<img width="1271" height="642" alt="Screenshot 2026-06-08 at 2 47 07 PM" src="https://github.com/user-attachments/assets/47345c06-6d39-4119-91ee-4523ea938dea" />

- `TestTeamAdminLLMGateway.test_views_refresh_policy_cache` pins the new behavior across all 6 cases.
- Existing `test_enable_view_*` / `test_revoke_view_*` / `test_clear_revoke_view_*` are unchanged and should remain green; the patch only adds a call before the redirect.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. Admin-only UI.

## 🤖 Agent context

Authored by Claude. Repro: enable a team via the inline button, then re-click Enable on the same team. The "Policy cache blob" row stays at "(no entry in Redis…)" until you also click the form's Save button.
