### PR TITLE
fix(data-warehouse): fail sync when ClickHouse validate read errors

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -272,15 +272,21 @@ async def validate_schema_and_update_table(
 
         except ServerException as err:
             if err.code == 636:
+                # 636 (CANNOT_EXTRACT_TABLE_STRUCTURE) just means there's nothing readable
+                # to validate yet — not a sync failure, so swallow and let the run complete.
                 logger.exception(
                     f"Data Warehouse: No data for schema {_schema_name} for external data job {job.pk}",
                     exc_info=err,
                 )
             else:
+                # Any other ClickHouse error means the synced data isn't queryable (e.g. Code: 48
+                # when schema drift leaves mixed-schema parquet files). Re-raise so the run is
+                # marked Failed instead of silently reporting Completed with the error only in logs.
                 logger.exception(
                     f"Data Warehouse: Unknown ServerException {job.pk}",
                     exc_info=err,
                 )
+                raise
         except Exception as e:
             # TODO: handle other exceptions here
             logger.exception(


### PR DESCRIPTION
## Problem

Some Postgres warehouse syncs were reporting **Completed** while actually failing — the synced table wasn't queryable in ClickHouse, but the run showed green and the error was buried in the run logs.

Root cause is in shared post-load code. When a source column is added or its type changes, the delta **write** succeeds (deltalake absorbs the new column), but the delta table's parquet files now have mixed schemas. When `validate_schema_and_update_table` reads the table back via ClickHouse to introspect columns, ClickHouse refuses to read across heterogeneous parquet files and raises a `ServerException`:

```
Code: 48. DB::Exception: Reading from files with different schema is not possible
(columns format version: 1, 19 columns ... is different from ... 20 columns ...
`batch_export_on_demand_id` Nullable(String)). (NOT_IMPLEMENTED)
```

That `ServerException` (any code other than `636`) was logged via `logger.exception(...)` and then **swallowed**, so `validate_schema_and_update_table` returned normally and the run was marked `Completed`. Retrying never helps — the divergent files don't self-heal — and the only signal a user had was an `ERROR` line hidden among hundreds of `DEBUG` lines in a "successful" run.

This is **not pipeline-v3-specific**: the swallow lives in `validate_schema_and_update_table` (`pipeline_sync.py`), which is called by the V2/dlt pipeline, the V3 consumer, and the shared `run_post_load_operations`. Observed failures so far are on the dlt/V2 path.

## Changes

In the `ServerException` handler in `validate_schema_and_update_table`, re-raise any non-`636` error instead of swallowing it. Code `636` (`CANNOT_EXTRACT_TABLE_STRUCTURE` — "no readable data yet") stays soft, as before.

Re-raising is bounded and surfaces the failure correctly on both paths:
- **dlt / V2** — the activity fails, the workflow's `except ActivityError` marks the job `Failed` and records the error (and picks up the friendlier schema-drift message from #61345 if that lands).
- **V3** — `_process_single` catches it, retries to `max_attempts`, then `_fail_run` marks the job `Failed`.

### Behavior change worth a look

Syncs that currently *silently* hit a non-636 validate read error will now surface as `Failed` rather than `Completed`. They were already broken (data not queryable); this just stops masking it. Expect a visible uptick in `Failed` syncs for affected tables — that's the honest state. The fix for the data itself is a delete + resync, which rewrites all parquet to a single schema.

## How did you test this code?

I'm an agent. So far this is the one-line behavior change plus lint/format/`ty` (clean via the pre-commit hook). No automated test added yet — `validate_schema_and_update_table` needs a DB + ClickHouse harness to exercise; I can add a focused test that mocks the introspection read to raise `ServerException(code=48)` (asserts it propagates) and `code=636` (asserts it's swallowed). Flagging before I invest in the harness wiring.

Not yet verified end-to-end against a live failing sync.

## 🤖 Agent context

Authored by Claude Code at Marcus's direction, off the back of a warehouse support thread where a Postgres `posthog_batchexportrun` sync gained a `batch_export_on_demand_id` column and started reporting `Completed` while ClickHouse couldn't read the mixed-schema parquet. Production run logs confirmed the exact swallow path: delta merge succeeds → `Validating schema and updating table` → `ERROR Code: 48` → `Finished validating schema and updating table` (returned normally) → `status Completed`.

Companion to #61345 (friendly schema-drift error message). This PR is the **status-correctness** half (make the run actually fail); #61345 is the **message-quality** half (make the failure readable). Kept separate intentionally — different file, different concern.
