### PR TITLE
fix(charts): debounce metric card hover so it doesn't chase the cursor

### DIFF
--- a/packages/quill/packages/charts/src/components/MetricCard/MetricCard.test.tsx
+++ b/packages/quill/packages/charts/src/components/MetricCard/MetricCard.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 
 import type { ChartTheme } from '../../core/types'
 import { renderHogChart, setupJsdom, setupSyncRaf } from '../../testing'
@@ -96,6 +96,37 @@ describe('MetricCard', () => {
             expect(container.textContent).toContain('+200.0%')
         })
 
+        it('ignores a quick pass-through and only follows the cursor once it settles past the dwell', () => {
+            jest.useFakeTimers()
+            try {
+                const { container, chart } = renderHogChart(
+                    <MetricCard
+                        title="Total"
+                        data={[100, 200, 300, 400]}
+                        labels={LABELS}
+                        theme={THEME}
+                        animationMs={0}
+                        formatValue={(v) => `$${Math.round(v)}`}
+                    />
+                )
+
+                // Cursor crosses a point but hasn't dwelled — headline stays at rest.
+                act(() => chart.hoverAtIndex(1))
+                expect(container.textContent).toContain('$400')
+                expect(container.textContent).toContain('Apr')
+                expect(container.textContent).not.toContain('$200')
+
+                // Pointer settles past the dwell — now the headline follows it.
+                act(() => {
+                    jest.advanceTimersByTime(140)
+                })
+                expect(container.textContent).toContain('$200')
+                expect(container.textContent).toContain('Feb')
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
         it('updates the headline value and label when hovering a different point', () => {
             const { container, chart } = renderHogChart(
                 <MetricCard
@@ -104,6 +135,7 @@ describe('MetricCard', () => {
                     labels={LABELS}
                     theme={THEME}
                     animationMs={0}
+                    hoverIntentMs={0}
                     formatValue={(v) => `$${Math.round(v)}`}
                 />
             )
@@ -120,6 +152,7 @@ describe('MetricCard', () => {
                     labels={LABELS}
                     theme={THEME}
                     animationMs={0}
+                    hoverIntentMs={0}
                     value={9999}
                     formatValue={(v) => `$${Math.round(v)}`}
                 />
@@ -138,6 +171,7 @@ describe('MetricCard', () => {
                     labels={LABELS}
                     theme={THEME}
                     animationMs={0}
+                    hoverIntentMs={0}
                     change={{ value: 12.5, label: '+12.5% vs. last week' }}
                     formatValue={(v) => `$${Math.round(v)}`}
                 />

--- a/packages/quill/packages/charts/src/components/MetricCard/MetricCard.tsx
+++ b/packages/quill/packages/charts/src/components/MetricCard/MetricCard.tsx
@@ -6,6 +6,7 @@ import { percentage } from '../../utils/format'
 import { Sparkline } from '../../charts/Sparkline/Sparkline'
 import { type MetricChange, resolveDelta } from './resolveDelta'
 import { useAnimatedNumber } from './useAnimatedNumber'
+import { useHoverIntent } from './useHoverIntent'
 
 export type { MetricChange }
 
@@ -42,6 +43,9 @@ export interface MetricCardProps {
     /** Caption under the headline. Defaults to `labels[activeIndex]` when a sparkline is present. */
     subtitle?: React.ReactNode
     animationMs?: number
+    /** Dwell (ms) a pointer must settle on the sparkline before the headline follows it.
+     *  Keeps a quick pass-through from grabbing attention. `0` disables the gating. */
+    hoverIntentMs?: number
     className?: string
     dataAttr?: string
     onError?: (error: Error, info: React.ErrorInfo) => void
@@ -84,6 +88,7 @@ function MetricCardInner({
     negativeColor = DEFAULT_NEGATIVE_COLOR,
     subtitle,
     animationMs = 350,
+    hoverIntentMs = 140,
     className,
     dataAttr,
 }: Omit<MetricCardProps, 'onError'>): React.ReactElement | null {
@@ -91,10 +96,11 @@ function MetricCardInner({
     const lastIndex = sparklineData ? sparklineData.length - 1 : -1
 
     const [hoverIndex, setHoverIndex] = useState(-1)
-    const activeIndex = hoverIndex >= 0 ? hoverIndex : lastIndex
+    const intentIndex = useHoverIntent(hoverIndex, hoverIntentMs)
+    const activeIndex = intentIndex >= 0 ? intentIndex : lastIndex
 
     const restingValue = value ?? (sparklineData ? sparklineData[lastIndex] : undefined)
-    const animationTarget = sparklineData && hoverIndex >= 0 ? (sparklineData[hoverIndex] ?? 0) : (restingValue ?? 0)
+    const animationTarget = sparklineData && intentIndex >= 0 ? (sparklineData[intentIndex] ?? 0) : (restingValue ?? 0)
     const animatedValue = useAnimatedNumber(animationTarget, animationMs)
 
     const baselineValue = useMemo(() => sparklineData?.find((v) => v !== 0 && Number.isFinite(v)), [sparklineData])

--- a/packages/quill/packages/charts/src/components/MetricCard/useHoverIntent.ts
+++ b/packages/quill/packages/charts/src/components/MetricCard/useHoverIntent.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Gates a raw hover index behind a short dwell so a cursor merely passing over the
+ * sparkline on its way elsewhere doesn't engage the headline. While disengaged, every
+ * change to the raw index re-arms the timer, so only a pointer that settles on a point
+ * past `delayMs` crosses the threshold. Once engaged the index tracks live; returning
+ * to the resting index (a negative value) disengages immediately.
+ *
+ * `delayMs <= 0` opts out entirely — the raw index passes through unchanged.
+ */
+export function useHoverIntent(rawIndex: number, delayMs: number): number {
+    const [engaged, setEngaged] = useState(false)
+
+    useEffect(() => {
+        if (delayMs <= 0) {
+            return
+        }
+        if (rawIndex < 0) {
+            // Pointer left the sparkline — disengage right away so the headline settles back.
+            setEngaged(false)
+            return
+        }
+        if (engaged) {
+            return
+        }
+        // Re-armed on each move while disengaged; only a settled pointer reaches this timeout.
+        const timer = setTimeout(() => setEngaged(true), delayMs)
+        return () => clearTimeout(timer)
+    }, [rawIndex, engaged, delayMs])
+
+    if (delayMs <= 0) {
+        return rawIndex
+    }
+    return engaged ? rawIndex : -1
+}

--- a/packages/quill/packages/charts/src/components/MetricCard/useHoverIntent.ts
+++ b/packages/quill/packages/charts/src/components/MetricCard/useHoverIntent.ts
@@ -1,36 +1,24 @@
 import { useEffect, useState } from 'react'
 
 /**
- * Gates a raw hover index behind a short dwell so a cursor merely passing over the
- * sparkline on its way elsewhere doesn't engage the headline. While disengaged, every
- * change to the raw index re-arms the timer, so only a pointer that settles on a point
- * past `delayMs` crosses the threshold. Once engaged the index tracks live; returning
- * to the resting index (a negative value) disengages immediately.
+ * Debounces a sparkline hover index so a cursor merely passing over the card on its way
+ * elsewhere doesn't swap the headline — the pointer has to settle on a point for `delayMs`
+ * before it takes effect. Leaving the sparkline (a negative index) applies immediately, so
+ * the headline drops straight back to rest. `delayMs <= 0` opts out.
  *
- * `delayMs <= 0` opts out entirely — the raw index passes through unchanged.
+ * Mirrors the app's `useDebouncedValue`, which this standalone package can't import.
  */
 export function useHoverIntent(rawIndex: number, delayMs: number): number {
-    const [engaged, setEngaged] = useState(false)
+    const [settledIndex, setSettledIndex] = useState(rawIndex)
 
     useEffect(() => {
-        if (delayMs <= 0) {
+        if (delayMs <= 0 || rawIndex < 0) {
+            setSettledIndex(rawIndex)
             return
         }
-        if (rawIndex < 0) {
-            // Pointer left the sparkline — disengage right away so the headline settles back.
-            setEngaged(false)
-            return
-        }
-        if (engaged) {
-            return
-        }
-        // Re-armed on each move while disengaged; only a settled pointer reaches this timeout.
-        const timer = setTimeout(() => setEngaged(true), delayMs)
+        const timer = setTimeout(() => setSettledIndex(rawIndex), delayMs)
         return () => clearTimeout(timer)
-    }, [rawIndex, engaged, delayMs])
+    }, [rawIndex, delayMs])
 
-    if (delayMs <= 0) {
-        return rawIndex
-    }
-    return engaged ? rawIndex : -1
+    return delayMs <= 0 ? rawIndex : settledIndex
 }

--- a/packages/quill/packages/charts/src/components/MetricCard/useHoverIntent.ts
+++ b/packages/quill/packages/charts/src/components/MetricCard/useHoverIntent.ts
@@ -20,5 +20,5 @@ export function useHoverIntent(rawIndex: number, delayMs: number): number {
         return () => clearTimeout(timer)
     }, [rawIndex, delayMs])
 
-    return delayMs <= 0 ? rawIndex : settledIndex
+    return delayMs <= 0 || rawIndex < 0 ? rawIndex : settledIndex
 }


### PR DESCRIPTION
## Problem

The `MetricCard` (used by the web analytics overview tiles and elsewhere) swapped and animated its headline number the instant the cursor crossed the sparkline — it followed the chart's `mousemove` hover index immediately. So just moving the mouse *past* a card on the way to click something else made the big number jump and animate, grabbing attention when the user wasn't interacting with it.

## Changes

Gate the headline-follows-cursor behavior behind a short **hover-intent dwell**:

- **`useHoverIntent.ts`** (new) — a small debounce hook (mirrors the app's `useDebouncedValue`, which this standalone package can't import). A hover index only takes effect once the pointer has settled on a point for `delayMs`; a cursor sweeping past keeps re-arming the timer, so the headline never swaps mid-sweep. It stays settle-based throughout rather than racing the cursor, which is the calmer behavior the report asked for. Leaving the sparkline (a negative index) applies immediately. `delayMs <= 0` opts out entirely.
- **`MetricCard.tsx`** — feed the raw sparkline hover index through `useHoverIntent`. New optional `hoverIntentMs` prop (default `140`). No call-site changes needed — every consumer, including the web analytics `OverviewMetricCardGrid`, picks up the calmer default automatically.
- **`MetricCard.test.tsx`** — added a test asserting a non-dwelling pass-through leaves the resting headline untouched and only follows once the pointer settles past the dwell; set `hoverIntentMs={0}` on the existing instant-hover tests so they stay synchronous.

The `140ms` default felt snappy but enough to ignore a sweep — easy to bump if it still feels eager, or to surface on the web analytics grid.

## How did you test this code?

I'm an agent. I ran the automated charts unit tests for this component — all 21 `MetricCard` tests pass, including the new hover-intent gating test — and confirmed the package's build typecheck (`tsconfig.build.json`) is clean. I did not perform manual in-browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) in response to a report that metric cards were "too eager to follow the mouse" and grabbed attention during a quick pass-through.

Root cause: `MetricCard` routed the chart's `onHoverIndexChange` (fired on every `mousemove`) straight into the headline swap + number animation, so a cursor merely crossing the sparkline triggered the animation. Rather than debounce the chart's hover events globally (which would affect tooltips and other consumers), the fix isolates the gating to the headline via a dwell hook local to `MetricCard`, so the headline only swaps once the pointer settles.

The hook started life as an engage-then-track-live state machine; on review feedback it was simplified to a plain debounce (settle-based throughout). That is a deliberate design choice — it never chases the cursor during a scrub, which better matches the original "too eager" complaint — not an oversight, so the dwell delay applies to every move, not just the first.
