### PR TITLE
chore(hogli): tear down profiled services in docker:services:down

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -523,12 +523,12 @@ docker:
         click: hogli_commands.devenv.cli:docker_services_up
         description: Start Docker services based on your intent config
     docker:services:down:
-        cmd: docker compose -f docker-compose.dev.yml down
+        cmd: docker compose -f docker-compose.dev.yml --profile "*" down --remove-orphans
         description: Stop Docker infrastructure services
         services:
             - docker
     docker:services:remove:
-        cmd: docker compose -f docker-compose.dev.yml down -v
+        cmd: docker compose -f docker-compose.dev.yml --profile "*" down -v --remove-orphans
         description: Stop Docker infrastructure services and remove all volumes (complete
             wipe)
         services:


### PR DESCRIPTION
## Problem

`hogli docker:services:down` leaves profiled containers running and can't remove the network and only tears down services in the currently active profile set — so anything under a `profiles:` gate (e.g. `opensearch`) is skipped, stays attached to `posthog_default`, and blocks the network removal:

```
[+] down 20/20
 ✔ Container posthog-maildev-1              Removed
 ✔ Container posthog-webhook-tester-1       Removed
 ✔ Container posthog-etcd-1                 Removed
 ✔ Container posthog-objectstorage-1        Removed
 ✔ Container posthog-kafka_ui-1             Removed
 ✔ Container posthog-feature-flags-1        Removed
 ✔ Container posthog-temporal-admin-tools-1 Removed
 ✔ Container posthog-proxy-1                Removed
 ✔ Container posthog-flower-1               Removed
 ✔ Container posthog-kafka-init-1           Removed
 ✔ Container posthog-clickhouse-1           Removed
 ✔ Container posthog-temporal-ui-1          Removed
 ✔ Container posthog-redis-cluster-1        Removed
 ✔ Container posthog-temporal-1             Removed
 ✔ Container posthog-elasticsearch-1        Removed
 ✔ Container posthog-kafka-1                Removed
 ✔ Container posthog-zookeeper-1            Removed
 ✔ Container posthog-db-1                   Removed
 ✔ Container posthog-redis7-1               Removed
 ! Network posthog_default                  Resource is still in use
```

The leftover `opensearch` containers had been running for days, invisible to a normal `down`

## Changes

- `docker:services:down` and `docker:services:remove` now run with **`--profile "*"`** 
- Added **`--remove-orphans`** as a backstop to sweep any leftover project container

## How did you test this code?

Manually:
1. Ran the new command (`docker compose ... --profile "*" down --remove-orphans`) — opensearch + dashboards + init were removed and `posthog_default` came down cleanly, no warning.
2. Ran `hogli docker:services:down` on this branch

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No