### PR TITLE
fix(cdp): treat missing $lib as non-browser in bot filter

### DIFF
--- a/nodejs/src/cdp/templates/_transformations/bot-detection/bot-detection.template.test.ts
+++ b/nodejs/src/cdp/templates/_transformations/bot-detection/bot-detection.template.test.ts
@@ -41,6 +41,7 @@ describe('bot-detection.template', () => {
         mockGlobals = tester.createGlobals({
             event: {
                 properties: {
+                    $lib: 'web',
                     $raw_user_agent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
                 },
             },
@@ -85,6 +86,7 @@ describe('bot-detection.template', () => {
         mockGlobals = tester.createGlobals({
             event: {
                 properties: {
+                    $lib: 'web',
                     $raw_user_agent: 'Some-CRAWLER-Agent/1.0',
                 },
             },
@@ -145,6 +147,7 @@ describe('bot-detection.template', () => {
         mockGlobals = tester.createGlobals({
             event: {
                 properties: {
+                    $lib: 'web',
                     $ip: '5.39.1.225',
                     $raw_user_agent:
                         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
@@ -225,19 +228,19 @@ describe('bot-detection.template', () => {
     })
 
     it.each([
-        ['posthog-python', 'python-httpx'],
-        ['posthog-node', 'axios/1.4.0'],
-        ['posthog-webhook', 'okhttp/4.10.0'],
-        ['posthog-ios', 'CFNetwork/1410.0.3'],
-    ])('should skip PostHog-curated bot UA list when $lib=%s (non-browser SDK)', async (lib, ua) => {
-        mockGlobals = tester.createGlobals({
-            event: {
-                properties: {
-                    $lib: lib,
-                    $raw_user_agent: ua,
-                },
-            },
-        })
+        ['posthog-python', 'python-httpx', 'posthog-python'],
+        ['posthog-node', 'axios/1.4.0', 'posthog-node'],
+        ['posthog-webhook', 'okhttp/4.10.0', 'posthog-webhook'],
+        ['posthog-ios', 'CFNetwork/1410.0.3', 'posthog-ios'],
+        // Some server-side capture paths (e.g. certain AI SDK paths) send no $lib at all.
+        // A real browser always identifies as web/js, so absent $lib is non-browser too.
+        ['(missing)', 'python-httpx', undefined],
+    ])('should skip PostHog-curated bot UA list when $lib=%s (non-browser source)', async (_label, ua, lib) => {
+        const properties: Record<string, string> = { $raw_user_agent: ua }
+        if (lib !== undefined) {
+            properties.$lib = lib
+        }
+        mockGlobals = tester.createGlobals({ event: { properties } })
 
         const response = await tester.invoke(DEFAULT_INPUTS, mockGlobals)
 
@@ -311,18 +314,15 @@ describe('bot-detection.template', () => {
         expect(response.execResult).toBeFalsy()
     })
 
-    it.each([
-        ['web', 'web' as string | undefined],
-        ['js', 'js' as string | undefined],
-        ['(missing)', undefined as string | undefined],
-    ])('should still filter known bot UA when $lib=%s (browser or unknown source)', async (_label, lib) => {
-        const properties: Record<string, string> = {
-            $raw_user_agent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-        }
-        if (lib !== undefined) {
-            properties.$lib = lib
-        }
-        mockGlobals = tester.createGlobals({ event: { properties } })
+    it.each([['web'], ['js']])('should still filter known bot UA when $lib=%s (browser SDK)', async (lib) => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $lib: lib,
+                    $raw_user_agent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+                },
+            },
+        })
 
         const response = await tester.invoke(DEFAULT_INPUTS, mockGlobals)
 

--- a/nodejs/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
+++ b/nodejs/src/cdp/templates/_transformations/bot-detection/bot-detection.template.ts
@@ -14,11 +14,12 @@ export const template: HogFunctionTemplate = {
     code: `
 // PostHog's curated bot UA and IP lists are tuned for browser traffic. Server-side
 // SDKs (posthog-python, posthog-node, ...) send HTTP-client UAs like 'python-httpx'
-// and backend IPs that match those lists but are not bots. Treat anything other than
-// the browser SDKs ($lib in {web, js}) as non-browser and skip the curated checks.
+// and backend IPs that match those lists but are not bots. Only the browser SDKs
+// identify as $lib 'web' or 'js'; everything else (including events with no $lib,
+// e.g. some AI SDK capture paths) is non-browser and skips the curated checks.
 // Customer-configured customBotPatterns and customIpPrefixes still apply regardless.
 let lib := event.properties['$lib']
-let is_browser_traffic := empty(lib) or lib == 'web' or lib == 'js'
+let is_browser_traffic := lib == 'web' or lib == 'js'
 
 // Get the user agent value
 let user_agent := event.properties[inputs.userAgent]


### PR DESCRIPTION
## Problem

Follow-up to #60557, which made the `Filter Bot Events` transformation (`template-bot-detection`) skip PostHog's curated bot UA/IP lists for non-browser SDK traffic. That change treated **missing `$lib` as browser traffic** (`empty(lib) or lib == 'web' or lib == 'js'`), on the assumption that absent `$lib` was most likely an anonymous/raw request worth filtering conservatively.

Production data shows that assumption is wrong for a real and important case: some server-side AI SDK capture paths send `$ai_*` events with **no `$lib` at all**. Under the merged logic those events are treated as browser traffic and run through the curated bot lists, where their HTTP-client UAs (e.g. `python-httpx`, `axios`) and datacenter IPs match — so they get dropped. This reproduces the original LLM-analytics-events-missing symptom that #60557 set out to fix, just via the empty-`$lib` path instead of the `posthog-node` path.

## Changes

Treat only the browser SDKs as browser traffic:

```hog
let is_browser_traffic := lib == 'web' or lib == 'js'   // empty/unknown => NOT browser
```

A real browser always identifies as `$lib` `web` (posthog-js) or `js` (posthog-js-lite). Anything else — including absent `$lib` — is non-browser and skips the curated lists. Customer-configured `customBotPatterns` and `customIpPrefixes` continue to apply to every event regardless of `$lib`, unchanged.

Trade-off: an event with empty `$lib` **and** a curated-bot-list UA/IP (e.g. server-side capture that passes through a crawler's UA without setting `$lib`) is no longer caught by the curated lists. That's a marginal case, it's arguably not browser-bot traffic anyway, and `customBotPatterns`/`customIpPrefixes` still cover it for anyone who wants it.

## How did you test this code?

I'm an agent, no manual end-to-end testing in this PR (a local E2E re-run was blocked by an unrelated local ingestion issue). Updated the Jest suite (`bot-detection.template.test.ts`), 24 tests pass via `hogli test`, including:

- missing `$lib` + curated bot UA -> event **kept** (the regression this fixes)
- `posthog-python` / `posthog-node` / `posthog-webhook` / `posthog-ios` + bot UA/IP -> kept
- `$lib in {web, js}` + bot UA/IP -> still dropped
- `customBotPatterns` / `customIpPrefixes` still apply for non-browser `$lib`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs in scope.

## 🤖 Agent context

Authored by Claude Code on Daniel's machine, as a follow-up after a customer whose `$ai_*` events were still being dropped post-#60557. Diagnosis from prod data: the customer's AI events arrive with empty `$lib` (every empty-`$lib` event on the team was an `$ai_*` event), so #60557's `empty(lib) => browser` rule subjected exactly those to the curated lists. The narrowest correct fix is to treat empty/unknown `$lib` as non-browser, since a genuine browser always sets `web`/`js`.

Note for reviewers: this reverses the empty-`$lib` decision from #60557 (which Greptile reviewed). The reversal is deliberate and data-driven. The separate question of *why* the AI SDK path emits events without `$lib` is worth chasing on the SDK side — if it set `$lib=posthog-node`, neither this nor #60557's edge case would arise.