### PR TITLE
fix(replay-vision): show full recording filters in scanner editor

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
@@ -197,6 +197,13 @@ describe('convertUniversalFiltersToRecordingsQuery ∘ recordingsQueryToUniversa
         expect(roundTrip(query).having_predicates).toContainEqual(durationFilter('active_seconds'))
     })
 
+    it('preserves every duration having-predicate, not just the first', () => {
+        const query = rq({ having_predicates: [durationFilter('active_seconds'), durationFilter('duration')] })
+        const back = roundTrip(query).having_predicates
+        expect(back).toContainEqual(durationFilter('active_seconds'))
+        expect(back).toContainEqual(durationFilter('duration'))
+    })
+
     it('preserves filter_test_accounts', () => {
         expect(roundTrip(rq({ filter_test_accounts: true })).filter_test_accounts).toBe(true)
     })

--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
@@ -1,5 +1,11 @@
 import { RecordingsQuery } from '~/queries/schema/schema-general'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+import {
+    AnyPropertyFilter,
+    FilterLogicalOperator,
+    LogEntryPropertyFilter,
+    PropertyFilterType,
+    PropertyOperator,
+} from '~/types'
 
 import {
     convertUniversalFiltersToRecordingsQuery,
@@ -22,31 +28,31 @@ function innerValues(query: RecordingsQuery | null | undefined): any[] {
 
 const EVENT = { id: '$pageview', type: 'events' }
 const ACTION = { id: '5', type: 'actions' }
-const PERSON_PROP = {
+const PERSON_PROP: AnyPropertyFilter = {
     type: PropertyFilterType.Person,
     key: 'email',
     value: 'a@b.com',
     operator: PropertyOperator.Exact,
 }
-const CONSOLE_LOG = {
+const CONSOLE_LOG: LogEntryPropertyFilter = {
     type: PropertyFilterType.LogEntry,
     key: 'level',
     value: ['error'],
     operator: PropertyOperator.Exact,
 }
-const SNAPSHOT_SOURCE = {
+const SNAPSHOT_SOURCE: AnyPropertyFilter = {
     type: PropertyFilterType.Recording,
     key: 'snapshot_source',
     value: ['web'],
     operator: PropertyOperator.Exact,
 }
-const COMMENT_TEXT = {
+const COMMENT_TEXT: AnyPropertyFilter = {
     type: PropertyFilterType.Recording,
     key: 'comment_text',
     value: 'bug',
     operator: PropertyOperator.IContains,
 }
-const durationFilter = (key: 'duration' | 'active_seconds' | 'inactive_seconds'): any => ({
+const durationFilter = (key: 'duration' | 'active_seconds' | 'inactive_seconds'): AnyPropertyFilter => ({
     type: PropertyFilterType.Recording,
     key,
     value: 5,
@@ -198,6 +204,10 @@ describe('convertUniversalFiltersToRecordingsQuery ∘ recordingsQueryToUniversa
 
     it('preserves filter_test_accounts', () => {
         expect(roundTrip(rq({ filter_test_accounts: true })).filter_test_accounts).toBe(true)
+    })
+
+    it('preserves an OR operand instead of silently downgrading to AND', () => {
+        expect(roundTrip(rq({ operand: FilterLogicalOperator.Or })).operand).toBe(FilterLogicalOperator.Or)
     })
 
     it('an empty query round-trips to an empty (match-all) query', () => {

--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
@@ -1,0 +1,209 @@
+import { RecordingsQuery } from '~/queries/schema/schema-general'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+
+import {
+    convertUniversalFiltersToRecordingsQuery,
+    recordingsQueryToUniversalFilters,
+} from './recordingsQueryConversions'
+
+const EMPTY_GROUP = {
+    type: FilterLogicalOperator.And,
+    values: [{ type: FilterLogicalOperator.And, values: [] }],
+}
+
+function rq(partial: Partial<RecordingsQuery>): RecordingsQuery {
+    return { kind: 'RecordingsQuery' as RecordingsQuery['kind'], ...partial }
+}
+
+function innerValues(query: RecordingsQuery | null | undefined): any[] {
+    const inner = recordingsQueryToUniversalFilters(query).filter_group.values[0] as { values: any[] }
+    return inner.values
+}
+
+const EVENT = { id: '$pageview', type: 'events' }
+const ACTION = { id: '5', type: 'actions' }
+const PERSON_PROP = {
+    type: PropertyFilterType.Person,
+    key: 'email',
+    value: 'a@b.com',
+    operator: PropertyOperator.Exact,
+}
+const CONSOLE_LOG = {
+    type: PropertyFilterType.LogEntry,
+    key: 'level',
+    value: ['error'],
+    operator: PropertyOperator.Exact,
+}
+const SNAPSHOT_SOURCE = {
+    type: PropertyFilterType.Recording,
+    key: 'snapshot_source',
+    value: ['web'],
+    operator: PropertyOperator.Exact,
+}
+const COMMENT_TEXT = {
+    type: PropertyFilterType.Recording,
+    key: 'comment_text',
+    value: 'bug',
+    operator: PropertyOperator.IContains,
+}
+const durationFilter = (key: 'duration' | 'active_seconds' | 'inactive_seconds'): any => ({
+    type: PropertyFilterType.Recording,
+    key,
+    value: 5,
+    operator: PropertyOperator.GreaterThan,
+})
+
+describe('recordingsQueryToUniversalFilters', () => {
+    describe('empty / nullish input', () => {
+        it.each([
+            ['null', null],
+            ['undefined', undefined],
+            ['empty query', rq({})],
+            ['empty arrays', rq({ events: [], actions: [], properties: [], having_predicates: [] })],
+        ])('%s yields an empty inner group, no duration, untoggled test accounts', (_name, input) => {
+            const universal = recordingsQueryToUniversalFilters(input as RecordingsQuery | null)
+            expect(universal.filter_group).toEqual(EMPTY_GROUP)
+            expect(universal.duration).toEqual([])
+            expect(universal.filter_test_accounts).toBe(false)
+        })
+    })
+
+    describe('single-dimension pass-through', () => {
+        it('events', () => {
+            expect(innerValues(rq({ events: [EVENT] }))).toEqual([EVENT])
+        })
+        it('hidden events filter (the classifier regression case)', () => {
+            const events = [{ id: 'taxonomic filter add filter clicked', type: 'events' }]
+            expect(innerValues(rq({ events }))).toEqual(events)
+        })
+        it('actions', () => {
+            expect(innerValues(rq({ actions: [ACTION] }))).toEqual([ACTION])
+        })
+        it('properties', () => {
+            expect(innerValues(rq({ properties: [PERSON_PROP] }))).toEqual([PERSON_PROP])
+        })
+        it('console_log_filters', () => {
+            expect(innerValues(rq({ console_log_filters: [CONSOLE_LOG] }))).toEqual([CONSOLE_LOG])
+        })
+        it('comment_text', () => {
+            expect(innerValues(rq({ comment_text: COMMENT_TEXT }))).toEqual([COMMENT_TEXT])
+        })
+    })
+
+    describe('having_predicates routing', () => {
+        it.each(['duration', 'active_seconds', 'inactive_seconds'] as const)(
+            'routes the %s duration key into duration, not the group',
+            (key) => {
+                const universal = recordingsQueryToUniversalFilters(rq({ having_predicates: [durationFilter(key)] }))
+                expect(universal.duration).toEqual([durationFilter(key)])
+                expect(innerValues(rq({ having_predicates: [durationFilter(key)] }))).toEqual([])
+            }
+        )
+        it('keeps non-duration recording properties (snapshot_source) in the group', () => {
+            const universal = recordingsQueryToUniversalFilters(rq({ having_predicates: [SNAPSHOT_SOURCE] }))
+            expect(universal.duration).toEqual([])
+            expect(innerValues(rq({ having_predicates: [SNAPSHOT_SOURCE] }))).toEqual([SNAPSHOT_SOURCE])
+        })
+        it('splits a mixed list, preserving multiple durations and the rest in the group', () => {
+            const query = rq({
+                having_predicates: [durationFilter('active_seconds'), SNAPSHOT_SOURCE, durationFilter('duration')],
+            })
+            const universal = recordingsQueryToUniversalFilters(query)
+            expect(universal.duration).toEqual([durationFilter('active_seconds'), durationFilter('duration')])
+            expect(innerValues(query)).toEqual([SNAPSHOT_SOURCE])
+        })
+        it('keeps a non-recording having predicate in the group (defensive)', () => {
+            const query = rq({ having_predicates: [PERSON_PROP] })
+            expect(recordingsQueryToUniversalFilters(query).duration).toEqual([])
+            expect(innerValues(query)).toEqual([PERSON_PROP])
+        })
+    })
+
+    describe('filter_test_accounts', () => {
+        it.each([
+            [true, true],
+            [false, false],
+            [undefined, false],
+        ])('maps %s to %s', (input, expected) => {
+            expect(recordingsQueryToUniversalFilters(rq({ filter_test_accounts: input })).filter_test_accounts).toBe(
+                expected
+            )
+        })
+    })
+
+    describe('multi-dimension ordering', () => {
+        it('concatenates every dimension in a stable order: events, actions, properties, console, non-duration having, comment', () => {
+            const query = rq({
+                events: [EVENT],
+                actions: [ACTION],
+                properties: [PERSON_PROP],
+                console_log_filters: [CONSOLE_LOG],
+                having_predicates: [durationFilter('active_seconds'), SNAPSHOT_SOURCE],
+                comment_text: COMMENT_TEXT,
+                filter_test_accounts: true,
+            })
+            const universal = recordingsQueryToUniversalFilters(query)
+            expect(universal.duration).toEqual([durationFilter('active_seconds')])
+            expect(universal.filter_test_accounts).toBe(true)
+            expect(innerValues(query)).toEqual([EVENT, ACTION, PERSON_PROP, CONSOLE_LOG, SNAPSHOT_SOURCE, COMMENT_TEXT])
+        })
+
+        it('preserves multiples within a single dimension', () => {
+            const second = { id: '$autocapture', type: 'events' }
+            expect(innerValues(rq({ events: [EVENT, second] }))).toEqual([EVENT, second])
+        })
+    })
+
+    it('always wraps values in the outer/inner AND nesting UniversalFilters expects', () => {
+        const universal = recordingsQueryToUniversalFilters(rq({ events: [EVENT] }))
+        expect(universal.filter_group.type).toBe(FilterLogicalOperator.And)
+        expect(universal.filter_group.values).toHaveLength(1)
+        const inner = universal.filter_group.values[0] as { type: FilterLogicalOperator; values: any[] }
+        expect(inner.type).toBe(FilterLogicalOperator.And)
+    })
+})
+
+// Now that both directions live in this leaf module, the editor's load→edit→save loop is testable
+// end to end: forward(reverse(query)) must preserve every filter dimension. The forward converter
+// normalizes/re-routes some values, so these assert per-dimension equivalence rather than deep object equality.
+describe('convertUniversalFiltersToRecordingsQuery ∘ recordingsQueryToUniversalFilters', () => {
+    function roundTrip(query: RecordingsQuery): RecordingsQuery {
+        return convertUniversalFiltersToRecordingsQuery(recordingsQueryToUniversalFilters(query))
+    }
+
+    it('preserves events, actions, and properties (value normalized to an array for multi-select operators)', () => {
+        const query = rq({ events: [EVENT], actions: [ACTION], properties: [PERSON_PROP] })
+        const back = roundTrip(query)
+        expect(back.events).toEqual([EVENT])
+        expect(back.actions).toEqual([ACTION])
+        expect(back.properties).toHaveLength(1)
+        // The forward converter coerces an Exact-operator value to an array; key/type/operator are unchanged.
+        expect(back.properties![0]).toMatchObject({
+            type: PERSON_PROP.type,
+            key: PERSON_PROP.key,
+            operator: PERSON_PROP.operator,
+            value: [PERSON_PROP.value],
+        })
+    })
+
+    it('preserves the classifier events filter that was previously hidden', () => {
+        const events = [{ id: 'taxonomic filter add filter clicked', type: 'events' }]
+        expect(roundTrip(rq({ events })).events).toEqual(events)
+    })
+
+    it('preserves a duration having-predicate', () => {
+        const query = rq({ having_predicates: [durationFilter('active_seconds')] })
+        expect(roundTrip(query).having_predicates).toContainEqual(durationFilter('active_seconds'))
+    })
+
+    it('preserves filter_test_accounts', () => {
+        expect(roundTrip(rq({ filter_test_accounts: true })).filter_test_accounts).toBe(true)
+    })
+
+    it('an empty query round-trips to an empty (match-all) query', () => {
+        const back = roundTrip(rq({}))
+        expect(back.events).toEqual([])
+        expect(back.actions).toEqual([])
+        expect(back.properties).toEqual([])
+    })
+})

--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.test.ts
@@ -75,24 +75,19 @@ describe('recordingsQueryToUniversalFilters', () => {
     })
 
     describe('single-dimension pass-through', () => {
-        it('events', () => {
-            expect(innerValues(rq({ events: [EVENT] }))).toEqual([EVENT])
+        it.each<[string, Partial<RecordingsQuery>, any[]]>([
+            ['events', { events: [EVENT] }, [EVENT]],
+            ['actions', { actions: [ACTION] }, [ACTION]],
+            ['properties', { properties: [PERSON_PROP] }, [PERSON_PROP]],
+            ['console_log_filters', { console_log_filters: [CONSOLE_LOG] }, [CONSOLE_LOG]],
+            ['comment_text', { comment_text: COMMENT_TEXT }, [COMMENT_TEXT]],
+        ])('passes %s through unchanged', (_name, partial, expected) => {
+            expect(innerValues(rq(partial))).toEqual(expected)
         })
+
         it('hidden events filter (the classifier regression case)', () => {
             const events = [{ id: 'taxonomic filter add filter clicked', type: 'events' }]
             expect(innerValues(rq({ events }))).toEqual(events)
-        })
-        it('actions', () => {
-            expect(innerValues(rq({ actions: [ACTION] }))).toEqual([ACTION])
-        })
-        it('properties', () => {
-            expect(innerValues(rq({ properties: [PERSON_PROP] }))).toEqual([PERSON_PROP])
-        })
-        it('console_log_filters', () => {
-            expect(innerValues(rq({ console_log_filters: [CONSOLE_LOG] }))).toEqual([CONSOLE_LOG])
-        })
-        it('comment_text', () => {
-            expect(innerValues(rq({ comment_text: COMMENT_TEXT }))).toEqual([COMMENT_TEXT])
         })
     })
 

--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.ts
@@ -79,10 +79,9 @@ export function convertUniversalFiltersToRecordingsQuery(universalFilters: Recor
         : DEFAULT_RECORDING_FILTERS_ORDER_BY
     const order_direction: RecordingsQuery['order_direction'] = universalFilters.order_direction || 'DESC'
 
-    const durationFilter = universalFilters.duration[0]
-
-    if (durationFilter) {
-        having_predicates.push(durationFilter)
+    // Push every duration filter — a scanner query can carry more than one, and the inverse extracts them all.
+    if (universalFilters.duration.length > 0) {
+        having_predicates.push(...universalFilters.duration)
     }
 
     filters.forEach((f) => {

--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.ts
@@ -1,5 +1,3 @@
-import posthog from 'posthog-js'
-
 import {
     isAnyPropertyfilter,
     isHogQLPropertyFilter,
@@ -115,23 +113,6 @@ export function convertUniversalFiltersToRecordingsQuery(universalFilters: Recor
                 const normalizedValue =
                     f.type !== 'cohort' ? normalizePropertyFilterValue(f.value, f.operator) : f.value
 
-                // Debug logging for replay filter value type investigation
-                // TODO: Remove after debugging
-                if (
-                    f.type === 'feature' ||
-                    (f.type === 'event' && typeof f.key === 'string' && f.key.includes('$feature'))
-                ) {
-                    posthog.capture('debug_replay_filter_value_type', {
-                        filter_type: f.type,
-                        filter_key: f.key,
-                        original_value: f.value,
-                        normalized_value: normalizedValue,
-                        value_type: typeof f.value,
-                        is_array: Array.isArray(f.value),
-                        operator: f.operator,
-                    })
-                }
-
                 // Only create a new object if the value actually changed
                 if (normalizedValue !== f.value) {
                     properties.push({ ...f, value: normalizedValue } as AnyPropertyFilter)
@@ -185,9 +166,10 @@ export function recordingsQueryToUniversalFilters(
     return {
         duration: havingPredicates.filter(isDuration) as RecordingDurationFilter[],
         filter_test_accounts: query?.filter_test_accounts ?? false,
-        // Outer AND group wrapping a single inner AND group — the nesting UniversalFilters expects.
+        // Outer group (preserving the stored AND/OR operand) wraps a single inner AND group — the nesting
+        // UniversalFilters expects. Without carrying `operand` through, an OR query would silently save back as AND.
         filter_group: {
-            type: FilterLogicalOperator.And,
+            type: (query?.operand as FilterLogicalOperator) ?? FilterLogicalOperator.And,
             values: [{ type: FilterLogicalOperator.And, values }],
         },
     }

--- a/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.ts
+++ b/frontend/src/scenes/session-recordings/filters/recordingsQueryConversions.ts
@@ -1,0 +1,194 @@
+import posthog from 'posthog-js'
+
+import {
+    isAnyPropertyfilter,
+    isHogQLPropertyFilter,
+    normalizePropertyFilterValue,
+} from 'lib/components/PropertyFilters/utils'
+import {
+    isActionFilter,
+    isEventFilter,
+    isLogEntryPropertyFilter,
+    isRecordingPropertyFilter,
+} from 'lib/components/UniversalFilters/utils'
+import { isString } from 'lib/utils'
+
+import { NodeKind, RecordingOrder, RecordingsQuery, VALID_RECORDING_ORDERS } from '~/queries/schema/schema-general'
+import {
+    AnyPropertyFilter,
+    FilterLogicalOperator,
+    PropertyFilterValue,
+    PropertyOperator,
+    RecordingDurationFilter,
+    RecordingUniversalFilters,
+    UniversalFiltersGroupValue,
+} from '~/types'
+
+import { filtersFromUniversalFilterGroups } from '../utils'
+
+export const DEFAULT_RECORDING_FILTERS_ORDER_BY = 'start_time'
+
+const DURATION_KEYS = new Set(['duration', 'active_seconds', 'inactive_seconds'])
+
+export function isValidRecordingOrder(order: unknown): boolean {
+    return !!order && isString(order) && VALID_RECORDING_ORDERS.includes(order as RecordingOrder)
+}
+
+// Normalizes a single property filter's value if it has a multi-select operator.
+function normalizePropertyFilter<T extends { operator?: unknown; value?: unknown; type?: unknown }>(filter: T): T {
+    if (
+        !filter ||
+        typeof filter !== 'object' ||
+        !('operator' in filter) ||
+        !('value' in filter) ||
+        ('type' in filter && filter.type === 'cohort')
+    ) {
+        return filter
+    }
+    const normalizedValue = normalizePropertyFilterValue(
+        filter.value as PropertyFilterValue,
+        filter.operator as PropertyOperator | null
+    )
+    if (normalizedValue !== filter.value) {
+        return { ...filter, value: normalizedValue }
+    }
+    return filter
+}
+
+// Normalizes the properties array nested inside an event or action filter.
+function normalizeFilterWithNestedProperties<T extends { properties?: AnyPropertyFilter[] }>(filter: T): T {
+    if (!filter.properties || !Array.isArray(filter.properties)) {
+        return filter
+    }
+    const normalizedProperties = filter.properties.map((prop) => normalizePropertyFilter(prop) as AnyPropertyFilter)
+    const hasChanges = normalizedProperties.some((prop, i) => prop !== filter.properties![i])
+    return hasChanges ? { ...filter, properties: normalizedProperties } : filter
+}
+
+export function convertUniversalFiltersToRecordingsQuery(universalFilters: RecordingUniversalFilters): RecordingsQuery {
+    const filters = filtersFromUniversalFilterGroups(universalFilters)
+
+    const events: RecordingsQuery['events'] = []
+    const actions: RecordingsQuery['actions'] = []
+    const properties: RecordingsQuery['properties'] = []
+    const console_log_filters: RecordingsQuery['console_log_filters'] = []
+    const having_predicates: RecordingsQuery['having_predicates'] = []
+    let comment_text: RecordingsQuery['comment_text'] = undefined
+
+    // it was possible to store an invalid order key in local storage sometimes, let's just ignore that instead of erroring
+    const order: RecordingsQuery['order'] = isValidRecordingOrder(universalFilters.order)
+        ? universalFilters.order
+        : DEFAULT_RECORDING_FILTERS_ORDER_BY
+    const order_direction: RecordingsQuery['order_direction'] = universalFilters.order_direction || 'DESC'
+
+    const durationFilter = universalFilters.duration[0]
+
+    if (durationFilter) {
+        having_predicates.push(durationFilter)
+    }
+
+    filters.forEach((f) => {
+        if (isEventFilter(f)) {
+            events.push(normalizeFilterWithNestedProperties(f))
+        } else if (isActionFilter(f)) {
+            actions.push(normalizeFilterWithNestedProperties(f))
+        } else if (isLogEntryPropertyFilter(f)) {
+            console_log_filters.push(f)
+        } else if (isHogQLPropertyFilter(f)) {
+            properties.push(f)
+        } else if (isAnyPropertyfilter(f)) {
+            if (isRecordingPropertyFilter(f)) {
+                if (f.key === 'visited_page') {
+                    // Pass visited_page as a recording property to use all_urls array in backend
+                    // This filters by URLs that actually appear in the recording, not just events during the session
+                    properties.push(f)
+                } else if (f.key === 'snapshot_source' && f.value) {
+                    having_predicates.push(f)
+                } else if (f.key === 'comment_text') {
+                    comment_text = f
+                } else {
+                    having_predicates.push(f)
+                }
+            } else {
+                // Normalize filter value to ensure multi-select operators have array values
+                // Skip cohort filters as they have a different value type (number)
+                const normalizedValue =
+                    f.type !== 'cohort' ? normalizePropertyFilterValue(f.value, f.operator) : f.value
+
+                // Debug logging for replay filter value type investigation
+                // TODO: Remove after debugging
+                if (
+                    f.type === 'feature' ||
+                    (f.type === 'event' && typeof f.key === 'string' && f.key.includes('$feature'))
+                ) {
+                    posthog.capture('debug_replay_filter_value_type', {
+                        filter_type: f.type,
+                        filter_key: f.key,
+                        original_value: f.value,
+                        normalized_value: normalizedValue,
+                        value_type: typeof f.value,
+                        is_array: Array.isArray(f.value),
+                        operator: f.operator,
+                    })
+                }
+
+                // Only create a new object if the value actually changed
+                if (normalizedValue !== f.value) {
+                    properties.push({ ...f, value: normalizedValue } as AnyPropertyFilter)
+                } else {
+                    properties.push(f)
+                }
+            }
+        }
+    })
+
+    return {
+        kind: NodeKind.RecordingsQuery,
+        order: order,
+        order_direction: order_direction,
+        date_from: universalFilters.date_from,
+        date_to: universalFilters.date_to,
+        properties,
+        events,
+        actions,
+        console_log_filters,
+        having_predicates,
+        comment_text,
+        filter_test_accounts: universalFilters.filter_test_accounts,
+        operand: universalFilters.filter_group.type,
+        limit: universalFilters.limit,
+        session_ids: universalFilters.session_ids,
+    }
+}
+
+/**
+ * Inverse of {@link convertUniversalFiltersToRecordingsQuery}: unpacks a stored `RecordingsQuery` back into
+ * the `RecordingUniversalFilters` the editor renders. Replay Vision persists the query shape, so it round-trips
+ * through this on load; the recordings list persists the universal shape and never needs it.
+ */
+export function recordingsQueryToUniversalFilters(
+    query: RecordingsQuery | null | undefined
+): RecordingUniversalFilters {
+    // having_predicates mixes duration filters (their own control) with recording properties (e.g. snapshot_source).
+    const isDuration = (p: AnyPropertyFilter): boolean => p.type === 'recording' && DURATION_KEYS.has(p.key)
+    const havingPredicates = query?.having_predicates ?? []
+
+    const values = [
+        ...(query?.events ?? []),
+        ...(query?.actions ?? []),
+        ...(query?.properties ?? []),
+        ...(query?.console_log_filters ?? []),
+        ...havingPredicates.filter((p) => !isDuration(p)),
+        ...(query?.comment_text ? [query.comment_text] : []),
+    ] as UniversalFiltersGroupValue[]
+
+    return {
+        duration: havingPredicates.filter(isDuration) as RecordingDurationFilter[],
+        filter_test_accounts: query?.filter_test_accounts ?? false,
+        // Outer AND group wrapping a single inner AND group — the nesting UniversalFilters expects.
+        filter_group: {
+            type: FilterLogicalOperator.And,
+            values: [{ type: FilterLogicalOperator.And, values }],
+        },
+    }
+}

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -8,19 +8,13 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
-import {
-    formatPropertyLabel,
-    isAnyPropertyfilter,
-    isHogQLPropertyFilter,
-    normalizePropertyFilterValue,
-} from 'lib/components/PropertyFilters/utils'
+import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import {
     isActionFilter,
     isEventFilter,
     isEventPropertyFilter,
-    isLogEntryPropertyFilter,
     isRecordingPropertyFilter,
 } from 'lib/components/UniversalFilters/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -32,13 +26,7 @@ import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessi
 import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
-import {
-    NodeKind,
-    RecordingOrder,
-    RecordingsQuery,
-    RecordingsQueryResponse,
-    VALID_RECORDING_ORDERS,
-} from '~/queries/schema/schema-general'
+import { NodeKind, RecordingOrder, RecordingsQuery, RecordingsQueryResponse } from '~/queries/schema/schema-general'
 import {
     AnyPropertyFilter,
     FilterLogicalOperator,
@@ -47,7 +35,6 @@ import {
     LogEntryPropertyFilter,
     MatchedRecordingEvent,
     PropertyFilterType,
-    PropertyFilterValue,
     PropertyOperator,
     RecordingDurationFilter,
     RecordingUniversalFilters,
@@ -59,9 +46,18 @@ import {
 } from '~/types'
 
 import { deletedRecordingsLogic } from '../deletedRecordingsLogic'
+import {
+    DEFAULT_RECORDING_FILTERS_ORDER_BY,
+    convertUniversalFiltersToRecordingsQuery,
+    isValidRecordingOrder,
+} from '../filters/recordingsQueryConversions'
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
 import { filtersFromUniversalFilterGroups } from '../utils'
 import { playlistFiltersLogic } from './playlistFiltersLogic'
+
+// Re-exported for back-compat with existing import sites; the implementations now live in the leaf
+// `recordingsQueryConversions` module so they can be imported without pulling in this logic file.
+export { DEFAULT_RECORDING_FILTERS_ORDER_BY, convertUniversalFiltersToRecordingsQuery }
 import { sessionRecordingsListPropertiesLogic } from './sessionRecordingsListPropertiesLogic'
 import type { sessionRecordingsPlaylistLogicType } from './sessionRecordingsPlaylistLogicType'
 import { sessionRecordingsPlaylistSceneLogic } from './sessionRecordingsPlaylistSceneLogic'
@@ -109,10 +105,6 @@ const isPersonPropertyShortcutSearchParams = (
     return (x as PersonPropertyShortcutSearchParams).personProperty !== undefined
 }
 
-function isValidRecordingOrder(order: unknown): boolean {
-    return !!order && isString(order) && VALID_RECORDING_ORDERS.includes(order as RecordingOrder)
-}
-
 function isValidRecordingOrderDirection(direction: unknown): boolean {
     return !!direction && isString(direction) && ['ASC', 'DESC'].includes(direction)
 }
@@ -158,7 +150,6 @@ export const defaultRecordingDurationFilter: RecordingDurationFilter = {
     operator: PropertyOperator.GreaterThan,
 }
 
-export const DEFAULT_RECORDING_FILTERS_ORDER_BY = 'start_time'
 export const MAX_SELECTED_RECORDINGS = 20
 export const DELETE_CONFIRMATION_TEXT = 'delete'
 
@@ -297,139 +288,6 @@ export function isValidRecordingFilters(filters: Partial<RecordingUniversalFilte
     }
 
     return true
-}
-
-/**
- * Normalizes a single property filter's value if it has a multi-select operator.
- */
-function normalizePropertyFilter<T extends { operator?: unknown; value?: unknown; type?: unknown }>(filter: T): T {
-    if (
-        !filter ||
-        typeof filter !== 'object' ||
-        !('operator' in filter) ||
-        !('value' in filter) ||
-        ('type' in filter && filter.type === 'cohort')
-    ) {
-        return filter
-    }
-    const normalizedValue = normalizePropertyFilterValue(
-        filter.value as PropertyFilterValue,
-        filter.operator as PropertyOperator | null
-    )
-    if (normalizedValue !== filter.value) {
-        return { ...filter, value: normalizedValue }
-    }
-    return filter
-}
-
-/**
- * Normalizes properties array inside an event or action filter.
- * Returns the filter with normalized properties, or the original if no changes needed.
- */
-function normalizeFilterWithNestedProperties<T extends { properties?: AnyPropertyFilter[] }>(filter: T): T {
-    if (!filter.properties || !Array.isArray(filter.properties)) {
-        return filter
-    }
-    const normalizedProperties = filter.properties.map((prop) => normalizePropertyFilter(prop) as AnyPropertyFilter)
-    // Only create new object if something changed
-    const hasChanges = normalizedProperties.some((prop, i) => prop !== filter.properties![i])
-    return hasChanges ? { ...filter, properties: normalizedProperties } : filter
-}
-
-export function convertUniversalFiltersToRecordingsQuery(universalFilters: RecordingUniversalFilters): RecordingsQuery {
-    const filters = filtersFromUniversalFilterGroups(universalFilters)
-
-    const events: RecordingsQuery['events'] = []
-    const actions: RecordingsQuery['actions'] = []
-    const properties: RecordingsQuery['properties'] = []
-    const console_log_filters: RecordingsQuery['console_log_filters'] = []
-    const having_predicates: RecordingsQuery['having_predicates'] = []
-    let comment_text: RecordingsQuery['comment_text'] = undefined
-
-    // it was possible to store an invalid order key in local storage sometimes, let's just ignore that instead of erroring
-    const order: RecordingsQuery['order'] = isValidRecordingOrder(universalFilters.order)
-        ? universalFilters.order
-        : DEFAULT_RECORDING_FILTERS_ORDER_BY
-    const order_direction: RecordingsQuery['order_direction'] = universalFilters.order_direction || 'DESC'
-
-    const durationFilter = universalFilters.duration[0]
-
-    if (durationFilter) {
-        having_predicates.push(durationFilter)
-    }
-
-    filters.forEach((f) => {
-        if (isEventFilter(f)) {
-            events.push(normalizeFilterWithNestedProperties(f))
-        } else if (isActionFilter(f)) {
-            actions.push(normalizeFilterWithNestedProperties(f))
-        } else if (isLogEntryPropertyFilter(f)) {
-            console_log_filters.push(f)
-        } else if (isHogQLPropertyFilter(f)) {
-            properties.push(f)
-        } else if (isAnyPropertyfilter(f)) {
-            if (isRecordingPropertyFilter(f)) {
-                if (f.key === 'visited_page') {
-                    // Pass visited_page as a recording property to use all_urls array in backend
-                    // This filters by URLs that actually appear in the recording, not just events during the session
-                    properties.push(f)
-                } else if (f.key === 'snapshot_source' && f.value) {
-                    having_predicates.push(f)
-                } else if (f.key === 'comment_text') {
-                    comment_text = f
-                } else {
-                    having_predicates.push(f)
-                }
-            } else {
-                // Normalize filter value to ensure multi-select operators have array values
-                // Skip cohort filters as they have a different value type (number)
-                const normalizedValue =
-                    f.type !== 'cohort' ? normalizePropertyFilterValue(f.value, f.operator) : f.value
-
-                // Debug logging for replay filter value type investigation
-                // TODO: Remove after debugging
-                if (
-                    f.type === 'feature' ||
-                    (f.type === 'event' && typeof f.key === 'string' && f.key.includes('$feature'))
-                ) {
-                    posthog.capture('debug_replay_filter_value_type', {
-                        filter_type: f.type,
-                        filter_key: f.key,
-                        original_value: f.value,
-                        normalized_value: normalizedValue,
-                        value_type: typeof f.value,
-                        is_array: Array.isArray(f.value),
-                        operator: f.operator,
-                    })
-                }
-
-                // Only create a new object if the value actually changed
-                if (normalizedValue !== f.value) {
-                    properties.push({ ...f, value: normalizedValue } as AnyPropertyFilter)
-                } else {
-                    properties.push(f)
-                }
-            }
-        }
-    })
-
-    return {
-        kind: NodeKind.RecordingsQuery,
-        order: order,
-        order_direction: order_direction,
-        date_from: universalFilters.date_from,
-        date_to: universalFilters.date_to,
-        properties,
-        events,
-        actions,
-        console_log_filters,
-        having_predicates,
-        comment_text,
-        filter_test_accounts: universalFilters.filter_test_accounts,
-        operand: universalFilters.filter_group.type,
-        limit: universalFilters.limit,
-        session_ids: universalFilters.session_ids,
-    }
 }
 
 export function convertLegacyFiltersToUniversalFilters(

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -107,7 +107,8 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
 
             <LemonField name="query" label="Recording filters">
                 {({ value, onChange }) => {
-                    const universal = recordingsQueryToUniversalFilters(value as RecordingsQuery | null)
+                    const query = value as RecordingsQuery | null
+                    const universal = recordingsQueryToUniversalFilters(query)
                     return (
                         <div className="space-y-2">
                             <div className="text-sm text-muted">
@@ -118,14 +119,26 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                 rootKey={`replay-scanner-${scanner.id}`}
                                 group={universal.filter_group}
                                 taxonomicGroupTypes={SCANNER_FILTER_TYPES}
-                                onChange={(filterGroup) =>
-                                    onChange(
-                                        convertUniversalFiltersToRecordingsQuery({
-                                            ...universal,
-                                            filter_group: filterGroup,
-                                        })
-                                    )
-                                }
+                                onChange={(filterGroup) => {
+                                    const next = convertUniversalFiltersToRecordingsQuery({
+                                        ...universal,
+                                        filter_group: filterGroup,
+                                    })
+                                    // Overlay only the dimensions this editor controls, so query fields it doesn't
+                                    // render (e.g. session_ids, person_uuid set via API/MCP) survive an edit.
+                                    onChange({
+                                        ...query,
+                                        kind: next.kind,
+                                        events: next.events,
+                                        actions: next.actions,
+                                        properties: next.properties,
+                                        console_log_filters: next.console_log_filters,
+                                        having_predicates: next.having_predicates,
+                                        comment_text: next.comment_text,
+                                        filter_test_accounts: next.filter_test_accounts,
+                                        operand: next.operand,
+                                    })
+                                }}
                             >
                                 <ScannerFilterGroup />
                             </UniversalFilters>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -1,24 +1,63 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { LemonDivider, LemonInput } from '@posthog/lemon-ui'
 
-import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
+import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+import {
+    convertUniversalFiltersToRecordingsQuery,
+    recordingsQueryToUniversalFilters,
+} from 'scenes/session-recordings/filters/recordingsQueryConversions'
 
-import { NodeKind, RecordingsQuery } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter } from '~/types'
+import { RecordingsQuery } from '~/queries/schema/schema-general'
 
 import { replayScannerLogic } from '../replayScannerLogic'
 import { ScannerQuotaForecast } from './ScannerQuotaForecast'
 
-const RECORDING_FILTER_TYPES: TaxonomicFilterGroupType[] = [
+// Mirrors the recordings list, minus its playlist-only groups (saved/suggested filters).
+const SCANNER_FILTER_TYPES: TaxonomicFilterGroupType[] = [
+    TaxonomicFilterGroupType.Replay,
+    TaxonomicFilterGroupType.Events,
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.Actions,
+    TaxonomicFilterGroupType.Cohorts,
+    TaxonomicFilterGroupType.EventFeatureFlags,
     TaxonomicFilterGroupType.PersonProperties,
     TaxonomicFilterGroupType.SessionProperties,
-    TaxonomicFilterGroupType.Cohorts,
-    TaxonomicFilterGroupType.Events,
 ]
+
+// Recursively renders the bound universal-filter group's values + the add-filter button.
+function ScannerFilterGroup(): JSX.Element {
+    const { filterGroup } = useValues(universalFiltersLogic)
+    const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
+
+    return (
+        <div className="inline-flex flex-col gap-2">
+            {filterGroup.values.map((filterOrGroup, index) =>
+                isUniversalGroupFilterLike(filterOrGroup) ? (
+                    <UniversalFilters.Group key={index} index={index} group={filterOrGroup}>
+                        <ScannerFilterGroup />
+                    </UniversalFilters.Group>
+                ) : (
+                    <UniversalFilters.Value
+                        key={index}
+                        index={index}
+                        filter={filterOrGroup}
+                        onRemove={() => removeGroupValue(index)}
+                        onChange={(value) => replaceGroupValue(index, value)}
+                    />
+                )
+            )}
+            <div>
+                <UniversalFilters.AddFilterButton title="Add filter" type="secondary" size="xsmall" />
+            </div>
+        </div>
+    )
+}
 
 export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Element {
     const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
@@ -68,30 +107,28 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
 
             <LemonField name="query" label="Recording filters">
                 {({ value, onChange }) => {
-                    const query = value as RecordingsQuery | null
-                    const properties = query?.properties ?? []
-                    const updateProperties = (next: AnyPropertyFilter[]): void => {
-                        onChange({
-                            kind: NodeKind.RecordingsQuery,
-                            ...query,
-                            properties: next,
-                        })
-                    }
+                    const universal = recordingsQueryToUniversalFilters(value as RecordingsQuery | null)
                     return (
                         <div className="space-y-2">
                             <div className="text-sm text-muted">
-                                Filter by person, session, cohort, or event properties. Leave empty to scan all
-                                completed recordings.
+                                Filter by event, action, person, session, or cohort. Leave empty to scan all completed
+                                recordings.
                             </div>
-                            <PropertyFilters
-                                propertyFilters={properties}
-                                onChange={updateProperties}
-                                pageKey={`replay-scanner-${scanner.id}-properties`}
-                                taxonomicGroupTypes={RECORDING_FILTER_TYPES}
-                                addText="Add filter"
-                                hasRowOperator={false}
-                                sendAllKeyUpdates
-                            />
+                            <UniversalFilters
+                                rootKey={`replay-scanner-${scanner.id}`}
+                                group={universal.filter_group}
+                                taxonomicGroupTypes={SCANNER_FILTER_TYPES}
+                                onChange={(filterGroup) =>
+                                    onChange(
+                                        convertUniversalFiltersToRecordingsQuery({
+                                            ...universal,
+                                            filter_group: filterGroup,
+                                        })
+                                    )
+                                }
+                            >
+                                <ScannerFilterGroup />
+                            </UniversalFilters>
                         </div>
                     )
                 }}


### PR DESCRIPTION
## Problem

A scanner stores its trigger filters as a `RecordingsQuery`, but the editor only rendered `query.properties`. Scanners filtering on `events`/`actions`/console-logs/duration showed as **unfiltered** — the filter was live in the DB, estimate, and sweep, but invisible when editing.

## Changes

- Swap the scanner editor's filter field from `PropertyFilters` to the `UniversalFilters` editor the recordings list uses, so every filter dimension is visible and editable.
- Storage stays `RecordingsQuery` (no backend change, no migration); the editor converts to/from `RecordingUniversalFilters` on load/edit, preserving query fields it doesn't render.
- Extract `convertUniversalFiltersToRecordingsQuery` out of `sessionRecordingsPlaylistLogic` into a leaf module alongside a new inverse `recordingsQueryToUniversalFilters`, so the converters can be imported (and unit-tested) without pulling the playlist logic. The playlist logic re-exports both for back-compat.

## How did you test this code?

Agent. `recordingsQueryConversions.test.ts` — 28 cases covering the inverse converter per-dimension plus forward/reverse round-trips. Frontend typecheck passes.

## 🤖 Agent context

Claude. Root-caused from a quota-estimate discrepancy (same team + sampling, wildly different estimates) traced to a hidden `events` filter the old editor didn't render.