### PR TITLE
fix(endpoints): search only visible fields in endpoints list

### DIFF
--- a/products/endpoints/frontend/endpointsLogic.tsx
+++ b/products/endpoints/frontend/endpointsLogic.tsx
@@ -71,7 +71,7 @@ export const endpointsLogic = kea<endpointsLogicType>([
 
                 if (filters.search) {
                     const fuse = createFuse<EndpointType>(results, {
-                        keys: ['name', 'description', 'query.query'],
+                        keys: ['name', 'description'],
                         threshold: 0.3,
                     })
                     results = fuse.search(filters.search).map((result) => result.item)


### PR DESCRIPTION
## Problem

On the Endpoints scene, the list search was too sensitive. Typing a term like "organization" matched endpoints that don't show that word anywhere in their row — because the search ran against `query.query`, the raw HogQL/SQL body of each endpoint. Endpoints whose query internals reference organization tables/columns got pulled in, making the results look like noise.

## Changes

Restricted the fuzzy search in `endpointsLogic` to `name` and `description` — the fields actually visible in the table — by dropping `query.query` from the Fuse search keys. Search results are now explainable from what's on screen. The `threshold: 0.3` is unchanged, since the hidden field was the real culprit rather than the match looseness.

## How did you test this code?

I'm an agent (Claude Code). This is a one-line frontend change to the Fuse search key list; I did not run manual UI testing. No automated tests were added or run for this change.

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by Claude Code at the user's request. The user reported that the endpoints list search was over-matching — e.g. "organization" surfaced unrelated endpoints. Diagnosed the cause as the search including `query.query` (the hidden raw query body) among the Fuse keys, so matches landed on text not visible in the list. Fix narrows the keys to the user-visible `name` and `description`. Considered also tightening the fuzzy `threshold` but left it as-is since the hidden-field match was the actual problem.
