### PR TITLE
fix(workflows): gate test-run groups on group_analytics

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.test.ts
@@ -1,7 +1,12 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_GROUP_TYPES } from 'lib/api.mock'
+
 import { expectLogic } from 'kea-test-utils'
 
+import { useAvailableFeatures } from '~/mocks/features'
+import { useMocks } from '~/mocks/jest'
+import { groupsModel } from '~/models/groupsModel'
 import { initKeaTests } from '~/test/init'
-import { GroupType, GroupTypeIndex } from '~/types'
+import { AvailableFeature, GroupType, GroupTypeIndex, OrganizationType } from '~/types'
 
 import {
     createGlobalsFromResponse,
@@ -107,6 +112,45 @@ describe('hogFlowEditorTestLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
+    })
+
+    describe('groupTypesForTest gating on group_analytics', () => {
+        const orgWithFeatures = (features: AvailableFeature[]): OrganizationType => ({
+            ...MOCK_DEFAULT_ORGANIZATION,
+            available_product_features: features.map((key) => ({ key, name: key })),
+        })
+
+        it('exposes all group types when group_analytics is available', () => {
+            initKeaTests(true, undefined as any, undefined as any, orgWithFeatures([AvailableFeature.GROUP_ANALYTICS]))
+            useMocks({ get: { '/api/projects/:team/groups_types': MOCK_GROUP_TYPES } })
+            useAvailableFeatures([AvailableFeature.GROUP_ANALYTICS])
+            groupsModel.mount()
+            groupsModel.actions.loadAllGroupTypesSuccess(MOCK_GROUP_TYPES)
+            logic = hogFlowEditorTestLogic({ id: 'test-workflow' })
+            logic.mount()
+
+            expect(logic.values.groupsEnabled).toBe(true)
+            expect(logic.values.groupTypesForTest.size).toBe(MOCK_GROUP_TYPES.length)
+            expect(groupSelectColumns(logic.values.groupTypesForTest)).toHaveLength(MOCK_GROUP_TYPES.length)
+        })
+
+        it('resolves no group types without group_analytics, matching gated real execution', () => {
+            initKeaTests(true, undefined as any, undefined as any, orgWithFeatures([]))
+            useMocks({ get: { '/api/projects/:team/groups_types': MOCK_GROUP_TYPES } })
+            useAvailableFeatures([])
+            groupsModel.mount()
+            // Group types load ungated, mirroring groupsModel.afterMount in real usage
+            groupsModel.actions.loadAllGroupTypesSuccess(MOCK_GROUP_TYPES)
+            logic = hogFlowEditorTestLogic({ id: 'test-workflow' })
+            logic.mount()
+
+            expect(logic.values.groupsEnabled).toBe(false)
+            // groupsModel still loaded the types ungated...
+            expect(logic.values.groupTypes.size).toBe(MOCK_GROUP_TYPES.length)
+            // ...but the test run must not use them, so no group columns are queried and groups stay empty
+            expect(logic.values.groupTypesForTest.size).toBe(0)
+            expect(groupSelectColumns(logic.values.groupTypesForTest)).toEqual([])
+        })
     })
 
     describe('accumulatedVariables reducer', () => {

--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -7,6 +7,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
+import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { uuid } from 'lib/utils'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -179,6 +180,8 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
             ['selectedNodeId'],
             groupsModel,
             ['groupTypes'],
+            groupsAccessLogic,
+            ['groupsEnabled'],
         ],
         actions: [hogFlowEditorLogic, ['setSelectedNodeId', 'setAnimatingEdgePair']],
     })),
@@ -315,7 +318,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                         const query: EventsQuery = {
                             kind: NodeKind.EventsQuery,
                             fixedProperties: [values.matchingFilters],
-                            select: ['*', 'person', ...groupSelectColumns(values.groupTypes)],
+                            select: ['*', 'person', ...groupSelectColumns(values.groupTypesForTest)],
                             after: timeRange,
                             limit: 10,
                             orderBy: ['timestamp DESC'],
@@ -368,7 +371,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
 
                         const event = response.results[resultIndex][0]
                         const person = response.results[resultIndex][1]
-                        const groups = parseGroupsFromResult(response.results[resultIndex], values.groupTypes)
+                        const groups = parseGroupsFromResult(response.results[resultIndex], values.groupTypesForTest)
 
                         return createGlobalsFromResponse(
                             event,
@@ -405,7 +408,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                                     ],
                                 },
                             ],
