### PR TITLE
fix(data-warehouse): read evolved Delta tables via deltaLake in get_count

### DIFF
--- a/products/data_warehouse/backend/models/test/test_table.py
+++ b/products/data_warehouse/backend/models/test/test_table.py
@@ -367,6 +367,34 @@ class TestTable(BaseTest):
             f"Expected single quote to be escaped as \\' in chdb query: {rendered_query}"
         )
 
+    @parameterized.expand(
+        [
+            ("delta_s3_wrapper", "DeltaS3Wrapper", "deltaLake(", "__query"),
+            ("parquet", "Parquet", "s3(", "deltaLake("),
+        ]
+    )
+    def test_get_count_delta_s3_wrapper_reads_via_deltalake(
+        self, _name: str, table_format: str, expected_in_query: str, not_expected_in_query: str
+    ):
+        credential = DataWarehouseCredential.objects.create(access_key="key", access_secret="secret", team=self.team)
+        table = DataWarehouseTable.objects.create(
+            name="test_table",
+            url_pattern="s3://bucket/team_2_postgres/posthog_batchexportrun",
+            queryable_folder="posthog_batchexportrun__query_123",
+            credential=credential,
+            format=table_format,
+            team=self.team,
+        )
+
+        with patch("products.warehouse_sources.backend.models.table.sync_execute") as sync_execute_results:
+            sync_execute_results.return_value = [[42]]
+            count = table.get_count()
+
+        assert count == 42
+        rendered_query: str = sync_execute_results.call_args.args[0]
+        assert expected_in_query in rendered_query, rendered_query
+        assert not_expected_in_query not in rendered_query, rendered_query
+
     def test_hogql_definition_old_style(self):
         credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
         table = DataWarehouseTable.objects.create(

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -351,7 +351,11 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         s3_table_func = build_function_call(
             url=self.url_pattern,
             queryable_folder=self.queryable_folder,
-            format=self.format,
+            # Read evolved Delta tables via deltaLake() (transaction-log aware) instead of a
+            # bare s3() glob over the query folder, which fails with ClickHouse Code: 48 when
+            # schema evolution leaves the parquet files with differing column counts. Mirrors
+            # get_columns(); user queries already pass an explicit structure for the same reason.
+            format="Delta" if self.format == "DeltaS3Wrapper" else self.format,
             access_key=self.credential.access_key if self.credential else None,
             access_secret=self.credential.access_secret if self.credential else None,
             context=placeholder_context,


### PR DESCRIPTION
## Problem

When a Postgres (or any SQL) source table gains a column, the Delta table evolves on write (new parquet files get the column; old files keep the old schema). The storage layer and most read paths already tolerate this — but **`get_count()` did not**, and it sits in the sync's validation step.

`get_count()` built a bare `s3(<queryable_folder>/**.parquet, 'Parquet')` glob with **no explicit structure**, so ClickHouse fell back to per-file schema inference and threw:

```
Code: 48. DB::Exception: Reading from files with different schema is not possible
(... 19 columns ... is different from ... 20 columns ... `batch_export_on_demand_id` ...). (NOT_IMPLEMENTED)
```

That `ServerException` is swallowed in `validate_schema_and_update_table`, so the run reported **Completed** while the count read was broken. Worse, on incremental/CDC syncs `get_count()` runs *before* the `DataWarehouseTable.save()` that advances `queryable_folder` — so when it threw, the table's `queryable_folder` and `columns` were never updated, leaving queries pinned to a **stale** query folder even though fresh data kept landing in Delta.

The other read paths were already evolution-aware:
- `get_columns()` reads via **`deltaLake()`** (transaction-log aware) — comment: *"to get table schema for evolved tables"*.
- Real HogQL queries pass an explicit `structure` to `s3(...)`.

`get_count()` was the lone holdout still doing per-file inference.

## Changes

In `get_count()`, switch the read to the `Delta` / `deltaLake()` function when the table format is `DeltaS3Wrapper` — exactly mirroring `get_columns()`. `deltaLake()` reads through the Delta transaction log, so a schema-evolved table with heterogeneous parquet files counts correctly instead of throwing `Code: 48`.

This makes the sync's validation step succeed on schema drift, which (because it no longer throws before `save()`) lets `queryable_folder`/`columns` advance again — so an already-drifted table recovers **without a delete + resync**.

## How did you test this code?

I'm an agent. Added a parameterized unit test (`test_get_count_delta_s3_wrapper_reads_via_deltalake`): `DeltaS3Wrapper` → the rendered count query uses `deltaLake(` (not the bare `s3()` query folder), `Parquet` → still `s3(`. Both pass (`2 passed` via `hogli test`). Lint/format/`ty` clean via pre-commit.

Not yet verified end-to-end against a live drifted source — flagging for a reviewer with warehouse access.

## 🤖 Agent context

Authored by Claude Code at Marcus's direction, from a warehouse support thread: a Postgres `posthog_batchexportrun` sync gained `batch_export_on_demand_id` (migration `1163`, PR #58107, ~May 20) and started reporting Completed-while-failing. Investigation traced it to `get_count()` being the one read path that wasn't schema-evolution-aware.

Supersedes #62240, which proposed making the run *fail loudly* on the swallowed error. That was the wrong remedy: the condition is recoverable (Delta evolves, `deltaLake()`/structure reads tolerate it), so the right fix makes the read succeed rather than converting a recoverable state into a hard failure. #62240 is closed.
