### PR TITLE
chore(skills): scope team-wide query optimization across frontend and backend

### DIFF
--- a/.agents/skills/optimizing-clickhouse-and-hogql-queries/SKILL.md
+++ b/.agents/skills/optimizing-clickhouse-and-hogql-queries/SKILL.md
@@ -11,6 +11,25 @@ The best way to optimize a HogQL query is to **start with the ClickHouse SQL it 
 
 This skill assumes you already know how to write HogQL. For writing new ClickHouse-backed queries from scratch, use `/writing-clickhouse-queries` first. For migration mechanics, use `/clickhouse-migrations`.
 
+## Optimizing every query a team owns
+
+Sometimes the job isn't one slow query — it's "optimize all the ClickHouse/HogQL queries owned by team X." Before diving into individual queries, build the full inventory first, or you'll optimize a subset and miss the rest.
+
+**Find the team's code via `.github/CODEOWNERS` and `.github/CODEOWNERS-soft`.** Grep both for the team's handle (e.g. `@PostHog/team-surveys`) to get every path the team owns. `CODEOWNERS-soft` in particular carries the product-area ownership most teams rely on.
+
+**The ownership paths drift out of date — verify each one exists before trusting it.** Products move (e.g. into `products/<name>/`), files get renamed, directories get restructured, but `CODEOWNERS-soft` often lags. After extracting the owned paths, check each actually exists on disk; for any that don't, find where the code moved (the product likely relocated under `products/`) and **flag the stale entries to the operator** so they can fix `CODEOWNERS-soft` — don't silently substitute and move on. A stale path you skip is a query you never optimized.
+
+**Search both backend AND frontend — owned paths include both.** A team's ownership almost always spans `frontend/src/...` as well as backend Python. The majority of ClickHouse/HogQL queries are written in Python (query runners, `execute_hogql_query`, raw `sync_execute`), **but not all of them** — plenty of products still build HogQL client-side in kea logics / React / TypeScript and POST it to the `/query` endpoint. If you only search backend paths and backend idioms, you'll miss these entirely (this is a real, recurring miss). When scoping a team, either search every owned path — frontend included — with both backend and frontend query idioms, or tell the operator up front that you're covering backend only and ask whether they want frontend too. Don't let an unstated "queries live in the backend" assumption narrow the search silently.
+
+Frontend HogQL doesn't look like the backend patterns in Step 0. Grep the team's `frontend/` paths for these too:
+
+- `api.queryHogQL(...)`, `HogQLQueryString`, the `` hogql`...` `` tagged template
+- `NodeKind.HogQLQuery` / `kind: 'HogQLQuery'` objects with a `query:` string
+- structured query nodes that compile to ClickHouse: `DataTableNode`, `EventsQuery`, `TrendsQuery`/`InsightVizNode`, and `PropertyFilterType.HogQL` expressions inside them
+- string literals with `SELECT ... FROM events`, or product-specific markers (event names like `'survey sent'`, property keys like `$survey_id`)
+
+The same logical query is sometimes implemented **twice** — once in a backend query runner / endpoint and once as frontend-built HogQL (often a stalled frontend→backend migration). Treat both copies as in-scope, and note the duplication: a printer- or function-level fix on the backend won't reach a hand-built frontend string emitting the same SQL.
+
 ## Step 0: confirm you're at the right layer
 
 Before walking through the workflow, check that the slow query in front of you actually goes to ClickHouse via HogQL. The fastest way is to look at how the query is built:


### PR DESCRIPTION
## Problem

The `optimizing-clickhouse-and-hogql-queries` skill assumes you arrive with a single slow query in hand. It has no guidance for the "optimize every ClickHouse/HogQL query a team owns" entry mode. In practice that mode has two failure points that the skill didn't warn about:

- `CODEOWNERS-soft` paths drift out of date (products move under `products/`, files get renamed), so a literal reading of the ownership list silently skips relocated code.
- The majority of queries are Python, which biases the search toward backend idioms — but some products still build HogQL client-side in kea/React and POST it to the `/query` endpoint. A backend-only sweep misses those entirely.

## Changes

Adds a short "Optimizing every query a team owns" section before Step 0 covering:

- building the inventory from `CODEOWNERS` / `CODEOWNERS-soft`
- treating the listed paths as drift-prone: verify each exists, and flag stale entries to the operator rather than silently substituting
- searching frontend as well as backend, with the concrete frontend query idioms to grep for (`api.queryHogQL`, `HogQLQueryString`, the `hogql` tagged template, `NodeKind.HogQLQuery`, `DataTableNode`/`EventsQuery`/`TrendsQuery`, `PropertyFilterType.HogQL`)
- a note that the same query is sometimes implemented twice (backend runner + frontend string, often a stalled migration), so a backend-layer fix won't reach the frontend copy

Docs/skill-only change — no code paths affected.

## How did you test this code?

I'm an agent. No automated tests apply to a Markdown skill file. The repo's `format:markdown` lint-staged hook ran on commit and reformatted nothing of substance. The guidance is grounded in a real session where a backend-only first pass missed the frontend surveys queries.

## 🤖 Agent context

Authored by PostHog Code (Claude). This came out of a survey-team query-optimization session: the first pass scoped only backend paths and missed the HogQL still built in `frontend/src/scenes/surveys/` (`surveyLogic.tsx`, `utils.ts`), despite `frontend/src/scenes/surveys/` being listed in `CODEOWNERS-soft`. The miss had two causes — dropping frontend paths from the search, and using backend-only grep idioms — both of which this section now calls out. Placed before Step 0 since it's a scoping concern that precedes per-query triage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
