### PR TITLE
fix(web-analytics): drop InitialReferringURL from eager warmer

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -84,9 +84,9 @@ BASELINE_BREAKDOWNS: tuple[WebStatsBreakdown, ...] = (
     # property `$session_entry_referrer` — there is no sessions-table column
     # for the full referrer URL. On high-volume teams that JSONExtract scans
     # the whole `properties` blob and OOMs the per-day insert, then falls
-    # back to a raw query that times out at 60s. The breakdown sees almost no
-    # real usage (single-digit queries/week across all teams), so warming it
-    # is pure wasted compute. It stays available as an on-demand breakdown.
+    # back to a raw query that times out at 60s. The breakdown sees
+    # negligible real usage, so warming it is pure wasted compute. It stays
+    # available as an on-demand breakdown.
     WebStatsBreakdown.INITIAL_UTM_SOURCE,
     WebStatsBreakdown.INITIAL_UTM_MEDIUM,
     WebStatsBreakdown.INITIAL_UTM_CAMPAIGN,

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -78,7 +78,15 @@ BASELINE_BREAKDOWNS: tuple[WebStatsBreakdown, ...] = (
     WebStatsBreakdown.SCREEN_NAME,
     WebStatsBreakdown.INITIAL_CHANNEL_TYPE,
     WebStatsBreakdown.INITIAL_REFERRING_DOMAIN,
-    WebStatsBreakdown.INITIAL_REFERRING_URL,
+    # INITIAL_REFERRING_URL is deliberately excluded. Unlike its domain
+    # sibling (which reads the aggregated `session.$entry_referring_domain`
+    # column), the full-URL breakdown reads the un-materialized event
+    # property `$session_entry_referrer` — there is no sessions-table column
+    # for the full referrer URL. On high-volume teams that JSONExtract scans
+    # the whole `properties` blob and OOMs the per-day insert, then falls
+    # back to a raw query that times out at 60s. The breakdown sees almost no
+    # real usage (single-digit queries/week across all teams), so warming it
+    # is pure wasted compute. It stays available as an on-demand breakdown.
     WebStatsBreakdown.INITIAL_UTM_SOURCE,
     WebStatsBreakdown.INITIAL_UTM_MEDIUM,
     WebStatsBreakdown.INITIAL_UTM_CAMPAIGN,


### PR DESCRIPTION
## Problem

The eager Web analytics precompute warmer runs the dashboard's full tile matrix hourly for enrolled teams. One tile — the `InitialReferringURL` breakdown — cannot succeed on high-volume teams: unlike its domain sibling (which reads the aggregated `session.$entry_referring_domain` column), the full-URL breakdown reads the **un-materialized** event property `$session_entry_referrer`. There is no sessions-table column for the full referrer URL, so the query does a raw `JSONExtract` over the entire `properties` blob, which OOMs the per-day precompute insert and then falls back to a raw query that times out at 60s — every run.

The breakdown also sees negligible real usage, so the warmer was burning compute (and emitting a recurring OOM + timeout) on a tile virtually no one opens.

## Changes

Remove `INITIAL_REFERRING_URL` from the eager warmer's `BASELINE_BREAKDOWNS`, with an inline comment documenting why. The breakdown remains fully available on-demand — this only stops it from being pre-warmed.

The two genuinely-used breakdowns that hit the same un-materialized-property issue (`Timezone` → `$timezone_offset`, `Language` → `$browser_language`) are handled separately by materializing those columns, which is the right fix where there's real demand.

## How did you test this code?

Agent-authored (Claude Code). The Dagster test suite (`test_eager_web_analytics_precompute.py`) is data-driven off `BASELINE_BREAKDOWNS` (`_QUERIES_PER_TEAM = 3 + len(BASELINE_BREAKDOWNS)`, and it asserts the warmed set equals `{b.value for b in BASELINE_BREAKDOWNS}`), so removing an element keeps every assertion internally consistent. I could not run the suite locally — it requires the dev Postgres, which wasn't available in the session — so I'm relying on CI to execute it. Ruff format/lint and the `ty` typecheck pass.

## 🤖 Agent context

Authored with Claude Code. Root-caused from production `query_log`: the `InitialReferringURL` lazy insert OOMs at the memory ceiling reading raw `properties` for `$session_entry_referrer`, then the runner falls through to the raw path and times out at the 60s ClickHouse limit. Confirmed the sessions table aggregates only the referrer *domain*, not the full URL, so the event-property read is unavoidable without a schema change. Weighed materializing the property vs. dropping it from the warm set; usage data showed the breakdown is effectively unused, so dropping it from warming (rather than paying for a permanent global event column) is the proportionate fix. The two high-demand siblings with the same root cause are addressed via column materialization instead.