-                            select: ['*', 'person', ...groupSelectColumns(values.groupTypes)],
+                            select: ['*', 'person', ...groupSelectColumns(values.groupTypesForTest)],
                             after: timeRange,
                             limit: 1,
                             orderBy: ['timestamp DESC'],
@@ -439,7 +442,7 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
 
                         const event = response.results[0][0]
                         const person = response.results[0][1]
-                        const groups = parseGroupsFromResult(response.results[0], values.groupTypes)
+                        const groups = parseGroupsFromResult(response.results[0], values.groupTypesForTest)
 
                         actions.setSampleGlobalsError(null)
                         actions.setCanTryExtendedSearch(false)
@@ -465,6 +468,13 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                 // Only load samples if the trigger is event
                 return !!(triggerAction && triggerAction.config.type === 'event')
             },
+        ],
+        // Mirror real execution: the worker's getGroupsForEvent gates on group_analytics, so without
+        // the addon the test run must also resolve no groups (otherwise a group condition could match
+        // here but never in production).
+        groupTypesForTest: [
+            (s) => [s.groupsEnabled, s.groupTypes],
+            (groupsEnabled, groupTypes): Map<GroupTypeIndex, GroupType> => (groupsEnabled ? groupTypes : new Map()),
         ],
         // TODO(workflows): DRY up matchingFilters with implementation in hogFunctionConfigurationLogic
         matchingFilters: [


### PR DESCRIPTION
## Problem

Follow-up to #61480, addressing @dmarchuk's review comment: https://github.com/PostHog/posthog/pull/61480#discussion_r3358014508

> Frontend loads group types ungated here, but the backend `getGroupsForEvent` gates on `group_analytics`. Could that make a group condition match in the test run but not in prod? Should this gate too? 🤔

It can. The two paths diverge for a team that has group data but **not** the `group_analytics` addon:

- **Real execution** — the cyclotron worker calls `GroupsManagerService.getGroupsForEvent`, which gates inside `fetchGroupTypes` on `group_analytics`. Without the addon it resolves `groups = {}`, so a group-property condition never matches.
- **Test run** — `hogFlowEditorTestLogic` connected `groupsModel.groupTypes`, which loads **ungated** (`groupsModel.afterMount` calls `loadAllGroupTypes()` unconditionally). It built `groupSelectColumns` / `parseGroupsFromResult` from those types and populated real group data into the editable sample globals that get POSTed to the test endpoint. The backend only resolves groups via the gated `getGroupsForEvent` **when the payload omits them** — since the frontend now supplied non-empty `groups`, the backend left them untouched, **bypassing the gate**.

Net effect: a group-property condition could match in the editor's test run while never matching in production.

## Changes

Frontend-only. Gate the test run's group resolution on the same `group_analytics` availability the backend uses, reusing the existing `groupsEnabled` selector from `groupsAccessLogic` (`hasAvailableFeature(AvailableFeature.GROUP_ANALYTICS)` — the exact frontend equivalent of the backend's `hasAvailableFeature(teamId, 'group_analytics')`).

- New `groupTypesForTest` selector returns the group-type map when `groupsEnabled`, otherwise an empty `Map`.
- Both sample-event loaders (`loadSampleGlobals`, `loadSampleEventByName`) now build group columns and parse groups from `groupTypesForTest` instead of the raw `groupTypes`.

When the addon is absent, no group columns are selected, `groups` stays `{}`, and the backend's gated `getGroupsForEvent` also returns `{}` — test and prod align. When the addon is present, behavior is unchanged from #61480.

## How did you test this code?

Automated, in `hogFlowEditorTestLogic.test.ts`:
- `groupTypesForTest` exposes all group types when `group_analytics` is available.
- `groupTypesForTest` resolves to empty when `group_analytics` is absent — even though `groupsModel.groupTypes` is populated — so no group columns are queried.

Built test-first (TDD): the gating tests were written and confirmed red against the missing selector, then implemented to green. Full suite passes (18/18); `oxlint` and `oxfmt` clean on the changed files; `tsc` clean on the change.

## 🤖 Agent context

Authored with PostHog Code (Opus 4.8). Reproduced the divergence by tracing both execution paths, then chose to gate on `groupsEnabled` rather than have the backend re-derive trust — the frontend is what was bypassing the existing backend gate, so aligning it there is the minimal fix. Considered gating inside the loaders directly but a single `groupTypesForTest` selector keeps both call sites consistent and is unit-testable. Out of scope (unchanged): the backend gate itself, and the separately-deferred question of group properties inside destinations during real execution.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
