### PR TITLE
chore(openapi): bump orval to 8.14.0

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -85,9 +85,9 @@ export interface PaginatedCIMDVerificationTokenListApi {
 
 /**
  * Create-response variant that includes the plaintext token.
-
-Only emitted from the create endpoint - storage-side we only persist the
-hash, so subsequent reads use the base serializer.
+ *
+ * Only emitted from the create endpoint - storage-side we only persist the
+ * hash, so subsequent reads use the base serializer.
  */
 export interface CIMDVerificationTokenWithValueApi {
     readonly id: string
@@ -150,7 +150,10 @@ export interface OrganizationDomainApi {
      * @nullable
      */
     id_jag_jwks_url?: string | null
-    /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
+    /**
+     * Allowed ID-JAG client IDs. Empty list allows any client_id.
+     * @items.maxLength 256
+     */
     id_jag_allowed_clients?: string[]
 }
 
@@ -210,14 +213,17 @@ export interface PatchedOrganizationDomainApi {
      * @nullable
      */
     id_jag_jwks_url?: string | null
-    /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
+    /**
+     * Allowed ID-JAG client IDs. Empty list allows any client_id.
+     * @items.maxLength 256
+     */
     id_jag_allowed_clients?: string[]
 }
 
 /**
  * * `1` - member
- * `8` - administrator
- * `15` - owner
+ * * `8` - administrator
+ * * `15` - owner
  */
 export type OrganizationMembershipLevelEnumApi =
     (typeof OrganizationMembershipLevelEnumApi)[keyof typeof OrganizationMembershipLevelEnumApi]
@@ -300,9 +306,9 @@ export interface PaginatedOrganizationOAuthApplicationListApi {
 
 /**
  * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-backward compatibility of the REST API.
-Do not use this in greenfield endpoints!
+ * passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+ * backward compatibility of the REST API.
+ * Do not use this in greenfield endpoints!
  */
 export interface ProjectBackwardCompatBasicApi {
     readonly id: number
@@ -350,9 +356,9 @@ export const EffectiveMembershipLevelEnumApi = {
 
 /**
  * * `30d` - 30 Days
- * `90d` - 90 Days
- * `1y` - 1 Year
- * `5y` - 5 Years
+ * * `90d` - 90 Days
+ * * `1y` - 1 Year
+ * * `5y` - 5 Years
  */
 export type SessionRecordingRetentionPeriodEnumApi =
     (typeof SessionRecordingRetentionPeriodEnumApi)[keyof typeof SessionRecordingRetentionPeriodEnumApi]
@@ -366,7 +372,7 @@ export const SessionRecordingRetentionPeriodEnumApi = {
 
 /**
  * * `0` - Sunday
- * `1` - Monday
+ * * `1` - Monday
  */
 export type WeekStartDayEnumApi = (typeof WeekStartDayEnumApi)[keyof typeof WeekStartDayEnumApi]
 
@@ -377,8 +383,8 @@ export const WeekStartDayEnumApi = {
 
 /**
  * * `b2b` - B2B
- * `b2c` - B2C
- * `other` - Other
+ * * `b2c` - B2C
+ * * `other` - Other
  */
 export type BusinessModelEnumApi = (typeof BusinessModelEnumApi)[keyof typeof BusinessModelEnumApi]
 
@@ -390,70 +396,70 @@ export const BusinessModelEnumApi = {
 
 /**
  * * `ingest_first_event` - ingest_first_event
- * `set_up_reverse_proxy` - set_up_reverse_proxy
- * `create_first_insight` - create_first_insight
- * `create_first_dashboard` - create_first_dashboard
- * `track_custom_events` - track_custom_events
- * `define_actions` - define_actions
- * `set_up_cohorts` - set_up_cohorts
- * `explore_trends_insight` - explore_trends_insight
- * `create_funnel` - create_funnel
- * `explore_retention_insight` - explore_retention_insight
- * `explore_paths_insight` - explore_paths_insight
- * `explore_stickiness_insight` - explore_stickiness_insight
- * `explore_lifecycle_insight` - explore_lifecycle_insight
- * `add_authorized_domain` - add_authorized_domain
- * `set_up_web_vitals` - set_up_web_vitals
- * `review_web_analytics_dashboard` - review_web_analytics_dashboard
- * `filter_web_analytics` - filter_web_analytics
- * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
- * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
- * `setup_session_recordings` - setup_session_recordings
- * `watch_session_recording` - watch_session_recording
- * `configure_recording_settings` - configure_recording_settings
- * `create_recording_playlist` - create_recording_playlist
- * `enable_console_logs` - enable_console_logs
- * `create_feature_flag` - create_feature_flag
- * `implement_flag_in_code` - implement_flag_in_code
- * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
- * `create_multivariate_flag` - create_multivariate_flag
- * `set_up_flag_payloads` - set_up_flag_payloads
- * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
- * `create_experiment` - create_experiment
- * `implement_experiment_variants` - implement_experiment_variants
- * `launch_experiment` - launch_experiment
- * `review_experiment_results` - review_experiment_results
- * `create_survey` - create_survey
- * `launch_survey` - launch_survey
- * `collect_survey_responses` - collect_survey_responses
- * `connect_source` - connect_source
- * `run_first_query` - run_first_query
- * `join_external_data` - join_external_data
- * `create_saved_view` - create_saved_view
- * `enable_error_tracking` - enable_error_tracking
- * `upload_source_maps` - upload_source_maps
- * `view_first_error` - view_first_error
- * `resolve_first_error` - resolve_first_error
- * `ingest_first_llm_event` - ingest_first_llm_event
- * `view_first_trace` - view_first_trace
- * `track_costs` - track_costs
- * `set_up_llm_evaluation` - set_up_llm_evaluation
- * `run_ai_playground` - run_ai_playground
- * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
- * `connect_revenue_source` - connect_revenue_source
- * `set_up_revenue_goal` - set_up_revenue_goal
- * `enable_log_capture` - enable_log_capture
- * `view_first_logs` - view_first_logs
- * `create_first_workflow` - create_first_workflow
- * `set_up_first_workflow_channel` - set_up_first_workflow_channel
- * `configure_workflow_trigger` - configure_workflow_trigger
- * `add_workflow_action` - add_workflow_action
- * `launch_workflow` - launch_workflow
- * `create_first_endpoint` - create_first_endpoint
- * `configure_endpoint` - configure_endpoint
- * `test_endpoint` - test_endpoint
- * `create_early_access_feature` - create_early_access_feature
- * `update_feature_stage` - update_feature_stage
+ * * `set_up_reverse_proxy` - set_up_reverse_proxy
+ * * `create_first_insight` - create_first_insight
+ * * `create_first_dashboard` - create_first_dashboard
+ * * `track_custom_events` - track_custom_events
+ * * `define_actions` - define_actions
+ * * `set_up_cohorts` - set_up_cohorts
+ * * `explore_trends_insight` - explore_trends_insight
+ * * `create_funnel` - create_funnel
+ * * `explore_retention_insight` - explore_retention_insight
+ * * `explore_paths_insight` - explore_paths_insight
+ * * `explore_stickiness_insight` - explore_stickiness_insight
+ * * `explore_lifecycle_insight` - explore_lifecycle_insight
+ * * `add_authorized_domain` - add_authorized_domain
+ * * `set_up_web_vitals` - set_up_web_vitals
+ * * `review_web_analytics_dashboard` - review_web_analytics_dashboard
+ * * `filter_web_analytics` - filter_web_analytics
+ * * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
+ * * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
+ * * `setup_session_recordings` - setup_session_recordings
+ * * `watch_session_recording` - watch_session_recording
+ * * `configure_recording_settings` - configure_recording_settings
+ * * `create_recording_playlist` - create_recording_playlist
+ * * `enable_console_logs` - enable_console_logs
+ * * `create_feature_flag` - create_feature_flag
+ * * `implement_flag_in_code` - implement_flag_in_code
+ * * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
+ * * `create_multivariate_flag` - create_multivariate_flag
+ * * `set_up_flag_payloads` - set_up_flag_payloads
+ * * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
+ * * `create_experiment` - create_experiment
+ * * `implement_experiment_variants` - implement_experiment_variants
+ * * `launch_experiment` - launch_experiment
+ * * `review_experiment_results` - review_experiment_results
+ * * `create_survey` - create_survey
+ * * `launch_survey` - launch_survey
+ * * `collect_survey_responses` - collect_survey_responses
+ * * `connect_source` - connect_source
+ * * `run_first_query` - run_first_query
+ * * `join_external_data` - join_external_data
+ * * `create_saved_view` - create_saved_view
+ * * `enable_error_tracking` - enable_error_tracking
+ * * `upload_source_maps` - upload_source_maps
+ * * `view_first_error` - view_first_error
+ * * `resolve_first_error` - resolve_first_error
+ * * `ingest_first_llm_event` - ingest_first_llm_event
+ * * `view_first_trace` - view_first_trace
+ * * `track_costs` - track_costs
+ * * `set_up_llm_evaluation` - set_up_llm_evaluation
+ * * `run_ai_playground` - run_ai_playground
+ * * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
+ * * `connect_revenue_source` - connect_revenue_source
+ * * `set_up_revenue_goal` - set_up_revenue_goal
+ * * `enable_log_capture` - enable_log_capture
+ * * `view_first_logs` - view_first_logs
+ * * `create_first_workflow` - create_first_workflow
+ * * `set_up_first_workflow_channel` - set_up_first_workflow_channel
+ * * `configure_workflow_trigger` - configure_workflow_trigger
+ * * `add_workflow_action` - add_workflow_action
+ * * `launch_workflow` - launch_workflow
+ * * `create_first_endpoint` - create_first_endpoint
+ * * `configure_endpoint` - configure_endpoint
+ * * `test_endpoint` - test_endpoint
+ * * `create_early_access_feature` - create_early_access_feature
+ * * `update_feature_stage` - update_feature_stage
  */
 export type AvailableSetupTaskIdsEnumApi =
     (typeof AvailableSetupTaskIdsEnumApi)[keyof typeof AvailableSetupTaskIdsEnumApi]
@@ -554,6 +560,7 @@ export interface ProjectBackwardCompatApi {
     readonly updated_at: string | null
     readonly uuid: string
     readonly api_token: string
+    /** @items.maxLength 200 */
     app_urls?: (string | null)[]
     /** When true, PostHog drops the IP address from every ingested event. */
     anonymize_ips?: boolean
@@ -570,609 +577,610 @@ export interface ProjectBackwardCompatApi {
     path_cleaning_filters?: unknown
     is_demo?: boolean
     /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-
-  * `Africa/Abidjan` - Africa/Abidjan
-  * `Africa/Accra` - Africa/Accra
-  * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-  * `Africa/Algiers` - Africa/Algiers
-  * `Africa/Asmara` - Africa/Asmara
-  * `Africa/Asmera` - Africa/Asmera
-  * `Africa/Bamako` - Africa/Bamako
-  * `Africa/Bangui` - Africa/Bangui
-  * `Africa/Banjul` - Africa/Banjul
-  * `Africa/Bissau` - Africa/Bissau
-  * `Africa/Blantyre` - Africa/Blantyre
-  * `Africa/Brazzaville` - Africa/Brazzaville
-  * `Africa/Bujumbura` - Africa/Bujumbura
-  * `Africa/Cairo` - Africa/Cairo
-  * `Africa/Casablanca` - Africa/Casablanca
-  * `Africa/Ceuta` - Africa/Ceuta
-  * `Africa/Conakry` - Africa/Conakry
-  * `Africa/Dakar` - Africa/Dakar
-  * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-  * `Africa/Djibouti` - Africa/Djibouti
-  * `Africa/Douala` - Africa/Douala
-  * `Africa/El_Aaiun` - Africa/El_Aaiun
-  * `Africa/Freetown` - Africa/Freetown
-  * `Africa/Gaborone` - Africa/Gaborone
-  * `Africa/Harare` - Africa/Harare
-  * `Africa/Johannesburg` - Africa/Johannesburg
-  * `Africa/Juba` - Africa/Juba
-  * `Africa/Kampala` - Africa/Kampala
-  * `Africa/Khartoum` - Africa/Khartoum
-  * `Africa/Kigali` - Africa/Kigali
-  * `Africa/Kinshasa` - Africa/Kinshasa
-  * `Africa/Lagos` - Africa/Lagos
-  * `Africa/Libreville` - Africa/Libreville
-  * `Africa/Lome` - Africa/Lome
-  * `Africa/Luanda` - Africa/Luanda
-  * `Africa/Lubumbashi` - Africa/Lubumbashi
-  * `Africa/Lusaka` - Africa/Lusaka
-  * `Africa/Malabo` - Africa/Malabo
-  * `Africa/Maputo` - Africa/Maputo
-  * `Africa/Maseru` - Africa/Maseru
-  * `Africa/Mbabane` - Africa/Mbabane
-  * `Africa/Mogadishu` - Africa/Mogadishu
-  * `Africa/Monrovia` - Africa/Monrovia
-  * `Africa/Nairobi` - Africa/Nairobi
-  * `Africa/Ndjamena` - Africa/Ndjamena
-  * `Africa/Niamey` - Africa/Niamey
-  * `Africa/Nouakchott` - Africa/Nouakchott
-  * `Africa/Ouagadougou` - Africa/Ouagadougou
-  * `Africa/Porto-Novo` - Africa/Porto-Novo
-  * `Africa/Sao_Tome` - Africa/Sao_Tome
-  * `Africa/Timbuktu` - Africa/Timbuktu
-  * `Africa/Tripoli` - Africa/Tripoli
-  * `Africa/Tunis` - Africa/Tunis
-  * `Africa/Windhoek` - Africa/Windhoek
-  * `America/Adak` - America/Adak
-  * `America/Anchorage` - America/Anchorage
-  * `America/Anguilla` - America/Anguilla
-  * `America/Antigua` - America/Antigua
-  * `America/Araguaina` - America/Araguaina
-  * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-  * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-  * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-  * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-  * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-  * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-  * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-  * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-  * `America/Argentina/Salta` - America/Argentina/Salta
-  * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-  * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-  * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-  * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-  * `America/Aruba` - America/Aruba
-  * `America/Asuncion` - America/Asuncion
-  * `America/Atikokan` - America/Atikokan
-  * `America/Atka` - America/Atka
-  * `America/Bahia` - America/Bahia
-  * `America/Bahia_Banderas` - America/Bahia_Banderas
-  * `America/Barbados` - America/Barbados
-  * `America/Belem` - America/Belem
-  * `America/Belize` - America/Belize
-  * `America/Blanc-Sablon` - America/Blanc-Sablon
-  * `America/Boa_Vista` - America/Boa_Vista
-  * `America/Bogota` - America/Bogota
-  * `America/Boise` - America/Boise
-  * `America/Buenos_Aires` - America/Buenos_Aires
-  * `America/Cambridge_Bay` - America/Cambridge_Bay
-  * `America/Campo_Grande` - America/Campo_Grande
-  * `America/Cancun` - America/Cancun
-  * `America/Caracas` - America/Caracas
-  * `America/Catamarca` - America/Catamarca
-  * `America/Cayenne` - America/Cayenne
-  * `America/Cayman` - America/Cayman
-  * `America/Chicago` - America/Chicago
-  * `America/Chihuahua` - America/Chihuahua
-  * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-  * `America/Coral_Harbour` - America/Coral_Harbour
-  * `America/Cordoba` - America/Cordoba
-  * `America/Costa_Rica` - America/Costa_Rica
-  * `America/Creston` - America/Creston
-  * `America/Cuiaba` - America/Cuiaba
-  * `America/Curacao` - America/Curacao
-  * `America/Danmarkshavn` - America/Danmarkshavn
-  * `America/Dawson` - America/Dawson
-  * `America/Dawson_Creek` - America/Dawson_Creek
-  * `America/Denver` - America/Denver
-  * `America/Detroit` - America/Detroit
-  * `America/Dominica` - America/Dominica
-  * `America/Edmonton` - America/Edmonton
-  * `America/Eirunepe` - America/Eirunepe
-  * `America/El_Salvador` - America/El_Salvador
-  * `America/Ensenada` - America/Ensenada
-  * `America/Fort_Nelson` - America/Fort_Nelson
-  * `America/Fort_Wayne` - America/Fort_Wayne
-  * `America/Fortaleza` - America/Fortaleza
-  * `America/Glace_Bay` - America/Glace_Bay
-  * `America/Godthab` - America/Godthab
-  * `America/Goose_Bay` - America/Goose_Bay
-  * `America/Grand_Turk` - America/Grand_Turk
-  * `America/Grenada` - America/Grenada
-  * `America/Guadeloupe` - America/Guadeloupe
-  * `America/Guatemala` - America/Guatemala
-  * `America/Guayaquil` - America/Guayaquil
-  * `America/Guyana` - America/Guyana
-  * `America/Halifax` - America/Halifax
-  * `America/Havana` - America/Havana
-  * `America/Hermosillo` - America/Hermosillo
-  * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-  * `America/Indiana/Knox` - America/Indiana/Knox
-  * `America/Indiana/Marengo` - America/Indiana/Marengo
-  * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-  * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-  * `America/Indiana/Vevay` - America/Indiana/Vevay
-  * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-  * `America/Indiana/Winamac` - America/Indiana/Winamac
-  * `America/Indianapolis` - America/Indianapolis
-  * `America/Inuvik` - America/Inuvik
-  * `America/Iqaluit` - America/Iqaluit
-  * `America/Jamaica` - America/Jamaica
-  * `America/Jujuy` - America/Jujuy
-  * `America/Juneau` - America/Juneau
-  * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-  * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-  * `America/Knox_IN` - America/Knox_IN
-  * `America/Kralendijk` - America/Kralendijk
-  * `America/La_Paz` - America/La_Paz
-  * `America/Lima` - America/Lima
-  * `America/Los_Angeles` - America/Los_Angeles
-  * `America/Louisville` - America/Louisville
-  * `America/Lower_Princes` - America/Lower_Princes
-  * `America/Maceio` - America/Maceio
-  * `America/Managua` - America/Managua
-  * `America/Manaus` - America/Manaus
-  * `America/Marigot` - America/Marigot
-  * `America/Martinique` - America/Martinique
-  * `America/Matamoros` - America/Matamoros
-  * `America/Mazatlan` - America/Mazatlan
-  * `America/Mendoza` - America/Mendoza
-  * `America/Menominee` - America/Menominee
-  * `America/Merida` - America/Merida
-  * `America/Metlakatla` - America/Metlakatla
-  * `America/Mexico_City` - America/Mexico_City
-  * `America/Miquelon` - America/Miquelon
-  * `America/Moncton` - America/Moncton
-  * `America/Monterrey` - America/Monterrey
-  * `America/Montevideo` - America/Montevideo
-  * `America/Montreal` - America/Montreal
-  * `America/Montserrat` - America/Montserrat
-  * `America/Nassau` - America/Nassau
-  * `America/New_York` - America/New_York
-  * `America/Nipigon` - America/Nipigon
-  * `America/Nome` - America/Nome
-  * `America/Noronha` - America/Noronha
-  * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-  * `America/North_Dakota/Center` - America/North_Dakota/Center
-  * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-  * `America/Nuuk` - America/Nuuk
-  * `America/Ojinaga` - America/Ojinaga
-  * `America/Panama` - America/Panama
-  * `America/Pangnirtung` - America/Pangnirtung
-  * `America/Paramaribo` - America/Paramaribo
-  * `America/Phoenix` - America/Phoenix
-  * `America/Port-au-Prince` - America/Port-au-Prince
-  * `America/Port_of_Spain` - America/Port_of_Spain
-  * `America/Porto_Acre` - America/Porto_Acre
-  * `America/Porto_Velho` - America/Porto_Velho
-  * `America/Puerto_Rico` - America/Puerto_Rico
-  * `America/Punta_Arenas` - America/Punta_Arenas
-  * `America/Rainy_River` - America/Rainy_River
-  * `America/Rankin_Inlet` - America/Rankin_Inlet
-  * `America/Recife` - America/Recife
-  * `America/Regina` - America/Regina
-  * `America/Resolute` - America/Resolute
-  * `America/Rio_Branco` - America/Rio_Branco
-  * `America/Rosario` - America/Rosario
-  * `America/Santa_Isabel` - America/Santa_Isabel
-  * `America/Santarem` - America/Santarem
-  * `America/Santiago` - America/Santiago
-  * `America/Santo_Domingo` - America/Santo_Domingo
-  * `America/Sao_Paulo` - America/Sao_Paulo
-  * `America/Scoresbysund` - America/Scoresbysund
-  * `America/Shiprock` - America/Shiprock
-  * `America/Sitka` - America/Sitka
-  * `America/St_Barthelemy` - America/St_Barthelemy
-  * `America/St_Johns` - America/St_Johns
-  * `America/St_Kitts` - America/St_Kitts
-  * `America/St_Lucia` - America/St_Lucia
-  * `America/St_Thomas` - America/St_Thomas
-  * `America/St_Vincent` - America/St_Vincent
-  * `America/Swift_Current` - America/Swift_Current
-  * `America/Tegucigalpa` - America/Tegucigalpa
-  * `America/Thule` - America/Thule
-  * `America/Thunder_Bay` - America/Thunder_Bay
-  * `America/Tijuana` - America/Tijuana
-  * `America/Toronto` - America/Toronto
-  * `America/Tortola` - America/Tortola
-  * `America/Vancouver` - America/Vancouver
-  * `America/Virgin` - America/Virgin
-  * `America/Whitehorse` - America/Whitehorse
-  * `America/Winnipeg` - America/Winnipeg
-  * `America/Yakutat` - America/Yakutat
-  * `America/Yellowknife` - America/Yellowknife
-  * `Antarctica/Casey` - Antarctica/Casey
-  * `Antarctica/Davis` - Antarctica/Davis
-  * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-  * `Antarctica/Macquarie` - Antarctica/Macquarie
-  * `Antarctica/Mawson` - Antarctica/Mawson
-  * `Antarctica/McMurdo` - Antarctica/McMurdo
-  * `Antarctica/Palmer` - Antarctica/Palmer
-  * `Antarctica/Rothera` - Antarctica/Rothera
-  * `Antarctica/South_Pole` - Antarctica/South_Pole
-  * `Antarctica/Syowa` - Antarctica/Syowa
-  * `Antarctica/Troll` - Antarctica/Troll
-  * `Antarctica/Vostok` - Antarctica/Vostok
-  * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-  * `Asia/Aden` - Asia/Aden
-  * `Asia/Almaty` - Asia/Almaty
-  * `Asia/Amman` - Asia/Amman
-  * `Asia/Anadyr` - Asia/Anadyr
-  * `Asia/Aqtau` - Asia/Aqtau
-  * `Asia/Aqtobe` - Asia/Aqtobe
-  * `Asia/Ashgabat` - Asia/Ashgabat
-  * `Asia/Ashkhabad` - Asia/Ashkhabad
-  * `Asia/Atyrau` - Asia/Atyrau
-  * `Asia/Baghdad` - Asia/Baghdad
-  * `Asia/Bahrain` - Asia/Bahrain
-  * `Asia/Baku` - Asia/Baku
-  * `Asia/Bangkok` - Asia/Bangkok
-  * `Asia/Barnaul` - Asia/Barnaul
-  * `Asia/Beirut` - Asia/Beirut
-  * `Asia/Bishkek` - Asia/Bishkek
-  * `Asia/Brunei` - Asia/Brunei
-  * `Asia/Calcutta` - Asia/Calcutta
-  * `Asia/Chita` - Asia/Chita
-  * `Asia/Choibalsan` - Asia/Choibalsan
-  * `Asia/Chongqing` - Asia/Chongqing
-  * `Asia/Chungking` - Asia/Chungking
-  * `Asia/Colombo` - Asia/Colombo
-  * `Asia/Dacca` - Asia/Dacca
-  * `Asia/Damascus` - Asia/Damascus
-  * `Asia/Dhaka` - Asia/Dhaka
-  * `Asia/Dili` - Asia/Dili
-  * `Asia/Dubai` - Asia/Dubai
-  * `Asia/Dushanbe` - Asia/Dushanbe
-  * `Asia/Famagusta` - Asia/Famagusta
-  * `Asia/Gaza` - Asia/Gaza
-  * `Asia/Harbin` - Asia/Harbin
-  * `Asia/Hebron` - Asia/Hebron
-  * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-  * `Asia/Hong_Kong` - Asia/Hong_Kong
-  * `Asia/Hovd` - Asia/Hovd
-  * `Asia/Irkutsk` - Asia/Irkutsk
-  * `Asia/Istanbul` - Asia/Istanbul
-  * `Asia/Jakarta` - Asia/Jakarta
-  * `Asia/Jayapura` - Asia/Jayapura
-  * `Asia/Jerusalem` - Asia/Jerusalem
-  * `Asia/Kabul` - Asia/Kabul
-  * `Asia/Kamchatka` - Asia/Kamchatka
-  * `Asia/Karachi` - Asia/Karachi
-  * `Asia/Kashgar` - Asia/Kashgar
-  * `Asia/Kathmandu` - Asia/Kathmandu
-  * `Asia/Katmandu` - Asia/Katmandu
-  * `Asia/Khandyga` - Asia/Khandyga
-  * `Asia/Kolkata` - Asia/Kolkata
-  * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-  * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-  * `Asia/Kuching` - Asia/Kuching
-  * `Asia/Kuwait` - Asia/Kuwait
-  * `Asia/Macao` - Asia/Macao
-  * `Asia/Macau` - Asia/Macau
-  * `Asia/Magadan` - Asia/Magadan
-  * `Asia/Makassar` - Asia/Makassar
-  * `Asia/Manila` - Asia/Manila
-  * `Asia/Muscat` - Asia/Muscat
-  * `Asia/Nicosia` - Asia/Nicosia
-  * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-  * `Asia/Novosibirsk` - Asia/Novosibirsk
-  * `Asia/Omsk` - Asia/Omsk
-  * `Asia/Oral` - Asia/Oral
-  * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-  * `Asia/Pontianak` - Asia/Pontianak
-  * `Asia/Pyongyang` - Asia/Pyongyang
-  * `Asia/Qatar` - Asia/Qatar
-  * `Asia/Qostanay` - Asia/Qostanay
-  * `Asia/Qyzylorda` - Asia/Qyzylorda
-  * `Asia/Rangoon` - Asia/Rangoon
-  * `Asia/Riyadh` - Asia/Riyadh
-  * `Asia/Saigon` - Asia/Saigon
-  * `Asia/Sakhalin` - Asia/Sakhalin
-  * `Asia/Samarkand` - Asia/Samarkand
-  * `Asia/Seoul` - Asia/Seoul
-  * `Asia/Shanghai` - Asia/Shanghai
-  * `Asia/Singapore` - Asia/Singapore
-  * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-  * `Asia/Taipei` - Asia/Taipei
-  * `Asia/Tashkent` - Asia/Tashkent
-  * `Asia/Tbilisi` - Asia/Tbilisi
-  * `Asia/Tehran` - Asia/Tehran
-  * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-  * `Asia/Thimbu` - Asia/Thimbu
-  * `Asia/Thimphu` - Asia/Thimphu
-  * `Asia/Tokyo` - Asia/Tokyo
-  * `Asia/Tomsk` - Asia/Tomsk
-  * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-  * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-  * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-  * `Asia/Urumqi` - Asia/Urumqi
-  * `Asia/Ust-Nera` - Asia/Ust-Nera
-  * `Asia/Vientiane` - Asia/Vientiane
-  * `Asia/Vladivostok` - Asia/Vladivostok
-  * `Asia/Yakutsk` - Asia/Yakutsk
-  * `Asia/Yangon` - Asia/Yangon
-  * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-  * `Asia/Yerevan` - Asia/Yerevan
-  * `Atlantic/Azores` - Atlantic/Azores
-  * `Atlantic/Bermuda` - Atlantic/Bermuda
-  * `Atlantic/Canary` - Atlantic/Canary
-  * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-  * `Atlantic/Faeroe` - Atlantic/Faeroe
-  * `Atlantic/Faroe` - Atlantic/Faroe
-  * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-  * `Atlantic/Madeira` - Atlantic/Madeira
-  * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-  * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-  * `Atlantic/St_Helena` - Atlantic/St_Helena
-  * `Atlantic/Stanley` - Atlantic/Stanley
-  * `Australia/ACT` - Australia/ACT
-  * `Australia/Adelaide` - Australia/Adelaide
-  * `Australia/Brisbane` - Australia/Brisbane
-  * `Australia/Broken_Hill` - Australia/Broken_Hill
-  * `Australia/Canberra` - Australia/Canberra
-  * `Australia/Currie` - Australia/Currie
-  * `Australia/Darwin` - Australia/Darwin
-  * `Australia/Eucla` - Australia/Eucla
-  * `Australia/Hobart` - Australia/Hobart
-  * `Australia/LHI` - Australia/LHI
-  * `Australia/Lindeman` - Australia/Lindeman
-  * `Australia/Lord_Howe` - Australia/Lord_Howe
-  * `Australia/Melbourne` - Australia/Melbourne
-  * `Australia/NSW` - Australia/NSW
-  * `Australia/North` - Australia/North
-  * `Australia/Perth` - Australia/Perth
-  * `Australia/Queensland` - Australia/Queensland
-  * `Australia/South` - Australia/South
-  * `Australia/Sydney` - Australia/Sydney
-  * `Australia/Tasmania` - Australia/Tasmania
-  * `Australia/Victoria` - Australia/Victoria
-  * `Australia/West` - Australia/West
-  * `Australia/Yancowinna` - Australia/Yancowinna
-  * `Brazil/Acre` - Brazil/Acre
-  * `Brazil/DeNoronha` - Brazil/DeNoronha
-  * `Brazil/East` - Brazil/East
-  * `Brazil/West` - Brazil/West
-  * `CET` - CET
-  * `CST6CDT` - CST6CDT
-  * `Canada/Atlantic` - Canada/Atlantic
-  * `Canada/Central` - Canada/Central
-  * `Canada/Eastern` - Canada/Eastern
-  * `Canada/Mountain` - Canada/Mountain
-  * `Canada/Newfoundland` - Canada/Newfoundland
-  * `Canada/Pacific` - Canada/Pacific
-  * `Canada/Saskatchewan` - Canada/Saskatchewan
-  * `Canada/Yukon` - Canada/Yukon
-  * `Chile/Continental` - Chile/Continental
-  * `Chile/EasterIsland` - Chile/EasterIsland
-  * `Cuba` - Cuba
-  * `EET` - EET
-  * `EST` - EST
-  * `EST5EDT` - EST5EDT
-  * `Egypt` - Egypt
-  * `Eire` - Eire
-  * `Etc/GMT` - Etc/GMT
-  * `Etc/GMT+0` - Etc/GMT+0
-  * `Etc/GMT+1` - Etc/GMT+1
-  * `Etc/GMT+10` - Etc/GMT+10
-  * `Etc/GMT+11` - Etc/GMT+11
-  * `Etc/GMT+12` - Etc/GMT+12
-  * `Etc/GMT+2` - Etc/GMT+2
-  * `Etc/GMT+3` - Etc/GMT+3
-  * `Etc/GMT+4` - Etc/GMT+4
-  * `Etc/GMT+5` - Etc/GMT+5
-  * `Etc/GMT+6` - Etc/GMT+6
-  * `Etc/GMT+7` - Etc/GMT+7
-  * `Etc/GMT+8` - Etc/GMT+8
-  * `Etc/GMT+9` - Etc/GMT+9
-  * `Etc/GMT-0` - Etc/GMT-0
-  * `Etc/GMT-1` - Etc/GMT-1
-  * `Etc/GMT-10` - Etc/GMT-10
-  * `Etc/GMT-11` - Etc/GMT-11
-  * `Etc/GMT-12` - Etc/GMT-12
-  * `Etc/GMT-13` - Etc/GMT-13
-  * `Etc/GMT-14` - Etc/GMT-14
-  * `Etc/GMT-2` - Etc/GMT-2
-  * `Etc/GMT-3` - Etc/GMT-3
-  * `Etc/GMT-4` - Etc/GMT-4
-  * `Etc/GMT-5` - Etc/GMT-5
-  * `Etc/GMT-6` - Etc/GMT-6
-  * `Etc/GMT-7` - Etc/GMT-7
-  * `Etc/GMT-8` - Etc/GMT-8
-  * `Etc/GMT-9` - Etc/GMT-9
-  * `Etc/GMT0` - Etc/GMT0
-  * `Etc/Greenwich` - Etc/Greenwich
-  * `Etc/UCT` - Etc/UCT
-  * `Etc/UTC` - Etc/UTC
-  * `Etc/Universal` - Etc/Universal
-  * `Etc/Zulu` - Etc/Zulu
-  * `Europe/Amsterdam` - Europe/Amsterdam
-  * `Europe/Andorra` - Europe/Andorra
-  * `Europe/Astrakhan` - Europe/Astrakhan
-  * `Europe/Athens` - Europe/Athens
-  * `Europe/Belfast` - Europe/Belfast
-  * `Europe/Belgrade` - Europe/Belgrade
-  * `Europe/Berlin` - Europe/Berlin
-  * `Europe/Bratislava` - Europe/Bratislava
-  * `Europe/Brussels` - Europe/Brussels
-  * `Europe/Bucharest` - Europe/Bucharest
-  * `Europe/Budapest` - Europe/Budapest
-  * `Europe/Busingen` - Europe/Busingen
-  * `Europe/Chisinau` - Europe/Chisinau
-  * `Europe/Copenhagen` - Europe/Copenhagen
-  * `Europe/Dublin` - Europe/Dublin
-  * `Europe/Gibraltar` - Europe/Gibraltar
-  * `Europe/Guernsey` - Europe/Guernsey
-  * `Europe/Helsinki` - Europe/Helsinki
-  * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-  * `Europe/Istanbul` - Europe/Istanbul
-  * `Europe/Jersey` - Europe/Jersey
-  * `Europe/Kaliningrad` - Europe/Kaliningrad
-  * `Europe/Kiev` - Europe/Kiev
-  * `Europe/Kirov` - Europe/Kirov
-  * `Europe/Kyiv` - Europe/Kyiv
-  * `Europe/Lisbon` - Europe/Lisbon
-  * `Europe/Ljubljana` - Europe/Ljubljana
-  * `Europe/London` - Europe/London
-  * `Europe/Luxembourg` - Europe/Luxembourg
-  * `Europe/Madrid` - Europe/Madrid
-  * `Europe/Malta` - Europe/Malta
-  * `Europe/Mariehamn` - Europe/Mariehamn
-  * `Europe/Minsk` - Europe/Minsk
-  * `Europe/Monaco` - Europe/Monaco
-  * `Europe/Moscow` - Europe/Moscow
-  * `Europe/Nicosia` - Europe/Nicosia
-  * `Europe/Oslo` - Europe/Oslo
-  * `Europe/Paris` - Europe/Paris
-  * `Europe/Podgorica` - Europe/Podgorica
-  * `Europe/Prague` - Europe/Prague
-  * `Europe/Riga` - Europe/Riga
-  * `Europe/Rome` - Europe/Rome
-  * `Europe/Samara` - Europe/Samara
-  * `Europe/San_Marino` - Europe/San_Marino
-  * `Europe/Sarajevo` - Europe/Sarajevo
-  * `Europe/Saratov` - Europe/Saratov
-  * `Europe/Simferopol` - Europe/Simferopol
-  * `Europe/Skopje` - Europe/Skopje
-  * `Europe/Sofia` - Europe/Sofia
-  * `Europe/Stockholm` - Europe/Stockholm
-  * `Europe/Tallinn` - Europe/Tallinn
-  * `Europe/Tirane` - Europe/Tirane
-  * `Europe/Tiraspol` - Europe/Tiraspol
-  * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-  * `Europe/Uzhgorod` - Europe/Uzhgorod
-  * `Europe/Vaduz` - Europe/Vaduz
-  * `Europe/Vatican` - Europe/Vatican
-  * `Europe/Vienna` - Europe/Vienna
-  * `Europe/Vilnius` - Europe/Vilnius
-  * `Europe/Volgograd` - Europe/Volgograd
-  * `Europe/Warsaw` - Europe/Warsaw
-  * `Europe/Zagreb` - Europe/Zagreb
-  * `Europe/Zaporozhye` - Europe/Zaporozhye
-  * `Europe/Zurich` - Europe/Zurich
-  * `GB` - GB
-  * `GB-Eire` - GB-Eire
-  * `GMT` - GMT
-  * `GMT+0` - GMT+0
-  * `GMT-0` - GMT-0
-  * `GMT0` - GMT0
-  * `Greenwich` - Greenwich
-  * `HST` - HST
-  * `Hongkong` - Hongkong
-  * `Iceland` - Iceland
-  * `Indian/Antananarivo` - Indian/Antananarivo
-  * `Indian/Chagos` - Indian/Chagos
-  * `Indian/Christmas` - Indian/Christmas
-  * `Indian/Cocos` - Indian/Cocos
-  * `Indian/Comoro` - Indian/Comoro
-  * `Indian/Kerguelen` - Indian/Kerguelen
-  * `Indian/Mahe` - Indian/Mahe
-  * `Indian/Maldives` - Indian/Maldives
-  * `Indian/Mauritius` - Indian/Mauritius
-  * `Indian/Mayotte` - Indian/Mayotte
-  * `Indian/Reunion` - Indian/Reunion
-  * `Iran` - Iran
-  * `Israel` - Israel
-  * `Jamaica` - Jamaica
-  * `Japan` - Japan
-  * `Kwajalein` - Kwajalein
-  * `Libya` - Libya
-  * `MET` - MET
-  * `MST` - MST
-  * `MST7MDT` - MST7MDT
-  * `Mexico/BajaNorte` - Mexico/BajaNorte
-  * `Mexico/BajaSur` - Mexico/BajaSur
-  * `Mexico/General` - Mexico/General
-  * `NZ` - NZ
-  * `NZ-CHAT` - NZ-CHAT
-  * `Navajo` - Navajo
-  * `PRC` - PRC
-  * `PST8PDT` - PST8PDT
-  * `Pacific/Apia` - Pacific/Apia
-  * `Pacific/Auckland` - Pacific/Auckland
-  * `Pacific/Bougainville` - Pacific/Bougainville
-  * `Pacific/Chatham` - Pacific/Chatham
-  * `Pacific/Chuuk` - Pacific/Chuuk
-  * `Pacific/Easter` - Pacific/Easter
-  * `Pacific/Efate` - Pacific/Efate
-  * `Pacific/Enderbury` - Pacific/Enderbury
-  * `Pacific/Fakaofo` - Pacific/Fakaofo
-  * `Pacific/Fiji` - Pacific/Fiji
-  * `Pacific/Funafuti` - Pacific/Funafuti
-  * `Pacific/Galapagos` - Pacific/Galapagos
-  * `Pacific/Gambier` - Pacific/Gambier
-  * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-  * `Pacific/Guam` - Pacific/Guam
-  * `Pacific/Honolulu` - Pacific/Honolulu
-  * `Pacific/Johnston` - Pacific/Johnston
-  * `Pacific/Kanton` - Pacific/Kanton
-  * `Pacific/Kiritimati` - Pacific/Kiritimati
-  * `Pacific/Kosrae` - Pacific/Kosrae
-  * `Pacific/Kwajalein` - Pacific/Kwajalein
-  * `Pacific/Majuro` - Pacific/Majuro
-  * `Pacific/Marquesas` - Pacific/Marquesas
-  * `Pacific/Midway` - Pacific/Midway
-  * `Pacific/Nauru` - Pacific/Nauru
-  * `Pacific/Niue` - Pacific/Niue
-  * `Pacific/Norfolk` - Pacific/Norfolk
-  * `Pacific/Noumea` - Pacific/Noumea
-  * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-  * `Pacific/Palau` - Pacific/Palau
-  * `Pacific/Pitcairn` - Pacific/Pitcairn
-  * `Pacific/Pohnpei` - Pacific/Pohnpei
-  * `Pacific/Ponape` - Pacific/Ponape
-  * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-  * `Pacific/Rarotonga` - Pacific/Rarotonga
-  * `Pacific/Saipan` - Pacific/Saipan
-  * `Pacific/Samoa` - Pacific/Samoa
-  * `Pacific/Tahiti` - Pacific/Tahiti
-  * `Pacific/Tarawa` - Pacific/Tarawa
-  * `Pacific/Tongatapu` - Pacific/Tongatapu
-  * `Pacific/Truk` - Pacific/Truk
-  * `Pacific/Wake` - Pacific/Wake
-  * `Pacific/Wallis` - Pacific/Wallis
-  * `Pacific/Yap` - Pacific/Yap
-  * `Poland` - Poland
-  * `Portugal` - Portugal
-  * `ROC` - ROC
-  * `ROK` - ROK
-  * `Singapore` - Singapore
-  * `Turkey` - Turkey
-  * `UCT` - UCT
-  * `US/Alaska` - US/Alaska
-  * `US/Aleutian` - US/Aleutian
-  * `US/Arizona` - US/Arizona
-  * `US/Central` - US/Central
-  * `US/East-Indiana` - US/East-Indiana
-  * `US/Eastern` - US/Eastern
-  * `US/Hawaii` - US/Hawaii
-  * `US/Indiana-Starke` - US/Indiana-Starke
-  * `US/Michigan` - US/Michigan
-  * `US/Mountain` - US/Mountain
-  * `US/Pacific` - US/Pacific
-  * `US/Samoa` - US/Samoa
-  * `UTC` - UTC
-  * `Universal` - Universal
-  * `W-SU` - W-SU
-  * `WET` - WET
-  * `Zulu` - Zulu */
+     *
+     * * `Africa/Abidjan` - Africa/Abidjan
+     * * `Africa/Accra` - Africa/Accra
+     * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+     * * `Africa/Algiers` - Africa/Algiers
+     * * `Africa/Asmara` - Africa/Asmara
+     * * `Africa/Asmera` - Africa/Asmera
+     * * `Africa/Bamako` - Africa/Bamako
+     * * `Africa/Bangui` - Africa/Bangui
+     * * `Africa/Banjul` - Africa/Banjul
+     * * `Africa/Bissau` - Africa/Bissau
+     * * `Africa/Blantyre` - Africa/Blantyre
+     * * `Africa/Brazzaville` - Africa/Brazzaville
+     * * `Africa/Bujumbura` - Africa/Bujumbura
+     * * `Africa/Cairo` - Africa/Cairo
+     * * `Africa/Casablanca` - Africa/Casablanca
+     * * `Africa/Ceuta` - Africa/Ceuta
+     * * `Africa/Conakry` - Africa/Conakry
+     * * `Africa/Dakar` - Africa/Dakar
+     * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+     * * `Africa/Djibouti` - Africa/Djibouti
+     * * `Africa/Douala` - Africa/Douala
+     * * `Africa/El_Aaiun` - Africa/El_Aaiun
+     * * `Africa/Freetown` - Africa/Freetown
+     * * `Africa/Gaborone` - Africa/Gaborone
+     * * `Africa/Harare` - Africa/Harare
+     * * `Africa/Johannesburg` - Africa/Johannesburg
+     * * `Africa/Juba` - Africa/Juba
+     * * `Africa/Kampala` - Africa/Kampala
+     * * `Africa/Khartoum` - Africa/Khartoum
+     * * `Africa/Kigali` - Africa/Kigali
+     * * `Africa/Kinshasa` - Africa/Kinshasa
+     * * `Africa/Lagos` - Africa/Lagos
+     * * `Africa/Libreville` - Africa/Libreville
+     * * `Africa/Lome` - Africa/Lome
+     * * `Africa/Luanda` - Africa/Luanda
+     * * `Africa/Lubumbashi` - Africa/Lubumbashi
+     * * `Africa/Lusaka` - Africa/Lusaka
+     * * `Africa/Malabo` - Africa/Malabo
+     * * `Africa/Maputo` - Africa/Maputo
+     * * `Africa/Maseru` - Africa/Maseru
+     * * `Africa/Mbabane` - Africa/Mbabane
+     * * `Africa/Mogadishu` - Africa/Mogadishu
+     * * `Africa/Monrovia` - Africa/Monrovia
+     * * `Africa/Nairobi` - Africa/Nairobi
+     * * `Africa/Ndjamena` - Africa/Ndjamena
+     * * `Africa/Niamey` - Africa/Niamey
+     * * `Africa/Nouakchott` - Africa/Nouakchott
+     * * `Africa/Ouagadougou` - Africa/Ouagadougou
+     * * `Africa/Porto-Novo` - Africa/Porto-Novo
+     * * `Africa/Sao_Tome` - Africa/Sao_Tome
+     * * `Africa/Timbuktu` - Africa/Timbuktu
+     * * `Africa/Tripoli` - Africa/Tripoli
+     * * `Africa/Tunis` - Africa/Tunis
+     * * `Africa/Windhoek` - Africa/Windhoek
+     * * `America/Adak` - America/Adak
+     * * `America/Anchorage` - America/Anchorage
+     * * `America/Anguilla` - America/Anguilla
+     * * `America/Antigua` - America/Antigua
+     * * `America/Araguaina` - America/Araguaina
+     * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+     * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+     * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+     * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+     * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+     * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+     * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+     * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+     * * `America/Argentina/Salta` - America/Argentina/Salta
+     * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+     * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+     * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+     * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+     * * `America/Aruba` - America/Aruba
+     * * `America/Asuncion` - America/Asuncion
+     * * `America/Atikokan` - America/Atikokan
+     * * `America/Atka` - America/Atka
+     * * `America/Bahia` - America/Bahia
+     * * `America/Bahia_Banderas` - America/Bahia_Banderas
+     * * `America/Barbados` - America/Barbados
+     * * `America/Belem` - America/Belem
+     * * `America/Belize` - America/Belize
+     * * `America/Blanc-Sablon` - America/Blanc-Sablon
+     * * `America/Boa_Vista` - America/Boa_Vista
+     * * `America/Bogota` - America/Bogota
+     * * `America/Boise` - America/Boise
+     * * `America/Buenos_Aires` - America/Buenos_Aires
+     * * `America/Cambridge_Bay` - America/Cambridge_Bay
+     * * `America/Campo_Grande` - America/Campo_Grande
+     * * `America/Cancun` - America/Cancun
+     * * `America/Caracas` - America/Caracas
+     * * `America/Catamarca` - America/Catamarca
+     * * `America/Cayenne` - America/Cayenne
+     * * `America/Cayman` - America/Cayman
+     * * `America/Chicago` - America/Chicago
+     * * `America/Chihuahua` - America/Chihuahua
+     * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+     * * `America/Coral_Harbour` - America/Coral_Harbour
+     * * `America/Cordoba` - America/Cordoba
+     * * `America/Costa_Rica` - America/Costa_Rica
+     * * `America/Creston` - America/Creston
+     * * `America/Cuiaba` - America/Cuiaba
+     * * `America/Curacao` - America/Curacao
+     * * `America/Danmarkshavn` - America/Danmarkshavn
+     * * `America/Dawson` - America/Dawson
+     * * `America/Dawson_Creek` - America/Dawson_Creek
+     * * `America/Denver` - America/Denver
+     * * `America/Detroit` - America/Detroit
+     * * `America/Dominica` - America/Dominica
+     * * `America/Edmonton` - America/Edmonton
+     * * `America/Eirunepe` - America/Eirunepe
+     * * `America/El_Salvador` - America/El_Salvador
+     * * `America/Ensenada` - America/Ensenada
+     * * `America/Fort_Nelson` - America/Fort_Nelson
+     * * `America/Fort_Wayne` - America/Fort_Wayne
+     * * `America/Fortaleza` - America/Fortaleza
+     * * `America/Glace_Bay` - America/Glace_Bay
+     * * `America/Godthab` - America/Godthab
+     * * `America/Goose_Bay` - America/Goose_Bay
+     * * `America/Grand_Turk` - America/Grand_Turk
+     * * `America/Grenada` - America/Grenada
+     * * `America/Guadeloupe` - America/Guadeloupe
+     * * `America/Guatemala` - America/Guatemala
+     * * `America/Guayaquil` - America/Guayaquil
+     * * `America/Guyana` - America/Guyana
+     * * `America/Halifax` - America/Halifax
+     * * `America/Havana` - America/Havana
+     * * `America/Hermosillo` - America/Hermosillo
+     * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+     * * `America/Indiana/Knox` - America/Indiana/Knox
+     * * `America/Indiana/Marengo` - America/Indiana/Marengo
+     * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+     * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+     * * `America/Indiana/Vevay` - America/Indiana/Vevay
+     * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+     * * `America/Indiana/Winamac` - America/Indiana/Winamac
+     * * `America/Indianapolis` - America/Indianapolis
+     * * `America/Inuvik` - America/Inuvik
+     * * `America/Iqaluit` - America/Iqaluit
+     * * `America/Jamaica` - America/Jamaica
+     * * `America/Jujuy` - America/Jujuy
+     * * `America/Juneau` - America/Juneau
+     * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+     * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+     * * `America/Knox_IN` - America/Knox_IN
+     * * `America/Kralendijk` - America/Kralendijk
+     * * `America/La_Paz` - America/La_Paz
+     * * `America/Lima` - America/Lima
+     * * `America/Los_Angeles` - America/Los_Angeles
+     * * `America/Louisville` - America/Louisville
+     * * `America/Lower_Princes` - America/Lower_Princes
+     * * `America/Maceio` - America/Maceio
+     * * `America/Managua` - America/Managua
+     * * `America/Manaus` - America/Manaus
+     * * `America/Marigot` - America/Marigot
+     * * `America/Martinique` - America/Martinique
+     * * `America/Matamoros` - America/Matamoros
+     * * `America/Mazatlan` - America/Mazatlan
+     * * `America/Mendoza` - America/Mendoza
+     * * `America/Menominee` - America/Menominee
+     * * `America/Merida` - America/Merida
+     * * `America/Metlakatla` - America/Metlakatla
+     * * `America/Mexico_City` - America/Mexico_City
+     * * `America/Miquelon` - America/Miquelon
+     * * `America/Moncton` - America/Moncton
+     * * `America/Monterrey` - America/Monterrey
+     * * `America/Montevideo` - America/Montevideo
+     * * `America/Montreal` - America/Montreal
+     * * `America/Montserrat` - America/Montserrat
+     * * `America/Nassau` - America/Nassau
+     * * `America/New_York` - America/New_York
+     * * `America/Nipigon` - America/Nipigon
+     * * `America/Nome` - America/Nome
+     * * `America/Noronha` - America/Noronha
+     * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+     * * `America/North_Dakota/Center` - America/North_Dakota/Center
+     * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+     * * `America/Nuuk` - America/Nuuk
+     * * `America/Ojinaga` - America/Ojinaga
+     * * `America/Panama` - America/Panama
+     * * `America/Pangnirtung` - America/Pangnirtung
+     * * `America/Paramaribo` - America/Paramaribo
+     * * `America/Phoenix` - America/Phoenix
+     * * `America/Port-au-Prince` - America/Port-au-Prince
+     * * `America/Port_of_Spain` - America/Port_of_Spain
+     * * `America/Porto_Acre` - America/Porto_Acre
+     * * `America/Porto_Velho` - America/Porto_Velho
+     * * `America/Puerto_Rico` - America/Puerto_Rico
+     * * `America/Punta_Arenas` - America/Punta_Arenas
+     * * `America/Rainy_River` - America/Rainy_River
+     * * `America/Rankin_Inlet` - America/Rankin_Inlet
+     * * `America/Recife` - America/Recife
+     * * `America/Regina` - America/Regina
+     * * `America/Resolute` - America/Resolute
+     * * `America/Rio_Branco` - America/Rio_Branco
+     * * `America/Rosario` - America/Rosario
+     * * `America/Santa_Isabel` - America/Santa_Isabel
+     * * `America/Santarem` - America/Santarem
+     * * `America/Santiago` - America/Santiago
+     * * `America/Santo_Domingo` - America/Santo_Domingo
+     * * `America/Sao_Paulo` - America/Sao_Paulo
+     * * `America/Scoresbysund` - America/Scoresbysund
+     * * `America/Shiprock` - America/Shiprock
+     * * `America/Sitka` - America/Sitka
+     * * `America/St_Barthelemy` - America/St_Barthelemy
+     * * `America/St_Johns` - America/St_Johns
+     * * `America/St_Kitts` - America/St_Kitts
+     * * `America/St_Lucia` - America/St_Lucia
+     * * `America/St_Thomas` - America/St_Thomas
+     * * `America/St_Vincent` - America/St_Vincent
+     * * `America/Swift_Current` - America/Swift_Current
+     * * `America/Tegucigalpa` - America/Tegucigalpa
+     * * `America/Thule` - America/Thule
+     * * `America/Thunder_Bay` - America/Thunder_Bay
+     * * `America/Tijuana` - America/Tijuana
+     * * `America/Toronto` - America/Toronto
+     * * `America/Tortola` - America/Tortola
+     * * `America/Vancouver` - America/Vancouver
+     * * `America/Virgin` - America/Virgin
+     * * `America/Whitehorse` - America/Whitehorse
+     * * `America/Winnipeg` - America/Winnipeg
+     * * `America/Yakutat` - America/Yakutat
+     * * `America/Yellowknife` - America/Yellowknife
+     * * `Antarctica/Casey` - Antarctica/Casey
+     * * `Antarctica/Davis` - Antarctica/Davis
+     * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+     * * `Antarctica/Macquarie` - Antarctica/Macquarie
+     * * `Antarctica/Mawson` - Antarctica/Mawson
+     * * `Antarctica/McMurdo` - Antarctica/McMurdo
+     * * `Antarctica/Palmer` - Antarctica/Palmer
+     * * `Antarctica/Rothera` - Antarctica/Rothera
+     * * `Antarctica/South_Pole` - Antarctica/South_Pole
+     * * `Antarctica/Syowa` - Antarctica/Syowa
+     * * `Antarctica/Troll` - Antarctica/Troll
+     * * `Antarctica/Vostok` - Antarctica/Vostok
+     * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+     * * `Asia/Aden` - Asia/Aden
+     * * `Asia/Almaty` - Asia/Almaty
+     * * `Asia/Amman` - Asia/Amman
+     * * `Asia/Anadyr` - Asia/Anadyr
+     * * `Asia/Aqtau` - Asia/Aqtau
+     * * `Asia/Aqtobe` - Asia/Aqtobe
+     * * `Asia/Ashgabat` - Asia/Ashgabat
+     * * `Asia/Ashkhabad` - Asia/Ashkhabad
+     * * `Asia/Atyrau` - Asia/Atyrau
+     * * `Asia/Baghdad` - Asia/Baghdad
+     * * `Asia/Bahrain` - Asia/Bahrain
+     * * `Asia/Baku` - Asia/Baku
+     * * `Asia/Bangkok` - Asia/Bangkok
+     * * `Asia/Barnaul` - Asia/Barnaul
+     * * `Asia/Beirut` - Asia/Beirut
+     * * `Asia/Bishkek` - Asia/Bishkek
+     * * `Asia/Brunei` - Asia/Brunei
+     * * `Asia/Calcutta` - Asia/Calcutta
+     * * `Asia/Chita` - Asia/Chita
+     * * `Asia/Choibalsan` - Asia/Choibalsan
+     * * `Asia/Chongqing` - Asia/Chongqing
+     * * `Asia/Chungking` - Asia/Chungking
+     * * `Asia/Colombo` - Asia/Colombo
+     * * `Asia/Dacca` - Asia/Dacca
+     * * `Asia/Damascus` - Asia/Damascus
+     * * `Asia/Dhaka` - Asia/Dhaka
+     * * `Asia/Dili` - Asia/Dili
+     * * `Asia/Dubai` - Asia/Dubai
+     * * `Asia/Dushanbe` - Asia/Dushanbe
+     * * `Asia/Famagusta` - Asia/Famagusta
+     * * `Asia/Gaza` - Asia/Gaza
+     * * `Asia/Harbin` - Asia/Harbin
+     * * `Asia/Hebron` - Asia/Hebron
+     * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+     * * `Asia/Hong_Kong` - Asia/Hong_Kong
+     * * `Asia/Hovd` - Asia/Hovd
+     * * `Asia/Irkutsk` - Asia/Irkutsk
+     * * `Asia/Istanbul` - Asia/Istanbul
+     * * `Asia/Jakarta` - Asia/Jakarta
+     * * `Asia/Jayapura` - Asia/Jayapura
+     * * `Asia/Jerusalem` - Asia/Jerusalem
+     * * `Asia/Kabul` - Asia/Kabul
+     * * `Asia/Kamchatka` - Asia/Kamchatka
+     * * `Asia/Karachi` - Asia/Karachi
+     * * `Asia/Kashgar` - Asia/Kashgar
+     * * `Asia/Kathmandu` - Asia/Kathmandu
+     * * `Asia/Katmandu` - Asia/Katmandu
+     * * `Asia/Khandyga` - Asia/Khandyga
+     * * `Asia/Kolkata` - Asia/Kolkata
+     * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+     * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+     * * `Asia/Kuching` - Asia/Kuching
+     * * `Asia/Kuwait` - Asia/Kuwait
+     * * `Asia/Macao` - Asia/Macao
+     * * `Asia/Macau` - Asia/Macau
+     * * `Asia/Magadan` - Asia/Magadan
+     * * `Asia/Makassar` - Asia/Makassar
+     * * `Asia/Manila` - Asia/Manila
+     * * `Asia/Muscat` - Asia/Muscat
+     * * `Asia/Nicosia` - Asia/Nicosia
+     * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+     * * `Asia/Novosibirsk` - Asia/Novosibirsk
+     * * `Asia/Omsk` - Asia/Omsk
+     * * `Asia/Oral` - Asia/Oral
+     * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+     * * `Asia/Pontianak` - Asia/Pontianak
+     * * `Asia/Pyongyang` - Asia/Pyongyang
+     * * `Asia/Qatar` - Asia/Qatar
+     * * `Asia/Qostanay` - Asia/Qostanay
+     * * `Asia/Qyzylorda` - Asia/Qyzylorda
+     * * `Asia/Rangoon` - Asia/Rangoon
+     * * `Asia/Riyadh` - Asia/Riyadh
+     * * `Asia/Saigon` - Asia/Saigon
+     * * `Asia/Sakhalin` - Asia/Sakhalin
+     * * `Asia/Samarkand` - Asia/Samarkand
+     * * `Asia/Seoul` - Asia/Seoul
+     * * `Asia/Shanghai` - Asia/Shanghai
+     * * `Asia/Singapore` - Asia/Singapore
+     * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+     * * `Asia/Taipei` - Asia/Taipei
+     * * `Asia/Tashkent` - Asia/Tashkent
+     * * `Asia/Tbilisi` - Asia/Tbilisi
+     * * `Asia/Tehran` - Asia/Tehran
+     * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+     * * `Asia/Thimbu` - Asia/Thimbu
+     * * `Asia/Thimphu` - Asia/Thimphu
+     * * `Asia/Tokyo` - Asia/Tokyo
+     * * `Asia/Tomsk` - Asia/Tomsk
+     * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+     * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+     * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+     * * `Asia/Urumqi` - Asia/Urumqi
+     * * `Asia/Ust-Nera` - Asia/Ust-Nera
+     * * `Asia/Vientiane` - Asia/Vientiane
+     * * `Asia/Vladivostok` - Asia/Vladivostok
+     * * `Asia/Yakutsk` - Asia/Yakutsk
+     * * `Asia/Yangon` - Asia/Yangon
+     * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+     * * `Asia/Yerevan` - Asia/Yerevan
+     * * `Atlantic/Azores` - Atlantic/Azores
+     * * `Atlantic/Bermuda` - Atlantic/Bermuda
+     * * `Atlantic/Canary` - Atlantic/Canary
+     * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+     * * `Atlantic/Faeroe` - Atlantic/Faeroe
+     * * `Atlantic/Faroe` - Atlantic/Faroe
+     * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+     * * `Atlantic/Madeira` - Atlantic/Madeira
+     * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+     * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+     * * `Atlantic/St_Helena` - Atlantic/St_Helena
+     * * `Atlantic/Stanley` - Atlantic/Stanley
+     * * `Australia/ACT` - Australia/ACT
+     * * `Australia/Adelaide` - Australia/Adelaide
+     * * `Australia/Brisbane` - Australia/Brisbane
+     * * `Australia/Broken_Hill` - Australia/Broken_Hill
+     * * `Australia/Canberra` - Australia/Canberra
+     * * `Australia/Currie` - Australia/Currie
+     * * `Australia/Darwin` - Australia/Darwin
+     * * `Australia/Eucla` - Australia/Eucla
+     * * `Australia/Hobart` - Australia/Hobart
+     * * `Australia/LHI` - Australia/LHI
+     * * `Australia/Lindeman` - Australia/Lindeman
+     * * `Australia/Lord_Howe` - Australia/Lord_Howe
+     * * `Australia/Melbourne` - Australia/Melbourne
+     * * `Australia/NSW` - Australia/NSW
+     * * `Australia/North` - Australia/North
+     * * `Australia/Perth` - Australia/Perth
+     * * `Australia/Queensland` - Australia/Queensland
+     * * `Australia/South` - Australia/South
+     * * `Australia/Sydney` - Australia/Sydney
+     * * `Australia/Tasmania` - Australia/Tasmania
+     * * `Australia/Victoria` - Australia/Victoria
+     * * `Australia/West` - Australia/West
+     * * `Australia/Yancowinna` - Australia/Yancowinna
+     * * `Brazil/Acre` - Brazil/Acre
+     * * `Brazil/DeNoronha` - Brazil/DeNoronha
+     * * `Brazil/East` - Brazil/East
+     * * `Brazil/West` - Brazil/West
+     * * `CET` - CET
+     * * `CST6CDT` - CST6CDT
+     * * `Canada/Atlantic` - Canada/Atlantic
+     * * `Canada/Central` - Canada/Central
+     * * `Canada/Eastern` - Canada/Eastern
+     * * `Canada/Mountain` - Canada/Mountain
+     * * `Canada/Newfoundland` - Canada/Newfoundland
+     * * `Canada/Pacific` - Canada/Pacific
+     * * `Canada/Saskatchewan` - Canada/Saskatchewan
+     * * `Canada/Yukon` - Canada/Yukon
+     * * `Chile/Continental` - Chile/Continental
+     * * `Chile/EasterIsland` - Chile/EasterIsland
+     * * `Cuba` - Cuba
+     * * `EET` - EET
+     * * `EST` - EST
+     * * `EST5EDT` - EST5EDT
+     * * `Egypt` - Egypt
+     * * `Eire` - Eire
+     * * `Etc/GMT` - Etc/GMT
+     * * `Etc/GMT+0` - Etc/GMT+0
+     * * `Etc/GMT+1` - Etc/GMT+1
+     * * `Etc/GMT+10` - Etc/GMT+10
+     * * `Etc/GMT+11` - Etc/GMT+11
+     * * `Etc/GMT+12` - Etc/GMT+12
+     * * `Etc/GMT+2` - Etc/GMT+2
+     * * `Etc/GMT+3` - Etc/GMT+3
+     * * `Etc/GMT+4` - Etc/GMT+4
+     * * `Etc/GMT+5` - Etc/GMT+5
+     * * `Etc/GMT+6` - Etc/GMT+6
+     * * `Etc/GMT+7` - Etc/GMT+7
+     * * `Etc/GMT+8` - Etc/GMT+8
+     * * `Etc/GMT+9` - Etc/GMT+9
+     * * `Etc/GMT-0` - Etc/GMT-0
+     * * `Etc/GMT-1` - Etc/GMT-1
+     * * `Etc/GMT-10` - Etc/GMT-10
+     * * `Etc/GMT-11` - Etc/GMT-11
+     * * `Etc/GMT-12` - Etc/GMT-12
+     * * `Etc/GMT-13` - Etc/GMT-13
+     * * `Etc/GMT-14` - Etc/GMT-14
+     * * `Etc/GMT-2` - Etc/GMT-2
+     * * `Etc/GMT-3` - Etc/GMT-3
+     * * `Etc/GMT-4` - Etc/GMT-4
+     * * `Etc/GMT-5` - Etc/GMT-5
+     * * `Etc/GMT-6` - Etc/GMT-6
+     * * `Etc/GMT-7` - Etc/GMT-7
+     * * `Etc/GMT-8` - Etc/GMT-8
+     * * `Etc/GMT-9` - Etc/GMT-9
+     * * `Etc/GMT0` - Etc/GMT0
+     * * `Etc/Greenwich` - Etc/Greenwich
+     * * `Etc/UCT` - Etc/UCT
+     * * `Etc/UTC` - Etc/UTC
+     * * `Etc/Universal` - Etc/Universal
+     * * `Etc/Zulu` - Etc/Zulu
+     * * `Europe/Amsterdam` - Europe/Amsterdam
+     * * `Europe/Andorra` - Europe/Andorra
+     * * `Europe/Astrakhan` - Europe/Astrakhan
+     * * `Europe/Athens` - Europe/Athens
+     * * `Europe/Belfast` - Europe/Belfast
+     * * `Europe/Belgrade` - Europe/Belgrade
+     * * `Europe/Berlin` - Europe/Berlin
+     * * `Europe/Bratislava` - Europe/Bratislava
+     * * `Europe/Brussels` - Europe/Brussels
+     * * `Europe/Bucharest` - Europe/Bucharest
+     * * `Europe/Budapest` - Europe/Budapest
+     * * `Europe/Busingen` - Europe/Busingen
+     * * `Europe/Chisinau` - Europe/Chisinau
+     * * `Europe/Copenhagen` - Europe/Copenhagen
+     * * `Europe/Dublin` - Europe/Dublin
+     * * `Europe/Gibraltar` - Europe/Gibraltar
+     * * `Europe/Guernsey` - Europe/Guernsey
+     * * `Europe/Helsinki` - Europe/Helsinki
+     * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+     * * `Europe/Istanbul` - Europe/Istanbul
+     * * `Europe/Jersey` - Europe/Jersey
+     * * `Europe/Kaliningrad` - Europe/Kaliningrad
+     * * `Europe/Kiev` - Europe/Kiev
+     * * `Europe/Kirov` - Europe/Kirov
+     * * `Europe/Kyiv` - Europe/Kyiv
+     * * `Europe/Lisbon` - Europe/Lisbon
+     * * `Europe/Ljubljana` - Europe/Ljubljana
+     * * `Europe/London` - Europe/London
+     * * `Europe/Luxembourg` - Europe/Luxembourg
+     * * `Europe/Madrid` - Europe/Madrid
+     * * `Europe/Malta` - Europe/Malta
+     * * `Europe/Mariehamn` - Europe/Mariehamn
+     * * `Europe/Minsk` - Europe/Minsk
+     * * `Europe/Monaco` - Europe/Monaco
+     * * `Europe/Moscow` - Europe/Moscow
+     * * `Europe/Nicosia` - Europe/Nicosia
+     * * `Europe/Oslo` - Europe/Oslo
+     * * `Europe/Paris` - Europe/Paris
+     * * `Europe/Podgorica` - Europe/Podgorica
+     * * `Europe/Prague` - Europe/Prague
+     * * `Europe/Riga` - Europe/Riga
+     * * `Europe/Rome` - Europe/Rome
+     * * `Europe/Samara` - Europe/Samara
+     * * `Europe/San_Marino` - Europe/San_Marino
+     * * `Europe/Sarajevo` - Europe/Sarajevo
+     * * `Europe/Saratov` - Europe/Saratov
+     * * `Europe/Simferopol` - Europe/Simferopol
+     * * `Europe/Skopje` - Europe/Skopje
+     * * `Europe/Sofia` - Europe/Sofia
+     * * `Europe/Stockholm` - Europe/Stockholm
+     * * `Europe/Tallinn` - Europe/Tallinn
+     * * `Europe/Tirane` - Europe/Tirane
+     * * `Europe/Tiraspol` - Europe/Tiraspol
+     * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+     * * `Europe/Uzhgorod` - Europe/Uzhgorod
+     * * `Europe/Vaduz` - Europe/Vaduz
+     * * `Europe/Vatican` - Europe/Vatican
+     * * `Europe/Vienna` - Europe/Vienna
+     * * `Europe/Vilnius` - Europe/Vilnius
+     * * `Europe/Volgograd` - Europe/Volgograd
+     * * `Europe/Warsaw` - Europe/Warsaw
+     * * `Europe/Zagreb` - Europe/Zagreb
+     * * `Europe/Zaporozhye` - Europe/Zaporozhye
+     * * `Europe/Zurich` - Europe/Zurich
+     * * `GB` - GB
+     * * `GB-Eire` - GB-Eire
+     * * `GMT` - GMT
+     * * `GMT+0` - GMT+0
+     * * `GMT-0` - GMT-0
+     * * `GMT0` - GMT0
+     * * `Greenwich` - Greenwich
+     * * `HST` - HST
+     * * `Hongkong` - Hongkong
+     * * `Iceland` - Iceland
+     * * `Indian/Antananarivo` - Indian/Antananarivo
+     * * `Indian/Chagos` - Indian/Chagos
+     * * `Indian/Christmas` - Indian/Christmas
+     * * `Indian/Cocos` - Indian/Cocos
+     * * `Indian/Comoro` - Indian/Comoro
+     * * `Indian/Kerguelen` - Indian/Kerguelen
+     * * `Indian/Mahe` - Indian/Mahe
+     * * `Indian/Maldives` - Indian/Maldives
+     * * `Indian/Mauritius` - Indian/Mauritius
+     * * `Indian/Mayotte` - Indian/Mayotte
+     * * `Indian/Reunion` - Indian/Reunion
+     * * `Iran` - Iran
+     * * `Israel` - Israel
+     * * `Jamaica` - Jamaica
+     * * `Japan` - Japan
+     * * `Kwajalein` - Kwajalein
+     * * `Libya` - Libya
+     * * `MET` - MET
+     * * `MST` - MST
+     * * `MST7MDT` - MST7MDT
+     * * `Mexico/BajaNorte` - Mexico/BajaNorte
+     * * `Mexico/BajaSur` - Mexico/BajaSur
+     * * `Mexico/General` - Mexico/General
+     * * `NZ` - NZ
+     * * `NZ-CHAT` - NZ-CHAT
+     * * `Navajo` - Navajo
+     * * `PRC` - PRC
+     * * `PST8PDT` - PST8PDT
+     * * `Pacific/Apia` - Pacific/Apia
+     * * `Pacific/Auckland` - Pacific/Auckland
+     * * `Pacific/Bougainville` - Pacific/Bougainville
+     * * `Pacific/Chatham` - Pacific/Chatham
+     * * `Pacific/Chuuk` - Pacific/Chuuk
+     * * `Pacific/Easter` - Pacific/Easter
+     * * `Pacific/Efate` - Pacific/Efate
+     * * `Pacific/Enderbury` - Pacific/Enderbury
+     * * `Pacific/Fakaofo` - Pacific/Fakaofo
+     * * `Pacific/Fiji` - Pacific/Fiji
+     * * `Pacific/Funafuti` - Pacific/Funafuti
+     * * `Pacific/Galapagos` - Pacific/Galapagos
+     * * `Pacific/Gambier` - Pacific/Gambier
+     * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+     * * `Pacific/Guam` - Pacific/Guam
+     * * `Pacific/Honolulu` - Pacific/Honolulu
+     * * `Pacific/Johnston` - Pacific/Johnston
+     * * `Pacific/Kanton` - Pacific/Kanton
+     * * `Pacific/Kiritimati` - Pacific/Kiritimati
+     * * `Pacific/Kosrae` - Pacific/Kosrae
+     * * `Pacific/Kwajalein` - Pacific/Kwajalein
+     * * `Pacific/Majuro` - Pacific/Majuro
+     * * `Pacific/Marquesas` - Pacific/Marquesas
+     * * `Pacific/Midway` - Pacific/Midway
+     * * `Pacific/Nauru` - Pacific/Nauru
+     * * `Pacific/Niue` - Pacific/Niue
+     * * `Pacific/Norfolk` - Pacific/Norfolk
+     * * `Pacific/Noumea` - Pacific/Noumea
+     * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+     * * `Pacific/Palau` - Pacific/Palau
+     * * `Pacific/Pitcairn` - Pacific/Pitcairn
+     * * `Pacific/Pohnpei` - Pacific/Pohnpei
+     * * `Pacific/Ponape` - Pacific/Ponape
+     * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+     * * `Pacific/Rarotonga` - Pacific/Rarotonga
+     * * `Pacific/Saipan` - Pacific/Saipan
+     * * `Pacific/Samoa` - Pacific/Samoa
+     * * `Pacific/Tahiti` - Pacific/Tahiti
+     * * `Pacific/Tarawa` - Pacific/Tarawa
+     * * `Pacific/Tongatapu` - Pacific/Tongatapu
+     * * `Pacific/Truk` - Pacific/Truk
+     * * `Pacific/Wake` - Pacific/Wake
+     * * `Pacific/Wallis` - Pacific/Wallis
+     * * `Pacific/Yap` - Pacific/Yap
+     * * `Poland` - Poland
+     * * `Portugal` - Portugal
+     * * `ROC` - ROC
+     * * `ROK` - ROK
+     * * `Singapore` - Singapore
+     * * `Turkey` - Turkey
+     * * `UCT` - UCT
+     * * `US/Alaska` - US/Alaska
+     * * `US/Aleutian` - US/Aleutian
+     * * `US/Arizona` - US/Arizona
+     * * `US/Central` - US/Central
+     * * `US/East-Indiana` - US/East-Indiana
+     * * `US/Eastern` - US/Eastern
+     * * `US/Hawaii` - US/Hawaii
+     * * `US/Indiana-Starke` - US/Indiana-Starke
+     * * `US/Michigan` - US/Michigan
+     * * `US/Mountain` - US/Mountain
+     * * `US/Pacific` - US/Pacific
+     * * `US/Samoa` - US/Samoa
+     * * `UTC` - UTC
+     * * `Universal` - Universal
+     * * `W-SU` - W-SU
+     * * `WET` - WET
+     * * `Zulu` - Zulu */
     timezone?: string
     /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
     data_attributes?: unknown
     /**
      * Ordered list of person properties used to render a human-friendly display name in the UI.
      * @nullable
+     * @items.maxLength 400
      */
     person_display_name_properties?: string[] | null
     correlation_config?: unknown
@@ -1235,19 +1243,19 @@ export interface ProjectBackwardCompatApi {
     /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
     session_recording_trigger_groups?: unknown
     /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-
-  * `30d` - 30 Days
-  * `90d` - 90 Days
-  * `1y` - 1 Year
-  * `5y` - 5 Years */
+     *
+     * * `30d` - 30 Days
+     * * `90d` - 90 Days
+     * * `1y` - 1 Year
+     * * `5y` - 5 Years */
     session_recording_retention_period?: SessionRecordingRetentionPeriodEnumApi
     session_replay_config?: unknown
     survey_config?: unknown
     access_control?: boolean
     /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-
-  * `0` - Sunday
-  * `1` - Monday */
+     *
+     * * `0` - Sunday
+     * * `1` - Monday */
     week_start_day?: WeekStartDayEnumApi | null
     /**
      * ID of the dashboard shown as the project's default landing dashboard.
@@ -1259,6 +1267,7 @@ export interface ProjectBackwardCompatApi {
     /**
      * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
      * @nullable
+     * @items.maxLength 200
      */
     recording_domains?: (string | null)[] | null
     readonly person_on_events_querying_enabled: boolean
@@ -1291,10 +1300,10 @@ export interface ProjectBackwardCompatApi {
     /** @nullable */
     receive_org_level_activity_logs?: boolean | null
     /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-
-  * `b2b` - B2B
-  * `b2c` - B2C
-  * `other` - Other */
+     *
+     * * `b2b` - B2B
+     * * `b2c` - B2C
+     * * `other` - Other */
     business_model?: BusinessModelEnumApi | BlankEnumApi | null
     /**
      * Enables the customer conversations / live chat product for this project.
@@ -1353,6 +1362,7 @@ export interface PatchedProjectBackwardCompatApi {
     readonly updated_at?: string | null
     readonly uuid?: string
     readonly api_token?: string
+    /** @items.maxLength 200 */
     app_urls?: (string | null)[]
     /** When true, PostHog drops the IP address from every ingested event. */
     anonymize_ips?: boolean
@@ -1369,609 +1379,610 @@ export interface PatchedProjectBackwardCompatApi {
     path_cleaning_filters?: unknown
     is_demo?: boolean
     /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-
-  * `Africa/Abidjan` - Africa/Abidjan
-  * `Africa/Accra` - Africa/Accra
-  * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-  * `Africa/Algiers` - Africa/Algiers
-  * `Africa/Asmara` - Africa/Asmara
-  * `Africa/Asmera` - Africa/Asmera
-  * `Africa/Bamako` - Africa/Bamako
-  * `Africa/Bangui` - Africa/Bangui
-  * `Africa/Banjul` - Africa/Banjul
-  * `Africa/Bissau` - Africa/Bissau
-  * `Africa/Blantyre` - Africa/Blantyre
-  * `Africa/Brazzaville` - Africa/Brazzaville
-  * `Africa/Bujumbura` - Africa/Bujumbura
-  * `Africa/Cairo` - Africa/Cairo
-  * `Africa/Casablanca` - Africa/Casablanca
-  * `Africa/Ceuta` - Africa/Ceuta
-  * `Africa/Conakry` - Africa/Conakry
-  * `Africa/Dakar` - Africa/Dakar
-  * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-  * `Africa/Djibouti` - Africa/Djibouti
-  * `Africa/Douala` - Africa/Douala
-  * `Africa/El_Aaiun` - Africa/El_Aaiun
-  * `Africa/Freetown` - Africa/Freetown
-  * `Africa/Gaborone` - Africa/Gaborone
-  * `Africa/Harare` - Africa/Harare
-  * `Africa/Johannesburg` - Africa/Johannesburg
-  * `Africa/Juba` - Africa/Juba
-  * `Africa/Kampala` - Africa/Kampala
-  * `Africa/Khartoum` - Africa/Khartoum
-  * `Africa/Kigali` - Africa/Kigali
-  * `Africa/Kinshasa` - Africa/Kinshasa
-  * `Africa/Lagos` - Africa/Lagos
-  * `Africa/Libreville` - Africa/Libreville
-  * `Africa/Lome` - Africa/Lome
-  * `Africa/Luanda` - Africa/Luanda
-  * `Africa/Lubumbashi` - Africa/Lubumbashi
-  * `Africa/Lusaka` - Africa/Lusaka
-  * `Africa/Malabo` - Africa/Malabo
-  * `Africa/Maputo` - Africa/Maputo
-  * `Africa/Maseru` - Africa/Maseru
-  * `Africa/Mbabane` - Africa/Mbabane
-  * `Africa/Mogadishu` - Africa/Mogadishu
-  * `Africa/Monrovia` - Africa/Monrovia
-  * `Africa/Nairobi` - Africa/Nairobi
-  * `Africa/Ndjamena` - Africa/Ndjamena
-  * `Africa/Niamey` - Africa/Niamey
-  * `Africa/Nouakchott` - Africa/Nouakchott
-  * `Africa/Ouagadougou` - Africa/Ouagadougou
-  * `Africa/Porto-Novo` - Africa/Porto-Novo
-  * `Africa/Sao_Tome` - Africa/Sao_Tome
-  * `Africa/Timbuktu` - Africa/Timbuktu
-  * `Africa/Tripoli` - Africa/Tripoli
-  * `Africa/Tunis` - Africa/Tunis
-  * `Africa/Windhoek` - Africa/Windhoek
-  * `America/Adak` - America/Adak
-  * `America/Anchorage` - America/Anchorage
-  * `America/Anguilla` - America/Anguilla
-  * `America/Antigua` - America/Antigua
-  * `America/Araguaina` - America/Araguaina
-  * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-  * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-  * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-  * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-  * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-  * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-  * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-  * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-  * `America/Argentina/Salta` - America/Argentina/Salta
-  * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-  * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-  * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-  * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-  * `America/Aruba` - America/Aruba
-  * `America/Asuncion` - America/Asuncion
-  * `America/Atikokan` - America/Atikokan
-  * `America/Atka` - America/Atka
-  * `America/Bahia` - America/Bahia
-  * `America/Bahia_Banderas` - America/Bahia_Banderas
-  * `America/Barbados` - America/Barbados
-  * `America/Belem` - America/Belem
-  * `America/Belize` - America/Belize
-  * `America/Blanc-Sablon` - America/Blanc-Sablon
-  * `America/Boa_Vista` - America/Boa_Vista
-  * `America/Bogota` - America/Bogota
-  * `America/Boise` - America/Boise
-  * `America/Buenos_Aires` - America/Buenos_Aires
-  * `America/Cambridge_Bay` - America/Cambridge_Bay
-  * `America/Campo_Grande` - America/Campo_Grande
-  * `America/Cancun` - America/Cancun
-  * `America/Caracas` - America/Caracas
-  * `America/Catamarca` - America/Catamarca
-  * `America/Cayenne` - America/Cayenne
-  * `America/Cayman` - America/Cayman
-  * `America/Chicago` - America/Chicago
-  * `America/Chihuahua` - America/Chihuahua
-  * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-  * `America/Coral_Harbour` - America/Coral_Harbour
-  * `America/Cordoba` - America/Cordoba
-  * `America/Costa_Rica` - America/Costa_Rica
-  * `America/Creston` - America/Creston
-  * `America/Cuiaba` - America/Cuiaba
-  * `America/Curacao` - America/Curacao
-  * `America/Danmarkshavn` - America/Danmarkshavn
-  * `America/Dawson` - America/Dawson
-  * `America/Dawson_Creek` - America/Dawson_Creek
-  * `America/Denver` - America/Denver
-  * `America/Detroit` - America/Detroit
-  * `America/Dominica` - America/Dominica
-  * `America/Edmonton` - America/Edmonton
-  * `America/Eirunepe` - America/Eirunepe
-  * `America/El_Salvador` - America/El_Salvador
-  * `America/Ensenada` - America/Ensenada
-  * `America/Fort_Nelson` - America/Fort_Nelson
-  * `America/Fort_Wayne` - America/Fort_Wayne
-  * `America/Fortaleza` - America/Fortaleza
-  * `America/Glace_Bay` - America/Glace_Bay
-  * `America/Godthab` - America/Godthab
-  * `America/Goose_Bay` - America/Goose_Bay
-  * `America/Grand_Turk` - America/Grand_Turk
-  * `America/Grenada` - America/Grenada
-  * `America/Guadeloupe` - America/Guadeloupe
-  * `America/Guatemala` - America/Guatemala
-  * `America/Guayaquil` - America/Guayaquil
-  * `America/Guyana` - America/Guyana
-  * `America/Halifax` - America/Halifax
-  * `America/Havana` - America/Havana
-  * `America/Hermosillo` - America/Hermosillo
-  * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-  * `America/Indiana/Knox` - America/Indiana/Knox
-  * `America/Indiana/Marengo` - America/Indiana/Marengo
-  * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-  * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-  * `America/Indiana/Vevay` - America/Indiana/Vevay
-  * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-  * `America/Indiana/Winamac` - America/Indiana/Winamac
-  * `America/Indianapolis` - America/Indianapolis
-  * `America/Inuvik` - America/Inuvik
-  * `America/Iqaluit` - America/Iqaluit
-  * `America/Jamaica` - America/Jamaica
-  * `America/Jujuy` - America/Jujuy
-  * `America/Juneau` - America/Juneau
-  * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-  * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-  * `America/Knox_IN` - America/Knox_IN
-  * `America/Kralendijk` - America/Kralendijk
-  * `America/La_Paz` - America/La_Paz
-  * `America/Lima` - America/Lima
-  * `America/Los_Angeles` - America/Los_Angeles
-  * `America/Louisville` - America/Louisville
-  * `America/Lower_Princes` - America/Lower_Princes
-  * `America/Maceio` - America/Maceio
-  * `America/Managua` - America/Managua
-  * `America/Manaus` - America/Manaus
-  * `America/Marigot` - America/Marigot
-  * `America/Martinique` - America/Martinique
-  * `America/Matamoros` - America/Matamoros
-  * `America/Mazatlan` - America/Mazatlan
-  * `America/Mendoza` - America/Mendoza
-  * `America/Menominee` - America/Menominee
-  * `America/Merida` - America/Merida
-  * `America/Metlakatla` - America/Metlakatla
-  * `America/Mexico_City` - America/Mexico_City
-  * `America/Miquelon` - America/Miquelon
-  * `America/Moncton` - America/Moncton
-  * `America/Monterrey` - America/Monterrey
-  * `America/Montevideo` - America/Montevideo
-  * `America/Montreal` - America/Montreal
-  * `America/Montserrat` - America/Montserrat
-  * `America/Nassau` - America/Nassau
-  * `America/New_York` - America/New_York
-  * `America/Nipigon` - America/Nipigon
-  * `America/Nome` - America/Nome
-  * `America/Noronha` - America/Noronha
-  * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-  * `America/North_Dakota/Center` - America/North_Dakota/Center
-  * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-  * `America/Nuuk` - America/Nuuk
-  * `America/Ojinaga` - America/Ojinaga
-  * `America/Panama` - America/Panama
-  * `America/Pangnirtung` - America/Pangnirtung
-  * `America/Paramaribo` - America/Paramaribo
-  * `America/Phoenix` - America/Phoenix
-  * `America/Port-au-Prince` - America/Port-au-Prince
-  * `America/Port_of_Spain` - America/Port_of_Spain
-  * `America/Porto_Acre` - America/Porto_Acre
-  * `America/Porto_Velho` - America/Porto_Velho
-  * `America/Puerto_Rico` - America/Puerto_Rico
-  * `America/Punta_Arenas` - America/Punta_Arenas
-  * `America/Rainy_River` - America/Rainy_River
-  * `America/Rankin_Inlet` - America/Rankin_Inlet
-  * `America/Recife` - America/Recife
-  * `America/Regina` - America/Regina
-  * `America/Resolute` - America/Resolute
-  * `America/Rio_Branco` - America/Rio_Branco
-  * `America/Rosario` - America/Rosario
-  * `America/Santa_Isabel` - America/Santa_Isabel
-  * `America/Santarem` - America/Santarem
-  * `America/Santiago` - America/Santiago
-  * `America/Santo_Domingo` - America/Santo_Domingo
-  * `America/Sao_Paulo` - America/Sao_Paulo
-  * `America/Scoresbysund` - America/Scoresbysund
-  * `America/Shiprock` - America/Shiprock
-  * `America/Sitka` - America/Sitka
-  * `America/St_Barthelemy` - America/St_Barthelemy
-  * `America/St_Johns` - America/St_Johns
-  * `America/St_Kitts` - America/St_Kitts
-  * `America/St_Lucia` - America/St_Lucia
-  * `America/St_Thomas` - America/St_Thomas
-  * `America/St_Vincent` - America/St_Vincent
-  * `America/Swift_Current` - America/Swift_Current
-  * `America/Tegucigalpa` - America/Tegucigalpa
-  * `America/Thule` - America/Thule
-  * `America/Thunder_Bay` - America/Thunder_Bay
-  * `America/Tijuana` - America/Tijuana
-  * `America/Toronto` - America/Toronto
-  * `America/Tortola` - America/Tortola
-  * `America/Vancouver` - America/Vancouver
-  * `America/Virgin` - America/Virgin
-  * `America/Whitehorse` - America/Whitehorse
-  * `America/Winnipeg` - America/Winnipeg
-  * `America/Yakutat` - America/Yakutat
-  * `America/Yellowknife` - America/Yellowknife
-  * `Antarctica/Casey` - Antarctica/Casey
-  * `Antarctica/Davis` - Antarctica/Davis
-  * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-  * `Antarctica/Macquarie` - Antarctica/Macquarie
-  * `Antarctica/Mawson` - Antarctica/Mawson
-  * `Antarctica/McMurdo` - Antarctica/McMurdo
-  * `Antarctica/Palmer` - Antarctica/Palmer
-  * `Antarctica/Rothera` - Antarctica/Rothera
-  * `Antarctica/South_Pole` - Antarctica/South_Pole
-  * `Antarctica/Syowa` - Antarctica/Syowa
-  * `Antarctica/Troll` - Antarctica/Troll
-  * `Antarctica/Vostok` - Antarctica/Vostok
-  * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-  * `Asia/Aden` - Asia/Aden
-  * `Asia/Almaty` - Asia/Almaty
-  * `Asia/Amman` - Asia/Amman
-  * `Asia/Anadyr` - Asia/Anadyr
-  * `Asia/Aqtau` - Asia/Aqtau
-  * `Asia/Aqtobe` - Asia/Aqtobe
-  * `Asia/Ashgabat` - Asia/Ashgabat
-  * `Asia/Ashkhabad` - Asia/Ashkhabad
-  * `Asia/Atyrau` - Asia/Atyrau
-  * `Asia/Baghdad` - Asia/Baghdad
-  * `Asia/Bahrain` - Asia/Bahrain
-  * `Asia/Baku` - Asia/Baku
-  * `Asia/Bangkok` - Asia/Bangkok
-  * `Asia/Barnaul` - Asia/Barnaul
-  * `Asia/Beirut` - Asia/Beirut
-  * `Asia/Bishkek` - Asia/Bishkek
-  * `Asia/Brunei` - Asia/Brunei
-  * `Asia/Calcutta` - Asia/Calcutta
-  * `Asia/Chita` - Asia/Chita
-  * `Asia/Choibalsan` - Asia/Choibalsan
-  * `Asia/Chongqing` - Asia/Chongqing
-  * `Asia/Chungking` - Asia/Chungking
-  * `Asia/Colombo` - Asia/Colombo
-  * `Asia/Dacca` - Asia/Dacca
-  * `Asia/Damascus` - Asia/Damascus
-  * `Asia/Dhaka` - Asia/Dhaka
-  * `Asia/Dili` - Asia/Dili
-  * `Asia/Dubai` - Asia/Dubai
-  * `Asia/Dushanbe` - Asia/Dushanbe
-  * `Asia/Famagusta` - Asia/Famagusta
-  * `Asia/Gaza` - Asia/Gaza
-  * `Asia/Harbin` - Asia/Harbin
-  * `Asia/Hebron` - Asia/Hebron
-  * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-  * `Asia/Hong_Kong` - Asia/Hong_Kong
-  * `Asia/Hovd` - Asia/Hovd
-  * `Asia/Irkutsk` - Asia/Irkutsk
-  * `Asia/Istanbul` - Asia/Istanbul
-  * `Asia/Jakarta` - Asia/Jakarta
-  * `Asia/Jayapura` - Asia/Jayapura
-  * `Asia/Jerusalem` - Asia/Jerusalem
-  * `Asia/Kabul` - Asia/Kabul
-  * `Asia/Kamchatka` - Asia/Kamchatka
-  * `Asia/Karachi` - Asia/Karachi
-  * `Asia/Kashgar` - Asia/Kashgar
-  * `Asia/Kathmandu` - Asia/Kathmandu
-  * `Asia/Katmandu` - Asia/Katmandu
-  * `Asia/Khandyga` - Asia/Khandyga
-  * `Asia/Kolkata` - Asia/Kolkata
-  * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-  * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-  * `Asia/Kuching` - Asia/Kuching
-  * `Asia/Kuwait` - Asia/Kuwait
-  * `Asia/Macao` - Asia/Macao
-  * `Asia/Macau` - Asia/Macau
-  * `Asia/Magadan` - Asia/Magadan
-  * `Asia/Makassar` - Asia/Makassar
-  * `Asia/Manila` - Asia/Manila
-  * `Asia/Muscat` - Asia/Muscat
-  * `Asia/Nicosia` - Asia/Nicosia
-  * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-  * `Asia/Novosibirsk` - Asia/Novosibirsk
-  * `Asia/Omsk` - Asia/Omsk
-  * `Asia/Oral` - Asia/Oral
-  * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-  * `Asia/Pontianak` - Asia/Pontianak
-  * `Asia/Pyongyang` - Asia/Pyongyang
-  * `Asia/Qatar` - Asia/Qatar
-  * `Asia/Qostanay` - Asia/Qostanay
-  * `Asia/Qyzylorda` - Asia/Qyzylorda
-  * `Asia/Rangoon` - Asia/Rangoon
-  * `Asia/Riyadh` - Asia/Riyadh
-  * `Asia/Saigon` - Asia/Saigon
-  * `Asia/Sakhalin` - Asia/Sakhalin
-  * `Asia/Samarkand` - Asia/Samarkand
-  * `Asia/Seoul` - Asia/Seoul
-  * `Asia/Shanghai` - Asia/Shanghai
-  * `Asia/Singapore` - Asia/Singapore
-  * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-  * `Asia/Taipei` - Asia/Taipei
-  * `Asia/Tashkent` - Asia/Tashkent
-  * `Asia/Tbilisi` - Asia/Tbilisi
-  * `Asia/Tehran` - Asia/Tehran
-  * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-  * `Asia/Thimbu` - Asia/Thimbu
-  * `Asia/Thimphu` - Asia/Thimphu
-  * `Asia/Tokyo` - Asia/Tokyo
-  * `Asia/Tomsk` - Asia/Tomsk
-  * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-  * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-  * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-  * `Asia/Urumqi` - Asia/Urumqi
-  * `Asia/Ust-Nera` - Asia/Ust-Nera
-  * `Asia/Vientiane` - Asia/Vientiane
-  * `Asia/Vladivostok` - Asia/Vladivostok
-  * `Asia/Yakutsk` - Asia/Yakutsk
-  * `Asia/Yangon` - Asia/Yangon
-  * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-  * `Asia/Yerevan` - Asia/Yerevan
-  * `Atlantic/Azores` - Atlantic/Azores
-  * `Atlantic/Bermuda` - Atlantic/Bermuda
-  * `Atlantic/Canary` - Atlantic/Canary
-  * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-  * `Atlantic/Faeroe` - Atlantic/Faeroe
-  * `Atlantic/Faroe` - Atlantic/Faroe
-  * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-  * `Atlantic/Madeira` - Atlantic/Madeira
-  * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-  * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-  * `Atlantic/St_Helena` - Atlantic/St_Helena
-  * `Atlantic/Stanley` - Atlantic/Stanley
-  * `Australia/ACT` - Australia/ACT
-  * `Australia/Adelaide` - Australia/Adelaide
-  * `Australia/Brisbane` - Australia/Brisbane
-  * `Australia/Broken_Hill` - Australia/Broken_Hill
-  * `Australia/Canberra` - Australia/Canberra
-  * `Australia/Currie` - Australia/Currie
-  * `Australia/Darwin` - Australia/Darwin
-  * `Australia/Eucla` - Australia/Eucla
-  * `Australia/Hobart` - Australia/Hobart
-  * `Australia/LHI` - Australia/LHI
-  * `Australia/Lindeman` - Australia/Lindeman
-  * `Australia/Lord_Howe` - Australia/Lord_Howe
-  * `Australia/Melbourne` - Australia/Melbourne
-  * `Australia/NSW` - Australia/NSW
-  * `Australia/North` - Australia/North
-  * `Australia/Perth` - Australia/Perth
-  * `Australia/Queensland` - Australia/Queensland
-  * `Australia/South` - Australia/South
-  * `Australia/Sydney` - Australia/Sydney
-  * `Australia/Tasmania` - Australia/Tasmania
-  * `Australia/Victoria` - Australia/Victoria
-  * `Australia/West` - Australia/West
-  * `Australia/Yancowinna` - Australia/Yancowinna
-  * `Brazil/Acre` - Brazil/Acre
-  * `Brazil/DeNoronha` - Brazil/DeNoronha
-  * `Brazil/East` - Brazil/East
-  * `Brazil/West` - Brazil/West
-  * `CET` - CET
-  * `CST6CDT` - CST6CDT
-  * `Canada/Atlantic` - Canada/Atlantic
-  * `Canada/Central` - Canada/Central
-  * `Canada/Eastern` - Canada/Eastern
-  * `Canada/Mountain` - Canada/Mountain
-  * `Canada/Newfoundland` - Canada/Newfoundland
-  * `Canada/Pacific` - Canada/Pacific
-  * `Canada/Saskatchewan` - Canada/Saskatchewan
-  * `Canada/Yukon` - Canada/Yukon
-  * `Chile/Continental` - Chile/Continental
-  * `Chile/EasterIsland` - Chile/EasterIsland
-  * `Cuba` - Cuba
-  * `EET` - EET
-  * `EST` - EST
-  * `EST5EDT` - EST5EDT
-  * `Egypt` - Egypt
-  * `Eire` - Eire
-  * `Etc/GMT` - Etc/GMT
-  * `Etc/GMT+0` - Etc/GMT+0
-  * `Etc/GMT+1` - Etc/GMT+1
-  * `Etc/GMT+10` - Etc/GMT+10
-  * `Etc/GMT+11` - Etc/GMT+11
-  * `Etc/GMT+12` - Etc/GMT+12
-  * `Etc/GMT+2` - Etc/GMT+2
-  * `Etc/GMT+3` - Etc/GMT+3
-  * `Etc/GMT+4` - Etc/GMT+4
-  * `Etc/GMT+5` - Etc/GMT+5
-  * `Etc/GMT+6` - Etc/GMT+6
-  * `Etc/GMT+7` - Etc/GMT+7
-  * `Etc/GMT+8` - Etc/GMT+8
-  * `Etc/GMT+9` - Etc/GMT+9
-  * `Etc/GMT-0` - Etc/GMT-0
-  * `Etc/GMT-1` - Etc/GMT-1
-  * `Etc/GMT-10` - Etc/GMT-10
-  * `Etc/GMT-11` - Etc/GMT-11
-  * `Etc/GMT-12` - Etc/GMT-12
-  * `Etc/GMT-13` - Etc/GMT-13
-  * `Etc/GMT-14` - Etc/GMT-14
-  * `Etc/GMT-2` - Etc/GMT-2
-  * `Etc/GMT-3` - Etc/GMT-3
-  * `Etc/GMT-4` - Etc/GMT-4
-  * `Etc/GMT-5` - Etc/GMT-5
-  * `Etc/GMT-6` - Etc/GMT-6
-  * `Etc/GMT-7` - Etc/GMT-7
-  * `Etc/GMT-8` - Etc/GMT-8
-  * `Etc/GMT-9` - Etc/GMT-9
-  * `Etc/GMT0` - Etc/GMT0
-  * `Etc/Greenwich` - Etc/Greenwich
-  * `Etc/UCT` - Etc/UCT
-  * `Etc/UTC` - Etc/UTC
-  * `Etc/Universal` - Etc/Universal
-  * `Etc/Zulu` - Etc/Zulu
-  * `Europe/Amsterdam` - Europe/Amsterdam
-  * `Europe/Andorra` - Europe/Andorra
-  * `Europe/Astrakhan` - Europe/Astrakhan
-  * `Europe/Athens` - Europe/Athens
-  * `Europe/Belfast` - Europe/Belfast
-  * `Europe/Belgrade` - Europe/Belgrade
-  * `Europe/Berlin` - Europe/Berlin
-  * `Europe/Bratislava` - Europe/Bratislava
-  * `Europe/Brussels` - Europe/Brussels
-  * `Europe/Bucharest` - Europe/Bucharest
-  * `Europe/Budapest` - Europe/Budapest
-  * `Europe/Busingen` - Europe/Busingen
-  * `Europe/Chisinau` - Europe/Chisinau
-  * `Europe/Copenhagen` - Europe/Copenhagen
-  * `Europe/Dublin` - Europe/Dublin
-  * `Europe/Gibraltar` - Europe/Gibraltar
-  * `Europe/Guernsey` - Europe/Guernsey
-  * `Europe/Helsinki` - Europe/Helsinki
-  * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-  * `Europe/Istanbul` - Europe/Istanbul
-  * `Europe/Jersey` - Europe/Jersey
-  * `Europe/Kaliningrad` - Europe/Kaliningrad
-  * `Europe/Kiev` - Europe/Kiev
-  * `Europe/Kirov` - Europe/Kirov
-  * `Europe/Kyiv` - Europe/Kyiv
-  * `Europe/Lisbon` - Europe/Lisbon
-  * `Europe/Ljubljana` - Europe/Ljubljana
-  * `Europe/London` - Europe/London
-  * `Europe/Luxembourg` - Europe/Luxembourg
-  * `Europe/Madrid` - Europe/Madrid
-  * `Europe/Malta` - Europe/Malta
-  * `Europe/Mariehamn` - Europe/Mariehamn
-  * `Europe/Minsk` - Europe/Minsk
-  * `Europe/Monaco` - Europe/Monaco
-  * `Europe/Moscow` - Europe/Moscow
-  * `Europe/Nicosia` - Europe/Nicosia
-  * `Europe/Oslo` - Europe/Oslo
-  * `Europe/Paris` - Europe/Paris
-  * `Europe/Podgorica` - Europe/Podgorica
-  * `Europe/Prague` - Europe/Prague
-  * `Europe/Riga` - Europe/Riga
-  * `Europe/Rome` - Europe/Rome
-  * `Europe/Samara` - Europe/Samara
-  * `Europe/San_Marino` - Europe/San_Marino
-  * `Europe/Sarajevo` - Europe/Sarajevo
-  * `Europe/Saratov` - Europe/Saratov
-  * `Europe/Simferopol` - Europe/Simferopol
-  * `Europe/Skopje` - Europe/Skopje
-  * `Europe/Sofia` - Europe/Sofia
-  * `Europe/Stockholm` - Europe/Stockholm
-  * `Europe/Tallinn` - Europe/Tallinn
-  * `Europe/Tirane` - Europe/Tirane
-  * `Europe/Tiraspol` - Europe/Tiraspol
-  * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-  * `Europe/Uzhgorod` - Europe/Uzhgorod
-  * `Europe/Vaduz` - Europe/Vaduz
-  * `Europe/Vatican` - Europe/Vatican
-  * `Europe/Vienna` - Europe/Vienna
-  * `Europe/Vilnius` - Europe/Vilnius
-  * `Europe/Volgograd` - Europe/Volgograd
-  * `Europe/Warsaw` - Europe/Warsaw
-  * `Europe/Zagreb` - Europe/Zagreb
-  * `Europe/Zaporozhye` - Europe/Zaporozhye
-  * `Europe/Zurich` - Europe/Zurich
-  * `GB` - GB
-  * `GB-Eire` - GB-Eire
-  * `GMT` - GMT
-  * `GMT+0` - GMT+0
-  * `GMT-0` - GMT-0
-  * `GMT0` - GMT0
-  * `Greenwich` - Greenwich
-  * `HST` - HST
-  * `Hongkong` - Hongkong
-  * `Iceland` - Iceland
-  * `Indian/Antananarivo` - Indian/Antananarivo
-  * `Indian/Chagos` - Indian/Chagos
-  * `Indian/Christmas` - Indian/Christmas
-  * `Indian/Cocos` - Indian/Cocos
-  * `Indian/Comoro` - Indian/Comoro
-  * `Indian/Kerguelen` - Indian/Kerguelen
-  * `Indian/Mahe` - Indian/Mahe
-  * `Indian/Maldives` - Indian/Maldives
-  * `Indian/Mauritius` - Indian/Mauritius
-  * `Indian/Mayotte` - Indian/Mayotte
-  * `Indian/Reunion` - Indian/Reunion
-  * `Iran` - Iran
-  * `Israel` - Israel
-  * `Jamaica` - Jamaica
-  * `Japan` - Japan
-  * `Kwajalein` - Kwajalein
-  * `Libya` - Libya
-  * `MET` - MET
-  * `MST` - MST
-  * `MST7MDT` - MST7MDT
-  * `Mexico/BajaNorte` - Mexico/BajaNorte
-  * `Mexico/BajaSur` - Mexico/BajaSur
-  * `Mexico/General` - Mexico/General
-  * `NZ` - NZ
-  * `NZ-CHAT` - NZ-CHAT
-  * `Navajo` - Navajo
-  * `PRC` - PRC
-  * `PST8PDT` - PST8PDT
-  * `Pacific/Apia` - Pacific/Apia
-  * `Pacific/Auckland` - Pacific/Auckland
-  * `Pacific/Bougainville` - Pacific/Bougainville
-  * `Pacific/Chatham` - Pacific/Chatham
-  * `Pacific/Chuuk` - Pacific/Chuuk
-  * `Pacific/Easter` - Pacific/Easter
-  * `Pacific/Efate` - Pacific/Efate
-  * `Pacific/Enderbury` - Pacific/Enderbury
-  * `Pacific/Fakaofo` - Pacific/Fakaofo
-  * `Pacific/Fiji` - Pacific/Fiji
-  * `Pacific/Funafuti` - Pacific/Funafuti
-  * `Pacific/Galapagos` - Pacific/Galapagos
-  * `Pacific/Gambier` - Pacific/Gambier
-  * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-  * `Pacific/Guam` - Pacific/Guam
-  * `Pacific/Honolulu` - Pacific/Honolulu
-  * `Pacific/Johnston` - Pacific/Johnston
-  * `Pacific/Kanton` - Pacific/Kanton
-  * `Pacific/Kiritimati` - Pacific/Kiritimati
-  * `Pacific/Kosrae` - Pacific/Kosrae
-  * `Pacific/Kwajalein` - Pacific/Kwajalein
-  * `Pacific/Majuro` - Pacific/Majuro
-  * `Pacific/Marquesas` - Pacific/Marquesas
-  * `Pacific/Midway` - Pacific/Midway
-  * `Pacific/Nauru` - Pacific/Nauru
-  * `Pacific/Niue` - Pacific/Niue
-  * `Pacific/Norfolk` - Pacific/Norfolk
-  * `Pacific/Noumea` - Pacific/Noumea
-  * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-  * `Pacific/Palau` - Pacific/Palau
-  * `Pacific/Pitcairn` - Pacific/Pitcairn
-  * `Pacific/Pohnpei` - Pacific/Pohnpei
-  * `Pacific/Ponape` - Pacific/Ponape
-  * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-  * `Pacific/Rarotonga` - Pacific/Rarotonga
-  * `Pacific/Saipan` - Pacific/Saipan
-  * `Pacific/Samoa` - Pacific/Samoa
-  * `Pacific/Tahiti` - Pacific/Tahiti
-  * `Pacific/Tarawa` - Pacific/Tarawa
-  * `Pacific/Tongatapu` - Pacific/Tongatapu
-  * `Pacific/Truk` - Pacific/Truk
-  * `Pacific/Wake` - Pacific/Wake
-  * `Pacific/Wallis` - Pacific/Wallis
-  * `Pacific/Yap` - Pacific/Yap
-  * `Poland` - Poland
-  * `Portugal` - Portugal
-  * `ROC` - ROC
-  * `ROK` - ROK
-  * `Singapore` - Singapore
-  * `Turkey` - Turkey
-  * `UCT` - UCT
-  * `US/Alaska` - US/Alaska
-  * `US/Aleutian` - US/Aleutian
-  * `US/Arizona` - US/Arizona
-  * `US/Central` - US/Central
-  * `US/East-Indiana` - US/East-Indiana
-  * `US/Eastern` - US/Eastern
-  * `US/Hawaii` - US/Hawaii
-  * `US/Indiana-Starke` - US/Indiana-Starke
-  * `US/Michigan` - US/Michigan
-  * `US/Mountain` - US/Mountain
-  * `US/Pacific` - US/Pacific
-  * `US/Samoa` - US/Samoa
-  * `UTC` - UTC
-  * `Universal` - Universal
-  * `W-SU` - W-SU
-  * `WET` - WET
-  * `Zulu` - Zulu */
+     *
+     * * `Africa/Abidjan` - Africa/Abidjan
+     * * `Africa/Accra` - Africa/Accra
+     * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+     * * `Africa/Algiers` - Africa/Algiers
+     * * `Africa/Asmara` - Africa/Asmara
+     * * `Africa/Asmera` - Africa/Asmera
+     * * `Africa/Bamako` - Africa/Bamako
+     * * `Africa/Bangui` - Africa/Bangui
+     * * `Africa/Banjul` - Africa/Banjul
+     * * `Africa/Bissau` - Africa/Bissau
+     * * `Africa/Blantyre` - Africa/Blantyre
+     * * `Africa/Brazzaville` - Africa/Brazzaville
+     * * `Africa/Bujumbura` - Africa/Bujumbura
+     * * `Africa/Cairo` - Africa/Cairo
+     * * `Africa/Casablanca` - Africa/Casablanca
+     * * `Africa/Ceuta` - Africa/Ceuta
+     * * `Africa/Conakry` - Africa/Conakry
+     * * `Africa/Dakar` - Africa/Dakar
+     * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+     * * `Africa/Djibouti` - Africa/Djibouti
+     * * `Africa/Douala` - Africa/Douala
+     * * `Africa/El_Aaiun` - Africa/El_Aaiun
+     * * `Africa/Freetown` - Africa/Freetown
+     * * `Africa/Gaborone` - Africa/Gaborone
+     * * `Africa/Harare` - Africa/Harare
+     * * `Africa/Johannesburg` - Africa/Johannesburg
+     * * `Africa/Juba` - Africa/Juba
+     * * `Africa/Kampala` - Africa/Kampala
+     * * `Africa/Khartoum` - Africa/Khartoum
+     * * `Africa/Kigali` - Africa/Kigali
+     * * `Africa/Kinshasa` - Africa/Kinshasa
+     * * `Africa/Lagos` - Africa/Lagos
+     * * `Africa/Libreville` - Africa/Libreville
+     * * `Africa/Lome` - Africa/Lome
+     * * `Africa/Luanda` - Africa/Luanda
+     * * `Africa/Lubumbashi` - Africa/Lubumbashi
+     * * `Africa/Lusaka` - Africa/Lusaka
+     * * `Africa/Malabo` - Africa/Malabo
+     * * `Africa/Maputo` - Africa/Maputo
+     * * `Africa/Maseru` - Africa/Maseru
+     * * `Africa/Mbabane` - Africa/Mbabane
+     * * `Africa/Mogadishu` - Africa/Mogadishu
+     * * `Africa/Monrovia` - Africa/Monrovia
+     * * `Africa/Nairobi` - Africa/Nairobi
+     * * `Africa/Ndjamena` - Africa/Ndjamena
+     * * `Africa/Niamey` - Africa/Niamey
+     * * `Africa/Nouakchott` - Africa/Nouakchott
+     * * `Africa/Ouagadougou` - Africa/Ouagadougou
+     * * `Africa/Porto-Novo` - Africa/Porto-Novo
+     * * `Africa/Sao_Tome` - Africa/Sao_Tome
+     * * `Africa/Timbuktu` - Africa/Timbuktu
+     * * `Africa/Tripoli` - Africa/Tripoli
+     * * `Africa/Tunis` - Africa/Tunis
+     * * `Africa/Windhoek` - Africa/Windhoek
+     * * `America/Adak` - America/Adak
+     * * `America/Anchorage` - America/Anchorage
+     * * `America/Anguilla` - America/Anguilla
+     * * `America/Antigua` - America/Antigua
+     * * `America/Araguaina` - America/Araguaina
+     * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+     * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+     * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+     * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+     * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+     * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+     * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+     * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+     * * `America/Argentina/Salta` - America/Argentina/Salta
+     * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+     * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+     * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+     * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+     * * `America/Aruba` - America/Aruba
+     * * `America/Asuncion` - America/Asuncion
+     * * `America/Atikokan` - America/Atikokan
+     * * `America/Atka` - America/Atka
+     * * `America/Bahia` - America/Bahia
+     * * `America/Bahia_Banderas` - America/Bahia_Banderas
+     * * `America/Barbados` - America/Barbados
+     * * `America/Belem` - America/Belem
+     * * `America/Belize` - America/Belize
+     * * `America/Blanc-Sablon` - America/Blanc-Sablon
+     * * `America/Boa_Vista` - America/Boa_Vista
+     * * `America/Bogota` - America/Bogota
+     * * `America/Boise` - America/Boise
+     * * `America/Buenos_Aires` - America/Buenos_Aires
+     * * `America/Cambridge_Bay` - America/Cambridge_Bay
+     * * `America/Campo_Grande` - America/Campo_Grande
+     * * `America/Cancun` - America/Cancun
+     * * `America/Caracas` - America/Caracas
+     * * `America/Catamarca` - America/Catamarca
+     * * `America/Cayenne` - America/Cayenne
+     * * `America/Cayman` - America/Cayman
+     * * `America/Chicago` - America/Chicago
+     * * `America/Chihuahua` - America/Chihuahua
+     * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+     * * `America/Coral_Harbour` - America/Coral_Harbour
+     * * `America/Cordoba` - America/Cordoba
+     * * `America/Costa_Rica` - America/Costa_Rica
+     * * `America/Creston` - America/Creston
+     * * `America/Cuiaba` - America/Cuiaba
+     * * `America/Curacao` - America/Curacao
+     * * `America/Danmarkshavn` - America/Danmarkshavn
+     * * `America/Dawson` - America/Dawson
+     * * `America/Dawson_Creek` - America/Dawson_Creek
+     * * `America/Denver` - America/Denver
+     * * `America/Detroit` - America/Detroit
+     * * `America/Dominica` - America/Dominica
+     * * `America/Edmonton` - America/Edmonton
+     * * `America/Eirunepe` - America/Eirunepe
+     * * `America/El_Salvador` - America/El_Salvador
+     * * `America/Ensenada` - America/Ensenada
+     * * `America/Fort_Nelson` - America/Fort_Nelson
+     * * `America/Fort_Wayne` - America/Fort_Wayne
+     * * `America/Fortaleza` - America/Fortaleza
+     * * `America/Glace_Bay` - America/Glace_Bay
+     * * `America/Godthab` - America/Godthab
+     * * `America/Goose_Bay` - America/Goose_Bay
+     * * `America/Grand_Turk` - America/Grand_Turk
+     * * `America/Grenada` - America/Grenada
+     * * `America/Guadeloupe` - America/Guadeloupe
+     * * `America/Guatemala` - America/Guatemala
+     * * `America/Guayaquil` - America/Guayaquil
+     * * `America/Guyana` - America/Guyana
+     * * `America/Halifax` - America/Halifax
+     * * `America/Havana` - America/Havana
+     * * `America/Hermosillo` - America/Hermosillo
+     * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+     * * `America/Indiana/Knox` - America/Indiana/Knox
+     * * `America/Indiana/Marengo` - America/Indiana/Marengo
+     * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+     * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+     * * `America/Indiana/Vevay` - America/Indiana/Vevay
+     * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+     * * `America/Indiana/Winamac` - America/Indiana/Winamac
+     * * `America/Indianapolis` - America/Indianapolis
+     * * `America/Inuvik` - America/Inuvik
+     * * `America/Iqaluit` - America/Iqaluit
+     * * `America/Jamaica` - America/Jamaica
+     * * `America/Jujuy` - America/Jujuy
+     * * `America/Juneau` - America/Juneau
+     * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+     * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+     * * `America/Knox_IN` - America/Knox_IN
+     * * `America/Kralendijk` - America/Kralendijk
+     * * `America/La_Paz` - America/La_Paz
+     * * `America/Lima` - America/Lima
+     * * `America/Los_Angeles` - America/Los_Angeles
+     * * `America/Louisville` - America/Louisville
+     * * `America/Lower_Princes` - America/Lower_Princes
+     * * `America/Maceio` - America/Maceio
+     * * `America/Managua` - America/Managua
+     * * `America/Manaus` - America/Manaus
+     * * `America/Marigot` - America/Marigot
+     * * `America/Martinique` - America/Martinique
+     * * `America/Matamoros` - America/Matamoros
+     * * `America/Mazatlan` - America/Mazatlan
+     * * `America/Mendoza` - America/Mendoza
+     * * `America/Menominee` - America/Menominee
+     * * `America/Merida` - America/Merida
+     * * `America/Metlakatla` - America/Metlakatla
+     * * `America/Mexico_City` - America/Mexico_City
+     * * `America/Miquelon` - America/Miquelon
+     * * `America/Moncton` - America/Moncton
+     * * `America/Monterrey` - America/Monterrey
+     * * `America/Montevideo` - America/Montevideo
+     * * `America/Montreal` - America/Montreal
+     * * `America/Montserrat` - America/Montserrat
+     * * `America/Nassau` - America/Nassau
+     * * `America/New_York` - America/New_York
+     * * `America/Nipigon` - America/Nipigon
+     * * `America/Nome` - America/Nome
+     * * `America/Noronha` - America/Noronha
+     * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+     * * `America/North_Dakota/Center` - America/North_Dakota/Center
+     * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+     * * `America/Nuuk` - America/Nuuk
+     * * `America/Ojinaga` - America/Ojinaga
+     * * `America/Panama` - America/Panama
+     * * `America/Pangnirtung` - America/Pangnirtung
+     * * `America/Paramaribo` - America/Paramaribo
+     * * `America/Phoenix` - America/Phoenix
+     * * `America/Port-au-Prince` - America/Port-au-Prince
+     * * `America/Port_of_Spain` - America/Port_of_Spain
+     * * `America/Porto_Acre` - America/Porto_Acre
+     * * `America/Porto_Velho` - America/Porto_Velho
+     * * `America/Puerto_Rico` - America/Puerto_Rico
+     * * `America/Punta_Arenas` - America/Punta_Arenas
+     * * `America/Rainy_River` - America/Rainy_River
+     * * `America/Rankin_Inlet` - America/Rankin_Inlet
+     * * `America/Recife` - America/Recife
+     * * `America/Regina` - America/Regina
+     * * `America/Resolute` - America/Resolute
+     * * `America/Rio_Branco` - America/Rio_Branco
+     * * `America/Rosario` - America/Rosario
+     * * `America/Santa_Isabel` - America/Santa_Isabel
+     * * `America/Santarem` - America/Santarem
+     * * `America/Santiago` - America/Santiago
+     * * `America/Santo_Domingo` - America/Santo_Domingo
+     * * `America/Sao_Paulo` - America/Sao_Paulo
+     * * `America/Scoresbysund` - America/Scoresbysund
+     * * `America/Shiprock` - America/Shiprock
+     * * `America/Sitka` - America/Sitka
+     * * `America/St_Barthelemy` - America/St_Barthelemy
+     * * `America/St_Johns` - America/St_Johns
+     * * `America/St_Kitts` - America/St_Kitts
+     * * `America/St_Lucia` - America/St_Lucia
+     * * `America/St_Thomas` - America/St_Thomas
+     * * `America/St_Vincent` - America/St_Vincent
+     * * `America/Swift_Current` - America/Swift_Current
+     * * `America/Tegucigalpa` - America/Tegucigalpa
+     * * `America/Thule` - America/Thule
+     * * `America/Thunder_Bay` - America/Thunder_Bay
+     * * `America/Tijuana` - America/Tijuana
+     * * `America/Toronto` - America/Toronto
+     * * `America/Tortola` - America/Tortola
+     * * `America/Vancouver` - America/Vancouver
+     * * `America/Virgin` - America/Virgin
+     * * `America/Whitehorse` - America/Whitehorse
+     * * `America/Winnipeg` - America/Winnipeg
+     * * `America/Yakutat` - America/Yakutat
+     * * `America/Yellowknife` - America/Yellowknife
+     * * `Antarctica/Casey` - Antarctica/Casey
+     * * `Antarctica/Davis` - Antarctica/Davis
+     * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+     * * `Antarctica/Macquarie` - Antarctica/Macquarie
+     * * `Antarctica/Mawson` - Antarctica/Mawson
+     * * `Antarctica/McMurdo` - Antarctica/McMurdo
+     * * `Antarctica/Palmer` - Antarctica/Palmer
+     * * `Antarctica/Rothera` - Antarctica/Rothera
+     * * `Antarctica/South_Pole` - Antarctica/South_Pole
+     * * `Antarctica/Syowa` - Antarctica/Syowa
+     * * `Antarctica/Troll` - Antarctica/Troll
+     * * `Antarctica/Vostok` - Antarctica/Vostok
+     * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+     * * `Asia/Aden` - Asia/Aden
+     * * `Asia/Almaty` - Asia/Almaty
+     * * `Asia/Amman` - Asia/Amman
+     * * `Asia/Anadyr` - Asia/Anadyr
+     * * `Asia/Aqtau` - Asia/Aqtau
+     * * `Asia/Aqtobe` - Asia/Aqtobe
+     * * `Asia/Ashgabat` - Asia/Ashgabat
+     * * `Asia/Ashkhabad` - Asia/Ashkhabad
+     * * `Asia/Atyrau` - Asia/Atyrau
+     * * `Asia/Baghdad` - Asia/Baghdad
+     * * `Asia/Bahrain` - Asia/Bahrain
+     * * `Asia/Baku` - Asia/Baku
+     * * `Asia/Bangkok` - Asia/Bangkok
+     * * `Asia/Barnaul` - Asia/Barnaul
+     * * `Asia/Beirut` - Asia/Beirut
+     * * `Asia/Bishkek` - Asia/Bishkek
+     * * `Asia/Brunei` - Asia/Brunei
+     * * `Asia/Calcutta` - Asia/Calcutta
+     * * `Asia/Chita` - Asia/Chita
+     * * `Asia/Choibalsan` - Asia/Choibalsan
+     * * `Asia/Chongqing` - Asia/Chongqing
+     * * `Asia/Chungking` - Asia/Chungking
+     * * `Asia/Colombo` - Asia/Colombo
+     * * `Asia/Dacca` - Asia/Dacca
+     * * `Asia/Damascus` - Asia/Damascus
+     * * `Asia/Dhaka` - Asia/Dhaka
+     * * `Asia/Dili` - Asia/Dili
+     * * `Asia/Dubai` - Asia/Dubai
+     * * `Asia/Dushanbe` - Asia/Dushanbe
+     * * `Asia/Famagusta` - Asia/Famagusta
+     * * `Asia/Gaza` - Asia/Gaza
+     * * `Asia/Harbin` - Asia/Harbin
+     * * `Asia/Hebron` - Asia/Hebron
+     * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+     * * `Asia/Hong_Kong` - Asia/Hong_Kong
+     * * `Asia/Hovd` - Asia/Hovd
+     * * `Asia/Irkutsk` - Asia/Irkutsk
+     * * `Asia/Istanbul` - Asia/Istanbul
+     * * `Asia/Jakarta` - Asia/Jakarta
+     * * `Asia/Jayapura` - Asia/Jayapura
+     * * `Asia/Jerusalem` - Asia/Jerusalem
+     * * `Asia/Kabul` - Asia/Kabul
+     * * `Asia/Kamchatka` - Asia/Kamchatka
+     * * `Asia/Karachi` - Asia/Karachi
+     * * `Asia/Kashgar` - Asia/Kashgar
+     * * `Asia/Kathmandu` - Asia/Kathmandu
+     * * `Asia/Katmandu` - Asia/Katmandu
+     * * `Asia/Khandyga` - Asia/Khandyga
+     * * `Asia/Kolkata` - Asia/Kolkata
+     * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+     * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+     * * `Asia/Kuching` - Asia/Kuching
+     * * `Asia/Kuwait` - Asia/Kuwait
+     * * `Asia/Macao` - Asia/Macao
+     * * `Asia/Macau` - Asia/Macau
+     * * `Asia/Magadan` - Asia/Magadan
+     * * `Asia/Makassar` - Asia/Makassar
+     * * `Asia/Manila` - Asia/Manila
+     * * `Asia/Muscat` - Asia/Muscat
+     * * `Asia/Nicosia` - Asia/Nicosia
+     * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+     * * `Asia/Novosibirsk` - Asia/Novosibirsk
+     * * `Asia/Omsk` - Asia/Omsk
+     * * `Asia/Oral` - Asia/Oral
+     * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+     * * `Asia/Pontianak` - Asia/Pontianak
+     * * `Asia/Pyongyang` - Asia/Pyongyang
+     * * `Asia/Qatar` - Asia/Qatar
+     * * `Asia/Qostanay` - Asia/Qostanay
+     * * `Asia/Qyzylorda` - Asia/Qyzylorda
+     * * `Asia/Rangoon` - Asia/Rangoon
+     * * `Asia/Riyadh` - Asia/Riyadh
+     * * `Asia/Saigon` - Asia/Saigon
+     * * `Asia/Sakhalin` - Asia/Sakhalin
+     * * `Asia/Samarkand` - Asia/Samarkand
+     * * `Asia/Seoul` - Asia/Seoul
+     * * `Asia/Shanghai` - Asia/Shanghai
+     * * `Asia/Singapore` - Asia/Singapore
+     * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+     * * `Asia/Taipei` - Asia/Taipei
+     * * `Asia/Tashkent` - Asia/Tashkent
+     * * `Asia/Tbilisi` - Asia/Tbilisi
+     * * `Asia/Tehran` - Asia/Tehran
+     * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+     * * `Asia/Thimbu` - Asia/Thimbu
+     * * `Asia/Thimphu` - Asia/Thimphu
+     * * `Asia/Tokyo` - Asia/Tokyo
+     * * `Asia/Tomsk` - Asia/Tomsk
+     * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+     * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+     * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+     * * `Asia/Urumqi` - Asia/Urumqi
+     * * `Asia/Ust-Nera` - Asia/Ust-Nera
+     * * `Asia/Vientiane` - Asia/Vientiane
+     * * `Asia/Vladivostok` - Asia/Vladivostok
+     * * `Asia/Yakutsk` - Asia/Yakutsk
+     * * `Asia/Yangon` - Asia/Yangon
+     * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+     * * `Asia/Yerevan` - Asia/Yerevan
+     * * `Atlantic/Azores` - Atlantic/Azores
+     * * `Atlantic/Bermuda` - Atlantic/Bermuda
+     * * `Atlantic/Canary` - Atlantic/Canary
+     * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+     * * `Atlantic/Faeroe` - Atlantic/Faeroe
+     * * `Atlantic/Faroe` - Atlantic/Faroe
+     * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+     * * `Atlantic/Madeira` - Atlantic/Madeira
+     * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+     * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+     * * `Atlantic/St_Helena` - Atlantic/St_Helena
+     * * `Atlantic/Stanley` - Atlantic/Stanley
+     * * `Australia/ACT` - Australia/ACT
+     * * `Australia/Adelaide` - Australia/Adelaide
+     * * `Australia/Brisbane` - Australia/Brisbane
+     * * `Australia/Broken_Hill` - Australia/Broken_Hill
+     * * `Australia/Canberra` - Australia/Canberra
+     * * `Australia/Currie` - Australia/Currie
+     * * `Australia/Darwin` - Australia/Darwin
+     * * `Australia/Eucla` - Australia/Eucla
+     * * `Australia/Hobart` - Australia/Hobart
+     * * `Australia/LHI` - Australia/LHI
+     * * `Australia/Lindeman` - Australia/Lindeman
+     * * `Australia/Lord_Howe` - Australia/Lord_Howe
+     * * `Australia/Melbourne` - Australia/Melbourne
+     * * `Australia/NSW` - Australia/NSW
+     * * `Australia/North` - Australia/North
+     * * `Australia/Perth` - Australia/Perth
+     * * `Australia/Queensland` - Australia/Queensland
+     * * `Australia/South` - Australia/South
+     * * `Australia/Sydney` - Australia/Sydney
+     * * `Australia/Tasmania` - Australia/Tasmania
+     * * `Australia/Victoria` - Australia/Victoria
+     * * `Australia/West` - Australia/West
+     * * `Australia/Yancowinna` - Australia/Yancowinna
+     * * `Brazil/Acre` - Brazil/Acre
+     * * `Brazil/DeNoronha` - Brazil/DeNoronha
+     * * `Brazil/East` - Brazil/East
+     * * `Brazil/West` - Brazil/West
+     * * `CET` - CET
+     * * `CST6CDT` - CST6CDT
+     * * `Canada/Atlantic` - Canada/Atlantic
+     * * `Canada/Central` - Canada/Central
+     * * `Canada/Eastern` - Canada/Eastern
+     * * `Canada/Mountain` - Canada/Mountain
+     * * `Canada/Newfoundland` - Canada/Newfoundland
+     * * `Canada/Pacific` - Canada/Pacific
+     * * `Canada/Saskatchewan` - Canada/Saskatchewan
+     * * `Canada/Yukon` - Canada/Yukon
+     * * `Chile/Continental` - Chile/Continental
+     * * `Chile/EasterIsland` - Chile/EasterIsland
+     * * `Cuba` - Cuba
+     * * `EET` - EET
+     * * `EST` - EST
+     * * `EST5EDT` - EST5EDT
+     * * `Egypt` - Egypt
+     * * `Eire` - Eire
+     * * `Etc/GMT` - Etc/GMT
+     * * `Etc/GMT+0` - Etc/GMT+0
+     * * `Etc/GMT+1` - Etc/GMT+1
+     * * `Etc/GMT+10` - Etc/GMT+10
+     * * `Etc/GMT+11` - Etc/GMT+11
+     * * `Etc/GMT+12` - Etc/GMT+12
+     * * `Etc/GMT+2` - Etc/GMT+2
+     * * `Etc/GMT+3` - Etc/GMT+3
+     * * `Etc/GMT+4` - Etc/GMT+4
+     * * `Etc/GMT+5` - Etc/GMT+5
+     * * `Etc/GMT+6` - Etc/GMT+6
+     * * `Etc/GMT+7` - Etc/GMT+7
+     * * `Etc/GMT+8` - Etc/GMT+8
+     * * `Etc/GMT+9` - Etc/GMT+9
+     * * `Etc/GMT-0` - Etc/GMT-0
+     * * `Etc/GMT-1` - Etc/GMT-1
+     * * `Etc/GMT-10` - Etc/GMT-10
+     * * `Etc/GMT-11` - Etc/GMT-11
+     * * `Etc/GMT-12` - Etc/GMT-12
+     * * `Etc/GMT-13` - Etc/GMT-13
+     * * `Etc/GMT-14` - Etc/GMT-14
+     * * `Etc/GMT-2` - Etc/GMT-2
+     * * `Etc/GMT-3` - Etc/GMT-3
+     * * `Etc/GMT-4` - Etc/GMT-4
+     * * `Etc/GMT-5` - Etc/GMT-5
+     * * `Etc/GMT-6` - Etc/GMT-6
+     * * `Etc/GMT-7` - Etc/GMT-7
+     * * `Etc/GMT-8` - Etc/GMT-8
+     * * `Etc/GMT-9` - Etc/GMT-9
+     * * `Etc/GMT0` - Etc/GMT0
+     * * `Etc/Greenwich` - Etc/Greenwich
+     * * `Etc/UCT` - Etc/UCT
+     * * `Etc/UTC` - Etc/UTC
+     * * `Etc/Universal` - Etc/Universal
+     * * `Etc/Zulu` - Etc/Zulu
+     * * `Europe/Amsterdam` - Europe/Amsterdam
+     * * `Europe/Andorra` - Europe/Andorra
+     * * `Europe/Astrakhan` - Europe/Astrakhan
+     * * `Europe/Athens` - Europe/Athens
+     * * `Europe/Belfast` - Europe/Belfast
+     * * `Europe/Belgrade` - Europe/Belgrade
+     * * `Europe/Berlin` - Europe/Berlin
+     * * `Europe/Bratislava` - Europe/Bratislava
+     * * `Europe/Brussels` - Europe/Brussels
+     * * `Europe/Bucharest` - Europe/Bucharest
+     * * `Europe/Budapest` - Europe/Budapest
+     * * `Europe/Busingen` - Europe/Busingen
+     * * `Europe/Chisinau` - Europe/Chisinau
+     * * `Europe/Copenhagen` - Europe/Copenhagen
+     * * `Europe/Dublin` - Europe/Dublin
+     * * `Europe/Gibraltar` - Europe/Gibraltar
+     * * `Europe/Guernsey` - Europe/Guernsey
+     * * `Europe/Helsinki` - Europe/Helsinki
+     * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+     * * `Europe/Istanbul` - Europe/Istanbul
+     * * `Europe/Jersey` - Europe/Jersey
+     * * `Europe/Kaliningrad` - Europe/Kaliningrad
+     * * `Europe/Kiev` - Europe/Kiev
+     * * `Europe/Kirov` - Europe/Kirov
+     * * `Europe/Kyiv` - Europe/Kyiv
+     * * `Europe/Lisbon` - Europe/Lisbon
+     * * `Europe/Ljubljana` - Europe/Ljubljana
+     * * `Europe/London` - Europe/London
+     * * `Europe/Luxembourg` - Europe/Luxembourg
+     * * `Europe/Madrid` - Europe/Madrid
+     * * `Europe/Malta` - Europe/Malta
+     * * `Europe/Mariehamn` - Europe/Mariehamn
+     * * `Europe/Minsk` - Europe/Minsk
+     * * `Europe/Monaco` - Europe/Monaco
+     * * `Europe/Moscow` - Europe/Moscow
+     * * `Europe/Nicosia` - Europe/Nicosia
+     * * `Europe/Oslo` - Europe/Oslo
+     * * `Europe/Paris` - Europe/Paris
+     * * `Europe/Podgorica` - Europe/Podgorica
+     * * `Europe/Prague` - Europe/Prague
+     * * `Europe/Riga` - Europe/Riga
+     * * `Europe/Rome` - Europe/Rome
+     * * `Europe/Samara` - Europe/Samara
+     * * `Europe/San_Marino` - Europe/San_Marino
+     * * `Europe/Sarajevo` - Europe/Sarajevo
+     * * `Europe/Saratov` - Europe/Saratov
+     * * `Europe/Simferopol` - Europe/Simferopol
+     * * `Europe/Skopje` - Europe/Skopje
+     * * `Europe/Sofia` - Europe/Sofia
+     * * `Europe/Stockholm` - Europe/Stockholm
+     * * `Europe/Tallinn` - Europe/Tallinn
+     * * `Europe/Tirane` - Europe/Tirane
+     * * `Europe/Tiraspol` - Europe/Tiraspol
+     * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+     * * `Europe/Uzhgorod` - Europe/Uzhgorod
+     * * `Europe/Vaduz` - Europe/Vaduz
+     * * `Europe/Vatican` - Europe/Vatican
+     * * `Europe/Vienna` - Europe/Vienna
+     * * `Europe/Vilnius` - Europe/Vilnius
+     * * `Europe/Volgograd` - Europe/Volgograd
+     * * `Europe/Warsaw` - Europe/Warsaw
+     * * `Europe/Zagreb` - Europe/Zagreb
+     * * `Europe/Zaporozhye` - Europe/Zaporozhye
+     * * `Europe/Zurich` - Europe/Zurich
+     * * `GB` - GB
+     * * `GB-Eire` - GB-Eire
+     * * `GMT` - GMT
+     * * `GMT+0` - GMT+0
+     * * `GMT-0` - GMT-0
+     * * `GMT0` - GMT0
+     * * `Greenwich` - Greenwich
+     * * `HST` - HST
+     * * `Hongkong` - Hongkong
+     * * `Iceland` - Iceland
+     * * `Indian/Antananarivo` - Indian/Antananarivo
+     * * `Indian/Chagos` - Indian/Chagos
+     * * `Indian/Christmas` - Indian/Christmas
+     * * `Indian/Cocos` - Indian/Cocos
+     * * `Indian/Comoro` - Indian/Comoro
+     * * `Indian/Kerguelen` - Indian/Kerguelen
+     * * `Indian/Mahe` - Indian/Mahe
+     * * `Indian/Maldives` - Indian/Maldives
+     * * `Indian/Mauritius` - Indian/Mauritius
+     * * `Indian/Mayotte` - Indian/Mayotte
+     * * `Indian/Reunion` - Indian/Reunion
+     * * `Iran` - Iran
+     * * `Israel` - Israel
+     * * `Jamaica` - Jamaica
+     * * `Japan` - Japan
+     * * `Kwajalein` - Kwajalein
+     * * `Libya` - Libya
+     * * `MET` - MET
+     * * `MST` - MST
+     * * `MST7MDT` - MST7MDT
+     * * `Mexico/BajaNorte` - Mexico/BajaNorte
+     * * `Mexico/BajaSur` - Mexico/BajaSur
+     * * `Mexico/General` - Mexico/General
+     * * `NZ` - NZ
+     * * `NZ-CHAT` - NZ-CHAT
+     * * `Navajo` - Navajo
+     * * `PRC` - PRC
+     * * `PST8PDT` - PST8PDT
+     * * `Pacific/Apia` - Pacific/Apia
+     * * `Pacific/Auckland` - Pacific/Auckland
+     * * `Pacific/Bougainville` - Pacific/Bougainville
+     * * `Pacific/Chatham` - Pacific/Chatham
+     * * `Pacific/Chuuk` - Pacific/Chuuk
+     * * `Pacific/Easter` - Pacific/Easter
+     * * `Pacific/Efate` - Pacific/Efate
+     * * `Pacific/Enderbury` - Pacific/Enderbury
+     * * `Pacific/Fakaofo` - Pacific/Fakaofo
+     * * `Pacific/Fiji` - Pacific/Fiji
+     * * `Pacific/Funafuti` - Pacific/Funafuti
+     * * `Pacific/Galapagos` - Pacific/Galapagos
+     * * `Pacific/Gambier` - Pacific/Gambier
+     * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+     * * `Pacific/Guam` - Pacific/Guam
+     * * `Pacific/Honolulu` - Pacific/Honolulu
+     * * `Pacific/Johnston` - Pacific/Johnston
+     * * `Pacific/Kanton` - Pacific/Kanton
+     * * `Pacific/Kiritimati` - Pacific/Kiritimati
+     * * `Pacific/Kosrae` - Pacific/Kosrae
+     * * `Pacific/Kwajalein` - Pacific/Kwajalein
+     * * `Pacific/Majuro` - Pacific/Majuro
+     * * `Pacific/Marquesas` - Pacific/Marquesas
+     * * `Pacific/Midway` - Pacific/Midway
+     * * `Pacific/Nauru` - Pacific/Nauru
+     * * `Pacific/Niue` - Pacific/Niue
+     * * `Pacific/Norfolk` - Pacific/Norfolk
+     * * `Pacific/Noumea` - Pacific/Noumea
+     * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+     * * `Pacific/Palau` - Pacific/Palau
+     * * `Pacific/Pitcairn` - Pacific/Pitcairn
+     * * `Pacific/Pohnpei` - Pacific/Pohnpei
+     * * `Pacific/Ponape` - Pacific/Ponape
+     * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+     * * `Pacific/Rarotonga` - Pacific/Rarotonga
+     * * `Pacific/Saipan` - Pacific/Saipan
+     * * `Pacific/Samoa` - Pacific/Samoa
+     * * `Pacific/Tahiti` - Pacific/Tahiti
+     * * `Pacific/Tarawa` - Pacific/Tarawa
+     * * `Pacific/Tongatapu` - Pacific/Tongatapu
+     * * `Pacific/Truk` - Pacific/Truk
+     * * `Pacific/Wake` - Pacific/Wake
+     * * `Pacific/Wallis` - Pacific/Wallis
+     * * `Pacific/Yap` - Pacific/Yap
+     * * `Poland` - Poland
+     * * `Portugal` - Portugal
+     * * `ROC` - ROC
+     * * `ROK` - ROK
+     * * `Singapore` - Singapore
+     * * `Turkey` - Turkey
+     * * `UCT` - UCT
+     * * `US/Alaska` - US/Alaska
+     * * `US/Aleutian` - US/Aleutian
+     * * `US/Arizona` - US/Arizona
+     * * `US/Central` - US/Central
+     * * `US/East-Indiana` - US/East-Indiana
+     * * `US/Eastern` - US/Eastern
+     * * `US/Hawaii` - US/Hawaii
+     * * `US/Indiana-Starke` - US/Indiana-Starke
+     * * `US/Michigan` - US/Michigan
+     * * `US/Mountain` - US/Mountain
+     * * `US/Pacific` - US/Pacific
+     * * `US/Samoa` - US/Samoa
+     * * `UTC` - UTC
+     * * `Universal` - Universal
+     * * `W-SU` - W-SU
+     * * `WET` - WET
+     * * `Zulu` - Zulu */
     timezone?: string
     /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
     data_attributes?: unknown
     /**
      * Ordered list of person properties used to render a human-friendly display name in the UI.
      * @nullable
+     * @items.maxLength 400
      */
     person_display_name_properties?: string[] | null
     correlation_config?: unknown
@@ -2034,19 +2045,19 @@ export interface PatchedProjectBackwardCompatApi {
     /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
     session_recording_trigger_groups?: unknown
     /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-
-  * `30d` - 30 Days
-  * `90d` - 90 Days
-  * `1y` - 1 Year
-  * `5y` - 5 Years */
+     *
+     * * `30d` - 30 Days
+     * * `90d` - 90 Days
+     * * `1y` - 1 Year
+     * * `5y` - 5 Years */
     session_recording_retention_period?: SessionRecordingRetentionPeriodEnumApi
     session_replay_config?: unknown
     survey_config?: unknown
     access_control?: boolean
     /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-
-  * `0` - Sunday
-  * `1` - Monday */
+     *
+     * * `0` - Sunday
+     * * `1` - Monday */
     week_start_day?: WeekStartDayEnumApi | null
     /**
      * ID of the dashboard shown as the project's default landing dashboard.
@@ -2058,6 +2069,7 @@ export interface PatchedProjectBackwardCompatApi {
     /**
      * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
      * @nullable
+     * @items.maxLength 200
      */
     recording_domains?: (string | null)[] | null
     readonly person_on_events_querying_enabled?: boolean
@@ -2090,10 +2102,10 @@ export interface PatchedProjectBackwardCompatApi {
     /** @nullable */
     receive_org_level_activity_logs?: boolean | null
     /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-
-  * `b2b` - B2B
-  * `b2c` - B2C
-  * `other` - Other */
+     *
+     * * `b2b` - B2B
+     * * `b2c` - B2C
+     * * `other` - Other */
     business_model?: BusinessModelEnumApi | BlankEnumApi | null
     /**
      * Enables the customer conversations / live chat product for this project.
@@ -2331,8 +2343,8 @@ export interface FileSystemShortcutReorderApi {
 
 /**
  * * `home` - Home
- * `pinned` - Pinned
- * `custom_products` - Custom Products
+ * * `pinned` - Pinned
+ * * `custom_products` - Custom Products
  */
 export type PersistedFolderTypeEnumApi = (typeof PersistedFolderTypeEnumApi)[keyof typeof PersistedFolderTypeEnumApi]
 
@@ -2345,10 +2357,10 @@ export const PersistedFolderTypeEnumApi = {
 export interface PersistedFolderApi {
     readonly id: string
     /** Which persisted folder this is for the user (home, pinned, custom_products).
-
-  * `home` - Home
-  * `pinned` - Pinned
-  * `custom_products` - Custom Products */
+     *
+     * * `home` - Home
+     * * `pinned` - Pinned
+     * * `custom_products` - Custom Products */
     type: PersistedFolderTypeEnumApi
     /**
      * Protocol prefix of the folder location, e.g. 'products://'.
@@ -2373,10 +2385,10 @@ export interface PaginatedPersistedFolderListApi {
 export interface PatchedPersistedFolderApi {
     readonly id?: string
     /** Which persisted folder this is for the user (home, pinned, custom_products).
-
-  * `home` - Home
-  * `pinned` - Pinned
-  * `custom_products` - Custom Products */
+     *
+     * * `home` - Home
+     * * `pinned` - Pinned
+     * * `custom_products` - Custom Products */
     type?: PersistedFolderTypeEnumApi
     /**
      * Protocol prefix of the folder location, e.g. 'products://'.
@@ -2391,13 +2403,13 @@ export interface PatchedPersistedFolderApi {
 
 /**
  * * `image/png` - image/png
- * `application/pdf` - application/pdf
- * `text/csv` - text/csv
- * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
- * `video/webm` - video/webm
- * `video/mp4` - video/mp4
- * `image/gif` - image/gif
- * `application/json` - application/json
+ * * `application/pdf` - application/pdf
+ * * `text/csv` - text/csv
+ * * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+ * * `video/webm` - video/webm
+ * * `video/mp4` - video/mp4
+ * * `image/gif` - image/gif
+ * * `application/json` - application/json
  */
 export type ExportFormatEnumApi = (typeof ExportFormatEnumApi)[keyof typeof ExportFormatEnumApi]
 
@@ -2485,10 +2497,10 @@ export interface PatchedProjectSecretAPIKeyApi {
 
 /**
  * * `DateTime` - DateTime
- * `String` - String
- * `Numeric` - Numeric
- * `Boolean` - Boolean
- * `Duration` - Duration
+ * * `String` - String
+ * * `Numeric` - Numeric
+ * * `Boolean` - Boolean
+ * * `Duration` - Duration
  */
 export type PropertyDefinitionTypeEnumApi =
     (typeof PropertyDefinitionTypeEnumApi)[keyof typeof PropertyDefinitionTypeEnumApi]
@@ -2558,8 +2570,8 @@ export interface PatchedEnterprisePropertyDefinitionApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -2576,10 +2588,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
@@ -2602,7 +2614,7 @@ export interface BulkUpdateTagsResponseApi {
 
 /**
  * * `disabled` - disabled
- * `toolbar` - toolbar
+ * * `toolbar` - toolbar
  */
 export type ToolbarModeEnumApi = (typeof ToolbarModeEnumApi)[keyof typeof ToolbarModeEnumApi]
 
@@ -2613,7 +2625,7 @@ export const ToolbarModeEnumApi = {
 
 /**
  * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
-Also used for nested serializers.
+ * Also used for nested serializers.
  */
 export interface TeamBasicApi {
     readonly id: number
@@ -2636,9 +2648,9 @@ export interface TeamBasicApi {
 
 /**
  * * `0` - none
- * `3` - config
- * `6` - install
- * `9` - root
+ * * `3` - config
+ * * `6` - install
+ * * `9` - root
  */
 export type PluginsAccessLevelEnumApi = (typeof PluginsAccessLevelEnumApi)[keyof typeof PluginsAccessLevelEnumApi]
 
@@ -2651,7 +2663,7 @@ export const PluginsAccessLevelEnumApi = {
 
 /**
  * * `bayesian` - Bayesian
- * `frequentist` - Frequentist
+ * * `frequentist` - Frequentist
  */
 export type DefaultExperimentStatsMethodEnumApi =
     (typeof DefaultExperimentStatsMethodEnumApi)[keyof typeof DefaultExperimentStatsMethodEnumApi]
@@ -2720,9 +2732,9 @@ export interface OrganizationApi {
     /** @nullable */
     readonly is_hipaa: boolean | null
     /** Default statistical method for new experiments in this organization.
-
-  * `bayesian` - Bayesian
-  * `frequentist` - Frequentist */
+     *
+     * * `bayesian` - Bayesian
+     * * `frequentist` - Frequentist */
     default_experiment_stats_method?: DefaultExperimentStatsMethodEnumApi | BlankEnumApi | null
     /** Default setting for 'Discard client IP data' for new projects in this organization. */
     default_anonymize_ips?: boolean
@@ -2750,7 +2762,7 @@ export interface OrganizationApi {
 
 /**
  * Serializer for `Organization` model with minimal attributes to speeed up loading and transfer times.
-Also used for nested serializers.
+ * Also used for nested serializers.
  */
 export interface OrganizationBasicApi {
     readonly id: string
@@ -2792,8 +2804,8 @@ export interface ScenePersonalisationBasicApi {
 
 /**
  * * `light` - Light
- * `dark` - Dark
- * `system` - System
+ * * `dark` - Dark
+ * * `system` - System
  */
 export type ThemeModeEnumApi = (typeof ThemeModeEnumApi)[keyof typeof ThemeModeEnumApi]
 
@@ -2805,8 +2817,8 @@ export const ThemeModeEnumApi = {
 
 /**
  * * `above` - Above
- * `below` - Below
- * `hidden` - Hidden
+ * * `below` - Below
+ * * `hidden` - Hidden
  */
 export type ShortcutPositionEnumApi = (typeof ShortcutPositionEnumApi)[keyof typeof ShortcutPositionEnumApi]
 
@@ -2818,8 +2830,8 @@ export const ShortcutPositionEnumApi = {
 
 /**
  * * `delegated` - Delegated to teammate
- * `later` - Skipped for later
- * `other` - Other
+ * * `later` - Skipped for later
+ * * `other` - Other
  */
 export type OnboardingSkippedReasonEnumApi =
     (typeof OnboardingSkippedReasonEnumApi)[keyof typeof OnboardingSkippedReasonEnumApi]
@@ -3131,7 +3143,7 @@ export interface UserGitHubLinkStartResponseApi {
 
 /**
  * * `later` - Later
- * `other` - Other
+ * * `other` - Other
  */
 export type OnboardingSkipRequestReasonEnumApi =
     (typeof OnboardingSkipRequestReasonEnumApi)[keyof typeof OnboardingSkipRequestReasonEnumApi]
@@ -3143,16 +3155,16 @@ export const OnboardingSkipRequestReasonEnumApi = {
 
 /**
  * Request body for POST /api/users/{id}/onboarding/skip/.
-
-Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
-runtime so the contract clients believe is enforced (length cap, choice validation,
-no extra fields) is actually enforced server-side.
+ *
+ * Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
+ * runtime so the contract clients believe is enforced (length cap, choice validation,
+ * no extra fields) is actually enforced server-side.
  */
 export interface OnboardingSkipRequestApi {
     /** Why the user is leaving onboarding. 'later' keeps them able to return; 'other' is a catch-all. 'delegated' is rejected here — use the delegate endpoint so the delegation invite is created atomically.
-
-  * `later` - Later
-  * `other` - Other */
+     *
+     * * `later` - Later
+     * * `other` - Other */
     reason: OnboardingSkipRequestReasonEnumApi
     /**
      * Onboarding step key the user was on when skipping, for analytics only.
@@ -3163,8 +3175,8 @@ export interface OnboardingSkipRequestApi {
 
 /**
  * * `ios` - iOS
- * `android` - Android
- * `web` - Web
+ * * `android` - Android
+ * * `web` - Web
  */
 export type PushTokenPlatformEnumApi = (typeof PushTokenPlatformEnumApi)[keyof typeof PushTokenPlatformEnumApi]
 
@@ -3181,10 +3193,10 @@ export interface UserPushTokenRegisterRequestApi {
      */
     token: string
     /** Device platform the token was issued for. One of `ios`, `android`, or `web`.
-
-  * `ios` - iOS
-  * `android` - Android
-  * `web` - Web */
+     *
+     * * `ios` - iOS
+     * * `android` - Android
+     * * `web` - Web */
     platform: PushTokenPlatformEnumApi
 }
 
@@ -3192,10 +3204,10 @@ export interface UserPushTokenItemApi {
     /** PostHog UserPushToken row id. */
     id: string
     /** Device platform the token was issued for.
-
-  * `ios` - iOS
-  * `android` - Android
-  * `web` - Web */
+     *
+     * * `ios` - iOS
+     * * `android` - Android
+     * * `web` - Web */
     platform: PushTokenPlatformEnumApi
     /** When this token was first registered. */
     created_at: string
@@ -3441,14 +3453,14 @@ export type PropertyDefinitionsListParams = {
      */
     search?: string
     /**
- * What property definitions to return
-
-* `event` - event
-* `person` - person
-* `group` - group
-* `session` - session
- * @minLength 1
- */
+     * What property definitions to return
+     *
+     * * `event` - event
+     * * `person` - person
+     * * `group` - group
+     * * `session` - session
+     * @minLength 1
+     */
     type?: PropertyDefinitionsListType
     /**
      * Filter by verified status. True returns only verified, false returns only unverified.

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -104,7 +104,7 @@ export const getCimdVerificationTokensListUrl = (organizationId: string, params?
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -117,13 +117,13 @@ export const getCimdVerificationTokensListUrl = (organizationId: string, params?
 
 /**
  * Manage CIMD verification tokens for an organization.
-
-A partner embeds the plaintext token in their CIMD metadata document under
-`posthog_verification_token`. When PostHog fetches the metadata, matching
-the token links the partner app to this organization and grants a higher
-default rate limit for account provisioning.
-
-The plaintext value is only available on creation; we store a hash.
+ *
+ * A partner embeds the plaintext token in their CIMD metadata document under
+ * `posthog_verification_token`. When PostHog fetches the metadata, matching
+ * the token links the partner app to this organization and grants a higher
+ * default rate limit for account provisioning.
+ *
+ * The plaintext value is only available on creation; we store a hash.
  */
 export const cimdVerificationTokensList = async (
     organizationId: string,
@@ -142,13 +142,13 @@ export const getCimdVerificationTokensCreateUrl = (organizationId: string) => {
 
 /**
  * Manage CIMD verification tokens for an organization.
-
-A partner embeds the plaintext token in their CIMD metadata document under
-`posthog_verification_token`. When PostHog fetches the metadata, matching
-the token links the partner app to this organization and grants a higher
-default rate limit for account provisioning.
-
-The plaintext value is only available on creation; we store a hash.
+ *
+ * A partner embeds the plaintext token in their CIMD metadata document under
+ * `posthog_verification_token`. When PostHog fetches the metadata, matching
+ * the token links the partner app to this organization and grants a higher
+ * default rate limit for account provisioning.
+ *
+ * The plaintext value is only available on creation; we store a hash.
  */
 export const cimdVerificationTokensCreate = async (
     organizationId: string,
@@ -169,13 +169,13 @@ export const getCimdVerificationTokensRetrieveUrl = (organizationId: string, id:
 
 /**
  * Manage CIMD verification tokens for an organization.
-
-A partner embeds the plaintext token in their CIMD metadata document under
-`posthog_verification_token`. When PostHog fetches the metadata, matching
-the token links the partner app to this organization and grants a higher
-default rate limit for account provisioning.
-
-The plaintext value is only available on creation; we store a hash.
+ *
+ * A partner embeds the plaintext token in their CIMD metadata document under
+ * `posthog_verification_token`. When PostHog fetches the metadata, matching
+ * the token links the partner app to this organization and grants a higher
+ * default rate limit for account provisioning.
+ *
+ * The plaintext value is only available on creation; we store a hash.
  */
 export const cimdVerificationTokensRetrieve = async (
     organizationId: string,
@@ -194,13 +194,13 @@ export const getCimdVerificationTokensDestroyUrl = (organizationId: string, id: 
 
 /**
  * Manage CIMD verification tokens for an organization.
-
-A partner embeds the plaintext token in their CIMD metadata document under
-`posthog_verification_token`. When PostHog fetches the metadata, matching
-the token links the partner app to this organization and grants a higher
-default rate limit for account provisioning.
-
-The plaintext value is only available on creation; we store a hash.
+ *
+ * A partner embeds the plaintext token in their CIMD metadata document under
+ * `posthog_verification_token`. When PostHog fetches the metadata, matching
+ * the token links the partner app to this organization and grants a higher
+ * default rate limit for account provisioning.
+ *
+ * The plaintext value is only available on creation; we store a hash.
  */
 export const cimdVerificationTokensDestroy = async (
     organizationId: string,
@@ -218,7 +218,7 @@ export const getDomainsListUrl = (organizationId: string, params?: DomainsListPa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -378,7 +378,7 @@ export const getInvitesListUrl = (organizationId: string, params?: InvitesListPa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -451,7 +451,7 @@ export const getInvitesDelegateCreateUrl = (organizationId: string) => {
 
 /**
  * Create an onboarding delegation invite: an admin-level invite flagged as a setup delegation.
-Sends a single dedicated delegation email and records the inviting user as having delegated.
+ * Sends a single dedicated delegation email and records the inviting user as having delegated.
  */
 export const invitesDelegateCreate = async (
     organizationId: string,
@@ -471,7 +471,7 @@ export const getOauthApplicationsListUrl = (organizationId: string, params?: Oau
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -504,7 +504,7 @@ export const getOrganizationsProjectsListUrl = (organizationId: string, params?:
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -801,8 +801,8 @@ export const getOrganizationsProjectsLogsConfigRetrieveUrl = (organizationId: st
 
 /**
  * Manage logs product configuration for this project's canonical environment.
-Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
-alongside the legacy /api/environments/:id/logs_config/ alias.
+ * Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+ * alongside the legacy /api/environments/:id/logs_config/ alias.
  */
 export const organizationsProjectsLogsConfigRetrieve = async (
     organizationId: string,
@@ -821,8 +821,8 @@ export const getOrganizationsProjectsLogsConfigPartialUpdateUrl = (organizationI
 
 /**
  * Manage logs product configuration for this project's canonical environment.
-Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
-alongside the legacy /api/environments/:id/logs_config/ alias.
+ * Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+ * alongside the legacy /api/environments/:id/logs_config/ alias.
  */
 export const organizationsProjectsLogsConfigPartialUpdate = async (
     organizationId: string,
@@ -988,7 +988,7 @@ export const getDesktopFileSystemListUrl = (projectId: string, params?: DesktopF
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1001,9 +1001,9 @@ export const getDesktopFileSystemListUrl = (projectId: string, params?: DesktopF
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemList = async (
     projectId: string,
@@ -1022,9 +1022,9 @@ export const getDesktopFileSystemCreateUrl = (projectId: string) => {
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemCreate = async (
     projectId: string,
@@ -1045,9 +1045,9 @@ export const getDesktopFileSystemRetrieveUrl = (projectId: string, id: string) =
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemRetrieve = async (
     projectId: string,
@@ -1066,9 +1066,9 @@ export const getDesktopFileSystemUpdateUrl = (projectId: string, id: string) => 
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemUpdate = async (
     projectId: string,
@@ -1090,9 +1090,9 @@ export const getDesktopFileSystemPartialUpdateUrl = (projectId: string, id: stri
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemPartialUpdate = async (
     projectId: string,
@@ -1114,9 +1114,9 @@ export const getDesktopFileSystemDestroyUrl = (projectId: string, id: string) =>
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDesktopFileSystemDestroyUrl(projectId, id), {
@@ -1233,7 +1233,7 @@ export const getDesktopFileSystemInstructionsVersionsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1268,9 +1268,9 @@ export const getDesktopFileSystemLinkCreateUrl = (projectId: string, id: string)
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemLinkCreate = async (
     projectId: string,
@@ -1292,9 +1292,9 @@ export const getDesktopFileSystemMoveCreateUrl = (projectId: string, id: string)
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemMoveCreate = async (
     projectId: string,
@@ -1336,9 +1336,9 @@ export const getDesktopFileSystemLogViewRetrieveUrl = (projectId: string) => {
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemLogViewRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDesktopFileSystemLogViewRetrieveUrl(projectId), {
@@ -1353,9 +1353,9 @@ export const getDesktopFileSystemLogViewCreateUrl = (projectId: string) => {
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemLogViewCreate = async (
     projectId: string,
@@ -1376,9 +1376,9 @@ export const getDesktopFileSystemUndoDeleteCreateUrl = (projectId: string) => {
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemUndoDeleteCreate = async (
     projectId: string,
@@ -1399,9 +1399,9 @@ export const getDesktopFileSystemUnfiledRetrieveUrl = (projectId: string) => {
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemUnfiledRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDesktopFileSystemUnfiledRetrieveUrl(projectId), {
@@ -1418,7 +1418,7 @@ export const getDesktopFileSystemShortcutListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1431,8 +1431,8 @@ export const getDesktopFileSystemShortcutListUrl = (
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutList = async (
     projectId: string,
@@ -1451,8 +1451,8 @@ export const getDesktopFileSystemShortcutCreateUrl = (projectId: string) => {
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutCreate = async (
     projectId: string,
@@ -1473,8 +1473,8 @@ export const getDesktopFileSystemShortcutRetrieveUrl = (projectId: string, id: s
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutRetrieve = async (
     projectId: string,
@@ -1493,8 +1493,8 @@ export const getDesktopFileSystemShortcutUpdateUrl = (projectId: string, id: str
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutUpdate = async (
     projectId: string,
@@ -1516,8 +1516,8 @@ export const getDesktopFileSystemShortcutPartialUpdateUrl = (projectId: string, 
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutPartialUpdate = async (
     projectId: string,
@@ -1539,8 +1539,8 @@ export const getDesktopFileSystemShortcutDestroyUrl = (projectId: string, id: st
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutDestroy = async (
     projectId: string,
@@ -1578,7 +1578,7 @@ export const getDesktopPersistedFolderListUrl = (projectId: string, params?: Des
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1591,8 +1591,8 @@ export const getDesktopPersistedFolderListUrl = (projectId: string, params?: Des
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderList = async (
     projectId: string,
@@ -1611,8 +1611,8 @@ export const getDesktopPersistedFolderCreateUrl = (projectId: string) => {
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderCreate = async (
     projectId: string,
@@ -1633,8 +1633,8 @@ export const getDesktopPersistedFolderRetrieveUrl = (projectId: string, id: stri
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderRetrieve = async (
     projectId: string,
@@ -1653,8 +1653,8 @@ export const getDesktopPersistedFolderUpdateUrl = (projectId: string, id: string
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderUpdate = async (
     projectId: string,
@@ -1676,8 +1676,8 @@ export const getDesktopPersistedFolderPartialUpdateUrl = (projectId: string, id:
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderPartialUpdate = async (
     projectId: string,
@@ -1699,8 +1699,8 @@ export const getDesktopPersistedFolderDestroyUrl = (projectId: string, id: strin
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderDestroy = async (
     projectId: string,
@@ -1718,7 +1718,7 @@ export const getExportsListUrl = (projectId: string, params?: ExportsListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1788,7 +1788,7 @@ export const getFileSystemListUrl = (projectId: string, params?: FileSystemListP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2027,7 +2027,7 @@ export const getFileSystemShortcutListUrl = (projectId: string, params?: FileSys
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2303,7 +2303,7 @@ export const getPersistedFolderListUrl = (projectId: string, params?: PersistedF
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2409,7 +2409,7 @@ export const getProjectSecretApiKeysListUrl = (projectId: string, params?: Proje
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2537,7 +2537,7 @@ export const getPropertyDefinitionsListUrl = (projectId: string, params?: Proper
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2631,22 +2631,22 @@ export const getPropertyDefinitionsBulkUpdateTagsCreateUrl = (projectId: string)
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const propertyDefinitionsBulkUpdateTagsCreate = async (
     projectId: string,
@@ -2667,7 +2667,7 @@ export const getPropertyDefinitionsSeenTogetherRetrieveUrl = (projectId: string)
 
 /**
  * Allows a caller to provide a list of event names and a single property name
-Returns a map of the event names to a boolean representing whether that property has ever been seen with that event_name
+ * Returns a map of the event names to a boolean representing whether that property has ever been seen with that event_name
  */
 export const propertyDefinitionsSeenTogetherRetrieve = async (
     projectId: string,
@@ -2761,7 +2761,7 @@ export const getUsersListUrl = (params?: UsersListParams) => {
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2900,7 +2900,7 @@ export const getUsersIntegrationsListUrl = (uuid: string, params?: UsersIntegrat
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2954,7 +2954,7 @@ export const getUsersIntegrationsGithubBranchesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2993,7 +2993,7 @@ export const getUsersIntegrationsGithubReposRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -3051,24 +3051,24 @@ export const getUsersIntegrationsGithubStartCreateUrl = (uuid: string) => {
 
 /**
  * Start GitHub linking: either full App install or OAuth-only (user-to-server).
-
-``**_kwargs`` absorbs ``parent_lookup_uuid`` from the nested
-``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
-under projects).
-
-Usually returns ``install_url`` pointing at ``/installations/new`` so the
-user can pick any GitHub org (new or already connected).  GitHub's install
-page handles both cases: orgs where the app is installed show "Configure"
-(no admin needed), orgs where it isn't show "Install" (needs admin).
-
-**OAuth fast path:** when the current project already has a team-level
-GitHub installation, and the user has no ``UserIntegration`` for that
-installation yet, we skip the org picker and redirect straight to
-``/login/oauth/authorize`` so the user only authorizes themselves.
-``connect_from`` is preserved for first-party clients so they return to
-the originating client immediately.
-
-In both cases the response key is ``install_url`` for compatibility with callers.
+ *
+ * ``**_kwargs`` absorbs ``parent_lookup_uuid`` from the nested
+ * ``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
+ * under projects).
+ *
+ * Usually returns ``install_url`` pointing at ``/installations/new`` so the
+ * user can pick any GitHub org (new or already connected).  GitHub's install
+ * page handles both cases: orgs where the app is installed show "Configure"
+ * (no admin needed), orgs where it isn't show "Install" (needs admin).
+ *
+ * **OAuth fast path:** when the current project already has a team-level
+ * GitHub installation, and the user has no ``UserIntegration`` for that
+ * installation yet, we skip the org picker and redirect straight to
+ * ``/login/oauth/authorize`` so the user only authorizes themselves.
+ * ``connect_from`` is preserved for first-party clients so they return to
+ * the originating client immediately.
+ *
+ * In both cases the response key is ``install_url`` for compatibility with callers.
  * @summary Start GitHub personal integration linking
  */
 export const usersIntegrationsGithubStartCreate = async (
@@ -3090,12 +3090,12 @@ export const getUsersOnboardingSkipCreateUrl = (uuid: string) => {
 
 /**
  * Mark the current user as having exited onboarding with a non-delegated reason.
-Idempotent: the skip timestamp is only set on the first successful call.
-
-Callers wanting to delegate setup to a teammate must use the dedicated
-/organizations/{id}/invites/delegate/ endpoint, which atomically creates the
-invite and sets reason="delegated". This endpoint rejects that reason so state
-can't be faked without a real invite.
+ * Idempotent: the skip timestamp is only set on the first successful call.
+ *
+ * Callers wanting to delegate setup to a teammate must use the dedicated
+ * /organizations/{id}/invites/delegate/ endpoint, which atomically creates the
+ * invite and sets reason="delegated". This endpoint rejects that reason so state
+ * can't be faked without a real invite.
  */
 export const usersOnboardingSkipCreate = async (
     uuid: string,

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -11,13 +11,13 @@ import * as zod from 'zod'
 
 /**
  * Manage CIMD verification tokens for an organization.
-
-A partner embeds the plaintext token in their CIMD metadata document under
-`posthog_verification_token`. When PostHog fetches the metadata, matching
-the token links the partner app to this organization and grants a higher
-default rate limit for account provisioning.
-
-The plaintext value is only available on creation; we store a hash.
+ *
+ * A partner embeds the plaintext token in their CIMD metadata document under
+ * `posthog_verification_token`. When PostHog fetches the metadata, matching
+ * the token links the partner app to this organization and grants a higher
+ * default rate limit for account provisioning.
+ *
+ * The plaintext value is only available on creation; we store a hash.
  */
 export const cimdVerificationTokensCreateBodyLabelMax = 40
 
@@ -266,7 +266,7 @@ export const InvitesBulkCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create an onboarding delegation invite: an admin-level invite flagged as a setup delegation.
-Sends a single dedicated delegation email and records the inviting user as having delegated.
+ * Sends a single dedicated delegation email and records the inviting user as having delegated.
  */
 export const invitesDelegateCreateBodyMessageMax = 1000
 
@@ -1908,8 +1908,8 @@ export const OrganizationsProjectsGenerateConversationsPublicTokenCreateBody = /
 
 /**
  * Manage logs product configuration for this project's canonical environment.
-Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
-alongside the legacy /api/environments/:id/logs_config/ alias.
+ * Mirrors the env-router action so /api/projects/:id/logs_config/ resolves
+ * alongside the legacy /api/environments/:id/logs_config/ alias.
  */
 export const organizationsProjectsLogsConfigPartialUpdateBodyNameMax = 200
 
@@ -2513,9 +2513,9 @@ export const DashboardsSharingRefreshCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemCreateBodyTypeMax = 100
 
@@ -2532,9 +2532,9 @@ export const DesktopFileSystemCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemUpdateBodyTypeMax = 100
 
@@ -2551,9 +2551,9 @@ export const DesktopFileSystemUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemPartialUpdateBodyTypeMax = 100
 
@@ -2618,9 +2618,9 @@ export const DesktopFileSystemInstructionsPartialUpdateBody = /* @__PURE__ */ zo
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemLinkCreateBodyTypeMax = 100
 
@@ -2637,9 +2637,9 @@ export const DesktopFileSystemLinkCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemMoveCreateBodyTypeMax = 100
 
@@ -2672,9 +2672,9 @@ export const DesktopFileSystemCountByPathCreateBody = /* @__PURE__ */ zod.object
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemLogViewCreateBodyTypeMax = 100
 
@@ -2691,9 +2691,9 @@ export const DesktopFileSystemLogViewCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const desktopFileSystemUndoDeleteCreateBodyTypeMax = 100
 
@@ -2710,8 +2710,8 @@ export const DesktopFileSystemUndoDeleteCreateBody = /* @__PURE__ */ zod.object(
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutCreateBodyTypeMax = 100
 
@@ -2746,8 +2746,8 @@ export const DesktopFileSystemShortcutCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutUpdateBodyTypeMax = 100
 
@@ -2782,8 +2782,8 @@ export const DesktopFileSystemShortcutUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Sidebar shortcuts for the desktop product surface. Reuses all FileSystemShortcutViewSet
-behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
-the default "web" surface.
+ * behaviour but is scoped to the "desktop" surface, so its shortcuts are fully isolated from
+ * the default "web" surface.
  */
 export const desktopFileSystemShortcutPartialUpdateBodyTypeMax = 100
 
@@ -2825,8 +2825,8 @@ export const DesktopFileSystemShortcutReorderCreateBody = /* @__PURE__ */ zod.ob
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderCreateBodyProtocolMax = 64
 
@@ -2847,8 +2847,8 @@ export const DesktopPersistedFolderCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderUpdateBodyProtocolMax = 64
 
@@ -2869,8 +2869,8 @@ export const DesktopPersistedFolderUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Persisted folders for the desktop product surface. Reuses all PersistedFolderViewSet behaviour
-but is scoped to the "desktop" surface, so its folders are fully isolated from the default
-"web" surface.
+ * but is scoped to the "desktop" surface, so its folders are fully isolated from the default
+ * "web" surface.
  */
 export const desktopPersistedFolderPartialUpdateBodyProtocolMax = 64
 
@@ -3280,22 +3280,22 @@ export const PropertyDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const propertyDefinitionsBulkUpdateTagsCreateBodyIdsMax = 500
 
@@ -3582,24 +3582,24 @@ export const UsersHedgehogConfigPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Start GitHub linking: either full App install or OAuth-only (user-to-server).
-
-``**_kwargs`` absorbs ``parent_lookup_uuid`` from the nested
-``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
-under projects).
-
-Usually returns ``install_url`` pointing at ``/installations/new`` so the
-user can pick any GitHub org (new or already connected).  GitHub's install
-page handles both cases: orgs where the app is installed show "Configure"
-(no admin needed), orgs where it isn't show "Install" (needs admin).
-
-**OAuth fast path:** when the current project already has a team-level
-GitHub installation, and the user has no ``UserIntegration`` for that
-installation yet, we skip the org picker and redirect straight to
-``/login/oauth/authorize`` so the user only authorizes themselves.
-``connect_from`` is preserved for first-party clients so they return to
-the originating client immediately.
-
-In both cases the response key is ``install_url`` for compatibility with callers.
+ *
+ * ``**_kwargs`` absorbs ``parent_lookup_uuid`` from the nested
+ * ``/api/users/{uuid}/integrations/`` router (same pattern as ``local_evaluation``
+ * under projects).
+ *
+ * Usually returns ``install_url`` pointing at ``/installations/new`` so the
+ * user can pick any GitHub org (new or already connected).  GitHub's install
+ * page handles both cases: orgs where the app is installed show "Configure"
+ * (no admin needed), orgs where it isn't show "Install" (needs admin).
+ *
+ * **OAuth fast path:** when the current project already has a team-level
+ * GitHub installation, and the user has no ``UserIntegration`` for that
+ * installation yet, we skip the org picker and redirect straight to
+ * ``/login/oauth/authorize`` so the user only authorizes themselves.
+ * ``connect_from`` is preserved for first-party clients so they return to
+ * the originating client immediately.
+ *
+ * In both cases the response key is ``install_url`` for compatibility with callers.
  * @summary Start GitHub personal integration linking
  */
 export const UsersIntegrationsGithubStartCreateBody = /* @__PURE__ */ zod.object({
@@ -3615,12 +3615,12 @@ export const UsersIntegrationsGithubStartCreateBody = /* @__PURE__ */ zod.object
 
 /**
  * Mark the current user as having exited onboarding with a non-delegated reason.
-Idempotent: the skip timestamp is only set on the first successful call.
-
-Callers wanting to delegate setup to a teammate must use the dedicated
-/organizations/{id}/invites/delegate/ endpoint, which atomically creates the
-invite and sets reason="delegated". This endpoint rejects that reason so state
-can't be faked without a real invite.
+ * Idempotent: the skip timestamp is only set on the first successful call.
+ *
+ * Callers wanting to delegate setup to a teammate must use the dedicated
+ * /organizations/{id}/invites/delegate/ endpoint, which atomically creates the
+ * invite and sets reason="delegated". This endpoint rejects that reason so state
+ * can't be faked without a real invite.
  */
 export const usersOnboardingSkipCreateBodyStepAtSkipMax = 64
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1511,7 +1511,7 @@ importers:
         version: 1.15.0
       '@temporalio/worker':
         specifier: ^1.12.0
-        version: 1.15.0(esbuild@0.27.7)(postcss@8.5.15)(tslib@2.8.1)
+        version: 1.15.0(esbuild@0.28.0)(postcss@8.5.15)(tslib@2.8.1)
       '@types/node':
         specifier: 'catalog:'
         version: 22.18.8
@@ -1752,7 +1752,7 @@ importers:
         version: 3.3.0
       jest:
         specifier: ^30.0.0
-        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-environment-node:
         specifier: ^30.0.0
         version: 30.0.5
@@ -1767,7 +1767,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.26.0)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.26.0))(esbuild@0.27.7)(jest-util@30.0.5)(jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.9(@babel/core@7.26.0)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.26.0))(esbuild@0.28.0)(jest-util@30.0.5)(jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)
@@ -2226,7 +2226,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -2558,7 +2558,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
   products/data_modeling:
     dependencies:
@@ -3627,7 +3627,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3981,8 +3981,8 @@ importers:
   tools/openapi-codegen:
     dependencies:
       orval:
-        specifier: 8.9.1
-        version: 8.9.1(prettier@3.8.2)(typescript@6.0.3)
+        specifier: 8.14.0
+        version: 8.14.0(prettier@3.8.2)(typescript@6.0.3)
     devDependencies:
       vitest:
         specifier: ^3.0.0
@@ -5818,6 +5818,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -5844,6 +5850,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -5878,6 +5890,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -5904,6 +5922,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -5938,6 +5962,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -5964,6 +5994,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -5998,6 +6034,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -6024,6 +6066,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -6058,6 +6106,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -6084,6 +6138,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -6118,6 +6178,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -6144,6 +6210,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -6178,6 +6250,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -6204,6 +6282,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -6238,6 +6322,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -6264,6 +6354,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -6298,6 +6394,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -6318,6 +6420,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -6352,6 +6460,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -6372,6 +6486,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -6406,6 +6526,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -6426,6 +6552,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -6460,6 +6592,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -6486,6 +6624,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -6520,6 +6664,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -6546,6 +6696,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -8149,43 +8305,46 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@orval/angular@8.9.1':
-    resolution: {integrity: sha512-S4OVIfyCO+lvNQ52tY6OnisYCYK71XiGKvSEP83I38YvQTKkkm1wJvkM5GC5Q9Evthqg169Qo59xSEiXFAftyw==}
+  '@orval/angular@8.14.0':
+    resolution: {integrity: sha512-Rq/C7yZRSx/7xL+chsW3v3B3WPf/dnN2SExBghtve/xUWOMODRA9bLLPy1sGJaBIztSXmRHPOAujCzzqHCzn3Q==}
 
-  '@orval/axios@8.9.1':
-    resolution: {integrity: sha512-OuZ6cY3r+GvL5HTfatoMYFgs3vDJw/my9S4CxwRRuQJF9sfP1Hsy5XYIbzCiDT60iIBQaakJg9CpXqP0yFLLkQ==}
+  '@orval/axios@8.14.0':
+    resolution: {integrity: sha512-IJogr/ugdCJHoY/0F5cr7tXLk/j0BjgA9CrWKzuBUsSlvefof7UvBB8fyPcIuAj4DePqc84J3IHPvZsfgLXtLQ==}
 
-  '@orval/core@8.9.1':
-    resolution: {integrity: sha512-RkMud8bC7f3NZnm79baLFZGkYHR6lDd4DMPYjpJ5EmreM7tTTcVH5Nd6HEB0FVVd0UvcsS0tGWDIYiHxq04sJA==}
+  '@orval/core@8.14.0':
+    resolution: {integrity: sha512-uijqeGeXxX8/+xeix+fd9WmLFH9i4smiiw6TwhDRYoQuU/9WXQd9NwmLXKAu6x6cUH+MzUiEiwWm4TsXkwfCHg==}
     peerDependencies:
       '@faker-js/faker': '>=10'
     peerDependenciesMeta:
       '@faker-js/faker':
         optional: true
 
-  '@orval/fetch@8.9.1':
-    resolution: {integrity: sha512-9SBqq0w6b5maIcHWbcSPYd0ZWg+VzOCTAmaVPsVpdmCR9ss8yZAkkmah1NiV44AAqE9PUtXTPEMZrH0MwUDoeg==}
+  '@orval/effect@8.14.0':
+    resolution: {integrity: sha512-mZNfZnObxIzvMGrG96zRw6rhGMqUACfrU7fPNMPiUC0YvGEP2K+32u0yeDy9JZo1/fiBRUtmw8w+NXaup1tZxQ==}
 
-  '@orval/hono@8.9.1':
-    resolution: {integrity: sha512-kwLMcxnT5bm5aB7MYDsfFxwOdMDBBNzPcxdDgbVHAjOeNUkgAtCN+92yX9wAK89OjhkGb14V8McvU7eJqHl+nw==}
+  '@orval/fetch@8.14.0':
+    resolution: {integrity: sha512-OYN9hEqX4dAzVMTBdX8dVdlfxjM6dMOrZZTPgnSfnOWK97dgWV45RK3G/egBzOGl9SPaEK4Iauhe3rVdNHXlVg==}
 
-  '@orval/mcp@8.9.1':
-    resolution: {integrity: sha512-2BL0tCclPZM0HIB8aUH3aWFwMqFGG1luoRgg5dLbJqQFpo2tMlIaahgQpNY9USOl1hIjhgY4CmlrcH1gqRXk4A==}
+  '@orval/hono@8.14.0':
+    resolution: {integrity: sha512-OTw9uyFxiypAG10a1U4DYz+nhYT8pS1e8ueynuKn8QjeGzbJmY1LuLZRtSm3+eULq41/7Ba+YLTBb21uFqTYaQ==}
 
-  '@orval/mock@8.9.1':
-    resolution: {integrity: sha512-o66CdbPXVJ5GI6TEwH1UagKsfx8abV1aQIQ77vlN+QX9X6/gAeUU3e+6YsuCjANzM9xwcGLJgnHMgIlYNP32cA==}
+  '@orval/mcp@8.14.0':
+    resolution: {integrity: sha512-wPYRhxnh3BUyoqxkrXDS0JsvLVH43i8uFfQv9BgHcZfn92IQW4cF+CmIfIrdnVjqEbNjwUHgSNcelijHMSv5tQ==}
 
-  '@orval/query@8.9.1':
-    resolution: {integrity: sha512-bCe903blfT4ICDR6OjszrLFFCvjfIA5bavyUUW3zxNxRdd65eaHrx9tLHv5fmpj+Rl+d1+t6XmJuAsQ4XJsXVg==}
+  '@orval/mock@8.14.0':
+    resolution: {integrity: sha512-qrP3XuEEsKRYEmWm6InEXKGtHeFVn08oYN322a9Txvmi6OTF1n2dDAcWFukoQelsdcMgx+6REQuRwQ0T50qu0Q==}
 
-  '@orval/solid-start@8.9.1':
-    resolution: {integrity: sha512-2qWiTBxM3hPOBlUvf3TBVcvDjAnTfztlf57dRpzUeVyS9IglIit/Cedc3tmp9PzkjHzM82SifHVNANYd5F29Xg==}
+  '@orval/query@8.14.0':
+    resolution: {integrity: sha512-uUAYpbOMy7FErOjUE51lGTmWhwx63wYyC3w4kGDYJIV10PLVtk7qSzKuriwIyh6Bhrs+ZKb16LRw4LMsnOX9KA==}
 
-  '@orval/swr@8.9.1':
-    resolution: {integrity: sha512-ijP3ERy6MwvPrVaMgS8USDxj/LtbvzXEufeIC9Zm3qNaGDv1dAeE22MegRE8FfXweSD9f+FSrGl0baPe4Ne+fQ==}
+  '@orval/solid-start@8.14.0':
+    resolution: {integrity: sha512-fB4GN24QAX17RxAnqJF0m94okb3IFnQm+1Gb49SBj0qoDYhi9ZrbyflJhlt9NC+xj8tdLOYbCuR3RwFek+GfkQ==}
 
-  '@orval/zod@8.9.1':
-    resolution: {integrity: sha512-MV75Xzz28W3ZttloNNmdTPa96AneY8FZExEwxmcySdY7lirJtErsqXt2EHnorETDAVEvSldVszhWG/AXpFBAPg==}
+  '@orval/swr@8.14.0':
+    resolution: {integrity: sha512-5B9Dz2WB/v23/66Pvf3VihuycNMnbL/paWy+9do3KXSYLLBoNkLs3AMJAcEf1gOp/Bcr4+o0wi55m+aZ9Gznyg==}
+
+  '@orval/zod@8.14.0':
+    resolution: {integrity: sha512-5QJsVZcyQQixAwJU3S3qy+8mJK3n9SoqsoJ4svSLLib8IaOFm0d3Kf2NL5yecwuocwZVL8JGkWNTSWWJ9gFKgg==}
 
   '@oxc-resolver/binding-darwin-arm64@1.12.0':
     resolution: {integrity: sha512-wYe+dlF8npM7cwopOOxbdNjtmJp17e/xF5c0K2WooQXy5VOh74icydM33+Uh/SZDgwyum09/U1FVCX5GdeQk+A==}
@@ -9784,32 +9943,36 @@ packages:
   '@rushstack/ts-command-line@5.3.4':
     resolution: {integrity: sha512-MLkVKVEN6/2clKTrjN2B2KqKCuPxRwnNsWY7a+FCAq2EMdkj10cM8YgiBSMeGFfzM0mDMzargpHNnNzaBi9Whg==}
 
-  '@scalar/helpers@0.5.2':
-    resolution: {integrity: sha512-Pi1GAl8jO6ungmGj2sjDfCfqiBNrKW6HXDZmminV94ybGU/KtRLOqHwd0n9FIhY3j0RYGpGC0VCuniCICfQPHg==}
-    engines: {node: '>=22'}
-
   '@scalar/helpers@0.5.5':
     resolution: {integrity: sha512-TqbErkqGijJJW6Ad8lpswHFTmlJaYFt9oolaWF1/Nn9171xdkK9ZDAk3pCaOCWs8WpwvcbUSxIVD8JxdBg0MFg==}
+    engines: {node: '>=22'}
+
+  '@scalar/helpers@0.8.1':
+    resolution: {integrity: sha512-yuiuBCadP5bjAnIv23QvifVN/NaMi9xBF6b8Wdk4QOzwzLPJmp699MAdf33J0A5i2qKcvnu32iz/VkEJmQRe5g==}
     engines: {node: '>=22'}
 
   '@scalar/json-magic@0.12.11':
     resolution: {integrity: sha512-oyICpNyEjBsRHM1DPbS8uyXFnU8fulFhqrMANLTTggSCH1XFNbVs7PMA8HxFLuQzJiQZzpUFf19M/Dx/TpXnpQ==}
     engines: {node: '>=22'}
 
-  '@scalar/json-magic@0.12.8':
-    resolution: {integrity: sha512-a559iO8tmFeA90JJAAM3U5x1Asf3mr0Z8uDC1PmyLTDjdSOfajP7EY9VzNoXE2cM48ilf9qrjmkbw/d4VCFjQw==}
+  '@scalar/json-magic@0.12.15':
+    resolution: {integrity: sha512-ZYgdYZ0jSZXQeyhG2lJ20FjzvKsaDRXk4bPguF/Ytl2nGBh9a6RIIr9NvVy4zAD67a/ahm+xipXlfoR1KtB5fg==}
     engines: {node: '>=22'}
 
-  '@scalar/openapi-parser@0.25.12':
-    resolution: {integrity: sha512-1hajBAbc7cbEcsSZEQxaPXZyCjMf6h6hObV+SO32jkC6rrxinPXQIucDu9HTu/jm/FaaMnNhc8/XDWz5/E49cQ==}
+  '@scalar/openapi-parser@0.28.6':
+    resolution: {integrity: sha512-gCl4r+rpmO+CKfwmmwI+GJVFhuNut7e6beUcD/xazanH4epkLT7V9ZgMv9YKbUBE73fkrOv6NJympeEGiU8aUw==}
     engines: {node: '>=22'}
 
   '@scalar/openapi-types@0.8.0':
     resolution: {integrity: sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g==}
     engines: {node: '>=22'}
 
-  '@scalar/openapi-upgrader@0.2.6':
-    resolution: {integrity: sha512-pvEmfSCDNYR4+lygidUqfo+shzyp4OSh9+UgK110rzA8Oot6WbJBM03Fuq3M255G7G6R9iXyfsebB7MBUocPkw==}
+  '@scalar/openapi-types@0.9.1':
+    resolution: {integrity: sha512-gkGhSkxSzADaBiNg+ZAbJuwj+ZUmzP2Pg9CWZ7ZP+0fck2WjPeDDM7aAbouAm0aQQMF9xBjSPXSA9a/qTHYaTw==}
+    engines: {node: '>=22'}
+
+  '@scalar/openapi-upgrader@0.2.9':
+    resolution: {integrity: sha512-D5b0rGLLZgmkO9mdW2j/ND1KBlH1u3RCpr87HPxv9P9ZSr6PtM5iLqFOJq0ACiaHjY2mikCrxgDmnUEhTzRpHQ==}
     engines: {node: '>=22'}
 
   '@sec-ant/readable-stream@0.4.1':
@@ -13552,10 +13715,6 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
-  commander@14.0.2:
-    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
-    engines: {node: '>=20'}
-
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -14657,6 +14816,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -15203,10 +15367,6 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
-    engines: {node: '>=14.14'}
-
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
@@ -15350,6 +15510,9 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
@@ -15455,10 +15618,6 @@ packages:
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
-
-  globby@16.1.0:
-    resolution: {integrity: sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==}
-    engines: {node: '>=20'}
 
   globjoin@0.1.4:
     resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
@@ -16094,10 +16253,6 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
-
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
 
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
@@ -18280,8 +18435,8 @@ packages:
   orderedmap@2.1.0:
     resolution: {integrity: sha512-/pIFexOm6S70EPdznemIz3BQZoJ4VTFrhqzu0ACBqBgeLsLxq8e6Jim63ImIfwW/zAD1AlXpRMlOv3aghmo4dA==}
 
-  orval@8.9.1:
-    resolution: {integrity: sha512-o9hgALCr3mCXOWxfct4IrsmlNtURt1iwDx9TecbPT5pwoXZMRpdT6W8/ED78NY0ZNnKs6L00QRNLN1SOArnU+w==}
+  orval@8.14.0:
+    resolution: {integrity: sha512-ZMOzZuaa+d5szRMShSptVCR6r28Md02Rd3g2BuPBx9QZ2QnlPu+UXF6fCUrcE9A1rhL/aC7nh9B8A4MW8hy+wg==}
     engines: {node: '>=22.18.0'}
     hasBin: true
     peerDependencies:
@@ -21714,10 +21869,6 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
-
-  unicorn-magic@0.4.0:
-    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
-    engines: {node: '>=20'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -25820,9 +25971,9 @@ snapshots:
 
   '@cloudflare/workers-types@4.20260207.0': {}
 
-  '@commander-js/extra-typings@14.0.0(commander@14.0.2)':
+  '@commander-js/extra-typings@14.0.0(commander@14.0.3)':
     dependencies:
-      commander: 14.0.2
+      commander: 14.0.3
 
   '@connectrpc/connect-node@2.1.1(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.11.0))':
     dependencies:
@@ -26230,6 +26381,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
@@ -26243,6 +26397,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -26260,6 +26417,9 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
@@ -26273,6 +26433,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -26290,6 +26453,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
@@ -26303,6 +26469,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -26320,6 +26489,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
@@ -26333,6 +26505,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -26350,6 +26525,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
@@ -26363,6 +26541,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -26380,6 +26561,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
@@ -26393,6 +26577,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -26410,6 +26597,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
@@ -26423,6 +26613,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -26440,6 +26633,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
@@ -26453,6 +26649,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -26470,6 +26669,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
@@ -26480,6 +26682,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -26497,6 +26702,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
@@ -26507,6 +26715,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -26524,6 +26735,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
@@ -26534,6 +26748,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -26551,6 +26768,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
@@ -26564,6 +26784,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -26581,6 +26804,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
@@ -26594,6 +26820,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@8.57.0)':
@@ -27174,7 +27403,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -27189,7 +27418,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -27210,7 +27439,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -27225,7 +27454,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -28875,109 +29104,118 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
 
-  '@orval/angular@8.9.1(typescript@6.0.3)':
+  '@orval/angular@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/axios@8.9.1(typescript@6.0.3)':
+  '@orval/axios@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/core@8.9.1(typescript@6.0.3)':
+  '@orval/core@8.14.0(typescript@6.0.3)':
     dependencies:
       '@scalar/openapi-types': 0.8.0
       acorn: 8.16.0
       compare-versions: 6.1.1
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       esutils: 2.0.3
-      fs-extra: 11.3.2
-      globby: 16.1.0
+      fs-extra: 11.3.5
       jiti: 2.6.1
       remeda: 2.34.0
+      tinyglobby: 0.2.16
       typedoc: 0.28.19(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@orval/fetch@8.9.1(typescript@6.0.3)':
+  '@orval/effect@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
+      remeda: 2.34.0
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
+  '@orval/fetch@8.14.0(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.14.0(typescript@6.0.3)
       '@scalar/openapi-types': 0.8.0
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/hono@8.9.1(typescript@6.0.3)':
+  '@orval/hono@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
-      '@orval/zod': 8.9.1(typescript@6.0.3)
-      fs-extra: 11.3.2
+      '@orval/core': 8.14.0(typescript@6.0.3)
+      '@orval/zod': 8.14.0(typescript@6.0.3)
+      fs-extra: 11.3.5
       remeda: 2.34.0
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/mcp@8.9.1(typescript@6.0.3)':
+  '@orval/mcp@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
-      '@orval/fetch': 8.9.1(typescript@6.0.3)
-      '@orval/zod': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
+      '@orval/fetch': 8.14.0(typescript@6.0.3)
+      '@orval/zod': 8.14.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/mock@8.9.1(typescript@6.0.3)':
+  '@orval/mock@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
       remeda: 2.34.0
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/query@8.9.1(typescript@6.0.3)':
+  '@orval/query@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
-      '@orval/fetch': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
+      '@orval/fetch': 8.14.0(typescript@6.0.3)
       remeda: 2.34.0
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/solid-start@8.9.1(typescript@6.0.3)':
+  '@orval/solid-start@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
       '@scalar/openapi-types': 0.8.0
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/swr@8.9.1(typescript@6.0.3)':
+  '@orval/swr@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
-      '@orval/fetch': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
+      '@orval/fetch': 8.14.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
       - typescript
 
-  '@orval/zod@8.9.1(typescript@6.0.3)':
+  '@orval/zod@8.14.0(typescript@6.0.3)':
     dependencies:
-      '@orval/core': 8.9.1(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
       remeda: 2.34.0
     transitivePeerDependencies:
       - '@faker-js/faker'
@@ -30647,9 +30885,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@scalar/helpers@0.5.2': {}
-
   '@scalar/helpers@0.5.5': {}
+
+  '@scalar/helpers@0.8.1': {}
 
   '@scalar/json-magic@0.12.11':
     dependencies:
@@ -30657,18 +30895,18 @@ snapshots:
       pathe: 2.0.3
       yaml: 2.9.0
 
-  '@scalar/json-magic@0.12.8':
+  '@scalar/json-magic@0.12.15':
     dependencies:
-      '@scalar/helpers': 0.5.2
+      '@scalar/helpers': 0.8.1
       pathe: 2.0.3
       yaml: 2.9.0
 
-  '@scalar/openapi-parser@0.25.12':
+  '@scalar/openapi-parser@0.28.6':
     dependencies:
-      '@scalar/helpers': 0.5.2
-      '@scalar/json-magic': 0.12.8
-      '@scalar/openapi-types': 0.8.0
-      '@scalar/openapi-upgrader': 0.2.6
+      '@scalar/helpers': 0.8.1
+      '@scalar/json-magic': 0.12.15
+      '@scalar/openapi-types': 0.9.1
+      '@scalar/openapi-upgrader': 0.2.9
       ajv: 8.20.0
       ajv-draft-04: 1.0.0(ajv@8.20.0)
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -30678,9 +30916,11 @@ snapshots:
 
   '@scalar/openapi-types@0.8.0': {}
 
-  '@scalar/openapi-upgrader@0.2.6':
+  '@scalar/openapi-types@0.9.1': {}
+
+  '@scalar/openapi-upgrader@0.2.9':
     dependencies:
-      '@scalar/openapi-types': 0.8.0
+      '@scalar/openapi-types': 0.9.1
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -32255,7 +32495,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.1
 
-  '@temporalio/worker@1.15.0(esbuild@0.27.7)(postcss@8.5.15)(tslib@2.8.1)':
+  '@temporalio/worker@1.15.0(esbuild@0.28.0)(postcss@8.5.15)(tslib@2.8.1)':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@swc/core': 1.15.18
@@ -32274,11 +32514,11 @@ snapshots:
       protobufjs: 7.6.1
       rxjs: 7.8.1
       source-map: 0.7.6
-      source-map-loader: 4.0.2(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15))
+      source-map-loader: 4.0.2(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15))
       supports-color: 8.1.1
-      swc-loader: 0.2.3(@swc/core@1.15.18)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15))
+      swc-loader: 0.2.3(@swc/core@1.15.18)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15))
       unionfs: 4.6.0
-      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -35316,8 +35556,6 @@ snapshots:
 
   commander@13.1.0: {}
 
-  commander@14.0.2: {}
-
   commander@14.0.3: {}
 
   commander@2.20.3: {}
@@ -36597,10 +36835,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-register@3.6.0(esbuild@0.27.7):
+  esbuild-register@3.6.0(esbuild@0.28.0):
     dependencies:
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -36758,6 +36996,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -37423,12 +37690,6 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.0
 
-  fs-extra@11.3.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
-
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -37594,6 +37855,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-uri@6.0.5:
     dependencies:
       basic-ftp: 5.3.1
@@ -37734,15 +37999,6 @@ snapshots:
       path-type: 6.0.0
       slash: 5.1.0
       unicorn-magic: 0.3.0
-
-  globby@16.1.0:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      is-path-inside: 4.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.4.0
 
   globjoin@0.1.4: {}
 
@@ -38455,8 +38711,6 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
-  is-path-inside@4.0.0: {}
-
   is-plain-obj@1.1.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -38844,15 +39098,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -38863,15 +39117,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -39098,7 +39352,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39126,13 +39380,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.27.7)
+      esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39160,13 +39414,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.27.7)
+      esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39194,7 +39448,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
-      esbuild-register: 3.6.0(esbuild@0.27.7)
+      esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -40129,12 +40383,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40142,12 +40396,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -42081,34 +42335,35 @@ snapshots:
 
   orderedmap@2.1.0: {}
 
-  orval@8.9.1(prettier@3.8.2)(typescript@6.0.3):
+  orval@8.14.0(prettier@3.8.2)(typescript@6.0.3):
     dependencies:
-      '@commander-js/extra-typings': 14.0.0(commander@14.0.2)
-      '@orval/angular': 8.9.1(typescript@6.0.3)
-      '@orval/axios': 8.9.1(typescript@6.0.3)
-      '@orval/core': 8.9.1(typescript@6.0.3)
-      '@orval/fetch': 8.9.1(typescript@6.0.3)
-      '@orval/hono': 8.9.1(typescript@6.0.3)
-      '@orval/mcp': 8.9.1(typescript@6.0.3)
-      '@orval/mock': 8.9.1(typescript@6.0.3)
-      '@orval/query': 8.9.1(typescript@6.0.3)
-      '@orval/solid-start': 8.9.1(typescript@6.0.3)
-      '@orval/swr': 8.9.1(typescript@6.0.3)
-      '@orval/zod': 8.9.1(typescript@6.0.3)
+      '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
+      '@orval/angular': 8.14.0(typescript@6.0.3)
+      '@orval/axios': 8.14.0(typescript@6.0.3)
+      '@orval/core': 8.14.0(typescript@6.0.3)
+      '@orval/effect': 8.14.0(typescript@6.0.3)
+      '@orval/fetch': 8.14.0(typescript@6.0.3)
+      '@orval/hono': 8.14.0(typescript@6.0.3)
+      '@orval/mcp': 8.14.0(typescript@6.0.3)
+      '@orval/mock': 8.14.0(typescript@6.0.3)
+      '@orval/query': 8.14.0(typescript@6.0.3)
+      '@orval/solid-start': 8.14.0(typescript@6.0.3)
+      '@orval/swr': 8.14.0(typescript@6.0.3)
+      '@orval/zod': 8.14.0(typescript@6.0.3)
       '@scalar/json-magic': 0.12.11
-      '@scalar/openapi-parser': 0.25.12
+      '@scalar/openapi-parser': 0.28.6
       '@scalar/openapi-types': 0.8.0
       chokidar: 5.0.0
-      commander: 14.0.2
+      commander: 14.0.3
       enquirer: 2.4.1
       execa: 9.6.1
       find-up: 8.0.0
-      fs-extra: 11.3.2
+      fs-extra: 11.3.5
+      get-tsconfig: 4.14.0
       jiti: 2.6.1
       js-yaml: 4.1.1
       remeda: 2.34.0
       string-argv: 0.3.2
-      tsconfck: 3.1.6(typescript@6.0.3)
       typedoc: 0.28.19(typescript@6.0.3)
       typedoc-plugin-coverage: 4.0.2(typedoc@0.28.19(typescript@6.0.3))
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
@@ -44921,11 +45176,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@4.0.2(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)):
+  source-map-loader@4.0.2(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)
 
   source-map-support@0.5.13:
     dependencies:
@@ -45444,10 +45699,10 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.3(@swc/core@1.15.18)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)):
+  swc-loader@0.2.3(@swc/core@1.15.18)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@swc/core': 1.15.18
-      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)
 
   symbol-tree@3.2.4: {}
 
@@ -45619,16 +45874,16 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.18
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       postcss: 8.5.15
 
   terser-webpack-plugin@5.6.0(postcss@8.5.15)(webpack@5.88.2):
@@ -45840,12 +46095,12 @@ snapshots:
       '@types/jest': 28.1.8
       babel-jest: 27.5.1(@babel/core@7.29.0)
 
-  ts-jest@29.4.9(@babel/core@7.26.0)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.26.0))(esbuild@0.27.7)(jest-util@30.0.5)(jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))(typescript@6.0.3):
+  ts-jest@29.4.9(@babel/core@7.26.0)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.26.0))(esbuild@0.28.0)(jest-util@30.0.5)(jest@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -45858,7 +46113,7 @@ snapshots:
       '@jest/transform': 30.0.5
       '@jest/types': 30.0.5
       babel-jest: 30.0.5(@babel/core@7.26.0)
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       jest-util: 30.0.5
 
   ts-json-schema-generator@2.4.0-next.6:
@@ -46198,8 +46453,6 @@ snapshots:
   unicode-property-aliases-ecmascript@2.1.0: {}
 
   unicorn-magic@0.3.0: {}
-
-  unicorn-magic@0.4.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -46862,7 +47115,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15):
+  webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -46886,7 +47139,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.27.7)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(esbuild@0.28.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/products/access_control/frontend/generated/api.schemas.ts
+++ b/products/access_control/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `read_write` - read_write
- * `read` - read
- * `none` - none
+ * * `read` - read
+ * * `none` - none
  */
 export type AccessLevelEnumApi = (typeof AccessLevelEnumApi)[keyof typeof AccessLevelEnumApi]
 
@@ -26,10 +26,10 @@ export const AccessLevelEnumApi = {
 export interface PropertyAccessControlRuleApi {
     readonly id: string
     /** The access level for this rule.
-
-  * `read_write` - read_write
-  * `read` - read
-  * `none` - none */
+     *
+     * * `read_write` - read_write
+     * * `read` - read
+     * * `none` - none */
     access_level: AccessLevelEnumApi
     /**
      * The organization member UUID this rule applies to, if any.
@@ -49,9 +49,9 @@ export interface PropertyAccessControlRuleApi {
 
 /**
  * Serializes the aggregate state for a property definition.
-
-Preserves the existing API shape: ``access_controls`` is the list
-of rules, plus the available levels and the computed default.
+ *
+ * Preserves the existing API shape: ``access_controls`` is the list
+ * of rules, plus the available levels and the computed default.
  */
 export interface PropertyAccessControlStateApi {
     /** List of all access control rules for this property definition. */
@@ -69,10 +69,10 @@ export interface PropertyAccessControlUpdateApi {
     /** The property definition ID this rule applies to. */
     property_definition_id: string
     /** The access level to set for this rule.
-
-  * `read_write` - read_write
-  * `read` - read
-  * `none` - none */
+     *
+     * * `read_write` - read_write
+     * * `read` - read
+     * * `none` - none */
     access_level: AccessLevelEnumApi
     /**
      * The organization member UUID to set an override for.

--- a/products/access_control/frontend/generated/api.ts
+++ b/products/access_control/frontend/generated/api.ts
@@ -24,7 +24,7 @@ export const getPropertyAccessControlsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -74,7 +74,7 @@ export const getPropertyAccessControlsDestroyUrl = (projectId: string, params: P
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/actions/frontend/generated/api.schemas.ts
+++ b/products/actions/frontend/generated/api.schemas.ts
@@ -9,32 +9,32 @@
  */
 /**
  * * `event` - event
- * `event_metadata` - event_metadata
- * `feature` - feature
- * `person` - person
- * `cohort` - cohort
- * `element` - element
- * `static-cohort` - static-cohort
- * `dynamic-cohort` - dynamic-cohort
- * `precalculated-cohort` - precalculated-cohort
- * `group` - group
- * `recording` - recording
- * `log_entry` - log_entry
- * `behavioral` - behavioral
- * `session` - session
- * `hogql` - hogql
- * `data_warehouse` - data_warehouse
- * `data_warehouse_person_property` - data_warehouse_person_property
- * `error_tracking_issue` - error_tracking_issue
- * `log` - log
- * `log_attribute` - log_attribute
- * `log_resource_attribute` - log_resource_attribute
- * `span` - span
- * `span_attribute` - span_attribute
- * `span_resource_attribute` - span_resource_attribute
- * `revenue_analytics` - revenue_analytics
- * `flag` - flag
- * `workflow_variable` - workflow_variable
+ * * `event_metadata` - event_metadata
+ * * `feature` - feature
+ * * `person` - person
+ * * `cohort` - cohort
+ * * `element` - element
+ * * `static-cohort` - static-cohort
+ * * `dynamic-cohort` - dynamic-cohort
+ * * `precalculated-cohort` - precalculated-cohort
+ * * `group` - group
+ * * `recording` - recording
+ * * `log_entry` - log_entry
+ * * `behavioral` - behavioral
+ * * `session` - session
+ * * `hogql` - hogql
+ * * `data_warehouse` - data_warehouse
+ * * `data_warehouse_person_property` - data_warehouse_person_property
+ * * `error_tracking_issue` - error_tracking_issue
+ * * `log` - log
+ * * `log_attribute` - log_attribute
+ * * `log_resource_attribute` - log_resource_attribute
+ * * `span` - span
+ * * `span_attribute` - span_attribute
+ * * `span_resource_attribute` - span_resource_attribute
+ * * `revenue_analytics` - revenue_analytics
+ * * `flag` - flag
+ * * `workflow_variable` - workflow_variable
  */
 export type PropertyFilterTypeEnumApi = (typeof PropertyFilterTypeEnumApi)[keyof typeof PropertyFilterTypeEnumApi]
 
@@ -70,11 +70,11 @@ export const PropertyFilterTypeEnumApi = {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
  */
 export type StringMatchOperatorEnumApi = (typeof StringMatchOperatorEnumApi)[keyof typeof StringMatchOperatorEnumApi]
 
@@ -94,55 +94,55 @@ export interface StringPropertyFilterApi {
     /** Key of the property you're filtering on. For example `email` or `$current_url`. */
     key: string
     /** Property type (event, person, session, etc.).
-
-  * `event` - event
-  * `event_metadata` - event_metadata
-  * `feature` - feature
-  * `person` - person
-  * `cohort` - cohort
-  * `element` - element
-  * `static-cohort` - static-cohort
-  * `dynamic-cohort` - dynamic-cohort
-  * `precalculated-cohort` - precalculated-cohort
-  * `group` - group
-  * `recording` - recording
-  * `log_entry` - log_entry
-  * `behavioral` - behavioral
-  * `session` - session
-  * `hogql` - hogql
-  * `data_warehouse` - data_warehouse
-  * `data_warehouse_person_property` - data_warehouse_person_property
-  * `error_tracking_issue` - error_tracking_issue
-  * `log` - log
-  * `log_attribute` - log_attribute
-  * `log_resource_attribute` - log_resource_attribute
-  * `span` - span
-  * `span_attribute` - span_attribute
-  * `span_resource_attribute` - span_resource_attribute
-  * `revenue_analytics` - revenue_analytics
-  * `flag` - flag
-  * `workflow_variable` - workflow_variable */
+     *
+     * * `event` - event
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable */
     type?: PropertyFilterTypeEnumApi
     /** String value to match against. */
     value: string
     /** String comparison operator.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains
-  * `regex` - regex
-  * `not_regex` - not_regex */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex */
     operator?: StringMatchOperatorEnumApi
 }
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `gt` - gt
- * `lt` - lt
- * `gte` - gte
- * `lte` - lte
+ * * `is_not` - is_not
+ * * `gt` - gt
+ * * `lt` - lt
+ * * `gte` - gte
+ * * `lte` - lte
  */
 export type NumericPropertyFilterOperatorEnumApi =
     (typeof NumericPropertyFilterOperatorEnumApi)[keyof typeof NumericPropertyFilterOperatorEnumApi]
@@ -163,53 +163,53 @@ export interface NumericPropertyFilterApi {
     /** Key of the property you're filtering on. For example `email` or `$current_url`. */
     key: string
     /** Property type (event, person, session, etc.).
-
-  * `event` - event
-  * `event_metadata` - event_metadata
-  * `feature` - feature
-  * `person` - person
-  * `cohort` - cohort
-  * `element` - element
-  * `static-cohort` - static-cohort
-  * `dynamic-cohort` - dynamic-cohort
-  * `precalculated-cohort` - precalculated-cohort
-  * `group` - group
-  * `recording` - recording
-  * `log_entry` - log_entry
-  * `behavioral` - behavioral
-  * `session` - session
-  * `hogql` - hogql
-  * `data_warehouse` - data_warehouse
-  * `data_warehouse_person_property` - data_warehouse_person_property
-  * `error_tracking_issue` - error_tracking_issue
-  * `log` - log
-  * `log_attribute` - log_attribute
-  * `log_resource_attribute` - log_resource_attribute
-  * `span` - span
-  * `span_attribute` - span_attribute
-  * `span_resource_attribute` - span_resource_attribute
-  * `revenue_analytics` - revenue_analytics
-  * `flag` - flag
-  * `workflow_variable` - workflow_variable */
+     *
+     * * `event` - event
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable */
     type?: PropertyFilterTypeEnumApi
     /** Numeric value to compare against. */
     value: number
     /** Numeric comparison operator.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `gt` - gt
-  * `lt` - lt
-  * `gte` - gte
-  * `lte` - lte */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `gte` - gte
+     * * `lte` - lte */
     operator?: NumericPropertyFilterOperatorEnumApi
 }
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `in` - in
- * `not_in` - not_in
+ * * `is_not` - is_not
+ * * `in` - in
+ * * `not_in` - not_in
  */
 export type ArrayPropertyFilterOperatorEnumApi =
     (typeof ArrayPropertyFilterOperatorEnumApi)[keyof typeof ArrayPropertyFilterOperatorEnumApi]
@@ -228,50 +228,50 @@ export interface ArrayPropertyFilterApi {
     /** Key of the property you're filtering on. For example `email` or `$current_url`. */
     key: string
     /** Property type (event, person, session, etc.).
-
-  * `event` - event
-  * `event_metadata` - event_metadata
-  * `feature` - feature
-  * `person` - person
-  * `cohort` - cohort
-  * `element` - element
-  * `static-cohort` - static-cohort
-  * `dynamic-cohort` - dynamic-cohort
-  * `precalculated-cohort` - precalculated-cohort
-  * `group` - group
-  * `recording` - recording
-  * `log_entry` - log_entry
-  * `behavioral` - behavioral
-  * `session` - session
-  * `hogql` - hogql
-  * `data_warehouse` - data_warehouse
-  * `data_warehouse_person_property` - data_warehouse_person_property
-  * `error_tracking_issue` - error_tracking_issue
-  * `log` - log
-  * `log_attribute` - log_attribute
-  * `log_resource_attribute` - log_resource_attribute
-  * `span` - span
-  * `span_attribute` - span_attribute
-  * `span_resource_attribute` - span_resource_attribute
-  * `revenue_analytics` - revenue_analytics
-  * `flag` - flag
-  * `workflow_variable` - workflow_variable */
+     *
+     * * `event` - event
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable */
     type?: PropertyFilterTypeEnumApi
     /** List of values to match. For example `["test@example.com", "ok@example.com"]`. */
     value: string[]
     /** Array comparison operator.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `in` - in
-  * `not_in` - not_in */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `in` - in
+     * * `not_in` - not_in */
     operator?: ArrayPropertyFilterOperatorEnumApi
 }
 
 /**
  * * `is_date_exact` - is_date_exact
- * `is_date_before` - is_date_before
- * `is_date_after` - is_date_after
+ * * `is_date_before` - is_date_before
+ * * `is_date_after` - is_date_after
  */
 export type DateOperatorEnumApi = (typeof DateOperatorEnumApi)[keyof typeof DateOperatorEnumApi]
 
@@ -288,48 +288,48 @@ export interface DatePropertyFilterApi {
     /** Key of the property you're filtering on. For example `email` or `$current_url`. */
     key: string
     /** Property type (event, person, session, etc.).
-
-  * `event` - event
-  * `event_metadata` - event_metadata
-  * `feature` - feature
-  * `person` - person
-  * `cohort` - cohort
-  * `element` - element
-  * `static-cohort` - static-cohort
-  * `dynamic-cohort` - dynamic-cohort
-  * `precalculated-cohort` - precalculated-cohort
-  * `group` - group
-  * `recording` - recording
-  * `log_entry` - log_entry
-  * `behavioral` - behavioral
-  * `session` - session
-  * `hogql` - hogql
-  * `data_warehouse` - data_warehouse
-  * `data_warehouse_person_property` - data_warehouse_person_property
-  * `error_tracking_issue` - error_tracking_issue
-  * `log` - log
-  * `log_attribute` - log_attribute
-  * `log_resource_attribute` - log_resource_attribute
-  * `span` - span
-  * `span_attribute` - span_attribute
-  * `span_resource_attribute` - span_resource_attribute
-  * `revenue_analytics` - revenue_analytics
-  * `flag` - flag
-  * `workflow_variable` - workflow_variable */
+     *
+     * * `event` - event
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable */
     type?: PropertyFilterTypeEnumApi
     /** Date or datetime string in ISO 8601 format (e.g. '2024-01-15' or '2024-01-15T10:30:00Z'). */
     value: string
     /** Date comparison operator.
-
-  * `is_date_exact` - is_date_exact
-  * `is_date_before` - is_date_before
-  * `is_date_after` - is_date_after */
+     *
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_before` - is_date_before
+     * * `is_date_after` - is_date_after */
     operator?: DateOperatorEnumApi
 }
 
 /**
  * * `is_set` - is_set
- * `is_not_set` - is_not_set
+ * * `is_not_set` - is_not_set
  */
 export type ExistenceOperatorEnumApi = (typeof ExistenceOperatorEnumApi)[keyof typeof ExistenceOperatorEnumApi]
 
@@ -345,39 +345,39 @@ export interface ExistencePropertyFilterApi {
     /** Key of the property you're filtering on. For example `email` or `$current_url`. */
     key: string
     /** Property type (event, person, session, etc.).
-
-  * `event` - event
-  * `event_metadata` - event_metadata
-  * `feature` - feature
-  * `person` - person
-  * `cohort` - cohort
-  * `element` - element
-  * `static-cohort` - static-cohort
-  * `dynamic-cohort` - dynamic-cohort
-  * `precalculated-cohort` - precalculated-cohort
-  * `group` - group
-  * `recording` - recording
-  * `log_entry` - log_entry
-  * `behavioral` - behavioral
-  * `session` - session
-  * `hogql` - hogql
-  * `data_warehouse` - data_warehouse
-  * `data_warehouse_person_property` - data_warehouse_person_property
-  * `error_tracking_issue` - error_tracking_issue
-  * `log` - log
-  * `log_attribute` - log_attribute
-  * `log_resource_attribute` - log_resource_attribute
-  * `span` - span
-  * `span_attribute` - span_attribute
-  * `span_resource_attribute` - span_resource_attribute
-  * `revenue_analytics` - revenue_analytics
-  * `flag` - flag
-  * `workflow_variable` - workflow_variable */
+     *
+     * * `event` - event
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable */
     type?: PropertyFilterTypeEnumApi
     /** Existence check operator.
-
-  * `is_set` - is_set
-  * `is_not_set` - is_not_set */
+     *
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set */
     operator: ExistenceOperatorEnumApi
 }
 
@@ -390,8 +390,8 @@ export type ActionStepPropertyFilterApi =
 
 /**
  * * `contains` - contains
- * `regex` - regex
- * `exact` - exact
+ * * `regex` - regex
+ * * `exact` - exact
  */
 export type ActionStepMatchingEnumApi = (typeof ActionStepMatchingEnumApi)[keyof typeof ActionStepMatchingEnumApi]
 
@@ -430,10 +430,10 @@ export interface ActionStepJSONApi {
      */
     text?: string | null
     /** How to match the text value. Defaults to exact.
-
-  * `contains` - contains
-  * `regex` - regex
-  * `exact` - exact */
+     *
+     * * `contains` - contains
+     * * `regex` - regex
+     * * `exact` - exact */
     text_matching?: ActionStepMatchingEnumApi | null
     /**
      * Link href attribute to match.
@@ -441,10 +441,10 @@ export interface ActionStepJSONApi {
      */
     href?: string | null
     /** How to match the href value. Defaults to exact.
-
-  * `contains` - contains
-  * `regex` - regex
-  * `exact` - exact */
+     *
+     * * `contains` - contains
+     * * `regex` - regex
+     * * `exact` - exact */
     href_matching?: ActionStepMatchingEnumApi | null
     /**
      * Page URL to match.
@@ -452,22 +452,22 @@ export interface ActionStepJSONApi {
      */
     url?: string | null
     /** How to match the URL value. Defaults to contains.
-
-  * `contains` - contains
-  * `regex` - regex
-  * `exact` - exact */
+     *
+     * * `contains` - contains
+     * * `regex` - regex
+     * * `exact` - exact */
     url_matching?: ActionStepMatchingEnumApi | null
 }
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -637,8 +637,8 @@ export interface ActionReferenceApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -655,10 +655,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]

--- a/products/actions/frontend/generated/api.ts
+++ b/products/actions/frontend/generated/api.ts
@@ -47,7 +47,7 @@ export const getActionsListUrl = (projectId: string, params?: ActionsListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -74,7 +74,7 @@ export const getActionsCreateUrl = (projectId: string, params?: ActionsCreatePar
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -104,7 +104,7 @@ export const getActionsRetrieveUrl = (projectId: string, id: number, params?: Ac
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -132,7 +132,7 @@ export const getActionsUpdateUrl = (projectId: string, id: number, params?: Acti
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -163,7 +163,7 @@ export const getActionsPartialUpdateUrl = (projectId: string, id: number, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -194,7 +194,7 @@ export const getActionsDestroyUrl = (projectId: string, id: number, params?: Act
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -225,7 +225,7 @@ export const getActionsReferencesListUrl = (projectId: string, id: number, param
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -253,7 +253,7 @@ export const getActionsBulkUpdateTagsCreateUrl = (projectId: string, params?: Ac
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -266,22 +266,22 @@ export const getActionsBulkUpdateTagsCreateUrl = (projectId: string, params?: Ac
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const actionsBulkUpdateTagsCreate = async (
     projectId: string,

--- a/products/actions/frontend/generated/api.zod.ts
+++ b/products/actions/frontend/generated/api.zod.ts
@@ -1225,22 +1225,22 @@ export const ActionsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const actionsBulkUpdateTagsCreateBodyIdsMax = 500
 

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -139,13 +139,13 @@ export interface _ErrorResponseApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -314,8 +314,8 @@ export interface EvaluationRunRequestApi {
 
 /**
  * * `active` - Active
- * `paused` - Paused
- * `error` - Error
+ * * `paused` - Paused
+ * * `error` - Error
  */
 export type EvaluationStatusEnumApi = (typeof EvaluationStatusEnumApi)[keyof typeof EvaluationStatusEnumApi]
 
@@ -327,8 +327,8 @@ export const EvaluationStatusEnumApi = {
 
 /**
  * * `trial_limit_reached` - Trial evaluation limit reached
- * `model_not_allowed` - Model not available on the trial plan
- * `provider_key_deleted` - Provider API key was deleted
+ * * `model_not_allowed` - Model not available on the trial plan
+ * * `provider_key_deleted` - Provider API key was deleted
  */
 export type StatusReasonEnumApi = (typeof StatusReasonEnumApi)[keyof typeof StatusReasonEnumApi]
 
@@ -340,7 +340,7 @@ export const StatusReasonEnumApi = {
 
 /**
  * * `llm_judge` - LLM as a judge
- * `hog` - Hog
+ * * `hog` - Hog
  */
 export type EvaluationTypeEnumApi = (typeof EvaluationTypeEnumApi)[keyof typeof EvaluationTypeEnumApi]
 
@@ -381,12 +381,12 @@ export interface EvaluationConditionApi {
 
 /**
  * * `openai` - Openai
- * `anthropic` - Anthropic
- * `gemini` - Gemini
- * `openrouter` - Openrouter
- * `fireworks` - Fireworks
- * `azure_openai` - Azure OpenAI
- * `together_ai` - Together AI
+ * * `anthropic` - Anthropic
+ * * `gemini` - Gemini
+ * * `openrouter` - Openrouter
+ * * `fireworks` - Fireworks
+ * * `azure_openai` - Azure OpenAI
+ * * `together_ai` - Together AI
  */
 export type LLMProviderEnumApi = (typeof LLMProviderEnumApi)[keyof typeof LLMProviderEnumApi]
 
@@ -454,15 +454,15 @@ export interface EvaluationApi {
     readonly status: EvaluationStatusEnumApi
     readonly status_reason: StatusReasonEnumApi | null
     /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-
-  * `llm_judge` - LLM as a judge
-  * `hog` - Hog */
+     *
+     * * `llm_judge` - LLM as a judge
+     * * `hog` - Hog */
     evaluation_type: EvaluationTypeEnumApi
     /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
     evaluation_config?: EvaluationApiEvaluationConfig
     /** Output format. Currently only 'boolean' is supported.
-
-  * `boolean` - Boolean (Pass/Fail) */
+     *
+     * * `boolean` - Boolean (Pass/Fail) */
     output_type: OutputTypeEnumApi
     /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
     output_config?: EvaluationApiOutputConfig
@@ -526,15 +526,15 @@ export interface PatchedEvaluationApi {
     readonly status?: EvaluationStatusEnumApi
     readonly status_reason?: StatusReasonEnumApi | null
     /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-
-  * `llm_judge` - LLM as a judge
-  * `hog` - Hog */
+     *
+     * * `llm_judge` - LLM as a judge
+     * * `hog` - Hog */
     evaluation_type?: EvaluationTypeEnumApi
     /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
     evaluation_config?: PatchedEvaluationApiEvaluationConfig
     /** Output format. Currently only 'boolean' is supported.
-
-  * `boolean` - Boolean (Pass/Fail) */
+     *
+     * * `boolean` - Boolean (Pass/Fail) */
     output_type?: OutputTypeEnumApi
     /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
     output_config?: PatchedEvaluationApiOutputConfig
@@ -605,8 +605,8 @@ export interface TestHogResponseApi {
 
 /**
  * * `trace` - trace
- * `generation` - generation
- * `evaluation` - evaluation
+ * * `generation` - generation
+ * * `evaluation` - evaluation
  */
 export type ClusteringJobAnalysisLevelEnumApi =
     (typeof ClusteringJobAnalysisLevelEnumApi)[keyof typeof ClusteringJobAnalysisLevelEnumApi]
@@ -652,7 +652,7 @@ export type ClusteringRunRequestApiEventFiltersItem = { [key: string]: unknown }
 
 /**
  * * `none` - none
- * `l2` - l2
+ * * `l2` - l2
  */
 export type EmbeddingNormalizationEnumApi =
     (typeof EmbeddingNormalizationEnumApi)[keyof typeof EmbeddingNormalizationEnumApi]
@@ -664,8 +664,8 @@ export const EmbeddingNormalizationEnumApi = {
 
 /**
  * * `none` - none
- * `umap` - umap
- * `pca` - pca
+ * * `umap` - umap
+ * * `pca` - pca
  */
 export type DimensionalityReductionMethodEnumApi =
     (typeof DimensionalityReductionMethodEnumApi)[keyof typeof DimensionalityReductionMethodEnumApi]
@@ -678,7 +678,7 @@ export const DimensionalityReductionMethodEnumApi = {
 
 /**
  * * `hdbscan` - hdbscan
- * `kmeans` - kmeans
+ * * `kmeans` - kmeans
  */
 export type ClusteringMethodEnumApi = (typeof ClusteringMethodEnumApi)[keyof typeof ClusteringMethodEnumApi]
 
@@ -689,8 +689,8 @@ export const ClusteringMethodEnumApi = {
 
 /**
  * * `umap` - umap
- * `pca` - pca
- * `tsne` - tsne
+ * * `pca` - pca
+ * * `tsne` - tsne
  */
 export type VisualizationMethodEnumApi = (typeof VisualizationMethodEnumApi)[keyof typeof VisualizationMethodEnumApi]
 
@@ -717,15 +717,15 @@ export interface ClusteringRunRequestApi {
      */
     max_samples?: number
     /** Embedding normalization method: 'none' (raw embeddings) or 'l2' (L2 normalize before clustering)
-
-  * `none` - none
-  * `l2` - l2 */
+     *
+     * * `none` - none
+     * * `l2` - l2 */
     embedding_normalization?: EmbeddingNormalizationEnumApi
     /** Dimensionality reduction method: 'none' (cluster on raw), 'umap', or 'pca'
-
-  * `none` - none
-  * `umap` - umap
-  * `pca` - pca */
+     *
+     * * `none` - none
+     * * `umap` - umap
+     * * `pca` - pca */
     dimensionality_reduction_method?: DimensionalityReductionMethodEnumApi
     /**
      * Target dimensions for dimensionality reduction (ignored if method is 'none')
@@ -734,9 +734,9 @@ export interface ClusteringRunRequestApi {
      */
     dimensionality_reduction_ndims?: number
     /** Clustering algorithm: 'hdbscan' (density-based, auto-determines k) or 'kmeans' (centroid-based)
-
-  * `hdbscan` - hdbscan
-  * `kmeans` - kmeans */
+     *
+     * * `hdbscan` - hdbscan
+     * * `kmeans` - kmeans */
     clustering_method?: ClusteringMethodEnumApi
     /**
      * Minimum cluster size as fraction of total samples (e.g., 0.02 = 2%)
@@ -768,10 +768,10 @@ export interface ClusteringRunRequestApi {
      */
     run_label?: string
     /** Method for 2D scatter plot visualization: 'umap', 'pca', or 'tsne'
-
-  * `umap` - umap
-  * `pca` - pca
-  * `tsne` - tsne */
+     *
+     * * `umap` - umap
+     * * `pca` - pca
+     * * `tsne` - tsne */
     visualization_method?: VisualizationMethodEnumApi
     /** Property filters to scope which traces are included in clustering (PostHog standard format) */
     event_filters?: ClusteringRunRequestApiEventFiltersItem[]
@@ -784,9 +784,9 @@ export interface ClusteringRunRequestApi {
 
 /**
  * * `unknown` - Unknown
- * `ok` - Ok
- * `invalid` - Invalid
- * `error` - Error
+ * * `ok` - Ok
+ * * `invalid` - Invalid
+ * * `error` - Error
  */
 export type LLMProviderKeyStateEnumApi = (typeof LLMProviderKeyStateEnumApi)[keyof typeof LLMProviderKeyStateEnumApi]
 
@@ -853,7 +853,7 @@ export interface EvaluationConfigSetActiveKeyRequestApi {
 
 /**
  * * `scheduled` - Scheduled
- * `every_n` - Every N
+ * * `every_n` - Every N
  */
 export type EvaluationReportFrequencyEnumApi =
     (typeof EvaluationReportFrequencyEnumApi)[keyof typeof EvaluationReportFrequencyEnumApi]
@@ -868,9 +868,9 @@ export interface EvaluationReportApi {
     /** UUID of the evaluation this report config belongs to. */
     evaluation: string
     /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-
-  * `scheduled` - Scheduled
-  * `every_n` - Every N */
+     *
+     * * `scheduled` - Scheduled
+     * * `every_n` - Every N */
     frequency?: EvaluationReportFrequencyEnumApi
     /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
     rrule?: string
@@ -940,9 +940,9 @@ export interface PatchedEvaluationReportApi {
     /** UUID of the evaluation this report config belongs to. */
     evaluation?: string
     /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-
-  * `scheduled` - Scheduled
-  * `every_n` - Every N */
+     *
+     * * `scheduled` - Scheduled
+     * * `every_n` - Every N */
     frequency?: EvaluationReportFrequencyEnumApi
     /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
     rrule?: string
@@ -1000,9 +1000,9 @@ export interface PatchedEvaluationReportApi {
 
 /**
  * * `pending` - Pending
- * `delivered` - Delivered
- * `partial_failure` - Partial Failure
- * `failed` - Failed
+ * * `delivered` - Delivered
+ * * `partial_failure` - Partial Failure
+ * * `failed` - Failed
  */
 export type DeliveryStatusEnumApi = (typeof DeliveryStatusEnumApi)[keyof typeof DeliveryStatusEnumApi]
 
@@ -1027,11 +1027,11 @@ export interface EvaluationReportRunApi {
     /** End of the evaluation window covered by this report. */
     readonly period_end: string
     /** 'pending', 'delivered', or 'failed'.
-
-  * `pending` - Pending
-  * `delivered` - Delivered
-  * `partial_failure` - Partial Failure
-  * `failed` - Failed */
+     *
+     * * `pending` - Pending
+     * * `delivered` - Delivered
+     * * `partial_failure` - Partial Failure
+     * * `failed` - Failed */
     readonly delivery_status: DeliveryStatusEnumApi
     /** List of delivery error messages if delivery failed. */
     readonly delivery_errors: unknown
@@ -1049,9 +1049,9 @@ export interface PaginatedEvaluationReportRunListApi {
 
 /**
  * * `all` - all
- * `pass` - pass
- * `fail` - fail
- * `na` - na
+ * * `pass` - pass
+ * * `fail` - fail
+ * * `na` - na
  */
 export type FilterEnumApi = (typeof FilterEnumApi)[keyof typeof FilterEnumApi]
 
@@ -1069,11 +1069,11 @@ export interface EvaluationSummaryRequestApi {
     /** UUID of the evaluation config to summarize */
     evaluation_id: string
     /** Filter type to apply ('all', 'pass', 'fail', or 'na')
-
-  * `all` - all
-  * `pass` - pass
-  * `fail` - fail
-  * `na` - na */
+     *
+     * * `all` - all
+     * * `pass` - pass
+     * * `fail` - fail
+     * * `na` - na */
     filter?: FilterEnumApi
     /**
      * Optional: specific generation IDs to include in summary (max 250)
@@ -1304,8 +1304,8 @@ export interface PatchedReviewQueueUpdateApi {
 
 /**
  * * `categorical` - categorical
- * `numeric` - numeric
- * `boolean` - boolean
+ * * `numeric` - numeric
+ * * `boolean` - boolean
  */
 export type ExperimentMetricKindEnumApi = (typeof ExperimentMetricKindEnumApi)[keyof typeof ExperimentMetricKindEnumApi]
 
@@ -1330,7 +1330,7 @@ export interface CategoricalScoreOptionApi {
 
 /**
  * * `single` - single
- * `multiple` - multiple
+ * * `multiple` - multiple
  */
 export type SelectionModeEnumApi = (typeof SelectionModeEnumApi)[keyof typeof SelectionModeEnumApi]
 
@@ -1343,9 +1343,9 @@ export interface CategoricalScoreDefinitionConfigApi {
     /** Ordered categorical options available to the scorer. */
     options: CategoricalScoreOptionApi[]
     /** Whether reviewers can select one option or multiple options. Defaults to `single`.
-
-  * `single` - single
-  * `multiple` - multiple */
+     *
+     * * `single` - single
+     * * `multiple` - multiple */
     selection_mode?: SelectionModeEnumApi
     /**
      * Optional minimum number of options that can be selected when `selection_mode` is `multiple`.
@@ -1435,10 +1435,10 @@ export interface ScoreDefinitionCreateApi {
      */
     description?: string | null
     /** Scorer kind. This cannot be changed after creation.
-
-  * `categorical` - categorical
-  * `numeric` - numeric
-  * `boolean` - boolean */
+     *
+     * * `categorical` - categorical
+     * * `numeric` - numeric
+     * * `boolean` - boolean */
     kind: ExperimentMetricKindEnumApi
     /** New scorers are always created as active. */
     archived?: boolean
@@ -1473,7 +1473,7 @@ export interface ScoreDefinitionNewVersionApi {
 
 /**
  * * `trace` - trace
- * `generation` - generation
+ * * `generation` - generation
  */
 export type SentimentRequestAnalysisLevelEnumApi =
     (typeof SentimentRequestAnalysisLevelEnumApi)[keyof typeof SentimentRequestAnalysisLevelEnumApi]
@@ -1491,9 +1491,9 @@ export interface SentimentRequestApi {
      */
     ids: string[]
     /** Whether the IDs are 'trace' IDs or 'generation' IDs.
-
-  * `trace` - trace
-  * `generation` - generation */
+     *
+     * * `trace` - trace
+     * * `generation` - generation */
     analysis_level?: SentimentRequestAnalysisLevelEnumApi
     /** If true, bypass cache and reclassify. */
     force_refresh?: boolean
@@ -1537,10 +1537,10 @@ export interface SentimentBatchResponseApi {
 
 /**
  * Filter shape mirrors the previous frontend `api.query({filters: ...})` payload.
-
-`filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
-path used (dateRange, filterTestAccounts, properties), so the migration is
-behaviour-preserving for callers that pass a request unchanged.
+ *
+ * `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
+ * path used (dateRange, filterTestAccounts, properties), so the migration is
+ * behaviour-preserving for callers that pass a request unchanged.
  */
 export interface SentimentGenerationsRequestApi {
     filters?: unknown
@@ -1552,7 +1552,7 @@ export interface SentimentGenerationsResponseApi {
 
 /**
  * * `trace` - trace
- * `event` - event
+ * * `event` - event
  */
 export type SummarizeTypeEnumApi = (typeof SummarizeTypeEnumApi)[keyof typeof SummarizeTypeEnumApi]
 
@@ -1563,7 +1563,7 @@ export const SummarizeTypeEnumApi = {
 
 /**
  * * `minimal` - minimal
- * `detailed` - detailed
+ * * `detailed` - detailed
  */
 export type DetailModeValueEnumApi = (typeof DetailModeValueEnumApi)[keyof typeof DetailModeValueEnumApi]
 
@@ -1574,14 +1574,14 @@ export const DetailModeValueEnumApi = {
 
 export interface SummarizeRequestApi {
     /** Type of entity to summarize. Inferred automatically when using trace_id or generation_id.
-
-  * `trace` - trace
-  * `event` - event */
+     *
+     * * `trace` - trace
+     * * `event` - event */
     summarize_type?: SummarizeTypeEnumApi
     /** Summary detail level: 'minimal' for 3-5 points, 'detailed' for 5-10 points
-
-  * `minimal` - minimal
-  * `detailed` - detailed */
+     *
+     * * `minimal` - minimal
+     * * `detailed` - detailed */
     mode?: DetailModeValueEnumApi
     /** Data to summarize. For traces: {trace, hierarchy}. For events: {event}. Not required when using trace_id or generation_id. */
     data?: unknown
@@ -1645,9 +1645,9 @@ export interface BatchCheckRequestApi {
      */
     trace_ids: string[]
     /** Summary detail level to check for
-
-  * `minimal` - minimal
-  * `detailed` - detailed */
+     *
+     * * `minimal` - minimal
+     * * `detailed` - detailed */
     mode?: DetailModeValueEnumApi
     /**
      * LLM model used for cached summaries
@@ -1668,9 +1668,9 @@ export interface BatchCheckResponseApi {
 
 /**
  * * `$ai_generation` - $ai_generation
- * `$ai_span` - $ai_span
- * `$ai_embedding` - $ai_embedding
- * `$ai_trace` - $ai_trace
+ * * `$ai_span` - $ai_span
+ * * `$ai_embedding` - $ai_embedding
+ * * `$ai_trace` - $ai_trace
  */
 export type EventTypeEnumApi = (typeof EventTypeEnumApi)[keyof typeof EventTypeEnumApi]
 
@@ -1706,11 +1706,11 @@ export interface TextReprOptionsApi {
 
 export interface TextReprRequestApi {
     /** Type of LLM event to stringify
-
-  * `$ai_generation` - $ai_generation
-  * `$ai_span` - $ai_span
-  * `$ai_embedding` - $ai_embedding
-  * `$ai_trace` - $ai_trace */
+     *
+     * * `$ai_generation` - $ai_generation
+     * * `$ai_span` - $ai_span
+     * * `$ai_embedding` - $ai_embedding
+     * * `$ai_trace` - $ai_trace */
     event_type: EventTypeEnumApi
     /** Event data to stringify. For traces, should include 'trace' and 'hierarchy' fields. */
     data: unknown
@@ -1811,6 +1811,7 @@ export interface TraceReviewScoreWriteApi {
      * Categorical option keys selected for this score.
      * @minItems 1
      * @nullable
+     * @items.maxLength 128
      */
     categorical_values?: string[] | null
     /**
@@ -2315,7 +2316,7 @@ export interface LLMSkillResolveResponseApi {
 
 /**
  * * `llm` - LLM
- * `hog` - Hog
+ * * `hog` - Hog
  */
 export type TaggerTypeEnumApi = (typeof TaggerTypeEnumApi)[keyof typeof TaggerTypeEnumApi]
 
@@ -2393,14 +2394,14 @@ export interface TaggerConditionApi {
  */
 export interface TaggerModelConfigurationApi {
     /** LLM provider to use for this tagger.
-
-  * `openai` - Openai
-  * `anthropic` - Anthropic
-  * `gemini` - Gemini
-  * `openrouter` - Openrouter
-  * `fireworks` - Fireworks
-  * `azure_openai` - Azure OpenAI
-  * `together_ai` - Together AI */
+     *
+     * * `openai` - Openai
+     * * `anthropic` - Anthropic
+     * * `gemini` - Gemini
+     * * `openrouter` - Openrouter
+     * * `fireworks` - Fireworks
+     * * `azure_openai` - Azure OpenAI
+     * * `together_ai` - Together AI */
     provider: LLMProviderEnumApi
     /**
      * Provider model identifier to use for this tagger.
@@ -2445,14 +2446,14 @@ export interface PaginatedTaggerListApi {
 
 export interface TaggerModelConfigurationWriteApi {
     /** LLM provider to use for this tagger.
-
-  * `openai` - Openai
-  * `anthropic` - Anthropic
-  * `gemini` - Gemini
-  * `openrouter` - Openrouter
-  * `fireworks` - Fireworks
-  * `azure_openai` - Azure OpenAI
-  * `together_ai` - Together AI */
+     *
+     * * `openai` - Openai
+     * * `anthropic` - Anthropic
+     * * `gemini` - Gemini
+     * * `openrouter` - Openrouter
+     * * `fireworks` - Fireworks
+     * * `azure_openai` - Azure OpenAI
+     * * `together_ai` - Together AI */
     provider: LLMProviderEnumApi
     /**
      * Provider model identifier to use for this tagger.
@@ -2626,13 +2627,13 @@ export type DatasetsListParams = {
      */
     offset?: number
     /**
- * Ordering
-
-* `created_at` - Created At
-* `-created_at` - Created At (descending)
-* `updated_at` - Updated At
-* `-updated_at` - Updated At (descending)
- */
+     * Ordering
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     */
     order_by?: string[]
     /**
      * Search in name, description, or metadata
@@ -2660,15 +2661,15 @@ export type EvaluationsListParams = {
      */
     offset?: number
     /**
- * Ordering
-
-* `created_at` - Created At
-* `-created_at` - Created At (descending)
-* `updated_at` - Updated At
-* `-updated_at` - Updated At (descending)
-* `name` - Name
-* `-name` - Name (descending)
- */
+     * Ordering
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
+     */
     order_by?: string[]
     /**
      * Search in name or description
@@ -2914,13 +2915,13 @@ export type LlmAnalyticsTranslateCreate200 = { [key: string]: unknown }
 
 export type LlmPromptsListParams = {
     /**
- * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-* `full` - full
-* `preview` - preview
-* `none` - none
- * @minLength 1
- */
+     * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
+     * @minLength 1
+     */
     content?: LlmPromptsListContent
     /**
      * Filter prompts by the ID of the user who created them.
@@ -2950,13 +2951,13 @@ export const LlmPromptsListContent = {
 
 export type LlmPromptsNameRetrieveParams = {
     /**
- * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-* `full` - full
-* `preview` - preview
-* `none` - none
- * @minLength 1
- */
+     * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
+     * @minLength 1
+     */
     content?: LlmPromptsNameRetrieveContent
     /**
      * Specific prompt version to fetch. If omitted, the latest version is returned.
@@ -3091,15 +3092,15 @@ export type TaggersListParams = {
      */
     offset?: number
     /**
- * Ordering
-
-* `created_at` - Created At
-* `-created_at` - Created At (descending)
-* `updated_at` - Updated At
-* `-updated_at` - Updated At (descending)
-* `name` - Name
-* `-name` - Name (descending)
- */
+     * Ordering
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
+     */
     order_by?: string[]
     /**
      * Search in name or description

--- a/products/ai_observability/frontend/generated/api.ts
+++ b/products/ai_observability/frontend/generated/api.ts
@@ -145,7 +145,7 @@ export const getLlmAnalyticsPersonalSpendListUrl = (params: LlmAnalyticsPersonal
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -174,7 +174,7 @@ export const getDatasetItemsListUrl = (projectId: string, params?: DatasetItemsL
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -283,7 +283,7 @@ export const getDatasetsListUrl = (projectId: string, params?: DatasetsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -389,9 +389,9 @@ export const getEvaluationRunsCreateUrl = (projectId: string) => {
 
 /**
  * Create a new evaluation run.
-
-This endpoint validates the request and enqueues a Temporal workflow
-to asynchronously execute the evaluation.
+ *
+ * This endpoint validates the request and enqueues a Temporal workflow
+ * to asynchronously execute the evaluation.
  */
 export const evaluationRunsCreate = async (
     projectId: string,
@@ -411,7 +411,7 @@ export const getEvaluationsListUrl = (projectId: string, params?: EvaluationsLis
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -580,7 +580,7 @@ export const getLlmAnalyticsClusteringJobsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -709,9 +709,9 @@ export const getLlmAnalyticsClusteringRunsCreateUrl = (projectId: string) => {
 
 /**
  * Trigger a new clustering workflow run.
-
-This endpoint validates the request parameters and starts a Temporal workflow
-to perform trace clustering with the specified configuration.
+ *
+ * This endpoint validates the request parameters and starts a Temporal workflow
+ * to perform trace clustering with the specified configuration.
  */
 export const llmAnalyticsClusteringRunsCreate = async (
     projectId: string,
@@ -771,7 +771,7 @@ export const getLlmAnalyticsEvaluationReportsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -921,7 +921,7 @@ export const getLlmAnalyticsEvaluationReportsRunsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -956,19 +956,19 @@ export const getLlmAnalyticsEvaluationSummaryCreateUrl = (projectId: string) => 
 
 /**
  *
-Generate an AI-powered summary of evaluation results.
-
-This endpoint analyzes evaluation runs and identifies patterns in passing
-and failing evaluations, providing actionable recommendations.
-
-Data is fetched server-side by evaluation ID to ensure data integrity.
-
-**Use Cases:**
-- Understand why evaluations are passing or failing
-- Identify systematic issues in LLM responses
-- Get recommendations for improving response quality
-- Review patterns across many evaluation runs at once
-
+ * Generate an AI-powered summary of evaluation results.
+ *
+ * This endpoint analyzes evaluation runs and identifies patterns in passing
+ * and failing evaluations, providing actionable recommendations.
+ *
+ * Data is fetched server-side by evaluation ID to ensure data integrity.
+ *
+ * **Use Cases:**
+ * - Understand why evaluations are passing or failing
+ * - Identify systematic issues in LLM responses
+ * - Get recommendations for improving response quality
+ * - Review patterns across many evaluation runs at once
+ *
  */
 export const llmAnalyticsEvaluationSummaryCreate = async (
     projectId: string,
@@ -988,7 +988,7 @@ export const getLlmAnalyticsModelsRetrieveUrl = (projectId: string, params: LlmA
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1041,7 +1041,7 @@ export const getLlmAnalyticsParserRecipesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1153,7 +1153,7 @@ export const getLlmAnalyticsProviderKeysListUrl = (projectId: string, params?: L
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1340,7 +1340,7 @@ export const getLlmAnalyticsReviewQueueItemsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1432,7 +1432,7 @@ export const getLlmAnalyticsReviewQueuesListUrl = (projectId: string, params?: L
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1527,7 +1527,7 @@ export const getLlmAnalyticsScoreDefinitionsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1657,27 +1657,27 @@ export const getLlmAnalyticsSummarizationCreateUrl = (projectId: string) => {
 
 /**
  *
-Generate an AI-powered summary of an LLM trace or event.
-
-This endpoint analyzes the provided trace/event, generates a line-numbered text
-representation, and uses an LLM to create a concise summary with line references.
-
-**Two ways to use this endpoint:**
-
-1. **By ID (recommended):** Pass `trace_id` or `generation_id` with an optional `date_from`/`date_to`.
-   The backend fetches the data automatically. `summarize_type` is inferred.
-2. **By data:** Pass the full trace/event data blob in `data` with `summarize_type`.
-   This is how the frontend uses it.
-
-**Summary Format:**
-- Title (concise, max 10 words)
-- Mermaid flow diagram showing the main flow
-- 3-10 summary bullets with line references
-- "Interesting Notes" section for failures, successes, or unusual patterns
-- Line references in [L45] or [L45-52] format pointing to relevant sections
-
-The response includes the structured summary, the text representation, and metadata.
-
+ * Generate an AI-powered summary of an LLM trace or event.
+ *
+ * This endpoint analyzes the provided trace/event, generates a line-numbered text
+ * representation, and uses an LLM to create a concise summary with line references.
+ *
+ * **Two ways to use this endpoint:**
+ *
+ * 1. **By ID (recommended):** Pass `trace_id` or `generation_id` with an optional `date_from`/`date_to`.
+ *    The backend fetches the data automatically. `summarize_type` is inferred.
+ * 2. **By data:** Pass the full trace/event data blob in `data` with `summarize_type`.
+ *    This is how the frontend uses it.
+ *
+ * **Summary Format:**
+ * - Title (concise, max 10 words)
+ * - Mermaid flow diagram showing the main flow
+ * - 3-10 summary bullets with line references
+ * - "Interesting Notes" section for failures, successes, or unusual patterns
+ * - Line references in [L45] or [L45-52] format pointing to relevant sections
+ *
+ * The response includes the structured summary, the text representation, and metadata.
+ *
  */
 export const llmAnalyticsSummarizationCreate = async (
     projectId: string,
@@ -1698,17 +1698,17 @@ export const getLlmAnalyticsSummarizationBatchCheckCreateUrl = (projectId: strin
 
 /**
  *
-Check which traces have cached summaries available.
-
-This endpoint allows batch checking of multiple trace IDs to see which ones
-have cached summaries. Returns only the traces that have cached summaries
-with their titles.
-
-**Use Cases:**
-- Load cached summaries on session view load
-- Avoid unnecessary LLM calls for already-summarized traces
-- Display summary previews without generating new summaries
-
+ * Check which traces have cached summaries available.
+ *
+ * This endpoint allows batch checking of multiple trace IDs to see which ones
+ * have cached summaries. Returns only the traces that have cached summaries
+ * with their titles.
+ *
+ * **Use Cases:**
+ * - Load cached summaries on session view load
+ * - Avoid unnecessary LLM calls for already-summarized traces
+ * - Display summary previews without generating new summaries
+ *
  */
 export const llmAnalyticsSummarizationBatchCheckCreate = async (
     projectId: string,
@@ -1729,39 +1729,39 @@ export const getLlmAnalyticsTextReprCreateUrl = (projectId: string) => {
 
 /**
  *
-Generate a human-readable text representation of an LLM trace event.
-
-This endpoint converts AI observability events ($ai_generation, $ai_span, $ai_embedding, or $ai_trace)
-into formatted text representations suitable for display, logging, or analysis.
-
-**Supported Event Types:**
-- `$ai_generation`: Individual LLM API calls with input/output messages
-- `$ai_span`: Logical spans with state transitions
-- `$ai_embedding`: Embedding generation events (text input → vector)
-- `$ai_trace`: Full traces with hierarchical structure
-
-**Options:**
-- `max_length`: Maximum character count (default: 2000000)
-- `truncated`: Enable middle-content truncation within events (default: true)
-- `truncate_buffer`: Characters at start/end when truncating (default: 1000)
-- `include_markers`: Use interactive markers vs plain text indicators (default: true)
-  - Frontend: set true for `<<<TRUNCATED|base64|...>>>` markers
-  - Backend/LLM: set false for `... (X chars truncated) ...` text
-- `collapsed`: Show summary vs full trace tree (default: false)
-- `include_hierarchy`: Include tree structure for traces (default: true)
-- `max_depth`: Maximum depth for hierarchical rendering (default: unlimited)
-- `tools_collapse_threshold`: Number of tools before auto-collapsing list (default: 5)
-  - Tool lists >5 items show `<<<TOOLS_EXPANDABLE|...>>>` marker for frontend
-  - Or `[+] AVAILABLE TOOLS: N` for backend when `include_markers: false`
-- `include_line_numbers`: Prefix each line with line number like L001:, L010: (default: false)
-
-**Use Cases:**
-- Frontend display: `truncated: true, include_markers: true, include_line_numbers: true`
-- Backend LLM context (summary): `truncated: true, include_markers: false, collapsed: true`
-- Backend LLM context (full): `truncated: false`
-
-The response includes the formatted text and metadata about the rendering.
-
+ * Generate a human-readable text representation of an LLM trace event.
+ *
+ * This endpoint converts AI observability events ($ai_generation, $ai_span, $ai_embedding, or $ai_trace)
+ * into formatted text representations suitable for display, logging, or analysis.
+ *
+ * **Supported Event Types:**
+ * - `$ai_generation`: Individual LLM API calls with input/output messages
+ * - `$ai_span`: Logical spans with state transitions
+ * - `$ai_embedding`: Embedding generation events (text input → vector)
+ * - `$ai_trace`: Full traces with hierarchical structure
+ *
+ * **Options:**
+ * - `max_length`: Maximum character count (default: 2000000)
+ * - `truncated`: Enable middle-content truncation within events (default: true)
+ * - `truncate_buffer`: Characters at start/end when truncating (default: 1000)
+ * - `include_markers`: Use interactive markers vs plain text indicators (default: true)
+ *   - Frontend: set true for `<<<TRUNCATED|base64|...>>>` markers
+ *   - Backend/LLM: set false for `... (X chars truncated) ...` text
+ * - `collapsed`: Show summary vs full trace tree (default: false)
+ * - `include_hierarchy`: Include tree structure for traces (default: true)
+ * - `max_depth`: Maximum depth for hierarchical rendering (default: unlimited)
+ * - `tools_collapse_threshold`: Number of tools before auto-collapsing list (default: 5)
+ *   - Tool lists >5 items show `<<<TOOLS_EXPANDABLE|...>>>` marker for frontend
+ *   - Or `[+] AVAILABLE TOOLS: N` for backend when `include_markers: false`
+ * - `include_line_numbers`: Prefix each line with line number like L001:, L010: (default: false)
+ *
+ * **Use Cases:**
+ * - Frontend display: `truncated: true, include_markers: true, include_line_numbers: true`
+ * - Backend LLM context (summary): `truncated: true, include_markers: false, collapsed: true`
+ * - Backend LLM context (full): `truncated: false`
+ *
+ * The response includes the formatted text and metadata about the rendering.
+ *
  */
 export const llmAnalyticsTextReprCreate = async (
     projectId: string,
@@ -1781,7 +1781,7 @@ export const getLlmAnalyticsTraceReviewsListUrl = (projectId: string, params?: L
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1893,7 +1893,7 @@ export const getLlmPromptsListUrl = (projectId: string, params?: LlmPromptsListP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1941,7 +1941,7 @@ export const getLlmPromptsNameRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2027,7 +2027,7 @@ export const getLlmPromptsResolveNameRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2055,7 +2055,7 @@ export const getLlmSkillsListUrl = (projectId: string, params?: LlmSkillsListPar
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2103,7 +2103,7 @@ export const getLlmSkillsNameRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2223,7 +2223,7 @@ export const getLlmSkillsNameFilesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2257,7 +2257,7 @@ export const getLlmSkillsNameFilesDestroyUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2290,7 +2290,7 @@ export const getLlmSkillsResolveNameRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2318,7 +2318,7 @@ export const getTaggersListUrl = (projectId: string, params?: TaggersListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -83,9 +83,9 @@ export const DatasetsPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create a new evaluation run.
-
-This endpoint validates the request and enqueues a Temporal workflow
-to asynchronously execute the evaluation.
+ *
+ * This endpoint validates the request and enqueues a Temporal workflow
+ * to asynchronously execute the evaluation.
  */
 export const evaluationRunsCreateBodyEventDefault = `$ai_generation`
 
@@ -512,9 +512,9 @@ export const LlmAnalyticsClusteringJobsPartialUpdateBody = /* @__PURE__ */ zod.o
 
 /**
  * Trigger a new clustering workflow run.
-
-This endpoint validates the request parameters and starts a Temporal workflow
-to perform trace clustering with the specified configuration.
+ *
+ * This endpoint validates the request parameters and starts a Temporal workflow
+ * to perform trace clustering with the specified configuration.
  */
 export const llmAnalyticsClusteringRunsCreateBodyLookbackDaysDefault = 7
 export const llmAnalyticsClusteringRunsCreateBodyLookbackDaysMax = 90
@@ -923,19 +923,19 @@ export const LlmAnalyticsEvaluationReportsPartialUpdateBody = /* @__PURE__ */ zo
 
 /**
  *
-Generate an AI-powered summary of evaluation results.
-
-This endpoint analyzes evaluation runs and identifies patterns in passing
-and failing evaluations, providing actionable recommendations.
-
-Data is fetched server-side by evaluation ID to ensure data integrity.
-
-**Use Cases:**
-- Understand why evaluations are passing or failing
-- Identify systematic issues in LLM responses
-- Get recommendations for improving response quality
-- Review patterns across many evaluation runs at once
-
+ * Generate an AI-powered summary of evaluation results.
+ *
+ * This endpoint analyzes evaluation runs and identifies patterns in passing
+ * and failing evaluations, providing actionable recommendations.
+ *
+ * Data is fetched server-side by evaluation ID to ensure data integrity.
+ *
+ * **Use Cases:**
+ * - Understand why evaluations are passing or failing
+ * - Identify systematic issues in LLM responses
+ * - Get recommendations for improving response quality
+ * - Review patterns across many evaluation runs at once
+ *
  */
 export const llmAnalyticsEvaluationSummaryCreateBodyFilterDefault = `all`
 export const llmAnalyticsEvaluationSummaryCreateBodyGenerationIdsMax = 250
@@ -1343,27 +1343,27 @@ export const LlmAnalyticsSentimentGenerationsCreateBody = /* @__PURE__ */ zod
 
 /**
  *
-Generate an AI-powered summary of an LLM trace or event.
-
-This endpoint analyzes the provided trace/event, generates a line-numbered text
-representation, and uses an LLM to create a concise summary with line references.
-
-**Two ways to use this endpoint:**
-
-1. **By ID (recommended):** Pass `trace_id` or `generation_id` with an optional `date_from`/`date_to`.
-   The backend fetches the data automatically. `summarize_type` is inferred.
-2. **By data:** Pass the full trace/event data blob in `data` with `summarize_type`.
-   This is how the frontend uses it.
-
-**Summary Format:**
-- Title (concise, max 10 words)
-- Mermaid flow diagram showing the main flow
-- 3-10 summary bullets with line references
-- "Interesting Notes" section for failures, successes, or unusual patterns
-- Line references in [L45] or [L45-52] format pointing to relevant sections
-
-The response includes the structured summary, the text representation, and metadata.
-
+ * Generate an AI-powered summary of an LLM trace or event.
+ *
+ * This endpoint analyzes the provided trace/event, generates a line-numbered text
+ * representation, and uses an LLM to create a concise summary with line references.
+ *
+ * **Two ways to use this endpoint:**
+ *
+ * 1. **By ID (recommended):** Pass `trace_id` or `generation_id` with an optional `date_from`/`date_to`.
+ *    The backend fetches the data automatically. `summarize_type` is inferred.
+ * 2. **By data:** Pass the full trace/event data blob in `data` with `summarize_type`.
+ *    This is how the frontend uses it.
+ *
+ * **Summary Format:**
+ * - Title (concise, max 10 words)
+ * - Mermaid flow diagram showing the main flow
+ * - 3-10 summary bullets with line references
+ * - "Interesting Notes" section for failures, successes, or unusual patterns
+ * - Line references in [L45] or [L45-52] format pointing to relevant sections
+ *
+ * The response includes the structured summary, the text representation, and metadata.
+ *
  */
 export const llmAnalyticsSummarizationCreateBodyModeDefault = `minimal`
 export const llmAnalyticsSummarizationCreateBodyForceRefreshDefault = false
@@ -1415,17 +1415,17 @@ export const LlmAnalyticsSummarizationCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  *
-Check which traces have cached summaries available.
-
-This endpoint allows batch checking of multiple trace IDs to see which ones
-have cached summaries. Returns only the traces that have cached summaries
-with their titles.
-
-**Use Cases:**
-- Load cached summaries on session view load
-- Avoid unnecessary LLM calls for already-summarized traces
-- Display summary previews without generating new summaries
-
+ * Check which traces have cached summaries available.
+ *
+ * This endpoint allows batch checking of multiple trace IDs to see which ones
+ * have cached summaries. Returns only the traces that have cached summaries
+ * with their titles.
+ *
+ * **Use Cases:**
+ * - Load cached summaries on session view load
+ * - Avoid unnecessary LLM calls for already-summarized traces
+ * - Display summary previews without generating new summaries
+ *
  */
 export const llmAnalyticsSummarizationBatchCheckCreateBodyTraceIdsMax = 100
 
@@ -1446,39 +1446,39 @@ export const LlmAnalyticsSummarizationBatchCheckCreateBody = /* @__PURE__ */ zod
 
 /**
  *
-Generate a human-readable text representation of an LLM trace event.
-
-This endpoint converts AI observability events ($ai_generation, $ai_span, $ai_embedding, or $ai_trace)
-into formatted text representations suitable for display, logging, or analysis.
-
-**Supported Event Types:**
-- `$ai_generation`: Individual LLM API calls with input/output messages
-- `$ai_span`: Logical spans with state transitions
-- `$ai_embedding`: Embedding generation events (text input → vector)
-- `$ai_trace`: Full traces with hierarchical structure
-
-**Options:**
-- `max_length`: Maximum character count (default: 2000000)
-- `truncated`: Enable middle-content truncation within events (default: true)
-- `truncate_buffer`: Characters at start/end when truncating (default: 1000)
-- `include_markers`: Use interactive markers vs plain text indicators (default: true)
-  - Frontend: set true for `<<<TRUNCATED|base64|...>>>` markers
-  - Backend/LLM: set false for `... (X chars truncated) ...` text
-- `collapsed`: Show summary vs full trace tree (default: false)
-- `include_hierarchy`: Include tree structure for traces (default: true)
-- `max_depth`: Maximum depth for hierarchical rendering (default: unlimited)
-- `tools_collapse_threshold`: Number of tools before auto-collapsing list (default: 5)
-  - Tool lists >5 items show `<<<TOOLS_EXPANDABLE|...>>>` marker for frontend
-  - Or `[+] AVAILABLE TOOLS: N` for backend when `include_markers: false`
-- `include_line_numbers`: Prefix each line with line number like L001:, L010: (default: false)
-
-**Use Cases:**
-- Frontend display: `truncated: true, include_markers: true, include_line_numbers: true`
-- Backend LLM context (summary): `truncated: true, include_markers: false, collapsed: true`
-- Backend LLM context (full): `truncated: false`
-
-The response includes the formatted text and metadata about the rendering.
-
+ * Generate a human-readable text representation of an LLM trace event.
+ *
+ * This endpoint converts AI observability events ($ai_generation, $ai_span, $ai_embedding, or $ai_trace)
+ * into formatted text representations suitable for display, logging, or analysis.
+ *
+ * **Supported Event Types:**
+ * - `$ai_generation`: Individual LLM API calls with input/output messages
+ * - `$ai_span`: Logical spans with state transitions
+ * - `$ai_embedding`: Embedding generation events (text input → vector)
+ * - `$ai_trace`: Full traces with hierarchical structure
+ *
+ * **Options:**
+ * - `max_length`: Maximum character count (default: 2000000)
+ * - `truncated`: Enable middle-content truncation within events (default: true)
+ * - `truncate_buffer`: Characters at start/end when truncating (default: 1000)
+ * - `include_markers`: Use interactive markers vs plain text indicators (default: true)
+ *   - Frontend: set true for `<<<TRUNCATED|base64|...>>>` markers
+ *   - Backend/LLM: set false for `... (X chars truncated) ...` text
+ * - `collapsed`: Show summary vs full trace tree (default: false)
+ * - `include_hierarchy`: Include tree structure for traces (default: true)
+ * - `max_depth`: Maximum depth for hierarchical rendering (default: unlimited)
+ * - `tools_collapse_threshold`: Number of tools before auto-collapsing list (default: 5)
+ *   - Tool lists >5 items show `<<<TOOLS_EXPANDABLE|...>>>` marker for frontend
+ *   - Or `[+] AVAILABLE TOOLS: N` for backend when `include_markers: false`
+ * - `include_line_numbers`: Prefix each line with line number like L001:, L010: (default: false)
+ *
+ * **Use Cases:**
+ * - Frontend display: `truncated: true, include_markers: true, include_line_numbers: true`
+ * - Backend LLM context (summary): `truncated: true, include_markers: false, collapsed: true`
+ * - Backend LLM context (full): `truncated: false`
+ *
+ * The response includes the formatted text and metadata about the rendering.
+ *
  */
 export const LlmAnalyticsTextReprCreateBody = /* @__PURE__ */ zod.object({
     event_type: zod

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -105,9 +105,9 @@ export interface AlertConditionApi {
 
 /**
  * * `Firing` - Firing
- * `Not firing` - Not firing
- * `Errored` - Errored
- * `Snoozed` - Snoozed
+ * * `Not firing` - Not firing
+ * * `Errored` - Errored
+ * * `Snoozed` - Snoozed
  */
 export type AlertCheckStateEnumApi = (typeof AlertCheckStateEnumApi)[keyof typeof AlertCheckStateEnumApi]
 
@@ -120,10 +120,10 @@ export const AlertCheckStateEnumApi = {
 
 /**
  * * `pending` - pending
- * `running` - running
- * `done` - done
- * `failed` - failed
- * `skipped` - skipped
+ * * `running` - running
+ * * `done` - done
+ * * `failed` - failed
+ * * `skipped` - skipped
  */
 export type InvestigationStatusEnumApi = (typeof InvestigationStatusEnumApi)[keyof typeof InvestigationStatusEnumApi]
 
@@ -137,8 +137,8 @@ export const InvestigationStatusEnumApi = {
 
 /**
  * * `true_positive` - true_positive
- * `false_positive` - false_positive
- * `inconclusive` - inconclusive
+ * * `false_positive` - false_positive
+ * * `inconclusive` - inconclusive
  */
 export type InvestigationVerdictEnumApi = (typeof InvestigationVerdictEnumApi)[keyof typeof InvestigationVerdictEnumApi]
 
@@ -382,10 +382,10 @@ export type DetectorConfigApi =
 
 /**
  * * `every_15_minutes` - every_15_minutes
- * `hourly` - hourly
- * `daily` - daily
- * `weekly` - weekly
- * `monthly` - monthly
+ * * `hourly` - hourly
+ * * `daily` - daily
+ * * `weekly` - weekly
+ * * `monthly` - monthly
  */
 export type CalculationIntervalEnumApi = (typeof CalculationIntervalEnumApi)[keyof typeof CalculationIntervalEnumApi]
 
@@ -411,7 +411,7 @@ export interface AlertScheduleRestrictionApi {
 
 /**
  * * `notify` - Notify
- * `suppress` - Suppress
+ * * `suppress` - Suppress
  */
 export type InvestigationInconclusiveActionEnumApi =
     (typeof InvestigationInconclusiveActionEnumApi)[keyof typeof InvestigationInconclusiveActionEnumApi]
@@ -456,12 +456,12 @@ export interface AlertApi {
     config?: TrendsAlertConfigApi | null
     detector_config?: DetectorConfigApi | null
     /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-
-  * `every_15_minutes` - every_15_minutes
-  * `hourly` - hourly
-  * `daily` - daily
-  * `weekly` - weekly
-  * `monthly` - monthly */
+     *
+     * * `every_15_minutes` - every_15_minutes
+     * * `hourly` - hourly
+     * * `daily` - daily
+     * * `weekly` - weekly
+     * * `monthly` - monthly */
     calculation_interval?: CalculationIntervalEnumApi
     /**
      * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -485,9 +485,9 @@ export interface AlertApi {
     /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
     investigation_gates_notifications?: boolean
     /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-
-  * `notify` - Notify
-  * `suppress` - Suppress */
+     *
+     * * `notify` - Notify
+     * * `suppress` - Suppress */
     investigation_inconclusive_action?: InvestigationInconclusiveActionEnumApi
 }
 
@@ -535,12 +535,12 @@ export interface PatchedAlertApi {
     config?: TrendsAlertConfigApi | null
     detector_config?: DetectorConfigApi | null
     /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-
-  * `every_15_minutes` - every_15_minutes
-  * `hourly` - hourly
-  * `daily` - daily
-  * `weekly` - weekly
-  * `monthly` - monthly */
+     *
+     * * `every_15_minutes` - every_15_minutes
+     * * `hourly` - hourly
+     * * `daily` - daily
+     * * `weekly` - weekly
+     * * `monthly` - monthly */
     calculation_interval?: CalculationIntervalEnumApi
     /**
      * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -564,9 +564,9 @@ export interface PatchedAlertApi {
     /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
     investigation_gates_notifications?: boolean
     /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-
-  * `notify` - Notify
-  * `suppress` - Suppress */
+     *
+     * * `notify` - Notify
+     * * `suppress` - Suppress */
     investigation_inconclusive_action?: InvestigationInconclusiveActionEnumApi
 }
 

--- a/products/alerts/frontend/generated/api.ts
+++ b/products/alerts/frontend/generated/api.ts
@@ -43,7 +43,7 @@ export const getAlertsListUrl = (projectId: string, params?: AlertsListParams) =
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -87,7 +87,7 @@ export const getAlertsRetrieveUrl = (projectId: string, id: string, params?: Ale
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -186,7 +186,7 @@ export const getInsightsThresholdsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/annotations/frontend/generated/api.schemas.ts
+++ b/products/annotations/frontend/generated/api.schemas.ts
@@ -9,7 +9,7 @@
  */
 /**
  * * `USR` - user
- * `GIT` - GitHub
+ * * `GIT` - GitHub
  */
 export type CreationTypeEnumApi = (typeof CreationTypeEnumApi)[keyof typeof CreationTypeEnumApi]
 
@@ -20,13 +20,13 @@ export const CreationTypeEnumApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -75,10 +75,10 @@ export interface UserBasicApi {
 
 /**
  * * `dashboard_item` - insight
- * `dashboard` - dashboard
- * `project` - project
- * `organization` - organization
- * `recording` - recording
+ * * `dashboard` - dashboard
+ * * `project` - project
+ * * `organization` - organization
+ * * `recording` - recording
  */
 export type AnnotationScopeEnumApi = (typeof AnnotationScopeEnumApi)[keyof typeof AnnotationScopeEnumApi]
 
@@ -104,9 +104,9 @@ export interface AnnotationApi {
      */
     date_marker?: string | null
     /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-
-  * `USR` - user
-  * `GIT` - GitHub */
+     *
+     * * `USR` - user
+     * * `GIT` - GitHub */
     creation_type?: CreationTypeEnumApi
     /** @nullable */
     dashboard_item?: number | null
@@ -127,12 +127,12 @@ export interface AnnotationApi {
     /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
     deleted?: boolean
     /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-
-  * `dashboard_item` - insight
-  * `dashboard` - dashboard
-  * `project` - project
-  * `organization` - organization
-  * `recording` - recording */
+     *
+     * * `dashboard_item` - insight
+     * * `dashboard` - dashboard
+     * * `project` - project
+     * * `organization` - organization
+     * * `recording` - recording */
     scope?: AnnotationScopeEnumApi
     /**
      * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -165,9 +165,9 @@ export interface PatchedAnnotationApi {
      */
     date_marker?: string | null
     /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-
-  * `USR` - user
-  * `GIT` - GitHub */
+     *
+     * * `USR` - user
+     * * `GIT` - GitHub */
     creation_type?: CreationTypeEnumApi
     /** @nullable */
     dashboard_item?: number | null
@@ -188,12 +188,12 @@ export interface PatchedAnnotationApi {
     /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
     deleted?: boolean
     /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-
-  * `dashboard_item` - insight
-  * `dashboard` - dashboard
-  * `project` - project
-  * `organization` - organization
-  * `recording` - recording */
+     *
+     * * `dashboard_item` - insight
+     * * `dashboard` - dashboard
+     * * `project` - project
+     * * `organization` - organization
+     * * `recording` - recording */
     scope?: AnnotationScopeEnumApi
     /**
      * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.

--- a/products/annotations/frontend/generated/api.ts
+++ b/products/annotations/frontend/generated/api.ts
@@ -37,7 +37,7 @@ export const getAnnotationsListUrl = (projectId: string, params?: AnnotationsLis
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `events` - Events
- * `persons` - Persons
- * `sessions` - Sessions
+ * * `persons` - Persons
+ * * `sessions` - Sessions
  */
 export type ModelEnumApi = (typeof ModelEnumApi)[keyof typeof ModelEnumApi]
 
@@ -28,18 +28,18 @@ export const BlankEnumApi = {
 
 /**
  * * `S3` - S3
- * `AwsS3` - Aws S3
- * `S3Compatible` - S3 Compatible
- * `Snowflake` - Snowflake
- * `Postgres` - Postgres
- * `Redshift` - Redshift
- * `BigQuery` - Bigquery
- * `Databricks` - Databricks
- * `AzureBlob` - Azure Blob
- * `Workflows` - Workflows
- * `HTTP` - Http
- * `NoOp` - Noop
- * `FileDownload` - File Download
+ * * `AwsS3` - Aws S3
+ * * `S3Compatible` - S3 Compatible
+ * * `Snowflake` - Snowflake
+ * * `Postgres` - Postgres
+ * * `Redshift` - Redshift
+ * * `BigQuery` - Bigquery
+ * * `Databricks` - Databricks
+ * * `AzureBlob` - Azure Blob
+ * * `Workflows` - Workflows
+ * * `HTTP` - Http
+ * * `NoOp` - Noop
+ * * `FileDownload` - File Download
  */
 export type BatchExportDestinationTypeEnumApi =
     (typeof BatchExportDestinationTypeEnumApi)[keyof typeof BatchExportDestinationTypeEnumApi]
@@ -69,9 +69,9 @@ export const DatabricksDestinationConfigApiType = {
 
 /**
  * Typed configuration for a Databricks batch-export destination.
-
-Credentials live in the linked Integration, not in this config. Mirrors
-`DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
+ *
+ * Credentials live in the linked Integration, not in this config. Mirrors
+ * `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
  */
 export interface DatabricksDestinationConfigApi {
     /** Databricks SQL warehouse HTTP path. */
@@ -91,10 +91,10 @@ export interface DatabricksDestinationConfigApi {
 
 /**
  * * `brotli` - brotli
- * `gzip` - gzip
- * `lz4` - lz4
- * `snappy` - snappy
- * `zstd` - zstd
+ * * `gzip` - gzip
+ * * `lz4` - lz4
+ * * `snappy` - snappy
+ * * `zstd` - zstd
  */
 export type CompressionEnumApi = (typeof CompressionEnumApi)[keyof typeof CompressionEnumApi]
 
@@ -108,7 +108,7 @@ export const CompressionEnumApi = {
 
 /**
  * * `JSONLines` - JSONLines
- * `Parquet` - Parquet
+ * * `Parquet` - Parquet
  */
 export type FileFormatEnumApi = (typeof FileFormatEnumApi)[keyof typeof FileFormatEnumApi]
 
@@ -126,9 +126,9 @@ export const AzureBlobDestinationConfigApiType = {
 
 /**
  * Typed configuration for an Azure Blob Storage batch-export destination.
-
-Credentials live in the linked Integration, not in this config. Mirrors
-`AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
+ *
+ * Credentials live in the linked Integration, not in this config. Mirrors
+ * `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
  */
 export interface AzureBlobDestinationConfigApi {
     /** Azure Blob Storage container name. */
@@ -136,17 +136,17 @@ export interface AzureBlobDestinationConfigApi {
     /** Object key prefix applied to every exported file. */
     prefix?: string
     /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
-
-  * `brotli` - brotli
-  * `gzip` - gzip
-  * `lz4` - lz4
-  * `snappy` - snappy
-  * `zstd` - zstd */
+     *
+     * * `brotli` - brotli
+     * * `gzip` - gzip
+     * * `lz4` - lz4
+     * * `snappy` - snappy
+     * * `zstd` - zstd */
     compression?: CompressionEnumApi | null
     /** File format used for exported objects.
-
-  * `JSONLines` - JSONLines
-  * `Parquet` - Parquet */
+     *
+     * * `JSONLines` - JSONLines
+     * * `Parquet` - Parquet */
     file_format?: FileFormatEnumApi
     /**
      * If set, rolls to a new file once the current file exceeds this size in MB.
@@ -165,10 +165,10 @@ export const BigQueryDestinationConfigApiType = {
 
 /**
  * Typed configuration for a BigQuery batch-export destination.
-
-Credentials live in the linked Integration, not in this config. Mirrors the
-non-credential fields of `BigQueryBatchExportInputs` in
-`products/batch_exports/backend/service.py`.
+ *
+ * Credentials live in the linked Integration, not in this config. Mirrors the
+ * non-credential fields of `BigQueryBatchExportInputs` in
+ * `products/batch_exports/backend/service.py`.
  */
 export interface BigQueryDestinationConfigApi {
     /** BigQuery dataset ID to write to. */
@@ -187,28 +187,28 @@ export type BatchExportDestinationConfigApi =
 
 /**
  * Serializer for an BatchExportDestination model.
-
-The `config` field is polymorphic and typed only for destinations that keep
-credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
-Other destination types accept the same JSON shape but without a typed
-OpenAPI schema. Secret fields are stripped from `config` on read.
+ *
+ * The `config` field is polymorphic and typed only for destinations that keep
+ * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
+ * Other destination types accept the same JSON shape but without a typed
+ * OpenAPI schema. Secret fields are stripped from `config` on read.
  */
 export interface BatchExportDestinationApi {
     /** A choice of supported BatchExportDestination types.
-
-  * `S3` - S3
-  * `AwsS3` - Aws S3
-  * `S3Compatible` - S3 Compatible
-  * `Snowflake` - Snowflake
-  * `Postgres` - Postgres
-  * `Redshift` - Redshift
-  * `BigQuery` - Bigquery
-  * `Databricks` - Databricks
-  * `AzureBlob` - Azure Blob
-  * `Workflows` - Workflows
-  * `HTTP` - Http
-  * `NoOp` - Noop
-  * `FileDownload` - File Download */
+     *
+     * * `S3` - S3
+     * * `AwsS3` - Aws S3
+     * * `S3Compatible` - S3 Compatible
+     * * `Snowflake` - Snowflake
+     * * `Postgres` - Postgres
+     * * `Redshift` - Redshift
+     * * `BigQuery` - Bigquery
+     * * `Databricks` - Databricks
+     * * `AzureBlob` - Azure Blob
+     * * `Workflows` - Workflows
+     * * `HTTP` - Http
+     * * `NoOp` - Noop
+     * * `FileDownload` - File Download */
     type: BatchExportDestinationTypeEnumApi
     /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
     config: BatchExportDestinationConfigApi
@@ -226,10 +226,10 @@ export interface BatchExportDestinationApi {
 
 /**
  * * `hour` - hour
- * `day` - day
- * `week` - week
- * `every 5 minutes` - every 5 minutes
- * `every 15 minutes` - every 15 minutes
+ * * `day` - day
+ * * `week` - week
+ * * `every 5 minutes` - every 5 minutes
+ * * `every 15 minutes` - every 15 minutes
  */
 export type IntervalEnumApi = (typeof IntervalEnumApi)[keyof typeof IntervalEnumApi]
 
@@ -243,15 +243,15 @@ export const IntervalEnumApi = {
 
 /**
  * * `Cancelled` - Cancelled
- * `Completed` - Completed
- * `ContinuedAsNew` - Continued As New
- * `Failed` - Failed
- * `FailedRetryable` - Failed Retryable
- * `FailedBilling` - Failed Billing
- * `Terminated` - Terminated
- * `TimedOut` - Timedout
- * `Running` - Running
- * `Starting` - Starting
+ * * `Completed` - Completed
+ * * `ContinuedAsNew` - Continued As New
+ * * `Failed` - Failed
+ * * `FailedRetryable` - Failed Retryable
+ * * `FailedBilling` - Failed Billing
+ * * `Terminated` - Terminated
+ * * `TimedOut` - Timedout
+ * * `Running` - Running
+ * * `Starting` - Starting
  */
 export type BatchExportRunStatusEnumApi = (typeof BatchExportRunStatusEnumApi)[keyof typeof BatchExportRunStatusEnumApi]
 
@@ -274,17 +274,17 @@ export const BatchExportRunStatusEnumApi = {
 export interface BatchExportRunApi {
     readonly id: string
     /** The status of this run.
-
-  * `Cancelled` - Cancelled
-  * `Completed` - Completed
-  * `ContinuedAsNew` - Continued As New
-  * `Failed` - Failed
-  * `FailedRetryable` - Failed Retryable
-  * `FailedBilling` - Failed Billing
-  * `Terminated` - Terminated
-  * `TimedOut` - Timedout
-  * `Running` - Running
-  * `Starting` - Starting */
+     *
+     * * `Cancelled` - Cancelled
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `FailedBilling` - Failed Billing
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting */
     status: BatchExportRunStatusEnumApi
     /**
      * The number of records that have been exported.
@@ -367,20 +367,20 @@ export interface BatchExportApi {
     /** A human-readable name for this BatchExport. */
     name: string
     /** Which model this BatchExport is exporting.
-
-  * `events` - Events
-  * `persons` - Persons
-  * `sessions` - Sessions */
+     *
+     * * `events` - Events
+     * * `persons` - Persons
+     * * `sessions` - Sessions */
     model?: ModelEnumApi | BlankEnumApi | null
     /** Destination configuration (type, config, and optional integration). */
     destination: BatchExportDestinationApi
     /** How often the batch export should run.
-
-  * `hour` - hour
-  * `day` - day
-  * `week` - week
-  * `every 5 minutes` - every 5 minutes
-  * `every 15 minutes` - every 15 minutes */
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * * `every 5 minutes` - every 5 minutes
+     * * `every 15 minutes` - every 15 minutes */
     interval: IntervalEnumApi
     /** Whether this BatchExport is paused or not. */
     paused?: boolean
@@ -411,603 +411,603 @@ export interface BatchExportApi {
     readonly schema: unknown
     filters?: unknown
     /** IANA timezone name controlling daily and weekly interval boundaries. Defaults to UTC.
-
-  * `Africa/Abidjan` - Africa/Abidjan
-  * `Africa/Accra` - Africa/Accra
-  * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-  * `Africa/Algiers` - Africa/Algiers
-  * `Africa/Asmara` - Africa/Asmara
-  * `Africa/Asmera` - Africa/Asmera
-  * `Africa/Bamako` - Africa/Bamako
-  * `Africa/Bangui` - Africa/Bangui
-  * `Africa/Banjul` - Africa/Banjul
-  * `Africa/Bissau` - Africa/Bissau
-  * `Africa/Blantyre` - Africa/Blantyre
-  * `Africa/Brazzaville` - Africa/Brazzaville
-  * `Africa/Bujumbura` - Africa/Bujumbura
-  * `Africa/Cairo` - Africa/Cairo
-  * `Africa/Casablanca` - Africa/Casablanca
-  * `Africa/Ceuta` - Africa/Ceuta
-  * `Africa/Conakry` - Africa/Conakry
-  * `Africa/Dakar` - Africa/Dakar
-  * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-  * `Africa/Djibouti` - Africa/Djibouti
-  * `Africa/Douala` - Africa/Douala
-  * `Africa/El_Aaiun` - Africa/El_Aaiun
-  * `Africa/Freetown` - Africa/Freetown
-  * `Africa/Gaborone` - Africa/Gaborone
-  * `Africa/Harare` - Africa/Harare
-  * `Africa/Johannesburg` - Africa/Johannesburg
-  * `Africa/Juba` - Africa/Juba
-  * `Africa/Kampala` - Africa/Kampala
-  * `Africa/Khartoum` - Africa/Khartoum
-  * `Africa/Kigali` - Africa/Kigali
-  * `Africa/Kinshasa` - Africa/Kinshasa
-  * `Africa/Lagos` - Africa/Lagos
-  * `Africa/Libreville` - Africa/Libreville
-  * `Africa/Lome` - Africa/Lome
-  * `Africa/Luanda` - Africa/Luanda
-  * `Africa/Lubumbashi` - Africa/Lubumbashi
-  * `Africa/Lusaka` - Africa/Lusaka
-  * `Africa/Malabo` - Africa/Malabo
-  * `Africa/Maputo` - Africa/Maputo
-  * `Africa/Maseru` - Africa/Maseru
-  * `Africa/Mbabane` - Africa/Mbabane
-  * `Africa/Mogadishu` - Africa/Mogadishu
-  * `Africa/Monrovia` - Africa/Monrovia
-  * `Africa/Nairobi` - Africa/Nairobi
-  * `Africa/Ndjamena` - Africa/Ndjamena
-  * `Africa/Niamey` - Africa/Niamey
-  * `Africa/Nouakchott` - Africa/Nouakchott
-  * `Africa/Ouagadougou` - Africa/Ouagadougou
-  * `Africa/Porto-Novo` - Africa/Porto-Novo
-  * `Africa/Sao_Tome` - Africa/Sao_Tome
-  * `Africa/Timbuktu` - Africa/Timbuktu
-  * `Africa/Tripoli` - Africa/Tripoli
-  * `Africa/Tunis` - Africa/Tunis
-  * `Africa/Windhoek` - Africa/Windhoek
-  * `America/Adak` - America/Adak
-  * `America/Anchorage` - America/Anchorage
-  * `America/Anguilla` - America/Anguilla
-  * `America/Antigua` - America/Antigua
-  * `America/Araguaina` - America/Araguaina
-  * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-  * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-  * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-  * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-  * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-  * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-  * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-  * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-  * `America/Argentina/Salta` - America/Argentina/Salta
-  * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-  * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-  * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-  * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-  * `America/Aruba` - America/Aruba
-  * `America/Asuncion` - America/Asuncion
-  * `America/Atikokan` - America/Atikokan
-  * `America/Atka` - America/Atka
-  * `America/Bahia` - America/Bahia
-  * `America/Bahia_Banderas` - America/Bahia_Banderas
-  * `America/Barbados` - America/Barbados
-  * `America/Belem` - America/Belem
-  * `America/Belize` - America/Belize
-  * `America/Blanc-Sablon` - America/Blanc-Sablon
-  * `America/Boa_Vista` - America/Boa_Vista
-  * `America/Bogota` - America/Bogota
-  * `America/Boise` - America/Boise
-  * `America/Buenos_Aires` - America/Buenos_Aires
-  * `America/Cambridge_Bay` - America/Cambridge_Bay
-  * `America/Campo_Grande` - America/Campo_Grande
-  * `America/Cancun` - America/Cancun
-  * `America/Caracas` - America/Caracas
-  * `America/Catamarca` - America/Catamarca
-  * `America/Cayenne` - America/Cayenne
-  * `America/Cayman` - America/Cayman
-  * `America/Chicago` - America/Chicago
-  * `America/Chihuahua` - America/Chihuahua
-  * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-  * `America/Coral_Harbour` - America/Coral_Harbour
-  * `America/Cordoba` - America/Cordoba
-  * `America/Costa_Rica` - America/Costa_Rica
-  * `America/Creston` - America/Creston
-  * `America/Cuiaba` - America/Cuiaba
-  * `America/Curacao` - America/Curacao
-  * `America/Danmarkshavn` - America/Danmarkshavn
-  * `America/Dawson` - America/Dawson
-  * `America/Dawson_Creek` - America/Dawson_Creek
-  * `America/Denver` - America/Denver
-  * `America/Detroit` - America/Detroit
-  * `America/Dominica` - America/Dominica
-  * `America/Edmonton` - America/Edmonton
-  * `America/Eirunepe` - America/Eirunepe
-  * `America/El_Salvador` - America/El_Salvador
-  * `America/Ensenada` - America/Ensenada
-  * `America/Fort_Nelson` - America/Fort_Nelson
-  * `America/Fort_Wayne` - America/Fort_Wayne
-  * `America/Fortaleza` - America/Fortaleza
-  * `America/Glace_Bay` - America/Glace_Bay
-  * `America/Godthab` - America/Godthab
-  * `America/Goose_Bay` - America/Goose_Bay
-  * `America/Grand_Turk` - America/Grand_Turk
-  * `America/Grenada` - America/Grenada
-  * `America/Guadeloupe` - America/Guadeloupe
-  * `America/Guatemala` - America/Guatemala
-  * `America/Guayaquil` - America/Guayaquil
-  * `America/Guyana` - America/Guyana
-  * `America/Halifax` - America/Halifax
-  * `America/Havana` - America/Havana
-  * `America/Hermosillo` - America/Hermosillo
-  * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-  * `America/Indiana/Knox` - America/Indiana/Knox
-  * `America/Indiana/Marengo` - America/Indiana/Marengo
-  * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-  * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-  * `America/Indiana/Vevay` - America/Indiana/Vevay
-  * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-  * `America/Indiana/Winamac` - America/Indiana/Winamac
-  * `America/Indianapolis` - America/Indianapolis
-  * `America/Inuvik` - America/Inuvik
-  * `America/Iqaluit` - America/Iqaluit
-  * `America/Jamaica` - America/Jamaica
-  * `America/Jujuy` - America/Jujuy
-  * `America/Juneau` - America/Juneau
-  * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-  * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-  * `America/Knox_IN` - America/Knox_IN
-  * `America/Kralendijk` - America/Kralendijk
-  * `America/La_Paz` - America/La_Paz
-  * `America/Lima` - America/Lima
-  * `America/Los_Angeles` - America/Los_Angeles
-  * `America/Louisville` - America/Louisville
-  * `America/Lower_Princes` - America/Lower_Princes
-  * `America/Maceio` - America/Maceio
-  * `America/Managua` - America/Managua
-  * `America/Manaus` - America/Manaus
-  * `America/Marigot` - America/Marigot
-  * `America/Martinique` - America/Martinique
-  * `America/Matamoros` - America/Matamoros
-  * `America/Mazatlan` - America/Mazatlan
-  * `America/Mendoza` - America/Mendoza
-  * `America/Menominee` - America/Menominee
-  * `America/Merida` - America/Merida
-  * `America/Metlakatla` - America/Metlakatla
-  * `America/Mexico_City` - America/Mexico_City
-  * `America/Miquelon` - America/Miquelon
-  * `America/Moncton` - America/Moncton
-  * `America/Monterrey` - America/Monterrey
-  * `America/Montevideo` - America/Montevideo
-  * `America/Montreal` - America/Montreal
-  * `America/Montserrat` - America/Montserrat
-  * `America/Nassau` - America/Nassau
-  * `America/New_York` - America/New_York
-  * `America/Nipigon` - America/Nipigon
-  * `America/Nome` - America/Nome
-  * `America/Noronha` - America/Noronha
-  * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-  * `America/North_Dakota/Center` - America/North_Dakota/Center
-  * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-  * `America/Nuuk` - America/Nuuk
-  * `America/Ojinaga` - America/Ojinaga
-  * `America/Panama` - America/Panama
-  * `America/Pangnirtung` - America/Pangnirtung
-  * `America/Paramaribo` - America/Paramaribo
-  * `America/Phoenix` - America/Phoenix
-  * `America/Port-au-Prince` - America/Port-au-Prince
-  * `America/Port_of_Spain` - America/Port_of_Spain
-  * `America/Porto_Acre` - America/Porto_Acre
-  * `America/Porto_Velho` - America/Porto_Velho
-  * `America/Puerto_Rico` - America/Puerto_Rico
-  * `America/Punta_Arenas` - America/Punta_Arenas
-  * `America/Rainy_River` - America/Rainy_River
-  * `America/Rankin_Inlet` - America/Rankin_Inlet
-  * `America/Recife` - America/Recife
-  * `America/Regina` - America/Regina
-  * `America/Resolute` - America/Resolute
-  * `America/Rio_Branco` - America/Rio_Branco
-  * `America/Rosario` - America/Rosario
-  * `America/Santa_Isabel` - America/Santa_Isabel
-  * `America/Santarem` - America/Santarem
-  * `America/Santiago` - America/Santiago
-  * `America/Santo_Domingo` - America/Santo_Domingo
-  * `America/Sao_Paulo` - America/Sao_Paulo
-  * `America/Scoresbysund` - America/Scoresbysund
-  * `America/Shiprock` - America/Shiprock
-  * `America/Sitka` - America/Sitka
-  * `America/St_Barthelemy` - America/St_Barthelemy
-  * `America/St_Johns` - America/St_Johns
-  * `America/St_Kitts` - America/St_Kitts
-  * `America/St_Lucia` - America/St_Lucia
-  * `America/St_Thomas` - America/St_Thomas
-  * `America/St_Vincent` - America/St_Vincent
-  * `America/Swift_Current` - America/Swift_Current
-  * `America/Tegucigalpa` - America/Tegucigalpa
-  * `America/Thule` - America/Thule
-  * `America/Thunder_Bay` - America/Thunder_Bay
-  * `America/Tijuana` - America/Tijuana
-  * `America/Toronto` - America/Toronto
-  * `America/Tortola` - America/Tortola
-  * `America/Vancouver` - America/Vancouver
-  * `America/Virgin` - America/Virgin
-  * `America/Whitehorse` - America/Whitehorse
-  * `America/Winnipeg` - America/Winnipeg
-  * `America/Yakutat` - America/Yakutat
-  * `America/Yellowknife` - America/Yellowknife
-  * `Antarctica/Casey` - Antarctica/Casey
-  * `Antarctica/Davis` - Antarctica/Davis
-  * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-  * `Antarctica/Macquarie` - Antarctica/Macquarie
-  * `Antarctica/Mawson` - Antarctica/Mawson
-  * `Antarctica/McMurdo` - Antarctica/McMurdo
-  * `Antarctica/Palmer` - Antarctica/Palmer
-  * `Antarctica/Rothera` - Antarctica/Rothera
-  * `Antarctica/South_Pole` - Antarctica/South_Pole
-  * `Antarctica/Syowa` - Antarctica/Syowa
-  * `Antarctica/Troll` - Antarctica/Troll
-  * `Antarctica/Vostok` - Antarctica/Vostok
-  * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-  * `Asia/Aden` - Asia/Aden
-  * `Asia/Almaty` - Asia/Almaty
-  * `Asia/Amman` - Asia/Amman
-  * `Asia/Anadyr` - Asia/Anadyr
-  * `Asia/Aqtau` - Asia/Aqtau
-  * `Asia/Aqtobe` - Asia/Aqtobe
-  * `Asia/Ashgabat` - Asia/Ashgabat
-  * `Asia/Ashkhabad` - Asia/Ashkhabad
-  * `Asia/Atyrau` - Asia/Atyrau
-  * `Asia/Baghdad` - Asia/Baghdad
-  * `Asia/Bahrain` - Asia/Bahrain
-  * `Asia/Baku` - Asia/Baku
-  * `Asia/Bangkok` - Asia/Bangkok
-  * `Asia/Barnaul` - Asia/Barnaul
-  * `Asia/Beirut` - Asia/Beirut
-  * `Asia/Bishkek` - Asia/Bishkek
-  * `Asia/Brunei` - Asia/Brunei
-  * `Asia/Calcutta` - Asia/Calcutta
-  * `Asia/Chita` - Asia/Chita
-  * `Asia/Choibalsan` - Asia/Choibalsan
-  * `Asia/Chongqing` - Asia/Chongqing
-  * `Asia/Chungking` - Asia/Chungking
-  * `Asia/Colombo` - Asia/Colombo
-  * `Asia/Dacca` - Asia/Dacca
-  * `Asia/Damascus` - Asia/Damascus
-  * `Asia/Dhaka` - Asia/Dhaka
-  * `Asia/Dili` - Asia/Dili
-  * `Asia/Dubai` - Asia/Dubai
-  * `Asia/Dushanbe` - Asia/Dushanbe
-  * `Asia/Famagusta` - Asia/Famagusta
-  * `Asia/Gaza` - Asia/Gaza
-  * `Asia/Harbin` - Asia/Harbin
-  * `Asia/Hebron` - Asia/Hebron
-  * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-  * `Asia/Hong_Kong` - Asia/Hong_Kong
-  * `Asia/Hovd` - Asia/Hovd
-  * `Asia/Irkutsk` - Asia/Irkutsk
-  * `Asia/Istanbul` - Asia/Istanbul
-  * `Asia/Jakarta` - Asia/Jakarta
-  * `Asia/Jayapura` - Asia/Jayapura
-  * `Asia/Jerusalem` - Asia/Jerusalem
-  * `Asia/Kabul` - Asia/Kabul
-  * `Asia/Kamchatka` - Asia/Kamchatka
-  * `Asia/Karachi` - Asia/Karachi
-  * `Asia/Kashgar` - Asia/Kashgar
-  * `Asia/Kathmandu` - Asia/Kathmandu
-  * `Asia/Katmandu` - Asia/Katmandu
-  * `Asia/Khandyga` - Asia/Khandyga
-  * `Asia/Kolkata` - Asia/Kolkata
-  * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-  * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-  * `Asia/Kuching` - Asia/Kuching
-  * `Asia/Kuwait` - Asia/Kuwait
-  * `Asia/Macao` - Asia/Macao
-  * `Asia/Macau` - Asia/Macau
-  * `Asia/Magadan` - Asia/Magadan
-  * `Asia/Makassar` - Asia/Makassar
-  * `Asia/Manila` - Asia/Manila
-  * `Asia/Muscat` - Asia/Muscat
-  * `Asia/Nicosia` - Asia/Nicosia
-  * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-  * `Asia/Novosibirsk` - Asia/Novosibirsk
-  * `Asia/Omsk` - Asia/Omsk
-  * `Asia/Oral` - Asia/Oral
-  * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-  * `Asia/Pontianak` - Asia/Pontianak
-  * `Asia/Pyongyang` - Asia/Pyongyang
-  * `Asia/Qatar` - Asia/Qatar
-  * `Asia/Qostanay` - Asia/Qostanay
-  * `Asia/Qyzylorda` - Asia/Qyzylorda
-  * `Asia/Rangoon` - Asia/Rangoon
-  * `Asia/Riyadh` - Asia/Riyadh
-  * `Asia/Saigon` - Asia/Saigon
-  * `Asia/Sakhalin` - Asia/Sakhalin
-  * `Asia/Samarkand` - Asia/Samarkand
-  * `Asia/Seoul` - Asia/Seoul
-  * `Asia/Shanghai` - Asia/Shanghai
-  * `Asia/Singapore` - Asia/Singapore
-  * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-  * `Asia/Taipei` - Asia/Taipei
-  * `Asia/Tashkent` - Asia/Tashkent
-  * `Asia/Tbilisi` - Asia/Tbilisi
-  * `Asia/Tehran` - Asia/Tehran
-  * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-  * `Asia/Thimbu` - Asia/Thimbu
-  * `Asia/Thimphu` - Asia/Thimphu
-  * `Asia/Tokyo` - Asia/Tokyo
-  * `Asia/Tomsk` - Asia/Tomsk
-  * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-  * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-  * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-  * `Asia/Urumqi` - Asia/Urumqi
-  * `Asia/Ust-Nera` - Asia/Ust-Nera
-  * `Asia/Vientiane` - Asia/Vientiane
-  * `Asia/Vladivostok` - Asia/Vladivostok
-  * `Asia/Yakutsk` - Asia/Yakutsk
-  * `Asia/Yangon` - Asia/Yangon
-  * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-  * `Asia/Yerevan` - Asia/Yerevan
-  * `Atlantic/Azores` - Atlantic/Azores
-  * `Atlantic/Bermuda` - Atlantic/Bermuda
-  * `Atlantic/Canary` - Atlantic/Canary
-  * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-  * `Atlantic/Faeroe` - Atlantic/Faeroe
-  * `Atlantic/Faroe` - Atlantic/Faroe
-  * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-  * `Atlantic/Madeira` - Atlantic/Madeira
-  * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-  * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-  * `Atlantic/St_Helena` - Atlantic/St_Helena
-  * `Atlantic/Stanley` - Atlantic/Stanley
-  * `Australia/ACT` - Australia/ACT
-  * `Australia/Adelaide` - Australia/Adelaide
-  * `Australia/Brisbane` - Australia/Brisbane
-  * `Australia/Broken_Hill` - Australia/Broken_Hill
-  * `Australia/Canberra` - Australia/Canberra
-  * `Australia/Currie` - Australia/Currie
-  * `Australia/Darwin` - Australia/Darwin
-  * `Australia/Eucla` - Australia/Eucla
-  * `Australia/Hobart` - Australia/Hobart
-  * `Australia/LHI` - Australia/LHI
-  * `Australia/Lindeman` - Australia/Lindeman
-  * `Australia/Lord_Howe` - Australia/Lord_Howe
-  * `Australia/Melbourne` - Australia/Melbourne
-  * `Australia/NSW` - Australia/NSW
-  * `Australia/North` - Australia/North
-  * `Australia/Perth` - Australia/Perth
-  * `Australia/Queensland` - Australia/Queensland
-  * `Australia/South` - Australia/South
-  * `Australia/Sydney` - Australia/Sydney
-  * `Australia/Tasmania` - Australia/Tasmania
-  * `Australia/Victoria` - Australia/Victoria
-  * `Australia/West` - Australia/West
-  * `Australia/Yancowinna` - Australia/Yancowinna
-  * `Brazil/Acre` - Brazil/Acre
-  * `Brazil/DeNoronha` - Brazil/DeNoronha
-  * `Brazil/East` - Brazil/East
-  * `Brazil/West` - Brazil/West
-  * `CET` - CET
-  * `CST6CDT` - CST6CDT
-  * `Canada/Atlantic` - Canada/Atlantic
-  * `Canada/Central` - Canada/Central
-  * `Canada/Eastern` - Canada/Eastern
-  * `Canada/Mountain` - Canada/Mountain
-  * `Canada/Newfoundland` - Canada/Newfoundland
-  * `Canada/Pacific` - Canada/Pacific
-  * `Canada/Saskatchewan` - Canada/Saskatchewan
-  * `Canada/Yukon` - Canada/Yukon
-  * `Chile/Continental` - Chile/Continental
-  * `Chile/EasterIsland` - Chile/EasterIsland
-  * `Cuba` - Cuba
-  * `EET` - EET
-  * `EST` - EST
-  * `EST5EDT` - EST5EDT
-  * `Egypt` - Egypt
-  * `Eire` - Eire
-  * `Etc/GMT` - Etc/GMT
-  * `Etc/GMT+0` - Etc/GMT+0
-  * `Etc/GMT+1` - Etc/GMT+1
-  * `Etc/GMT+10` - Etc/GMT+10
-  * `Etc/GMT+11` - Etc/GMT+11
-  * `Etc/GMT+12` - Etc/GMT+12
-  * `Etc/GMT+2` - Etc/GMT+2
-  * `Etc/GMT+3` - Etc/GMT+3
-  * `Etc/GMT+4` - Etc/GMT+4
-  * `Etc/GMT+5` - Etc/GMT+5
-  * `Etc/GMT+6` - Etc/GMT+6
-  * `Etc/GMT+7` - Etc/GMT+7
-  * `Etc/GMT+8` - Etc/GMT+8
-  * `Etc/GMT+9` - Etc/GMT+9
-  * `Etc/GMT-0` - Etc/GMT-0
-  * `Etc/GMT-1` - Etc/GMT-1
-  * `Etc/GMT-10` - Etc/GMT-10
-  * `Etc/GMT-11` - Etc/GMT-11
-  * `Etc/GMT-12` - Etc/GMT-12
-  * `Etc/GMT-13` - Etc/GMT-13
-  * `Etc/GMT-14` - Etc/GMT-14
-  * `Etc/GMT-2` - Etc/GMT-2
-  * `Etc/GMT-3` - Etc/GMT-3
-  * `Etc/GMT-4` - Etc/GMT-4
-  * `Etc/GMT-5` - Etc/GMT-5
-  * `Etc/GMT-6` - Etc/GMT-6
-  * `Etc/GMT-7` - Etc/GMT-7
-  * `Etc/GMT-8` - Etc/GMT-8
-  * `Etc/GMT-9` - Etc/GMT-9
-  * `Etc/GMT0` - Etc/GMT0
-  * `Etc/Greenwich` - Etc/Greenwich
-  * `Etc/UCT` - Etc/UCT
-  * `Etc/UTC` - Etc/UTC
-  * `Etc/Universal` - Etc/Universal
-  * `Etc/Zulu` - Etc/Zulu
-  * `Europe/Amsterdam` - Europe/Amsterdam
-  * `Europe/Andorra` - Europe/Andorra
-  * `Europe/Astrakhan` - Europe/Astrakhan
-  * `Europe/Athens` - Europe/Athens
-  * `Europe/Belfast` - Europe/Belfast
-  * `Europe/Belgrade` - Europe/Belgrade
-  * `Europe/Berlin` - Europe/Berlin
-  * `Europe/Bratislava` - Europe/Bratislava
-  * `Europe/Brussels` - Europe/Brussels
-  * `Europe/Bucharest` - Europe/Bucharest
-  * `Europe/Budapest` - Europe/Budapest
-  * `Europe/Busingen` - Europe/Busingen
-  * `Europe/Chisinau` - Europe/Chisinau
-  * `Europe/Copenhagen` - Europe/Copenhagen
-  * `Europe/Dublin` - Europe/Dublin
-  * `Europe/Gibraltar` - Europe/Gibraltar
-  * `Europe/Guernsey` - Europe/Guernsey
-  * `Europe/Helsinki` - Europe/Helsinki
-  * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-  * `Europe/Istanbul` - Europe/Istanbul
-  * `Europe/Jersey` - Europe/Jersey
-  * `Europe/Kaliningrad` - Europe/Kaliningrad
-  * `Europe/Kiev` - Europe/Kiev
-  * `Europe/Kirov` - Europe/Kirov
-  * `Europe/Kyiv` - Europe/Kyiv
-  * `Europe/Lisbon` - Europe/Lisbon
-  * `Europe/Ljubljana` - Europe/Ljubljana
-  * `Europe/London` - Europe/London
-  * `Europe/Luxembourg` - Europe/Luxembourg
-  * `Europe/Madrid` - Europe/Madrid
-  * `Europe/Malta` - Europe/Malta
-  * `Europe/Mariehamn` - Europe/Mariehamn
-  * `Europe/Minsk` - Europe/Minsk
-  * `Europe/Monaco` - Europe/Monaco
-  * `Europe/Moscow` - Europe/Moscow
-  * `Europe/Nicosia` - Europe/Nicosia
-  * `Europe/Oslo` - Europe/Oslo
-  * `Europe/Paris` - Europe/Paris
-  * `Europe/Podgorica` - Europe/Podgorica
-  * `Europe/Prague` - Europe/Prague
-  * `Europe/Riga` - Europe/Riga
-  * `Europe/Rome` - Europe/Rome
-  * `Europe/Samara` - Europe/Samara
-  * `Europe/San_Marino` - Europe/San_Marino
-  * `Europe/Sarajevo` - Europe/Sarajevo
-  * `Europe/Saratov` - Europe/Saratov
-  * `Europe/Simferopol` - Europe/Simferopol
-  * `Europe/Skopje` - Europe/Skopje
-  * `Europe/Sofia` - Europe/Sofia
-  * `Europe/Stockholm` - Europe/Stockholm
-  * `Europe/Tallinn` - Europe/Tallinn
-  * `Europe/Tirane` - Europe/Tirane
-  * `Europe/Tiraspol` - Europe/Tiraspol
-  * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-  * `Europe/Uzhgorod` - Europe/Uzhgorod
-  * `Europe/Vaduz` - Europe/Vaduz
-  * `Europe/Vatican` - Europe/Vatican
-  * `Europe/Vienna` - Europe/Vienna
-  * `Europe/Vilnius` - Europe/Vilnius
-  * `Europe/Volgograd` - Europe/Volgograd
-  * `Europe/Warsaw` - Europe/Warsaw
-  * `Europe/Zagreb` - Europe/Zagreb
-  * `Europe/Zaporozhye` - Europe/Zaporozhye
-  * `Europe/Zurich` - Europe/Zurich
-  * `GB` - GB
-  * `GB-Eire` - GB-Eire
-  * `GMT` - GMT
-  * `GMT+0` - GMT+0
-  * `GMT-0` - GMT-0
-  * `GMT0` - GMT0
-  * `Greenwich` - Greenwich
-  * `HST` - HST
-  * `Hongkong` - Hongkong
-  * `Iceland` - Iceland
-  * `Indian/Antananarivo` - Indian/Antananarivo
-  * `Indian/Chagos` - Indian/Chagos
-  * `Indian/Christmas` - Indian/Christmas
-  * `Indian/Cocos` - Indian/Cocos
-  * `Indian/Comoro` - Indian/Comoro
-  * `Indian/Kerguelen` - Indian/Kerguelen
-  * `Indian/Mahe` - Indian/Mahe
-  * `Indian/Maldives` - Indian/Maldives
-  * `Indian/Mauritius` - Indian/Mauritius
-  * `Indian/Mayotte` - Indian/Mayotte
-  * `Indian/Reunion` - Indian/Reunion
-  * `Iran` - Iran
-  * `Israel` - Israel
-  * `Jamaica` - Jamaica
-  * `Japan` - Japan
-  * `Kwajalein` - Kwajalein
-  * `Libya` - Libya
-  * `MET` - MET
-  * `MST` - MST
-  * `MST7MDT` - MST7MDT
-  * `Mexico/BajaNorte` - Mexico/BajaNorte
-  * `Mexico/BajaSur` - Mexico/BajaSur
-  * `Mexico/General` - Mexico/General
-  * `NZ` - NZ
-  * `NZ-CHAT` - NZ-CHAT
-  * `Navajo` - Navajo
-  * `PRC` - PRC
-  * `PST8PDT` - PST8PDT
-  * `Pacific/Apia` - Pacific/Apia
-  * `Pacific/Auckland` - Pacific/Auckland
-  * `Pacific/Bougainville` - Pacific/Bougainville
-  * `Pacific/Chatham` - Pacific/Chatham
-  * `Pacific/Chuuk` - Pacific/Chuuk
-  * `Pacific/Easter` - Pacific/Easter
-  * `Pacific/Efate` - Pacific/Efate
-  * `Pacific/Enderbury` - Pacific/Enderbury
-  * `Pacific/Fakaofo` - Pacific/Fakaofo
-  * `Pacific/Fiji` - Pacific/Fiji
-  * `Pacific/Funafuti` - Pacific/Funafuti
-  * `Pacific/Galapagos` - Pacific/Galapagos
-  * `Pacific/Gambier` - Pacific/Gambier
-  * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-  * `Pacific/Guam` - Pacific/Guam
-  * `Pacific/Honolulu` - Pacific/Honolulu
-  * `Pacific/Johnston` - Pacific/Johnston
-  * `Pacific/Kanton` - Pacific/Kanton
-  * `Pacific/Kiritimati` - Pacific/Kiritimati
-  * `Pacific/Kosrae` - Pacific/Kosrae
-  * `Pacific/Kwajalein` - Pacific/Kwajalein
-  * `Pacific/Majuro` - Pacific/Majuro
-  * `Pacific/Marquesas` - Pacific/Marquesas
-  * `Pacific/Midway` - Pacific/Midway
-  * `Pacific/Nauru` - Pacific/Nauru
-  * `Pacific/Niue` - Pacific/Niue
-  * `Pacific/Norfolk` - Pacific/Norfolk
-  * `Pacific/Noumea` - Pacific/Noumea
-  * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-  * `Pacific/Palau` - Pacific/Palau
-  * `Pacific/Pitcairn` - Pacific/Pitcairn
-  * `Pacific/Pohnpei` - Pacific/Pohnpei
-  * `Pacific/Ponape` - Pacific/Ponape
-  * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-  * `Pacific/Rarotonga` - Pacific/Rarotonga
-  * `Pacific/Saipan` - Pacific/Saipan
-  * `Pacific/Samoa` - Pacific/Samoa
-  * `Pacific/Tahiti` - Pacific/Tahiti
-  * `Pacific/Tarawa` - Pacific/Tarawa
-  * `Pacific/Tongatapu` - Pacific/Tongatapu
-  * `Pacific/Truk` - Pacific/Truk
-  * `Pacific/Wake` - Pacific/Wake
-  * `Pacific/Wallis` - Pacific/Wallis
-  * `Pacific/Yap` - Pacific/Yap
-  * `Poland` - Poland
-  * `Portugal` - Portugal
-  * `ROC` - ROC
-  * `ROK` - ROK
-  * `Singapore` - Singapore
-  * `Turkey` - Turkey
-  * `UCT` - UCT
-  * `US/Alaska` - US/Alaska
-  * `US/Aleutian` - US/Aleutian
-  * `US/Arizona` - US/Arizona
-  * `US/Central` - US/Central
-  * `US/East-Indiana` - US/East-Indiana
-  * `US/Eastern` - US/Eastern
-  * `US/Hawaii` - US/Hawaii
-  * `US/Indiana-Starke` - US/Indiana-Starke
-  * `US/Michigan` - US/Michigan
-  * `US/Mountain` - US/Mountain
-  * `US/Pacific` - US/Pacific
-  * `US/Samoa` - US/Samoa
-  * `UTC` - UTC
-  * `Universal` - Universal
-  * `W-SU` - W-SU
-  * `WET` - WET
-  * `Zulu` - Zulu */
+     *
+     * * `Africa/Abidjan` - Africa/Abidjan
+     * * `Africa/Accra` - Africa/Accra
+     * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+     * * `Africa/Algiers` - Africa/Algiers
+     * * `Africa/Asmara` - Africa/Asmara
+     * * `Africa/Asmera` - Africa/Asmera
+     * * `Africa/Bamako` - Africa/Bamako
+     * * `Africa/Bangui` - Africa/Bangui
+     * * `Africa/Banjul` - Africa/Banjul
+     * * `Africa/Bissau` - Africa/Bissau
+     * * `Africa/Blantyre` - Africa/Blantyre
+     * * `Africa/Brazzaville` - Africa/Brazzaville
+     * * `Africa/Bujumbura` - Africa/Bujumbura
+     * * `Africa/Cairo` - Africa/Cairo
+     * * `Africa/Casablanca` - Africa/Casablanca
+     * * `Africa/Ceuta` - Africa/Ceuta
+     * * `Africa/Conakry` - Africa/Conakry
+     * * `Africa/Dakar` - Africa/Dakar
+     * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+     * * `Africa/Djibouti` - Africa/Djibouti
+     * * `Africa/Douala` - Africa/Douala
+     * * `Africa/El_Aaiun` - Africa/El_Aaiun
+     * * `Africa/Freetown` - Africa/Freetown
+     * * `Africa/Gaborone` - Africa/Gaborone
+     * * `Africa/Harare` - Africa/Harare
+     * * `Africa/Johannesburg` - Africa/Johannesburg
+     * * `Africa/Juba` - Africa/Juba
+     * * `Africa/Kampala` - Africa/Kampala
+     * * `Africa/Khartoum` - Africa/Khartoum
+     * * `Africa/Kigali` - Africa/Kigali
+     * * `Africa/Kinshasa` - Africa/Kinshasa
+     * * `Africa/Lagos` - Africa/Lagos
+     * * `Africa/Libreville` - Africa/Libreville
+     * * `Africa/Lome` - Africa/Lome
+     * * `Africa/Luanda` - Africa/Luanda
+     * * `Africa/Lubumbashi` - Africa/Lubumbashi
+     * * `Africa/Lusaka` - Africa/Lusaka
+     * * `Africa/Malabo` - Africa/Malabo
+     * * `Africa/Maputo` - Africa/Maputo
+     * * `Africa/Maseru` - Africa/Maseru
+     * * `Africa/Mbabane` - Africa/Mbabane
+     * * `Africa/Mogadishu` - Africa/Mogadishu
+     * * `Africa/Monrovia` - Africa/Monrovia
+     * * `Africa/Nairobi` - Africa/Nairobi
+     * * `Africa/Ndjamena` - Africa/Ndjamena
+     * * `Africa/Niamey` - Africa/Niamey
+     * * `Africa/Nouakchott` - Africa/Nouakchott
+     * * `Africa/Ouagadougou` - Africa/Ouagadougou
+     * * `Africa/Porto-Novo` - Africa/Porto-Novo
+     * * `Africa/Sao_Tome` - Africa/Sao_Tome
+     * * `Africa/Timbuktu` - Africa/Timbuktu
+     * * `Africa/Tripoli` - Africa/Tripoli
+     * * `Africa/Tunis` - Africa/Tunis
+     * * `Africa/Windhoek` - Africa/Windhoek
+     * * `America/Adak` - America/Adak
+     * * `America/Anchorage` - America/Anchorage
+     * * `America/Anguilla` - America/Anguilla
+     * * `America/Antigua` - America/Antigua
+     * * `America/Araguaina` - America/Araguaina
+     * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+     * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+     * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+     * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+     * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+     * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+     * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+     * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+     * * `America/Argentina/Salta` - America/Argentina/Salta
+     * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+     * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+     * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+     * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+     * * `America/Aruba` - America/Aruba
+     * * `America/Asuncion` - America/Asuncion
+     * * `America/Atikokan` - America/Atikokan
+     * * `America/Atka` - America/Atka
+     * * `America/Bahia` - America/Bahia
+     * * `America/Bahia_Banderas` - America/Bahia_Banderas
+     * * `America/Barbados` - America/Barbados
+     * * `America/Belem` - America/Belem
+     * * `America/Belize` - America/Belize
+     * * `America/Blanc-Sablon` - America/Blanc-Sablon
+     * * `America/Boa_Vista` - America/Boa_Vista
+     * * `America/Bogota` - America/Bogota
+     * * `America/Boise` - America/Boise
+     * * `America/Buenos_Aires` - America/Buenos_Aires
+     * * `America/Cambridge_Bay` - America/Cambridge_Bay
+     * * `America/Campo_Grande` - America/Campo_Grande
+     * * `America/Cancun` - America/Cancun
+     * * `America/Caracas` - America/Caracas
+     * * `America/Catamarca` - America/Catamarca
+     * * `America/Cayenne` - America/Cayenne
+     * * `America/Cayman` - America/Cayman
+     * * `America/Chicago` - America/Chicago
+     * * `America/Chihuahua` - America/Chihuahua
+     * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+     * * `America/Coral_Harbour` - America/Coral_Harbour
+     * * `America/Cordoba` - America/Cordoba
+     * * `America/Costa_Rica` - America/Costa_Rica
+     * * `America/Creston` - America/Creston
+     * * `America/Cuiaba` - America/Cuiaba
+     * * `America/Curacao` - America/Curacao
+     * * `America/Danmarkshavn` - America/Danmarkshavn
+     * * `America/Dawson` - America/Dawson
+     * * `America/Dawson_Creek` - America/Dawson_Creek
+     * * `America/Denver` - America/Denver
+     * * `America/Detroit` - America/Detroit
+     * * `America/Dominica` - America/Dominica
+     * * `America/Edmonton` - America/Edmonton
+     * * `America/Eirunepe` - America/Eirunepe
+     * * `America/El_Salvador` - America/El_Salvador
+     * * `America/Ensenada` - America/Ensenada
+     * * `America/Fort_Nelson` - America/Fort_Nelson
+     * * `America/Fort_Wayne` - America/Fort_Wayne
+     * * `America/Fortaleza` - America/Fortaleza
+     * * `America/Glace_Bay` - America/Glace_Bay
+     * * `America/Godthab` - America/Godthab
+     * * `America/Goose_Bay` - America/Goose_Bay
+     * * `America/Grand_Turk` - America/Grand_Turk
+     * * `America/Grenada` - America/Grenada
+     * * `America/Guadeloupe` - America/Guadeloupe
+     * * `America/Guatemala` - America/Guatemala
+     * * `America/Guayaquil` - America/Guayaquil
+     * * `America/Guyana` - America/Guyana
+     * * `America/Halifax` - America/Halifax
+     * * `America/Havana` - America/Havana
+     * * `America/Hermosillo` - America/Hermosillo
+     * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+     * * `America/Indiana/Knox` - America/Indiana/Knox
+     * * `America/Indiana/Marengo` - America/Indiana/Marengo
+     * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+     * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+     * * `America/Indiana/Vevay` - America/Indiana/Vevay
+     * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+     * * `America/Indiana/Winamac` - America/Indiana/Winamac
+     * * `America/Indianapolis` - America/Indianapolis
+     * * `America/Inuvik` - America/Inuvik
+     * * `America/Iqaluit` - America/Iqaluit
+     * * `America/Jamaica` - America/Jamaica
+     * * `America/Jujuy` - America/Jujuy
+     * * `America/Juneau` - America/Juneau
+     * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+     * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+     * * `America/Knox_IN` - America/Knox_IN
+     * * `America/Kralendijk` - America/Kralendijk
+     * * `America/La_Paz` - America/La_Paz
+     * * `America/Lima` - America/Lima
+     * * `America/Los_Angeles` - America/Los_Angeles
+     * * `America/Louisville` - America/Louisville
+     * * `America/Lower_Princes` - America/Lower_Princes
+     * * `America/Maceio` - America/Maceio
+     * * `America/Managua` - America/Managua
+     * * `America/Manaus` - America/Manaus
+     * * `America/Marigot` - America/Marigot
+     * * `America/Martinique` - America/Martinique
+     * * `America/Matamoros` - America/Matamoros
+     * * `America/Mazatlan` - America/Mazatlan
+     * * `America/Mendoza` - America/Mendoza
+     * * `America/Menominee` - America/Menominee
+     * * `America/Merida` - America/Merida
+     * * `America/Metlakatla` - America/Metlakatla
+     * * `America/Mexico_City` - America/Mexico_City
+     * * `America/Miquelon` - America/Miquelon
+     * * `America/Moncton` - America/Moncton
+     * * `America/Monterrey` - America/Monterrey
+     * * `America/Montevideo` - America/Montevideo
+     * * `America/Montreal` - America/Montreal
+     * * `America/Montserrat` - America/Montserrat
+     * * `America/Nassau` - America/Nassau
+     * * `America/New_York` - America/New_York
+     * * `America/Nipigon` - America/Nipigon
+     * * `America/Nome` - America/Nome
+     * * `America/Noronha` - America/Noronha
+     * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+     * * `America/North_Dakota/Center` - America/North_Dakota/Center
+     * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+     * * `America/Nuuk` - America/Nuuk
+     * * `America/Ojinaga` - America/Ojinaga
+     * * `America/Panama` - America/Panama
+     * * `America/Pangnirtung` - America/Pangnirtung
+     * * `America/Paramaribo` - America/Paramaribo
+     * * `America/Phoenix` - America/Phoenix
+     * * `America/Port-au-Prince` - America/Port-au-Prince
+     * * `America/Port_of_Spain` - America/Port_of_Spain
+     * * `America/Porto_Acre` - America/Porto_Acre
+     * * `America/Porto_Velho` - America/Porto_Velho
+     * * `America/Puerto_Rico` - America/Puerto_Rico
+     * * `America/Punta_Arenas` - America/Punta_Arenas
+     * * `America/Rainy_River` - America/Rainy_River
+     * * `America/Rankin_Inlet` - America/Rankin_Inlet
+     * * `America/Recife` - America/Recife
+     * * `America/Regina` - America/Regina
+     * * `America/Resolute` - America/Resolute
+     * * `America/Rio_Branco` - America/Rio_Branco
+     * * `America/Rosario` - America/Rosario
+     * * `America/Santa_Isabel` - America/Santa_Isabel
+     * * `America/Santarem` - America/Santarem
+     * * `America/Santiago` - America/Santiago
+     * * `America/Santo_Domingo` - America/Santo_Domingo
+     * * `America/Sao_Paulo` - America/Sao_Paulo
+     * * `America/Scoresbysund` - America/Scoresbysund
+     * * `America/Shiprock` - America/Shiprock
+     * * `America/Sitka` - America/Sitka
+     * * `America/St_Barthelemy` - America/St_Barthelemy
+     * * `America/St_Johns` - America/St_Johns
+     * * `America/St_Kitts` - America/St_Kitts
+     * * `America/St_Lucia` - America/St_Lucia
+     * * `America/St_Thomas` - America/St_Thomas
+     * * `America/St_Vincent` - America/St_Vincent
+     * * `America/Swift_Current` - America/Swift_Current
+     * * `America/Tegucigalpa` - America/Tegucigalpa
+     * * `America/Thule` - America/Thule
+     * * `America/Thunder_Bay` - America/Thunder_Bay
+     * * `America/Tijuana` - America/Tijuana
+     * * `America/Toronto` - America/Toronto
+     * * `America/Tortola` - America/Tortola
+     * * `America/Vancouver` - America/Vancouver
+     * * `America/Virgin` - America/Virgin
+     * * `America/Whitehorse` - America/Whitehorse
+     * * `America/Winnipeg` - America/Winnipeg
+     * * `America/Yakutat` - America/Yakutat
+     * * `America/Yellowknife` - America/Yellowknife
+     * * `Antarctica/Casey` - Antarctica/Casey
+     * * `Antarctica/Davis` - Antarctica/Davis
+     * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+     * * `Antarctica/Macquarie` - Antarctica/Macquarie
+     * * `Antarctica/Mawson` - Antarctica/Mawson
+     * * `Antarctica/McMurdo` - Antarctica/McMurdo
+     * * `Antarctica/Palmer` - Antarctica/Palmer
+     * * `Antarctica/Rothera` - Antarctica/Rothera
+     * * `Antarctica/South_Pole` - Antarctica/South_Pole
+     * * `Antarctica/Syowa` - Antarctica/Syowa
+     * * `Antarctica/Troll` - Antarctica/Troll
+     * * `Antarctica/Vostok` - Antarctica/Vostok
+     * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+     * * `Asia/Aden` - Asia/Aden
+     * * `Asia/Almaty` - Asia/Almaty
+     * * `Asia/Amman` - Asia/Amman
+     * * `Asia/Anadyr` - Asia/Anadyr
+     * * `Asia/Aqtau` - Asia/Aqtau
+     * * `Asia/Aqtobe` - Asia/Aqtobe
+     * * `Asia/Ashgabat` - Asia/Ashgabat
+     * * `Asia/Ashkhabad` - Asia/Ashkhabad
+     * * `Asia/Atyrau` - Asia/Atyrau
+     * * `Asia/Baghdad` - Asia/Baghdad
+     * * `Asia/Bahrain` - Asia/Bahrain
+     * * `Asia/Baku` - Asia/Baku
+     * * `Asia/Bangkok` - Asia/Bangkok
+     * * `Asia/Barnaul` - Asia/Barnaul
+     * * `Asia/Beirut` - Asia/Beirut
+     * * `Asia/Bishkek` - Asia/Bishkek
+     * * `Asia/Brunei` - Asia/Brunei
+     * * `Asia/Calcutta` - Asia/Calcutta
+     * * `Asia/Chita` - Asia/Chita
+     * * `Asia/Choibalsan` - Asia/Choibalsan
+     * * `Asia/Chongqing` - Asia/Chongqing
+     * * `Asia/Chungking` - Asia/Chungking
+     * * `Asia/Colombo` - Asia/Colombo
+     * * `Asia/Dacca` - Asia/Dacca
+     * * `Asia/Damascus` - Asia/Damascus
+     * * `Asia/Dhaka` - Asia/Dhaka
+     * * `Asia/Dili` - Asia/Dili
+     * * `Asia/Dubai` - Asia/Dubai
+     * * `Asia/Dushanbe` - Asia/Dushanbe
+     * * `Asia/Famagusta` - Asia/Famagusta
+     * * `Asia/Gaza` - Asia/Gaza
+     * * `Asia/Harbin` - Asia/Harbin
+     * * `Asia/Hebron` - Asia/Hebron
+     * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+     * * `Asia/Hong_Kong` - Asia/Hong_Kong
+     * * `Asia/Hovd` - Asia/Hovd
+     * * `Asia/Irkutsk` - Asia/Irkutsk
+     * * `Asia/Istanbul` - Asia/Istanbul
+     * * `Asia/Jakarta` - Asia/Jakarta
+     * * `Asia/Jayapura` - Asia/Jayapura
+     * * `Asia/Jerusalem` - Asia/Jerusalem
+     * * `Asia/Kabul` - Asia/Kabul
+     * * `Asia/Kamchatka` - Asia/Kamchatka
+     * * `Asia/Karachi` - Asia/Karachi
+     * * `Asia/Kashgar` - Asia/Kashgar
+     * * `Asia/Kathmandu` - Asia/Kathmandu
+     * * `Asia/Katmandu` - Asia/Katmandu
+     * * `Asia/Khandyga` - Asia/Khandyga
+     * * `Asia/Kolkata` - Asia/Kolkata
+     * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+     * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+     * * `Asia/Kuching` - Asia/Kuching
+     * * `Asia/Kuwait` - Asia/Kuwait
+     * * `Asia/Macao` - Asia/Macao
+     * * `Asia/Macau` - Asia/Macau
+     * * `Asia/Magadan` - Asia/Magadan
+     * * `Asia/Makassar` - Asia/Makassar
+     * * `Asia/Manila` - Asia/Manila
+     * * `Asia/Muscat` - Asia/Muscat
+     * * `Asia/Nicosia` - Asia/Nicosia
+     * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+     * * `Asia/Novosibirsk` - Asia/Novosibirsk
+     * * `Asia/Omsk` - Asia/Omsk
+     * * `Asia/Oral` - Asia/Oral
+     * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+     * * `Asia/Pontianak` - Asia/Pontianak
+     * * `Asia/Pyongyang` - Asia/Pyongyang
+     * * `Asia/Qatar` - Asia/Qatar
+     * * `Asia/Qostanay` - Asia/Qostanay
+     * * `Asia/Qyzylorda` - Asia/Qyzylorda
+     * * `Asia/Rangoon` - Asia/Rangoon
+     * * `Asia/Riyadh` - Asia/Riyadh
+     * * `Asia/Saigon` - Asia/Saigon
+     * * `Asia/Sakhalin` - Asia/Sakhalin
+     * * `Asia/Samarkand` - Asia/Samarkand
+     * * `Asia/Seoul` - Asia/Seoul
+     * * `Asia/Shanghai` - Asia/Shanghai
+     * * `Asia/Singapore` - Asia/Singapore
+     * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+     * * `Asia/Taipei` - Asia/Taipei
+     * * `Asia/Tashkent` - Asia/Tashkent
+     * * `Asia/Tbilisi` - Asia/Tbilisi
+     * * `Asia/Tehran` - Asia/Tehran
+     * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+     * * `Asia/Thimbu` - Asia/Thimbu
+     * * `Asia/Thimphu` - Asia/Thimphu
+     * * `Asia/Tokyo` - Asia/Tokyo
+     * * `Asia/Tomsk` - Asia/Tomsk
+     * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+     * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+     * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+     * * `Asia/Urumqi` - Asia/Urumqi
+     * * `Asia/Ust-Nera` - Asia/Ust-Nera
+     * * `Asia/Vientiane` - Asia/Vientiane
+     * * `Asia/Vladivostok` - Asia/Vladivostok
+     * * `Asia/Yakutsk` - Asia/Yakutsk
+     * * `Asia/Yangon` - Asia/Yangon
+     * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+     * * `Asia/Yerevan` - Asia/Yerevan
+     * * `Atlantic/Azores` - Atlantic/Azores
+     * * `Atlantic/Bermuda` - Atlantic/Bermuda
+     * * `Atlantic/Canary` - Atlantic/Canary
+     * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+     * * `Atlantic/Faeroe` - Atlantic/Faeroe
+     * * `Atlantic/Faroe` - Atlantic/Faroe
+     * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+     * * `Atlantic/Madeira` - Atlantic/Madeira
+     * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+     * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+     * * `Atlantic/St_Helena` - Atlantic/St_Helena
+     * * `Atlantic/Stanley` - Atlantic/Stanley
+     * * `Australia/ACT` - Australia/ACT
+     * * `Australia/Adelaide` - Australia/Adelaide
+     * * `Australia/Brisbane` - Australia/Brisbane
+     * * `Australia/Broken_Hill` - Australia/Broken_Hill
+     * * `Australia/Canberra` - Australia/Canberra
+     * * `Australia/Currie` - Australia/Currie
+     * * `Australia/Darwin` - Australia/Darwin
+     * * `Australia/Eucla` - Australia/Eucla
+     * * `Australia/Hobart` - Australia/Hobart
+     * * `Australia/LHI` - Australia/LHI
+     * * `Australia/Lindeman` - Australia/Lindeman
+     * * `Australia/Lord_Howe` - Australia/Lord_Howe
+     * * `Australia/Melbourne` - Australia/Melbourne
+     * * `Australia/NSW` - Australia/NSW
+     * * `Australia/North` - Australia/North
+     * * `Australia/Perth` - Australia/Perth
+     * * `Australia/Queensland` - Australia/Queensland
+     * * `Australia/South` - Australia/South
+     * * `Australia/Sydney` - Australia/Sydney
+     * * `Australia/Tasmania` - Australia/Tasmania
+     * * `Australia/Victoria` - Australia/Victoria
+     * * `Australia/West` - Australia/West
+     * * `Australia/Yancowinna` - Australia/Yancowinna
+     * * `Brazil/Acre` - Brazil/Acre
+     * * `Brazil/DeNoronha` - Brazil/DeNoronha
+     * * `Brazil/East` - Brazil/East
+     * * `Brazil/West` - Brazil/West
+     * * `CET` - CET
+     * * `CST6CDT` - CST6CDT
+     * * `Canada/Atlantic` - Canada/Atlantic
+     * * `Canada/Central` - Canada/Central
+     * * `Canada/Eastern` - Canada/Eastern
+     * * `Canada/Mountain` - Canada/Mountain
+     * * `Canada/Newfoundland` - Canada/Newfoundland
+     * * `Canada/Pacific` - Canada/Pacific
+     * * `Canada/Saskatchewan` - Canada/Saskatchewan
+     * * `Canada/Yukon` - Canada/Yukon
+     * * `Chile/Continental` - Chile/Continental
+     * * `Chile/EasterIsland` - Chile/EasterIsland
+     * * `Cuba` - Cuba
+     * * `EET` - EET
+     * * `EST` - EST
+     * * `EST5EDT` - EST5EDT
+     * * `Egypt` - Egypt
+     * * `Eire` - Eire
+     * * `Etc/GMT` - Etc/GMT
+     * * `Etc/GMT+0` - Etc/GMT+0
+     * * `Etc/GMT+1` - Etc/GMT+1
+     * * `Etc/GMT+10` - Etc/GMT+10
+     * * `Etc/GMT+11` - Etc/GMT+11
+     * * `Etc/GMT+12` - Etc/GMT+12
+     * * `Etc/GMT+2` - Etc/GMT+2
+     * * `Etc/GMT+3` - Etc/GMT+3
+     * * `Etc/GMT+4` - Etc/GMT+4
+     * * `Etc/GMT+5` - Etc/GMT+5
+     * * `Etc/GMT+6` - Etc/GMT+6
+     * * `Etc/GMT+7` - Etc/GMT+7
+     * * `Etc/GMT+8` - Etc/GMT+8
+     * * `Etc/GMT+9` - Etc/GMT+9
+     * * `Etc/GMT-0` - Etc/GMT-0
+     * * `Etc/GMT-1` - Etc/GMT-1
+     * * `Etc/GMT-10` - Etc/GMT-10
+     * * `Etc/GMT-11` - Etc/GMT-11
+     * * `Etc/GMT-12` - Etc/GMT-12
+     * * `Etc/GMT-13` - Etc/GMT-13
+     * * `Etc/GMT-14` - Etc/GMT-14
+     * * `Etc/GMT-2` - Etc/GMT-2
+     * * `Etc/GMT-3` - Etc/GMT-3
+     * * `Etc/GMT-4` - Etc/GMT-4
+     * * `Etc/GMT-5` - Etc/GMT-5
+     * * `Etc/GMT-6` - Etc/GMT-6
+     * * `Etc/GMT-7` - Etc/GMT-7
+     * * `Etc/GMT-8` - Etc/GMT-8
+     * * `Etc/GMT-9` - Etc/GMT-9
+     * * `Etc/GMT0` - Etc/GMT0
+     * * `Etc/Greenwich` - Etc/Greenwich
+     * * `Etc/UCT` - Etc/UCT
+     * * `Etc/UTC` - Etc/UTC
+     * * `Etc/Universal` - Etc/Universal
+     * * `Etc/Zulu` - Etc/Zulu
+     * * `Europe/Amsterdam` - Europe/Amsterdam
+     * * `Europe/Andorra` - Europe/Andorra
+     * * `Europe/Astrakhan` - Europe/Astrakhan
+     * * `Europe/Athens` - Europe/Athens
+     * * `Europe/Belfast` - Europe/Belfast
+     * * `Europe/Belgrade` - Europe/Belgrade
+     * * `Europe/Berlin` - Europe/Berlin
+     * * `Europe/Bratislava` - Europe/Bratislava
+     * * `Europe/Brussels` - Europe/Brussels
+     * * `Europe/Bucharest` - Europe/Bucharest
+     * * `Europe/Budapest` - Europe/Budapest
+     * * `Europe/Busingen` - Europe/Busingen
+     * * `Europe/Chisinau` - Europe/Chisinau
+     * * `Europe/Copenhagen` - Europe/Copenhagen
+     * * `Europe/Dublin` - Europe/Dublin
+     * * `Europe/Gibraltar` - Europe/Gibraltar
+     * * `Europe/Guernsey` - Europe/Guernsey
+     * * `Europe/Helsinki` - Europe/Helsinki
+     * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+     * * `Europe/Istanbul` - Europe/Istanbul
+     * * `Europe/Jersey` - Europe/Jersey
+     * * `Europe/Kaliningrad` - Europe/Kaliningrad
+     * * `Europe/Kiev` - Europe/Kiev
+     * * `Europe/Kirov` - Europe/Kirov
+     * * `Europe/Kyiv` - Europe/Kyiv
+     * * `Europe/Lisbon` - Europe/Lisbon
+     * * `Europe/Ljubljana` - Europe/Ljubljana
+     * * `Europe/London` - Europe/London
+     * * `Europe/Luxembourg` - Europe/Luxembourg
+     * * `Europe/Madrid` - Europe/Madrid
+     * * `Europe/Malta` - Europe/Malta
+     * * `Europe/Mariehamn` - Europe/Mariehamn
+     * * `Europe/Minsk` - Europe/Minsk
+     * * `Europe/Monaco` - Europe/Monaco
+     * * `Europe/Moscow` - Europe/Moscow
+     * * `Europe/Nicosia` - Europe/Nicosia
+     * * `Europe/Oslo` - Europe/Oslo
+     * * `Europe/Paris` - Europe/Paris
+     * * `Europe/Podgorica` - Europe/Podgorica
+     * * `Europe/Prague` - Europe/Prague
+     * * `Europe/Riga` - Europe/Riga
+     * * `Europe/Rome` - Europe/Rome
+     * * `Europe/Samara` - Europe/Samara
+     * * `Europe/San_Marino` - Europe/San_Marino
+     * * `Europe/Sarajevo` - Europe/Sarajevo
+     * * `Europe/Saratov` - Europe/Saratov
+     * * `Europe/Simferopol` - Europe/Simferopol
+     * * `Europe/Skopje` - Europe/Skopje
+     * * `Europe/Sofia` - Europe/Sofia
+     * * `Europe/Stockholm` - Europe/Stockholm
+     * * `Europe/Tallinn` - Europe/Tallinn
+     * * `Europe/Tirane` - Europe/Tirane
+     * * `Europe/Tiraspol` - Europe/Tiraspol
+     * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+     * * `Europe/Uzhgorod` - Europe/Uzhgorod
+     * * `Europe/Vaduz` - Europe/Vaduz
+     * * `Europe/Vatican` - Europe/Vatican
+     * * `Europe/Vienna` - Europe/Vienna
+     * * `Europe/Vilnius` - Europe/Vilnius
+     * * `Europe/Volgograd` - Europe/Volgograd
+     * * `Europe/Warsaw` - Europe/Warsaw
+     * * `Europe/Zagreb` - Europe/Zagreb
+     * * `Europe/Zaporozhye` - Europe/Zaporozhye
+     * * `Europe/Zurich` - Europe/Zurich
+     * * `GB` - GB
+     * * `GB-Eire` - GB-Eire
+     * * `GMT` - GMT
+     * * `GMT+0` - GMT+0
+     * * `GMT-0` - GMT-0
+     * * `GMT0` - GMT0
+     * * `Greenwich` - Greenwich
+     * * `HST` - HST
+     * * `Hongkong` - Hongkong
+     * * `Iceland` - Iceland
+     * * `Indian/Antananarivo` - Indian/Antananarivo
+     * * `Indian/Chagos` - Indian/Chagos
+     * * `Indian/Christmas` - Indian/Christmas
+     * * `Indian/Cocos` - Indian/Cocos
+     * * `Indian/Comoro` - Indian/Comoro
+     * * `Indian/Kerguelen` - Indian/Kerguelen
+     * * `Indian/Mahe` - Indian/Mahe
+     * * `Indian/Maldives` - Indian/Maldives
+     * * `Indian/Mauritius` - Indian/Mauritius
+     * * `Indian/Mayotte` - Indian/Mayotte
+     * * `Indian/Reunion` - Indian/Reunion
+     * * `Iran` - Iran
+     * * `Israel` - Israel
+     * * `Jamaica` - Jamaica
+     * * `Japan` - Japan
+     * * `Kwajalein` - Kwajalein
+     * * `Libya` - Libya
+     * * `MET` - MET
+     * * `MST` - MST
+     * * `MST7MDT` - MST7MDT
+     * * `Mexico/BajaNorte` - Mexico/BajaNorte
+     * * `Mexico/BajaSur` - Mexico/BajaSur
+     * * `Mexico/General` - Mexico/General
+     * * `NZ` - NZ
+     * * `NZ-CHAT` - NZ-CHAT
+     * * `Navajo` - Navajo
+     * * `PRC` - PRC
+     * * `PST8PDT` - PST8PDT
+     * * `Pacific/Apia` - Pacific/Apia
+     * * `Pacific/Auckland` - Pacific/Auckland
+     * * `Pacific/Bougainville` - Pacific/Bougainville
+     * * `Pacific/Chatham` - Pacific/Chatham
+     * * `Pacific/Chuuk` - Pacific/Chuuk
+     * * `Pacific/Easter` - Pacific/Easter
+     * * `Pacific/Efate` - Pacific/Efate
+     * * `Pacific/Enderbury` - Pacific/Enderbury
+     * * `Pacific/Fakaofo` - Pacific/Fakaofo
+     * * `Pacific/Fiji` - Pacific/Fiji
+     * * `Pacific/Funafuti` - Pacific/Funafuti
+     * * `Pacific/Galapagos` - Pacific/Galapagos
+     * * `Pacific/Gambier` - Pacific/Gambier
+     * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+     * * `Pacific/Guam` - Pacific/Guam
+     * * `Pacific/Honolulu` - Pacific/Honolulu
+     * * `Pacific/Johnston` - Pacific/Johnston
+     * * `Pacific/Kanton` - Pacific/Kanton
+     * * `Pacific/Kiritimati` - Pacific/Kiritimati
+     * * `Pacific/Kosrae` - Pacific/Kosrae
+     * * `Pacific/Kwajalein` - Pacific/Kwajalein
+     * * `Pacific/Majuro` - Pacific/Majuro
+     * * `Pacific/Marquesas` - Pacific/Marquesas
+     * * `Pacific/Midway` - Pacific/Midway
+     * * `Pacific/Nauru` - Pacific/Nauru
+     * * `Pacific/Niue` - Pacific/Niue
+     * * `Pacific/Norfolk` - Pacific/Norfolk
+     * * `Pacific/Noumea` - Pacific/Noumea
+     * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+     * * `Pacific/Palau` - Pacific/Palau
+     * * `Pacific/Pitcairn` - Pacific/Pitcairn
+     * * `Pacific/Pohnpei` - Pacific/Pohnpei
+     * * `Pacific/Ponape` - Pacific/Ponape
+     * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+     * * `Pacific/Rarotonga` - Pacific/Rarotonga
+     * * `Pacific/Saipan` - Pacific/Saipan
+     * * `Pacific/Samoa` - Pacific/Samoa
+     * * `Pacific/Tahiti` - Pacific/Tahiti
+     * * `Pacific/Tarawa` - Pacific/Tarawa
+     * * `Pacific/Tongatapu` - Pacific/Tongatapu
+     * * `Pacific/Truk` - Pacific/Truk
+     * * `Pacific/Wake` - Pacific/Wake
+     * * `Pacific/Wallis` - Pacific/Wallis
+     * * `Pacific/Yap` - Pacific/Yap
+     * * `Poland` - Poland
+     * * `Portugal` - Portugal
+     * * `ROC` - ROC
+     * * `ROK` - ROK
+     * * `Singapore` - Singapore
+     * * `Turkey` - Turkey
+     * * `UCT` - UCT
+     * * `US/Alaska` - US/Alaska
+     * * `US/Aleutian` - US/Aleutian
+     * * `US/Arizona` - US/Arizona
+     * * `US/Central` - US/Central
+     * * `US/East-Indiana` - US/East-Indiana
+     * * `US/Eastern` - US/Eastern
+     * * `US/Hawaii` - US/Hawaii
+     * * `US/Indiana-Starke` - US/Indiana-Starke
+     * * `US/Michigan` - US/Michigan
+     * * `US/Mountain` - US/Mountain
+     * * `US/Pacific` - US/Pacific
+     * * `US/Samoa` - US/Samoa
+     * * `UTC` - UTC
+     * * `Universal` - Universal
+     * * `W-SU` - W-SU
+     * * `WET` - WET
+     * * `Zulu` - Zulu */
     timezone?: string | null
     /**
      * Day-of-week offset for weekly intervals (0=Sunday, 6=Saturday). Only valid when interval is 'week'.
@@ -1092,29 +1092,29 @@ export type BatchExportDestinationRequestApi =
 
 /**
  * Request body for create/partial_update on BatchExportViewSet.
-
-Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-`destination` schema so integration_id is marked required on the types that need
-it. Responses continue to use `BatchExportSerializer`.
+ *
+ * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+ * `destination` schema so integration_id is marked required on the types that need
+ * it. Responses continue to use `BatchExportSerializer`.
  */
 export interface BatchExportRequestApi {
     /** Human-readable name for the batch export. */
     name: string
     /** Which data model to export (events, persons, sessions).
-
-  * `events` - Events
-  * `persons` - Persons
-  * `sessions` - Sessions */
+     *
+     * * `events` - Events
+     * * `persons` - Persons
+     * * `sessions` - Sessions */
     model?: ModelEnumApi
     /** Destination configuration. Required integration_id is enforced per destination type. */
     destination: BatchExportDestinationRequestApi
     /** How often the batch export should run.
-
-  * `hour` - hour
-  * `day` - day
-  * `week` - week
-  * `every 5 minutes` - every 5 minutes
-  * `every 15 minutes` - every 15 minutes */
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * * `every 5 minutes` - every 5 minutes
+     * * `every 15 minutes` - every 15 minutes */
     interval: IntervalEnumApi
     /** Whether the batch export is paused. */
     paused?: boolean
@@ -1144,14 +1144,14 @@ export interface BatchExportRequestApi {
 
 /**
  * * `Cancelled` - Cancelled
- * `Completed` - Completed
- * `ContinuedAsNew` - Continued As New
- * `Failed` - Failed
- * `FailedRetryable` - Failed Retryable
- * `Terminated` - Terminated
- * `TimedOut` - Timedout
- * `Running` - Running
- * `Starting` - Starting
+ * * `Completed` - Completed
+ * * `ContinuedAsNew` - Continued As New
+ * * `Failed` - Failed
+ * * `FailedRetryable` - Failed Retryable
+ * * `Terminated` - Terminated
+ * * `TimedOut` - Timedout
+ * * `Running` - Running
+ * * `Starting` - Starting
  */
 export type BatchExportBackfillStatusEnumApi =
     (typeof BatchExportBackfillStatusEnumApi)[keyof typeof BatchExportBackfillStatusEnumApi]
@@ -1195,16 +1195,16 @@ export interface BatchExportBackfillApi {
      */
     end_at?: string | null
     /** The status of this backfill.
-
-  * `Cancelled` - Cancelled
-  * `Completed` - Completed
-  * `ContinuedAsNew` - Continued As New
-  * `Failed` - Failed
-  * `FailedRetryable` - Failed Retryable
-  * `Terminated` - Terminated
-  * `TimedOut` - Timedout
-  * `Running` - Running
-  * `Starting` - Starting */
+     *
+     * * `Cancelled` - Cancelled
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting */
     status: BatchExportBackfillStatusEnumApi
     /** The timestamp at which this BatchExportBackfill was created. */
     readonly created_at: string
@@ -1251,29 +1251,29 @@ export interface PaginatedBatchExportRunListApi {
 
 /**
  * Request body for create/partial_update on BatchExportViewSet.
-
-Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-`destination` schema so integration_id is marked required on the types that need
-it. Responses continue to use `BatchExportSerializer`.
+ *
+ * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+ * `destination` schema so integration_id is marked required on the types that need
+ * it. Responses continue to use `BatchExportSerializer`.
  */
 export interface PatchedBatchExportRequestApi {
     /** Human-readable name for the batch export. */
     name?: string
     /** Which data model to export (events, persons, sessions).
-
-  * `events` - Events
-  * `persons` - Persons
-  * `sessions` - Sessions */
+     *
+     * * `events` - Events
+     * * `persons` - Persons
+     * * `sessions` - Sessions */
     model?: ModelEnumApi
     /** Destination configuration. Required integration_id is enforced per destination type. */
     destination?: BatchExportDestinationRequestApi
     /** How often the batch export should run.
-
-  * `hour` - hour
-  * `day` - day
-  * `week` - week
-  * `every 5 minutes` - every 5 minutes
-  * `every 15 minutes` - every 15 minutes */
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * * `every 5 minutes` - every 5 minutes
+     * * `every 15 minutes` - every 15 minutes */
     interval?: IntervalEnumApi
     /** Whether the batch export is paused. */
     paused?: boolean
@@ -1308,17 +1308,17 @@ export interface ListOutputApi {
     /** ID of the file download batch export run. */
     id: string
     /** Current status of the file download batch export run.
-
-  * `Cancelled` - Cancelled
-  * `Completed` - Completed
-  * `ContinuedAsNew` - Continued As New
-  * `Failed` - Failed
-  * `FailedRetryable` - Failed Retryable
-  * `FailedBilling` - Failed Billing
-  * `Terminated` - Terminated
-  * `TimedOut` - Timedout
-  * `Running` - Running
-  * `Starting` - Starting */
+     *
+     * * `Cancelled` - Cancelled
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `FailedBilling` - Failed Billing
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting */
     status: BatchExportRunStatusEnumApi
 }
 
@@ -1336,17 +1336,17 @@ export interface PaginatedListOutputListApi {
  */
 export interface FileDownloadDestinationFileConfigApi {
     /** File format
-
-  * `Parquet` - Parquet
-  * `JSONLines` - JSONLines */
+     *
+     * * `Parquet` - Parquet
+     * * `JSONLines` - JSONLines */
     format?: FileFormatEnumApi
     /** Compress the file with a supported compression format
-
-  * `zstd` - zstd
-  * `gzip` - gzip
-  * `brotli` - brotli
-  * `lz4` - lz4
-  * `snappy` - snappy */
+     *
+     * * `zstd` - zstd
+     * * `gzip` - gzip
+     * * `brotli` - brotli
+     * * `lz4` - lz4
+     * * `snappy` - snappy */
     compression?: CompressionEnumApi | null
     /**
      * Split download into multiple files of at most this size in MB
@@ -1478,8 +1478,8 @@ export type RetrieveFileDownloadResponseApi =
 
 /**
  * * `events` - events
- * `persons` - persons
- * `sessions` - sessions
+ * * `persons` - persons
+ * * `sessions` - sessions
  */
 export type FileDownloadBatchExportOnDemandModelEnumApi =
     (typeof FileDownloadBatchExportOnDemandModelEnumApi)[keyof typeof FileDownloadBatchExportOnDemandModelEnumApi]
@@ -1534,8 +1534,8 @@ export const FileDownloadSessionsRequestModelEnumApi = {
 
 /**
  * * `Starting` - Starting
- * `Running` - Running
- * `Cancelled` - Cancelled
+ * * `Running` - Running
+ * * `Cancelled` - Cancelled
  */
 export type RetrieveBasicOutputStatusEnumApi =
     (typeof RetrieveBasicOutputStatusEnumApi)[keyof typeof RetrieveBasicOutputStatusEnumApi]
@@ -1558,10 +1558,10 @@ export const RetrieveCompletedOutputStatusEnumApi = {
 
 /**
  * * `Failed` - Failed
- * `FailedRetryable` - FailedRetryable
- * `FailedBilling` - FailedBilling
- * `Terminated` - Terminated
- * `TimedOut` - TimedOut
+ * * `FailedRetryable` - FailedRetryable
+ * * `FailedBilling` - FailedBilling
+ * * `Terminated` - Terminated
+ * * `TimedOut` - TimedOut
  */
 export type RetrieveFailedOutputStatusEnumApi =
     (typeof RetrieveFailedOutputStatusEnumApi)[keyof typeof RetrieveFailedOutputStatusEnumApi]

--- a/products/batch_exports/frontend/generated/api.ts
+++ b/products/batch_exports/frontend/generated/api.ts
@@ -53,7 +53,7 @@ export const getBatchExportsListUrl = (projectId: string, params?: BatchExportsL
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -101,7 +101,7 @@ export const getBatchExportsBackfillsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -114,8 +114,8 @@ export const getBatchExportsBackfillsListUrl = (
 
 /**
  * ViewSet for BatchExportBackfill models.
-
-Allows creating and reading backfills, but not updating or deleting them.
+ *
+ * Allows creating and reading backfills, but not updating or deleting them.
  */
 export const batchExportsBackfillsList = async (
     projectId: string,
@@ -159,8 +159,8 @@ export const getBatchExportsBackfillsRetrieveUrl = (projectId: string, batchExpo
 
 /**
  * ViewSet for BatchExportBackfill models.
-
-Allows creating and reading backfills, but not updating or deleting them.
+ *
+ * Allows creating and reading backfills, but not updating or deleting them.
  */
 export const batchExportsBackfillsRetrieve = async (
     projectId: string,
@@ -205,7 +205,7 @@ export const getBatchExportsRunsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -276,7 +276,7 @@ export const getBatchExportsRunsLogsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -306,9 +306,9 @@ export const getBatchExportsRunsRetryCreateUrl = (projectId: string, batchExport
 
 /**
  * Retry a batch export run.
-
-We use the same underlying mechanism as when backfilling a batch export, as retrying
-a run is the same as backfilling one run.
+ *
+ * We use the same underlying mechanism as when backfilling a batch export, as retrying
+ * a run is the same as backfilling one run.
  */
 export const batchExportsRunsRetryCreate = async (
     projectId: string,
@@ -396,7 +396,7 @@ export const getBatchExportsLogsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -512,7 +512,7 @@ export const getFileDownloadBatchExportsListUrl = (projectId: string, params?: F
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -560,10 +560,10 @@ export const getFileDownloadBatchExportsRetrieveUrl = (projectId: string, id: st
 
 /**
  * Get a batch export on demand run.
-
-If the underlying batch export run has completed, we return keys to the
-generated file downloads so that users may download them by making a request
-to /download.
+ *
+ * If the underlying batch export run has completed, we return keys to the
+ * generated file downloads so that users may download them by making a request
+ * to /download.
  */
 export const fileDownloadBatchExportsRetrieve = async (
     projectId: string,
@@ -603,14 +603,14 @@ export const getFileDownloadBatchExportsDownloadRetrieveUrl = (projectId: string
 
 /**
  * Download a file (or a part) from this batch export run.
-
-Users can provide a part component with an id or index, or no part component at
-all:
-* If part id is included: The file download matching the id is downloaded.
-* If part index is included: The file download matching the index (as ordered
-    by key) is downloaded.
-* If no part component is present: If there is only one file downloaded, that
-    is downloaded. Otherwise the first one as sorted by key is downloaded.
+ *
+ * Users can provide a part component with an id or index, or no part component at
+ * all:
+ * * If part id is included: The file download matching the id is downloaded.
+ * * If part index is included: The file download matching the index (as ordered
+ *     by key) is downloaded.
+ * * If no part component is present: If there is only one file downloaded, that
+ *     is downloaded. Otherwise the first one as sorted by key is downloaded.
  */
 export const fileDownloadBatchExportsDownloadRetrieve = async (
     projectId: string,
@@ -632,7 +632,7 @@ export const getFileDownloadBatchExportsLogsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -354,9 +354,9 @@ export const BatchExportsRunsCancelCreateBody = /* @__PURE__ */ zod
 
 /**
  * Retry a batch export run.
-
-We use the same underlying mechanism as when backfilling a batch export, as retrying
-a run is the same as backfilling one run.
+ *
+ * We use the same underlying mechanism as when backfilling a batch export, as retrying
+ * a run is the same as backfilling one run.
  */
 export const batchExportsRunsRetryCreateBodyRecordsCompletedMin = -2147483648
 export const batchExportsRunsRetryCreateBodyRecordsCompletedMax = 2147483647

--- a/products/business_knowledge/frontend/generated/api.schemas.ts
+++ b/products/business_knowledge/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `text` - Text
- * `url` - URL
- * `file` - File
+ * * `url` - URL
+ * * `file` - File
  */
 export type KnowledgeSourceSourceTypeEnumApi =
     (typeof KnowledgeSourceSourceTypeEnumApi)[keyof typeof KnowledgeSourceSourceTypeEnumApi]
@@ -23,9 +23,9 @@ export const KnowledgeSourceSourceTypeEnumApi = {
 
 /**
  * * `pending` - Pending
- * `processing` - Processing
- * `ready` - Ready
- * `error` - Error
+ * * `processing` - Processing
+ * * `ready` - Ready
+ * * `error` - Error
  */
 export type KnowledgeSourceStatusEnumApi =
     (typeof KnowledgeSourceStatusEnumApi)[keyof typeof KnowledgeSourceStatusEnumApi]
@@ -39,8 +39,8 @@ export const KnowledgeSourceStatusEnumApi = {
 
 /**
  * * `success` - Success
- * `not_modified` - Not modified
- * `error` - Error
+ * * `not_modified` - Not modified
+ * * `error` - Error
  */
 export type LastRefreshStatusEnumApi = (typeof LastRefreshStatusEnumApi)[keyof typeof LastRefreshStatusEnumApi]
 
@@ -52,10 +52,10 @@ export const LastRefreshStatusEnumApi = {
 
 /**
  * * `manual` - Manual only
- * `1h` - Every hour
- * `6h` - Every 6 hours
- * `24h` - Every day
- * `7d` - Every week
+ * * `1h` - Every hour
+ * * `6h` - Every 6 hours
+ * * `24h` - Every day
+ * * `7d` - Every week
  */
 export type RefreshIntervalEnumApi = (typeof RefreshIntervalEnumApi)[keyof typeof RefreshIntervalEnumApi]
 
@@ -69,9 +69,9 @@ export const RefreshIntervalEnumApi = {
 
 /**
  * * `single` - Single page
- * `sitemap` - Sitemap
- * `same_origin` - Same origin crawl
- * `github_repo` - GitHub repository
+ * * `sitemap` - Sitemap
+ * * `same_origin` - Same origin crawl
+ * * `github_repo` - GitHub repository
  */
 export type CrawlModeEnumApi = (typeof CrawlModeEnumApi)[keyof typeof CrawlModeEnumApi]
 
@@ -138,7 +138,7 @@ export interface CreateTextSourceApi {
 
 /**
  * PATCH payload for text sources. Both fields optional, at least one
-required. `text` triggers a re-chunk; `name` alone does not.
+ * required. `text` triggers a re-chunk; `name` alone does not.
  */
 export interface PatchedUpdateTextSourceApi {
     /**

--- a/products/business_knowledge/frontend/generated/api.ts
+++ b/products/business_knowledge/frontend/generated/api.ts
@@ -39,7 +39,7 @@ export const getBusinessKnowledgeSourcesListUrl = (projectId: string, params?: B
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/cdp/frontend/generated/api.schemas.ts
+++ b/products/cdp/frontend/generated/api.schemas.ts
@@ -91,13 +91,13 @@ export interface PaginatedHogFunctionTemplateListApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -146,11 +146,11 @@ export interface UserBasicApi {
 
 /**
  * * `0` - 0
- * `1` - 1
- * `2` - 2
- * `3` - 3
- * `11` - 11
- * `12` - 12
+ * * `1` - 1
+ * * `2` - 2
+ * * `3` - 3
+ * * `11` - 11
+ * * `12` - 12
  */
 export type HogFunctionStatusStateEnumApi =
     (typeof HogFunctionStatusStateEnumApi)[keyof typeof HogFunctionStatusStateEnumApi]
@@ -201,7 +201,7 @@ export interface PaginatedHogFunctionMinimalListApi {
 
 /**
  * * `hog` - hog
- * `liquid` - liquid
+ * * `liquid` - liquid
  */
 export type HogFunctionTemplatingEnumApi =
     (typeof HogFunctionTemplatingEnumApi)[keyof typeof HogFunctionTemplatingEnumApi]
@@ -226,12 +226,12 @@ export type HogFunctionApiInputs = { [key: string]: InputsItemApi }
 
 /**
  * * `destination` - Destination
- * `site_destination` - Site Destination
- * `internal_destination` - Internal Destination
- * `source_webhook` - Source Webhook
- * `warehouse_source_webhook` - Warehouse Source Webhook
- * `site_app` - Site App
- * `transformation` - Transformation
+ * * `site_destination` - Site Destination
+ * * `internal_destination` - Internal Destination
+ * * `source_webhook` - Source Webhook
+ * * `warehouse_source_webhook` - Warehouse Source Webhook
+ * * `site_app` - Site App
+ * * `transformation` - Transformation
  */
 export type HogFunctionTypeEnumApi = (typeof HogFunctionTypeEnumApi)[keyof typeof HogFunctionTypeEnumApi]
 
@@ -247,19 +247,19 @@ export const HogFunctionTypeEnumApi = {
 
 /**
  * * `string` - string
- * `number` - number
- * `boolean` - boolean
- * `dictionary` - dictionary
- * `choice` - choice
- * `json` - json
- * `integration` - integration
- * `integration_field` - integration_field
- * `email` - email
- * `native_email` - native_email
- * `posthog_assignee` - posthog_assignee
- * `posthog_ticket_tags` - posthog_ticket_tags
- * `posthog_business_hours` - posthog_business_hours
- * `non_failure_status_codes` - non_failure_status_codes
+ * * `number` - number
+ * * `boolean` - boolean
+ * * `dictionary` - dictionary
+ * * `choice` - choice
+ * * `json` - json
+ * * `integration` - integration
+ * * `integration_field` - integration_field
+ * * `email` - email
+ * * `native_email` - native_email
+ * * `posthog_assignee` - posthog_assignee
+ * * `posthog_ticket_tags` - posthog_ticket_tags
+ * * `posthog_business_hours` - posthog_business_hours
+ * * `non_failure_status_codes` - non_failure_status_codes
  */
 export type InputsSchemaItemTypeEnumApi = (typeof InputsSchemaItemTypeEnumApi)[keyof typeof InputsSchemaItemTypeEnumApi]
 
@@ -303,8 +303,8 @@ export interface InputsSchemaItemApi {
 
 /**
  * * `events` - events
- * `person-updates` - person-updates
- * `data-warehouse-table` - data-warehouse-table
+ * * `person-updates` - person-updates
+ * * `data-warehouse-table` - data-warehouse-table
  */
 export type HogFunctionFiltersSourceEnumApi =
     (typeof HogFunctionFiltersSourceEnumApi)[keyof typeof HogFunctionFiltersSourceEnumApi]
@@ -365,14 +365,14 @@ export interface MappingsApi {
 export interface HogFunctionApi {
     readonly id: string
     /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-
-  * `destination` - Destination
-  * `site_destination` - Site Destination
-  * `internal_destination` - Internal Destination
-  * `source_webhook` - Source Webhook
-  * `warehouse_source_webhook` - Warehouse Source Webhook
-  * `site_app` - Site App
-  * `transformation` - Transformation */
+     *
+     * * `destination` - Destination
+     * * `site_destination` - Site Destination
+     * * `internal_destination` - Internal Destination
+     * * `source_webhook` - Source Webhook
+     * * `warehouse_source_webhook` - Warehouse Source Webhook
+     * * `site_app` - Site App
+     * * `transformation` - Transformation */
     type?: HogFunctionTypeEnumApi | null
     /**
      * Display name for the function.
@@ -440,14 +440,14 @@ export type PatchedHogFunctionApiInputs = { [key: string]: InputsItemApi }
 export interface PatchedHogFunctionApi {
     readonly id?: string
     /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-
-  * `destination` - Destination
-  * `site_destination` - Site Destination
-  * `internal_destination` - Internal Destination
-  * `source_webhook` - Source Webhook
-  * `warehouse_source_webhook` - Warehouse Source Webhook
-  * `site_app` - Site App
-  * `transformation` - Transformation */
+     *
+     * * `destination` - Destination
+     * * `site_destination` - Site Destination
+     * * `internal_destination` - Internal Destination
+     * * `source_webhook` - Source Webhook
+     * * `warehouse_source_webhook` - Warehouse Source Webhook
+     * * `site_app` - Site App
+     * * `transformation` - Transformation */
     type?: HogFunctionTypeEnumApi | null
     /**
      * Display name for the function.
@@ -565,8 +565,8 @@ export interface PatchedHogFunctionRearrangeApi {
 
 /**
  * * `SYSTEM` - SYSTEM
- * `PLUGIN` - PLUGIN
- * `CONSOLE` - CONSOLE
+ * * `PLUGIN` - PLUGIN
+ * * `CONSOLE` - CONSOLE
  */
 export type PluginLogEntrySourceEnumApi = (typeof PluginLogEntrySourceEnumApi)[keyof typeof PluginLogEntrySourceEnumApi]
 
@@ -578,10 +578,10 @@ export const PluginLogEntrySourceEnumApi = {
 
 /**
  * * `DEBUG` - DEBUG
- * `LOG` - LOG
- * `INFO` - INFO
- * `WARN` - WARN
- * `ERROR` - ERROR
+ * * `LOG` - LOG
+ * * `INFO` - INFO
+ * * `WARN` - WARN
+ * * `ERROR` - ERROR
  */
 export type PluginLogEntryTypeEnumApi = (typeof PluginLogEntryTypeEnumApi)[keyof typeof PluginLogEntryTypeEnumApi]
 
@@ -701,12 +701,12 @@ export type HogFunctionsMetricsRetrieveParams = {
      */
     before?: string
     /**
- * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-* `name` - name
-* `kind` - kind
- * @minLength 1
- */
+     * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
+     *
+     * * `name` - name
+     * * `kind` - kind
+     * @minLength 1
+     */
     breakdown_by?: HogFunctionsMetricsRetrieveBreakdownBy
     /**
      * Filter metrics to a specific execution instance.
@@ -714,13 +714,13 @@ export type HogFunctionsMetricsRetrieveParams = {
      */
     instance_id?: string
     /**
- * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-* `hour` - hour
-* `day` - day
-* `week` - week
- * @minLength 1
- */
+     * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * @minLength 1
+     */
     interval?: HogFunctionsMetricsRetrieveInterval
     /**
      * Comma-separated metric kinds to filter by, e.g. 'success,failure'.
@@ -763,12 +763,12 @@ export type HogFunctionsMetricsTotalsRetrieveParams = {
      */
     before?: string
     /**
- * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-* `name` - name
-* `kind` - kind
- * @minLength 1
- */
+     * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
+     *
+     * * `name` - name
+     * * `kind` - kind
+     * @minLength 1
+     */
     breakdown_by?: HogFunctionsMetricsTotalsRetrieveBreakdownBy
     /**
      * Filter metrics to a specific execution instance.
@@ -776,13 +776,13 @@ export type HogFunctionsMetricsTotalsRetrieveParams = {
      */
     instance_id?: string
     /**
- * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-* `hour` - hour
-* `day` - day
-* `week` - week
- * @minLength 1
- */
+     * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * @minLength 1
+     */
     interval?: HogFunctionsMetricsTotalsRetrieveInterval
     /**
      * Comma-separated metric kinds to filter by, e.g. 'success,failure'.

--- a/products/cdp/frontend/generated/api.ts
+++ b/products/cdp/frontend/generated/api.ts
@@ -50,7 +50,7 @@ export const getHogFunctionTemplatesListUrl = (projectId: string, params?: HogFu
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -92,7 +92,7 @@ export const getHogFunctionsListUrl = (projectId: string, params?: HogFunctionsL
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -241,7 +241,7 @@ export const getHogFunctionsLogsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -273,7 +273,7 @@ export const getHogFunctionsMetricsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -305,7 +305,7 @@ export const getHogFunctionsMetricsTotalsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -379,7 +379,7 @@ export const getPluginConfigsLogsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -407,7 +407,7 @@ export const getPublicHogFunctionTemplatesListUrl = (params?: PublicHogFunctionT
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/cohorts/frontend/generated/api.schemas.ts
+++ b/products/cohorts/frontend/generated/api.schemas.ts
@@ -93,13 +93,13 @@ export interface CohortFiltersApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -148,10 +148,10 @@ export interface UserBasicApi {
 
 /**
  * * `static` - static
- * `person_property` - person_property
- * `behavioral` - behavioral
- * `realtime` - realtime
- * `analytical` - analytical
+ * * `person_property` - person_property
+ * * `behavioral` - behavioral
+ * * `realtime` - realtime
+ * * `analytical` - analytical
  */
 export type CohortTypeEnumApi = (typeof CohortTypeEnumApi)[keyof typeof CohortTypeEnumApi]
 
@@ -195,12 +195,12 @@ export interface CohortApi {
     readonly count: number | null
     is_static?: boolean
     /** Type of cohort based on filter complexity
-
-  * `static` - static
-  * `person_property` - person_property
-  * `behavioral` - behavioral
-  * `realtime` - realtime
-  * `analytical` - analytical */
+     *
+     * * `static` - static
+     * * `person_property` - person_property
+     * * `behavioral` - behavioral
+     * * `realtime` - realtime
+     * * `analytical` - analytical */
     cohort_type?: CohortTypeEnumApi | BlankEnumApi | null
     readonly experiment_set: readonly number[]
     _create_in_folder?: string
@@ -248,12 +248,12 @@ export interface PatchedCohortApi {
     readonly count?: number | null
     is_static?: boolean
     /** Type of cohort based on filter complexity
-
-  * `static` - static
-  * `person_property` - person_property
-  * `behavioral` - behavioral
-  * `realtime` - realtime
-  * `analytical` - analytical */
+     *
+     * * `static` - static
+     * * `person_property` - person_property
+     * * `behavioral` - behavioral
+     * * `realtime` - realtime
+     * * `analytical` - analytical */
     cohort_type?: CohortTypeEnumApi | BlankEnumApi | null
     readonly experiment_set?: readonly number[]
     _create_in_folder?: string

--- a/products/cohorts/frontend/generated/api.ts
+++ b/products/cohorts/frontend/generated/api.ts
@@ -41,7 +41,7 @@ export const getCohortsListUrl = (projectId: string, params?: CohortsListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -190,7 +190,7 @@ export const getCohortsPersonsRetrieveUrl = (projectId: string, id: number, para
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `idle` - Idle
- * `in_progress` - In progress
- * `canceling` - Canceling
+ * * `in_progress` - In progress
+ * * `canceling` - Canceling
  */
 export type ConversationStatusApi = (typeof ConversationStatusApi)[keyof typeof ConversationStatusApi]
 
@@ -22,13 +22,13 @@ export const ConversationStatusApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -77,9 +77,9 @@ export interface UserBasicApi {
 
 /**
  * * `assistant` - Assistant
- * `tool_call` - Tool call
- * `deep_research` - Deep research
- * `slack` - Slack
+ * * `tool_call` - Tool call
+ * * `deep_research` - Deep research
+ * * `slack` - Slack
  */
 export type ConversationTypeApi = (typeof ConversationTypeApi)[keyof typeof ConversationTypeApi]
 
@@ -134,17 +134,17 @@ export type MessageApiContextualTools = { [key: string]: unknown }
 
 /**
  * * `product_analytics` - product_analytics
- * `sql` - sql
- * `session_replay` - session_replay
- * `error_tracking` - error_tracking
- * `plan` - plan
- * `execution` - execution
- * `survey` - survey
- * `research` - research
- * `flags` - flags
- * `llm_analytics` - llm_analytics
- * `sandbox` - sandbox
- * `user_interview` - user_interview
+ * * `sql` - sql
+ * * `session_replay` - session_replay
+ * * `error_tracking` - error_tracking
+ * * `plan` - plan
+ * * `execution` - execution
+ * * `survey` - survey
+ * * `research` - research
+ * * `flags` - flags
+ * * `llm_analytics` - llm_analytics
+ * * `sandbox` - sandbox
+ * * `user_interview` - user_interview
  */
 export type AgentModeEnumApi = (typeof AgentModeEnumApi)[keyof typeof AgentModeEnumApi]
 
@@ -222,9 +222,9 @@ export interface ConversationApi {
     readonly agent_mode: string | null
     readonly is_sandbox: boolean
     /** Return pending approval cards as structured data.
-
-  Combines metadata from conversation.approval_decisions with payload from checkpoint
-  interrupts (single source of truth for payload data). */
+     *
+     * Combines metadata from conversation.approval_decisions with payload from checkpoint
+     * interrupts (single source of truth for payload data). */
     readonly pending_approvals: readonly ConversationApiPendingApprovalsItem[]
 }
 
@@ -275,18 +275,18 @@ export interface PatchedConversationApi {
     readonly agent_mode?: string | null
     readonly is_sandbox?: boolean
     /** Return pending approval cards as structured data.
-
-  Combines metadata from conversation.approval_decisions with payload from checkpoint
-  interrupts (single source of truth for payload data). */
+     *
+     * Combines metadata from conversation.approval_decisions with payload from checkpoint
+     * interrupts (single source of truth for payload data). */
     readonly pending_approvals?: readonly PatchedConversationApiPendingApprovalsItem[]
 }
 
 /**
  * * `widget` - Widget
- * `email` - Email
- * `slack` - Slack
- * `teams` - Microsoft Teams
- * `github` - GitHub
+ * * `email` - Email
+ * * `slack` - Slack
+ * * `teams` - Microsoft Teams
+ * * `github` - GitHub
  */
 export type ChannelSourceEnumApi = (typeof ChannelSourceEnumApi)[keyof typeof ChannelSourceEnumApi]
 
@@ -300,13 +300,13 @@ export const ChannelSourceEnumApi = {
 
 /**
  * * `slack_channel_message` - Channel message
- * `slack_bot_mention` - Bot mention
- * `slack_emoji_reaction` - Emoji reaction
- * `teams_channel_message` - Teams channel message
- * `teams_bot_mention` - Teams bot mention
- * `widget_embedded` - Widget
- * `widget_api` - API
- * `github_issue` - GitHub issue
+ * * `slack_bot_mention` - Bot mention
+ * * `slack_emoji_reaction` - Emoji reaction
+ * * `teams_channel_message` - Teams channel message
+ * * `teams_bot_mention` - Teams bot mention
+ * * `widget_embedded` - Widget
+ * * `widget_api` - API
+ * * `github_issue` - GitHub issue
  */
 export type ChannelDetailEnumApi = (typeof ChannelDetailEnumApi)[keyof typeof ChannelDetailEnumApi]
 
@@ -323,10 +323,10 @@ export const ChannelDetailEnumApi = {
 
 /**
  * * `new` - New
- * `open` - Open
- * `pending` - Pending
- * `on_hold` - On hold
- * `resolved` - Resolved
+ * * `open` - Open
+ * * `pending` - Pending
+ * * `on_hold` - On hold
+ * * `resolved` - Resolved
  */
 export type TicketStatusEnumApi = (typeof TicketStatusEnumApi)[keyof typeof TicketStatusEnumApi]
 
@@ -340,8 +340,8 @@ export const TicketStatusEnumApi = {
 
 /**
  * * `low` - Low
- * `medium` - Medium
- * `high` - High
+ * * `medium` - Medium
+ * * `high` - High
  */
 export type PriorityEnumApi = (typeof PriorityEnumApi)[keyof typeof PriorityEnumApi]
 
@@ -398,18 +398,18 @@ export interface TicketApi {
     readonly channel_detail: ChannelDetailEnumApi | null
     readonly distinct_id: string
     /** Ticket status: new, open, pending, on_hold, or resolved
-
-  * `new` - New
-  * `open` - Open
-  * `pending` - Pending
-  * `on_hold` - On hold
-  * `resolved` - Resolved */
+     *
+     * * `new` - New
+     * * `open` - Open
+     * * `pending` - Pending
+     * * `on_hold` - On hold
+     * * `resolved` - Resolved */
     status?: TicketStatusEnumApi
     /** Ticket priority: low, medium, or high. Null if unset.
-
-  * `low` - Low
-  * `medium` - Medium
-  * `high` - High */
+     *
+     * * `low` - Low
+     * * `medium` - Medium
+     * * `high` - High */
     priority?: PriorityEnumApi | BlankEnumApi | null
     readonly assignee: TicketAssignmentApi
     /** Customer-provided traits such as name and email */
@@ -476,18 +476,18 @@ export interface PatchedTicketApi {
     readonly channel_detail?: ChannelDetailEnumApi | null
     readonly distinct_id?: string
     /** Ticket status: new, open, pending, on_hold, or resolved
-
-  * `new` - New
-  * `open` - Open
-  * `pending` - Pending
-  * `on_hold` - On hold
-  * `resolved` - Resolved */
+     *
+     * * `new` - New
+     * * `open` - Open
+     * * `pending` - Pending
+     * * `on_hold` - On hold
+     * * `resolved` - Resolved */
     status?: TicketStatusEnumApi
     /** Ticket priority: low, medium, or high. Null if unset.
-
-  * `low` - Low
-  * `medium` - Medium
-  * `high` - High */
+     *
+     * * `low` - Low
+     * * `medium` - Medium
+     * * `high` - High */
     priority?: PriorityEnumApi | BlankEnumApi | null
     readonly assignee?: TicketAssignmentApi
     /** Customer-provided traits such as name and email */
@@ -551,12 +551,12 @@ export interface BulkUpdateStatusRequestApi {
      */
     ids: string[]
     /** New status to apply to all selected tickets: new, open, pending, on_hold, or resolved.
-
-  * `new` - New
-  * `open` - Open
-  * `pending` - Pending
-  * `on_hold` - On hold
-  * `resolved` - Resolved */
+     *
+     * * `new` - New
+     * * `open` - Open
+     * * `pending` - Pending
+     * * `on_hold` - On hold
+     * * `resolved` - Resolved */
     status: TicketStatusEnumApi
 }
 
@@ -569,8 +569,8 @@ export interface BulkUpdateStatusResponseApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -587,10 +587,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]

--- a/products/conversations/frontend/generated/api.ts
+++ b/products/conversations/frontend/generated/api.ts
@@ -53,7 +53,7 @@ export const getConversationsListUrl = (projectId: string, params?: Conversation
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -81,9 +81,9 @@ export const getConversationsCreateUrl = (projectId: string) => {
 
 /**
  * Unified endpoint that handles both conversation creation and streaming.
-
-- If message is provided: Start new conversation processing
-- If no message: Stream from existing conversation
+ *
+ * - If message is provided: Start new conversation processing
+ * - If no message: Stream from existing conversation
  */
 export const conversationsCreate = async (
     projectId: string,
@@ -137,8 +137,8 @@ export const getConversationsAppendMessageCreateUrl = (projectId: string, conver
 
 /**
  * Appends a message to an existing conversation without triggering AI processing.
-This is used for client-side generated messages that need to be persisted
-(e.g., support ticket confirmation messages).
+ * This is used for client-side generated messages that need to be persisted
+ * (e.g., support ticket confirmation messages).
  */
 export const conversationsAppendMessageCreate = async (
     projectId: string,
@@ -263,7 +263,7 @@ export const getConversationsTicketsListUrl = (projectId: string, params?: Conve
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -398,9 +398,9 @@ export const getConversationsTicketsBulkUpdateStatusCreateUrl = (projectId: stri
 
 /**
  * Update the status of multiple tickets in a single request.
-
-Only tickets belonging to the current team are affected; other-team UUIDs
-are silently ignored.  Tickets already in the requested status are skipped.
+ *
+ * Only tickets belonging to the current team are affected; other-team UUIDs
+ * are silently ignored.  Tickets already in the requested status are skipped.
  */
 export const conversationsTicketsBulkUpdateStatusCreate = async (
     projectId: string,
@@ -421,22 +421,22 @@ export const getConversationsTicketsBulkUpdateTagsCreateUrl = (projectId: string
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const conversationsTicketsBulkUpdateTagsCreate = async (
     projectId: string,
@@ -477,9 +477,9 @@ export const getConversationsTicketsUnreadCountRetrieveUrl = (projectId: string)
 
 /**
  * Get total unread ticket count for the team.
-
-Returns the sum of unread_team_count for all non-resolved tickets.
-Cached in Redis for 30 seconds, invalidated on changes.
+ *
+ * Returns the sum of unread_team_count for all non-resolved tickets.
+ * Cached in Redis for 30 seconds, invalidated on changes.
  */
 export const conversationsTicketsUnreadCountRetrieve = async (
     projectId: string,
@@ -496,7 +496,7 @@ export const getConversationsViewsListUrl = (projectId: string, params?: Convers
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -11,9 +11,9 @@ import * as zod from 'zod'
 
 /**
  * Unified endpoint that handles both conversation creation and streaming.
-
-- If message is provided: Start new conversation processing
-- If no message: Stream from existing conversation
+ *
+ * - If message is provided: Start new conversation processing
+ * - If no message: Stream from existing conversation
  */
 export const conversationsCreateBodyContentMax = 40000
 
@@ -54,8 +54,8 @@ export const ConversationsCreateBody = /* @__PURE__ */ zod
 
 /**
  * Appends a message to an existing conversation without triggering AI processing.
-This is used for client-side generated messages that need to be persisted
-(e.g., support ticket confirmation messages).
+ * This is used for client-side generated messages that need to be persisted
+ * (e.g., support ticket confirmation messages).
  */
 export const conversationsAppendMessageCreateBodyContentMax = 10000
 
@@ -177,9 +177,9 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Update the status of multiple tickets in a single request.
-
-Only tickets belonging to the current team are affected; other-team UUIDs
-are silently ignored.  Tickets already in the requested status are skipped.
+ *
+ * Only tickets belonging to the current team are affected; other-team UUIDs
+ * are silently ignored.  Tickets already in the requested status are skipped.
  */
 export const conversationsTicketsBulkUpdateStatusCreateBodyIdsMax = 500
 
@@ -200,22 +200,22 @@ export const ConversationsTicketsBulkUpdateStatusCreateBody = /* @__PURE__ */ zo
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const conversationsTicketsBulkUpdateTagsCreateBodyIdsMax = 500
 

--- a/products/core_events/frontend/generated/api.schemas.ts
+++ b/products/core_events/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `acquisition` - Acquisition
- * `activation` - Activation
- * `monetization` - Monetization
- * `expansion` - Expansion
- * `referral` - Referral
- * `retention` - Retention
- * `churn` - Churn
- * `reactivation` - Reactivation
+ * * `activation` - Activation
+ * * `monetization` - Monetization
+ * * `expansion` - Expansion
+ * * `referral` - Referral
+ * * `retention` - Retention
+ * * `churn` - Churn
+ * * `reactivation` - Reactivation
  */
 export type CoreEventCategoryEnumApi = (typeof CoreEventCategoryEnumApi)[keyof typeof CoreEventCategoryEnumApi]
 
@@ -40,15 +40,15 @@ export interface CoreEventApi {
     /** Optional description */
     description?: string
     /** Lifecycle category for this core event
-
-  * `acquisition` - Acquisition
-  * `activation` - Activation
-  * `monetization` - Monetization
-  * `expansion` - Expansion
-  * `referral` - Referral
-  * `retention` - Retention
-  * `churn` - Churn
-  * `reactivation` - Reactivation */
+     *
+     * * `acquisition` - Acquisition
+     * * `activation` - Activation
+     * * `monetization` - Monetization
+     * * `expansion` - Expansion
+     * * `referral` - Referral
+     * * `retention` - Retention
+     * * `churn` - Churn
+     * * `reactivation` - Reactivation */
     category: CoreEventCategoryEnumApi
     /** Filter configuration - event, action, or data warehouse node */
     filter: unknown
@@ -75,15 +75,15 @@ export interface PatchedCoreEventApi {
     /** Optional description */
     description?: string
     /** Lifecycle category for this core event
-
-  * `acquisition` - Acquisition
-  * `activation` - Activation
-  * `monetization` - Monetization
-  * `expansion` - Expansion
-  * `referral` - Referral
-  * `retention` - Retention
-  * `churn` - Churn
-  * `reactivation` - Reactivation */
+     *
+     * * `acquisition` - Acquisition
+     * * `activation` - Activation
+     * * `monetization` - Monetization
+     * * `expansion` - Expansion
+     * * `referral` - Referral
+     * * `retention` - Retention
+     * * `churn` - Churn
+     * * `reactivation` - Reactivation */
     category?: CoreEventCategoryEnumApi
     /** Filter configuration - event, action, or data warehouse node */
     filter?: unknown

--- a/products/core_events/frontend/generated/api.ts
+++ b/products/core_events/frontend/generated/api.ts
@@ -32,7 +32,7 @@ export const getCoreEventsListUrl = (projectId: string, params?: CoreEventsListP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -45,9 +45,9 @@ export const getCoreEventsListUrl = (projectId: string, params?: CoreEventsListP
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsList = async (
     projectId: string,
@@ -66,9 +66,9 @@ export const getCoreEventsCreateUrl = (projectId: string) => {
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsCreate = async (
     projectId: string,
@@ -89,9 +89,9 @@ export const getCoreEventsRetrieveUrl = (projectId: string, id: string) => {
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsRetrieve = async (
     projectId: string,
@@ -110,9 +110,9 @@ export const getCoreEventsUpdateUrl = (projectId: string, id: string) => {
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsUpdate = async (
     projectId: string,
@@ -134,9 +134,9 @@ export const getCoreEventsPartialUpdateUrl = (projectId: string, id: string) => 
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsPartialUpdate = async (
     projectId: string,
@@ -158,9 +158,9 @@ export const getCoreEventsDestroyUrl = (projectId: string, id: string) => {
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getCoreEventsDestroyUrl(projectId, id), {

--- a/products/core_events/frontend/generated/api.zod.ts
+++ b/products/core_events/frontend/generated/api.zod.ts
@@ -11,9 +11,9 @@ import * as zod from 'zod'
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsCreateBodyNameMax = 255
 
@@ -42,9 +42,9 @@ export const CoreEventsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsUpdateBodyNameMax = 255
 
@@ -73,9 +73,9 @@ export const CoreEventsUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * CRUD operations for Core Events.
-
-Core events are reusable event definitions that can be shared across
-Marketing analytics, Customer analytics, and Revenue analytics.
+ *
+ * Core events are reusable event definitions that can be shared across
+ * Marketing analytics, Customer analytics, and Revenue analytics.
  */
 export const coreEventsPartialUpdateBodyNameMax = 255
 

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -86,13 +86,13 @@ export interface PaginatedAccountListApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -277,11 +277,11 @@ export interface PatchedCustomerJourneyApi {
 
 /**
  * * `person` - Person
- * `group_0` - Group 0
- * `group_1` - Group 1
- * `group_2` - Group 2
- * `group_3` - Group 3
- * `group_4` - Group 4
+ * * `group_0` - Group 0
+ * * `group_1` - Group 1
+ * * `group_2` - Group 2
+ * * `group_3` - Group 3
+ * * `group_4` - Group 4
  */
 export type CustomerProfileConfigScopeEnumApi =
     (typeof CustomerProfileConfigScopeEnumApi)[keyof typeof CustomerProfileConfigScopeEnumApi]
@@ -326,7 +326,7 @@ export interface PatchedCustomerProfileConfigApi {
 
 /**
  * * `numeric` - numeric
- * `currency` - currency
+ * * `currency` - currency
  */
 export type GroupUsageMetricFormatEnumApi =
     (typeof GroupUsageMetricFormatEnumApi)[keyof typeof GroupUsageMetricFormatEnumApi]
@@ -338,7 +338,7 @@ export const GroupUsageMetricFormatEnumApi = {
 
 /**
  * * `number` - number
- * `sparkline` - sparkline
+ * * `sparkline` - sparkline
  */
 export type GroupUsageMetricDisplayEnumApi =
     (typeof GroupUsageMetricDisplayEnumApi)[keyof typeof GroupUsageMetricDisplayEnumApi]
@@ -350,7 +350,7 @@ export const GroupUsageMetricDisplayEnumApi = {
 
 /**
  * * `count` - count
- * `sum` - sum
+ * * `sum` - sum
  */
 export type MathEnumApi = (typeof MathEnumApi)[keyof typeof MathEnumApi]
 
@@ -361,10 +361,10 @@ export const MathEnumApi = {
 
 /**
  * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-**Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-**Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+ *
+ * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+ *
+ * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
  */
 export type GroupUsageMetricApiFilters = { [key: string]: unknown }
 
@@ -376,27 +376,27 @@ export interface GroupUsageMetricApi {
      */
     name: string
     /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-
-  * `numeric` - numeric
-  * `currency` - currency */
+     *
+     * * `numeric` - numeric
+     * * `currency` - currency */
     format?: GroupUsageMetricFormatEnumApi
     /** Rolling time window in days used to compute the metric. Defaults to 7. */
     interval?: number
     /** Visual representation in the UI. One of `number` or `sparkline`.
-
-  * `number` - number
-  * `sparkline` - sparkline */
+     *
+     * * `number` - number
+     * * `sparkline` - sparkline */
     display?: GroupUsageMetricDisplayEnumApi
     /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-  **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-  **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+     *
+     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+     *
+     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
     filters: GroupUsageMetricApiFilters
     /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-
-  * `count` - count
-  * `sum` - sum */
+     *
+     * * `count` - count
+     * * `sum` - sum */
     math?: MathEnumApi
     /**
      * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -417,10 +417,10 @@ export interface PaginatedGroupUsageMetricListApi {
 
 /**
  * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-**Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-**Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+ *
+ * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+ *
+ * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
  */
 export type PatchedGroupUsageMetricApiFilters = { [key: string]: unknown }
 
@@ -432,27 +432,27 @@ export interface PatchedGroupUsageMetricApi {
      */
     name?: string
     /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-
-  * `numeric` - numeric
-  * `currency` - currency */
+     *
+     * * `numeric` - numeric
+     * * `currency` - currency */
     format?: GroupUsageMetricFormatEnumApi
     /** Rolling time window in days used to compute the metric. Defaults to 7. */
     interval?: number
     /** Visual representation in the UI. One of `number` or `sparkline`.
-
-  * `number` - number
-  * `sparkline` - sparkline */
+     *
+     * * `number` - number
+     * * `sparkline` - sparkline */
     display?: GroupUsageMetricDisplayEnumApi
     /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-  **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-  **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+     *
+     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+     *
+     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
     filters?: PatchedGroupUsageMetricApiFilters
     /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-
-  * `count` - count
-  * `sum` - sum */
+     *
+     * * `count` - count
+     * * `sum` - sum */
     math?: MathEnumApi
     /**
      * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -52,7 +52,7 @@ export const getAccountsListUrl = (projectId: string, params?: AccountsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -100,7 +100,7 @@ export const getAccountsNotebooksListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -236,7 +236,7 @@ export const getCustomerJourneysListUrl = (projectId: string, params?: CustomerJ
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -342,7 +342,7 @@ export const getCustomerProfileConfigsListUrl = (projectId: string, params?: Cus
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -456,7 +456,7 @@ export const getGroupsTypesMetricsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -64,8 +64,8 @@ export interface UserBasicApi {
 
 /**
  * * `team` - Only team
- * `global` - Global
- * `feature_flag` - Feature Flag
+ * * `global` - Global
+ * * `feature_flag` - Feature Flag
  */
 export type DashboardTemplateScopeEnumApi =
     (typeof DashboardTemplateScopeEnumApi)[keyof typeof DashboardTemplateScopeEnumApi]
@@ -89,7 +89,10 @@ export interface DashboardTemplateApi {
      */
     dashboard_description?: string | null
     dashboard_filters?: unknown
-    /** @nullable */
+    /**
+     * @nullable
+     * @items.maxLength 255
+     */
     tags?: string[] | null
     tiles?: unknown
     variables?: unknown
@@ -106,7 +109,10 @@ export interface DashboardTemplateApi {
     /** @nullable */
     readonly team_id: number | null
     scope?: DashboardTemplateScopeEnumApi | BlankEnumApi | null
-    /** @nullable */
+    /**
+     * @nullable
+     * @items.maxLength 255
+     */
     availability_contexts?: string[] | null
     /** Manually curated; used to highlight templates in the UI. */
     is_featured?: boolean
@@ -134,7 +140,10 @@ export interface PatchedDashboardTemplateApi {
      */
     dashboard_description?: string | null
     dashboard_filters?: unknown
-    /** @nullable */
+    /**
+     * @nullable
+     * @items.maxLength 255
+     */
     tags?: string[] | null
     tiles?: unknown
     variables?: unknown
@@ -151,7 +160,10 @@ export interface PatchedDashboardTemplateApi {
     /** @nullable */
     readonly team_id?: number | null
     scope?: DashboardTemplateScopeEnumApi | BlankEnumApi | null
-    /** @nullable */
+    /**
+     * @nullable
+     * @items.maxLength 255
+     */
     availability_contexts?: string[] | null
     /** Manually curated; used to highlight templates in the UI. */
     is_featured?: boolean
@@ -164,9 +176,9 @@ export interface CopyDashboardTemplateApi {
 
 /**
  * * `default` - Default
- * `template` - Template
- * `duplicate` - Duplicate
- * `unlisted` - Unlisted (product-embedded)
+ * * `template` - Template
+ * * `duplicate` - Duplicate
+ * * `unlisted` - Unlisted (product-embedded)
  */
 export type CreationModeEnumApi = (typeof CreationModeEnumApi)[keyof typeof CreationModeEnumApi]
 
@@ -179,7 +191,7 @@ export const CreationModeEnumApi = {
 
 /**
  * * `21` - Everyone in the project can edit
- * `37` - Only those invited to this dashboard can edit
+ * * `37` - Only those invited to this dashboard can edit
  */
 export type RestrictionLevelEnumApi = (typeof RestrictionLevelEnumApi)[keyof typeof RestrictionLevelEnumApi]
 
@@ -221,9 +233,9 @@ export interface DashboardBasicApi {
     readonly creation_mode: CreationModeEnumApi
     tags?: unknown[]
     /** Controls who can edit the dashboard.
-
-  * `21` - Everyone in the project can edit
-  * `37` - Only those invited to this dashboard can edit */
+     *
+     * * `21` - Everyone in the project can edit
+     * * `37` - Only those invited to this dashboard can edit */
     readonly restriction_level: RestrictionLevelEnumApi
     readonly effective_restriction_level: EffectivePrivilegeLevelEnumApi
     readonly effective_privilege_level: EffectivePrivilegeLevelEnumApi
@@ -549,7 +561,7 @@ export interface CustomEventConversionGoalApi {
 
 export interface DateRangeApi {
     /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-  -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
+     * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
     date_from?: string | null
     /** End of the date range. Same format as date_from. Omit or null for "now". */
     date_to?: string | null
@@ -1830,14 +1842,14 @@ export type TrendsFilterApiResultCustomizations =
 
 export interface TrendsFilterApi {
     /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-
-  - `numeric` (default): raw numbers, e.g. `1,234`.
-  - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-  - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-  - `percentage`: values are already in the 0-100 range; appends `%`.
-  - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-  - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-  - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
+     *
+     * - `numeric` (default): raw numbers, e.g. `1,234`.
+     * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+     * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+     * - `percentage`: values are already in the 0-100 range; appends `%`.
+     * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+     * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+     * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
     aggregationAxisFormat?: AggregationAxisFormatApi | null
     /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
     aggregationAxisPostfix?: string | null
@@ -7383,10 +7395,10 @@ export interface HogQueryApi {
 
 /**
  * The query definition for this insight. The `kind` field determines the query type:
-- `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
-- `DataVisualizationNode` — SQL insights using HogQL
-- `DataTableNode` — raw data tables
-- `HogQuery` — Hog language queries
+ * - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+ * - `DataVisualizationNode` — SQL insights using HogQL
+ * - `DataTableNode` — raw data tables
+ * - `HogQuery` — Hog language queries
  */
 export type _InsightQuerySchemaApi = InsightVizNodeApi | DataTableNodeApi | DataVisualizationNodeApi | HogQueryApi
 
@@ -7437,21 +7449,21 @@ export interface InsightApi {
     order?: number | null
     deleted?: boolean
     /**
-          DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-          A dashboard ID for each of the dashboards that this insight is displayed on.
-           */
+     *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+     *         A dashboard ID for each of the dashboards that this insight is displayed on.
+     *          */
     dashboards?: number[]
     /**
-      A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-       */
+     *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+     *      */
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
     /**
      *
-      The datetime this insight's results were generated.
-      If added to one or more dashboards the insight can be refreshed separately on each.
-      Returns the appropriate last_refresh datetime for the context the insight is viewed in
-      (see from_dashboard query parameter).
-
+     *     The datetime this insight's results were generated.
+     *     If added to one or more dashboards the insight can be refreshed separately on each.
+     *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+     *     (see from_dashboard query parameter).
+     *
      * @nullable
      */
     readonly last_refresh: string | null
@@ -7462,9 +7474,9 @@ export interface InsightApi {
     readonly cache_target_age: string | null
     /**
      *
-      The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-      by querying the database.
-
+     *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+     *     by querying the database.
+     *
      * @nullable
      */
     readonly next_allowed_client_refresh: string | null
@@ -7531,7 +7543,7 @@ export interface TextApi {
 
 /**
  * * `left` - left
- * `right` - right
+ * * `right` - right
  */
 export type PlacementEnumApi = (typeof PlacementEnumApi)[keyof typeof PlacementEnumApi]
 
@@ -7542,7 +7554,7 @@ export const PlacementEnumApi = {
 
 /**
  * * `primary` - Primary
- * `secondary` - Secondary
+ * * `secondary` - Secondary
  */
 export type StyleEnumApi = (typeof StyleEnumApi)[keyof typeof StyleEnumApi]
 
@@ -7568,10 +7580,10 @@ export interface ButtonTileApi {
 
 /**
  * * `last_seen` - last_seen
- * `first_seen` - first_seen
- * `occurrences` - occurrences
- * `users` - users
- * `sessions` - sessions
+ * * `first_seen` - first_seen
+ * * `occurrences` - occurrences
+ * * `users` - users
+ * * `sessions` - sessions
  */
 export type ErrorTrackingIssueOrderByEnumApi =
     (typeof ErrorTrackingIssueOrderByEnumApi)[keyof typeof ErrorTrackingIssueOrderByEnumApi]
@@ -7586,7 +7598,7 @@ export const ErrorTrackingIssueOrderByEnumApi = {
 
 /**
  * * `ASC` - ASC
- * `DESC` - DESC
+ * * `DESC` - DESC
  */
 export type OrderDirectionEnumApi = (typeof OrderDirectionEnumApi)[keyof typeof OrderDirectionEnumApi]
 
@@ -7597,11 +7609,11 @@ export const OrderDirectionEnumApi = {
 
 /**
  * * `archived` - archived
- * `active` - active
- * `resolved` - resolved
- * `pending_release` - pending_release
- * `suppressed` - suppressed
- * `all` - all
+ * * `active` - active
+ * * `resolved` - resolved
+ * * `pending_release` - pending_release
+ * * `suppressed` - suppressed
+ * * `all` - all
  */
 export type ErrorTrackingIssueStatusEnumApi =
     (typeof ErrorTrackingIssueStatusEnumApi)[keyof typeof ErrorTrackingIssueStatusEnumApi]
@@ -7617,7 +7629,7 @@ export const ErrorTrackingIssueStatusEnumApi = {
 
 /**
  * * `user` - user
- * `role` - role
+ * * `role` - role
  */
 export type AssigneeTypeEnumApi = (typeof AssigneeTypeEnumApi)[keyof typeof AssigneeTypeEnumApi]
 
@@ -7630,9 +7642,9 @@ export interface ErrorTrackingAssigneeApi {
     /** User ID or role UUID to filter by. */
     id: string | number | null
     /** Assignee target type: user or role.
-
-  * `user` - user
-  * `role` - role */
+     *
+     * * `user` - user
+     * * `role` - role */
     type: AssigneeTypeEnumApi
 }
 
@@ -7651,12 +7663,12 @@ export interface WidgetFilterConfigEntryApi {
 
 /**
  * * `-14d` - -14d
- * `-1h` - -1h
- * `-24h` - -24h
- * `-30d` - -30d
- * `-3h` - -3h
- * `-7d` - -7d
- * `-90d` - -90d
+ * * `-1h` - -1h
+ * * `-24h` - -24h
+ * * `-30d` - -30d
+ * * `-3h` - -3h
+ * * `-7d` - -7d
+ * * `-90d` - -90d
  */
 export type DateFromEnumApi = (typeof DateFromEnumApi)[keyof typeof DateFromEnumApi]
 
@@ -7672,14 +7684,14 @@ export const DateFromEnumApi = {
 
 export interface WidgetDateRangeApi {
     /** Relative lookback window (for example '-7d'). Omit to use the project default range.
-
-  * `-14d` - -14d
-  * `-1h` - -1h
-  * `-24h` - -24h
-  * `-30d` - -30d
-  * `-3h` - -3h
-  * `-7d` - -7d
-  * `-90d` - -90d */
+     *
+     * * `-14d` - -14d
+     * * `-1h` - -1h
+     * * `-24h` - -24h
+     * * `-30d` - -30d
+     * * `-3h` - -3h
+     * * `-7d` - -7d
+     * * `-90d` - -90d */
     date_from?: DateFromEnumApi | null
 }
 
@@ -7696,26 +7708,26 @@ export interface ErrorTrackingListWidgetConfigApi {
      */
     limit?: number
     /** Issue ranking column.
-
-  * `first_seen` - first_seen
-  * `last_seen` - last_seen
-  * `occurrences` - occurrences
-  * `sessions` - sessions
-  * `users` - users */
+     *
+     * * `first_seen` - first_seen
+     * * `last_seen` - last_seen
+     * * `occurrences` - occurrences
+     * * `sessions` - sessions
+     * * `users` - users */
     orderBy?: ErrorTrackingIssueOrderByEnumApi
     /** Sort direction for orderBy.
-
-  * `ASC` - ASC
-  * `DESC` - DESC */
+     *
+     * * `ASC` - ASC
+     * * `DESC` - DESC */
     orderDirection?: OrderDirectionEnumApi
     /** Issue status filter.
-
-  * `archived` - archived
-  * `active` - active
-  * `resolved` - resolved
-  * `pending_release` - pending_release
-  * `suppressed` - suppressed
-  * `all` - all */
+     *
+     * * `archived` - archived
+     * * `active` - active
+     * * `resolved` - resolved
+     * * `pending_release` - pending_release
+     * * `suppressed` - suppressed
+     * * `all` - all */
     status?: ErrorTrackingIssueStatusEnumApi
     /** Filter by assignee ({type: user|role, id}). Omit for any assignee. */
     assignee?: ErrorTrackingAssigneeApi | null
@@ -7729,11 +7741,11 @@ export interface ErrorTrackingListWidgetConfigApi {
 
 /**
  * * `activity_score` - activity_score
- * `click_count` - click_count
- * `console_error_count` - console_error_count
- * `duration` - duration
- * `recording_duration` - recording_duration
- * `start_time` - start_time
+ * * `click_count` - click_count
+ * * `console_error_count` - console_error_count
+ * * `duration` - duration
+ * * `recording_duration` - recording_duration
+ * * `start_time` - start_time
  */
 export type SessionReplayListWidgetConfigOrderByEnumApi =
     (typeof SessionReplayListWidgetConfigOrderByEnumApi)[keyof typeof SessionReplayListWidgetConfigOrderByEnumApi]
@@ -7760,18 +7772,18 @@ export interface SessionReplayListWidgetConfigApi {
      */
     limit?: number
     /** Recording ranking column.
-
-  * `activity_score` - activity_score
-  * `click_count` - click_count
-  * `console_error_count` - console_error_count
-  * `duration` - duration
-  * `recording_duration` - recording_duration
-  * `start_time` - start_time */
+     *
+     * * `activity_score` - activity_score
+     * * `click_count` - click_count
+     * * `console_error_count` - console_error_count
+     * * `duration` - duration
+     * * `recording_duration` - recording_duration
+     * * `start_time` - start_time */
     orderBy?: SessionReplayListWidgetConfigOrderByEnumApi
     /** Sort direction for orderBy.
-
-  * `ASC` - ASC
-  * `DESC` - DESC */
+     *
+     * * `ASC` - ASC
+     * * `DESC` - DESC */
     orderDirection?: OrderDirectionEnumApi
     /** Optional relative date range override. */
     dateRange?: WidgetDateRangeApi | null
@@ -7852,8 +7864,8 @@ export interface PatchedMoveTileRequestApi {
 
 /**
  * * `preserve` - preserve
- * `two_column` - two_column
- * `full_width` - full_width
+ * * `two_column` - two_column
+ * * `full_width` - full_width
  */
 export type LayoutEnumApi = (typeof LayoutEnumApi)[keyof typeof LayoutEnumApi]
 
@@ -7870,10 +7882,10 @@ export interface ReorderTilesRequestApi {
      */
     tile_order: number[]
     /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
-
-  * `preserve` - preserve
-  * `two_column` - two_column
-  * `full_width` - full_width */
+     *
+     * * `preserve` - preserve
+     * * `two_column` - two_column
+     * * `full_width` - full_width */
     layout?: LayoutEnumApi
 }
 
@@ -8035,8 +8047,8 @@ export interface AddDashboardWidgetsBatchResponseApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -8053,10 +8065,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -82,7 +82,7 @@ export const getDashboardTemplatesListUrl = (projectId: string, params?: Dashboa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -227,7 +227,7 @@ export const getDashboardsListUrl = (projectId: string, params?: DashboardsListP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -254,7 +254,7 @@ export const getDashboardsCreateUrl = (projectId: string, params?: DashboardsCre
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -333,7 +333,7 @@ export const getDashboardsRetrieveUrl = (projectId: string, id: number, params?:
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -361,7 +361,7 @@ export const getDashboardsUpdateUrl = (projectId: string, id: number, params?: D
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -396,7 +396,7 @@ export const getDashboardsPartialUpdateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -427,7 +427,7 @@ export const getDashboardsDestroyUrl = (projectId: string, id: number, params?: 
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -462,7 +462,7 @@ export const getDashboardsCopyTileCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -500,7 +500,7 @@ export const getDashboardsCreateTextTileCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -513,9 +513,9 @@ export const getDashboardsCreateTextTileCreateUrl = (
 
 /**
  * Add a markdown text tile to a dashboard.
-
-Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
-or annotations between insight tiles to give the dashboard structure.
+ *
+ * Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+ * or annotations between insight tiles to give the dashboard structure.
  */
 export const dashboardsCreateTextTileCreate = async (
     projectId: string,
@@ -537,7 +537,7 @@ export const getDashboardsDeleteTileUrl = (projectId: string, id: number, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -550,10 +550,10 @@ export const getDashboardsDeleteTileUrl = (projectId: string, id: number, params
 
 /**
  * Soft-delete a single tile from a dashboard.
-
-Works for text, insight, and button tiles. The underlying Insight, Text, or ButtonTile
-object is preserved — only the dashboard tile is hidden. To delete the entire dashboard,
-use the dashboard delete endpoint instead.
+ *
+ * Works for text, insight, and button tiles. The underlying Insight, Text, or ButtonTile
+ * object is preserved — only the dashboard tile is hidden. To delete the entire dashboard,
+ * use the dashboard delete endpoint instead.
  */
 export const dashboardsDeleteTile = async (
     projectId: string,
@@ -579,7 +579,7 @@ export const getDashboardsMoveTileCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -614,7 +614,7 @@ export const getDashboardsMoveTilePartialUpdateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -649,7 +649,7 @@ export const getDashboardsReorderTilesCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -684,7 +684,7 @@ export const getDashboardsRunInsightsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -719,7 +719,7 @@ export const getDashboardsRunWidgetsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -751,7 +751,7 @@ export const getDashboardsStreamTilesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -786,7 +786,7 @@ export const getDashboardsUpdateTextTileCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -824,7 +824,7 @@ export const getDashboardsWidgetsBatchCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -861,7 +861,7 @@ export const getDashboardsBulkUpdateTagsCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -874,22 +874,22 @@ export const getDashboardsBulkUpdateTagsCreateUrl = (
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const dashboardsBulkUpdateTagsCreate = async (
     projectId: string,
@@ -913,7 +913,7 @@ export const getDashboardsCreateFromTemplateJsonCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -946,7 +946,7 @@ export const getDashboardsCreateUnlistedDashboardCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -959,8 +959,8 @@ export const getDashboardsCreateUnlistedDashboardCreateUrl = (
 
 /**
  * Creates an unlisted dashboard from template by tag.
-Enforces uniqueness (one per tag per team).
-Returns 409 if unlisted dashboard with this tag already exists.
+ * Enforces uniqueness (one per tag per team).
+ * Returns 409 if unlisted dashboard with this tag already exists.
  */
 export const dashboardsCreateUnlistedDashboardCreate = async (
     projectId: string,
@@ -984,7 +984,7 @@ export const getDashboardsWidgetCatalogRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1014,7 +1014,7 @@ export const getDataColorThemesListUrl = (projectId: string, params?: DataColorT
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -256,9 +256,9 @@ export const DashboardsCopyTileCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Add a markdown text tile to a dashboard.
-
-Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
-or annotations between insight tiles to give the dashboard structure.
+ *
+ * Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+ * or annotations between insight tiles to give the dashboard structure.
  */
 export const dashboardsCreateTextTileCreateBodyBodyMax = 4000
 
@@ -306,10 +306,10 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Soft-delete a single tile from a dashboard.
-
-Works for text, insight, and button tiles. The underlying Insight, Text, or ButtonTile
-object is preserved — only the dashboard tile is hidden. To delete the entire dashboard,
-use the dashboard delete endpoint instead.
+ *
+ * Works for text, insight, and button tiles. The underlying Insight, Text, or ButtonTile
+ * object is preserved — only the dashboard tile is hidden. To delete the entire dashboard,
+ * use the dashboard delete endpoint instead.
  */
 export const DashboardsDeleteTileBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.'),
@@ -741,22 +741,22 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const dashboardsBulkUpdateTagsCreateBodyIdsMax = 500
 
@@ -814,8 +814,8 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
 
 /**
  * Creates an unlisted dashboard from template by tag.
-Enforces uniqueness (one per tag per team).
-Returns 409 if unlisted dashboard with this tag already exists.
+ * Enforces uniqueness (one per tag per team).
+ * Returns 409 if unlisted dashboard with this tag already exists.
  */
 export const dashboardsCreateUnlistedDashboardCreateBodyNameMax = 400
 

--- a/products/data_modeling/frontend/generated/api.schemas.ts
+++ b/products/data_modeling/frontend/generated/api.schemas.ts
@@ -91,9 +91,9 @@ export interface PatchedEdgeApi {
 
 /**
  * * `table` - Table
- * `view` - View
- * `matview` - Mat View
- * `endpoint` - Endpoint
+ * * `view` - View
+ * * `matview` - Mat View
+ * * `endpoint` - Endpoint
  */
 export type NodeTypeEnumApi = (typeof NodeTypeEnumApi)[keyof typeof NodeTypeEnumApi]
 

--- a/products/data_modeling/frontend/generated/api.ts
+++ b/products/data_modeling/frontend/generated/api.ts
@@ -45,7 +45,7 @@ export const getDataModelingDagsListUrl = (projectId: string, params?: DataModel
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -133,7 +133,7 @@ export const getDataModelingEdgesListUrl = (projectId: string, params?: DataMode
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -239,7 +239,7 @@ export const getDataModelingNodesListUrl = (projectId: string, params?: DataMode
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -385,11 +385,11 @@ export const getDataModelingNodesRunCreateUrl = (projectId: string, id: string) 
 
 /**
  * Run this node and its upstream or downstream dependencies.
-
-Request body:
-    direction: "upstream" | "downstream" (required)
-        - "upstream": Run all ancestors of this node, plus this node
-        - "downstream": Run this node and all its descendants
+ *
+ * Request body:
+ *     direction: "upstream" | "downstream" (required)
+ *         - "upstream": Run all ancestors of this node, plus this node
+ *         - "downstream": Run this node and all its descendants
  */
 export const dataModelingNodesRunCreate = async (
     projectId: string,

--- a/products/data_modeling/frontend/generated/api.zod.ts
+++ b/products/data_modeling/frontend/generated/api.zod.ts
@@ -105,11 +105,11 @@ export const DataModelingNodesMaterializeCreateBody = /* @__PURE__ */ zod.object
 
 /**
  * Run this node and its upstream or downstream dependencies.
-
-Request body:
-    direction: "upstream" | "downstream" (required)
-        - "upstream": Run all ancestors of this node, plus this node
-        - "downstream": Run this node and all its descendants
+ *
+ * Request body:
+ *     direction: "upstream" | "downstream" (required)
+ *         - "upstream": Run all ancestors of this node, plus this node
+ *         - "downstream": Run this node and all its descendants
  */
 export const dataModelingNodesRunCreateBodyNameMax = 2048
 

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -9,9 +9,9 @@
  */
 /**
  * * `Cancelled` - Cancelled
- * `Completed` - Completed
- * `Failed` - Failed
- * `Running` - Running
+ * * `Completed` - Completed
+ * * `Failed` - Failed
+ * * `Running` - Running
  */
 export type DataModelingJobStatusEnumApi =
     (typeof DataModelingJobStatusEnumApi)[keyof typeof DataModelingJobStatusEnumApi]
@@ -79,11 +79,11 @@ export interface ResetPasswordResponseApi {
 
 /**
  * * `pending` - pending
- * `provisioning` - provisioning
- * `ready` - ready
- * `failed` - failed
- * `deleting` - deleting
- * `deleted` - deleted
+ * * `provisioning` - provisioning
+ * * `ready` - ready
+ * * `failed` - failed
+ * * `deleting` - deleting
+ * * `deleted` - deleted
  */
 export type WarehouseStatusResponseStateEnumApi =
     (typeof WarehouseStatusResponseStateEnumApi)[keyof typeof WarehouseStatusResponseStateEnumApi]
@@ -109,10 +109,10 @@ export interface WarehouseStatusResponseApi {
 
 /**
  * * `full_refresh` - full_refresh
- * `incremental` - incremental
- * `append` - append
- * `webhook` - webhook
- * `cdc` - cdc
+ * * `incremental` - incremental
+ * * `append` - append
+ * * `webhook` - webhook
+ * * `cdc` - cdc
  */
 export type SyncTypeEnumApi = (typeof SyncTypeEnumApi)[keyof typeof SyncTypeEnumApi]
 
@@ -126,11 +126,11 @@ export const SyncTypeEnumApi = {
 
 /**
  * * `integer` - integer
- * `numeric` - numeric
- * `datetime` - datetime
- * `date` - date
- * `timestamp` - timestamp
- * `objectid` - objectid
+ * * `numeric` - numeric
+ * * `datetime` - datetime
+ * * `date` - date
+ * * `timestamp` - timestamp
+ * * `objectid` - objectid
  */
 export type IncrementalFieldTypeEnumApi = (typeof IncrementalFieldTypeEnumApi)[keyof typeof IncrementalFieldTypeEnumApi]
 
@@ -145,16 +145,16 @@ export const IncrementalFieldTypeEnumApi = {
 
 /**
  * * `never` - never
- * `1min` - 1min
- * `5min` - 5min
- * `15min` - 15min
- * `30min` - 30min
- * `1hour` - 1hour
- * `6hour` - 6hour
- * `12hour` - 12hour
- * `24hour` - 24hour
- * `7day` - 7day
- * `30day` - 30day
+ * * `1min` - 1min
+ * * `5min` - 5min
+ * * `15min` - 15min
+ * * `30min` - 30min
+ * * `1hour` - 1hour
+ * * `6hour` - 6hour
+ * * `12hour` - 12hour
+ * * `24hour` - 24hour
+ * * `7day` - 7day
+ * * `30day` - 30day
  */
 export type SyncFrequencyEnumApi = (typeof SyncFrequencyEnumApi)[keyof typeof SyncFrequencyEnumApi]
 
@@ -174,8 +174,8 @@ export const SyncFrequencyEnumApi = {
 
 /**
  * * `consolidated` - consolidated
- * `cdc_only` - cdc_only
- * `both` - both
+ * * `cdc_only` - cdc_only
+ * * `both` - both
  */
 export type CdcTableModeEnumApi = (typeof CdcTableModeEnumApi)[keyof typeof CdcTableModeEnumApi]
 
@@ -227,12 +227,12 @@ export interface ExternalDataSchemaApi {
     /** @nullable */
     readonly status: string | null
     /** Sync strategy: incremental, full_refresh, append, or cdc.
-
-  * `full_refresh` - full_refresh
-  * `incremental` - incremental
-  * `append` - append
-  * `webhook` - webhook
-  * `cdc` - cdc */
+     *
+     * * `full_refresh` - full_refresh
+     * * `incremental` - incremental
+     * * `append` - append
+     * * `webhook` - webhook
+     * * `cdc` - cdc */
     sync_type?: SyncTypeEnumApi | null
     /**
      * Column name used to track sync progress.
@@ -240,27 +240,27 @@ export interface ExternalDataSchemaApi {
      */
     incremental_field?: string | null
     /** Data type of the incremental field.
-
-  * `integer` - integer
-  * `numeric` - numeric
-  * `datetime` - datetime
-  * `date` - date
-  * `timestamp` - timestamp
-  * `objectid` - objectid */
+     *
+     * * `integer` - integer
+     * * `numeric` - numeric
+     * * `datetime` - datetime
+     * * `date` - date
+     * * `timestamp` - timestamp
+     * * `objectid` - objectid */
     incremental_field_type?: IncrementalFieldTypeEnumApi | null
     /** How often to sync.
-
-  * `never` - never
-  * `1min` - 1min
-  * `5min` - 5min
-  * `15min` - 15min
-  * `30min` - 30min
-  * `1hour` - 1hour
-  * `6hour` - 6hour
-  * `12hour` - 12hour
-  * `24hour` - 24hour
-  * `7day` - 7day
-  * `30day` - 30day */
+     *
+     * * `never` - never
+     * * `1min` - 1min
+     * * `5min` - 5min
+     * * `15min` - 15min
+     * * `30min` - 30min
+     * * `1hour` - 1hour
+     * * `6hour` - 6hour
+     * * `12hour` - 12hour
+     * * `24hour` - 24hour
+     * * `7day` - 7day
+     * * `30day` - 30day */
     sync_frequency?: SyncFrequencyEnumApi | null
     /**
      * UTC time of day to run the sync (HH:MM:SS).
@@ -275,10 +275,10 @@ export interface ExternalDataSchemaApi {
      */
     primary_key_columns?: string[] | null
     /** For CDC syncs: consolidated, cdc_only, or both.
-
-  * `consolidated` - consolidated
-  * `cdc_only` - cdc_only
-  * `both` - both */
+     *
+     * * `consolidated` - consolidated
+     * * `cdc_only` - cdc_only
+     * * `both` - both */
     cdc_table_mode?: CdcTableModeEnumApi | null
     /**
      * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -345,12 +345,12 @@ export interface PatchedExternalDataSchemaApi {
     /** @nullable */
     readonly status?: string | null
     /** Sync strategy: incremental, full_refresh, append, or cdc.
-
-  * `full_refresh` - full_refresh
-  * `incremental` - incremental
-  * `append` - append
-  * `webhook` - webhook
-  * `cdc` - cdc */
+     *
+     * * `full_refresh` - full_refresh
+     * * `incremental` - incremental
+     * * `append` - append
+     * * `webhook` - webhook
+     * * `cdc` - cdc */
     sync_type?: SyncTypeEnumApi | null
     /**
      * Column name used to track sync progress.
@@ -358,27 +358,27 @@ export interface PatchedExternalDataSchemaApi {
      */
     incremental_field?: string | null
     /** Data type of the incremental field.
-
-  * `integer` - integer
-  * `numeric` - numeric
-  * `datetime` - datetime
-  * `date` - date
-  * `timestamp` - timestamp
-  * `objectid` - objectid */
+     *
+     * * `integer` - integer
+     * * `numeric` - numeric
+     * * `datetime` - datetime
+     * * `date` - date
+     * * `timestamp` - timestamp
+     * * `objectid` - objectid */
     incremental_field_type?: IncrementalFieldTypeEnumApi | null
     /** How often to sync.
-
-  * `never` - never
-  * `1min` - 1min
-  * `5min` - 5min
-  * `15min` - 15min
-  * `30min` - 30min
-  * `1hour` - 1hour
-  * `6hour` - 6hour
-  * `12hour` - 12hour
-  * `24hour` - 24hour
-  * `7day` - 7day
-  * `30day` - 30day */
+     *
+     * * `never` - never
+     * * `1min` - 1min
+     * * `5min` - 5min
+     * * `15min` - 15min
+     * * `30min` - 30min
+     * * `1hour` - 1hour
+     * * `6hour` - 6hour
+     * * `12hour` - 12hour
+     * * `24hour` - 24hour
+     * * `7day` - 7day
+     * * `30day` - 30day */
     sync_frequency?: SyncFrequencyEnumApi | null
     /**
      * UTC time of day to run the sync (HH:MM:SS).
@@ -393,10 +393,10 @@ export interface PatchedExternalDataSchemaApi {
      */
     primary_key_columns?: string[] | null
     /** For CDC syncs: consolidated, cdc_only, or both.
-
-  * `consolidated` - consolidated
-  * `cdc_only` - cdc_only
-  * `both` - both */
+     *
+     * * `consolidated` - consolidated
+     * * `cdc_only` - cdc_only
+     * * `both` - both */
     cdc_table_mode?: CdcTableModeEnumApi | null
     /**
      * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -414,8 +414,8 @@ export interface PatchedExternalDataSchemaApi {
 
 /**
  * * `web` - web
- * `api` - api
- * `mcp` - mcp
+ * * `api` - api
+ * * `mcp` - mcp
  */
 export type CreatedViaEnumApi = (typeof CreatedViaEnumApi)[keyof typeof CreatedViaEnumApi]
 
@@ -427,153 +427,153 @@ export const CreatedViaEnumApi = {
 
 /**
  * * `Ashby` - Ashby
- * `Supabase` - Supabase
- * `CustomerIO` - CustomerIO
- * `Github` - Github
- * `Stripe` - Stripe
- * `Hubspot` - Hubspot
- * `Postgres` - Postgres
- * `Zendesk` - Zendesk
- * `Snowflake` - Snowflake
- * `Salesforce` - Salesforce
- * `MySQL` - MySQL
- * `MongoDB` - MongoDB
- * `MSSQL` - MSSQL
- * `Vitally` - Vitally
- * `BigQuery` - BigQuery
- * `Chargebee` - Chargebee
- * `Clerk` - Clerk
- * `GoogleAds` - GoogleAds
- * `GoogleSearchConsole` - GoogleSearchConsole
- * `TemporalIO` - TemporalIO
- * `DoIt` - DoIt
- * `GoogleSheets` - GoogleSheets
- * `MetaAds` - MetaAds
- * `Klaviyo` - Klaviyo
- * `Mailchimp` - Mailchimp
- * `Braze` - Braze
- * `Mailjet` - Mailjet
- * `Redshift` - Redshift
- * `Polar` - Polar
- * `RevenueCat` - RevenueCat
- * `LinkedinAds` - LinkedinAds
- * `RedditAds` - RedditAds
- * `TikTokAds` - TikTokAds
- * `BingAds` - BingAds
- * `Shopify` - Shopify
- * `Attio` - Attio
- * `SnapchatAds` - SnapchatAds
- * `Linear` - Linear
- * `Intercom` - Intercom
- * `Amplitude` - Amplitude
- * `Mixpanel` - Mixpanel
- * `Jira` - Jira
- * `ActiveCampaign` - ActiveCampaign
- * `Marketo` - Marketo
- * `Adjust` - Adjust
- * `AppsFlyer` - AppsFlyer
- * `Freshdesk` - Freshdesk
- * `GoogleAnalytics` - GoogleAnalytics
- * `Pipedrive` - Pipedrive
- * `SendGrid` - SendGrid
- * `Slack` - Slack
- * `PagerDuty` - PagerDuty
- * `Asana` - Asana
- * `Notion` - Notion
- * `Airtable` - Airtable
- * `Greenhouse` - Greenhouse
- * `BambooHR` - BambooHR
- * `Lever` - Lever
- * `GitLab` - GitLab
- * `Datadog` - Datadog
- * `Sentry` - Sentry
- * `Pendo` - Pendo
- * `FullStory` - FullStory
- * `AmazonAds` - AmazonAds
- * `PinterestAds` - PinterestAds
- * `AppleSearchAds` - AppleSearchAds
- * `QuickBooks` - QuickBooks
- * `Xero` - Xero
- * `NetSuite` - NetSuite
- * `WooCommerce` - WooCommerce
- * `BigCommerce` - BigCommerce
- * `PayPal` - PayPal
- * `Square` - Square
- * `Zoom` - Zoom
- * `Trello` - Trello
- * `Monday` - Monday
- * `ClickUp` - ClickUp
- * `Confluence` - Confluence
- * `Recurly` - Recurly
- * `SalesLoft` - SalesLoft
- * `Outreach` - Outreach
- * `Gong` - Gong
- * `Calendly` - Calendly
- * `Typeform` - Typeform
- * `Iterable` - Iterable
- * `ZohoCRM` - ZohoCRM
- * `Close` - Close
- * `Oracle` - Oracle
- * `DynamoDB` - DynamoDB
- * `Elasticsearch` - Elasticsearch
- * `Kafka` - Kafka
- * `LaunchDarkly` - LaunchDarkly
- * `Braintree` - Braintree
- * `Recharge` - Recharge
- * `HelpScout` - HelpScout
- * `Gorgias` - Gorgias
- * `Instagram` - Instagram
- * `YouTubeAnalytics` - YouTubeAnalytics
- * `FacebookPages` - FacebookPages
- * `TwitterAds` - TwitterAds
- * `Workday` - Workday
- * `ServiceNow` - ServiceNow
- * `Pardot` - Pardot
- * `Copper` - Copper
- * `Front` - Front
- * `ChartMogul` - ChartMogul
- * `Zuora` - Zuora
- * `Paddle` - Paddle
- * `CircleCI` - CircleCI
- * `CockroachDB` - CockroachDB
- * `Firebase` - Firebase
- * `AzureBlob` - AzureBlob
- * `GoogleDrive` - GoogleDrive
- * `OneDrive` - OneDrive
- * `SharePoint` - SharePoint
- * `Box` - Box
- * `SFTP` - SFTP
- * `MicrosoftTeams` - MicrosoftTeams
- * `Aircall` - Aircall
- * `Webflow` - Webflow
- * `Okta` - Okta
- * `Auth0` - Auth0
- * `Productboard` - Productboard
- * `Smartsheet` - Smartsheet
- * `Wrike` - Wrike
- * `Plaid` - Plaid
- * `SurveyMonkey` - SurveyMonkey
- * `Eventbrite` - Eventbrite
- * `RingCentral` - RingCentral
- * `Twilio` - Twilio
- * `Freshsales` - Freshsales
- * `Shortcut` - Shortcut
- * `ConvertKit` - ConvertKit
- * `Drip` - Drip
- * `CampaignMonitor` - CampaignMonitor
- * `MailerLite` - MailerLite
- * `Omnisend` - Omnisend
- * `Brevo` - Brevo
- * `Postmark` - Postmark
- * `Granola` - Granola
- * `BuildBetter` - BuildBetter
- * `Convex` - Convex
- * `ClickHouse` - ClickHouse
- * `Plain` - Plain
- * `Resend` - Resend
- * `PgAnalyze` - PgAnalyze
- * `WorkOS` - WorkOS
- * `Custom` - Custom
+ * * `Supabase` - Supabase
+ * * `CustomerIO` - CustomerIO
+ * * `Github` - Github
+ * * `Stripe` - Stripe
+ * * `Hubspot` - Hubspot
+ * * `Postgres` - Postgres
+ * * `Zendesk` - Zendesk
+ * * `Snowflake` - Snowflake
+ * * `Salesforce` - Salesforce
+ * * `MySQL` - MySQL
+ * * `MongoDB` - MongoDB
+ * * `MSSQL` - MSSQL
+ * * `Vitally` - Vitally
+ * * `BigQuery` - BigQuery
+ * * `Chargebee` - Chargebee
+ * * `Clerk` - Clerk
+ * * `GoogleAds` - GoogleAds
+ * * `GoogleSearchConsole` - GoogleSearchConsole
+ * * `TemporalIO` - TemporalIO
+ * * `DoIt` - DoIt
+ * * `GoogleSheets` - GoogleSheets
+ * * `MetaAds` - MetaAds
+ * * `Klaviyo` - Klaviyo
+ * * `Mailchimp` - Mailchimp
+ * * `Braze` - Braze
+ * * `Mailjet` - Mailjet
+ * * `Redshift` - Redshift
+ * * `Polar` - Polar
+ * * `RevenueCat` - RevenueCat
+ * * `LinkedinAds` - LinkedinAds
+ * * `RedditAds` - RedditAds
+ * * `TikTokAds` - TikTokAds
+ * * `BingAds` - BingAds
+ * * `Shopify` - Shopify
+ * * `Attio` - Attio
+ * * `SnapchatAds` - SnapchatAds
+ * * `Linear` - Linear
+ * * `Intercom` - Intercom
+ * * `Amplitude` - Amplitude
+ * * `Mixpanel` - Mixpanel
+ * * `Jira` - Jira
+ * * `ActiveCampaign` - ActiveCampaign
+ * * `Marketo` - Marketo
+ * * `Adjust` - Adjust
+ * * `AppsFlyer` - AppsFlyer
+ * * `Freshdesk` - Freshdesk
+ * * `GoogleAnalytics` - GoogleAnalytics
+ * * `Pipedrive` - Pipedrive
+ * * `SendGrid` - SendGrid
+ * * `Slack` - Slack
+ * * `PagerDuty` - PagerDuty
+ * * `Asana` - Asana
+ * * `Notion` - Notion
+ * * `Airtable` - Airtable
+ * * `Greenhouse` - Greenhouse
+ * * `BambooHR` - BambooHR
+ * * `Lever` - Lever
+ * * `GitLab` - GitLab
+ * * `Datadog` - Datadog
+ * * `Sentry` - Sentry
+ * * `Pendo` - Pendo
+ * * `FullStory` - FullStory
+ * * `AmazonAds` - AmazonAds
+ * * `PinterestAds` - PinterestAds
+ * * `AppleSearchAds` - AppleSearchAds
+ * * `QuickBooks` - QuickBooks
+ * * `Xero` - Xero
+ * * `NetSuite` - NetSuite
+ * * `WooCommerce` - WooCommerce
+ * * `BigCommerce` - BigCommerce
+ * * `PayPal` - PayPal
+ * * `Square` - Square
+ * * `Zoom` - Zoom
+ * * `Trello` - Trello
+ * * `Monday` - Monday
+ * * `ClickUp` - ClickUp
+ * * `Confluence` - Confluence
+ * * `Recurly` - Recurly
+ * * `SalesLoft` - SalesLoft
+ * * `Outreach` - Outreach
+ * * `Gong` - Gong
+ * * `Calendly` - Calendly
+ * * `Typeform` - Typeform
+ * * `Iterable` - Iterable
+ * * `ZohoCRM` - ZohoCRM
+ * * `Close` - Close
+ * * `Oracle` - Oracle
+ * * `DynamoDB` - DynamoDB
+ * * `Elasticsearch` - Elasticsearch
+ * * `Kafka` - Kafka
+ * * `LaunchDarkly` - LaunchDarkly
+ * * `Braintree` - Braintree
+ * * `Recharge` - Recharge
+ * * `HelpScout` - HelpScout
+ * * `Gorgias` - Gorgias
+ * * `Instagram` - Instagram
+ * * `YouTubeAnalytics` - YouTubeAnalytics
+ * * `FacebookPages` - FacebookPages
+ * * `TwitterAds` - TwitterAds
+ * * `Workday` - Workday
+ * * `ServiceNow` - ServiceNow
+ * * `Pardot` - Pardot
+ * * `Copper` - Copper
+ * * `Front` - Front
+ * * `ChartMogul` - ChartMogul
+ * * `Zuora` - Zuora
+ * * `Paddle` - Paddle
+ * * `CircleCI` - CircleCI
+ * * `CockroachDB` - CockroachDB
+ * * `Firebase` - Firebase
+ * * `AzureBlob` - AzureBlob
+ * * `GoogleDrive` - GoogleDrive
+ * * `OneDrive` - OneDrive
+ * * `SharePoint` - SharePoint
+ * * `Box` - Box
+ * * `SFTP` - SFTP
+ * * `MicrosoftTeams` - MicrosoftTeams
+ * * `Aircall` - Aircall
+ * * `Webflow` - Webflow
+ * * `Okta` - Okta
+ * * `Auth0` - Auth0
+ * * `Productboard` - Productboard
+ * * `Smartsheet` - Smartsheet
+ * * `Wrike` - Wrike
+ * * `Plaid` - Plaid
+ * * `SurveyMonkey` - SurveyMonkey
+ * * `Eventbrite` - Eventbrite
+ * * `RingCentral` - RingCentral
+ * * `Twilio` - Twilio
+ * * `Freshsales` - Freshsales
+ * * `Shortcut` - Shortcut
+ * * `ConvertKit` - ConvertKit
+ * * `Drip` - Drip
+ * * `CampaignMonitor` - CampaignMonitor
+ * * `MailerLite` - MailerLite
+ * * `Omnisend` - Omnisend
+ * * `Brevo` - Brevo
+ * * `Postmark` - Postmark
+ * * `Granola` - Granola
+ * * `BuildBetter` - BuildBetter
+ * * `Convex` - Convex
+ * * `ClickHouse` - ClickHouse
+ * * `Plain` - Plain
+ * * `Resend` - Resend
+ * * `PgAnalyze` - PgAnalyze
+ * * `WorkOS` - WorkOS
+ * * `Custom` - Custom
  */
 export type ExternalDataSourceTypeEnumApi =
     (typeof ExternalDataSourceTypeEnumApi)[keyof typeof ExternalDataSourceTypeEnumApi]
@@ -731,7 +731,7 @@ export const ExternalDataSourceTypeEnumApi = {
 
 /**
  * * `warehouse` - warehouse
- * `direct` - direct
+ * * `direct` - direct
  */
 export type AccessMethodEnumApi = (typeof AccessMethodEnumApi)[keyof typeof AccessMethodEnumApi]
 
@@ -742,7 +742,7 @@ export const AccessMethodEnumApi = {
 
 /**
  * * `duckdb` - duckdb
- * `postgres` - postgres
+ * * `postgres` - postgres
  */
 export type EngineEnumApi = (typeof EngineEnumApi)[keyof typeof EngineEnumApi]
 
@@ -767,10 +767,10 @@ export interface ExternalDataSourceSerializersApi {
     /** @nullable */
     readonly created_by: string | null
     /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-
-  * `web` - web
-  * `api` - api
-  * `mcp` - mcp */
+     *
+     * * `web` - web
+     * * `api` - api
+     * * `mcp` - mcp */
     created_via?: CreatedViaEnumApi | null
     readonly status: string
     client_secret: string
@@ -790,9 +790,9 @@ export interface ExternalDataSourceSerializersApi {
     description?: string | null
     readonly access_method: AccessMethodEnumApi
     /** Backend engine detected for the direct connection.
-
-  * `duckdb` - duckdb
-  * `postgres` - postgres */
+     *
+     * * `duckdb` - duckdb
+     * * `postgres` - postgres */
     readonly engine: EngineEnumApi | null
     /** @nullable */
     readonly last_run_at: string | null
@@ -825,155 +825,155 @@ export type ExternalDataSourceCreateApiPayload = { [key: string]: unknown }
 
 export interface ExternalDataSourceCreateApi {
     /** The source type (e.g. 'Postgres', 'Stripe').
-
-  * `Ashby` - Ashby
-  * `Supabase` - Supabase
-  * `CustomerIO` - CustomerIO
-  * `Github` - Github
-  * `Stripe` - Stripe
-  * `Hubspot` - Hubspot
-  * `Postgres` - Postgres
-  * `Zendesk` - Zendesk
-  * `Snowflake` - Snowflake
-  * `Salesforce` - Salesforce
-  * `MySQL` - MySQL
-  * `MongoDB` - MongoDB
-  * `MSSQL` - MSSQL
-  * `Vitally` - Vitally
-  * `BigQuery` - BigQuery
-  * `Chargebee` - Chargebee
-  * `Clerk` - Clerk
-  * `GoogleAds` - GoogleAds
-  * `GoogleSearchConsole` - GoogleSearchConsole
-  * `TemporalIO` - TemporalIO
-  * `DoIt` - DoIt
-  * `GoogleSheets` - GoogleSheets
-  * `MetaAds` - MetaAds
-  * `Klaviyo` - Klaviyo
-  * `Mailchimp` - Mailchimp
-  * `Braze` - Braze
-  * `Mailjet` - Mailjet
-  * `Redshift` - Redshift
-  * `Polar` - Polar
-  * `RevenueCat` - RevenueCat
-  * `LinkedinAds` - LinkedinAds
-  * `RedditAds` - RedditAds
-  * `TikTokAds` - TikTokAds
-  * `BingAds` - BingAds
-  * `Shopify` - Shopify
-  * `Attio` - Attio
-  * `SnapchatAds` - SnapchatAds
-  * `Linear` - Linear
-  * `Intercom` - Intercom
-  * `Amplitude` - Amplitude
-  * `Mixpanel` - Mixpanel
-  * `Jira` - Jira
-  * `ActiveCampaign` - ActiveCampaign
-  * `Marketo` - Marketo
-  * `Adjust` - Adjust
-  * `AppsFlyer` - AppsFlyer
-  * `Freshdesk` - Freshdesk
-  * `GoogleAnalytics` - GoogleAnalytics
-  * `Pipedrive` - Pipedrive
-  * `SendGrid` - SendGrid
-  * `Slack` - Slack
-  * `PagerDuty` - PagerDuty
-  * `Asana` - Asana
-  * `Notion` - Notion
-  * `Airtable` - Airtable
-  * `Greenhouse` - Greenhouse
-  * `BambooHR` - BambooHR
-  * `Lever` - Lever
-  * `GitLab` - GitLab
-  * `Datadog` - Datadog
-  * `Sentry` - Sentry
-  * `Pendo` - Pendo
-  * `FullStory` - FullStory
-  * `AmazonAds` - AmazonAds
-  * `PinterestAds` - PinterestAds
-  * `AppleSearchAds` - AppleSearchAds
-  * `QuickBooks` - QuickBooks
-  * `Xero` - Xero
-  * `NetSuite` - NetSuite
-  * `WooCommerce` - WooCommerce
-  * `BigCommerce` - BigCommerce
-  * `PayPal` - PayPal
-  * `Square` - Square
-  * `Zoom` - Zoom
-  * `Trello` - Trello
-  * `Monday` - Monday
-  * `ClickUp` - ClickUp
-  * `Confluence` - Confluence
-  * `Recurly` - Recurly
-  * `SalesLoft` - SalesLoft
-  * `Outreach` - Outreach
-  * `Gong` - Gong
-  * `Calendly` - Calendly
-  * `Typeform` - Typeform
-  * `Iterable` - Iterable
-  * `ZohoCRM` - ZohoCRM
-  * `Close` - Close
-  * `Oracle` - Oracle
-  * `DynamoDB` - DynamoDB
-  * `Elasticsearch` - Elasticsearch
-  * `Kafka` - Kafka
-  * `LaunchDarkly` - LaunchDarkly
-  * `Braintree` - Braintree
-  * `Recharge` - Recharge
-  * `HelpScout` - HelpScout
-  * `Gorgias` - Gorgias
-  * `Instagram` - Instagram
-  * `YouTubeAnalytics` - YouTubeAnalytics
-  * `FacebookPages` - FacebookPages
-  * `TwitterAds` - TwitterAds
-  * `Workday` - Workday
-  * `ServiceNow` - ServiceNow
-  * `Pardot` - Pardot
-  * `Copper` - Copper
-  * `Front` - Front
-  * `ChartMogul` - ChartMogul
-  * `Zuora` - Zuora
-  * `Paddle` - Paddle
-  * `CircleCI` - CircleCI
-  * `CockroachDB` - CockroachDB
-  * `Firebase` - Firebase
-  * `AzureBlob` - AzureBlob
-  * `GoogleDrive` - GoogleDrive
-  * `OneDrive` - OneDrive
-  * `SharePoint` - SharePoint
-  * `Box` - Box
-  * `SFTP` - SFTP
-  * `MicrosoftTeams` - MicrosoftTeams
-  * `Aircall` - Aircall
-  * `Webflow` - Webflow
-  * `Okta` - Okta
-  * `Auth0` - Auth0
-  * `Productboard` - Productboard
-  * `Smartsheet` - Smartsheet
-  * `Wrike` - Wrike
-  * `Plaid` - Plaid
-  * `SurveyMonkey` - SurveyMonkey
-  * `Eventbrite` - Eventbrite
-  * `RingCentral` - RingCentral
-  * `Twilio` - Twilio
-  * `Freshsales` - Freshsales
-  * `Shortcut` - Shortcut
-  * `ConvertKit` - ConvertKit
-  * `Drip` - Drip
-  * `CampaignMonitor` - CampaignMonitor
-  * `MailerLite` - MailerLite
-  * `Omnisend` - Omnisend
-  * `Brevo` - Brevo
-  * `Postmark` - Postmark
-  * `Granola` - Granola
-  * `BuildBetter` - BuildBetter
-  * `Convex` - Convex
-  * `ClickHouse` - ClickHouse
-  * `Plain` - Plain
-  * `Resend` - Resend
-  * `PgAnalyze` - PgAnalyze
-  * `WorkOS` - WorkOS
-  * `Custom` - Custom */
+     *
+     * * `Ashby` - Ashby
+     * * `Supabase` - Supabase
+     * * `CustomerIO` - CustomerIO
+     * * `Github` - Github
+     * * `Stripe` - Stripe
+     * * `Hubspot` - Hubspot
+     * * `Postgres` - Postgres
+     * * `Zendesk` - Zendesk
+     * * `Snowflake` - Snowflake
+     * * `Salesforce` - Salesforce
+     * * `MySQL` - MySQL
+     * * `MongoDB` - MongoDB
+     * * `MSSQL` - MSSQL
+     * * `Vitally` - Vitally
+     * * `BigQuery` - BigQuery
+     * * `Chargebee` - Chargebee
+     * * `Clerk` - Clerk
+     * * `GoogleAds` - GoogleAds
+     * * `GoogleSearchConsole` - GoogleSearchConsole
+     * * `TemporalIO` - TemporalIO
+     * * `DoIt` - DoIt
+     * * `GoogleSheets` - GoogleSheets
+     * * `MetaAds` - MetaAds
+     * * `Klaviyo` - Klaviyo
+     * * `Mailchimp` - Mailchimp
+     * * `Braze` - Braze
+     * * `Mailjet` - Mailjet
+     * * `Redshift` - Redshift
+     * * `Polar` - Polar
+     * * `RevenueCat` - RevenueCat
+     * * `LinkedinAds` - LinkedinAds
+     * * `RedditAds` - RedditAds
+     * * `TikTokAds` - TikTokAds
+     * * `BingAds` - BingAds
+     * * `Shopify` - Shopify
+     * * `Attio` - Attio
+     * * `SnapchatAds` - SnapchatAds
+     * * `Linear` - Linear
+     * * `Intercom` - Intercom
+     * * `Amplitude` - Amplitude
+     * * `Mixpanel` - Mixpanel
+     * * `Jira` - Jira
+     * * `ActiveCampaign` - ActiveCampaign
+     * * `Marketo` - Marketo
+     * * `Adjust` - Adjust
+     * * `AppsFlyer` - AppsFlyer
+     * * `Freshdesk` - Freshdesk
+     * * `GoogleAnalytics` - GoogleAnalytics
+     * * `Pipedrive` - Pipedrive
+     * * `SendGrid` - SendGrid
+     * * `Slack` - Slack
+     * * `PagerDuty` - PagerDuty
+     * * `Asana` - Asana
+     * * `Notion` - Notion
+     * * `Airtable` - Airtable
+     * * `Greenhouse` - Greenhouse
+     * * `BambooHR` - BambooHR
+     * * `Lever` - Lever
+     * * `GitLab` - GitLab
+     * * `Datadog` - Datadog
+     * * `Sentry` - Sentry
+     * * `Pendo` - Pendo
+     * * `FullStory` - FullStory
+     * * `AmazonAds` - AmazonAds
+     * * `PinterestAds` - PinterestAds
+     * * `AppleSearchAds` - AppleSearchAds
+     * * `QuickBooks` - QuickBooks
+     * * `Xero` - Xero
+     * * `NetSuite` - NetSuite
+     * * `WooCommerce` - WooCommerce
+     * * `BigCommerce` - BigCommerce
+     * * `PayPal` - PayPal
+     * * `Square` - Square
+     * * `Zoom` - Zoom
+     * * `Trello` - Trello
+     * * `Monday` - Monday
+     * * `ClickUp` - ClickUp
+     * * `Confluence` - Confluence
+     * * `Recurly` - Recurly
+     * * `SalesLoft` - SalesLoft
+     * * `Outreach` - Outreach
+     * * `Gong` - Gong
+     * * `Calendly` - Calendly
+     * * `Typeform` - Typeform
+     * * `Iterable` - Iterable
+     * * `ZohoCRM` - ZohoCRM
+     * * `Close` - Close
+     * * `Oracle` - Oracle
+     * * `DynamoDB` - DynamoDB
+     * * `Elasticsearch` - Elasticsearch
+     * * `Kafka` - Kafka
+     * * `LaunchDarkly` - LaunchDarkly
+     * * `Braintree` - Braintree
+     * * `Recharge` - Recharge
+     * * `HelpScout` - HelpScout
+     * * `Gorgias` - Gorgias
+     * * `Instagram` - Instagram
+     * * `YouTubeAnalytics` - YouTubeAnalytics
+     * * `FacebookPages` - FacebookPages
+     * * `TwitterAds` - TwitterAds
+     * * `Workday` - Workday
+     * * `ServiceNow` - ServiceNow
+     * * `Pardot` - Pardot
+     * * `Copper` - Copper
+     * * `Front` - Front
+     * * `ChartMogul` - ChartMogul
+     * * `Zuora` - Zuora
+     * * `Paddle` - Paddle
+     * * `CircleCI` - CircleCI
+     * * `CockroachDB` - CockroachDB
+     * * `Firebase` - Firebase
+     * * `AzureBlob` - AzureBlob
+     * * `GoogleDrive` - GoogleDrive
+     * * `OneDrive` - OneDrive
+     * * `SharePoint` - SharePoint
+     * * `Box` - Box
+     * * `SFTP` - SFTP
+     * * `MicrosoftTeams` - MicrosoftTeams
+     * * `Aircall` - Aircall
+     * * `Webflow` - Webflow
+     * * `Okta` - Okta
+     * * `Auth0` - Auth0
+     * * `Productboard` - Productboard
+     * * `Smartsheet` - Smartsheet
+     * * `Wrike` - Wrike
+     * * `Plaid` - Plaid
+     * * `SurveyMonkey` - SurveyMonkey
+     * * `Eventbrite` - Eventbrite
+     * * `RingCentral` - RingCentral
+     * * `Twilio` - Twilio
+     * * `Freshsales` - Freshsales
+     * * `Shortcut` - Shortcut
+     * * `ConvertKit` - ConvertKit
+     * * `Drip` - Drip
+     * * `CampaignMonitor` - CampaignMonitor
+     * * `MailerLite` - MailerLite
+     * * `Omnisend` - Omnisend
+     * * `Brevo` - Brevo
+     * * `Postmark` - Postmark
+     * * `Granola` - Granola
+     * * `BuildBetter` - BuildBetter
+     * * `Convex` - Convex
+     * * `ClickHouse` - ClickHouse
+     * * `Plain` - Plain
+     * * `Resend` - Resend
+     * * `PgAnalyze` - PgAnalyze
+     * * `WorkOS` - WorkOS
+     * * `Custom` - Custom */
     source_type: ExternalDataSourceTypeEnumApi
     /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
     payload: ExternalDataSourceCreateApiPayload
@@ -990,15 +990,15 @@ export interface ExternalDataSourceCreateApi {
      */
     description?: string | null
     /** Connection mode: 'warehouse' (import) or 'direct' (live query).
-
-  * `warehouse` - warehouse
-  * `direct` - direct */
+     *
+     * * `warehouse` - warehouse
+     * * `direct` - direct */
     access_method?: AccessMethodEnumApi
     /** Where the request came from
-
-  * `web` - web
-  * `api` - api
-  * `mcp` - mcp */
+     *
+     * * `web` - web
+     * * `api` - api
+     * * `mcp` - mcp */
     created_via?: CreatedViaEnumApi
 }
 
@@ -1013,10 +1013,10 @@ export interface PatchedExternalDataSourceSerializersApi {
     /** @nullable */
     readonly created_by?: string | null
     /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-
-  * `web` - web
-  * `api` - api
-  * `mcp` - mcp */
+     *
+     * * `web` - web
+     * * `api` - api
+     * * `mcp` - mcp */
     created_via?: CreatedViaEnumApi | null
     readonly status?: string
     client_secret?: string
@@ -1036,9 +1036,9 @@ export interface PatchedExternalDataSourceSerializersApi {
     description?: string | null
     readonly access_method?: AccessMethodEnumApi
     /** Backend engine detected for the direct connection.
-
-  * `duckdb` - duckdb
-  * `postgres` - postgres */
+     *
+     * * `duckdb` - duckdb
+     * * `postgres` - postgres */
     readonly engine?: EngineEnumApi | null
     /** @nullable */
     readonly last_run_at?: string | null
@@ -1061,12 +1061,12 @@ export interface ExternalDataSourceBulkUpdateSchemaApi {
     /** Whether the schema should be queryable/synced. */
     should_sync?: boolean
     /** Requested sync mode for the schema.
-
-  * `full_refresh` - full_refresh
-  * `incremental` - incremental
-  * `append` - append
-  * `webhook` - webhook
-  * `cdc` - cdc */
+     *
+     * * `full_refresh` - full_refresh
+     * * `incremental` - incremental
+     * * `append` - append
+     * * `webhook` - webhook
+     * * `cdc` - cdc */
     sync_type?: SyncTypeEnumApi | null
     /**
      * Incremental cursor field for incremental or append syncs.
@@ -1089,10 +1089,10 @@ export interface ExternalDataSourceBulkUpdateSchemaApi {
      */
     sync_time_of_day?: string | null
     /** How CDC-backed tables should be exposed.
-
-  * `consolidated` - consolidated
-  * `cdc_only` - cdc_only
-  * `both` - both */
+     *
+     * * `consolidated` - consolidated
+     * * `cdc_only` - cdc_only
+     * * `both` - both */
     cdc_table_mode?: CdcTableModeEnumApi | null
     /**
      * Columns to sync. Null means sync all columns.
@@ -1111,9 +1111,9 @@ export interface ExternalDataSourceConnectionOptionApi {
     /** @nullable */
     readonly prefix: string | null
     /** Backend engine detected for the direct connection.
-
-  * `duckdb` - duckdb
-  * `postgres` - postgres */
+     *
+     * * `duckdb` - duckdb
+     * * `postgres` - postgres */
     readonly engine: EngineEnumApi | null
 }
 
@@ -1128,171 +1128,171 @@ export interface PaginatedExternalDataSourceConnectionOptionListApi {
 
 /**
  * Validate credentials and preview available tables from a remote database.
-
-The request body contains source_type plus flat source-specific credential fields
-(e.g. host, port, database, user, password, schema for Postgres). The credential
-fields vary per source_type and are validated dynamically by the source registry.
+ *
+ * The request body contains source_type plus flat source-specific credential fields
+ * (e.g. host, port, database, user, password, schema for Postgres). The credential
+ * fields vary per source_type and are validated dynamically by the source registry.
  */
 export interface DatabaseSchemaRequestApi {
     /** The source type to validate against.
-
-  * `Ashby` - Ashby
-  * `Supabase` - Supabase
-  * `CustomerIO` - CustomerIO
-  * `Github` - Github
-  * `Stripe` - Stripe
-  * `Hubspot` - Hubspot
-  * `Postgres` - Postgres
-  * `Zendesk` - Zendesk
-  * `Snowflake` - Snowflake
-  * `Salesforce` - Salesforce
-  * `MySQL` - MySQL
-  * `MongoDB` - MongoDB
-  * `MSSQL` - MSSQL
-  * `Vitally` - Vitally
-  * `BigQuery` - BigQuery
-  * `Chargebee` - Chargebee
-  * `Clerk` - Clerk
-  * `GoogleAds` - GoogleAds
-  * `GoogleSearchConsole` - GoogleSearchConsole
-  * `TemporalIO` - TemporalIO
-  * `DoIt` - DoIt
-  * `GoogleSheets` - GoogleSheets
-  * `MetaAds` - MetaAds
-  * `Klaviyo` - Klaviyo
-  * `Mailchimp` - Mailchimp
-  * `Braze` - Braze
-  * `Mailjet` - Mailjet
-  * `Redshift` - Redshift
-  * `Polar` - Polar
-  * `RevenueCat` - RevenueCat
-  * `LinkedinAds` - LinkedinAds
-  * `RedditAds` - RedditAds
-  * `TikTokAds` - TikTokAds
-  * `BingAds` - BingAds
-  * `Shopify` - Shopify
-  * `Attio` - Attio
-  * `SnapchatAds` - SnapchatAds
-  * `Linear` - Linear
-  * `Intercom` - Intercom
-  * `Amplitude` - Amplitude
-  * `Mixpanel` - Mixpanel
-  * `Jira` - Jira
-  * `ActiveCampaign` - ActiveCampaign
-  * `Marketo` - Marketo
-  * `Adjust` - Adjust
-  * `AppsFlyer` - AppsFlyer
-  * `Freshdesk` - Freshdesk
-  * `GoogleAnalytics` - GoogleAnalytics
-  * `Pipedrive` - Pipedrive
-  * `SendGrid` - SendGrid
-  * `Slack` - Slack
-  * `PagerDuty` - PagerDuty
-  * `Asana` - Asana
-  * `Notion` - Notion
-  * `Airtable` - Airtable
-  * `Greenhouse` - Greenhouse
-  * `BambooHR` - BambooHR
-  * `Lever` - Lever
-  * `GitLab` - GitLab
-  * `Datadog` - Datadog
-  * `Sentry` - Sentry
-  * `Pendo` - Pendo
-  * `FullStory` - FullStory
-  * `AmazonAds` - AmazonAds
-  * `PinterestAds` - PinterestAds
-  * `AppleSearchAds` - AppleSearchAds
-  * `QuickBooks` - QuickBooks
-  * `Xero` - Xero
-  * `NetSuite` - NetSuite
-  * `WooCommerce` - WooCommerce
-  * `BigCommerce` - BigCommerce
-  * `PayPal` - PayPal
-  * `Square` - Square
-  * `Zoom` - Zoom
-  * `Trello` - Trello
-  * `Monday` - Monday
-  * `ClickUp` - ClickUp
-  * `Confluence` - Confluence
-  * `Recurly` - Recurly
-  * `SalesLoft` - SalesLoft
-  * `Outreach` - Outreach
-  * `Gong` - Gong
-  * `Calendly` - Calendly
-  * `Typeform` - Typeform
-  * `Iterable` - Iterable
-  * `ZohoCRM` - ZohoCRM
-  * `Close` - Close
-  * `Oracle` - Oracle
-  * `DynamoDB` - DynamoDB
-  * `Elasticsearch` - Elasticsearch
-  * `Kafka` - Kafka
-  * `LaunchDarkly` - LaunchDarkly
-  * `Braintree` - Braintree
-  * `Recharge` - Recharge
-  * `HelpScout` - HelpScout
-  * `Gorgias` - Gorgias
-  * `Instagram` - Instagram
-  * `YouTubeAnalytics` - YouTubeAnalytics
-  * `FacebookPages` - FacebookPages
-  * `TwitterAds` - TwitterAds
-  * `Workday` - Workday
-  * `ServiceNow` - ServiceNow
-  * `Pardot` - Pardot
-  * `Copper` - Copper
-  * `Front` - Front
-  * `ChartMogul` - ChartMogul
-  * `Zuora` - Zuora
-  * `Paddle` - Paddle
-  * `CircleCI` - CircleCI
-  * `CockroachDB` - CockroachDB
-  * `Firebase` - Firebase
-  * `AzureBlob` - AzureBlob
-  * `GoogleDrive` - GoogleDrive
-  * `OneDrive` - OneDrive
-  * `SharePoint` - SharePoint
-  * `Box` - Box
-  * `SFTP` - SFTP
-  * `MicrosoftTeams` - MicrosoftTeams
-  * `Aircall` - Aircall
-  * `Webflow` - Webflow
-  * `Okta` - Okta
-  * `Auth0` - Auth0
-  * `Productboard` - Productboard
-  * `Smartsheet` - Smartsheet
-  * `Wrike` - Wrike
-  * `Plaid` - Plaid
-  * `SurveyMonkey` - SurveyMonkey
-  * `Eventbrite` - Eventbrite
-  * `RingCentral` - RingCentral
-  * `Twilio` - Twilio
-  * `Freshsales` - Freshsales
-  * `Shortcut` - Shortcut
-  * `ConvertKit` - ConvertKit
-  * `Drip` - Drip
-  * `CampaignMonitor` - CampaignMonitor
-  * `MailerLite` - MailerLite
-  * `Omnisend` - Omnisend
-  * `Brevo` - Brevo
-  * `Postmark` - Postmark
-  * `Granola` - Granola
-  * `BuildBetter` - BuildBetter
-  * `Convex` - Convex
-  * `ClickHouse` - ClickHouse
-  * `Plain` - Plain
-  * `Resend` - Resend
-  * `PgAnalyze` - PgAnalyze
-  * `WorkOS` - WorkOS
-  * `Custom` - Custom */
+     *
+     * * `Ashby` - Ashby
+     * * `Supabase` - Supabase
+     * * `CustomerIO` - CustomerIO
+     * * `Github` - Github
+     * * `Stripe` - Stripe
+     * * `Hubspot` - Hubspot
+     * * `Postgres` - Postgres
+     * * `Zendesk` - Zendesk
+     * * `Snowflake` - Snowflake
+     * * `Salesforce` - Salesforce
+     * * `MySQL` - MySQL
+     * * `MongoDB` - MongoDB
+     * * `MSSQL` - MSSQL
+     * * `Vitally` - Vitally
+     * * `BigQuery` - BigQuery
+     * * `Chargebee` - Chargebee
+     * * `Clerk` - Clerk
+     * * `GoogleAds` - GoogleAds
+     * * `GoogleSearchConsole` - GoogleSearchConsole
+     * * `TemporalIO` - TemporalIO
+     * * `DoIt` - DoIt
+     * * `GoogleSheets` - GoogleSheets
+     * * `MetaAds` - MetaAds
+     * * `Klaviyo` - Klaviyo
+     * * `Mailchimp` - Mailchimp
+     * * `Braze` - Braze
+     * * `Mailjet` - Mailjet
+     * * `Redshift` - Redshift
+     * * `Polar` - Polar
+     * * `RevenueCat` - RevenueCat
+     * * `LinkedinAds` - LinkedinAds
+     * * `RedditAds` - RedditAds
+     * * `TikTokAds` - TikTokAds
+     * * `BingAds` - BingAds
+     * * `Shopify` - Shopify
+     * * `Attio` - Attio
+     * * `SnapchatAds` - SnapchatAds
+     * * `Linear` - Linear
+     * * `Intercom` - Intercom
+     * * `Amplitude` - Amplitude
+     * * `Mixpanel` - Mixpanel
+     * * `Jira` - Jira
+     * * `ActiveCampaign` - ActiveCampaign
+     * * `Marketo` - Marketo
+     * * `Adjust` - Adjust
+     * * `AppsFlyer` - AppsFlyer
+     * * `Freshdesk` - Freshdesk
+     * * `GoogleAnalytics` - GoogleAnalytics
+     * * `Pipedrive` - Pipedrive
+     * * `SendGrid` - SendGrid
+     * * `Slack` - Slack
+     * * `PagerDuty` - PagerDuty
+     * * `Asana` - Asana
+     * * `Notion` - Notion
+     * * `Airtable` - Airtable
+     * * `Greenhouse` - Greenhouse
+     * * `BambooHR` - BambooHR
+     * * `Lever` - Lever
+     * * `GitLab` - GitLab
+     * * `Datadog` - Datadog
+     * * `Sentry` - Sentry
+     * * `Pendo` - Pendo
+     * * `FullStory` - FullStory
+     * * `AmazonAds` - AmazonAds
+     * * `PinterestAds` - PinterestAds
+     * * `AppleSearchAds` - AppleSearchAds
+     * * `QuickBooks` - QuickBooks
+     * * `Xero` - Xero
+     * * `NetSuite` - NetSuite
+     * * `WooCommerce` - WooCommerce
+     * * `BigCommerce` - BigCommerce
+     * * `PayPal` - PayPal
+     * * `Square` - Square
+     * * `Zoom` - Zoom
+     * * `Trello` - Trello
+     * * `Monday` - Monday
+     * * `ClickUp` - ClickUp
+     * * `Confluence` - Confluence
+     * * `Recurly` - Recurly
+     * * `SalesLoft` - SalesLoft
+     * * `Outreach` - Outreach
+     * * `Gong` - Gong
+     * * `Calendly` - Calendly
+     * * `Typeform` - Typeform
+     * * `Iterable` - Iterable
+     * * `ZohoCRM` - ZohoCRM
+     * * `Close` - Close
+     * * `Oracle` - Oracle
+     * * `DynamoDB` - DynamoDB
+     * * `Elasticsearch` - Elasticsearch
+     * * `Kafka` - Kafka
+     * * `LaunchDarkly` - LaunchDarkly
+     * * `Braintree` - Braintree
+     * * `Recharge` - Recharge
+     * * `HelpScout` - HelpScout
+     * * `Gorgias` - Gorgias
+     * * `Instagram` - Instagram
+     * * `YouTubeAnalytics` - YouTubeAnalytics
+     * * `FacebookPages` - FacebookPages
+     * * `TwitterAds` - TwitterAds
+     * * `Workday` - Workday
+     * * `ServiceNow` - ServiceNow
+     * * `Pardot` - Pardot
+     * * `Copper` - Copper
+     * * `Front` - Front
+     * * `ChartMogul` - ChartMogul
+     * * `Zuora` - Zuora
+     * * `Paddle` - Paddle
+     * * `CircleCI` - CircleCI
+     * * `CockroachDB` - CockroachDB
+     * * `Firebase` - Firebase
+     * * `AzureBlob` - AzureBlob
+     * * `GoogleDrive` - GoogleDrive
+     * * `OneDrive` - OneDrive
+     * * `SharePoint` - SharePoint
+     * * `Box` - Box
+     * * `SFTP` - SFTP
+     * * `MicrosoftTeams` - MicrosoftTeams
+     * * `Aircall` - Aircall
+     * * `Webflow` - Webflow
+     * * `Okta` - Okta
+     * * `Auth0` - Auth0
+     * * `Productboard` - Productboard
+     * * `Smartsheet` - Smartsheet
+     * * `Wrike` - Wrike
+     * * `Plaid` - Plaid
+     * * `SurveyMonkey` - SurveyMonkey
+     * * `Eventbrite` - Eventbrite
+     * * `RingCentral` - RingCentral
+     * * `Twilio` - Twilio
+     * * `Freshsales` - Freshsales
+     * * `Shortcut` - Shortcut
+     * * `ConvertKit` - ConvertKit
+     * * `Drip` - Drip
+     * * `CampaignMonitor` - CampaignMonitor
+     * * `MailerLite` - MailerLite
+     * * `Omnisend` - Omnisend
+     * * `Brevo` - Brevo
+     * * `Postmark` - Postmark
+     * * `Granola` - Granola
+     * * `BuildBetter` - BuildBetter
+     * * `Convex` - Convex
+     * * `ClickHouse` - ClickHouse
+     * * `Plain` - Plain
+     * * `Resend` - Resend
+     * * `PgAnalyze` - PgAnalyze
+     * * `WorkOS` - WorkOS
+     * * `Custom` - Custom */
     source_type: ExternalDataSourceTypeEnumApi
 }
 
 /**
  * * `String` - String
- * `Number` - Number
- * `Boolean` - Boolean
- * `List` - List
- * `Date` - Date
+ * * `Number` - Number
+ * * `Boolean` - Boolean
+ * * `List` - List
+ * * `Date` - Date
  */
 export type InsightVariableTypeEnumApi = (typeof InsightVariableTypeEnumApi)[keyof typeof InsightVariableTypeEnumApi]
 
@@ -1313,12 +1313,12 @@ export interface InsightVariableApi {
      */
     name: string
     /** Variable type. Controls how the value is rendered and substituted in HogQL.
-
-  * `String` - String
-  * `Number` - Number
-  * `Boolean` - Boolean
-  * `List` - List
-  * `Date` - Date */
+     *
+     * * `String` - String
+     * * `Number` - Number
+     * * `Boolean` - Boolean
+     * * `List` - List
+     * * `Date` - Date */
     type: InsightVariableTypeEnumApi
     /** Default value used when a query references this variable. */
     default_value?: unknown
@@ -1356,12 +1356,12 @@ export interface PatchedInsightVariableApi {
      */
     name?: string
     /** Variable type. Controls how the value is rendered and substituted in HogQL.
-
-  * `String` - String
-  * `Number` - Number
-  * `Boolean` - Boolean
-  * `List` - List
-  * `Date` - Date */
+     *
+     * * `String` - String
+     * * `Number` - Number
+     * * `Boolean` - Boolean
+     * * `List` - List
+     * * `Date` - Date */
     type?: InsightVariableTypeEnumApi
     /** Default value used when a query references this variable. */
     default_value?: unknown
@@ -1384,11 +1384,11 @@ export interface PatchedInsightVariableApi {
 export interface QueryTabStateApi {
     readonly id: string
     /**
-              Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-              and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-              ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-              for a user.
-               */
+     *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+     *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+     *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+     *             for a user.
+     *              */
     state?: unknown
 }
 
@@ -1404,23 +1404,23 @@ export interface PaginatedQueryTabStateListApi {
 export interface PatchedQueryTabStateApi {
     readonly id?: string
     /**
-              Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-              and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-              ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-              for a user.
-               */
+     *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+     *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+     *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+     *             for a user.
+     *              */
     state?: unknown
 }
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -1492,10 +1492,10 @@ export interface PaginatedDataWarehouseModelPathListApi {
 
 /**
  * * `Cancelled` - Cancelled
- * `Modified` - Modified
- * `Completed` - Completed
- * `Failed` - Failed
- * `Running` - Running
+ * * `Modified` - Modified
+ * * `Completed` - Completed
+ * * `Failed` - Failed
+ * * `Running` - Running
  */
 export type SavedQueryStatusEnumApi = (typeof SavedQueryStatusEnumApi)[keyof typeof SavedQueryStatusEnumApi]
 
@@ -1509,8 +1509,8 @@ export const SavedQueryStatusEnumApi = {
 
 /**
  * * `data_warehouse` - Data Warehouse
- * `endpoint` - Endpoint
- * `managed_viewset` - Managed Viewset
+ * * `endpoint` - Endpoint
+ * * `managed_viewset` - Managed Viewset
  */
 export type OriginEnumApi = (typeof OriginEnumApi)[keyof typeof OriginEnumApi]
 
@@ -1536,12 +1536,12 @@ export interface DataWarehouseSavedQueryMinimalApi {
     readonly sync_frequency: string | null
     readonly columns: readonly DataWarehouseSavedQueryMinimalApiColumnsItem[]
     /** The status of when this SavedQuery last ran.
-
-  * `Cancelled` - Cancelled
-  * `Modified` - Modified
-  * `Completed` - Completed
-  * `Failed` - Failed
-  * `Running` - Running */
+     *
+     * * `Cancelled` - Cancelled
+     * * `Modified` - Modified
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running */
     readonly status: SavedQueryStatusEnumApi | null
     /** @nullable */
     readonly last_run_at: string | null
@@ -1556,10 +1556,10 @@ export interface DataWarehouseSavedQueryMinimalApi {
     /** @nullable */
     readonly is_materialized: boolean | null
     /** Where this SavedQuery is created.
-
-  * `data_warehouse` - Data Warehouse
-  * `endpoint` - Endpoint
-  * `managed_viewset` - Managed Viewset */
+     *
+     * * `data_warehouse` - Data Warehouse
+     * * `endpoint` - Endpoint
+     * * `managed_viewset` - Managed Viewset */
     readonly origin: OriginEnumApi | null
     /** Whether this view is for testing only and will auto-expire. */
     readonly is_test: boolean
@@ -1603,8 +1603,8 @@ export type DataWarehouseSavedQueryApiColumnsItem = { [key: string]: unknown }
 
 /**
  * Shared methods for DataWarehouseSavedQuery serializers.
-
-This mixin is intended to be used with serializers.ModelSerializer subclasses.
+ *
+ * This mixin is intended to be used with serializers.ModelSerializer subclasses.
  */
 export interface DataWarehouseSavedQueryApi {
     readonly id: string
@@ -1623,12 +1623,12 @@ export interface DataWarehouseSavedQueryApi {
     readonly sync_frequency: string | null
     readonly columns: readonly DataWarehouseSavedQueryApiColumnsItem[]
     /** The status of when this SavedQuery last ran.
-
-  * `Cancelled` - Cancelled
-  * `Modified` - Modified
-  * `Completed` - Completed
-  * `Failed` - Failed
-  * `Running` - Running */
+     *
+     * * `Cancelled` - Cancelled
+     * * `Modified` - Modified
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running */
     readonly status: SavedQueryStatusEnumApi | null
     /** @nullable */
     readonly last_run_at: string | null
@@ -1666,10 +1666,10 @@ export interface DataWarehouseSavedQueryApi {
     /** @nullable */
     readonly is_materialized: boolean | null
     /** Where this SavedQuery is created.
-
-  * `data_warehouse` - Data Warehouse
-  * `endpoint` - Endpoint
-  * `managed_viewset` - Managed Viewset */
+     *
+     * * `data_warehouse` - Data Warehouse
+     * * `endpoint` - Endpoint
+     * * `managed_viewset` - Managed Viewset */
     readonly origin: OriginEnumApi | null
     /** Whether this view is for testing only and will auto-expire. */
     is_test?: boolean
@@ -1704,8 +1704,8 @@ export type PatchedDataWarehouseSavedQueryApiColumnsItem = { [key: string]: unkn
 
 /**
  * Shared methods for DataWarehouseSavedQuery serializers.
-
-This mixin is intended to be used with serializers.ModelSerializer subclasses.
+ *
+ * This mixin is intended to be used with serializers.ModelSerializer subclasses.
  */
 export interface PatchedDataWarehouseSavedQueryApi {
     readonly id?: string
@@ -1724,12 +1724,12 @@ export interface PatchedDataWarehouseSavedQueryApi {
     readonly sync_frequency?: string | null
     readonly columns?: readonly PatchedDataWarehouseSavedQueryApiColumnsItem[]
     /** The status of when this SavedQuery last ran.
-
-  * `Cancelled` - Cancelled
-  * `Modified` - Modified
-  * `Completed` - Completed
-  * `Failed` - Failed
-  * `Running` - Running */
+     *
+     * * `Cancelled` - Cancelled
+     * * `Modified` - Modified
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running */
     readonly status?: SavedQueryStatusEnumApi | null
     /** @nullable */
     readonly last_run_at?: string | null
@@ -1767,10 +1767,10 @@ export interface PatchedDataWarehouseSavedQueryApi {
     /** @nullable */
     readonly is_materialized?: boolean | null
     /** Where this SavedQuery is created.
-
-  * `data_warehouse` - Data Warehouse
-  * `endpoint` - Endpoint
-  * `managed_viewset` - Managed Viewset */
+     *
+     * * `data_warehouse` - Data Warehouse
+     * * `endpoint` - Endpoint
+     * * `managed_viewset` - Managed Viewset */
     readonly origin?: OriginEnumApi | null
     /** Whether this view is for testing only and will auto-expire. */
     is_test?: boolean
@@ -1875,11 +1875,11 @@ export interface PatchedDataWarehouseSavedQueryFolderApi {
 
 /**
  * * `CSV` - CSV
- * `CSVWithNames` - CSVWithNames
- * `Parquet` - Parquet
- * `JSONEachRow` - JSON
- * `Delta` - Delta
- * `DeltaS3Wrapper` - DeltaS3Wrapper
+ * * `CSVWithNames` - CSVWithNames
+ * * `Parquet` - Parquet
+ * * `JSONEachRow` - JSON
+ * * `Delta` - Delta
+ * * `DeltaS3Wrapper` - DeltaS3Wrapper
  */
 export type TableFormatEnumApi = (typeof TableFormatEnumApi)[keyof typeof TableFormatEnumApi]
 

--- a/products/data_warehouse/frontend/generated/api.ts
+++ b/products/data_warehouse/frontend/generated/api.ts
@@ -90,7 +90,7 @@ export const getDataModelingJobsListUrl = (projectId: string, params?: DataModel
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -175,7 +175,7 @@ export const getDataWarehouseCheckDatabaseNameRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -206,7 +206,7 @@ export const getDataWarehouseCompletedActivityRetrieveUrl = (projectId: string) 
 
 /**
  * Returns completed/non-running activities (jobs with status 'Completed').
-Supports pagination and cutoff time filtering.
+ * Supports pagination and cutoff time filtering.
  */
 export const dataWarehouseCompletedActivityRetrieve = async (
     projectId: string,
@@ -224,7 +224,7 @@ export const getDataWarehouseDataHealthIssuesRetrieveUrl = (projectId: string) =
 
 /**
  * Returns failed/disabled data pipeline items for the Pipeline status side panel.
-Includes: materializations, syncs, sources, destinations, and transformations.
+ * Includes: materializations, syncs, sources, destinations, and transformations.
  */
 export const dataWarehouseDataHealthIssuesRetrieve = async (
     projectId: string,
@@ -276,7 +276,7 @@ export const getDataWarehouseJobStatsRetrieveUrl = (projectId: string) => {
 
 /**
  * Returns success and failed job statistics for the last 1, 7, or 30 days.
-Query parameter 'days' can be 1, 7, or 30 (default: 7).
+ * Query parameter 'days' can be 1, 7, or 30 (default: 7).
  */
 export const dataWarehouseJobStatsRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDataWarehouseJobStatsRetrieveUrl(projectId), {
@@ -342,7 +342,7 @@ export const getDataWarehouseRunningActivityRetrieveUrl = (projectId: string) =>
 
 /**
  * Returns currently running activities (jobs with status 'Running').
-Supports pagination and cutoff time filtering.
+ * Supports pagination and cutoff time filtering.
  */
 export const dataWarehouseRunningActivityRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDataWarehouseRunningActivityRetrieveUrl(projectId), {
@@ -357,7 +357,7 @@ export const getDataWarehouseTotalRowsStatsRetrieveUrl = (projectId: string) => 
 
 /**
  * Returns aggregated statistics for the data warehouse total rows processed within the current billing period.
-Used by the frontend data warehouse scene to display usage information.
+ * Used by the frontend data warehouse scene to display usage information.
  */
 export const dataWarehouseTotalRowsStatsRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDataWarehouseTotalRowsStatsRetrieveUrl(projectId), {
@@ -388,7 +388,7 @@ export const getExternalDataSchemasListUrl = (projectId: string, params?: Extern
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -585,7 +585,7 @@ export const getExternalDataSourcesListUrl = (projectId: string, params?: Extern
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -717,7 +717,7 @@ export const getExternalDataSourcesBulkUpdateSchemasPartialUpdateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -755,11 +755,11 @@ export const getExternalDataSourcesCdcStatusRetrieveUrl = (projectId: string, id
 
 /**
  * Live CDC health for an existing source: slot/publication existence and WAL lag.
-
-Reads from the source DB via the engine adapter. Returns ``{"enabled": false}``
-when CDC is off, or the stored config plus live ``slot_exists`` /
-``publication_exists`` / ``lag_bytes`` when on. 400s if the source DB is
-unreachable so the UI can show a degraded/unreachable state.
+ *
+ * Reads from the source DB via the engine adapter. Returns ``{"enabled": false}``
+ * when CDC is off, or the stored config plus live ``slot_exists`` /
+ * ``publication_exists`` / ``lag_bytes`` when on. 400s if the source DB is
+ * unreachable so the UI can show a degraded/unreachable state.
  */
 export const externalDataSourcesCdcStatusRetrieve = async (
     projectId: string,
@@ -778,15 +778,15 @@ export const getExternalDataSourcesCheckCdcPrerequisitesForSourceCreateUrl = (pr
 
 /**
  * Validate CDC prerequisites for an existing source using its stored credentials.
-
-The detail=False ``check_cdc_prerequisites`` action is for the creation wizard,
-where the client still holds the raw connection config (incl. password) in the
-form. On the Configuration page the source already exists and secret fields are
-stripped from API responses — so the client can't supply them. This reads the
-stored (encrypted) credentials from the DB via the adapter instead.
-
-Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
-``cdc_slot_name`` (optional), ``cdc_publication_name`` (optional).
+ *
+ * The detail=False ``check_cdc_prerequisites`` action is for the creation wizard,
+ * where the client still holds the raw connection config (incl. password) in the
+ * form. On the Configuration page the source already exists and secret fields are
+ * stripped from API responses — so the client can't supply them. This reads the
+ * stored (encrypted) credentials from the DB via the adapter instead.
+ *
+ * Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
+ * ``cdc_slot_name`` (optional), ``cdc_publication_name`` (optional).
  */
 export const externalDataSourcesCheckCdcPrerequisitesForSourceCreate = async (
     projectId: string,
@@ -850,13 +850,13 @@ export const getExternalDataSourcesDisableCdcCreateUrl = (projectId: string, id:
 
 /**
  * Disable CDC on an existing source.
-
-Cancels any running CDC extraction workflow, deletes the extraction schedule,
-delegates engine-side teardown to the source's adapter (drops slot/publication
-for Postgres; equivalent for other engines), clears ``cdc_*`` keys from
-``job_inputs``, soft-deletes companion CDC tables, and sets all CDC schemas to
-``sync_type=None``, ``should_sync=False`` so the user must pick a new sync
-strategy before they resume.
+ *
+ * Cancels any running CDC extraction workflow, deletes the extraction schedule,
+ * delegates engine-side teardown to the source's adapter (drops slot/publication
+ * for Postgres; equivalent for other engines), clears ``cdc_*`` keys from
+ * ``job_inputs``, soft-deletes companion CDC tables, and sets all CDC schemas to
+ * ``sync_type=None``, ``should_sync=False`` so the user must pick a new sync
+ * strategy before they resume.
  */
 export const externalDataSourcesDisableCdcCreate = async (
     projectId: string,
@@ -878,17 +878,17 @@ export const getExternalDataSourcesEnableCdcCreateUrl = (projectId: string, id: 
 
 /**
  * Enable CDC on an existing source.
-
-Provisions engine-side CDC resources via the source's adapter, writes the CDC
-config into ``source.job_inputs``, and ensures the CDC extraction schedule
-exists. Re-runs prereq checks server-side so we never trust a stale
-client-side check.
-
-Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
-plus engine-specific identifier hints (e.g. ``cdc_slot_name``,
-``cdc_publication_name`` for Postgres). Universal tuning fields:
-``cdc_auto_drop_slot`` (optional bool), ``cdc_lag_warning_threshold_mb``
-(optional int), ``cdc_lag_critical_threshold_mb`` (optional int).
+ *
+ * Provisions engine-side CDC resources via the source's adapter, writes the CDC
+ * config into ``source.job_inputs``, and ensures the CDC extraction schedule
+ * exists. Re-runs prereq checks server-side so we never trust a stale
+ * client-side check.
+ *
+ * Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
+ * plus engine-specific identifier hints (e.g. ``cdc_slot_name``,
+ * ``cdc_publication_name`` for Postgres). Universal tuning fields:
+ * ``cdc_auto_drop_slot`` (optional bool), ``cdc_lag_warning_threshold_mb``
+ * (optional int), ``cdc_lag_critical_threshold_mb`` (optional int).
  */
 export const externalDataSourcesEnableCdcCreate = async (
     projectId: string,
@@ -991,11 +991,11 @@ export const getExternalDataSourcesUpdateCdcSettingsCreateUrl = (projectId: stri
 
 /**
  * Update CDC tuning fields without enabling/disabling.
-
-Lets users edit ``cdc_auto_drop_slot``, ``cdc_lag_warning_threshold_mb``, and
-``cdc_lag_critical_threshold_mb`` independently. These fields are universal
-across engines. Engine-specific identifiers (slot name, management mode, …)
-are immutable post-enable — switching them requires disable + enable.
+ *
+ * Lets users edit ``cdc_auto_drop_slot``, ``cdc_lag_warning_threshold_mb``, and
+ * ``cdc_lag_critical_threshold_mb`` independently. These fields are universal
+ * across engines. Engine-specific identifiers (slot name, management mode, …)
+ * are immutable post-enable — switching them requires disable + enable.
  */
 export const externalDataSourcesUpdateCdcSettingsCreate = async (
     projectId: string,
@@ -1056,9 +1056,9 @@ export const getExternalDataSourcesCheckCdcPrerequisitesCreateUrl = (projectId: 
 
 /**
  * Validate CDC prerequisites against a live Postgres connection.
-
-Used by the source wizard to surface ✅/❌ checks before source creation,
-and by the self-managed setup popup to verify user-created publications.
+ *
+ * Used by the source wizard to surface ✅/❌ checks before source creation,
+ * and by the self-managed setup popup to verify user-created publications.
  */
 export const externalDataSourcesCheckCdcPrerequisitesCreate = async (
     projectId: string,
@@ -1081,7 +1081,7 @@ export const getExternalDataSourcesConnectionsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1168,7 +1168,7 @@ export const getFixHogqlListUrl = (projectId: string, params?: FixHogqlListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1250,7 +1250,7 @@ export const getInsightVariablesListUrl = (projectId: string, params?: InsightVa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1368,7 +1368,7 @@ export const getManagedViewsetsRetrieveUrl = (projectId: string, kind: 'revenue_
 
 /**
  * Get all views associated with a specific managed viewset.
-GET /api/environments/{team_id}/managed_viewsets/{kind}/
+ * GET /api/environments/{team_id}/managed_viewsets/{kind}/
  */
 export const managedViewsetsRetrieve = async (
     projectId: string,
@@ -1387,7 +1387,7 @@ export const getManagedViewsetsUpdateUrl = (projectId: string, kind: 'revenue_an
 
 /**
  * Enable or disable a managed viewset by kind.
-PUT /api/environments/{team_id}/managed_viewsets/{kind}/ with body {"enabled": true/false}
+ * PUT /api/environments/{team_id}/managed_viewsets/{kind}/ with body {"enabled": true/false}
  */
 export const managedViewsetsUpdate = async (
     projectId: string,
@@ -1405,7 +1405,7 @@ export const getQueryTabStateListUrl = (projectId: string, params?: QueryTabStat
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1560,7 +1560,7 @@ export const getWarehouseModelPathsListUrl = (projectId: string, params?: Wareho
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1602,7 +1602,7 @@ export const getWarehouseSavedQueriesListUrl = (projectId: string, params?: Ware
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1752,10 +1752,10 @@ export const getWarehouseSavedQueriesAncestorsCreateUrl = (projectId: string, id
 
 /**
  * Return the ancestors of this saved query.
-
-By default, we return the immediate parents. The `level` parameter can be used to
-look further back into the ancestor tree. If `level` overshoots (i.e. points to only
-ancestors beyond the root), we return an empty list.
+ *
+ * By default, we return the immediate parents. The `level` parameter can be used to
+ * look further back into the ancestor tree. If `level` overshoots (i.e. points to only
+ * ancestors beyond the root), we return an empty list.
  */
 export const warehouseSavedQueriesAncestorsCreate = async (
     projectId: string,
@@ -1816,10 +1816,10 @@ export const getWarehouseSavedQueriesDescendantsCreateUrl = (projectId: string, 
 
 /**
  * Return the descendants of this saved query.
-
-By default, we return the immediate children. The `level` parameter can be used to
-look further ahead into the descendants tree. If `level` overshoots (i.e. points to only
-descendants further than a leaf), we return an empty list.
+ *
+ * By default, we return the immediate children. The `level` parameter can be used to
+ * look further ahead into the descendants tree. If `level` overshoots (i.e. points to only
+ * descendants further than a leaf), we return an empty list.
  */
 export const warehouseSavedQueriesDescendantsCreate = async (
     projectId: string,
@@ -1862,7 +1862,7 @@ export const getWarehouseSavedQueriesRevertMaterializationCreateUrl = (projectId
 
 /**
  * Undo materialization, revert back to the original view.
-(i.e. delete the materialized table and the schedule)
+ * (i.e. delete the materialized table and the schedule)
  */
 export const warehouseSavedQueriesRevertMaterializationCreate = async (
     projectId: string,
@@ -1926,9 +1926,9 @@ export const getWarehouseSavedQueriesResumeSchedulesCreateUrl = (projectId: stri
 
 /**
  * Resume paused materialization schedules for multiple matviews.
-
-Accepts a list of view IDs in the request body: {"view_ids": ["id1", "id2", ...]}
-This endpoint is idempotent - calling it on already running or non-existent schedules is safe.
+ *
+ * Accepts a list of view IDs in the request body: {"view_ids": ["id1", "id2", ...]}
+ * This endpoint is idempotent - calling it on already running or non-existent schedules is safe.
  */
 export const warehouseSavedQueriesResumeSchedulesCreate = async (
     projectId: string,
@@ -1951,7 +1951,7 @@ export const getWarehouseSavedQueryDraftsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2143,7 +2143,7 @@ export const getWarehouseTablesListUrl = (projectId: string, params?: WarehouseT
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2340,7 +2340,7 @@ export const getWarehouseViewLinkListUrl = (projectId: string, params?: Warehous
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -2484,7 +2484,7 @@ export const getWarehouseViewLinksListUrl = (projectId: string, params?: Warehou
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/data_warehouse/frontend/generated/api.zod.ts
+++ b/products/data_warehouse/frontend/generated/api.zod.ts
@@ -836,15 +836,15 @@ export const ExternalDataSourcesBulkUpdateSchemasPartialUpdateBody = /* @__PURE_
 
 /**
  * Validate CDC prerequisites for an existing source using its stored credentials.
-
-The detail=False ``check_cdc_prerequisites`` action is for the creation wizard,
-where the client still holds the raw connection config (incl. password) in the
-form. On the Configuration page the source already exists and secret fields are
-stripped from API responses — so the client can't supply them. This reads the
-stored (encrypted) credentials from the DB via the adapter instead.
-
-Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
-``cdc_slot_name`` (optional), ``cdc_publication_name`` (optional).
+ *
+ * The detail=False ``check_cdc_prerequisites`` action is for the creation wizard,
+ * where the client still holds the raw connection config (incl. password) in the
+ * form. On the Configuration page the source already exists and secret fields are
+ * stripped from API responses — so the client can't supply them. This reads the
+ * stored (encrypted) credentials from the DB via the adapter instead.
+ *
+ * Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
+ * ``cdc_slot_name`` (optional), ``cdc_publication_name`` (optional).
  */
 export const externalDataSourcesCheckCdcPrerequisitesForSourceCreateBodyPrefixMax = 100
 
@@ -926,13 +926,13 @@ export const ExternalDataSourcesDeleteWebhookCreateBody = /* @__PURE__ */ zod
 
 /**
  * Disable CDC on an existing source.
-
-Cancels any running CDC extraction workflow, deletes the extraction schedule,
-delegates engine-side teardown to the source's adapter (drops slot/publication
-for Postgres; equivalent for other engines), clears ``cdc_*`` keys from
-``job_inputs``, soft-deletes companion CDC tables, and sets all CDC schemas to
-``sync_type=None``, ``should_sync=False`` so the user must pick a new sync
-strategy before they resume.
+ *
+ * Cancels any running CDC extraction workflow, deletes the extraction schedule,
+ * delegates engine-side teardown to the source's adapter (drops slot/publication
+ * for Postgres; equivalent for other engines), clears ``cdc_*`` keys from
+ * ``job_inputs``, soft-deletes companion CDC tables, and sets all CDC schemas to
+ * ``sync_type=None``, ``should_sync=False`` so the user must pick a new sync
+ * strategy before they resume.
  */
 export const externalDataSourcesDisableCdcCreateBodyPrefixMax = 100
 
@@ -959,17 +959,17 @@ export const ExternalDataSourcesDisableCdcCreateBody = /* @__PURE__ */ zod
 
 /**
  * Enable CDC on an existing source.
-
-Provisions engine-side CDC resources via the source's adapter, writes the CDC
-config into ``source.job_inputs``, and ensures the CDC extraction schedule
-exists. Re-runs prereq checks server-side so we never trust a stale
-client-side check.
-
-Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
-plus engine-specific identifier hints (e.g. ``cdc_slot_name``,
-``cdc_publication_name`` for Postgres). Universal tuning fields:
-``cdc_auto_drop_slot`` (optional bool), ``cdc_lag_warning_threshold_mb``
-(optional int), ``cdc_lag_critical_threshold_mb`` (optional int).
+ *
+ * Provisions engine-side CDC resources via the source's adapter, writes the CDC
+ * config into ``source.job_inputs``, and ensures the CDC extraction schedule
+ * exists. Re-runs prereq checks server-side so we never trust a stale
+ * client-side check.
+ *
+ * Body params: ``cdc_management_mode`` (``"posthog"`` | ``"self_managed"``),
+ * plus engine-specific identifier hints (e.g. ``cdc_slot_name``,
+ * ``cdc_publication_name`` for Postgres). Universal tuning fields:
+ * ``cdc_auto_drop_slot`` (optional bool), ``cdc_lag_warning_threshold_mb``
+ * (optional int), ``cdc_lag_critical_threshold_mb`` (optional int).
  */
 export const externalDataSourcesEnableCdcCreateBodyPrefixMax = 100
 
@@ -1077,11 +1077,11 @@ export const ExternalDataSourcesRevenueAnalyticsConfigPartialUpdateBody = /* @__
 
 /**
  * Update CDC tuning fields without enabling/disabling.
-
-Lets users edit ``cdc_auto_drop_slot``, ``cdc_lag_warning_threshold_mb``, and
-``cdc_lag_critical_threshold_mb`` independently. These fields are universal
-across engines. Engine-specific identifiers (slot name, management mode, …)
-are immutable post-enable — switching them requires disable + enable.
+ *
+ * Lets users edit ``cdc_auto_drop_slot``, ``cdc_lag_warning_threshold_mb``, and
+ * ``cdc_lag_critical_threshold_mb`` independently. These fields are universal
+ * across engines. Engine-specific identifiers (slot name, management mode, …)
+ * are immutable post-enable — switching them requires disable + enable.
  */
 export const externalDataSourcesUpdateCdcSettingsCreateBodyPrefixMax = 100
 
@@ -1547,10 +1547,10 @@ export const WarehouseSavedQueriesPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Return the ancestors of this saved query.
-
-By default, we return the immediate parents. The `level` parameter can be used to
-look further back into the ancestor tree. If `level` overshoots (i.e. points to only
-ancestors beyond the root), we return an empty list.
+ *
+ * By default, we return the immediate parents. The `level` parameter can be used to
+ * look further back into the ancestor tree. If `level` overshoots (i.e. points to only
+ * ancestors beyond the root), we return an empty list.
  */
 export const warehouseSavedQueriesAncestorsCreateBodyNameMax = 128
 
@@ -1637,10 +1637,10 @@ export const WarehouseSavedQueriesCancelCreateBody = /* @__PURE__ */ zod
 
 /**
  * Return the descendants of this saved query.
-
-By default, we return the immediate children. The `level` parameter can be used to
-look further ahead into the descendants tree. If `level` overshoots (i.e. points to only
-descendants further than a leaf), we return an empty list.
+ *
+ * By default, we return the immediate children. The `level` parameter can be used to
+ * look further ahead into the descendants tree. If `level` overshoots (i.e. points to only
+ * descendants further than a leaf), we return an empty list.
  */
 export const warehouseSavedQueriesDescendantsCreateBodyNameMax = 128
 
@@ -1727,7 +1727,7 @@ export const WarehouseSavedQueriesMaterializeCreateBody = /* @__PURE__ */ zod
 
 /**
  * Undo materialization, revert back to the original view.
-(i.e. delete the materialized table and the schedule)
+ * (i.e. delete the materialized table and the schedule)
  */
 export const warehouseSavedQueriesRevertMaterializationCreateBodyNameMax = 128
 
@@ -1816,9 +1816,9 @@ export const WarehouseSavedQueriesRunCreateBody = /* @__PURE__ */ zod
 
 /**
  * Resume paused materialization schedules for multiple matviews.
-
-Accepts a list of view IDs in the request body: {"view_ids": ["id1", "id2", ...]}
-This endpoint is idempotent - calling it on already running or non-existent schedules is safe.
+ *
+ * Accepts a list of view IDs in the request body: {"view_ids": ["id1", "id2", ...]}
+ * This endpoint is idempotent - calling it on already running or non-existent schedules is safe.
  */
 export const warehouseSavedQueriesResumeSchedulesCreateBodyNameMax = 128
 

--- a/products/desktop_recordings/frontend/generated/api.schemas.ts
+++ b/products/desktop_recordings/frontend/generated/api.schemas.ts
@@ -9,10 +9,10 @@
  */
 /**
  * * `zoom` - Zoom
- * `teams` - Microsoft Teams
- * `meet` - Google Meet
- * `desktop_audio` - Desktop audio
- * `slack` - Slack huddle
+ * * `teams` - Microsoft Teams
+ * * `meet` - Google Meet
+ * * `desktop_audio` - Desktop audio
+ * * `slack` - Slack huddle
  */
 export type MeetingPlatformEnumApi = (typeof MeetingPlatformEnumApi)[keyof typeof MeetingPlatformEnumApi]
 
@@ -26,10 +26,10 @@ export const MeetingPlatformEnumApi = {
 
 /**
  * * `recording` - Recording
- * `uploading` - Uploading
- * `processing` - Processing
- * `ready` - Ready
- * `error` - Error
+ * * `uploading` - Uploading
+ * * `processing` - Processing
+ * * `ready` - Ready
+ * * `error` - Error
  */
 export type DesktopRecordingStatusEnumApi =
     (typeof DesktopRecordingStatusEnumApi)[keyof typeof DesktopRecordingStatusEnumApi]
@@ -148,10 +148,10 @@ export interface PaginatedDesktopRecordingListApi {
 
 /**
  * * `zoom` - zoom
- * `teams` - teams
- * `meet` - meet
- * `desktop_audio` - desktop_audio
- * `slack` - slack
+ * * `teams` - teams
+ * * `meet` - meet
+ * * `desktop_audio` - desktop_audio
+ * * `slack` - slack
  */
 export type CreateRecordingRequestPlatformEnumApi =
     (typeof CreateRecordingRequestPlatformEnumApi)[keyof typeof CreateRecordingRequestPlatformEnumApi]
@@ -169,12 +169,12 @@ export const CreateRecordingRequestPlatformEnumApi = {
  */
 export interface CreateRecordingRequestApi {
     /** Meeting platform being recorded
-
-  * `zoom` - zoom
-  * `teams` - teams
-  * `meet` - meet
-  * `desktop_audio` - desktop_audio
-  * `slack` - slack */
+     *
+     * * `zoom` - zoom
+     * * `teams` - teams
+     * * `meet` - meet
+     * * `desktop_audio` - desktop_audio
+     * * `slack` - slack */
     platform?: CreateRecordingRequestPlatformEnumApi
 }
 

--- a/products/desktop_recordings/frontend/generated/api.ts
+++ b/products/desktop_recordings/frontend/generated/api.ts
@@ -40,7 +40,7 @@ export const getDesktopRecordingsListUrl = (projectId: string, params?: DesktopR
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -53,8 +53,8 @@ export const getDesktopRecordingsListUrl = (projectId: string, params?: DesktopR
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsList = async (
     projectId: string,
@@ -93,8 +93,8 @@ export const getDesktopRecordingsRetrieveUrl = (projectId: string, id: string) =
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsRetrieve = async (
     projectId: string,
@@ -113,8 +113,8 @@ export const getDesktopRecordingsUpdateUrl = (projectId: string, id: string) => 
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsUpdate = async (
     projectId: string,
@@ -136,8 +136,8 @@ export const getDesktopRecordingsPartialUpdateUrl = (projectId: string, id: stri
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsPartialUpdate = async (
     projectId: string,
@@ -159,8 +159,8 @@ export const getDesktopRecordingsDestroyUrl = (projectId: string, id: string) =>
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getDesktopRecordingsDestroyUrl(projectId, id), {

--- a/products/desktop_recordings/frontend/generated/api.zod.ts
+++ b/products/desktop_recordings/frontend/generated/api.zod.ts
@@ -30,8 +30,8 @@ export const DesktopRecordingsCreateBody = /* @__PURE__ */ zod
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsUpdateBodyMeetingTitleMax = 255
 
@@ -109,8 +109,8 @@ export const DesktopRecordingsUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * RESTful API for managing desktop meeting recordings.
-
-Standard CRUD operations plus transcript management as a subresource.
+ *
+ * Standard CRUD operations plus transcript management as a subresource.
  */
 export const desktopRecordingsPartialUpdateBodyMeetingTitleMax = 255
 

--- a/products/early_access_features/frontend/generated/api.schemas.ts
+++ b/products/early_access_features/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `server` - Server
- * `client` - Client
- * `all` - All
+ * * `client` - Client
+ * * `all` - All
  */
 export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
 
@@ -28,7 +28,7 @@ export const BlankEnumApi = {
 
 /**
  * * `distinct_id` - User ID (default)
- * `device_id` - Device ID
+ * * `device_id` - Device ID
  */
 export type BucketingIdentifierEnumApi = (typeof BucketingIdentifierEnumApi)[keyof typeof BucketingIdentifierEnumApi]
 
@@ -57,26 +57,26 @@ export interface MinimalFeatureFlagApi {
      */
     version?: number | null
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     readonly evaluation_contexts: readonly string[]
 }
 
 /**
  * * `draft` - draft
- * `concept` - concept
- * `alpha` - alpha
- * `beta` - beta
- * `general-availability` - general availability
- * `archived` - archived
+ * * `concept` - concept
+ * * `alpha` - alpha
+ * * `beta` - beta
+ * * `general-availability` - general availability
+ * * `archived` - archived
  */
 export type StageEnumApi = (typeof StageEnumApi)[keyof typeof StageEnumApi]
 
@@ -105,13 +105,13 @@ export interface EarlyAccessFeatureApi {
     /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
     description?: string
     /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-  * `draft` - draft
-  * `concept` - concept
-  * `alpha` - alpha
-  * `beta` - beta
-  * `general-availability` - general availability
-  * `archived` - archived */
+     *
+     * * `draft` - draft
+     * * `concept` - concept
+     * * `alpha` - alpha
+     * * `beta` - beta
+     * * `general-availability` - general availability
+     * * `archived` - archived */
     stage: StageEnumApi
     /**
      * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -142,13 +142,13 @@ export interface EarlyAccessFeatureSerializerCreateOnlyApi {
     /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
     description?: string
     /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-  * `draft` - draft
-  * `concept` - concept
-  * `alpha` - alpha
-  * `beta` - beta
-  * `general-availability` - general availability
-  * `archived` - archived */
+     *
+     * * `draft` - draft
+     * * `concept` - concept
+     * * `alpha` - alpha
+     * * `beta` - beta
+     * * `general-availability` - general availability
+     * * `archived` - archived */
     stage: StageEnumApi
     /**
      * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -180,13 +180,13 @@ export interface PatchedEarlyAccessFeatureApi {
     /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
     description?: string
     /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-  * `draft` - draft
-  * `concept` - concept
-  * `alpha` - alpha
-  * `beta` - beta
-  * `general-availability` - general availability
-  * `archived` - archived */
+     *
+     * * `draft` - draft
+     * * `concept` - concept
+     * * `alpha` - alpha
+     * * `beta` - beta
+     * * `general-availability` - general availability
+     * * `archived` - archived */
     stage?: StageEnumApi
     /**
      * URL to external documentation for this feature. Shown to users in the opt-in UI.

--- a/products/early_access_features/frontend/generated/api.ts
+++ b/products/early_access_features/frontend/generated/api.ts
@@ -38,7 +38,7 @@ export const getEarlyAccessFeatureListUrl = (projectId: string, params?: EarlyAc
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -440,14 +440,14 @@ export interface EndpointRunResponseApi {
 
 /**
  * Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-
-For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-
-For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-
-For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-
-Unknown variable names will return a 400 error.
+ *
+ * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+ *
+ * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+ *
+ * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+ *
+ * Unknown variable names will return a 400 error.
  */
 export type EndpointRunRequestApiVariables = { [key: string]: unknown } | null
 
@@ -792,14 +792,14 @@ export interface EndpointRunRequestApi {
     offset?: number | null
     refresh?: EndpointRefreshModeApi | null
     /** Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-
-  For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-
-  For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-
-  For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-
-  Unknown variable names will return a 400 error. */
+     *
+     * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+     *
+     * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+     *
+     * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+     *
+     * Unknown variable names will return a 400 error. */
     variables?: EndpointRunRequestApiVariables
     /** Specific endpoint version to execute. If not provided, the latest version is used. */
     version?: number | null

--- a/products/endpoints/frontend/generated/api.ts
+++ b/products/endpoints/frontend/generated/api.ts
@@ -31,7 +31,7 @@ export const getEndpointsListUrl = (projectId: string, params?: EndpointsListPar
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -198,7 +198,7 @@ export const getEndpointsOpenapiSpecRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -268,7 +268,7 @@ export const getEndpointsVersionsListUrl = (projectId: string, name: string, par
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/engineering_analytics/frontend/generated/api.schemas.ts
+++ b/products/engineering_analytics/frontend/generated/api.schemas.ts
@@ -40,8 +40,8 @@ export interface RepoRefApi {
 
 /**
  * * `open` - OPEN
- * `closed` - CLOSED
- * `merged` - MERGED
+ * * `closed` - CLOSED
+ * * `merged` - MERGED
  */
 export type EngineeringAnalyticsPRStateEnumApi =
     (typeof EngineeringAnalyticsPRStateEnumApi)[keyof typeof EngineeringAnalyticsPRStateEnumApi]
@@ -64,10 +64,10 @@ export interface PullRequestApi {
     /** Pull request title. */
     title: string
     /** Derived state: 'open', 'closed', or 'merged'.
-
-  * `open` - OPEN
-  * `closed` - CLOSED
-  * `merged` - MERGED */
+     *
+     * * `open` - OPEN
+     * * `closed` - CLOSED
+     * * `merged` - MERGED */
     state: EngineeringAnalyticsPRStateEnumApi
     /** True if the pull request is a draft. */
     is_draft: boolean
@@ -87,10 +87,10 @@ export interface PullRequestApi {
 
 /**
  * * `opened` - OPENED
- * `ci_started` - CI_STARTED
- * `ci_finished` - CI_FINISHED
- * `merged` - MERGED
- * `closed` - CLOSED
+ * * `ci_started` - CI_STARTED
+ * * `ci_finished` - CI_FINISHED
+ * * `merged` - MERGED
+ * * `closed` - CLOSED
  */
 export type PRLifecycleEventKindEnumApi = (typeof PRLifecycleEventKindEnumApi)[keyof typeof PRLifecycleEventKindEnumApi]
 
@@ -104,12 +104,12 @@ export const PRLifecycleEventKindEnumApi = {
 
 export interface PRLifecycleEventApi {
     /** Event kind: opened, ci_started, ci_finished, merged, or closed.
-
-  * `opened` - OPENED
-  * `ci_started` - CI_STARTED
-  * `ci_finished` - CI_FINISHED
-  * `merged` - MERGED
-  * `closed` - CLOSED */
+     *
+     * * `opened` - OPENED
+     * * `ci_started` - CI_STARTED
+     * * `ci_finished` - CI_FINISHED
+     * * `merged` - MERGED
+     * * `closed` - CLOSED */
     kind: PRLifecycleEventKindEnumApi
     /** When the event occurred. */
     at: string
@@ -122,8 +122,8 @@ export interface PRLifecycleEventApi {
 
 /**
  * * `precise` - PRECISE
- * `coarse` - COARSE
- * `partial` - PARTIAL
+ * * `coarse` - COARSE
+ * * `partial` - PARTIAL
  */
 export type MetricQualityEnumApi = (typeof MetricQualityEnumApi)[keyof typeof MetricQualityEnumApi]
 
@@ -139,10 +139,10 @@ export interface PRLifecycleApi {
     /** Lifecycle events ordered by time. */
     events: PRLifecycleEventApi[]
     /** Always 'partial' — CI events only; reviews and comments are not yet available.
-
-  * `precise` - PRECISE
-  * `coarse` - COARSE
-  * `partial` - PARTIAL */
+     *
+     * * `precise` - PRECISE
+     * * `coarse` - COARSE
+     * * `partial` - PARTIAL */
     metric_quality?: MetricQualityEnumApi
 }
 
@@ -169,10 +169,10 @@ export interface PullRequestListItemApi {
     /** Pull request title. */
     title: string
     /** Derived state: 'open', 'closed', or 'merged'.
-
-  * `open` - OPEN
-  * `closed` - CLOSED
-  * `merged` - MERGED */
+     *
+     * * `open` - OPEN
+     * * `closed` - CLOSED
+     * * `merged` - MERGED */
     state: EngineeringAnalyticsPRStateEnumApi
     /** True if the pull request is a draft. */
     is_draft: boolean

--- a/products/engineering_analytics/frontend/generated/api.ts
+++ b/products/engineering_analytics/frontend/generated/api.ts
@@ -43,7 +43,7 @@ export const getEngineeringAnalyticsPrLifecycleUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -76,7 +76,7 @@ export const getEngineeringAnalyticsPullRequestsUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -109,7 +109,7 @@ export const getEngineeringAnalyticsWorkflowHealthUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -315,7 +315,7 @@ export interface PropertyGroupFilterValueApi {
 
 /**
  * * `user` - user
- * `role` - role
+ * * `role` - role
  */
 export type AssigneeTypeEnumApi = (typeof AssigneeTypeEnumApi)[keyof typeof AssigneeTypeEnumApi]
 
@@ -326,9 +326,9 @@ export const AssigneeTypeEnumApi = {
 
 export interface ErrorTrackingAssignmentRuleAssigneeRequestApi {
     /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-
-  * `user` - user
-  * `role` - role */
+     *
+     * * `user` - user
+     * * `role` - role */
     type: AssigneeTypeEnumApi
     /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
     id: number | string
@@ -469,9 +469,9 @@ export interface ErrorTrackingGroupingRuleListResponseApi {
 
 export interface ErrorTrackingGroupingRuleAssigneeRequestApi {
     /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-
-  * `user` - user
-  * `role` - role */
+     *
+     * * `user` - user
+     * * `role` - role */
     type: AssigneeTypeEnumApi
     /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
     id: number | string
@@ -537,10 +537,10 @@ export interface PatchedErrorTrackingGroupingRuleApi {
 
 /**
  * * `archived` - Archived
- * `active` - Active
- * `resolved` - Resolved
- * `pending_release` - Pending release
- * `suppressed` - Suppressed
+ * * `active` - Active
+ * * `resolved` - Resolved
+ * * `pending_release` - Pending release
+ * * `suppressed` - Suppressed
  */
 export type ErrorTrackingIssueFullStatusEnumApi =
     (typeof ErrorTrackingIssueFullStatusEnumApi)[keyof typeof ErrorTrackingIssueFullStatusEnumApi]
@@ -795,22 +795,22 @@ export interface ErrorTrackingIssueDetailApi {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
- * `gt` - gt
- * `lt` - lt
- * `gte` - gte
- * `lte` - lte
- * `is_set` - is_set
- * `is_not_set` - is_not_set
- * `is_date_exact` - is_date_exact
- * `is_date_after` - is_date_after
- * `is_date_before` - is_date_before
- * `in` - in
- * `not_in` - not_in
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
+ * * `gt` - gt
+ * * `lt` - lt
+ * * `gte` - gte
+ * * `lte` - lte
+ * * `is_set` - is_set
+ * * `is_not_set` - is_not_set
+ * * `is_date_exact` - is_date_exact
+ * * `is_date_after` - is_date_after
+ * * `is_date_before` - is_date_before
+ * * `in` - in
+ * * `not_in` - not_in
  */
 export type PropertyItemOperatorEnumApi = (typeof PropertyItemOperatorEnumApi)[keyof typeof PropertyItemOperatorEnumApi]
 
@@ -842,32 +842,32 @@ export const BlankEnumApi = {
 
 /**
  * * `event` - event
- * `event_metadata` - event_metadata
- * `feature` - feature
- * `person` - person
- * `cohort` - cohort
- * `element` - element
- * `static-cohort` - static-cohort
- * `dynamic-cohort` - dynamic-cohort
- * `precalculated-cohort` - precalculated-cohort
- * `group` - group
- * `recording` - recording
- * `log_entry` - log_entry
- * `behavioral` - behavioral
- * `session` - session
- * `hogql` - hogql
- * `data_warehouse` - data_warehouse
- * `data_warehouse_person_property` - data_warehouse_person_property
- * `error_tracking_issue` - error_tracking_issue
- * `log` - log
- * `log_attribute` - log_attribute
- * `log_resource_attribute` - log_resource_attribute
- * `span` - span
- * `span_attribute` - span_attribute
- * `span_resource_attribute` - span_resource_attribute
- * `revenue_analytics` - revenue_analytics
- * `flag` - flag
- * `workflow_variable` - workflow_variable
+ * * `event_metadata` - event_metadata
+ * * `feature` - feature
+ * * `person` - person
+ * * `cohort` - cohort
+ * * `element` - element
+ * * `static-cohort` - static-cohort
+ * * `dynamic-cohort` - dynamic-cohort
+ * * `precalculated-cohort` - precalculated-cohort
+ * * `group` - group
+ * * `recording` - recording
+ * * `log_entry` - log_entry
+ * * `behavioral` - behavioral
+ * * `session` - session
+ * * `hogql` - hogql
+ * * `data_warehouse` - data_warehouse
+ * * `data_warehouse_person_property` - data_warehouse_person_property
+ * * `error_tracking_issue` - error_tracking_issue
+ * * `log` - log
+ * * `log_attribute` - log_attribute
+ * * `log_resource_attribute` - log_resource_attribute
+ * * `span` - span
+ * * `span_attribute` - span_attribute
+ * * `span_resource_attribute` - span_resource_attribute
+ * * `revenue_analytics` - revenue_analytics
+ * * `flag` - flag
+ * * `workflow_variable` - workflow_variable
  */
 export type PropertyFilterTypeEnumApi = (typeof PropertyFilterTypeEnumApi)[keyof typeof PropertyFilterTypeEnumApi]
 
@@ -913,7 +913,7 @@ export interface PropertyItemApi {
 
 /**
  * * `ASC` - ASC
- * `DESC` - DESC
+ * * `DESC` - DESC
  */
 export type OrderDirectionEnumApi = (typeof OrderDirectionEnumApi)[keyof typeof OrderDirectionEnumApi]
 
@@ -924,8 +924,8 @@ export const OrderDirectionEnumApi = {
 
 /**
  * * `summary` - summary
- * `stack` - stack
- * `raw` - raw
+ * * `stack` - stack
+ * * `raw` - raw
  */
 export type VerbosityEnumApi = (typeof VerbosityEnumApi)[keyof typeof VerbosityEnumApi]
 
@@ -950,9 +950,9 @@ export interface ErrorTrackingIssueEventsQueryRequestApi {
      */
     searchQuery?: string
     /** Timestamp sort direction. Defaults to DESC.
-
-  * `ASC` - ASC
-  * `DESC` - DESC */
+     *
+     * * `ASC` - ASC
+     * * `DESC` - DESC */
     orderDirection?: OrderDirectionEnumApi
     /**
      * Page size.
@@ -966,10 +966,10 @@ export interface ErrorTrackingIssueEventsQueryRequestApi {
      */
     offset?: number
     /** Controls exception detail size: summary, stack, or raw. Defaults to summary.
-
-  * `summary` - summary
-  * `stack` - stack
-  * `raw` - raw */
+     *
+     * * `summary` - summary
+     * * `stack` - stack
+     * * `raw` - raw */
     verbosity?: VerbosityEnumApi
     /** When true, include only stack frames marked in_app. Defaults to true. */
     onlyAppFrames?: boolean
@@ -1006,11 +1006,11 @@ export interface ErrorTrackingIssueEventsResponseApi {
 
 /**
  * * `archived` - archived
- * `active` - active
- * `resolved` - resolved
- * `pending_release` - pending_release
- * `suppressed` - suppressed
- * `all` - all
+ * * `active` - active
+ * * `resolved` - resolved
+ * * `pending_release` - pending_release
+ * * `suppressed` - suppressed
+ * * `all` - all
  */
 export type ErrorTrackingIssueStatusEnumApi =
     (typeof ErrorTrackingIssueStatusEnumApi)[keyof typeof ErrorTrackingIssueStatusEnumApi]
@@ -1028,18 +1028,18 @@ export interface ErrorTrackingAssigneeApi {
     /** User ID or role UUID to filter by. */
     id: string | number | null
     /** Assignee target type: user or role.
-
-  * `user` - user
-  * `role` - role */
+     *
+     * * `user` - user
+     * * `role` - role */
     type: AssigneeTypeEnumApi
 }
 
 /**
  * * `last_seen` - last_seen
- * `first_seen` - first_seen
- * `occurrences` - occurrences
- * `users` - users
- * `sessions` - sessions
+ * * `first_seen` - first_seen
+ * * `occurrences` - occurrences
+ * * `users` - users
+ * * `sessions` - sessions
  */
 export type ErrorTrackingIssueOrderByEnumApi =
     (typeof ErrorTrackingIssueOrderByEnumApi)[keyof typeof ErrorTrackingIssueOrderByEnumApi]
@@ -1056,13 +1056,13 @@ export interface ErrorTrackingIssuesListQueryRequestApi {
     /** Date range for issue aggregates. Defaults to the last 7 days. */
     dateRange?: ErrorTrackingDateRangeApi
     /** Filter by issue status. Defaults to active.
-
-  * `archived` - archived
-  * `active` - active
-  * `resolved` - resolved
-  * `pending_release` - pending_release
-  * `suppressed` - suppressed
-  * `all` - all */
+     *
+     * * `archived` - archived
+     * * `active` - active
+     * * `resolved` - resolved
+     * * `pending_release` - pending_release
+     * * `suppressed` - suppressed
+     * * `all` - all */
     status?: ErrorTrackingIssueStatusEnumApi
     /** Filter by issue assignee. Omit to include all assignees. */
     assignee?: ErrorTrackingAssigneeApi | null
@@ -1076,17 +1076,17 @@ export interface ErrorTrackingIssuesListQueryRequestApi {
     /** Advanced flat AND property filters. Prefer typed shortcut fields when they fit. HogQL filters are rejected. */
     filterGroup?: PropertyItemApi[]
     /** Field used to sort issues. Defaults to occurrences.
-
-  * `last_seen` - last_seen
-  * `first_seen` - first_seen
-  * `occurrences` - occurrences
-  * `users` - users
-  * `sessions` - sessions */
+     *
+     * * `last_seen` - last_seen
+     * * `first_seen` - first_seen
+     * * `occurrences` - occurrences
+     * * `users` - users
+     * * `sessions` - sessions */
     orderBy?: ErrorTrackingIssueOrderByEnumApi
     /** Sort direction. Defaults to DESC.
-
-  * `ASC` - ASC
-  * `DESC` - DESC */
+     *
+     * * `ASC` - ASC
+     * * `DESC` - DESC */
     orderDirection?: OrderDirectionEnumApi
     /**
      * Page size.
@@ -1189,7 +1189,7 @@ export interface ErrorTrackingIssuesListResponseApi {
 
 /**
  * * `ready` - Ready
- * `computing` - Computing
+ * * `computing` - Computing
  */
 export type ErrorTrackingRecommendationStatusEnumApi =
     (typeof ErrorTrackingRecommendationStatusEnumApi)[keyof typeof ErrorTrackingRecommendationStatusEnumApi]
@@ -1214,9 +1214,9 @@ export interface ErrorTrackingRecommendationApi {
     /** Whether the recommendation's recommended action has been satisfied. */
     readonly completed: boolean
     /** 'ready' if meta is fresh, 'computing' if a refresh is in progress.
-
-  * `ready` - Ready
-  * `computing` - Computing */
+     *
+     * * `ready` - Ready
+     * * `computing` - Computing */
     readonly status: ErrorTrackingRecommendationStatusEnumApi
     /**
      * Timestamp meta was last successfully computed.
@@ -1732,16 +1732,16 @@ export type ErrorTrackingSymbolSetsListParams = {
      */
     offset?: number
     /**
- * Sort order for symbol sets. Prefix with `-` for descending order.
-
-* `created_at` - created_at
-* `-created_at` - -created_at
-* `ref` - ref
-* `-ref` - -ref
-* `last_used` - last_used
-* `-last_used` - -last_used
- * @minLength 1
- */
+     * Sort order for symbol sets. Prefix with `-` for descending order.
+     *
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `ref` - ref
+     * * `-ref` - -ref
+     * * `last_used` - last_used
+     * * `-last_used` - -last_used
+     * @minLength 1
+     */
     order_by?: string
     /**
      * Exact symbol set reference to filter by.
@@ -1754,13 +1754,13 @@ export type ErrorTrackingSymbolSetsListParams = {
      */
     search?: string
     /**
- * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-
-* `all` - all
-* `valid` - valid
-* `invalid` - invalid
- * @minLength 1
- */
+     * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
+     *
+     * * `all` - all
+     * * `valid` - valid
+     * * `invalid` - invalid
+     * @minLength 1
+     */
     status?: ErrorTrackingSymbolSetsListStatus
 }
 

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -103,7 +103,7 @@ export const getErrorTrackingAssignmentRulesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -236,7 +236,7 @@ export const getErrorTrackingExternalReferencesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -322,7 +322,7 @@ export const getErrorTrackingFingerprintsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -388,7 +388,7 @@ export const getErrorTrackingGitProviderFileLinksResolveGithubRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -421,7 +421,7 @@ export const getErrorTrackingGitProviderFileLinksResolveGitlabRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -565,7 +565,7 @@ export const getErrorTrackingIssuesListUrl = (projectId: string, params?: ErrorT
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -884,7 +884,7 @@ export const getErrorTrackingRecommendationsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -959,7 +959,7 @@ export const getErrorTrackingReleasesListUrl = (projectId: string, params?: Erro
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1149,7 +1149,7 @@ export const getErrorTrackingSpikeEventsListUrl = (projectId: string, params?: E
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1176,7 +1176,7 @@ export const getErrorTrackingStackFramesListUrl = (projectId: string, params?: E
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1256,7 +1256,7 @@ export const getErrorTrackingSuppressionRulesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1386,7 +1386,7 @@ export const getErrorTrackingSymbolSetsListUrl = (projectId: string, params?: Er
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/event_definitions/frontend/generated/api.schemas.ts
+++ b/products/event_definitions/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -64,7 +64,7 @@ export interface UserBasicApi {
 
 /**
  * * `allow` - Allow
- * `reject` - Reject
+ * * `reject` - Reject
  */
 export type EnforcementModeEnumApi = (typeof EnforcementModeEnumApi)[keyof typeof EnforcementModeEnumApi]
 
@@ -168,8 +168,8 @@ export interface PatchedEnterpriseEventDefinitionApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -186,10 +186,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]

--- a/products/event_definitions/frontend/generated/api.ts
+++ b/products/event_definitions/frontend/generated/api.ts
@@ -43,7 +43,7 @@ export const getEventDefinitionsListUrl = (projectId: string, params?: EventDefi
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -165,22 +165,22 @@ export const getEventDefinitionsBulkUpdateTagsCreateUrl = (projectId: string) =>
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const eventDefinitionsBulkUpdateTagsCreate = async (
     projectId: string,
@@ -203,7 +203,7 @@ export const getEventDefinitionsByNameRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -247,7 +247,7 @@ export const getEventDefinitionsPrimaryPropertiesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -260,10 +260,10 @@ export const getEventDefinitionsPrimaryPropertiesRetrieveUrl = (
 
 /**
  * Resolve team-configured primary properties for event definitions.
-
-The response only contains entries where a non-null primary_property is set on the
-EventDefinition. Callers should fall back to the core taxonomy defaults client-side
-for names not present in the response.
+ *
+ * The response only contains entries where a non-null primary_property is set on the
+ * EventDefinition. Callers should fall back to the core taxonomy defaults client-side
+ * for names not present in the response.
  */
 export const eventDefinitionsPrimaryPropertiesRetrieve = async (
     projectId: string,

--- a/products/event_definitions/frontend/generated/api.zod.ts
+++ b/products/event_definitions/frontend/generated/api.zod.ts
@@ -92,22 +92,22 @@ export const EventDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const eventDefinitionsBulkUpdateTagsCreateBodyIdsMax = 500
 

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -258,7 +258,7 @@ export interface ExperimentToSavedMetricApi {
 
 /**
  * * `web` - web
- * `product` - product
+ * * `product` - product
  */
 export type ExperimentTypeEnumApi = (typeof ExperimentTypeEnumApi)[keyof typeof ExperimentTypeEnumApi]
 
@@ -476,10 +476,10 @@ export type _ExperimentApiMetricsListApi = ExperimentApiMetricApi[]
 
 /**
  * * `won` - won
- * `lost` - lost
- * `inconclusive` - inconclusive
- * `stopped_early` - stopped_early
- * `invalid` - invalid
+ * * `lost` - lost
+ * * `inconclusive` - inconclusive
+ * * `stopped_early` - stopped_early
+ * * `invalid` - invalid
  */
 export type ConclusionEnumApi = (typeof ConclusionEnumApi)[keyof typeof ConclusionEnumApi]
 
@@ -549,9 +549,9 @@ export interface ExperimentApi {
     readonly created_at: string
     readonly updated_at: string
     /** Experiment type: web for frontend UI changes, product for backend/API changes.
-
-  * `web` - web
-  * `product` - product */
+     *
+     * * `web` - web
+     * * `product` - product */
     type?: ExperimentTypeEnumApi | null
     /** Exposure configuration including filter test accounts and custom exposure events. */
     exposure_criteria?: ExperimentApiExposureCriteriaApi | null
@@ -565,12 +565,12 @@ export interface ExperimentApi {
     allow_unknown_events?: boolean
     _create_in_folder?: string
     /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-
-  * `won` - won
-  * `lost` - lost
-  * `inconclusive` - inconclusive
-  * `stopped_early` - stopped_early
-  * `invalid` - invalid */
+     *
+     * * `won` - won
+     * * `lost` - lost
+     * * `inconclusive` - inconclusive
+     * * `stopped_early` - stopped_early
+     * * `invalid` - invalid */
     conclusion?: ConclusionEnumApi | null
     /**
      * Comment about the experiment conclusion.
@@ -649,9 +649,9 @@ export interface PatchedExperimentApi {
     readonly created_at?: string
     readonly updated_at?: string
     /** Experiment type: web for frontend UI changes, product for backend/API changes.
-
-  * `web` - web
-  * `product` - product */
+     *
+     * * `web` - web
+     * * `product` - product */
     type?: ExperimentTypeEnumApi | null
     /** Exposure configuration including filter test accounts and custom exposure events. */
     exposure_criteria?: ExperimentApiExposureCriteriaApi | null
@@ -665,12 +665,12 @@ export interface PatchedExperimentApi {
     allow_unknown_events?: boolean
     _create_in_folder?: string
     /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-
-  * `won` - won
-  * `lost` - lost
-  * `inconclusive` - inconclusive
-  * `stopped_early` - stopped_early
-  * `invalid` - invalid */
+     *
+     * * `won` - won
+     * * `lost` - lost
+     * * `inconclusive` - inconclusive
+     * * `stopped_early` - stopped_early
+     * * `invalid` - invalid */
     conclusion?: ConclusionEnumApi | null
     /**
      * Comment about the experiment conclusion.
@@ -702,12 +702,12 @@ export interface CopyExperimentToProjectApi {
 
 export interface EndExperimentApi {
     /** The conclusion of the experiment.
-
-  * `won` - won
-  * `lost` - lost
-  * `inconclusive` - inconclusive
-  * `stopped_early` - stopped_early
-  * `invalid` - invalid */
+     *
+     * * `won` - won
+     * * `lost` - lost
+     * * `inconclusive` - inconclusive
+     * * `stopped_early` - stopped_early
+     * * `invalid` - invalid */
     conclusion?: ConclusionEnumApi | null
     /**
      * Optional comment about the experiment conclusion.
@@ -718,12 +718,12 @@ export interface EndExperimentApi {
 
 export interface ShipVariantApi {
     /** The conclusion of the experiment.
-
-  * `won` - won
-  * `lost` - lost
-  * `inconclusive` - inconclusive
-  * `stopped_early` - stopped_early
-  * `invalid` - invalid */
+     *
+     * * `won` - won
+     * * `lost` - lost
+     * * `inconclusive` - inconclusive
+     * * `stopped_early` - stopped_early
+     * * `invalid` - invalid */
     conclusion?: ConclusionEnumApi | null
     /**
      * Optional comment about the experiment conclusion.
@@ -738,8 +738,8 @@ export interface ShipVariantApi {
 
 /**
  * * `cost` - cost
- * `latency` - latency
- * `eval_pass_rate` - eval_pass_rate
+ * * `latency` - latency
+ * * `eval_pass_rate` - eval_pass_rate
  */
 export type TemplatesEnumApi = (typeof TemplatesEnumApi)[keyof typeof TemplatesEnumApi]
 
@@ -756,6 +756,7 @@ export interface CreateFromPromptInputApi {
      * Ordered list of prompt version numbers to assign to experiment variants. The first entry is the control variant. Must contain between 2 and 10 distinct versions.
      * @minItems 2
      * @maxItems 10
+     * @items.minimum 1
      */
     versions: number[]
     /**

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -170,8 +170,8 @@ export interface PatchedExperimentSavedMetricApi {
 
 /**
  * * `server` - Server
- * `client` - Client
- * `all` - All
+ * * `client` - Client
+ * * `all` - All
  */
 export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
 
@@ -183,7 +183,7 @@ export const EvaluationRuntimeEnumApi = {
 
 /**
  * * `distinct_id` - User ID (default)
- * `device_id` - Device ID
+ * * `device_id` - Device ID
  */
 export type BucketingIdentifierEnumApi = (typeof BucketingIdentifierEnumApi)[keyof typeof BucketingIdentifierEnumApi]
 
@@ -212,15 +212,15 @@ export interface MinimalFeatureFlagApi {
      */
     version?: number | null
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     readonly evaluation_contexts: readonly string[]
 }

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -51,7 +51,7 @@ export const getExperimentHoldoutsListUrl = (projectId: string, params?: Experim
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -161,7 +161,7 @@ export const getExperimentSavedMetricsListUrl = (projectId: string, params?: Exp
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -271,7 +271,7 @@ export const getExperimentsListUrl = (projectId: string, params?: ExperimentsLis
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -340,10 +340,10 @@ export const getExperimentsUpdateUrl = (projectId: string, id: number) => {
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsUpdate = async (
     projectId: string,
@@ -400,10 +400,10 @@ export const getExperimentsArchiveCreateUrl = (projectId: string, id: number) =>
 
 /**
  * Archive an ended experiment.
-
-Hides the experiment from the default list view. The experiment can be
-restored at any time by updating archived=false. Returns 400 if the
-experiment is already archived or has not ended yet.
+ *
+ * Hides the experiment from the default list view. The experiment can be
+ * restored at any time by updating archived=false. Returns 400 if the
+ * experiment is already archived or has not ended yet.
  */
 export const experimentsArchiveCreate = async (
     projectId: string,
@@ -422,10 +422,10 @@ export const getExperimentsCopyToProjectCreateUrl = (projectId: string, id: numb
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsCopyToProjectCreate = async (
     projectId: string,
@@ -447,10 +447,10 @@ export const getExperimentsCreateExposureCohortForExperimentCreateUrl = (project
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsCreateExposureCohortForExperimentCreate = async (
     projectId: string,
@@ -472,10 +472,10 @@ export const getExperimentsDuplicateCreateUrl = (projectId: string, id: number) 
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsDuplicateCreate = async (
     projectId: string,
@@ -497,27 +497,27 @@ export const getExperimentsEndCreateUrl = (projectId: string, id: number) => {
 
 /**
  * End a running experiment without shipping a variant.
-
-Sets end_date to now and marks the experiment as stopped. The feature
-flag is NOT modified — users continue to see their assigned variants
-and exposure events ($feature_flag_called) continue to be recorded.
-However, only data up to end_date is included in experiment results.
-
-Use this when:
-
-- You want to freeze the results window without changing which variant
-  users see.
-- A variant was already shipped manually via the feature flag UI and
-  the experiment just needs to be marked complete.
-
-The end_date can be adjusted after ending via PATCH if it needs to be
-backdated (e.g. to match when the flag was actually paused).
-
-Other options:
-- Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
-- Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
-
-Returns 400 if the experiment is not running.
+ *
+ * Sets end_date to now and marks the experiment as stopped. The feature
+ * flag is NOT modified — users continue to see their assigned variants
+ * and exposure events ($feature_flag_called) continue to be recorded.
+ * However, only data up to end_date is included in experiment results.
+ *
+ * Use this when:
+ *
+ * - You want to freeze the results window without changing which variant
+ *   users see.
+ * - A variant was already shipped manually via the feature flag UI and
+ *   the experiment just needs to be marked complete.
+ *
+ * The end_date can be adjusted after ending via PATCH if it needs to be
+ * backdated (e.g. to match when the flag was actually paused).
+ *
+ * Other options:
+ * - Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
+ * - Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
+ *
+ * Returns 400 if the experiment is not running.
  */
 export const experimentsEndCreate = async (
     projectId: string,
@@ -539,11 +539,11 @@ export const getExperimentsLaunchCreateUrl = (projectId: string, id: number) => 
 
 /**
  * Launch a draft experiment.
-
-Validates the experiment is in draft state, activates its linked feature flag,
-sets start_date to the current server time, and transitions the experiment to running.
-Returns 400 if the experiment has already been launched or if the feature flag
-configuration is invalid (e.g. missing "control" variant or fewer than 2 variants).
+ *
+ * Validates the experiment is in draft state, activates its linked feature flag,
+ * sets start_date to the current server time, and transitions the experiment to running.
+ * Returns 400 if the experiment has already been launched or if the feature flag
+ * configuration is invalid (e.g. missing "control" variant or fewer than 2 variants).
  */
 export const experimentsLaunchCreate = async (
     projectId: string,
@@ -562,12 +562,12 @@ export const getExperimentsPauseCreateUrl = (projectId: string, id: number) => {
 
 /**
  * Pause a running experiment.
-
-Deactivates the linked feature flag so it is no longer returned by the
-/decide endpoint. Users fall back to the application default (typically
-the control experience), and no new exposure events are recorded (i.e.
-$feature_flag_called is not fired).
-Returns 400 if the experiment is not running or is already paused.
+ *
+ * Deactivates the linked feature flag so it is no longer returned by the
+ * /decide endpoint. Users fall back to the application default (typically
+ * the control experience), and no new exposure events are recorded (i.e.
+ * $feature_flag_called is not fired).
+ * Returns 400 if the experiment is not running or is already paused.
  */
 export const experimentsPauseCreate = async (
     projectId: string,
@@ -586,10 +586,10 @@ export const getExperimentsRecalculateTimeseriesCreateUrl = (projectId: string, 
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsRecalculateTimeseriesCreate = async (
     projectId: string,
@@ -611,14 +611,14 @@ export const getExperimentsResetCreateUrl = (projectId: string, id: number) => {
 
 /**
  * Reset an experiment back to draft state.
-
-Clears start/end dates, conclusion, and archived flag. The feature
-flag is left unchanged — users continue to see their assigned variants.
-
-Previously collected events still exist but won't be included in
-results unless the start date is manually adjusted after re-launch.
-
-Returns 400 if the experiment is already in draft state.
+ *
+ * Clears start/end dates, conclusion, and archived flag. The feature
+ * flag is left unchanged — users continue to see their assigned variants.
+ *
+ * Previously collected events still exist but won't be included in
+ * results unless the start date is manually adjusted after re-launch.
+ *
+ * Returns 400 if the experiment is already in draft state.
  */
 export const experimentsResetCreate = async (
     projectId: string,
@@ -637,11 +637,11 @@ export const getExperimentsResumeCreateUrl = (projectId: string, id: number) => 
 
 /**
  * Resume a paused experiment.
-
-Reactivates the linked feature flag so it is returned by /decide again.
-Users are re-bucketed deterministically into the same variants they had
-before the pause, and exposure tracking resumes.
-Returns 400 if the experiment is not running or is not paused.
+ *
+ * Reactivates the linked feature flag so it is returned by /decide again.
+ * Users are re-bucketed deterministically into the same variants they had
+ * before the pause, and exposure tracking resumes.
+ * Returns 400 if the experiment is not running or is not paused.
  */
 export const experimentsResumeCreate = async (
     projectId: string,
@@ -660,25 +660,25 @@ export const getExperimentsShipVariantCreateUrl = (projectId: string, id: number
 
 /**
  * Ship a variant and (optionally) end the experiment.
-
-Updates the feature flag so the selected variant gets 100% of the variant
-distribution. By default, existing release conditions on the flag are preserved
-untouched — the variant is served only to users who already match them. Pass
-``release_to_everyone: true`` to also prepend a catch-all release condition
-that rolls the variant out to 100% of users (overrides any existing release
-conditions on the flag).
-
-Can be called on both running and stopped experiments. If the experiment is
-still running, it will also be ended (end_date set and status marked as stopped).
-If the experiment has already ended, only the flag is rewritten - this supports
-the "end first, ship later" workflow.
-
-If an approval policy requires review before changes on the flag take effect,
-the API returns 409 with a change_request_id. The experiment is NOT ended until
-the change request is approved and the user retries.
-
-Returns 400 if the experiment is in draft state, the variant_key is not found
-on the flag, or the experiment has no linked feature flag.
+ *
+ * Updates the feature flag so the selected variant gets 100% of the variant
+ * distribution. By default, existing release conditions on the flag are preserved
+ * untouched — the variant is served only to users who already match them. Pass
+ * ``release_to_everyone: true`` to also prepend a catch-all release condition
+ * that rolls the variant out to 100% of users (overrides any existing release
+ * conditions on the flag).
+ *
+ * Can be called on both running and stopped experiments. If the experiment is
+ * still running, it will also be ended (end_date set and status marked as stopped).
+ * If the experiment has already ended, only the flag is rewritten - this supports
+ * the "end first, ship later" workflow.
+ *
+ * If an approval policy requires review before changes on the flag take effect,
+ * the API returns 409 with a change_request_id. The experiment is NOT ended until
+ * the change request is approved and the user retries.
+ *
+ * Returns 400 if the experiment is in draft state, the variant_key is not found
+ * on the flag, or the experiment has no linked feature flag.
  */
 export const experimentsShipVariantCreate = async (
     projectId: string,
@@ -703,7 +703,7 @@ export const getExperimentsTimeseriesResultsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -716,10 +716,10 @@ export const getExperimentsTimeseriesResultsRetrieveUrl = (
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsTimeseriesResultsRetrieve = async (
     projectId: string,
@@ -739,9 +739,9 @@ export const getExperimentsUnarchiveCreateUrl = (projectId: string, id: number) 
 
 /**
  * Unarchive an archived experiment.
-
-Restores the experiment to the default list view. Returns 400 if the
-experiment is not currently archived.
+ *
+ * Restores the experiment to the default list view. Returns 400 if the
+ * experiment is not currently archived.
  */
 export const experimentsUnarchiveCreate = async (
     projectId: string,
@@ -760,12 +760,12 @@ export const getExperimentsCreateFromPromptCreateUrl = (projectId: string) => {
 
 /**
  * Create an experiment that compares N versions of an LLM prompt using a metric template.
-
-The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
-(cost / latency / eval_pass_rate). The endpoint builds the matching variants
-(control + test-N, each named after its prompt version) and attaches one
-metric per selected template, each scoped to the prompt's $ai_prompt_name.
-Resulting experiment is in draft state.
+ *
+ * The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
+ * (cost / latency / eval_pass_rate). The endpoint builds the matching variants
+ * (control + test-N, each named after its prompt version) and attaches one
+ * metric per selected template, each scoped to the prompt's $ai_prompt_name.
+ * Resulting experiment is in draft state.
  */
 export const experimentsCreateFromPromptCreate = async (
     projectId: string,
@@ -786,20 +786,20 @@ export const getExperimentsEligibleFeatureFlagsRetrieveUrl = (projectId: string)
 
 /**
  * Returns a paginated list of feature flags eligible for use in experiments.
-
-Eligible flags must:
-- Be multivariate with at least 2 variants
-- Have "control" as the first variant key
-
-Query parameters:
-- search: Filter by flag key or name (case insensitive)
-- limit: Number of results per page (default: 20)
-- offset: Pagination offset (default: 0)
-- active: Filter by active status ("true" or "false")
-- created_by_id: Filter by creator user ID
-- order: Sort order field
-- evaluation_runtime: Filter by evaluation runtime
-- has_evaluation_contexts: Filter by presence of evaluation contexts ("true" or "false")
+ *
+ * Eligible flags must:
+ * - Be multivariate with at least 2 variants
+ * - Have "control" as the first variant key
+ *
+ * Query parameters:
+ * - search: Filter by flag key or name (case insensitive)
+ * - limit: Number of results per page (default: 20)
+ * - offset: Pagination offset (default: 0)
+ * - active: Filter by active status ("true" or "false")
+ * - created_by_id: Filter by creator user ID
+ * - order: Sort order field
+ * - evaluation_runtime: Filter by evaluation runtime
+ * - has_evaluation_contexts: Filter by presence of evaluation contexts ("true" or "false")
  */
 export const experimentsEligibleFeatureFlagsRetrieve = async (
     projectId: string,
@@ -837,10 +837,10 @@ export const getExperimentsRequiresFlagImplementationRetrieveUrl = (projectId: s
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsRequiresFlagImplementationRetrieve = async (
     projectId: string,
@@ -858,10 +858,10 @@ export const getExperimentsStatsRetrieveUrl = (projectId: string) => {
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const experimentsStatsRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getExperimentsStatsRetrieveUrl(projectId), {

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -122,10 +122,10 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsUpdateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -140,10 +140,10 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
     target_team_id: zod.number().describe('The team ID to copy the experiment to.'),
@@ -153,10 +153,10 @@ export const ExperimentsCopyToProjectCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsCreateExposureCohortForExperimentCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -164,10 +164,10 @@ export const ExperimentsCreateExposureCohortForExperimentCreateBody = /* @__PURE
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -175,27 +175,27 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
 
 /**
  * End a running experiment without shipping a variant.
-
-Sets end_date to now and marks the experiment as stopped. The feature
-flag is NOT modified — users continue to see their assigned variants
-and exposure events ($feature_flag_called) continue to be recorded.
-However, only data up to end_date is included in experiment results.
-
-Use this when:
-
-- You want to freeze the results window without changing which variant
-  users see.
-- A variant was already shipped manually via the feature flag UI and
-  the experiment just needs to be marked complete.
-
-The end_date can be adjusted after ending via PATCH if it needs to be
-backdated (e.g. to match when the flag was actually paused).
-
-Other options:
-- Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
-- Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
-
-Returns 400 if the experiment is not running.
+ *
+ * Sets end_date to now and marks the experiment as stopped. The feature
+ * flag is NOT modified — users continue to see their assigned variants
+ * and exposure events ($feature_flag_called) continue to be recorded.
+ * However, only data up to end_date is included in experiment results.
+ *
+ * Use this when:
+ *
+ * - You want to freeze the results window without changing which variant
+ *   users see.
+ * - A variant was already shipped manually via the feature flag UI and
+ *   the experiment just needs to be marked complete.
+ *
+ * The end_date can be adjusted after ending via PATCH if it needs to be
+ * backdated (e.g. to match when the flag was actually paused).
+ *
+ * Other options:
+ * - Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
+ * - Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
+ *
+ * Returns 400 if the experiment is not running.
  */
 export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
     conclusion: zod
@@ -216,10 +216,10 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -227,25 +227,25 @@ export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
 
 /**
  * Ship a variant and (optionally) end the experiment.
-
-Updates the feature flag so the selected variant gets 100% of the variant
-distribution. By default, existing release conditions on the flag are preserved
-untouched — the variant is served only to users who already match them. Pass
-``release_to_everyone: true`` to also prepend a catch-all release condition
-that rolls the variant out to 100% of users (overrides any existing release
-conditions on the flag).
-
-Can be called on both running and stopped experiments. If the experiment is
-still running, it will also be ended (end_date set and status marked as stopped).
-If the experiment has already ended, only the flag is rewritten - this supports
-the "end first, ship later" workflow.
-
-If an approval policy requires review before changes on the flag take effect,
-the API returns 409 with a change_request_id. The experiment is NOT ended until
-the change request is approved and the user retries.
-
-Returns 400 if the experiment is in draft state, the variant_key is not found
-on the flag, or the experiment has no linked feature flag.
+ *
+ * Updates the feature flag so the selected variant gets 100% of the variant
+ * distribution. By default, existing release conditions on the flag are preserved
+ * untouched — the variant is served only to users who already match them. Pass
+ * ``release_to_everyone: true`` to also prepend a catch-all release condition
+ * that rolls the variant out to 100% of users (overrides any existing release
+ * conditions on the flag).
+ *
+ * Can be called on both running and stopped experiments. If the experiment is
+ * still running, it will also be ended (end_date set and status marked as stopped).
+ * If the experiment has already ended, only the flag is rewritten - this supports
+ * the "end first, ship later" workflow.
+ *
+ * If an approval policy requires review before changes on the flag take effect,
+ * the API returns 409 with a change_request_id. The experiment is NOT ended until
+ * the change request is approved and the user retries.
+ *
+ * Returns 400 if the experiment is in draft state, the variant_key is not found
+ * on the flag, or the experiment has no linked feature flag.
  */
 export const experimentsShipVariantCreateBodyReleaseToEveryoneDefault = false
 
@@ -275,12 +275,12 @@ export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create an experiment that compares N versions of an LLM prompt using a metric template.
-
-The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
-(cost / latency / eval_pass_rate). The endpoint builds the matching variants
-(control + test-N, each named after its prompt version) and attaches one
-metric per selected template, each scoped to the prompt's $ai_prompt_name.
-Resulting experiment is in draft state.
+ *
+ * The user picks 2+ versions of an existing LLMPrompt and 1+ metric templates
+ * (cost / latency / eval_pass_rate). The endpoint builds the matching variants
+ * (control + test-N, each named after its prompt version) and attaches one
+ * metric per selected template, each scoped to the prompt's $ai_prompt_name.
+ * Resulting experiment is in draft state.
  */
 
 export const experimentsCreateFromPromptCreateBodyVersionsMin = 2

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -52,13 +52,13 @@ export interface CopyFlagsResponseApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -107,11 +107,11 @@ export interface UserBasicApi {
 
 /**
  * * `feature_flags` - feature_flags
- * `experiments` - experiments
- * `surveys` - surveys
- * `early_access_features` - early_access_features
- * `web_experiments` - web_experiments
- * `product_tours` - product_tours
+ * * `experiments` - experiments
+ * * `surveys` - surveys
+ * * `early_access_features` - early_access_features
+ * * `web_experiments` - web_experiments
+ * * `product_tours` - product_tours
  */
 export type FeatureFlagCreationContextEnumApi =
     (typeof FeatureFlagCreationContextEnumApi)[keyof typeof FeatureFlagCreationContextEnumApi]
@@ -127,8 +127,8 @@ export const FeatureFlagCreationContextEnumApi = {
 
 /**
  * * `server` - Server
- * `client` - Client
- * `all` - All
+ * * `client` - Client
+ * * `all` - All
  */
 export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
 
@@ -140,7 +140,7 @@ export const EvaluationRuntimeEnumApi = {
 
 /**
  * * `distinct_id` - User ID (default)
- * `device_id` - Device ID
+ * * `device_id` - Device ID
  */
 export type BucketingIdentifierEnumApi = (typeof BucketingIdentifierEnumApi)[keyof typeof BucketingIdentifierEnumApi]
 
@@ -197,13 +197,13 @@ export interface FeatureFlagApi {
      */
     readonly user_access_level: string | null
     /** Indicates the origin product of the feature flag. Choices: 'feature_flags', 'experiments', 'surveys', 'early_access_features', 'web_experiments', 'product_tours'.
-
-  * `feature_flags` - feature_flags
-  * `experiments` - experiments
-  * `surveys` - surveys
-  * `early_access_features` - early_access_features
-  * `web_experiments` - web_experiments
-  * `product_tours` - product_tours */
+     *
+     * * `feature_flags` - feature_flags
+     * * `experiments` - experiments
+     * * `surveys` - surveys
+     * * `early_access_features` - early_access_features
+     * * `web_experiments` - web_experiments
+     * * `product_tours` - product_tours */
     creation_context?: FeatureFlagCreationContextEnumApi
     /** @nullable */
     is_remote_configuration?: boolean | null
@@ -211,15 +211,15 @@ export interface FeatureFlagApi {
     has_encrypted_payloads?: boolean | null
     readonly status: string
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     /**
      * Last time this feature flag was called (from $feature_flag_called events)
@@ -243,8 +243,8 @@ export interface PaginatedFeatureFlagListApi {
 
 /**
  * * `cohort` - cohort
- * `person` - person
- * `group` - group
+ * * `person` - person
+ * * `group` - group
  */
 export type PropertyGroupTypeEnumApi = (typeof PropertyGroupTypeEnumApi)[keyof typeof PropertyGroupTypeEnumApi]
 
@@ -256,15 +256,15 @@ export const PropertyGroupTypeEnumApi = {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
- * `gt` - gt
- * `gte` - gte
- * `lt` - lt
- * `lte` - lte
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
+ * * `gt` - gt
+ * * `gte` - gte
+ * * `lt` - lt
+ * * `lte` - lte
  */
 export type FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi]
@@ -286,10 +286,10 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -304,23 +304,23 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Comparison value for the property filter. Supports strings, numbers, booleans, and arrays. */
     value: unknown
     /** Operator used to compare the property value.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains
-  * `regex` - regex
-  * `not_regex` - not_regex
-  * `gt` - gt
-  * `gte` - gte
-  * `lt` - lt
-  * `lte` - lte */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `gte` - gte
+     * * `lt` - lt
+     * * `lte` - lte */
     operator: FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi
 }
 
 /**
  * * `is_set` - is_set
- * `is_not_set` - is_not_set
+ * * `is_not_set` - is_not_set
  */
 export type ExistenceOperatorEnumApi = (typeof ExistenceOperatorEnumApi)[keyof typeof ExistenceOperatorEnumApi]
 
@@ -333,10 +333,10 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -349,9 +349,9 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     group_type_index?: number | null
     /** Existence operator.
-
-  * `is_set` - is_set
-  * `is_not_set` - is_not_set */
+     *
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set */
     operator: ExistenceOperatorEnumApi
     /** Optional value. Runtime behavior determines whether this is ignored. */
     value?: unknown
@@ -359,8 +359,8 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
 
 /**
  * * `is_date_exact` - is_date_exact
- * `is_date_before` - is_date_before
- * `is_date_after` - is_date_after
+ * * `is_date_before` - is_date_before
+ * * `is_date_after` - is_date_after
  */
 export type DateOperatorEnumApi = (typeof DateOperatorEnumApi)[keyof typeof DateOperatorEnumApi]
 
@@ -374,10 +374,10 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -390,10 +390,10 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     group_type_index?: number | null
     /** Date comparison operator.
-
-  * `is_date_exact` - is_date_exact
-  * `is_date_after` - is_date_after
-  * `is_date_before` - is_date_before */
+     *
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_after` - is_date_after
+     * * `is_date_before` - is_date_before */
     operator: DateOperatorEnumApi
     /** Date value in ISO format or relative date expression. */
     value: string
@@ -401,14 +401,14 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
 
 /**
  * * `semver_gt` - semver_gt
- * `semver_gte` - semver_gte
- * `semver_lt` - semver_lt
- * `semver_lte` - semver_lte
- * `semver_eq` - semver_eq
- * `semver_neq` - semver_neq
- * `semver_tilde` - semver_tilde
- * `semver_caret` - semver_caret
- * `semver_wildcard` - semver_wildcard
+ * * `semver_gte` - semver_gte
+ * * `semver_lt` - semver_lt
+ * * `semver_lte` - semver_lte
+ * * `semver_eq` - semver_eq
+ * * `semver_neq` - semver_neq
+ * * `semver_tilde` - semver_tilde
+ * * `semver_caret` - semver_caret
+ * * `semver_wildcard` - semver_wildcard
  */
 export type FeatureFlagFilterPropertySemverSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertySemverSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertySemverSchemaOperatorEnumApi]
@@ -429,10 +429,10 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -445,16 +445,16 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     group_type_index?: number | null
     /** Semantic version comparison operator.
-
-  * `semver_gt` - semver_gt
-  * `semver_gte` - semver_gte
-  * `semver_lt` - semver_lt
-  * `semver_lte` - semver_lte
-  * `semver_eq` - semver_eq
-  * `semver_neq` - semver_neq
-  * `semver_tilde` - semver_tilde
-  * `semver_caret` - semver_caret
-  * `semver_wildcard` - semver_wildcard */
+     *
+     * * `semver_gt` - semver_gt
+     * * `semver_gte` - semver_gte
+     * * `semver_lt` - semver_lt
+     * * `semver_lte` - semver_lte
+     * * `semver_eq` - semver_eq
+     * * `semver_neq` - semver_neq
+     * * `semver_tilde` - semver_tilde
+     * * `semver_caret` - semver_caret
+     * * `semver_wildcard` - semver_wildcard */
     operator: FeatureFlagFilterPropertySemverSchemaOperatorEnumApi
     /** Semantic version string. */
     value: string
@@ -462,7 +462,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
 
 /**
  * * `icontains_multi` - icontains_multi
- * `not_icontains_multi` - not_icontains_multi
+ * * `not_icontains_multi` - not_icontains_multi
  */
 export type FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi]
@@ -476,10 +476,10 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -492,9 +492,9 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     group_type_index?: number | null
     /** Multi-contains operator.
-
-  * `icontains_multi` - icontains_multi
-  * `not_icontains_multi` - not_icontains_multi */
+     *
+     * * `icontains_multi` - icontains_multi
+     * * `not_icontains_multi` - not_icontains_multi */
     operator: FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi
     /** List of strings to evaluate against. */
     value: string[]
@@ -512,7 +512,7 @@ export const FeatureFlagFilterPropertyCohortInSchemaTypeEnumApi = {
 
 /**
  * * `in` - in
- * `not_in` - not_in
+ * * `not_in` - not_in
  */
 export type FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi]
@@ -526,8 +526,8 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Cohort property type required for in/not_in operators.
-
-  * `cohort` - cohort */
+     *
+     * * `cohort` - cohort */
     type: FeatureFlagFilterPropertyCohortInSchemaTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -540,9 +540,9 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     group_type_index?: number | null
     /** Membership operator for cohort properties.
-
-  * `in` - in
-  * `not_in` - not_in */
+     *
+     * * `in` - in
+     * * `not_in` - not_in */
     operator: FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi
     /** Cohort comparison value (single or list, depending on usage). */
     value: unknown
@@ -572,8 +572,8 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Flag property type required for flag dependency checks.
-
-  * `flag` - flag */
+     *
+     * * `flag` - flag */
     type: FeatureFlagFilterPropertyFlagEvaluatesSchemaTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -586,8 +586,8 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     group_type_index?: number | null
     /** Operator for feature flag dependency evaluation.
-
-  * `flag_evaluates_to` - flag_evaluates_to */
+     *
+     * * `flag_evaluates_to` - flag_evaluates_to */
     operator: FeatureFlagFilterPropertyFlagEvaluatesSchemaOperatorEnumApi
     /** Value to compare flag evaluation against. */
     value: unknown
@@ -882,15 +882,15 @@ export interface FeatureFlagVersionResponseApi {
     /** @nullable */
     has_encrypted_payloads?: boolean | null
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     /**
      * Last time this feature flag was called (from $feature_flag_called events)
@@ -913,8 +913,8 @@ export interface FeatureFlagVersionResponseApi {
 
 /**
  * * `true` - true
- * `false` - false
- * `STALE` - STALE
+ * * `false` - false
+ * * `STALE` - STALE
  */
 export type ActiveEnumApi = (typeof ActiveEnumApi)[keyof typeof ActiveEnumApi]
 
@@ -926,9 +926,9 @@ export const ActiveEnumApi = {
 
 /**
  * * `boolean` - boolean
- * `multivariant` - multivariant
- * `experiment` - experiment
- * `remote_config` - remote_config
+ * * `multivariant` - multivariant
+ * * `experiment` - experiment
+ * * `remote_config` - remote_config
  */
 export type BulkDeleteFiltersTypeEnumApi =
     (typeof BulkDeleteFiltersTypeEnumApi)[keyof typeof BulkDeleteFiltersTypeEnumApi]
@@ -945,27 +945,27 @@ export const BulkDeleteFiltersTypeEnumApi = {
  */
 export interface BulkDeleteFiltersApi {
     /** Filter by active state.
-
-  * `true` - true
-  * `false` - false
-  * `STALE` - STALE */
+     *
+     * * `true` - true
+     * * `false` - false
+     * * `STALE` - STALE */
     active?: ActiveEnumApi
     /** Filter to flags created by a specific user ID. */
     created_by_id?: number
     /** Search by feature flag key or name (case-insensitive). */
     search?: string
     /** Filter by flag type.
-
-  * `boolean` - boolean
-  * `multivariant` - multivariant
-  * `experiment` - experiment
-  * `remote_config` - remote_config */
+     *
+     * * `boolean` - boolean
+     * * `multivariant` - multivariant
+     * * `experiment` - experiment
+     * * `remote_config` - remote_config */
     type?: BulkDeleteFiltersTypeEnumApi
     /** Filter by evaluation runtime.
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi
     /** JSON-encoded property filter to exclude. Same shape as the list endpoint. */
     excluded_properties?: string
@@ -978,14 +978,17 @@ export interface BulkDeleteFiltersApi {
 export interface BulkDeleteRequestApi {
     /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to bulk-delete by search/active/tags/etc. instead of supplying explicit IDs. */
     filters?: BulkDeleteFiltersApi
-    /** Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`. */
+    /**
+     * Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`.
+     * @items.minimum 1
+     */
     ids?: number[]
 }
 
 /**
  * * `fully_rolled_out` - fully_rolled_out
- * `not_rolled_out` - not_rolled_out
- * `partial` - partial
+ * * `not_rolled_out` - not_rolled_out
+ * * `partial` - partial
  */
 export type RolloutStateEnumApi = (typeof RolloutStateEnumApi)[keyof typeof RolloutStateEnumApi]
 
@@ -1001,10 +1004,10 @@ export interface BulkDeleteDeletedItemApi {
     /** The flag key at the time of deletion. */
     key: string
     /** Rollout state captured before deletion.
-
-  * `fully_rolled_out` - fully_rolled_out
-  * `not_rolled_out` - not_rolled_out
-  * `partial` - partial */
+     *
+     * * `fully_rolled_out` - fully_rolled_out
+     * * `not_rolled_out` - not_rolled_out
+     * * `partial` - partial */
     rollout_state: RolloutStateEnumApi
     /**
      * Variant key when a multivariate flag was fully rolled out to a single variant; otherwise null.
@@ -1024,11 +1027,11 @@ export interface BulkDeleteErrorItemApi {
 
 /**
  * Schema-only — referenced from ``@extend_schema(responses=...)`` to describe the wire format.
-Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
-declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
-so accessing ``serializer.errors`` would return this field descriptor instead of validation
-errors. The handler builds the response dict directly; this class exists only so drf-spectacular
-can render the response in the OpenAPI spec and downstream generated clients.
+ * Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
+ * declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
+ * so accessing ``serializer.errors`` would return this field descriptor instead of validation
+ * errors. The handler builds the response dict directly; this class exists only so drf-spectacular
+ * can render the response in the OpenAPI spec and downstream generated clients.
  */
 export interface BulkDeleteResponseApi {
     /** Flags successfully soft-deleted. */
@@ -1056,8 +1059,8 @@ export interface BulkKeysResponseApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -1074,10 +1077,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
@@ -1118,15 +1121,15 @@ export interface MinimalFeatureFlagApi {
      */
     version?: number | null
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     readonly evaluation_contexts: readonly string[]
 }
@@ -1178,9 +1181,9 @@ export const ModelNameEnumApi = {
 
 /**
  * * `daily` - daily
- * `weekly` - weekly
- * `monthly` - monthly
- * `yearly` - yearly
+ * * `weekly` - weekly
+ * * `monthly` - monthly
+ * * `yearly` - yearly
  */
 export type RecurrenceIntervalEnumApi = (typeof RecurrenceIntervalEnumApi)[keyof typeof RecurrenceIntervalEnumApi]
 
@@ -1200,8 +1203,8 @@ export interface ScheduledChangeApi {
      */
     record_id: string
     /** The type of record to modify. Currently only "FeatureFlag" is supported.
-
-  * `FeatureFlag` - feature flag */
+     *
+     * * `FeatureFlag` - feature flag */
     model_name: ModelNameEnumApi
     /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
     payload: unknown
@@ -1220,11 +1223,11 @@ export interface ScheduledChangeApi {
     /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
     is_recurring?: boolean
     /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-
-  * `daily` - daily
-  * `weekly` - weekly
-  * `monthly` - monthly
-  * `yearly` - yearly */
+     *
+     * * `daily` - daily
+     * * `weekly` - weekly
+     * * `monthly` - monthly
+     * * `yearly` - yearly */
     recurrence_interval?: RecurrenceIntervalEnumApi | null
     /**
      * @maxLength 100
@@ -1260,8 +1263,8 @@ export interface PatchedScheduledChangeApi {
      */
     record_id?: string
     /** The type of record to modify. Currently only "FeatureFlag" is supported.
-
-  * `FeatureFlag` - feature flag */
+     *
+     * * `FeatureFlag` - feature flag */
     model_name?: ModelNameEnumApi
     /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
     payload?: unknown
@@ -1280,11 +1283,11 @@ export interface PatchedScheduledChangeApi {
     /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
     is_recurring?: boolean
     /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-
-  * `daily` - daily
-  * `weekly` - weekly
-  * `monthly` - monthly
-  * `yearly` - yearly */
+     *
+     * * `daily` - daily
+     * * `weekly` - weekly
+     * * `monthly` - monthly
+     * * `yearly` - yearly */
     recurrence_interval?: RecurrenceIntervalEnumApi | null
     /**
      * @maxLength 100

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -97,7 +97,7 @@ export const getFeatureFlagsListUrl = (projectId: string, params?: FeatureFlagsL
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -110,8 +110,8 @@ export const getFeatureFlagsListUrl = (projectId: string, params?: FeatureFlagsL
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsList = async (
     projectId: string,
@@ -130,8 +130,8 @@ export const getFeatureFlagsCreateUrl = (projectId: string) => {
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsCreate = async (
     projectId: string,
@@ -152,8 +152,8 @@ export const getFeatureFlagsRetrieveUrl = (projectId: string, id: number) => {
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsRetrieve = async (
     projectId: string,
@@ -172,8 +172,8 @@ export const getFeatureFlagsUpdateUrl = (projectId: string, id: number) => {
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsUpdate = async (
     projectId: string,
@@ -195,8 +195,8 @@ export const getFeatureFlagsPartialUpdateUrl = (projectId: string, id: number) =
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsPartialUpdate = async (
     projectId: string,
@@ -235,7 +235,7 @@ export const getFeatureFlagsActivityRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -248,8 +248,8 @@ export const getFeatureFlagsActivityRetrieveUrl = (
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsActivityRetrieve = async (
     projectId: string,
@@ -269,8 +269,8 @@ export const getFeatureFlagsCreateStaticCohortForFlagCreateUrl = (projectId: str
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsCreateStaticCohortForFlagCreate = async (
     projectId: string,
@@ -292,8 +292,8 @@ export const getFeatureFlagsDashboardCreateUrl = (projectId: string, id: number)
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsDashboardCreate = async (
     projectId: string,
@@ -333,8 +333,8 @@ export const getFeatureFlagsEnrichUsageDashboardCreateUrl = (projectId: string, 
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsEnrichUsageDashboardCreate = async (
     projectId: string,
@@ -356,8 +356,8 @@ export const getFeatureFlagsRemoteConfigRetrieveUrl = (projectId: string, id: nu
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsRemoteConfigRetrieve = async (
     projectId: string,
@@ -376,8 +376,8 @@ export const getFeatureFlagsStatusRetrieveUrl = (projectId: string, id: number) 
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsStatusRetrieve = async (
     projectId: string,
@@ -396,10 +396,10 @@ export const getFeatureFlagsTestEvaluationCreateUrl = (projectId: string, id: nu
 
 /**
  * Test feature flag evaluation against a specific user at an optional point in time.
-
-This endpoint allows testing how a feature flag would evaluate for a specific user,
-optionally at a historical timestamp. When a timestamp is provided, both the flag
-conditions and person properties are evaluated as they existed at that time.
+ *
+ * This endpoint allows testing how a feature flag would evaluate for a specific user,
+ * optionally at a historical timestamp. When a timestamp is provided, both the flag
+ * conditions and person properties are evaluated as they existed at that time.
  */
 export const featureFlagsTestEvaluationCreate = async (
     projectId: string,
@@ -421,8 +421,8 @@ export const getFeatureFlagsVersionsRetrieveUrl = (projectId: string, id: number
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsVersionsRetrieve = async (
     projectId: string,
@@ -444,7 +444,7 @@ export const getFeatureFlagsAllActivityRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -457,8 +457,8 @@ export const getFeatureFlagsAllActivityRetrieveUrl = (
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsAllActivityRetrieve = async (
     projectId: string,
@@ -477,15 +477,15 @@ export const getFeatureFlagsBulkDeleteCreateUrl = (projectId: string) => {
 
 /**
  * Bulk delete feature flags by filter criteria or explicit IDs.
-
-Accepts either:
-- {"filters": {...}} - Same filter params as list endpoint (search, active, type, etc.)
-- {"ids": [...]} - Explicit list of flag IDs (no limit)
-
-Returns same format as bulk_delete for UI compatibility.
-
-Uses bulk operations for efficiency: database updates are batched and cache
-invalidation happens once at the end rather than per-flag.
+ *
+ * Accepts either:
+ * - {"filters": {...}} - Same filter params as list endpoint (search, active, type, etc.)
+ * - {"ids": [...]} - Explicit list of flag IDs (no limit)
+ *
+ * Returns same format as bulk_delete for UI compatibility.
+ *
+ * Uses bulk operations for efficiency: database updates are batched and cache
+ * invalidation happens once at the end rather than per-flag.
  */
 export const featureFlagsBulkDeleteCreate = async (
     projectId: string,
@@ -506,7 +506,7 @@ export const getFeatureFlagsBulkKeysRetrieveUrl = (projectId: string) => {
 
 /**
  * Get feature flag keys by IDs.
-Accepts a list of feature flag IDs and returns a mapping of ID to key.
+ * Accepts a list of feature flag IDs and returns a mapping of ID to key.
  */
 export const featureFlagsBulkKeysRetrieve = async (
     projectId: string,
@@ -527,22 +527,22 @@ export const getFeatureFlagsBulkUpdateTagsCreateUrl = (projectId: string) => {
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const featureFlagsBulkUpdateTagsCreate = async (
     projectId: string,
@@ -565,7 +565,7 @@ export const getFeatureFlagsEvaluationReasonsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -578,8 +578,8 @@ export const getFeatureFlagsEvaluationReasonsRetrieveUrl = (
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsEvaluationReasonsRetrieve = async (
     projectId: string,
@@ -598,8 +598,8 @@ export const getFeatureFlagsMatchingIdsRetrieveUrl = (projectId: string) => {
 
 /**
  * Get IDs of all feature flags matching the current filters.
-Uses the same filtering logic as the list endpoint.
-Returns only IDs that the user has permission to edit.
+ * Uses the same filtering logic as the list endpoint.
+ * Returns only IDs that the user has permission to edit.
  */
 export const featureFlagsMatchingIdsRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getFeatureFlagsMatchingIdsRetrieveUrl(projectId), {
@@ -613,7 +613,7 @@ export const getFeatureFlagsMyFlagsRetrieveUrl = (projectId: string, params?: Fe
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -626,8 +626,8 @@ export const getFeatureFlagsMyFlagsRetrieveUrl = (projectId: string, params?: Fe
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsMyFlagsRetrieve = async (
     projectId: string,
@@ -646,8 +646,8 @@ export const getFeatureFlagsUserBlastRadiusCreateUrl = (projectId: string) => {
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsUserBlastRadiusCreate = async (
     projectId: string,
@@ -667,7 +667,7 @@ export const getFlagValueValuesRetrieveUrl = (projectId: string, params?: FlagVa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -680,12 +680,12 @@ export const getFlagValueValuesRetrieveUrl = (projectId: string, params?: FlagVa
 
 /**
  * Get possible values for a feature flag.
-
-Query parameters:
-- key: The flag ID (required)
-Returns:
-
-- Array of objects with 'name' field containing possible values
+ *
+ * Query parameters:
+ * - key: The flag ID (required)
+ * Returns:
+ *
+ * - Array of objects with 'name' field containing possible values
  */
 export const flagValueValuesRetrieve = async (
     projectId: string,
@@ -703,7 +703,7 @@ export const getScheduledChangesListUrl = (projectId: string, params?: Scheduled
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -35,8 +35,8 @@ export const FeatureFlagsCopyFlagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsCreateBodyFiltersOneEarlyExitDefault = false
 
@@ -336,8 +336,8 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsUpdateBodyKeyMax = 400
 
@@ -416,8 +416,8 @@ export const FeatureFlagsUpdateBody = /* @__PURE__ */ zod
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsPartialUpdateBodyFiltersOneEarlyExitDefault = false
 
@@ -717,8 +717,8 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsCreateStaticCohortForFlagCreateBodyKeyMax = 400
 
@@ -799,8 +799,8 @@ export const FeatureFlagsCreateStaticCohortForFlagCreateBody = /* @__PURE__ */ z
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsDashboardCreateBodyKeyMax = 400
 
@@ -881,8 +881,8 @@ export const FeatureFlagsDashboardCreateBody = /* @__PURE__ */ zod
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const featureFlagsEnrichUsageDashboardCreateBodyKeyMax = 400
 
@@ -963,10 +963,10 @@ export const FeatureFlagsEnrichUsageDashboardCreateBody = /* @__PURE__ */ zod
 
 /**
  * Test feature flag evaluation against a specific user at an optional point in time.
-
-This endpoint allows testing how a feature flag would evaluate for a specific user,
-optionally at a historical timestamp. When a timestamp is provided, both the flag
-conditions and person properties are evaluated as they existed at that time.
+ *
+ * This endpoint allows testing how a feature flag would evaluate for a specific user,
+ * optionally at a historical timestamp. When a timestamp is provided, both the flag
+ * conditions and person properties are evaluated as they existed at that time.
  */
 export const FeatureFlagsTestEvaluationCreateBody = /* @__PURE__ */ zod.object({
     distinct_id: zod
@@ -988,15 +988,15 @@ export const FeatureFlagsTestEvaluationCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Bulk delete feature flags by filter criteria or explicit IDs.
-
-Accepts either:
-- {"filters": {...}} - Same filter params as list endpoint (search, active, type, etc.)
-- {"ids": [...]} - Explicit list of flag IDs (no limit)
-
-Returns same format as bulk_delete for UI compatibility.
-
-Uses bulk operations for efficiency: database updates are batched and cache
-invalidation happens once at the end rather than per-flag.
+ *
+ * Accepts either:
+ * - {"filters": {...}} - Same filter params as list endpoint (search, active, type, etc.)
+ * - {"ids": [...]} - Explicit list of flag IDs (no limit)
+ *
+ * Returns same format as bulk_delete for UI compatibility.
+ *
+ * Uses bulk operations for efficiency: database updates are batched and cache
+ * invalidation happens once at the end rather than per-flag.
  */
 
 export const FeatureFlagsBulkDeleteCreateBody = /* @__PURE__ */ zod.object({
@@ -1051,7 +1051,7 @@ export const FeatureFlagsBulkDeleteCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Get feature flag keys by IDs.
-Accepts a list of feature flag IDs and returns a mapping of ID to key.
+ * Accepts a list of feature flag IDs and returns a mapping of ID to key.
  */
 export const FeatureFlagsBulkKeysRetrieveBody = /* @__PURE__ */ zod.object({
     ids: zod
@@ -1064,22 +1064,22 @@ export const FeatureFlagsBulkKeysRetrieveBody = /* @__PURE__ */ zod.object({
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const featureFlagsBulkUpdateTagsCreateBodyIdsMax = 500
 
@@ -1099,8 +1099,8 @@ export const FeatureFlagsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsUserBlastRadiusCreateBody = /* @__PURE__ */ zod.object({
     condition: zod.record(zod.string(), zod.unknown()).describe('The release condition to evaluate'),

--- a/products/groups/frontend/generated/api.ts
+++ b/products/groups/frontend/generated/api.ts
@@ -41,7 +41,7 @@ export const getGroupsListUrl = (projectId: string, params: GroupsListParams) =>
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -54,10 +54,10 @@ export const getGroupsListUrl = (projectId: string, params: GroupsListParams) =>
 
 /**
  * List all groups of a specific group type. You must pass ?group_type_index= in the URL.
-To get a list of valid group types, call /api/:project_id/groups_types/.
-
-Uses forward-only keyset pagination via the `cursor` parameter.
-The `previous` field in the response envelope is always null.
+ * To get a list of valid group types, call /api/:project_id/groups_types/.
+ *
+ * Uses forward-only keyset pagination via the `cursor` parameter.
+ * The `previous` field in the response envelope is always null.
  */
 export const groupsList = async (
     projectId: string,
@@ -92,7 +92,7 @@ export const getGroupsActivityRetrieveUrl = (projectId: string, params: GroupsAc
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -119,7 +119,7 @@ export const getGroupsDeletePropertyCreateUrl = (projectId: string, params: Grou
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -149,7 +149,7 @@ export const getGroupsFindRetrieveUrl = (projectId: string, params: GroupsFindRe
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -198,7 +198,7 @@ export const getGroupsRelatedRetrieveUrl = (projectId: string, params: GroupsRel
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -225,7 +225,7 @@ export const getGroupsUpdatePropertyCreateUrl = (projectId: string, params: Grou
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -19,13 +19,13 @@ export const OrganizationIntegrationKindEnumApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -150,41 +150,41 @@ export interface RoleLookupResponseApi {
 
 /**
  * * `anthropic` - Anthropic
- * `apns` - Apple Push
- * `azure-blob` - Azure Blob
- * `bing-ads` - Bing Ads
- * `clickup` - Clickup
- * `customerio-app` - Customerio App
- * `customerio-track` - Customerio Track
- * `customerio-webhook` - Customerio Webhook
- * `databricks` - Databricks
- * `email` - Email
- * `firebase` - Firebase
- * `github` - Github
- * `gitlab` - Gitlab
- * `google-ads` - Google Ads
- * `google-cloud-service-account` - Google Cloud Service Account
- * `google-cloud-storage` - Google Cloud Storage
- * `google-pubsub` - Google Pubsub
- * `google-search-console` - Google Search Console
- * `google-sheets` - Google Sheets
- * `hubspot` - Hubspot
- * `intercom` - Intercom
- * `jira` - Jira
- * `linear` - Linear
- * `linkedin-ads` - Linkedin Ads
- * `meta-ads` - Meta Ads
- * `pinterest-ads` - Pinterest Ads
- * `postgresql` - Postgresql
- * `reddit-ads` - Reddit Ads
- * `salesforce` - Salesforce
- * `slack` - Slack
- * `slack-posthog-code` - Slack Posthog Code
- * `snapchat` - Snapchat
- * `stripe` - Stripe
- * `tiktok-ads` - Tiktok Ads
- * `twilio` - Twilio
- * `vercel` - Vercel
+ * * `apns` - Apple Push
+ * * `azure-blob` - Azure Blob
+ * * `bing-ads` - Bing Ads
+ * * `clickup` - Clickup
+ * * `customerio-app` - Customerio App
+ * * `customerio-track` - Customerio Track
+ * * `customerio-webhook` - Customerio Webhook
+ * * `databricks` - Databricks
+ * * `email` - Email
+ * * `firebase` - Firebase
+ * * `github` - Github
+ * * `gitlab` - Gitlab
+ * * `google-ads` - Google Ads
+ * * `google-cloud-service-account` - Google Cloud Service Account
+ * * `google-cloud-storage` - Google Cloud Storage
+ * * `google-pubsub` - Google Pubsub
+ * * `google-search-console` - Google Search Console
+ * * `google-sheets` - Google Sheets
+ * * `hubspot` - Hubspot
+ * * `intercom` - Intercom
+ * * `jira` - Jira
+ * * `linear` - Linear
+ * * `linkedin-ads` - Linkedin Ads
+ * * `meta-ads` - Meta Ads
+ * * `pinterest-ads` - Pinterest Ads
+ * * `postgresql` - Postgresql
+ * * `reddit-ads` - Reddit Ads
+ * * `salesforce` - Salesforce
+ * * `slack` - Slack
+ * * `slack-posthog-code` - Slack Posthog Code
+ * * `snapchat` - Snapchat
+ * * `stripe` - Stripe
+ * * `tiktok-ads` - Tiktok Ads
+ * * `twilio` - Twilio
+ * * `vercel` - Vercel
  */
 export type IntegrationKindEnumApi = (typeof IntegrationKindEnumApi)[keyof typeof IntegrationKindEnumApi]
 
@@ -371,41 +371,41 @@ export type RoleExternalReferencesLookupRetrieveParams = {
 export type IntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-     * `apns` - Apple Push
-     * `azure-blob` - Azure Blob
-     * `bing-ads` - Bing Ads
-     * `clickup` - Clickup
-     * `customerio-app` - Customerio App
-     * `customerio-track` - Customerio Track
-     * `customerio-webhook` - Customerio Webhook
-     * `databricks` - Databricks
-     * `email` - Email
-     * `firebase` - Firebase
-     * `github` - Github
-     * `gitlab` - Gitlab
-     * `google-ads` - Google Ads
-     * `google-cloud-service-account` - Google Cloud Service Account
-     * `google-cloud-storage` - Google Cloud Storage
-     * `google-pubsub` - Google Pubsub
-     * `google-search-console` - Google Search Console
-     * `google-sheets` - Google Sheets
-     * `hubspot` - Hubspot
-     * `intercom` - Intercom
-     * `jira` - Jira
-     * `linear` - Linear
-     * `linkedin-ads` - Linkedin Ads
-     * `meta-ads` - Meta Ads
-     * `pinterest-ads` - Pinterest Ads
-     * `postgresql` - Postgresql
-     * `reddit-ads` - Reddit Ads
-     * `salesforce` - Salesforce
-     * `slack` - Slack
-     * `slack-posthog-code` - Slack Posthog Code
-     * `snapchat` - Snapchat
-     * `stripe` - Stripe
-     * `tiktok-ads` - Tiktok Ads
-     * `twilio` - Twilio
-     * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     kind?: IntegrationsListKind
     /**

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -54,13 +54,13 @@ export const getIntegrationsEnvironmentMappingPartialUpdateUrl = (organizationId
 
 /**
  * ViewSet for organization-level integrations.
-
-Provides access to integrations that are scoped to the entire organization
-(vs. project-level integrations). Examples include Vercel, AWS Marketplace, etc.
-
-Creation is handled by the integration installation flows
-(e.g., Vercel marketplace installation). Users can disconnect integrations
-via the DELETE endpoint.
+ *
+ * Provides access to integrations that are scoped to the entire organization
+ * (vs. project-level integrations). Examples include Vercel, AWS Marketplace, etc.
+ *
+ * Creation is handled by the integration installation flows
+ * (e.g., Vercel marketplace installation). Users can disconnect integrations
+ * via the DELETE endpoint.
  */
 export const integrationsEnvironmentMappingPartialUpdate = async (
     organizationId: string,
@@ -84,7 +84,7 @@ export const getRoleExternalReferencesListUrl = (organizationId: string, params?
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -146,7 +146,7 @@ export const getRoleExternalReferencesLookupRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -173,7 +173,7 @@ export const getIntegrationsListUrl = (projectId: string, params?: IntegrationsL
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -292,7 +292,7 @@ export const getIntegrationsChannelsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -405,7 +405,7 @@ export const getIntegrationsGithubBranchesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -437,7 +437,7 @@ export const getIntegrationsGithubReposRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -484,7 +484,7 @@ export const getIntegrationsGithubTeamsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -629,10 +629,10 @@ export const getIntegrationsDomainConnectApplyUrlCreateUrl = (projectId: string)
 
 /**
  * Unified endpoint for generating Domain Connect apply URLs.
-
-Accepts a context ("email" or "proxy") and the relevant resource ID.
-The backend resolves the domain, template variables, and service ID
-based on context, then builds the signed apply URL.
+ *
+ * Accepts a context ("email" or "proxy") and the relevant resource ID.
+ * The backend resolves the domain, template variables, and service ID
+ * based on context, then builds the signed apply URL.
  */
 export const integrationsDomainConnectApplyUrlCreate = async (
     projectId: string,

--- a/products/integrations/frontend/generated/api.zod.ts
+++ b/products/integrations/frontend/generated/api.zod.ts
@@ -11,13 +11,13 @@ import * as zod from 'zod'
 
 /**
  * ViewSet for organization-level integrations.
-
-Provides access to integrations that are scoped to the entire organization
-(vs. project-level integrations). Examples include Vercel, AWS Marketplace, etc.
-
-Creation is handled by the integration installation flows
-(e.g., Vercel marketplace installation). Users can disconnect integrations
-via the DELETE endpoint.
+ *
+ * Provides access to integrations that are scoped to the entire organization
+ * (vs. project-level integrations). Examples include Vercel, AWS Marketplace, etc.
+ *
+ * Creation is handled by the integration installation flows
+ * (e.g., Vercel marketplace installation). Users can disconnect integrations
+ * via the DELETE endpoint.
  */
 export const IntegrationsEnvironmentMappingPartialUpdateBody = /* @__PURE__ */ zod
     .looseObject({})
@@ -205,10 +205,10 @@ export const IntegrationsEmailVerifyCreateBody = /* @__PURE__ */ zod
 
 /**
  * Unified endpoint for generating Domain Connect apply URLs.
-
-Accepts a context ("email" or "proxy") and the relevant resource ID.
-The backend resolves the domain, template variables, and service ID
-based on context, then builds the signed apply URL.
+ *
+ * Accepts a context ("email" or "proxy") and the relevant resource ID.
+ * The backend resolves the domain, template variables, and service ID
+ * based on context, then builds the signed apply URL.
  */
 export const IntegrationsDomainConnectApplyUrlCreateBody = /* @__PURE__ */ zod
     .object({

--- a/products/legal_documents/frontend/generated/api.schemas.ts
+++ b/products/legal_documents/frontend/generated/api.schemas.ts
@@ -36,7 +36,7 @@ export interface PaginatedLegalDocumentDTOListApi {
 
 /**
  * * `BAA` - BAA
- * `DPA` - DPA
+ * * `DPA` - DPA
  */
 export type CreateLegalDocumentDocumentTypeEnumApi =
     (typeof CreateLegalDocumentDocumentTypeEnumApi)[keyof typeof CreateLegalDocumentDocumentTypeEnumApi]
@@ -48,14 +48,14 @@ export const CreateLegalDocumentDocumentTypeEnumApi = {
 
 /**
  * Input serializer for POST. Mirrors the submittable fields on the model plus
-cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
-organization and submitting user.
+ * cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
+ * organization and submitting user.
  */
 export interface CreateLegalDocumentApi {
     /** Either 'BAA' or 'DPA'.
-
-  * `BAA` - BAA
-  * `DPA` - DPA */
+     *
+     * * `BAA` - BAA
+     * * `DPA` - DPA */
     document_type: CreateLegalDocumentDocumentTypeEnumApi
     /**
      * The customer legal entity entering the agreement (PandaDoc's Client.Company).

--- a/products/legal_documents/frontend/generated/api.ts
+++ b/products/legal_documents/frontend/generated/api.ts
@@ -20,7 +20,7 @@ export const getLegalDocumentsListUrl = (organizationId: string, params?: LegalD
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -80,14 +80,14 @@ export const getLegalDocumentsDestroyUrl = (organizationId: string, id: string) 
 
 /**
  * Delete an unsigned legal document. The PandaDoc envelope is voided
-first so the original signer can no longer complete it; only if that
-succeeds is the row removed, freeing the unique-per-org-per-type
-constraint so a fresh document can be generated.
-
-Returns 503 if the PandaDoc void fails — the row stays in that case
-and the frontend should prompt the user to retry. Returns 403 for
-signed documents (legal artifacts; staff can still delete signed
-rows from Django admin).
+ * first so the original signer can no longer complete it; only if that
+ * succeeds is the row removed, freeing the unique-per-org-per-type
+ * constraint so a fresh document can be generated.
+ *
+ * Returns 503 if the PandaDoc void fails — the row stays in that case
+ * and the frontend should prompt the user to retry. Returns 403 for
+ * signed documents (legal artifacts; staff can still delete signed
+ * rows from Django admin).
  */
 export const legalDocumentsDestroy = async (
     organizationId: string,
@@ -106,9 +106,9 @@ export const getLegalDocumentsDownloadRetrieveUrl = (organizationId: string, id:
 
 /**
  * Short-lived redirect to the signed PDF in object storage. 404 while the
-envelope is still out for signature (or if the upload hasn't completed
-yet). The underlying presigned URL expires in ~60s; clients should hit
-this endpoint each time they want to view the PDF rather than caching.
+ * envelope is still out for signature (or if the upload hasn't completed
+ * yet). The underlying presigned URL expires in ~60s; clients should hit
+ * this endpoint each time they want to view the PDF rather than caching.
  */
 export const legalDocumentsDownloadRetrieve = async (
     organizationId: string,

--- a/products/live_debugger/frontend/generated/api.ts
+++ b/products/live_debugger/frontend/generated/api.ts
@@ -41,7 +41,7 @@ export const getLiveDebuggerBreakpointsListUrl = (projectId: string, params?: Li
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -172,7 +172,7 @@ export const getLiveDebuggerBreakpointsActiveRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -185,8 +185,8 @@ export const getLiveDebuggerBreakpointsActiveRetrieveUrl = (
 
 /**
  * External API endpoint for client applications to fetch active breakpoints using Project API key. This endpoint allows external client applications (like Python scripts, Node.js apps, etc.) to fetch the list of active breakpoints so they can instrument their code accordingly.
-
-Authentication: Requires a Project API Key in the Authorization header: `Authorization: Bearer phs_<your-project-api-key>`. You can find your Project API Key in PostHog at: Settings → Project → Project API Key
+ *
+ * Authentication: Requires a Project API Key in the Authorization header: `Authorization: Bearer phs_<your-project-api-key>`. You can find your Project API Key in PostHog at: Settings → Project → Project API Key
  * @summary Get active breakpoints (External API)
  */
 export const liveDebuggerBreakpointsActiveRetrieve = async (
@@ -208,7 +208,7 @@ export const getLiveDebuggerBreakpointsBreakpointHitsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -221,8 +221,8 @@ export const getLiveDebuggerBreakpointsBreakpointHitsRetrieveUrl = (
 
 /**
  * Retrieve breakpoint hit events from ClickHouse with optional filtering and pagination. Returns hit events containing stack traces, local variables, and execution context from your application's runtime.
-
-Security: Breakpoint IDs are filtered to only include those belonging to the current team.
+ *
+ * Security: Breakpoint IDs are filtered to only include those belonging to the current team.
  * @summary Get breakpoint hits
  */
 export const liveDebuggerBreakpointsBreakpointHitsRetrieve = async (

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -305,7 +305,7 @@ export interface LogsAlertFiltersApi {
 
 /**
  * * `above` - Above
- * `below` - Below
+ * * `below` - Below
  */
 export type ThresholdOperatorEnumApi = (typeof ThresholdOperatorEnumApi)[keyof typeof ThresholdOperatorEnumApi]
 
@@ -316,11 +316,11 @@ export const ThresholdOperatorEnumApi = {
 
 /**
  * * `not_firing` - Not firing
- * `firing` - Firing
- * `pending_resolve` - Pending resolve
- * `errored` - Errored
- * `snoozed` - Snoozed
- * `broken` - Broken
+ * * `firing` - Firing
+ * * `pending_resolve` - Pending resolve
+ * * `errored` - Errored
+ * * `snoozed` - Snoozed
+ * * `broken` - Broken
  */
 export type LogsAlertConfigurationStateEnumApi =
     (typeof LogsAlertConfigurationStateEnumApi)[keyof typeof LogsAlertConfigurationStateEnumApi]
@@ -340,13 +340,13 @@ export interface LogsAlertStateIntervalApi {
     /** Interval end (UTC, exclusive). */
     end: string
     /** Alert state during this interval.
-
-  * `not_firing` - Not firing
-  * `firing` - Firing
-  * `pending_resolve` - Pending resolve
-  * `errored` - Errored
-  * `snoozed` - Snoozed
-  * `broken` - Broken */
+     *
+     * * `not_firing` - Not firing
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken */
     state: LogsAlertConfigurationStateEnumApi
     /** Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive. */
     enabled: boolean
@@ -354,7 +354,7 @@ export interface LogsAlertStateIntervalApi {
 
 /**
  * * `slack` - slack
- * `webhook` - webhook
+ * * `webhook` - webhook
  */
 export type NotificationDestinationTypeEnumApi =
     (typeof NotificationDestinationTypeEnumApi)[keyof typeof NotificationDestinationTypeEnumApi]
@@ -366,13 +366,13 @@ export const NotificationDestinationTypeEnumApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -437,22 +437,22 @@ export interface LogsAlertConfigurationApi {
      */
     threshold_count?: number
     /** Whether the alert fires when the count is above or below the threshold.
-
-  * `above` - Above
-  * `below` - Below */
+     *
+     * * `above` - Above
+     * * `below` - Below */
     threshold_operator?: ThresholdOperatorEnumApi
     /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
     window_minutes?: number
     /** How often the alert is evaluated, in minutes. Server-managed. */
     readonly check_interval_minutes: number
     /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-
-  * `not_firing` - Not firing
-  * `firing` - Firing
-  * `pending_resolve` - Pending resolve
-  * `errored` - Errored
-  * `snoozed` - Snoozed
-  * `broken` - Broken */
+     *
+     * * `not_firing` - Not firing
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken */
     readonly state: LogsAlertConfigurationStateEnumApi
     /**
      * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -544,22 +544,22 @@ export interface PatchedLogsAlertConfigurationApi {
      */
     threshold_count?: number
     /** Whether the alert fires when the count is above or below the threshold.
-
-  * `above` - Above
-  * `below` - Below */
+     *
+     * * `above` - Above
+     * * `below` - Below */
     threshold_operator?: ThresholdOperatorEnumApi
     /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
     window_minutes?: number
     /** How often the alert is evaluated, in minutes. Server-managed. */
     readonly check_interval_minutes?: number
     /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-
-  * `not_firing` - Not firing
-  * `firing` - Firing
-  * `pending_resolve` - Pending resolve
-  * `errored` - Errored
-  * `snoozed` - Snoozed
-  * `broken` - Broken */
+     *
+     * * `not_firing` - Not firing
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken */
     readonly state?: LogsAlertConfigurationStateEnumApi
     /**
      * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -626,9 +626,9 @@ export interface PatchedLogsAlertConfigurationApi {
 
 export interface LogsAlertCreateDestinationApi {
     /** Destination type — slack or webhook.
-
-  * `slack` - slack
-  * `webhook` - webhook */
+     *
+     * * `slack` - slack
+     * * `webhook` - webhook */
     type: NotificationDestinationTypeEnumApi
     /** Integration ID for the Slack workspace. Required when type=slack. */
     slack_workspace_id?: number
@@ -654,13 +654,13 @@ export interface LogsAlertDeleteDestinationApi {
 
 /**
  * * `check` - Check
- * `reset` - Reset
- * `enable` - Enable
- * `disable` - Disable
- * `snooze` - Snooze
- * `unsnooze` - Unsnooze
- * `threshold_change` - Threshold change
- * `broken_config` - Broken config
+ * * `reset` - Reset
+ * * `enable` - Enable
+ * * `disable` - Disable
+ * * `snooze` - Snooze
+ * * `unsnooze` - Unsnooze
+ * * `threshold_change` - Threshold change
+ * * `broken_config` - Broken config
  */
 export type LogsAlertEventKindEnumApi = (typeof LogsAlertEventKindEnumApi)[keyof typeof LogsAlertEventKindEnumApi]
 
@@ -708,9 +708,9 @@ export interface LogsAlertSimulateRequestApi {
      */
     threshold_count: number
     /** Whether the alert fires when the count is above or below the threshold.
-
-  * `above` - Above
-  * `below` - Below */
+     *
+     * * `above` - Above
+     * * `below` - Below */
     threshold_operator: ThresholdOperatorEnumApi
     /** Window size in minutes — determines bucket interval. */
     window_minutes: number
@@ -786,8 +786,8 @@ export interface _DateRangeApi {
 
 /**
  * * `log` - log
- * `log_attribute` - log_attribute
- * `log_resource_attribute` - log_resource_attribute
+ * * `log_attribute` - log_attribute
+ * * `log_resource_attribute` - log_resource_attribute
  */
 export type _LogPropertyFilterTypeEnumApi =
     (typeof _LogPropertyFilterTypeEnumApi)[keyof typeof _LogPropertyFilterTypeEnumApi]
@@ -800,18 +800,18 @@ export const _LogPropertyFilterTypeEnumApi = {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
- * `gt` - gt
- * `lt` - lt
- * `is_date_exact` - is_date_exact
- * `is_date_before` - is_date_before
- * `is_date_after` - is_date_after
- * `is_set` - is_set
- * `is_not_set` - is_not_set
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
+ * * `gt` - gt
+ * * `lt` - lt
+ * * `is_date_exact` - is_date_exact
+ * * `is_date_before` - is_date_before
+ * * `is_date_after` - is_date_after
+ * * `is_set` - is_set
+ * * `is_not_set` - is_not_set
  */
 export type _LogPropertyFilterOperatorEnumApi =
     (typeof _LogPropertyFilterOperatorEnumApi)[keyof typeof _LogPropertyFilterOperatorEnumApi]
@@ -836,26 +836,26 @@ export interface _LogPropertyFilterApi {
     /** Attribute key. For type "log", use "message". For "log_attribute"/"log_resource_attribute", use the attribute key (e.g. "k8s.container.name"). */
     key: string
     /** "log" filters the log body/message. "log_attribute" filters log-level attributes. "log_resource_attribute" filters resource-level attributes.
-
-  * `log` - log
-  * `log_attribute` - log_attribute
-  * `log_resource_attribute` - log_resource_attribute */
+     *
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute */
     type: _LogPropertyFilterTypeEnumApi
     /** Comparison operator.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains
-  * `regex` - regex
-  * `not_regex` - not_regex
-  * `gt` - gt
-  * `lt` - lt
-  * `is_date_exact` - is_date_exact
-  * `is_date_before` - is_date_before
-  * `is_date_after` - is_date_after
-  * `is_set` - is_set
-  * `is_not_set` - is_not_set */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_before` - is_date_before
+     * * `is_date_after` - is_date_after
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set */
     operator: _LogPropertyFilterOperatorEnumApi
     /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
     value?: unknown
@@ -863,7 +863,7 @@ export interface _LogPropertyFilterApi {
 
 /**
  * * `key` - key
- * `value` - value
+ * * `value` - value
  */
 export type MatchedOnEnumApi = (typeof MatchedOnEnumApi)[keyof typeof MatchedOnEnumApi]
 
@@ -877,9 +877,9 @@ export interface _LogAttributeEntryApi {
     /** Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering. */
     propertyFilterType: string
     /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
-
-  * `key` - key
-  * `value` - value */
+     *
+     * * `key` - key
+     * * `value` - value */
     matchedOn: MatchedOnEnumApi
     /**
      * Sample matching value — only set when matchedOn is "value".
@@ -897,11 +897,11 @@ export interface _LogsAttributesResponseApi {
 
 /**
  * * `trace` - trace
- * `debug` - debug
- * `info` - info
- * `warn` - warn
- * `error` - error
- * `fatal` - fatal
+ * * `debug` - debug
+ * * `info` - info
+ * * `warn` - warn
+ * * `error` - error
+ * * `fatal` - fatal
  */
 export type SeverityLevelsEnumApi = (typeof SeverityLevelsEnumApi)[keyof typeof SeverityLevelsEnumApi]
 
@@ -988,7 +988,7 @@ export interface ExplainRequestApi {
 
 /**
  * * `latest` - latest
- * `earliest` - earliest
+ * * `earliest` - earliest
  */
 export type OrderByEnumApi = (typeof OrderByEnumApi)[keyof typeof OrderByEnumApi]
 
@@ -1005,9 +1005,9 @@ export interface _LogsQueryBodyApi {
     /** Filter by service names. */
     serviceNames?: string[]
     /** Order results by timestamp.
-
-  * `latest` - latest
-  * `earliest` - earliest */
+     *
+     * * `latest` - latest
+     * * `earliest` - earliest */
     orderBy?: OrderByEnumApi
     /** Full-text search term to filter log bodies. */
     searchTerm?: string
@@ -1086,8 +1086,8 @@ export interface _LogsQueryResponseApi {
 
 /**
  * * `severity_sampling` - Severity-based reduction
- * `path_drop` - Path exclusion
- * `rate_limit` - Rate limit
+ * * `path_drop` - Path exclusion
+ * * `rate_limit` - Rate limit
  */
 export type RuleTypeEnumApi = (typeof RuleTypeEnumApi)[keyof typeof RuleTypeEnumApi]
 
@@ -1116,10 +1116,10 @@ export interface LogsSamplingRuleApi {
      */
     priority?: number | null
     /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-
-  * `severity_sampling` - Severity-based reduction
-  * `path_drop` - Path exclusion
-  * `rate_limit` - Rate limit */
+     *
+     * * `severity_sampling` - Severity-based reduction
+     * * `path_drop` - Path exclusion
+     * * `rate_limit` - Rate limit */
     rule_type: RuleTypeEnumApi
     /**
      * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -1173,10 +1173,10 @@ export interface PatchedLogsSamplingRuleApi {
      */
     priority?: number | null
     /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-
-  * `severity_sampling` - Severity-based reduction
-  * `path_drop` - Path exclusion
-  * `rate_limit` - Rate limit */
+     *
+     * * `severity_sampling` - Severity-based reduction
+     * * `path_drop` - Path exclusion
+     * * `rate_limit` - Rate limit */
     rule_type?: RuleTypeEnumApi
     /**
      * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -1287,7 +1287,7 @@ export interface _LogsServicesResponseApi {
 
 /**
  * * `severity` - severity
- * `service` - service
+ * * `service` - service
  */
 export type SparklineBreakdownByEnumApi = (typeof SparklineBreakdownByEnumApi)[keyof typeof SparklineBreakdownByEnumApi]
 
@@ -1308,9 +1308,9 @@ export interface _LogsSparklineBodyApi {
     /** Property filters for the query. */
     filterGroup?: _LogPropertyFilterApi[]
     /** Break down sparkline by "severity" (default) or "service".
-
-  * `severity` - severity
-  * `service` - service */
+     *
+     * * `severity` - severity
+     * * `service` - service */
     sparklineBreakdownBy?: SparklineBreakdownByEnumApi
 }
 
@@ -1421,12 +1421,12 @@ export type LogsAlertsEventsListParams = {
 
 export type LogsAttributesRetrieveParams = {
     /**
- * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-
-* `log` - log
-* `resource` - resource
- * @minLength 1
- */
+     * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
+     *
+     * * `log` - log
+     * * `resource` - resource
+     * @minLength 1
+     */
     attribute_type?: LogsAttributesRetrieveAttributeType
     /**
      * Date range to search within. Defaults to last hour.
@@ -1498,12 +1498,12 @@ export type LogsSamplingRulesReorderCreateParams = {
 
 export type LogsValuesRetrieveParams = {
     /**
- * Type of attribute: "log" or "resource". Defaults to "log".
-
-* `log` - log
-* `resource` - resource
- * @minLength 1
- */
+     * Type of attribute: "log" or "resource". Defaults to "log".
+     *
+     * * `log` - log
+     * * `resource` - resource
+     * @minLength 1
+     */
     attribute_type?: LogsValuesRetrieveAttributeType
     /**
      * Date range to search within. Defaults to last hour.

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -72,7 +72,7 @@ export const getLogsAlertsListUrl = (projectId: string, params?: LogsAlertsListP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -220,7 +220,7 @@ export const getLogsAlertsEventsListUrl = (projectId: string, id: string, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -289,7 +289,7 @@ export const getLogsAttributesRetrieveUrl = (projectId: string, params?: LogsAtt
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -351,8 +351,8 @@ export const getLogsExplainLogWithAICreateUrl = (projectId: string) => {
 
 /**
  * Explain a log entry using AI.
-
-POST /api/environments/:id/logs/explainLogWithAI/
+ *
+ * POST /api/environments/:id/logs/explainLogWithAI/
  */
 export const logsExplainLogWithAICreate = async (
     projectId: string,
@@ -414,7 +414,7 @@ export const getLogsSamplingRulesListUrl = (projectId: string, params?: LogsSamp
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -541,7 +541,7 @@ export const getLogsSamplingRulesReorderCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -608,7 +608,7 @@ export const getLogsValuesRetrieveUrl = (projectId: string, params: LogsValuesRe
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -635,7 +635,7 @@ export const getLogsViewsListUrl = (projectId: string, params?: LogsViewsListPar
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -582,8 +582,8 @@ export const LogsCountRangesCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Explain a log entry using AI.
-
-POST /api/environments/:id/logs/explainLogWithAI/
+ *
+ * POST /api/environments/:id/logs/explainLogWithAI/
  */
 export const logsExplainLogWithAICreateBodyForceRefreshDefault = false
 

--- a/products/managed_migrations/frontend/generated/api.schemas.ts
+++ b/products/managed_migrations/frontend/generated/api.schemas.ts
@@ -9,9 +9,9 @@
  */
 /**
  * * `completed` - Completed
- * `failed` - Failed
- * `paused` - Paused
- * `running` - Running
+ * * `failed` - Failed
+ * * `paused` - Paused
+ * * `running` - Running
  */
 export type BatchImportStatusEnumApi = (typeof BatchImportStatusEnumApi)[keyof typeof BatchImportStatusEnumApi]
 
@@ -94,9 +94,9 @@ export type ManagedMigrationsListParams = {
     search?: string
     /**
      * * `completed` - Completed
-     * `failed` - Failed
-     * `paused` - Paused
-     * `running` - Running
+     * * `failed` - Failed
+     * * `paused` - Paused
+     * * `running` - Running
      */
     status?: ManagedMigrationsListStatus
 }

--- a/products/managed_migrations/frontend/generated/api.ts
+++ b/products/managed_migrations/frontend/generated/api.ts
@@ -37,7 +37,7 @@ export const getManagedMigrationsListUrl = (projectId: string, params?: ManagedM
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/marketing_analytics/frontend/generated/api.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.schemas.ts
@@ -297,11 +297,23 @@ export interface GoalExplanationApi {
      * @nullable
      */
     non_integrated_count: number | null
-    /** List of [event_name, count] pairs */
+    /**
+     * List of [event_name, count] pairs
+     * @items.minItems 2
+     * @items.maxItems 2
+     */
     by_event: [string, number][]
-    /** List of [utm_source, count] pairs */
+    /**
+     * List of [utm_source, count] pairs
+     * @items.minItems 2
+     * @items.maxItems 2
+     */
     by_utm_source: [string, number][]
-    /** List of [integration, count] pairs */
+    /**
+     * List of [integration, count] pairs
+     * @items.minItems 2
+     * @items.maxItems 2
+     */
     by_matched_integration: [string, number][]
     /** A small sample of matching events */
     samples: GoalEventSampleApi[]
@@ -320,7 +332,11 @@ export interface CandidateEventApi {
     pct_with_utm_source: number
     /** Percentage of events that carry a utm_campaign */
     pct_with_utm_campaign: number
-    /** List of [utm_source, count] pairs */
+    /**
+     * List of [utm_source, count] pairs
+     * @items.minItems 2
+     * @items.maxItems 2
+     */
     top_utm_sources: [string, number][]
     /** Whether this event is already configured as a goal */
     is_already_a_goal: boolean
@@ -435,7 +451,7 @@ export interface UtmMappingSuggestionsResponseApi {
 
 /**
  * * `error` - error
- * `warning` - warning
+ * * `warning` - warning
  */
 export type UtmIssueSeverityEnumApi = (typeof UtmIssueSeverityEnumApi)[keyof typeof UtmIssueSeverityEnumApi]
 
@@ -448,9 +464,9 @@ export interface UtmIssueApi {
     /** The UTM field with the issue (e.g. utm_campaign, utm_source) */
     field: string
     /** Issue severity level
-
-  * `error` - error
-  * `warning` - warning */
+     *
+     * * `error` - error
+     * * `warning` - warning */
     severity: UtmIssueSeverityEnumApi
     /** Human-readable description of the issue */
     message: string
@@ -479,8 +495,8 @@ export interface CampaignAuditResultApi {
 
 /**
  * * `none` - none
- * `auto` - auto
- * `mapped` - mapped
+ * * `auto` - auto
+ * * `mapped` - mapped
  */
 export type SourceMatchEnumApi = (typeof SourceMatchEnumApi)[keyof typeof SourceMatchEnumApi]
 
@@ -498,16 +514,16 @@ export interface UtmEventApi {
     /** Number of pageview events with this UTM combination */
     event_count: number
     /** How utm_campaign matched: none, auto (direct name/id), or mapped (manual mapping)
-
-  * `none` - none
-  * `auto` - auto
-  * `mapped` - mapped */
+     *
+     * * `none` - none
+     * * `auto` - auto
+     * * `mapped` - mapped */
     campaign_match: SourceMatchEnumApi
     /** How utm_source matched: none, auto (default source), or mapped (custom mapping)
-
-  * `none` - none
-  * `auto` - auto
-  * `mapped` - mapped */
+     *
+     * * `none` - none
+     * * `auto` - auto
+     * * `mapped` - mapped */
     source_match: SourceMatchEnumApi
     /**
      * Name of the matched campaign, if any

--- a/products/marketing_analytics/frontend/generated/api.ts
+++ b/products/marketing_analytics/frontend/generated/api.ts
@@ -50,7 +50,7 @@ export const getMarketingAnalyticsDataSourcesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -84,7 +84,7 @@ export const getMarketingAnalyticsDiagnoseRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -118,7 +118,7 @@ export const getMarketingAnalyticsExplainConversionGoalRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -152,7 +152,7 @@ export const getMarketingAnalyticsSuggestConversionGoalsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -189,7 +189,7 @@ export const getMarketingAnalyticsSuggestUtmMappingsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -237,7 +237,7 @@ export const getMarketingAnalyticsUtmAuditRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/mcp_analytics/frontend/generated/api.schemas.ts
+++ b/products/mcp_analytics/frontend/generated/api.schemas.ts
@@ -9,7 +9,7 @@
  */
 /**
  * * `feedback` - Feedback
- * `missing_capability` - Missing capability
+ * * `missing_capability` - Missing capability
  */
 export type MCPAnalyticsSubmissionKindEnumApi =
     (typeof MCPAnalyticsSubmissionKindEnumApi)[keyof typeof MCPAnalyticsSubmissionKindEnumApi]
@@ -23,9 +23,9 @@ export interface MCPAnalyticsSubmissionApi {
     /** Unique identifier for this submission. */
     readonly id: string
     /** Whether this submission is general feedback or a missing capability report.
-
-  * `feedback` - Feedback
-  * `missing_capability` - Missing capability */
+     *
+     * * `feedback` - Feedback
+     * * `missing_capability` - Missing capability */
     readonly kind: MCPAnalyticsSubmissionKindEnumApi
     /** The user's goal in plain language. */
     goal: string
@@ -69,10 +69,10 @@ export interface PaginatedMCPAnalyticsSubmissionListApi {
 
 /**
  * * `results` - Results
- * `usability` - Usability
- * `bug` - Bug
- * `docs` - Docs
- * `other` - Other
+ * * `usability` - Usability
+ * * `bug` - Bug
+ * * `docs` - Docs
+ * * `other` - Other
  */
 export type MCPFeedbackCreateCategoryEnumApi =
     (typeof MCPFeedbackCreateCategoryEnumApi)[keyof typeof MCPFeedbackCreateCategoryEnumApi]
@@ -132,19 +132,19 @@ export interface MCPFeedbackCreateApi {
      */
     feedback: string
     /** High-level category for the feedback.
-
-  * `results` - Results
-  * `usability` - Usability
-  * `bug` - Bug
-  * `docs` - Docs
-  * `other` - Other */
+     *
+     * * `results` - Results
+     * * `usability` - Usability
+     * * `bug` - Bug
+     * * `docs` - Docs
+     * * `other` - Other */
     category?: MCPFeedbackCreateCategoryEnumApi
 }
 
 /**
  * * `idle` - Idle
- * `computing` - Computing
- * `error` - Error
+ * * `computing` - Computing
+ * * `error` - Error
  */
 export type MCPIntentClusterSnapshotStatusEnumApi =
     (typeof MCPIntentClusterSnapshotStatusEnumApi)[keyof typeof MCPIntentClusterSnapshotStatusEnumApi]
@@ -170,7 +170,7 @@ export interface MCPIntentClusterToolEntryApi {
 
 /**
  * * `completed` - Completed
- * `error` - Error
+ * * `error` - Error
  */
 export type OutcomeEnumApi = (typeof OutcomeEnumApi)[keyof typeof OutcomeEnumApi]
 
@@ -183,9 +183,9 @@ export interface MCPIntentClusterJourneyPathApi {
     /** Ordered tool names called during the path. Length is fixed; null entries indicate the session ended before this step. */
     readonly steps: readonly (string | null)[]
     /** Terminal outcome of the sessions following this path.
-
-  * `completed` - Completed
-  * `error` - Error */
+     *
+     * * `completed` - Completed
+     * * `error` - Error */
     readonly outcome: OutcomeEnumApi
     /** Number of sessions in this cluster that followed this exact path. */
     readonly count: number
@@ -238,10 +238,10 @@ export interface MCPIntentClusterSnapshotMetaApi {
 
 export interface MCPIntentClusterSnapshotApi {
     /** Whether a snapshot is current (idle), being recomputed (computing), or failed (error).
-
-  * `idle` - Idle
-  * `computing` - Computing
-  * `error` - Error */
+     *
+     * * `idle` - Idle
+     * * `computing` - Computing
+     * * `error` - Error */
     readonly status: MCPIntentClusterSnapshotStatusEnumApi
     /** Error message from the most recent failed run, otherwise empty. */
     readonly error_message: string

--- a/products/mcp_analytics/frontend/generated/api.ts
+++ b/products/mcp_analytics/frontend/generated/api.ts
@@ -28,7 +28,7 @@ export const getMcpAnalyticsFeedbackListUrl = (projectId: string, params?: McpAn
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -115,7 +115,7 @@ export const getMcpAnalyticsMissingCapabilitiesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -168,7 +168,7 @@ export const getMcpAnalyticsSessionsListUrl = (projectId: string, params?: McpAn
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -220,7 +220,7 @@ export const getMcpAnalyticsSessionsToolCallsUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -9,7 +9,7 @@
  */
 /**
  * * `api_key` - API Key
- * `oauth` - OAuth
+ * * `oauth` - OAuth
  */
 export type MCPAuthTypeEnumApi = (typeof MCPAuthTypeEnumApi)[keyof typeof MCPAuthTypeEnumApi]
 
@@ -59,8 +59,8 @@ export interface PatchedMCPServerInstallationUpdateApi {
 
 /**
  * * `approved` - Approved
- * `needs_approval` - Needs approval
- * `do_not_use` - Do not use
+ * * `needs_approval` - Needs approval
+ * * `do_not_use` - Do not use
  */
 export type MCPServerInstallationToolApprovalStateEnumApi =
     (typeof MCPServerInstallationToolApprovalStateEnumApi)[keyof typeof MCPServerInstallationToolApprovalStateEnumApi]
@@ -97,8 +97,8 @@ export interface PaginatedMCPServerInstallationToolListApi {
 
 /**
  * * `approved` - approved
- * `needs_approval` - needs_approval
- * `do_not_use` - do_not_use
+ * * `needs_approval` - needs_approval
+ * * `do_not_use` - do_not_use
  */
 export type ToolApprovalUpdateApprovalStateEnumApi =
     (typeof ToolApprovalUpdateApprovalStateEnumApi)[keyof typeof ToolApprovalUpdateApprovalStateEnumApi]
@@ -115,7 +115,7 @@ export interface PatchedToolApprovalUpdateApi {
 
 /**
  * * `api_key` - api_key
- * `oauth` - oauth
+ * * `oauth` - oauth
  */
 export type InstallCustomAuthTypeEnumApi =
     (typeof InstallCustomAuthTypeEnumApi)[keyof typeof InstallCustomAuthTypeEnumApi]
@@ -127,7 +127,7 @@ export const InstallCustomAuthTypeEnumApi = {
 
 /**
  * * `posthog` - posthog
- * `posthog-code` - posthog-code
+ * * `posthog-code` - posthog-code
  */
 export type InstallSourceEnumApi = (typeof InstallSourceEnumApi)[keyof typeof InstallSourceEnumApi]
 
@@ -163,11 +163,11 @@ export interface InstallTemplateApi {
 
 /**
  * * `business` - Business Operations
- * `data` - Data & Analytics
- * `design` - Design & Content
- * `dev` - Developer Tools & APIs
- * `infra` - Infrastructure
- * `productivity` - Productivity & Collaboration
+ * * `data` - Data & Analytics
+ * * `design` - Design & Content
+ * * `dev` - Developer Tools & APIs
+ * * `infra` - Infrastructure
+ * * `productivity` - Productivity & Collaboration
  */
 export type MCPServerTemplateCategoryEnumApi =
     (typeof MCPServerTemplateCategoryEnumApi)[keyof typeof MCPServerTemplateCategoryEnumApi]
@@ -219,7 +219,7 @@ export type McpServerInstallationsListParams = {
 export type McpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-     * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: McpServerInstallationsAuthorizeRetrieveInstallSource

--- a/products/mcp_store/frontend/generated/api.ts
+++ b/products/mcp_store/frontend/generated/api.ts
@@ -46,7 +46,7 @@ export const getMcpServerInstallationsListUrl = (projectId: string, params?: Mcp
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -238,7 +238,7 @@ export const getMcpServerInstallationsAuthorizeRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -251,10 +251,10 @@ export const getMcpServerInstallationsAuthorizeRetrieveUrl = (
 
 /**
  * Start (or re-start) an OAuth flow.
-
-Pass ``template_id`` to (re)connect a catalog template, or
-``installation_id`` to reconnect an existing custom install using its
-cached metadata and per-user DCR creds.
+ *
+ * Pass ``template_id`` to (re)connect a catalog template, or
+ * ``installation_id`` to reconnect an existing custom install using its
+ * cached metadata and per-user DCR creds.
  */
 export const mcpServerInstallationsAuthorizeRetrieve = async (
     projectId: string,
@@ -312,7 +312,7 @@ export const getMcpServersListUrl = (projectId: string, params?: McpServersListP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -325,9 +325,9 @@ export const getMcpServersListUrl = (projectId: string, params?: McpServersListP
 
 /**
  * Lists curated MCP server templates that users can install with one click.
-
-Templates are seeded by PostHog operators and carry shared, encrypted
-OAuth client credentials. Inactive templates are hidden from the catalog.
+ *
+ * Templates are seeded by PostHog operators and carry shared, encrypted
+ * OAuth client credentials. Inactive templates are hidden from the catalog.
  */
 export const mcpServersList = async (
     projectId: string,

--- a/products/messaging/frontend/generated/api.schemas.ts
+++ b/products/messaging/frontend/generated/api.schemas.ts
@@ -9,7 +9,7 @@
  */
 /**
  * * `marketing` - Marketing
- * `transactional` - Transactional
+ * * `transactional` - Transactional
  */
 export type CategoryTypeEnumApi = (typeof CategoryTypeEnumApi)[keyof typeof CategoryTypeEnumApi]
 
@@ -81,7 +81,7 @@ export interface MessagePreferencesApi {
 
 /**
  * * `hog` - hog
- * `liquid` - liquid
+ * * `liquid` - liquid
  */
 export type HogFunctionTemplatingEnumApi =
     (typeof HogFunctionTemplatingEnumApi)[keyof typeof HogFunctionTemplatingEnumApi]
@@ -105,13 +105,13 @@ export interface MessageTemplateContentApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 

--- a/products/messaging/frontend/generated/api.ts
+++ b/products/messaging/frontend/generated/api.ts
@@ -43,7 +43,7 @@ export const getMessagingCategoriesListUrl = (projectId: string, params?: Messag
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -157,8 +157,8 @@ export const getMessagingCategoriesImportFromCustomerioCreateUrl = (projectId: s
 
 /**
  * Import subscription topics and globally unsubscribed users from Customer.io API.
-Persists the App API key in Integration(kind="customerio-app").
-If no app_api_key is provided, reuses the stored Integration key.
+ * Persists the App API key in Integration(kind="customerio-app").
+ * If no app_api_key is provided, reuses the stored Integration key.
  */
 export const messagingCategoriesImportFromCustomerioCreate = async (
     projectId: string,
@@ -179,7 +179,7 @@ export const getMessagingCategoriesImportPreferencesCsvCreateUrl = (projectId: s
 
 /**
  * Import customer preferences from CSV file
-Expected CSV columns: id, email, cio_subscription_preferences
+ * Expected CSV columns: id, email, cio_subscription_preferences
  */
 export const messagingCategoriesImportPreferencesCsvCreate = async (
     projectId: string,
@@ -215,7 +215,7 @@ export const getMessagingCategoriesOptoutSyncConfigRetrieveUrl = (projectId: str
 
 /**
  * Get the Customer.io sync configuration state for this team.
-Used by the frontend to derive step completion.
+ * Used by the frontend to derive step completion.
  */
 export const messagingCategoriesOptoutSyncConfigRetrieve = async (
     projectId: string,
@@ -284,12 +284,12 @@ export const getMessagingCategoriesSaveTrackConfigCreateUrl = (projectId: string
 
 /**
  * Save Customer.io Track API credentials and/or toggle outbound sync.
-
-Accepts:
-  - site_id (optional): set on first creation only
-  - api_key (optional): set on first creation only
-  - region (optional): "us" or "eu", set on first creation only
-  - track_enabled (required): enable or disable outbound sync
+ *
+ * Accepts:
+ *   - site_id (optional): set on first creation only
+ *   - api_key (optional): set on first creation only
+ *   - region (optional): "us" or "eu", set on first creation only
+ *   - track_enabled (required): enable or disable outbound sync
  */
 export const messagingCategoriesSaveTrackConfigCreate = async (
     projectId: string,
@@ -310,10 +310,10 @@ export const getMessagingCategoriesSaveWebhookConfigCreateUrl = (projectId: stri
 
 /**
  * Save webhook signing secret and/or toggle the Customer.io webhook sync.
-
-Accepts:
-  - webhook_signing_secret (optional): set on first creation only
-  - webhook_enabled (required): enable or disable the webhook
+ *
+ * Accepts:
+ *   - webhook_signing_secret (optional): set on first creation only
+ *   - webhook_enabled (required): enable or disable the webhook
  */
 export const messagingCategoriesSaveWebhookConfigCreate = async (
     projectId: string,
@@ -402,7 +402,7 @@ export const getMessagingTemplatesListUrl = (projectId: string, params?: Messagi
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/messaging/frontend/generated/api.zod.ts
+++ b/products/messaging/frontend/generated/api.zod.ts
@@ -59,8 +59,8 @@ export const MessagingCategoriesPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Import subscription topics and globally unsubscribed users from Customer.io API.
-Persists the App API key in Integration(kind="customerio-app").
-If no app_api_key is provided, reuses the stored Integration key.
+ * Persists the App API key in Integration(kind="customerio-app").
+ * If no app_api_key is provided, reuses the stored Integration key.
  */
 export const messagingCategoriesImportFromCustomerioCreateBodyKeyMax = 64
 
@@ -80,7 +80,7 @@ export const MessagingCategoriesImportFromCustomerioCreateBody = /* @__PURE__ */
 
 /**
  * Import customer preferences from CSV file
-Expected CSV columns: id, email, cio_subscription_preferences
+ * Expected CSV columns: id, email, cio_subscription_preferences
  */
 export const messagingCategoriesImportPreferencesCsvCreateBodyKeyMax = 64
 
@@ -100,12 +100,12 @@ export const MessagingCategoriesImportPreferencesCsvCreateBody = /* @__PURE__ */
 
 /**
  * Save Customer.io Track API credentials and/or toggle outbound sync.
-
-Accepts:
-  - site_id (optional): set on first creation only
-  - api_key (optional): set on first creation only
-  - region (optional): "us" or "eu", set on first creation only
-  - track_enabled (required): enable or disable outbound sync
+ *
+ * Accepts:
+ *   - site_id (optional): set on first creation only
+ *   - api_key (optional): set on first creation only
+ *   - region (optional): "us" or "eu", set on first creation only
+ *   - track_enabled (required): enable or disable outbound sync
  */
 export const messagingCategoriesSaveTrackConfigCreateBodyKeyMax = 64
 
@@ -125,10 +125,10 @@ export const MessagingCategoriesSaveTrackConfigCreateBody = /* @__PURE__ */ zod.
 
 /**
  * Save webhook signing secret and/or toggle the Customer.io webhook sync.
-
-Accepts:
-  - webhook_signing_secret (optional): set on first creation only
-  - webhook_enabled (required): enable or disable the webhook
+ *
+ * Accepts:
+ *   - webhook_signing_secret (optional): set on first creation only
+ *   - webhook_enabled (required): enable or disable the webhook
  */
 export const messagingCategoriesSaveWebhookConfigCreateBodyKeyMax = 64
 

--- a/products/metrics/frontend/generated/api.schemas.ts
+++ b/products/metrics/frontend/generated/api.schemas.ts
@@ -25,9 +25,9 @@ export interface AppMetricsTotalsResponseApi {
 
 /**
  * * `sum` - sum
- * `avg` - avg
- * `count` - count
- * `p95` - p95
+ * * `avg` - avg
+ * * `count` - count
+ * * `p95` - p95
  */
 export type AggregationEnumApi = (typeof AggregationEnumApi)[keyof typeof AggregationEnumApi]
 
@@ -45,11 +45,11 @@ export interface _MetricQueryBodyApi {
      */
     metricName: string
     /** Aggregation applied per time bucket.
-
-  * `sum` - sum
-  * `avg` - avg
-  * `count` - count
-  * `p95` - p95 */
+     *
+     * * `sum` - sum
+     * * `avg` - avg
+     * * `count` - count
+     * * `p95` - p95 */
     aggregation?: AggregationEnumApi
     /** Lower bound (inclusive) for the query range. ISO 8601. */
     dateFrom: string

--- a/products/metrics/frontend/generated/api.ts
+++ b/products/metrics/frontend/generated/api.ts
@@ -24,10 +24,10 @@ export const getEventFilterMetricsRetrieveUrl = (projectId: string) => {
 
 /**
  * Single event filter per team.
-GET  /event_filter/ — returns the config (or null if not yet created)
-POST /event_filter/ — creates or updates the config (upsert)
-GET  /event_filter/metrics/ — time-series metrics
-GET  /event_filter/metrics/totals/ — aggregate totals
+ * GET  /event_filter/ — returns the config (or null if not yet created)
+ * POST /event_filter/ — creates or updates the config (upsert)
+ * GET  /event_filter/metrics/ — time-series metrics
+ * GET  /event_filter/metrics/totals/ — aggregate totals
  */
 export const eventFilterMetricsRetrieve = async (
     projectId: string,
@@ -45,10 +45,10 @@ export const getEventFilterMetricsTotalsRetrieveUrl = (projectId: string) => {
 
 /**
  * Single event filter per team.
-GET  /event_filter/ — returns the config (or null if not yet created)
-POST /event_filter/ — creates or updates the config (upsert)
-GET  /event_filter/metrics/ — time-series metrics
-GET  /event_filter/metrics/totals/ — aggregate totals
+ * GET  /event_filter/ — returns the config (or null if not yet created)
+ * POST /event_filter/ — creates or updates the config (upsert)
+ * GET  /event_filter/metrics/ — time-series metrics
+ * GET  /event_filter/metrics/totals/ — aggregate totals
  */
 export const eventFilterMetricsTotalsRetrieve = async (
     projectId: string,
@@ -96,7 +96,7 @@ export const getMetricsValuesRetrieveUrl = (projectId: string, params?: MetricsV
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -221,10 +221,10 @@ export interface NotebookCollabSaveApi {
 
 export type NotebooksListParams = {
     /**
- * Filter for notebooks that match a provided filter.
-                Each match pair is separated by a colon,
-                multiple match pairs can be sent separated by a space or a comma
- */
+     * Filter for notebooks that match a provided filter.
+     *                 Each match pair is separated by a colon,
+     *                 multiple match pairs can be sent separated by a space or a comma
+     */
     contains?: string
     /**
      * The UUID of the Notebook's creator

--- a/products/notebooks/frontend/generated/api.ts
+++ b/products/notebooks/frontend/generated/api.ts
@@ -38,7 +38,7 @@ export const getNotebooksListUrl = (projectId: string, params?: NotebooksListPar
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/notifications/frontend/generated/api.schemas.ts
+++ b/products/notifications/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `replay` - REPLAY
- * `notebook` - NOTEBOOK
- * `insight` - INSIGHT
- * `feature_flag` - FEATURE_FLAG
- * `dashboard` - DASHBOARD
- * `survey` - SURVEY
- * `experiment` - EXPERIMENT
- * `error_tracking` - ERROR_TRACKING
+ * * `notebook` - NOTEBOOK
+ * * `insight` - INSIGHT
+ * * `feature_flag` - FEATURE_FLAG
+ * * `dashboard` - DASHBOARD
+ * * `survey` - SURVEY
+ * * `experiment` - EXPERIMENT
+ * * `error_tracking` - ERROR_TRACKING
  */
 export type NotificationEventSourceTypeEnumApi =
     (typeof NotificationEventSourceTypeEnumApi)[keyof typeof NotificationEventSourceTypeEnumApi]

--- a/products/notifications/frontend/generated/api.ts
+++ b/products/notifications/frontend/generated/api.ts
@@ -19,7 +19,7 @@ export const getNotificationsListUrl = (projectId: string, params?: Notification
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/persons/frontend/generated/api.schemas.ts
+++ b/products/persons/frontend/generated/api.schemas.ts
@@ -16,22 +16,22 @@ export const PropertyGroupOperatorApi = {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
- * `gt` - gt
- * `lt` - lt
- * `gte` - gte
- * `lte` - lte
- * `is_set` - is_set
- * `is_not_set` - is_not_set
- * `is_date_exact` - is_date_exact
- * `is_date_after` - is_date_after
- * `is_date_before` - is_date_before
- * `in` - in
- * `not_in` - not_in
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
+ * * `gt` - gt
+ * * `lt` - lt
+ * * `gte` - gte
+ * * `lte` - lte
+ * * `is_set` - is_set
+ * * `is_not_set` - is_not_set
+ * * `is_date_exact` - is_date_exact
+ * * `is_date_after` - is_date_after
+ * * `is_date_before` - is_date_before
+ * * `in` - in
+ * * `not_in` - not_in
  */
 export type PropertyItemOperatorEnumApi = (typeof PropertyItemOperatorEnumApi)[keyof typeof PropertyItemOperatorEnumApi]
 
@@ -63,32 +63,32 @@ export const BlankEnumApi = {
 
 /**
  * * `event` - event
- * `event_metadata` - event_metadata
- * `feature` - feature
- * `person` - person
- * `cohort` - cohort
- * `element` - element
- * `static-cohort` - static-cohort
- * `dynamic-cohort` - dynamic-cohort
- * `precalculated-cohort` - precalculated-cohort
- * `group` - group
- * `recording` - recording
- * `log_entry` - log_entry
- * `behavioral` - behavioral
- * `session` - session
- * `hogql` - hogql
- * `data_warehouse` - data_warehouse
- * `data_warehouse_person_property` - data_warehouse_person_property
- * `error_tracking_issue` - error_tracking_issue
- * `log` - log
- * `log_attribute` - log_attribute
- * `log_resource_attribute` - log_resource_attribute
- * `span` - span
- * `span_attribute` - span_attribute
- * `span_resource_attribute` - span_resource_attribute
- * `revenue_analytics` - revenue_analytics
- * `flag` - flag
- * `workflow_variable` - workflow_variable
+ * * `event_metadata` - event_metadata
+ * * `feature` - feature
+ * * `person` - person
+ * * `cohort` - cohort
+ * * `element` - element
+ * * `static-cohort` - static-cohort
+ * * `dynamic-cohort` - dynamic-cohort
+ * * `precalculated-cohort` - precalculated-cohort
+ * * `group` - group
+ * * `recording` - recording
+ * * `log_entry` - log_entry
+ * * `behavioral` - behavioral
+ * * `session` - session
+ * * `hogql` - hogql
+ * * `data_warehouse` - data_warehouse
+ * * `data_warehouse_person_property` - data_warehouse_person_property
+ * * `error_tracking_issue` - error_tracking_issue
+ * * `log` - log
+ * * `log_attribute` - log_attribute
+ * * `log_resource_attribute` - log_resource_attribute
+ * * `span` - span
+ * * `span_attribute` - span_attribute
+ * * `span_resource_attribute` - span_resource_attribute
+ * * `revenue_analytics` - revenue_analytics
+ * * `flag` - flag
+ * * `workflow_variable` - workflow_variable
  */
 export type PropertyFilterTypeEnumApi = (typeof PropertyFilterTypeEnumApi)[keyof typeof PropertyFilterTypeEnumApi]
 
@@ -134,48 +134,48 @@ export interface PropertyItemApi {
 
 export interface PropertyApi {
     /**
-   You can use a simplified version:
-  ```json
-  {
-      "properties": [
-          {
-              "key": "email",
-              "value": "x@y.com",
-              "operator": "exact",
-              "type": "event"
-          }
-      ]
-  }
-  ```
-
-  Or you can create more complicated queries with AND and OR:
-  ```json
-  {
-      "properties": {
-          "type": "AND",
-          "values": [
-              {
-                  "type": "OR",
-                  "values": [
-                      {"key": "email", ...},
-                      {"key": "email", ...}
-                  ]
-              },
-              {
-                  "type": "AND",
-                  "values": [
-                      {"key": "email", ...},
-                      {"key": "email", ...}
-                  ]
-              }
-          ]
-      ]
-  }
-  ```
-
-
-  * `AND` - AND
-  * `OR` - OR */
+     *  You can use a simplified version:
+     * ```json
+     * {
+     *     "properties": [
+     *         {
+     *             "key": "email",
+     *             "value": "x@y.com",
+     *             "operator": "exact",
+     *             "type": "event"
+     *         }
+     *     ]
+     * }
+     * ```
+     *
+     * Or you can create more complicated queries with AND and OR:
+     * ```json
+     * {
+     *     "properties": {
+     *         "type": "AND",
+     *         "values": [
+     *             {
+     *                 "type": "OR",
+     *                 "values": [
+     *                     {"key": "email", ...},
+     *                     {"key": "email", ...}
+     *                 ]
+     *             },
+     *             {
+     *                 "type": "AND",
+     *                 "values": [
+     *                     {"key": "email", ...},
+     *                     {"key": "email", ...}
+     *                 ]
+     *             }
+     *         ]
+     *     ]
+     * }
+     * ```
+     *
+     *
+     * * `AND` - AND
+     * * `OR` - OR */
     type?: PropertyGroupOperatorApi
     values: PropertyItemApi[]
 }

--- a/products/persons/frontend/generated/api.ts
+++ b/products/persons/frontend/generated/api.ts
@@ -66,7 +66,7 @@ export const getPersonsListUrl = (projectId: string, params?: PersonsListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -96,7 +96,7 @@ export const getPersonsRetrieveUrl = (projectId: string, id: string, params?: Pe
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -127,7 +127,7 @@ export const getPersonsUpdateUrl = (projectId: string, id: string, params?: Pers
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -140,8 +140,8 @@ export const getPersonsUpdateUrl = (projectId: string, id: string, params?: Pers
 
 /**
  * Only for setting properties on the person. "properties" from the request data will be updated via a "$set" event.
-This means that only the properties listed will be updated, but other properties won't be removed nor updated.
-If you would like to remove a property use the `delete_property` endpoint.
+ * This means that only the properties listed will be updated, but other properties won't be removed nor updated.
+ * If you would like to remove a property use the `delete_property` endpoint.
  */
 export const personsUpdate = async (
     projectId: string,
@@ -163,7 +163,7 @@ export const getPersonsPartialUpdateUrl = (projectId: string, id: string, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -201,7 +201,7 @@ export const getPersonsActivityRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -236,7 +236,7 @@ export const getPersonsDeletePropertyCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -274,7 +274,7 @@ export const getPersonsPropertiesTimelineRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -305,7 +305,7 @@ export const getPersonsSplitCreateUrl = (projectId: string, id: string, params?:
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -348,7 +348,7 @@ export const getPersonsUpdatePropertyCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -382,7 +382,7 @@ export const getPersonsAllActivityRetrieveUrl = (projectId: string, params?: Per
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -415,7 +415,7 @@ export const getPersonsBatchByDistinctIdsCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -448,7 +448,7 @@ export const getPersonsBatchByUuidsCreateUrl = (projectId: string, params?: Pers
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -481,7 +481,7 @@ export const getPersonsBulkDeleteCreateUrl = (projectId: string, params?: Person
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -514,7 +514,7 @@ export const getPersonsCohortsRetrieveUrl = (projectId: string, params: PersonsC
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -544,7 +544,7 @@ export const getPersonsDeletionStatusListUrl = (projectId: string, params?: Pers
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -574,7 +574,7 @@ export const getPersonsFunnelRetrieveUrl = (projectId: string, params?: PersonsF
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -604,7 +604,7 @@ export const getPersonsFunnelCreateUrl = (projectId: string, params?: PersonsFun
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -637,7 +637,7 @@ export const getPersonsLifecycleRetrieveUrl = (projectId: string, params?: Perso
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -670,7 +670,7 @@ export const getPersonsPropertiesAtTimeRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -683,14 +683,14 @@ export const getPersonsPropertiesAtTimeRetrieveUrl = (
 
 /**
  * Get person properties as they existed at a specific point in time.
-
-This endpoint reconstructs person properties by querying ClickHouse events
-for $set and $set_once operations up to the specified timestamp.
-
-Query parameters:
-- distinct_id: The distinct_id of the person
-- timestamp: ISO datetime string for the point in time (e.g., "2023-06-15T14:30:00Z")
-- include_set_once: Whether to handle $set_once operations (default: false)
+ *
+ * This endpoint reconstructs person properties by querying ClickHouse events
+ * for $set and $set_once operations up to the specified timestamp.
+ *
+ * Query parameters:
+ * - distinct_id: The distinct_id of the person
+ * - timestamp: ISO datetime string for the point in time (e.g., "2023-06-15T14:30:00Z")
+ * - include_set_once: Whether to handle $set_once operations (default: false)
  */
 export const personsPropertiesAtTimeRetrieve = async (
     projectId: string,
@@ -711,7 +711,7 @@ export const getPersonsResetPersonDistinctIdCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -744,7 +744,7 @@ export const getPersonsTrendsRetrieveUrl = (projectId: string, params?: PersonsT
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -774,7 +774,7 @@ export const getPersonsValuesRetrieveUrl = (projectId: string, params: PersonsVa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/persons/frontend/generated/api.ts
+++ b/products/persons/frontend/generated/api.ts
@@ -318,11 +318,11 @@ export const getPersonsSplitCreateUrl = (projectId: string, id: string, params?:
 
 /**
  * Split distinct_ids off a merged person. Two mutually exclusive modes:
-
-- **`distinct_ids_to_split`** (recommended for surgical edits): moves only the listed distinct_ids off this person onto new single-id persons. The original person keeps every other distinct_id and its properties.
-- **`main_distinct_id`** (legacy semantics): keeps only the specified distinct_id on this person; moves every *other* distinct_id off onto its own new person. If omitted, the person's properties are wiped and the first distinct_id is treated as the one to keep.
-
-The split runs asynchronously: a 201 response means the task was enqueued. Newly-created split-off persons get a deterministic UUID derived from `(team_id, distinct_id)`, so they can be located client-side without polling. If you need to delete a split-off person after this call, prefer looking it up by that deterministic UUID rather than by distinct_id, since the latter still resolves to the original merged person until the async task completes.
+ *
+ * - **`distinct_ids_to_split`** (recommended for surgical edits): moves only the listed distinct_ids off this person onto new single-id persons. The original person keeps every other distinct_id and its properties.
+ * - **`main_distinct_id`** (legacy semantics): keeps only the specified distinct_id on this person; moves every *other* distinct_id off onto its own new person. If omitted, the person's properties are wiped and the first distinct_id is treated as the one to keep.
+ *
+ * The split runs asynchronously: a 201 response means the task was enqueued. Newly-created split-off persons get a deterministic UUID derived from `(team_id, distinct_id)`, so they can be located client-side without polling. If you need to delete a split-off person after this call, prefer looking it up by that deterministic UUID rather than by distinct_id, since the latter still resolves to the original merged person until the async task completes.
  */
 export const personsSplitCreate = async (
     projectId: string,

--- a/products/persons/frontend/generated/api.zod.ts
+++ b/products/persons/frontend/generated/api.zod.ts
@@ -40,11 +40,11 @@ export const PersonsDeletePropertyCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Split distinct_ids off a merged person. Two mutually exclusive modes:
-
-- **`distinct_ids_to_split`** (recommended for surgical edits): moves only the listed distinct_ids off this person onto new single-id persons. The original person keeps every other distinct_id and its properties.
-- **`main_distinct_id`** (legacy semantics): keeps only the specified distinct_id on this person; moves every *other* distinct_id off onto its own new person. If omitted, the person's properties are wiped and the first distinct_id is treated as the one to keep.
-
-The split runs asynchronously: a 201 response means the task was enqueued. Newly-created split-off persons get a deterministic UUID derived from `(team_id, distinct_id)`, so they can be located client-side without polling. If you need to delete a split-off person after this call, prefer looking it up by that deterministic UUID rather than by distinct_id, since the latter still resolves to the original merged person until the async task completes.
+ *
+ * - **`distinct_ids_to_split`** (recommended for surgical edits): moves only the listed distinct_ids off this person onto new single-id persons. The original person keeps every other distinct_id and its properties.
+ * - **`main_distinct_id`** (legacy semantics): keeps only the specified distinct_id on this person; moves every *other* distinct_id off onto its own new person. If omitted, the person's properties are wiped and the first distinct_id is treated as the one to keep.
+ *
+ * The split runs asynchronously: a 201 response means the task was enqueued. Newly-created split-off persons get a deterministic UUID derived from `(team_id, distinct_id)`, so they can be located client-side without polling. If you need to delete a split-off person after this call, prefer looking it up by that deterministic UUID rather than by distinct_id, since the latter still resolves to the original merged person until the async task completes.
  */
 export const PersonsSplitCreateBody = /* @__PURE__ */ zod.object({
     main_distinct_id: zod

--- a/products/persons/frontend/generated/api.zod.ts
+++ b/products/persons/frontend/generated/api.zod.ts
@@ -11,8 +11,8 @@ import * as zod from 'zod'
 
 /**
  * Only for setting properties on the person. "properties" from the request data will be updated via a "$set" event.
-This means that only the properties listed will be updated, but other properties won't be removed nor updated.
-If you would like to remove a property use the `delete_property` endpoint.
+ * This means that only the properties listed will be updated, but other properties won't be removed nor updated.
+ * If you would like to remove a property use the `delete_property` endpoint.
  */
 export const PersonsUpdateBody = /* @__PURE__ */ zod.object({
     properties: zod

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -18,9 +18,9 @@ export const EffectiveMembershipLevelEnumApi = {
 
 /**
  * * `0` - none
- * `3` - config
- * `6` - install
- * `9` - root
+ * * `3` - config
+ * * `6` - install
+ * * `9` - root
  */
 export type PluginsAccessLevelEnumApi = (typeof PluginsAccessLevelEnumApi)[keyof typeof PluginsAccessLevelEnumApi]
 
@@ -33,7 +33,7 @@ export const PluginsAccessLevelEnumApi = {
 
 /**
  * * `bayesian` - Bayesian
- * `frequentist` - Frequentist
+ * * `frequentist` - Frequentist
  */
 export type DefaultExperimentStatsMethodEnumApi =
     (typeof DefaultExperimentStatsMethodEnumApi)[keyof typeof DefaultExperimentStatsMethodEnumApi]
@@ -108,9 +108,9 @@ export interface OrganizationApi {
     /** @nullable */
     readonly is_hipaa: boolean | null
     /** Default statistical method for new experiments in this organization.
-
-  * `bayesian` - Bayesian
-  * `frequentist` - Frequentist */
+     *
+     * * `bayesian` - Bayesian
+     * * `frequentist` - Frequentist */
     default_experiment_stats_method?: DefaultExperimentStatsMethodEnumApi | BlankEnumApi | null
     /** Default setting for 'Discard client IP data' for new projects in this organization. */
     default_anonymize_ips?: boolean
@@ -204,9 +204,9 @@ export interface PatchedOrganizationApi {
     /** @nullable */
     readonly is_hipaa?: boolean | null
     /** Default statistical method for new experiments in this organization.
-
-  * `bayesian` - Bayesian
-  * `frequentist` - Frequentist */
+     *
+     * * `bayesian` - Bayesian
+     * * `frequentist` - Frequentist */
     default_experiment_stats_method?: DefaultExperimentStatsMethodEnumApi | BlankEnumApi | null
     /** Default setting for 'Discard client IP data' for new projects in this organization. */
     default_anonymize_ips?: boolean
@@ -234,13 +234,13 @@ export interface PatchedOrganizationApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -283,8 +283,8 @@ export interface UserBasicApi {
 
 /**
  * * `1` - member
- * `8` - administrator
- * `15` - owner
+ * * `8` - administrator
+ * * `15` - owner
  */
 export type OrganizationMembershipLevelEnumApi =
     (typeof OrganizationMembershipLevelEnumApi)[keyof typeof OrganizationMembershipLevelEnumApi]
@@ -437,9 +437,9 @@ export interface _WelcomeInviterApi {
 
 /**
  * * `today` - today
- * `this_week` - this_week
- * `inactive` - inactive
- * `never` - never
+ * * `this_week` - this_week
+ * * `inactive` - inactive
+ * * `never` - never
  */
 export type LastActiveEnumApi = (typeof LastActiveEnumApi)[keyof typeof LastActiveEnumApi]
 
@@ -620,9 +620,9 @@ export interface PatchedApprovalPolicyApi {
 
 /**
  * * `valid` - Valid
- * `invalid` - Invalid
- * `expired` - Expired
- * `stale` - Stale (resource changed)
+ * * `invalid` - Invalid
+ * * `expired` - Expired
+ * * `stale` - Stale (resource changed)
  */
 export type ValidationStatusEnumApi = (typeof ValidationStatusEnumApi)[keyof typeof ValidationStatusEnumApi]
 
@@ -635,11 +635,11 @@ export const ValidationStatusEnumApi = {
 
 /**
  * * `pending` - Pending
- * `approved` - Approved (awaiting application)
- * `applied` - Applied
- * `rejected` - Rejected
- * `expired` - Expired
- * `failed` - Failed to apply
+ * * `approved` - Approved (awaiting application)
+ * * `applied` - Applied
+ * * `rejected` - Rejected
+ * * `expired` - Expired
+ * * `failed` - Failed to apply
  */
 export type ChangeRequestStateEnumApi = (typeof ChangeRequestStateEnumApi)[keyof typeof ChangeRequestStateEnumApi]
 
@@ -912,72 +912,72 @@ export type ActivityLogListParams = {
      */
     page_size?: number
     /**
- * Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".
-
-* `Cohort` - Cohort
-* `FeatureFlag` - FeatureFlag
-* `Person` - Person
-* `Group` - Group
-* `Insight` - Insight
-* `Plugin` - Plugin
-* `PluginConfig` - PluginConfig
-* `HogFunction` - HogFunction
-* `HogFlow` - HogFlow
-* `DataManagement` - DataManagement
-* `EventDefinition` - EventDefinition
-* `PropertyDefinition` - PropertyDefinition
-* `Notebook` - Notebook
-* `Endpoint` - Endpoint
-* `EndpointVersion` - EndpointVersion
-* `Dashboard` - Dashboard
-* `Replay` - Replay
-* `Experiment` - Experiment
-* `ExperimentHoldout` - ExperimentHoldout
-* `ExperimentSavedMetric` - ExperimentSavedMetric
-* `Survey` - Survey
-* `EarlyAccessFeature` - EarlyAccessFeature
-* `SessionRecordingPlaylist` - SessionRecordingPlaylist
-* `Comment` - Comment
-* `Team` - Team
-* `Project` - Project
-* `ErrorTrackingIssue` - ErrorTrackingIssue
-* `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-* `LegalDocument` - LegalDocument
-* `Organization` - Organization
-* `OrganizationDomain` - OrganizationDomain
-* `OrganizationMembership` - OrganizationMembership
-* `Role` - Role
-* `UserGroup` - UserGroup
-* `BatchExport` - BatchExport
-* `BatchImport` - BatchImport
-* `Integration` - Integration
-* `Annotation` - Annotation
-* `Tag` - Tag
-* `TaggedItem` - TaggedItem
-* `Subscription` - Subscription
-* `PersonalAPIKey` - PersonalAPIKey
-* `ProjectSecretAPIKey` - ProjectSecretAPIKey
-* `User` - User
-* `Action` - Action
-* `AlertConfiguration` - AlertConfiguration
-* `Threshold` - Threshold
-* `AlertSubscription` - AlertSubscription
-* `ExternalDataSource` - ExternalDataSource
-* `ExternalDataSchema` - ExternalDataSchema
-* `Evaluation` - Evaluation
-* `LLMTrace` - LLMTrace
-* `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-* `CustomerProfileConfig` - CustomerProfileConfig
-* `Log` - Log
-* `LogsAlertConfiguration` - LogsAlertConfiguration
-* `LogsExclusionRule` - LogsExclusionRule
-* `DashboardWidget` - DashboardWidget
-* `ProductTour` - ProductTour
-* `Ticket` - Ticket
-* `InstanceSetting` - InstanceSetting
-* `SignalScoutConfig` - SignalScoutConfig
- * @minLength 1
- */
+     * Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".
+     *
+     * * `Cohort` - Cohort
+     * * `FeatureFlag` - FeatureFlag
+     * * `Person` - Person
+     * * `Group` - Group
+     * * `Insight` - Insight
+     * * `Plugin` - Plugin
+     * * `PluginConfig` - PluginConfig
+     * * `HogFunction` - HogFunction
+     * * `HogFlow` - HogFlow
+     * * `DataManagement` - DataManagement
+     * * `EventDefinition` - EventDefinition
+     * * `PropertyDefinition` - PropertyDefinition
+     * * `Notebook` - Notebook
+     * * `Endpoint` - Endpoint
+     * * `EndpointVersion` - EndpointVersion
+     * * `Dashboard` - Dashboard
+     * * `Replay` - Replay
+     * * `Experiment` - Experiment
+     * * `ExperimentHoldout` - ExperimentHoldout
+     * * `ExperimentSavedMetric` - ExperimentSavedMetric
+     * * `Survey` - Survey
+     * * `EarlyAccessFeature` - EarlyAccessFeature
+     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+     * * `Comment` - Comment
+     * * `Team` - Team
+     * * `Project` - Project
+     * * `ErrorTrackingIssue` - ErrorTrackingIssue
+     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+     * * `LegalDocument` - LegalDocument
+     * * `Organization` - Organization
+     * * `OrganizationDomain` - OrganizationDomain
+     * * `OrganizationMembership` - OrganizationMembership
+     * * `Role` - Role
+     * * `UserGroup` - UserGroup
+     * * `BatchExport` - BatchExport
+     * * `BatchImport` - BatchImport
+     * * `Integration` - Integration
+     * * `Annotation` - Annotation
+     * * `Tag` - Tag
+     * * `TaggedItem` - TaggedItem
+     * * `Subscription` - Subscription
+     * * `PersonalAPIKey` - PersonalAPIKey
+     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `User` - User
+     * * `Action` - Action
+     * * `AlertConfiguration` - AlertConfiguration
+     * * `Threshold` - Threshold
+     * * `AlertSubscription` - AlertSubscription
+     * * `ExternalDataSource` - ExternalDataSource
+     * * `ExternalDataSchema` - ExternalDataSchema
+     * * `Evaluation` - Evaluation
+     * * `LLMTrace` - LLMTrace
+     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+     * * `CustomerProfileConfig` - CustomerProfileConfig
+     * * `Log` - Log
+     * * `LogsAlertConfiguration` - LogsAlertConfiguration
+     * * `LogsExclusionRule` - LogsExclusionRule
+     * * `DashboardWidget` - DashboardWidget
+     * * `ProductTour` - ProductTour
+     * * `Ticket` - Ticket
+     * * `InstanceSetting` - InstanceSetting
+     * * `SignalScoutConfig` - SignalScoutConfig
+     * @minLength 1
+     */
     scope?: ActivityLogListScope
     /**
      * Filter by multiple activity scopes, comma-separated. Values must be valid ActivityScope enum values. E.g. "FeatureFlag,Insight".
@@ -1058,67 +1058,67 @@ export const ActivityLogListScope = {
 
 /**
  * * `Cohort` - Cohort
- * `FeatureFlag` - FeatureFlag
- * `Person` - Person
- * `Group` - Group
- * `Insight` - Insight
- * `Plugin` - Plugin
- * `PluginConfig` - PluginConfig
- * `HogFunction` - HogFunction
- * `HogFlow` - HogFlow
- * `DataManagement` - DataManagement
- * `EventDefinition` - EventDefinition
- * `PropertyDefinition` - PropertyDefinition
- * `Notebook` - Notebook
- * `Endpoint` - Endpoint
- * `EndpointVersion` - EndpointVersion
- * `Dashboard` - Dashboard
- * `Replay` - Replay
- * `Experiment` - Experiment
- * `ExperimentHoldout` - ExperimentHoldout
- * `ExperimentSavedMetric` - ExperimentSavedMetric
- * `Survey` - Survey
- * `EarlyAccessFeature` - EarlyAccessFeature
- * `SessionRecordingPlaylist` - SessionRecordingPlaylist
- * `Comment` - Comment
- * `Team` - Team
- * `Project` - Project
- * `ErrorTrackingIssue` - ErrorTrackingIssue
- * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
- * `LegalDocument` - LegalDocument
- * `Organization` - Organization
- * `OrganizationDomain` - OrganizationDomain
- * `OrganizationMembership` - OrganizationMembership
- * `Role` - Role
- * `UserGroup` - UserGroup
- * `BatchExport` - BatchExport
- * `BatchImport` - BatchImport
- * `Integration` - Integration
- * `Annotation` - Annotation
- * `Tag` - Tag
- * `TaggedItem` - TaggedItem
- * `Subscription` - Subscription
- * `PersonalAPIKey` - PersonalAPIKey
- * `ProjectSecretAPIKey` - ProjectSecretAPIKey
- * `User` - User
- * `Action` - Action
- * `AlertConfiguration` - AlertConfiguration
- * `Threshold` - Threshold
- * `AlertSubscription` - AlertSubscription
- * `ExternalDataSource` - ExternalDataSource
- * `ExternalDataSchema` - ExternalDataSchema
- * `Evaluation` - Evaluation
- * `LLMTrace` - LLMTrace
- * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
- * `CustomerProfileConfig` - CustomerProfileConfig
- * `Log` - Log
- * `LogsAlertConfiguration` - LogsAlertConfiguration
- * `LogsExclusionRule` - LogsExclusionRule
- * `DashboardWidget` - DashboardWidget
- * `ProductTour` - ProductTour
- * `Ticket` - Ticket
- * `InstanceSetting` - InstanceSetting
- * `SignalScoutConfig` - SignalScoutConfig
+ * * `FeatureFlag` - FeatureFlag
+ * * `Person` - Person
+ * * `Group` - Group
+ * * `Insight` - Insight
+ * * `Plugin` - Plugin
+ * * `PluginConfig` - PluginConfig
+ * * `HogFunction` - HogFunction
+ * * `HogFlow` - HogFlow
+ * * `DataManagement` - DataManagement
+ * * `EventDefinition` - EventDefinition
+ * * `PropertyDefinition` - PropertyDefinition
+ * * `Notebook` - Notebook
+ * * `Endpoint` - Endpoint
+ * * `EndpointVersion` - EndpointVersion
+ * * `Dashboard` - Dashboard
+ * * `Replay` - Replay
+ * * `Experiment` - Experiment
+ * * `ExperimentHoldout` - ExperimentHoldout
+ * * `ExperimentSavedMetric` - ExperimentSavedMetric
+ * * `Survey` - Survey
+ * * `EarlyAccessFeature` - EarlyAccessFeature
+ * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+ * * `Comment` - Comment
+ * * `Team` - Team
+ * * `Project` - Project
+ * * `ErrorTrackingIssue` - ErrorTrackingIssue
+ * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+ * * `LegalDocument` - LegalDocument
+ * * `Organization` - Organization
+ * * `OrganizationDomain` - OrganizationDomain
+ * * `OrganizationMembership` - OrganizationMembership
+ * * `Role` - Role
+ * * `UserGroup` - UserGroup
+ * * `BatchExport` - BatchExport
+ * * `BatchImport` - BatchImport
+ * * `Integration` - Integration
+ * * `Annotation` - Annotation
+ * * `Tag` - Tag
+ * * `TaggedItem` - TaggedItem
+ * * `Subscription` - Subscription
+ * * `PersonalAPIKey` - PersonalAPIKey
+ * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+ * * `User` - User
+ * * `Action` - Action
+ * * `AlertConfiguration` - AlertConfiguration
+ * * `Threshold` - Threshold
+ * * `AlertSubscription` - AlertSubscription
+ * * `ExternalDataSource` - ExternalDataSource
+ * * `ExternalDataSchema` - ExternalDataSchema
+ * * `Evaluation` - Evaluation
+ * * `LLMTrace` - LLMTrace
+ * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+ * * `CustomerProfileConfig` - CustomerProfileConfig
+ * * `Log` - Log
+ * * `LogsAlertConfiguration` - LogsAlertConfiguration
+ * * `LogsExclusionRule` - LogsExclusionRule
+ * * `DashboardWidget` - DashboardWidget
+ * * `ProductTour` - ProductTour
+ * * `Ticket` - Ticket
+ * * `InstanceSetting` - InstanceSetting
+ * * `SignalScoutConfig` - SignalScoutConfig
  */
 export type ActivityLogListScopesItem = (typeof ActivityLogListScopesItem)[keyof typeof ActivityLogListScopesItem]
 
@@ -1291,13 +1291,13 @@ export type ChangeRequestsListParams = {
 
 export type CommentsListParams = {
     /**
- * When kind=task, restrict to open (incomplete) or completed tasks. Ignored when kind is not 'task'. Defaults to 'any' (no filter).
-
-* `any` - any
-* `open` - open
-* `completed` - completed
- * @minLength 1
- */
+     * When kind=task, restrict to open (incomplete) or completed tasks. Ignored when kind is not 'task'. Defaults to 'any' (no filter).
+     *
+     * * `any` - any
+     * * `open` - open
+     * * `completed` - completed
+     * @minLength 1
+     */
     completed?: CommentsListCompleted
     /**
      * The pagination cursor value.
@@ -1309,13 +1309,13 @@ export type CommentsListParams = {
      */
     item_id?: string
     /**
- * Filter by comment kind. 'task' returns only items intentionally created as actionable. 'comment' excludes tasks. Defaults to 'any' (no filter).
-
-* `any` - any
-* `comment` - comment
-* `task` - task
- * @minLength 1
- */
+     * Filter by comment kind. 'task' returns only items intentionally created as actionable. 'comment' excludes tasks. Defaults to 'any' (no filter).
+     *
+     * * `any` - any
+     * * `comment` - comment
+     * * `task` - task
+     * @minLength 1
+     */
     kind?: CommentsListKind
     /**
      * Filter by resource type (e.g. Dashboard, FeatureFlag, Insight, Replay).

--- a/products/platform_features/frontend/generated/api.ts
+++ b/products/platform_features/frontend/generated/api.ts
@@ -70,7 +70,7 @@ export const getListUrl = (params?: ListParams) => {
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -163,7 +163,7 @@ export const getMembersListUrl = (organizationId: string, params?: MembersListPa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -256,7 +256,7 @@ export const getPersonalApiKeysListUrl = (organizationId: string, params?: Perso
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -283,7 +283,7 @@ export const getRolesListUrl = (organizationId: string, params?: RolesListParams
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -389,7 +389,7 @@ export const getRolesRoleMembershipsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -484,7 +484,7 @@ export const getActivityLogListUrl = (projectId: string, params?: ActivityLogLis
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -511,7 +511,7 @@ export const getAdvancedActivityLogsListUrl = (projectId: string, params?: Advan
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -569,7 +569,7 @@ export const getApprovalPoliciesListUrl = (projectId: string, params?: ApprovalP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -675,7 +675,7 @@ export const getChangeRequestsListUrl = (projectId: string, params?: ChangeReque
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -718,7 +718,7 @@ export const getChangeRequestsApproveCreateUrl = (projectId: string, id: string)
 
 /**
  * Approve a change request.
-If quorum is reached, automatically applies the change immediately.
+ * If quorum is reached, automatically applies the change immediately.
  */
 export const changeRequestsApproveCreate = async (
     projectId: string,
@@ -740,7 +740,7 @@ export const getChangeRequestsCancelCreateUrl = (projectId: string, id: string) 
 
 /**
  * Cancel a change request.
-Only the requester can cancel their own pending change request.
+ * Only the requester can cancel their own pending change request.
  */
 export const changeRequestsCancelCreate = async (
     projectId: string,
@@ -782,7 +782,7 @@ export const getCommentsListUrl = (projectId: string, params?: CommentsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/platform_features/frontend/generated/api.zod.ts
+++ b/products/platform_features/frontend/generated/api.zod.ts
@@ -264,13 +264,13 @@ export const ApprovalPoliciesPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Approve a change request.
-If quorum is reached, automatically applies the change immediately.
+ * If quorum is reached, automatically applies the change immediately.
  */
 export const ChangeRequestsApproveCreateBody = /* @__PURE__ */ zod.looseObject({})
 
 /**
  * Cancel a change request.
-Only the requester can cancel their own pending change request.
+ * Only the requester can cancel their own pending change request.
  */
 export const ChangeRequestsCancelCreateBody = /* @__PURE__ */ zod.looseObject({})
 

--- a/products/posthog_ai/frontend/generated/api.ts
+++ b/products/posthog_ai/frontend/generated/api.ts
@@ -16,11 +16,11 @@ export const getMcpToolsCreateUrl = (projectId: string, toolName: string) => {
 
 /**
  * Invoke an MCP tool by name.
-
-This endpoint allows MCP callers to invoke Max AI tools directly
-without going through the full LangChain conversation flow.
-
-Scopes are resolved dynamically per tool via dangerously_get_required_scopes.
+ *
+ * This endpoint allows MCP callers to invoke Max AI tools directly
+ * without going through the full LangChain conversation flow.
+ *
+ * Scopes are resolved dynamically per tool via dangerously_get_required_scopes.
  */
 export const mcpToolsCreate = async (
     projectId: string,

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9,7 +9,7 @@
  */
 /**
  * * `private` - Private (only visible to creator)
- * `shared` - Shared with team
+ * * `shared` - Shared with team
  */
 export type VisibilityEnumApi = (typeof VisibilityEnumApi)[keyof typeof VisibilityEnumApi]
 
@@ -78,7 +78,10 @@ export interface ElementApi {
      * @nullable
      */
     tag_name?: string | null
-    /** @nullable */
+    /**
+     * @nullable
+     * @items.maxLength 200
+     */
     attr_class?: string[] | null
     /**
      * @maxLength 10000
@@ -131,7 +134,10 @@ export interface PatchedElementApi {
      * @nullable
      */
     tag_name?: string | null
-    /** @nullable */
+    /**
+     * @nullable
+     * @items.maxLength 200
+     */
     attr_class?: string[] | null
     /**
      * @maxLength 10000
@@ -242,7 +248,7 @@ export interface CustomEventConversionGoalApi {
 
 export interface DateRangeApi {
     /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-  -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
+     * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
     date_from?: string | null
     /** End of the date range. Same format as date_from. Omit or null for "now". */
     date_to?: string | null
@@ -1523,14 +1529,14 @@ export type TrendsFilterApiResultCustomizations =
 
 export interface TrendsFilterApi {
     /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-
-  - `numeric` (default): raw numbers, e.g. `1,234`.
-  - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-  - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-  - `percentage`: values are already in the 0-100 range; appends `%`.
-  - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-  - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-  - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
+     *
+     * - `numeric` (default): raw numbers, e.g. `1,234`.
+     * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+     * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+     * - `percentage`: values are already in the 0-100 range; appends `%`.
+     * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+     * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+     * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
     aggregationAxisFormat?: AggregationAxisFormatApi | null
     /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
     aggregationAxisPostfix?: string | null
@@ -7076,10 +7082,10 @@ export interface HogQueryApi {
 
 /**
  * The query definition for this insight. The `kind` field determines the query type:
-- `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
-- `DataVisualizationNode` — SQL insights using HogQL
-- `DataTableNode` — raw data tables
-- `HogQuery` — Hog language queries
+ * - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+ * - `DataVisualizationNode` — SQL insights using HogQL
+ * - `DataTableNode` — raw data tables
+ * - `HogQuery` — Hog language queries
  */
 export type _InsightQuerySchemaApi = InsightVizNodeApi | DataTableNodeApi | DataVisualizationNodeApi | HogQueryApi
 
@@ -7092,13 +7098,13 @@ export interface DashboardTileBasicApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -7193,21 +7199,21 @@ export interface InsightApi {
     order?: number | null
     deleted?: boolean
     /**
-          DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-          A dashboard ID for each of the dashboards that this insight is displayed on.
-           */
+     *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+     *         A dashboard ID for each of the dashboards that this insight is displayed on.
+     *          */
     dashboards?: number[]
     /**
-      A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-       */
+     *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+     *      */
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
     /**
      *
-      The datetime this insight's results were generated.
-      If added to one or more dashboards the insight can be refreshed separately on each.
-      Returns the appropriate last_refresh datetime for the context the insight is viewed in
-      (see from_dashboard query parameter).
-
+     *     The datetime this insight's results were generated.
+     *     If added to one or more dashboards the insight can be refreshed separately on each.
+     *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+     *     (see from_dashboard query parameter).
+     *
      * @nullable
      */
     readonly last_refresh: string | null
@@ -7218,9 +7224,9 @@ export interface InsightApi {
     readonly cache_target_age: string | null
     /**
      *
-      The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-      by querying the database.
-
+     *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+     *     by querying the database.
+     *
      * @nullable
      */
     readonly next_allowed_client_refresh: string | null
@@ -7313,21 +7319,21 @@ export interface PatchedInsightApi {
     order?: number | null
     deleted?: boolean
     /**
-          DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-          A dashboard ID for each of the dashboards that this insight is displayed on.
-           */
+     *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+     *         A dashboard ID for each of the dashboards that this insight is displayed on.
+     *          */
     dashboards?: number[]
     /**
-      A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-       */
+     *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+     *      */
     readonly dashboard_tiles?: readonly DashboardTileBasicApi[]
     /**
      *
-      The datetime this insight's results were generated.
-      If added to one or more dashboards the insight can be refreshed separately on each.
-      Returns the appropriate last_refresh datetime for the context the insight is viewed in
-      (see from_dashboard query parameter).
-
+     *     The datetime this insight's results were generated.
+     *     If added to one or more dashboards the insight can be refreshed separately on each.
+     *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+     *     (see from_dashboard query parameter).
+     *
      * @nullable
      */
     readonly last_refresh?: string | null
@@ -7338,9 +7344,9 @@ export interface PatchedInsightApi {
     readonly cache_target_age?: string | null
     /**
      *
-      The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-      by querying the database.
-
+     *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+     *     by querying the database.
+     *
      * @nullable
      */
     readonly next_allowed_client_refresh?: string | null
@@ -7451,8 +7457,8 @@ export interface ActivityLogPaginatedResponseApi {
 
 /**
  * * `add` - add
- * `remove` - remove
- * `set` - set
+ * * `remove` - remove
+ * * `set` - set
  */
 export type ActionEnumApi = (typeof ActionEnumApi)[keyof typeof ActionEnumApi]
 
@@ -7469,10 +7475,10 @@ export interface BulkUpdateTagsRequestApi {
      */
     ids: number[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-  * `add` - add
-  * `remove` - remove
-  * `set` - set */
+     *
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set */
     action: ActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
@@ -7638,16 +7644,16 @@ export type InsightsListParams = {
      */
     offset?: number
     /**
- *
-Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-- `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-- `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-- `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-- `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-- `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-- `'force_async'` - kick off background calculation, even if fresh results are already cached
-Background calculation can be tracked using the `query_status` response field.
- */
+     *
+     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
+     */
     refresh?: InsightsListRefresh
     /**
      * When truthy, restricts results to insights that are saved (or attached to a visible dashboard). When falsy, only unsaved insights.
@@ -7718,22 +7724,22 @@ export type InsightsRetrieveParams = {
     filters_override?: string
     format?: InsightsRetrieveFormat
     /**
- *
-Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-When set, the specified dashboard's filters and date range override will be applied.
- */
+     *
+     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+     * When set, the specified dashboard's filters and date range override will be applied.
+     */
     from_dashboard?: number
     /**
- *
-Whether to refresh the insight, how aggresively, and if sync or async:
-- `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-- `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-- `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-- `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-- `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-- `'force_async'` - kick off background calculation, even if fresh results are already cached
-Background calculation can be tracked using the `query_status` response field.
- */
+     *
+     * Whether to refresh the insight, how aggresively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
+     */
     refresh?: InsightsRetrieveRefresh
     /**
      * Object (or pre-encoded JSON string) to override the insight's HogQL variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `insight-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.

--- a/products/product_analytics/frontend/generated/api.ts
+++ b/products/product_analytics/frontend/generated/api.ts
@@ -66,7 +66,7 @@ export const getColumnConfigurationsListUrl = (projectId: string, params?: Colum
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -176,7 +176,7 @@ export const getElementsListUrl = (projectId: string, params?: ElementsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -279,9 +279,9 @@ export const getElementsStatsRetrieveUrl = (projectId: string) => {
 
 /**
  * The original version of this API always and only returned $autocapture elements
-If no include query parameter is sent this remains true.
-Now, you can pass a combination of include query parameters to get different types of elements
-Currently only $autocapture and $rageclick and $dead_click are supported
+ * If no include query parameter is sent this remains true.
+ * Now, you can pass a combination of include query parameters to get different types of elements
+ * Currently only $autocapture and $rageclick and $dead_click are supported
  */
 export const elementsStatsRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getElementsStatsRetrieveUrl(projectId), {
@@ -306,7 +306,7 @@ export const getInsightsListUrl = (projectId: string, params?: InsightsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -319,11 +319,11 @@ export const getInsightsListUrl = (projectId: string, params?: InsightsListParam
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsList = async (
     projectId: string,
@@ -341,7 +341,7 @@ export const getInsightsCreateUrl = (projectId: string, params?: InsightsCreateP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -354,11 +354,11 @@ export const getInsightsCreateUrl = (projectId: string, params?: InsightsCreateP
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsCreate = async (
     projectId: string,
@@ -379,7 +379,7 @@ export const getInsightsRetrieveUrl = (projectId: string, id: number | string, p
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -392,11 +392,11 @@ export const getInsightsRetrieveUrl = (projectId: string, id: number | string, p
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsRetrieve = async (
     projectId: string,
@@ -415,7 +415,7 @@ export const getInsightsUpdateUrl = (projectId: string, id: number | string, par
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -428,11 +428,11 @@ export const getInsightsUpdateUrl = (projectId: string, id: number | string, par
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsUpdate = async (
     projectId: string,
@@ -458,7 +458,7 @@ export const getInsightsPartialUpdateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -471,11 +471,11 @@ export const getInsightsPartialUpdateUrl = (
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsPartialUpdate = async (
     projectId: string,
@@ -497,7 +497,7 @@ export const getInsightsDestroyUrl = (projectId: string, id: number | string, pa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -532,7 +532,7 @@ export const getInsightsActivityRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -567,7 +567,7 @@ export const getInsightsAnalyzeRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -580,11 +580,11 @@ export const getInsightsAnalyzeRetrieveUrl = (
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsAnalyzeRetrieve = async (
     projectId: string,
@@ -607,7 +607,7 @@ export const getInsightsSuggestionsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -620,11 +620,11 @@ export const getInsightsSuggestionsRetrieveUrl = (
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsSuggestionsRetrieve = async (
     projectId: string,
@@ -647,7 +647,7 @@ export const getInsightsSuggestionsCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -660,11 +660,11 @@ export const getInsightsSuggestionsCreateUrl = (
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsSuggestionsCreate = async (
     projectId: string,
@@ -686,7 +686,7 @@ export const getInsightsAllActivityRetrieveUrl = (projectId: string, params?: In
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -716,7 +716,7 @@ export const getInsightsBulkUpdateTagsCreateUrl = (projectId: string, params?: I
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -729,22 +729,22 @@ export const getInsightsBulkUpdateTagsCreateUrl = (projectId: string, params?: I
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const insightsBulkUpdateTagsCreate = async (
     projectId: string,
@@ -765,7 +765,7 @@ export const getInsightsCancelCreateUrl = (projectId: string, params?: InsightsC
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -778,11 +778,11 @@ export const getInsightsCancelCreateUrl = (projectId: string, params?: InsightsC
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const insightsCancelCreate = async (
     projectId: string,
@@ -806,7 +806,7 @@ export const getInsightsGenerateMetadataCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -839,7 +839,7 @@ export const getInsightsMyLastViewedRetrieveUrl = (projectId: string, params?: I
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -869,7 +869,7 @@ export const getInsightsTrendingRetrieveUrl = (projectId: string, params?: Insig
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -899,7 +899,7 @@ export const getInsightsViewedCreateUrl = (projectId: string, params?: InsightsV
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/product_analytics/frontend/generated/api.zod.ts
+++ b/products/product_analytics/frontend/generated/api.zod.ts
@@ -175,11 +175,11 @@ export const ElementsPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -187,11 +187,11 @@ export const InsightsCreateBody = /* @__PURE__ */ zod
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsUpdateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -199,11 +199,11 @@ export const InsightsUpdateBody = /* @__PURE__ */ zod
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -211,11 +211,11 @@ export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsSuggestionsCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())
@@ -223,22 +223,22 @@ export const InsightsSuggestionsCreateBody = /* @__PURE__ */ zod
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const insightsBulkUpdateTagsCreateBodyIdsMax = 500
 
@@ -258,11 +258,11 @@ export const InsightsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsCancelCreateBody = /* @__PURE__ */ zod
     .record(zod.string(), zod.unknown())

--- a/products/product_tours/frontend/generated/api.schemas.ts
+++ b/products/product_tours/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `server` - Server
- * `client` - Client
- * `all` - All
+ * * `client` - Client
+ * * `all` - All
  */
 export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
 
@@ -28,7 +28,7 @@ export const BlankEnumApi = {
 
 /**
  * * `distinct_id` - User ID (default)
- * `device_id` - Device ID
+ * * `device_id` - Device ID
  */
 export type BucketingIdentifierEnumApi = (typeof BucketingIdentifierEnumApi)[keyof typeof BucketingIdentifierEnumApi]
 
@@ -57,28 +57,28 @@ export interface MinimalFeatureFlagApi {
      */
     version?: number | null
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     readonly evaluation_contexts: readonly string[]
 }
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -165,7 +165,7 @@ export interface PaginatedProductTourListApi {
 
 /**
  * * `app` - app
- * `toolbar` - toolbar
+ * * `toolbar` - toolbar
  */
 export type ProductTourSerializerCreateUpdateOnlyCreationContextEnumApi =
     (typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnumApi)[keyof typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnumApi]
@@ -199,9 +199,9 @@ export interface ProductTourSerializerCreateUpdateOnlyApi {
     readonly updated_at: string
     archived?: boolean
     /** Where the tour was created/updated from
-
-  * `app` - app
-  * `toolbar` - toolbar */
+     *
+     * * `app` - app
+     * * `toolbar` - toolbar */
     creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnumApi
 }
 
@@ -229,9 +229,9 @@ export interface PatchedProductTourSerializerCreateUpdateOnlyApi {
     readonly updated_at?: string
     archived?: boolean
     /** Where the tour was created/updated from
-
-  * `app` - app
-  * `toolbar` - toolbar */
+     *
+     * * `app` - app
+     * * `toolbar` - toolbar */
     creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnumApi
 }
 

--- a/products/product_tours/frontend/generated/api.ts
+++ b/products/product_tours/frontend/generated/api.ts
@@ -41,7 +41,7 @@ export const getProductToursListUrl = (projectId: string, params?: ProductToursL
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -226,9 +226,9 @@ export const getProductToursPublishDraftCreateUrl = (projectId: string, id: stri
 
 /**
  * Commit draft to live tour. Runs full validation and triggers side effects.
-
-Accepts an optional body payload. If provided, merges it into the draft
-before publishing so the caller can save + publish in a single request.
+ *
+ * Accepts an optional body payload. If provided, merges it into the draft
+ * before publishing so the caller can save + publish in a single request.
  */
 export const productToursPublishDraftCreate = async (
     projectId: string,

--- a/products/product_tours/frontend/generated/api.zod.ts
+++ b/products/product_tours/frontend/generated/api.zod.ts
@@ -109,9 +109,9 @@ export const ProductToursGenerateCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Commit draft to live tour. Runs full validation and triggers side effects.
-
-Accepts an optional body payload. If provided, merges it into the draft
-before publishing so the caller can save + publish in a single request.
+ *
+ * Accepts an optional body payload. If provided, merges it into the draft
+ * before publishing so the caller can save + publish in a single request.
  */
 export const productToursPublishDraftCreateBodyNameMax = 400
 

--- a/products/replay/frontend/generated/api.schemas.ts
+++ b/products/replay/frontend/generated/api.schemas.ts
@@ -23,13 +23,13 @@ export interface SessionSummariesApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -78,7 +78,7 @@ export interface UserBasicApi {
 
 /**
  * * `collection` - Collection
- * `filters` - Filters
+ * * `filters` - Filters
  */
 export type SessionRecordingPlaylistTypeEnumApi =
     (typeof SessionRecordingPlaylistTypeEnumApi)[keyof typeof SessionRecordingPlaylistTypeEnumApi]
@@ -118,9 +118,9 @@ export interface SessionRecordingPlaylistApi {
     readonly last_modified_by: UserBasicApi
     readonly recordings_counts: SessionRecordingPlaylistApiRecordingsCounts
     /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-
-  * `collection` - Collection
-  * `filters` - Filters */
+     *
+     * * `collection` - Collection
+     * * `filters` - Filters */
     type?: SessionRecordingPlaylistTypeEnumApi | null
     /** Return whether this is a synthetic playlist */
     readonly is_synthetic: boolean
@@ -168,9 +168,9 @@ export interface PatchedSessionRecordingPlaylistApi {
     readonly last_modified_by?: UserBasicApi
     readonly recordings_counts?: PatchedSessionRecordingPlaylistApiRecordingsCounts
     /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-
-  * `collection` - Collection
-  * `filters` - Filters */
+     *
+     * * `collection` - Collection
+     * * `filters` - Filters */
     type?: SessionRecordingPlaylistTypeEnumApi | null
     /** Return whether this is a synthetic playlist */
     readonly is_synthetic?: boolean

--- a/products/replay/frontend/generated/api.ts
+++ b/products/replay/frontend/generated/api.ts
@@ -68,7 +68,7 @@ export const getSessionRecordingPlaylistsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -245,7 +245,7 @@ export const getSessionRecordingsListUrl = (projectId: string, params?: SessionR
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -334,7 +334,7 @@ export const getSingleSessionSummariesListUrl = (projectId: string, params?: Sin
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -9,10 +9,10 @@
  */
 /**
  * * `pending` - Pending
- * `running` - Running
- * `succeeded` - Succeeded
- * `failed` - Failed
- * `ineligible` - Ineligible
+ * * `running` - Running
+ * * `succeeded` - Succeeded
+ * * `failed` - Failed
+ * * `ineligible` - Ineligible
  */
 export type ObservationStatusEnumApi = (typeof ObservationStatusEnumApi)[keyof typeof ObservationStatusEnumApi]
 
@@ -26,9 +26,9 @@ export const ObservationStatusEnumApi = {
 
 /**
  * * `monitor` - Monitor
- * `classifier` - Classifier
- * `scorer` - Scorer
- * `summarizer` - Summarizer
+ * * `classifier` - Classifier
+ * * `scorer` - Scorer
+ * * `summarizer` - Summarizer
  */
 export type ScannerTypeEnumApi = (typeof ScannerTypeEnumApi)[keyof typeof ScannerTypeEnumApi]
 
@@ -41,7 +41,7 @@ export const ScannerTypeEnumApi = {
 
 /**
  * * `gemini-3-flash-preview` - Gemini 3 Flash
- * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
+ * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
  */
 export type ScannerModelEnumApi = (typeof ScannerModelEnumApi)[keyof typeof ScannerModelEnumApi]
 
@@ -66,22 +66,22 @@ export interface ScannerSnapshotApi {
     /** Scanner name at run time. */
     name: string
     /** Scanner type (monitor, classifier, scorer, summarizer) at run time.
-
-  * `monitor` - Monitor
-  * `classifier` - Classifier
-  * `scorer` - Scorer
-  * `summarizer` - Summarizer */
+     *
+     * * `monitor` - Monitor
+     * * `classifier` - Classifier
+     * * `scorer` - Scorer
+     * * `summarizer` - Summarizer */
     scanner_type: ScannerTypeEnumApi
     /** The `ReplayScanner.scanner_version` value at the moment the workflow ran. */
     scanner_version: number
     /** Concrete model that ran the observation.
-
-  * `gemini-3-flash-preview` - Gemini 3 Flash
-  * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+     *
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+     * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
     model: ScannerModelEnumApi
     /** Concrete provider that ran the observation.
-
-  * `google` - Google */
+     *
+     * * `google` - Google */
     provider: ScannerProviderEnumApi
     /** Whether the observation was run with Signal emission enabled. */
     emits_signals: boolean
@@ -104,7 +104,7 @@ export interface ScannerResultApi {
 
 /**
  * * `schedule` - Schedule
- * `on_demand` - On demand
+ * * `on_demand` - On demand
  */
 export type ObservationTriggerEnumApi = (typeof ObservationTriggerEnumApi)[keyof typeof ObservationTriggerEnumApi]
 
@@ -115,13 +115,13 @@ export const ObservationTriggerEnumApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -175,12 +175,12 @@ export interface ReplayObservationApi {
     /** Session recording id this scanner was applied to. */
     readonly session_id: string
     /** Observation status (pending, running, succeeded, failed, ineligible).
-
-  * `pending` - Pending
-  * `running` - Running
-  * `succeeded` - Succeeded
-  * `failed` - Failed
-  * `ineligible` - Ineligible */
+     *
+     * * `pending` - Pending
+     * * `running` - Running
+     * * `succeeded` - Succeeded
+     * * `failed` - Failed
+     * * `ineligible` - Ineligible */
     readonly status: ObservationStatusEnumApi
     /** Populated on terminal non-success statuses; formatted as `kind:human-readable message`. For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / validation_failed / internal_error. */
     readonly error_reason: string
@@ -191,9 +191,9 @@ export interface ReplayObservationApi {
     /** Result data persisted on success; null until the observation succeeds. */
     readonly scanner_result: ScannerResultApi | null
     /** Whether this observation came from the schedule or an on-demand request.
-
-  * `schedule` - Schedule
-  * `on_demand` - On demand */
+     *
+     * * `schedule` - Schedule
+     * * `on_demand` - On demand */
     readonly triggered_by: ObservationTriggerEnumApi
     /** User who triggered an on-demand observation; null for scheduled observations. */
     readonly triggered_by_user: UserBasicApi | null
@@ -238,11 +238,11 @@ export interface ReplayScannerApi {
     /** Free-form description shown in the scanner management UI. */
     description?: string
     /** What the scanner does: monitor, classifier, scorer, or summarizer.
-
-  * `monitor` - Monitor
-  * `classifier` - Classifier
-  * `scorer` - Scorer
-  * `summarizer` - Summarizer */
+     *
+     * * `monitor` - Monitor
+     * * `classifier` - Classifier
+     * * `scorer` - Scorer
+     * * `summarizer` - Summarizer */
     scanner_type: ScannerTypeEnumApi
     /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
     scanner_config: unknown
@@ -255,13 +255,13 @@ export interface ReplayScannerApi {
      */
     sampling_rate?: number
     /** LLM provider. v1 is Google-only.
-
-  * `google` - Google */
+     *
+     * * `google` - Google */
     provider?: ScannerProviderEnumApi
     /** Concrete model to use for this scanner.
-
-  * `gemini-3-flash-preview` - Gemini 3 Flash
-  * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+     *
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+     * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
     model: ScannerModelEnumApi
     /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
     enabled?: boolean
@@ -296,11 +296,11 @@ export interface PatchedReplayScannerApi {
     /** Free-form description shown in the scanner management UI. */
     description?: string
     /** What the scanner does: monitor, classifier, scorer, or summarizer.
-
-  * `monitor` - Monitor
-  * `classifier` - Classifier
-  * `scorer` - Scorer
-  * `summarizer` - Summarizer */
+     *
+     * * `monitor` - Monitor
+     * * `classifier` - Classifier
+     * * `scorer` - Scorer
+     * * `summarizer` - Summarizer */
     scanner_type?: ScannerTypeEnumApi
     /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
     scanner_config?: unknown
@@ -313,13 +313,13 @@ export interface PatchedReplayScannerApi {
      */
     sampling_rate?: number
     /** LLM provider. v1 is Google-only.
-
-  * `google` - Google */
+     *
+     * * `google` - Google */
     provider?: ScannerProviderEnumApi
     /** Concrete model to use for this scanner.
-
-  * `gemini-3-flash-preview` - Gemini 3 Flash
-  * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+     *
+     * * `gemini-3-flash-preview` - Gemini 3 Flash
+     * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
     model?: ScannerModelEnumApi
     /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
     enabled?: boolean

--- a/products/replay_vision/frontend/generated/api.ts
+++ b/products/replay_vision/frontend/generated/api.ts
@@ -50,7 +50,7 @@ export const getVisionObservationsListUrl = (projectId: string, params: VisionOb
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -112,7 +112,7 @@ export const getVisionScannersListUrl = (projectId: string, params?: VisionScann
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -240,7 +240,7 @@ export const getVisionScannersObservationsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -297,7 +297,7 @@ export const getVisionScannersObservationsStatsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -38,14 +38,14 @@ export interface PauseResponseApi {
 
 /**
  * * `potential` - Potential
- * `candidate` - Candidate
- * `in_progress` - In Progress
- * `pending_input` - Pending Input
- * `ready` - Ready
- * `resolved` - Resolved
- * `failed` - Failed
- * `deleted` - Deleted
- * `suppressed` - Suppressed
+ * * `candidate` - Candidate
+ * * `in_progress` - In Progress
+ * * `pending_input` - Pending Input
+ * * `ready` - Ready
+ * * `resolved` - Resolved
+ * * `failed` - Failed
+ * * `deleted` - Deleted
+ * * `suppressed` - Suppressed
  */
 export type SignalReportStatusEnumApi = (typeof SignalReportStatusEnumApi)[keyof typeof SignalReportStatusEnumApi]
 
@@ -110,7 +110,7 @@ export interface PaginatedSignalReportListApi {
 
 /**
  * * `suppressed` - suppressed
- * `potential` - potential
+ * * `potential` - potential
  */
 export type SignalReportStateRequestStateEnumApi =
     (typeof SignalReportStateRequestStateEnumApi)[keyof typeof SignalReportStateRequestStateEnumApi]
@@ -122,9 +122,9 @@ export const SignalReportStateRequestStateEnumApi = {
 
 export interface SignalReportStateRequestApi {
     /** Target state for the report. Use 'suppressed' to dismiss the report from the inbox, or 'potential' to snooze/reopen it for later review.
-
-  * `suppressed` - suppressed
-  * `potential` - potential */
+     *
+     * * `suppressed` - suppressed
+     * * `potential` - potential */
     state: SignalReportStateRequestStateEnumApi
     /** Optional short reason code for the dismissal (e.g. 'not_a_bug', 'wont_fix', 'duplicate'). The set of reason codes is owned by the caller and is not validated server-side. */
     dismissal_reason?: string
@@ -143,9 +143,9 @@ export interface SignalReportStateRequestApi {
 
 /**
  * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-
-One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-when it discovers a scout skill; this serializer lets agents tune the row.
+ *
+ * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+ * when it discovers a scout skill; this serializer lets agents tune the row.
  */
 export interface SignalScoutConfigApi {
     readonly id: string
@@ -171,9 +171,9 @@ export interface SignalScoutConfigApi {
 
 /**
  * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-
-One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-when it discovers a scout skill; this serializer lets agents tune the row.
+ *
+ * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+ * when it discovers a scout skill; this serializer lets agents tune the row.
  */
 export interface PatchedSignalScoutConfigApi {
     readonly id?: string
@@ -665,10 +665,10 @@ export interface TopEventEntryApi {
 
 /**
  * The deterministic inventory layer of a project profile.
-
-Read this to orient on the team's product mix, integrations, warehouse sources, signal
-coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
-profile is ground truth from authoritative tables; memory is agent inference.
+ *
+ * Read this to orient on the team's product mix, integrations, warehouse sources, signal
+ * coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
+ * profile is ground truth from authoritative tables; memory is agent inference.
  */
 export interface ProjectProfileInventoryApi {
     /** Free-form orientation: human-set product description + registered app URLs. */
@@ -716,9 +716,9 @@ export interface ProjectProfileInventoryApi {
 
 /**
  * Top-level `payload` shape on a `SignalProjectProfile` row.
-
-v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
-`narrative` slots — they're absent (not null) in v1 responses.
+ *
+ * v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
+ * `narrative` slots — they're absent (not null) in v1 responses.
  */
 export interface ProjectProfilePayloadApi {
     /** Deterministic snapshot of what's true about the project. */
@@ -727,11 +727,11 @@ export interface ProjectProfilePayloadApi {
 
 /**
  * Wire shape for the project profile returned by `signals-scout-harness-project-profile-list`.
-
-Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
-is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
-latest cached profile or a freshly-built one if the cache was stale or the caller passed
-`force_refresh=true`.
+ *
+ * Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
+ * is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
+ * latest cached profile or a freshly-built one if the cache was stale or the caller passed
+ * `force_refresh=true`.
  */
 export interface ProjectProfileApi {
     /** UUID of the `SignalProjectProfile` row. */
@@ -748,8 +748,8 @@ export interface ProjectProfileApi {
 
 /**
  * Lightweight projection of a `SignalScoutRun` row used by `search-recent-runs`.
-
-Status and timestamps flow from the linked `tasks.TaskRun`.
+ *
+ * Status and timestamps flow from the linked `tasks.TaskRun`.
  */
 export interface SignalScoutRunSummaryApi {
     /** UUID of the bridge row. */
@@ -792,8 +792,8 @@ export interface SignalScoutRunSummaryApi {
 
 /**
  * Full `SignalScoutRun` projection used by `get-run`. Same shape as the summary
-today; kept distinct so future detail-only extensions (linked Signal rows,
-LLMA token-cost join) can land here without bloating the list response.
+ * today; kept distinct so future detail-only extensions (linked Signal rows,
+ * LLMA token-cost join) can land here without bloating the list response.
  */
 export interface SignalScoutRunDetailApi {
     /** UUID of the bridge row. */
@@ -836,10 +836,10 @@ export interface SignalScoutRunDetailApi {
 
 /**
  * * `P0` - P0
- * `P1` - P1
- * `P2` - P2
- * `P3` - P3
- * `P4` - P4
+ * * `P1` - P1
+ * * `P2` - P2
+ * * `P3` - P3
+ * * `P4` - P4
  */
 export type AutonomyPriorityEnumApi = (typeof AutonomyPriorityEnumApi)[keyof typeof AutonomyPriorityEnumApi]
 
@@ -853,9 +853,9 @@ export const AutonomyPriorityEnumApi = {
 
 /**
  * One finding a scout run emitted to the inbox — the persisted, queryable record of
-*what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
-lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
-back into the underlying signal store.
+ * *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
+ * lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
+ * back into the underlying signal store.
  */
 export interface SignalScoutEmissionApi {
     readonly id: string
@@ -878,12 +878,12 @@ export interface SignalScoutEmissionApi {
      */
     confidence: number
     /** Optional severity tag — one of P0, P1, P2, P3, P4 — or null if the run didn't set one.
-
-  * `P0` - P0
-  * `P1` - P1
-  * `P2` - P2
-  * `P3` - P3
-  * `P4` - P4 */
+     *
+     * * `P0` - P0
+     * * `P1` - P1
+     * * `P2` - P2
+     * * `P3` - P3
+     * * `P4` - P4 */
     severity: AutonomyPriorityEnumApi | null
     /** Deterministic `run:<run_id>:finding:<finding_id>` — the join key into the underlying signal store. */
     source_id: string
@@ -939,12 +939,12 @@ export interface EmitFindingRequestApi {
      */
     hypothesis?: string | null
     /** Optional severity tag — one of P0, P1, P2, P3, P4. Informational only.
-
-  * `P0` - P0
-  * `P1` - P1
-  * `P2` - P2
-  * `P3` - P3
-  * `P4` - P4 */
+     *
+     * * `P0` - P0
+     * * `P1` - P1
+     * * `P2` - P2
+     * * `P3` - P3
+     * * `P4` - P4 */
     severity?: AutonomyPriorityEnumApi | null
     /** Optional keys for downstream dedupe (e.g. `error_tracking_issue:<id>`). */
     dedupe_keys?: string[]
@@ -1039,15 +1039,15 @@ export interface ForgetResponseApi {
 
 /**
  * * `session_replay` - Session replay
- * `llm_analytics` - LLM analytics
- * `github` - GitHub
- * `linear` - Linear
- * `zendesk` - Zendesk
- * `conversations` - Conversations
- * `error_tracking` - Error tracking
- * `pganalyze` - pganalyze
- * `signals_scout` - Signals scout
- * `logs` - Logs
+ * * `llm_analytics` - LLM analytics
+ * * `github` - GitHub
+ * * `linear` - Linear
+ * * `zendesk` - Zendesk
+ * * `conversations` - Conversations
+ * * `error_tracking` - Error tracking
+ * * `pganalyze` - pganalyze
+ * * `signals_scout` - Signals scout
+ * * `logs` - Logs
  */
 export type SourceProductEnumApi = (typeof SourceProductEnumApi)[keyof typeof SourceProductEnumApi]
 
@@ -1066,14 +1066,14 @@ export const SourceProductEnumApi = {
 
 /**
  * * `session_analysis_cluster` - Session analysis cluster
- * `evaluation` - Evaluation
- * `issue` - Issue
- * `ticket` - Ticket
- * `issue_created` - Issue created
- * `issue_reopened` - Issue reopened
- * `issue_spiking` - Issue spiking
- * `cross_source_issue` - Cross source issue
- * `alert_state_change` - Alert state change
+ * * `evaluation` - Evaluation
+ * * `issue` - Issue
+ * * `ticket` - Ticket
+ * * `issue_created` - Issue created
+ * * `issue_reopened` - Issue reopened
+ * * `issue_spiking` - Issue spiking
+ * * `cross_source_issue` - Cross source issue
+ * * `alert_state_change` - Alert state change
  */
 export type SignalSourceConfigSourceTypeEnumApi =
     (typeof SignalSourceConfigSourceTypeEnumApi)[keyof typeof SignalSourceConfigSourceTypeEnumApi]
@@ -1153,12 +1153,12 @@ export interface SignalUserAutonomyConfigApi {
      */
     slack_notification_channel?: string | null
     /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
-
-  * `P0` - P0
-  * `P1` - P1
-  * `P2` - P2
-  * `P3` - P3
-  * `P4` - P4 */
+     *
+     * * `P0` - P0
+     * * `P1` - P1
+     * * `P2` - P2
+     * * `P3` - P3
+     * * `P4` - P4 */
     slack_notification_min_priority?: AutonomyPriorityEnumApi | BlankEnumApi | null
     readonly created_at: string
     readonly updated_at: string

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -61,7 +61,7 @@ export const getSignalsProcessingListUrl = (projectId: string, params?: SignalsP
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -128,7 +128,7 @@ export const getSignalsReportsListUrl = (projectId: string, params?: SignalsRepo
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -171,20 +171,20 @@ export const getSignalsReportsStateCreateUrl = (projectId: string, id: string) =
 
 /**
  * Transition a report to a new state. The model validates allowed transitions.
-
-The request body is validated by SignalReportStateRequestSerializer — only the
-fields it declares (state, dismissal_reason, dismissal_note, snooze_for) are read,
-and only snooze_for is ever forwarded to transition_to. Any other key is ignored,
-so internal transition_to kwargs (reset_weight, error, ...) can't be injected.
-
-Body: {
-    "state": "suppressed" | "potential",
-    # Optional dismissal feedback (honored when state == "suppressed" or "potential"):
-    "dismissal_reason": "<any string code, owned by the caller>",
-    "dismissal_note": "free-form text",
-    # Optional, only honored for state == "potential":
-    "snooze_for": <number of additional signals before re-promotion>,
-}
+ *
+ * The request body is validated by SignalReportStateRequestSerializer — only the
+ * fields it declares (state, dismissal_reason, dismissal_note, snooze_for) are read,
+ * and only snooze_for is ever forwarded to transition_to. Any other key is ignored,
+ * so internal transition_to kwargs (reset_weight, error, ...) can't be injected.
+ *
+ * Body: {
+ *     "state": "suppressed" | "potential",
+ *     # Optional dismissal feedback (honored when state == "suppressed" or "potential"):
+ *     "dismissal_reason": "<any string code, owned by the caller>",
+ *     "dismissal_note": "free-form text",
+ *     # Optional, only honored for state == "potential":
+ *     "snooze_for": <number of additional signals before re-promotion>,
+ * }
  */
 export const signalsReportsStateCreate = async (
     projectId: string,
@@ -248,7 +248,7 @@ export const getSignalsScoutProjectProfileGetUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -279,7 +279,7 @@ export const getSignalsScoutRunsListUrl = (projectId: string, params?: SignalsSc
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -370,7 +370,7 @@ export const getSignalsScoutScratchpadSearchUrl = (projectId: string, params?: S
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -443,7 +443,7 @@ export const getSignalsSourceConfigsListUrl = (projectId: string, params?: Signa
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -554,10 +554,10 @@ export const getUsersSignalAutonomyRetrieveUrl = (userId: string) => {
 
 /**
  * Per-user signal autonomy config (singleton keyed by user).
-
-GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
-POST   /api/users/<id>/signal_autonomy/ → create or update
-DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
+ *
+ * GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
+ * POST   /api/users/<id>/signal_autonomy/ → create or update
+ * DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
  */
 export const usersSignalAutonomyRetrieve = async (
     userId: string,
@@ -575,10 +575,10 @@ export const getUsersSignalAutonomyCreateUrl = (userId: string) => {
 
 /**
  * Per-user signal autonomy config (singleton keyed by user).
-
-GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
-POST   /api/users/<id>/signal_autonomy/ → create or update
-DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
+ *
+ * GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
+ * POST   /api/users/<id>/signal_autonomy/ → create or update
+ * DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
  */
 export const usersSignalAutonomyCreate = async (
     userId: string,
@@ -599,10 +599,10 @@ export const getUsersSignalAutonomyDestroyUrl = (userId: string) => {
 
 /**
  * Per-user signal autonomy config (singleton keyed by user).
-
-GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
-POST   /api/users/<id>/signal_autonomy/ → create or update
-DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
+ *
+ * GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
+ * POST   /api/users/<id>/signal_autonomy/ → create or update
+ * DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
  */
 export const usersSignalAutonomyDestroy = async (userId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getUsersSignalAutonomyDestroyUrl(userId), {

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -20,20 +20,20 @@ export const SignalsProcessingPauseUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Transition a report to a new state. The model validates allowed transitions.
-
-The request body is validated by SignalReportStateRequestSerializer — only the
-fields it declares (state, dismissal_reason, dismissal_note, snooze_for) are read,
-and only snooze_for is ever forwarded to transition_to. Any other key is ignored,
-so internal transition_to kwargs (reset_weight, error, ...) can't be injected.
-
-Body: {
-    "state": "suppressed" | "potential",
-    # Optional dismissal feedback (honored when state == "suppressed" or "potential"):
-    "dismissal_reason": "<any string code, owned by the caller>",
-    "dismissal_note": "free-form text",
-    # Optional, only honored for state == "potential":
-    "snooze_for": <number of additional signals before re-promotion>,
-}
+ *
+ * The request body is validated by SignalReportStateRequestSerializer — only the
+ * fields it declares (state, dismissal_reason, dismissal_note, snooze_for) are read,
+ * and only snooze_for is ever forwarded to transition_to. Any other key is ignored,
+ * so internal transition_to kwargs (reset_weight, error, ...) can't be injected.
+ *
+ * Body: {
+ *     "state": "suppressed" | "potential",
+ *     # Optional dismissal feedback (honored when state == "suppressed" or "potential"):
+ *     "dismissal_reason": "<any string code, owned by the caller>",
+ *     "dismissal_note": "free-form text",
+ *     # Optional, only honored for state == "potential":
+ *     "snooze_for": <number of additional signals before re-promotion>,
+ * }
  */
 export const signalsReportsStateCreateBodyDismissalNoteMax = 4000
 
@@ -332,10 +332,10 @@ export const SignalsSourceConfigsPartialUpdateBody = /* @__PURE__ */ zod.object(
 
 /**
  * Per-user signal autonomy config (singleton keyed by user).
-
-GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
-POST   /api/users/<id>/signal_autonomy/ → create or update
-DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
+ *
+ * GET    /api/users/<id>/signal_autonomy/ → current config (or 404)
+ * POST   /api/users/<id>/signal_autonomy/ → create or update
+ * DELETE /api/users/<id>/signal_autonomy/ → remove (opt out)
  */
 export const usersSignalAutonomyCreateBodySlackNotificationChannelMax = 255
 

--- a/products/subscriptions/frontend/generated/api.schemas.ts
+++ b/products/subscriptions/frontend/generated/api.schemas.ts
@@ -9,9 +9,9 @@
  */
 /**
  * * `starting` - Starting
- * `completed` - Completed
- * `failed` - Failed
- * `skipped` - Skipped
+ * * `completed` - Completed
+ * * `failed` - Failed
+ * * `skipped` - Skipped
  */
 export type SubscriptionDeliveryStatusEnumApi =
     (typeof SubscriptionDeliveryStatusEnumApi)[keyof typeof SubscriptionDeliveryStatusEnumApi]
@@ -43,18 +43,22 @@ export interface SubscriptionDeliveryApi {
     readonly target_type: string
     /** Destination snapshot at send time (emails, channel id, URL). */
     readonly target_value: string
-    /** ExportedAsset ids generated for this send. */
+    /**
+     * ExportedAsset ids generated for this send.
+     * @items.minimum -2147483648
+     * @items.maximum 2147483647
+     */
     readonly exported_asset_ids: readonly number[]
     /** Snapshot at send time: dashboard metadata, total_insight_count, and per-exported-insight entries (id, short_id, name, query_hash, cache_key, query_results, optional query_error). */
     readonly content_snapshot: unknown
     /** Per-destination outcomes; items use status success, failed, or partial. */
     readonly recipient_results: unknown
     /** Overall run status: starting, completed, failed, or skipped.
-
-  * `starting` - Starting
-  * `completed` - Completed
-  * `failed` - Failed
-  * `skipped` - Skipped */
+     *
+     * * `starting` - Starting
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `skipped` - Skipped */
     readonly status: SubscriptionDeliveryStatusEnumApi
     /** Top-level failure payload when status is failed, if any. */
     readonly error: unknown
@@ -84,8 +88,8 @@ export interface PaginatedSubscriptionDeliveryListApi {
 
 /**
  * * `insight` - Insight
- * `dashboard` - Dashboard
- * `ai_prompt` - AI prompt
+ * * `dashboard` - Dashboard
+ * * `ai_prompt` - AI prompt
  */
 export type ResourceTypeEnumApi = (typeof ResourceTypeEnumApi)[keyof typeof ResourceTypeEnumApi]
 
@@ -97,7 +101,7 @@ export const ResourceTypeEnumApi = {
 
 /**
  * * `email` - Email
- * `slack` - Slack
+ * * `slack` - Slack
  */
 export type TargetTypeEnumApi = (typeof TargetTypeEnumApi)[keyof typeof TargetTypeEnumApi]
 
@@ -108,9 +112,9 @@ export const TargetTypeEnumApi = {
 
 /**
  * * `daily` - Daily
- * `weekly` - Weekly
- * `monthly` - Monthly
- * `yearly` - Yearly
+ * * `weekly` - Weekly
+ * * `monthly` - Monthly
+ * * `yearly` - Yearly
  */
 export type SubscriptionFrequencyEnumApi =
     (typeof SubscriptionFrequencyEnumApi)[keyof typeof SubscriptionFrequencyEnumApi]
@@ -124,12 +128,12 @@ export const SubscriptionFrequencyEnumApi = {
 
 /**
  * * `monday` - Monday
- * `tuesday` - Tuesday
- * `wednesday` - Wednesday
- * `thursday` - Thursday
- * `friday` - Friday
- * `saturday` - Saturday
- * `sunday` - Sunday
+ * * `tuesday` - Tuesday
+ * * `wednesday` - Wednesday
+ * * `thursday` - Thursday
+ * * `friday` - Friday
+ * * `saturday` - Saturday
+ * * `sunday` - Sunday
  */
 export type SubscriptionApiByweekdayItem =
     (typeof SubscriptionApiByweekdayItem)[keyof typeof SubscriptionApiByweekdayItem]
@@ -146,13 +150,13 @@ export const SubscriptionApiByweekdayItem = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -205,10 +209,10 @@ export interface UserBasicApi {
 export interface SubscriptionApi {
     readonly id: number
     /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-
-  * `insight` - Insight
-  * `dashboard` - Dashboard
-  * `ai_prompt` - AI prompt */
+     *
+     * * `insight` - Insight
+     * * `dashboard` - Dashboard
+     * * `ai_prompt` - AI prompt */
     readonly resource_type: ResourceTypeEnumApi
     /**
      * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -232,18 +236,18 @@ export interface SubscriptionApi {
      */
     prompt?: string | null
     /** Delivery channel: email or slack.
-
-  * `email` - Email
-  * `slack` - Slack */
+     *
+     * * `email` - Email
+     * * `slack` - Slack */
     target_type: TargetTypeEnumApi
     /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
     target_value: string
     /** How often to deliver: daily, weekly, monthly, or yearly.
-
-  * `daily` - Daily
-  * `weekly` - Weekly
-  * `monthly` - Monthly
-  * `yearly` - Yearly */
+     *
+     * * `daily` - Daily
+     * * `weekly` - Weekly
+     * * `monthly` - Monthly
+     * * `yearly` - Yearly */
     frequency: SubscriptionFrequencyEnumApi
     /**
      * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -323,12 +327,12 @@ export interface PaginatedSubscriptionListApi {
 
 /**
  * * `monday` - Monday
- * `tuesday` - Tuesday
- * `wednesday` - Wednesday
- * `thursday` - Thursday
- * `friday` - Friday
- * `saturday` - Saturday
- * `sunday` - Sunday
+ * * `tuesday` - Tuesday
+ * * `wednesday` - Wednesday
+ * * `thursday` - Thursday
+ * * `friday` - Friday
+ * * `saturday` - Saturday
+ * * `sunday` - Sunday
  */
 export type PatchedSubscriptionApiByweekdayItem =
     (typeof PatchedSubscriptionApiByweekdayItem)[keyof typeof PatchedSubscriptionApiByweekdayItem]
@@ -349,10 +353,10 @@ export const PatchedSubscriptionApiByweekdayItem = {
 export interface PatchedSubscriptionApi {
     readonly id?: number
     /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-
-  * `insight` - Insight
-  * `dashboard` - Dashboard
-  * `ai_prompt` - AI prompt */
+     *
+     * * `insight` - Insight
+     * * `dashboard` - Dashboard
+     * * `ai_prompt` - AI prompt */
     readonly resource_type?: ResourceTypeEnumApi
     /**
      * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -376,18 +380,18 @@ export interface PatchedSubscriptionApi {
      */
     prompt?: string | null
     /** Delivery channel: email or slack.
-
-  * `email` - Email
-  * `slack` - Slack */
+     *
+     * * `email` - Email
+     * * `slack` - Slack */
     target_type?: TargetTypeEnumApi
     /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
     target_value?: string
     /** How often to deliver: daily, weekly, monthly, or yearly.
-
-  * `daily` - Daily
-  * `weekly` - Weekly
-  * `monthly` - Monthly
-  * `yearly` - Yearly */
+     *
+     * * `daily` - Daily
+     * * `weekly` - Weekly
+     * * `monthly` - Monthly
+     * * `yearly` - Yearly */
     frequency?: SubscriptionFrequencyEnumApi
     /**
      * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.

--- a/products/subscriptions/frontend/generated/api.ts
+++ b/products/subscriptions/frontend/generated/api.ts
@@ -45,7 +45,7 @@ export const getSubscriptionsDeliveriesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -100,7 +100,7 @@ export const getSubscriptionsListUrl = (projectId: string, params?: Subscription
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -9,9 +9,9 @@
  */
 /**
  * * `popover` - popover
- * `widget` - widget
- * `external_survey` - external survey
- * `api` - api
+ * * `widget` - widget
+ * * `external_survey` - external survey
+ * * `api` - api
  */
 export type SurveyTypeApi = (typeof SurveyTypeApi)[keyof typeof SurveyTypeApi]
 
@@ -24,8 +24,8 @@ export const SurveyTypeApi = {
 
 /**
  * * `server` - Server
- * `client` - Client
- * `all` - All
+ * * `client` - Client
+ * * `all` - All
  */
 export type EvaluationRuntimeEnumApi = (typeof EvaluationRuntimeEnumApi)[keyof typeof EvaluationRuntimeEnumApi]
 
@@ -43,7 +43,7 @@ export const BlankEnumApi = {
 
 /**
  * * `distinct_id` - User ID (default)
- * `device_id` - Device ID
+ * * `device_id` - Device ID
  */
 export type BucketingIdentifierEnumApi = (typeof BucketingIdentifierEnumApi)[keyof typeof BucketingIdentifierEnumApi]
 
@@ -72,28 +72,28 @@ export interface MinimalFeatureFlagApi {
      */
     version?: number | null
     /** Specifies where this feature flag should be evaluated
-
-  * `server` - Server
-  * `client` - Client
-  * `all` - All */
+     *
+     * * `server` - Server
+     * * `client` - Client
+     * * `all` - All */
     evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | null
     /** Identifier used for bucketing users into rollout and variants
-
-  * `distinct_id` - User ID (default)
-  * `device_id` - Device ID */
+     *
+     * * `distinct_id` - User ID (default)
+     * * `device_id` - Device ID */
     bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | null
     readonly evaluation_contexts: readonly string[]
 }
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -136,8 +136,8 @@ export interface UserBasicApi {
 
 /**
  * * `day` - day
- * `week` - week
- * `month` - month
+ * * `week` - week
+ * * `month` - month
  */
 export type ResponseSamplingIntervalTypeEnumApi =
     (typeof ResponseSamplingIntervalTypeEnumApi)[keyof typeof ResponseSamplingIntervalTypeEnumApi]
@@ -174,117 +174,117 @@ export interface SurveyApi {
     readonly targeting_flag: MinimalFeatureFlagApi
     readonly internal_targeting_flag: MinimalFeatureFlagApi
     /**
-          The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-          Basic (open-ended question)
-          - `id`: The question ID
-          - `type`: `open`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Link (a question with a link)
-          - `id`: The question ID
-          - `type`: `link`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `link`: The URL associated with the question.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Rating (a question with a rating scale)
-          - `id`: The question ID
-          - `type`: `rating`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `display`: Display style of the rating (`number` or `emoji`).
-          - `scale`: The scale of the rating (`number`).
-          - `lowerBoundLabel`: Label for the lower bound of the scale.
-          - `upperBoundLabel`: Label for the upper bound of the scale.
-          - `isNpsQuestion`: Whether the question is an NPS rating.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Multiple choice
-          - `id`: The question ID
-          - `type`: `single_choice` or `multiple_choice`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `choices`: An array of choices for the question.
-          - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-          - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Branching logic can be one of the following types:
-
-          Next question: Proceeds to the next question
-          ```json
-          {
-              "type": "next_question"
-          }
-          ```
-
-          End: Ends the survey, optionally displaying a confirmation message.
-          ```json
-          {
-              "type": "end"
-          }
-          ```
-
-          Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-          ```json
-          {
-              "type": "response_based",
-              "responseValues": {
-                  "responseKey": "value"
-              }
-          }
-          ```
-
-          Specific question: Proceeds to a specific question by index.
-          ```json
-          {
-              "type": "specific_question",
-              "index": 2
-          }
-          ```
-
-          Translations: Each question can include inline translations.
-          - `translations`: Object mapping language codes to translated fields.
-          - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-          - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-          Example with translations:
-          ```json
-          {
-              "id": "uuid",
-              "type": "rating",
-              "question": "How satisfied are you?",
-              "lowerBoundLabel": "Not satisfied",
-              "upperBoundLabel": "Very satisfied",
-              "translations": {
-                  "es": {
-                      "question": "¿Qué tan satisfecho estás?",
-                      "lowerBoundLabel": "No satisfecho",
-                      "upperBoundLabel": "Muy satisfecho"
-                  },
-                  "fr": {
-                      "question": "Dans quelle mesure êtes-vous satisfait?"
-                  }
-              }
-          }
-          ```
-           */
+     *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+     *
+     *         Basic (open-ended question)
+     *         - `id`: The question ID
+     *         - `type`: `open`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Link (a question with a link)
+     *         - `id`: The question ID
+     *         - `type`: `link`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `link`: The URL associated with the question.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Rating (a question with a rating scale)
+     *         - `id`: The question ID
+     *         - `type`: `rating`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `display`: Display style of the rating (`number` or `emoji`).
+     *         - `scale`: The scale of the rating (`number`).
+     *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+     *         - `upperBoundLabel`: Label for the upper bound of the scale.
+     *         - `isNpsQuestion`: Whether the question is an NPS rating.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Multiple choice
+     *         - `id`: The question ID
+     *         - `type`: `single_choice` or `multiple_choice`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `choices`: An array of choices for the question.
+     *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+     *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Branching logic can be one of the following types:
+     *
+     *         Next question: Proceeds to the next question
+     *         ```json
+     *         {
+     *             "type": "next_question"
+     *         }
+     *         ```
+     *
+     *         End: Ends the survey, optionally displaying a confirmation message.
+     *         ```json
+     *         {
+     *             "type": "end"
+     *         }
+     *         ```
+     *
+     *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+     *         ```json
+     *         {
+     *             "type": "response_based",
+     *             "responseValues": {
+     *                 "responseKey": "value"
+     *             }
+     *         }
+     *         ```
+     *
+     *         Specific question: Proceeds to a specific question by index.
+     *         ```json
+     *         {
+     *             "type": "specific_question",
+     *             "index": 2
+     *         }
+     *         ```
+     *
+     *         Translations: Each question can include inline translations.
+     *         - `translations`: Object mapping language codes to translated fields.
+     *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+     *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+     *
+     *         Example with translations:
+     *         ```json
+     *         {
+     *             "id": "uuid",
+     *             "type": "rating",
+     *             "question": "How satisfied are you?",
+     *             "lowerBoundLabel": "Not satisfied",
+     *             "upperBoundLabel": "Very satisfied",
+     *             "translations": {
+     *                 "es": {
+     *                     "question": "¿Qué tan satisfecho estás?",
+     *                     "lowerBoundLabel": "No satisfecho",
+     *                     "upperBoundLabel": "Muy satisfecho"
+     *                 },
+     *                 "fr": {
+     *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+     *                 }
+     *             }
+     *         }
+     *         ```
+     *          */
     questions?: unknown
     /** @nullable */
     readonly conditions: SurveyApiConditions
@@ -370,8 +370,8 @@ export interface PaginatedSurveyListApi {
 
 /**
  * * `once` - once
- * `recurring` - recurring
- * `always` - always
+ * * `recurring` - recurring
+ * * `always` - always
  */
 export type ScheduleEnumApi = (typeof ScheduleEnumApi)[keyof typeof ScheduleEnumApi]
 
@@ -383,8 +383,8 @@ export const ScheduleEnumApi = {
 
 /**
  * * `cohort` - cohort
- * `person` - person
- * `group` - group
+ * * `person` - person
+ * * `group` - group
  */
 export type PropertyGroupTypeEnumApi = (typeof PropertyGroupTypeEnumApi)[keyof typeof PropertyGroupTypeEnumApi]
 
@@ -396,15 +396,15 @@ export const PropertyGroupTypeEnumApi = {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
- * `gt` - gt
- * `gte` - gte
- * `lt` - lt
- * `lte` - lte
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
+ * * `gt` - gt
+ * * `gte` - gte
+ * * `lt` - lt
+ * * `lte` - lte
  */
 export type FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi]
@@ -426,10 +426,10 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -444,23 +444,23 @@ export interface FeatureFlagFilterPropertyGenericSchemaApi {
     /** Comparison value for the property filter. Supports strings, numbers, booleans, and arrays. */
     value: unknown
     /** Operator used to compare the property value.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains
-  * `regex` - regex
-  * `not_regex` - not_regex
-  * `gt` - gt
-  * `gte` - gte
-  * `lt` - lt
-  * `lte` - lte */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `gte` - gte
+     * * `lt` - lt
+     * * `lte` - lte */
     operator: FeatureFlagFilterPropertyGenericSchemaOperatorEnumApi
 }
 
 /**
  * * `is_set` - is_set
- * `is_not_set` - is_not_set
+ * * `is_not_set` - is_not_set
  */
 export type ExistenceOperatorEnumApi = (typeof ExistenceOperatorEnumApi)[keyof typeof ExistenceOperatorEnumApi]
 
@@ -473,10 +473,10 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -489,9 +489,9 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
      */
     group_type_index?: number | null
     /** Existence operator.
-
-  * `is_set` - is_set
-  * `is_not_set` - is_not_set */
+     *
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set */
     operator: ExistenceOperatorEnumApi
     /** Optional value. Runtime behavior determines whether this is ignored. */
     value?: unknown
@@ -499,8 +499,8 @@ export interface FeatureFlagFilterPropertyExistsSchemaApi {
 
 /**
  * * `is_date_exact` - is_date_exact
- * `is_date_before` - is_date_before
- * `is_date_after` - is_date_after
+ * * `is_date_before` - is_date_before
+ * * `is_date_after` - is_date_after
  */
 export type DateOperatorEnumApi = (typeof DateOperatorEnumApi)[keyof typeof DateOperatorEnumApi]
 
@@ -514,10 +514,10 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -530,10 +530,10 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
      */
     group_type_index?: number | null
     /** Date comparison operator.
-
-  * `is_date_exact` - is_date_exact
-  * `is_date_after` - is_date_after
-  * `is_date_before` - is_date_before */
+     *
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_after` - is_date_after
+     * * `is_date_before` - is_date_before */
     operator: DateOperatorEnumApi
     /** Date value in ISO format or relative date expression. */
     value: string
@@ -541,14 +541,14 @@ export interface FeatureFlagFilterPropertyDateSchemaApi {
 
 /**
  * * `semver_gt` - semver_gt
- * `semver_gte` - semver_gte
- * `semver_lt` - semver_lt
- * `semver_lte` - semver_lte
- * `semver_eq` - semver_eq
- * `semver_neq` - semver_neq
- * `semver_tilde` - semver_tilde
- * `semver_caret` - semver_caret
- * `semver_wildcard` - semver_wildcard
+ * * `semver_gte` - semver_gte
+ * * `semver_lt` - semver_lt
+ * * `semver_lte` - semver_lte
+ * * `semver_eq` - semver_eq
+ * * `semver_neq` - semver_neq
+ * * `semver_tilde` - semver_tilde
+ * * `semver_caret` - semver_caret
+ * * `semver_wildcard` - semver_wildcard
  */
 export type FeatureFlagFilterPropertySemverSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertySemverSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertySemverSchemaOperatorEnumApi]
@@ -569,10 +569,10 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -585,16 +585,16 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
      */
     group_type_index?: number | null
     /** Semantic version comparison operator.
-
-  * `semver_gt` - semver_gt
-  * `semver_gte` - semver_gte
-  * `semver_lt` - semver_lt
-  * `semver_lte` - semver_lte
-  * `semver_eq` - semver_eq
-  * `semver_neq` - semver_neq
-  * `semver_tilde` - semver_tilde
-  * `semver_caret` - semver_caret
-  * `semver_wildcard` - semver_wildcard */
+     *
+     * * `semver_gt` - semver_gt
+     * * `semver_gte` - semver_gte
+     * * `semver_lt` - semver_lt
+     * * `semver_lte` - semver_lte
+     * * `semver_eq` - semver_eq
+     * * `semver_neq` - semver_neq
+     * * `semver_tilde` - semver_tilde
+     * * `semver_caret` - semver_caret
+     * * `semver_wildcard` - semver_wildcard */
     operator: FeatureFlagFilterPropertySemverSchemaOperatorEnumApi
     /** Semantic version string. */
     value: string
@@ -602,7 +602,7 @@ export interface FeatureFlagFilterPropertySemverSchemaApi {
 
 /**
  * * `icontains_multi` - icontains_multi
- * `not_icontains_multi` - not_icontains_multi
+ * * `not_icontains_multi` - not_icontains_multi
  */
 export type FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi]
@@ -616,10 +616,10 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Property filter type. Common values are 'person' and 'cohort'.
-
-  * `cohort` - cohort
-  * `person` - person
-  * `group` - group */
+     *
+     * * `cohort` - cohort
+     * * `person` - person
+     * * `group` - group */
     type?: PropertyGroupTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -632,9 +632,9 @@ export interface FeatureFlagFilterPropertyMultiContainsSchemaApi {
      */
     group_type_index?: number | null
     /** Multi-contains operator.
-
-  * `icontains_multi` - icontains_multi
-  * `not_icontains_multi` - not_icontains_multi */
+     *
+     * * `icontains_multi` - icontains_multi
+     * * `not_icontains_multi` - not_icontains_multi */
     operator: FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnumApi
     /** List of strings to evaluate against. */
     value: string[]
@@ -652,7 +652,7 @@ export const FeatureFlagFilterPropertyCohortInSchemaTypeEnumApi = {
 
 /**
  * * `in` - in
- * `not_in` - not_in
+ * * `not_in` - not_in
  */
 export type FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi =
     (typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi)[keyof typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi]
@@ -666,8 +666,8 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Cohort property type required for in/not_in operators.
-
-  * `cohort` - cohort */
+     *
+     * * `cohort` - cohort */
     type: FeatureFlagFilterPropertyCohortInSchemaTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -680,9 +680,9 @@ export interface FeatureFlagFilterPropertyCohortInSchemaApi {
      */
     group_type_index?: number | null
     /** Membership operator for cohort properties.
-
-  * `in` - in
-  * `not_in` - not_in */
+     *
+     * * `in` - in
+     * * `not_in` - not_in */
     operator: FeatureFlagFilterPropertyCohortInSchemaOperatorEnumApi
     /** Cohort comparison value (single or list, depending on usage). */
     value: unknown
@@ -712,8 +712,8 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
     /** Property key used in this feature flag condition. */
     key: string
     /** Flag property type required for flag dependency checks.
-
-  * `flag` - flag */
+     *
+     * * `flag` - flag */
     type: FeatureFlagFilterPropertyFlagEvaluatesSchemaTypeEnumApi
     /**
      * Resolved cohort name for cohort-type filters.
@@ -726,8 +726,8 @@ export interface FeatureFlagFilterPropertyFlagEvaluatesSchemaApi {
      */
     group_type_index?: number | null
     /** Operator for feature flag dependency evaluation.
-
-  * `flag_evaluates_to` - flag_evaluates_to */
+     *
+     * * `flag_evaluates_to` - flag_evaluates_to */
     operator: FeatureFlagFilterPropertyFlagEvaluatesSchemaOperatorEnumApi
     /** Value to compare flag evaluation against. */
     value: unknown
@@ -811,7 +811,7 @@ export const SurveyOpenQuestionSchemaTypeEnumApi = {
 
 /**
  * * `html` - html
- * `text` - text
+ * * `text` - text
  */
 export type DescriptionContentTypeEnumApi =
     (typeof DescriptionContentTypeEnumApi)[keyof typeof DescriptionContentTypeEnumApi]
@@ -828,9 +828,9 @@ export interface SurveyOpenQuestionSchemaApi {
     /** Optional helper text. */
     description?: string
     /** Format for the description field.
-
-  * `text` - text
-  * `html` - html */
+     *
+     * * `text` - text
+     * * `html` - html */
     descriptionContentType?: DescriptionContentTypeEnumApi
     /** Whether respondents may skip this question. */
     optional?: boolean
@@ -855,9 +855,9 @@ export interface SurveyLinkQuestionSchemaApi {
     /** Optional helper text. */
     description?: string
     /** Format for the description field.
-
-  * `text` - text
-  * `html` - html */
+     *
+     * * `text` - text
+     * * `html` - html */
     descriptionContentType?: DescriptionContentTypeEnumApi
     /** Whether respondents may skip this question. */
     optional?: boolean
@@ -879,7 +879,7 @@ export const SurveyRatingQuestionSchemaTypeEnumApi = {
 
 /**
  * * `number` - number
- * `emoji` - emoji
+ * * `emoji` - emoji
  */
 export type SurveyRatingQuestionSchemaDisplayEnumApi =
     (typeof SurveyRatingQuestionSchemaDisplayEnumApi)[keyof typeof SurveyRatingQuestionSchemaDisplayEnumApi]
@@ -901,8 +901,8 @@ export const SurveyNextQuestionBranchingTypeEnumApi = {
 
 export interface SurveyNextQuestionBranchingApi {
     /** Continue to the next question in sequence.
-
-  * `next_question` - next_question */
+     *
+     * * `next_question` - next_question */
     type: SurveyNextQuestionBranchingTypeEnumApi
 }
 
@@ -918,8 +918,8 @@ export const SurveyEndBranchingTypeEnumApi = {
 
 export interface SurveyEndBranchingApi {
     /** End the survey.
-
-  * `end` - end */
+     *
+     * * `end` - end */
     type: SurveyEndBranchingTypeEnumApi
 }
 
@@ -935,8 +935,8 @@ export const SurveySpecificQuestionBranchingTypeEnumApi = {
 
 export interface SurveySpecificQuestionBranchingApi {
     /** Jump to a specific question index.
-
-  * `specific_question` - specific_question */
+     *
+     * * `specific_question` - specific_question */
     type: SurveySpecificQuestionBranchingTypeEnumApi
     /**
      * 0-based index of the next question.
@@ -962,8 +962,8 @@ export type SurveyResponseBasedBranchingApiResponseValues = { [key: string]: num
 
 export interface SurveyResponseBasedBranchingApi {
     /** Branch based on the selected or entered response.
-
-  * `response_based` - response_based */
+     *
+     * * `response_based` - response_based */
     type: SurveyResponseBasedBranchingTypeEnumApi
     /** Response-based branching map. Values can be a question index or 'end'. */
     responseValues: SurveyResponseBasedBranchingApiResponseValues
@@ -982,18 +982,18 @@ export interface SurveyRatingQuestionSchemaApi {
     /** Optional helper text. */
     description?: string
     /** Format for the description field.
-
-  * `text` - text
-  * `html` - html */
+     *
+     * * `text` - text
+     * * `html` - html */
     descriptionContentType?: DescriptionContentTypeEnumApi
     /** Whether respondents may skip this question. */
     optional?: boolean
     /** Custom button label. */
     buttonText?: string
     /** Display format: 'number' shows numeric scale, 'emoji' shows emoji scale.
-
-  * `number` - number
-  * `emoji` - emoji */
+     *
+     * * `number` - number
+     * * `emoji` - emoji */
     display?: SurveyRatingQuestionSchemaDisplayEnumApi
     /**
      * Rating scale can be one of 3, 5, or 7
@@ -1024,9 +1024,9 @@ export interface SurveySingleChoiceQuestionSchemaApi {
     /** Optional helper text. */
     description?: string
     /** Format for the description field.
-
-  * `text` - text
-  * `html` - html */
+     *
+     * * `text` - text
+     * * `html` - html */
     descriptionContentType?: DescriptionContentTypeEnumApi
     /** Whether respondents may skip this question. */
     optional?: boolean
@@ -1062,9 +1062,9 @@ export interface SurveyMultipleChoiceQuestionSchemaApi {
     /** Optional helper text. */
     description?: string
     /** Format for the description field.
-
-  * `text` - text
-  * `html` - html */
+     *
+     * * `text` - text
+     * * `html` - html */
     descriptionContentType?: DescriptionContentTypeEnumApi
     /** Whether respondents may skip this question. */
     optional?: boolean
@@ -1091,11 +1091,11 @@ export type SurveyQuestionInputSchemaApi =
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
  */
 export type StringMatchOperatorEnumApi = (typeof StringMatchOperatorEnumApi)[keyof typeof StringMatchOperatorEnumApi]
 
@@ -1122,8 +1122,8 @@ export interface SurveyEventsConditionSchemaApi {
 
 /**
  * * `Desktop` - Desktop
- * `Mobile` - Mobile
- * `Tablet` - Tablet
+ * * `Mobile` - Mobile
+ * * `Tablet` - Tablet
  */
 export type DeviceTypesEnumApi = (typeof DeviceTypesEnumApi)[keyof typeof DeviceTypesEnumApi]
 
@@ -1142,25 +1142,25 @@ export interface SurveyConditionsSchemaApi {
      */
     seenSurveyWaitPeriodInDays?: number
     /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-
-  * `regex` - regex
-  * `not_regex` - not_regex
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains */
+     *
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains */
     urlMatchType?: StringMatchOperatorEnumApi
     events?: SurveyEventsConditionSchemaApi
     /** Device types that should match for this survey to be shown. */
     deviceTypes?: DeviceTypesEnumApi[]
     /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-
-  * `regex` - regex
-  * `not_regex` - not_regex
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains */
+     *
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains */
     deviceTypesMatchType?: StringMatchOperatorEnumApi
     /** The variant of the feature flag linked to this survey. */
     linkedFlagVariant?: string
@@ -1168,8 +1168,8 @@ export interface SurveyConditionsSchemaApi {
 
 /**
  * * `button` - button
- * `tab` - tab
- * `selector` - selector
+ * * `tab` - tab
+ * * `selector` - selector
  */
 export type WidgetTypeEnumApi = (typeof WidgetTypeEnumApi)[keyof typeof WidgetTypeEnumApi]
 
@@ -1222,17 +1222,17 @@ export interface SurveySerializerCreateUpdateOnlySchemaApi {
     /** Survey description. */
     description?: string
     /** Survey type.
-
-  * `popover` - popover
-  * `widget` - widget
-  * `external_survey` - external survey
-  * `api` - api */
+     *
+     * * `popover` - popover
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api */
     type: SurveyTypeApi
     /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-
-  * `once` - once
-  * `recurring` - recurring
-  * `always` - always */
+     *
+     * * `once` - once
+     * * `recurring` - recurring
+     * * `always` - always */
     schedule?: ScheduleEnumApi | null
     readonly linked_flag: MinimalFeatureFlagApi
     /**
@@ -1255,117 +1255,117 @@ export interface SurveySerializerCreateUpdateOnlySchemaApi {
     remove_targeting_flag?: boolean | null
     /**
      *
-          The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-          Basic (open-ended question)
-          - `id`: The question ID
-          - `type`: `open`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Link (a question with a link)
-          - `id`: The question ID
-          - `type`: `link`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `link`: The URL associated with the question.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Rating (a question with a rating scale)
-          - `id`: The question ID
-          - `type`: `rating`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `display`: Display style of the rating (`number` or `emoji`).
-          - `scale`: The scale of the rating (`number`).
-          - `lowerBoundLabel`: Label for the lower bound of the scale.
-          - `upperBoundLabel`: Label for the upper bound of the scale.
-          - `isNpsQuestion`: Whether the question is an NPS rating.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Multiple choice
-          - `id`: The question ID
-          - `type`: `single_choice` or `multiple_choice`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `choices`: An array of choices for the question.
-          - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-          - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Branching logic can be one of the following types:
-
-          Next question: Proceeds to the next question
-          ```json
-          {
-              "type": "next_question"
-          }
-          ```
-
-          End: Ends the survey, optionally displaying a confirmation message.
-          ```json
-          {
-              "type": "end"
-          }
-          ```
-
-          Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-          ```json
-          {
-              "type": "response_based",
-              "responseValues": {
-                  "responseKey": "value"
-              }
-          }
-          ```
-
-          Specific question: Proceeds to a specific question by index.
-          ```json
-          {
-              "type": "specific_question",
-              "index": 2
-          }
-          ```
-
-          Translations: Each question can include inline translations.
-          - `translations`: Object mapping language codes to translated fields.
-          - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-          - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-          Example with translations:
-          ```json
-          {
-              "id": "uuid",
-              "type": "rating",
-              "question": "How satisfied are you?",
-              "lowerBoundLabel": "Not satisfied",
-              "upperBoundLabel": "Very satisfied",
-              "translations": {
-                  "es": {
-                      "question": "¿Qué tan satisfecho estás?",
-                      "lowerBoundLabel": "No satisfecho",
-                      "upperBoundLabel": "Muy satisfecho"
-                  },
-                  "fr": {
-                      "question": "Dans quelle mesure êtes-vous satisfait?"
-                  }
-              }
-          }
-          ```
-
+     *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+     *
+     *         Basic (open-ended question)
+     *         - `id`: The question ID
+     *         - `type`: `open`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Link (a question with a link)
+     *         - `id`: The question ID
+     *         - `type`: `link`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `link`: The URL associated with the question.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Rating (a question with a rating scale)
+     *         - `id`: The question ID
+     *         - `type`: `rating`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `display`: Display style of the rating (`number` or `emoji`).
+     *         - `scale`: The scale of the rating (`number`).
+     *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+     *         - `upperBoundLabel`: Label for the upper bound of the scale.
+     *         - `isNpsQuestion`: Whether the question is an NPS rating.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Multiple choice
+     *         - `id`: The question ID
+     *         - `type`: `single_choice` or `multiple_choice`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `choices`: An array of choices for the question.
+     *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+     *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Branching logic can be one of the following types:
+     *
+     *         Next question: Proceeds to the next question
+     *         ```json
+     *         {
+     *             "type": "next_question"
+     *         }
+     *         ```
+     *
+     *         End: Ends the survey, optionally displaying a confirmation message.
+     *         ```json
+     *         {
+     *             "type": "end"
+     *         }
+     *         ```
+     *
+     *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+     *         ```json
+     *         {
+     *             "type": "response_based",
+     *             "responseValues": {
+     *                 "responseKey": "value"
+     *             }
+     *         }
+     *         ```
+     *
+     *         Specific question: Proceeds to a specific question by index.
+     *         ```json
+     *         {
+     *             "type": "specific_question",
+     *             "index": 2
+     *         }
+     *         ```
+     *
+     *         Translations: Each question can include inline translations.
+     *         - `translations`: Object mapping language codes to translated fields.
+     *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+     *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+     *
+     *         Example with translations:
+     *         ```json
+     *         {
+     *             "id": "uuid",
+     *             "type": "rating",
+     *             "question": "How satisfied are you?",
+     *             "lowerBoundLabel": "Not satisfied",
+     *             "upperBoundLabel": "Very satisfied",
+     *             "translations": {
+     *                 "es": {
+     *                     "question": "¿Qué tan satisfecho estás?",
+     *                     "lowerBoundLabel": "No satisfecho",
+     *                     "upperBoundLabel": "Muy satisfecho"
+     *                 },
+     *                 "fr": {
+     *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+     *                 }
+     *             }
+     *         }
+     *         ```
+     *
      * @nullable
      */
     questions?: SurveyQuestionInputSchemaApi[] | null
@@ -1469,117 +1469,117 @@ export interface SurveySerializerCreateUpdateOnlyApi {
     /** @nullable */
     remove_targeting_flag?: boolean | null
     /**
-          The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-          Basic (open-ended question)
-          - `id`: The question ID
-          - `type`: `open`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Link (a question with a link)
-          - `id`: The question ID
-          - `type`: `link`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `link`: The URL associated with the question.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Rating (a question with a rating scale)
-          - `id`: The question ID
-          - `type`: `rating`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `display`: Display style of the rating (`number` or `emoji`).
-          - `scale`: The scale of the rating (`number`).
-          - `lowerBoundLabel`: Label for the lower bound of the scale.
-          - `upperBoundLabel`: Label for the upper bound of the scale.
-          - `isNpsQuestion`: Whether the question is an NPS rating.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Multiple choice
-          - `id`: The question ID
-          - `type`: `single_choice` or `multiple_choice`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `choices`: An array of choices for the question.
-          - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-          - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Branching logic can be one of the following types:
-
-          Next question: Proceeds to the next question
-          ```json
-          {
-              "type": "next_question"
-          }
-          ```
-
-          End: Ends the survey, optionally displaying a confirmation message.
-          ```json
-          {
-              "type": "end"
-          }
-          ```
-
-          Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-          ```json
-          {
-              "type": "response_based",
-              "responseValues": {
-                  "responseKey": "value"
-              }
-          }
-          ```
-
-          Specific question: Proceeds to a specific question by index.
-          ```json
-          {
-              "type": "specific_question",
-              "index": 2
-          }
-          ```
-
-          Translations: Each question can include inline translations.
-          - `translations`: Object mapping language codes to translated fields.
-          - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-          - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-          Example with translations:
-          ```json
-          {
-              "id": "uuid",
-              "type": "rating",
-              "question": "How satisfied are you?",
-              "lowerBoundLabel": "Not satisfied",
-              "upperBoundLabel": "Very satisfied",
-              "translations": {
-                  "es": {
-                      "question": "¿Qué tan satisfecho estás?",
-                      "lowerBoundLabel": "No satisfecho",
-                      "upperBoundLabel": "Muy satisfecho"
-                  },
-                  "fr": {
-                      "question": "Dans quelle mesure êtes-vous satisfait?"
-                  }
-              }
-          }
-          ```
-           */
+     *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+     *
+     *         Basic (open-ended question)
+     *         - `id`: The question ID
+     *         - `type`: `open`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Link (a question with a link)
+     *         - `id`: The question ID
+     *         - `type`: `link`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `link`: The URL associated with the question.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Rating (a question with a rating scale)
+     *         - `id`: The question ID
+     *         - `type`: `rating`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `display`: Display style of the rating (`number` or `emoji`).
+     *         - `scale`: The scale of the rating (`number`).
+     *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+     *         - `upperBoundLabel`: Label for the upper bound of the scale.
+     *         - `isNpsQuestion`: Whether the question is an NPS rating.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Multiple choice
+     *         - `id`: The question ID
+     *         - `type`: `single_choice` or `multiple_choice`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `choices`: An array of choices for the question.
+     *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+     *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Branching logic can be one of the following types:
+     *
+     *         Next question: Proceeds to the next question
+     *         ```json
+     *         {
+     *             "type": "next_question"
+     *         }
+     *         ```
+     *
+     *         End: Ends the survey, optionally displaying a confirmation message.
+     *         ```json
+     *         {
+     *             "type": "end"
+     *         }
+     *         ```
+     *
+     *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+     *         ```json
+     *         {
+     *             "type": "response_based",
+     *             "responseValues": {
+     *                 "responseKey": "value"
+     *             }
+     *         }
+     *         ```
+     *
+     *         Specific question: Proceeds to a specific question by index.
+     *         ```json
+     *         {
+     *             "type": "specific_question",
+     *             "index": 2
+     *         }
+     *         ```
+     *
+     *         Translations: Each question can include inline translations.
+     *         - `translations`: Object mapping language codes to translated fields.
+     *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+     *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+     *
+     *         Example with translations:
+     *         ```json
+     *         {
+     *             "id": "uuid",
+     *             "type": "rating",
+     *             "question": "How satisfied are you?",
+     *             "lowerBoundLabel": "Not satisfied",
+     *             "upperBoundLabel": "Very satisfied",
+     *             "translations": {
+     *                 "es": {
+     *                     "question": "¿Qué tan satisfecho estás?",
+     *                     "lowerBoundLabel": "No satisfecho",
+     *                     "upperBoundLabel": "Muy satisfecho"
+     *                 },
+     *                 "fr": {
+     *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+     *                 }
+     *             }
+     *         }
+     *         ```
+     *          */
     questions?: unknown
     conditions?: unknown
     appearance?: unknown
@@ -1659,17 +1659,17 @@ export interface PatchedSurveySerializerCreateUpdateOnlySchemaApi {
     /** Survey description. */
     description?: string
     /** Survey type.
-
-  * `popover` - popover
-  * `widget` - widget
-  * `external_survey` - external survey
-  * `api` - api */
+     *
+     * * `popover` - popover
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api */
     type?: SurveyTypeApi
     /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-
-  * `once` - once
-  * `recurring` - recurring
-  * `always` - always */
+     *
+     * * `once` - once
+     * * `recurring` - recurring
+     * * `always` - always */
     schedule?: ScheduleEnumApi | null
     readonly linked_flag?: MinimalFeatureFlagApi
     /**
@@ -1692,117 +1692,117 @@ export interface PatchedSurveySerializerCreateUpdateOnlySchemaApi {
     remove_targeting_flag?: boolean | null
     /**
      *
-          The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-          Basic (open-ended question)
-          - `id`: The question ID
-          - `type`: `open`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Link (a question with a link)
-          - `id`: The question ID
-          - `type`: `link`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `link`: The URL associated with the question.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Rating (a question with a rating scale)
-          - `id`: The question ID
-          - `type`: `rating`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `display`: Display style of the rating (`number` or `emoji`).
-          - `scale`: The scale of the rating (`number`).
-          - `lowerBoundLabel`: Label for the lower bound of the scale.
-          - `upperBoundLabel`: Label for the upper bound of the scale.
-          - `isNpsQuestion`: Whether the question is an NPS rating.
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Multiple choice
-          - `id`: The question ID
-          - `type`: `single_choice` or `multiple_choice`
-          - `question`: The text of the question.
-          - `description`: Optional description of the question.
-          - `descriptionContentType`: Content type of the description (`html` or `text`).
-          - `optional`: Whether the question is optional (`boolean`).
-          - `buttonText`: Text displayed on the submit button.
-          - `choices`: An array of choices for the question.
-          - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-          - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-          - `branching`: Branching logic for the question. See branching types below for details.
-
-          Branching logic can be one of the following types:
-
-          Next question: Proceeds to the next question
-          ```json
-          {
-              "type": "next_question"
-          }
-          ```
-
-          End: Ends the survey, optionally displaying a confirmation message.
-          ```json
-          {
-              "type": "end"
-          }
-          ```
-
-          Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-          ```json
-          {
-              "type": "response_based",
-              "responseValues": {
-                  "responseKey": "value"
-              }
-          }
-          ```
-
-          Specific question: Proceeds to a specific question by index.
-          ```json
-          {
-              "type": "specific_question",
-              "index": 2
-          }
-          ```
-
-          Translations: Each question can include inline translations.
-          - `translations`: Object mapping language codes to translated fields.
-          - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-          - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-          Example with translations:
-          ```json
-          {
-              "id": "uuid",
-              "type": "rating",
-              "question": "How satisfied are you?",
-              "lowerBoundLabel": "Not satisfied",
-              "upperBoundLabel": "Very satisfied",
-              "translations": {
-                  "es": {
-                      "question": "¿Qué tan satisfecho estás?",
-                      "lowerBoundLabel": "No satisfecho",
-                      "upperBoundLabel": "Muy satisfecho"
-                  },
-                  "fr": {
-                      "question": "Dans quelle mesure êtes-vous satisfait?"
-                  }
-              }
-          }
-          ```
-
+     *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+     *
+     *         Basic (open-ended question)
+     *         - `id`: The question ID
+     *         - `type`: `open`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Link (a question with a link)
+     *         - `id`: The question ID
+     *         - `type`: `link`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `link`: The URL associated with the question.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Rating (a question with a rating scale)
+     *         - `id`: The question ID
+     *         - `type`: `rating`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `display`: Display style of the rating (`number` or `emoji`).
+     *         - `scale`: The scale of the rating (`number`).
+     *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+     *         - `upperBoundLabel`: Label for the upper bound of the scale.
+     *         - `isNpsQuestion`: Whether the question is an NPS rating.
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Multiple choice
+     *         - `id`: The question ID
+     *         - `type`: `single_choice` or `multiple_choice`
+     *         - `question`: The text of the question.
+     *         - `description`: Optional description of the question.
+     *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+     *         - `optional`: Whether the question is optional (`boolean`).
+     *         - `buttonText`: Text displayed on the submit button.
+     *         - `choices`: An array of choices for the question.
+     *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+     *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+     *         - `branching`: Branching logic for the question. See branching types below for details.
+     *
+     *         Branching logic can be one of the following types:
+     *
+     *         Next question: Proceeds to the next question
+     *         ```json
+     *         {
+     *             "type": "next_question"
+     *         }
+     *         ```
+     *
+     *         End: Ends the survey, optionally displaying a confirmation message.
+     *         ```json
+     *         {
+     *             "type": "end"
+     *         }
+     *         ```
+     *
+     *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+     *         ```json
+     *         {
+     *             "type": "response_based",
+     *             "responseValues": {
+     *                 "responseKey": "value"
+     *             }
+     *         }
+     *         ```
+     *
+     *         Specific question: Proceeds to a specific question by index.
+     *         ```json
+     *         {
+     *             "type": "specific_question",
+     *             "index": 2
+     *         }
+     *         ```
+     *
+     *         Translations: Each question can include inline translations.
+     *         - `translations`: Object mapping language codes to translated fields.
+     *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+     *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+     *
+     *         Example with translations:
+     *         ```json
+     *         {
+     *             "id": "uuid",
+     *             "type": "rating",
+     *             "question": "How satisfied are you?",
+     *             "lowerBoundLabel": "Not satisfied",
+     *             "upperBoundLabel": "Very satisfied",
+     *             "translations": {
+     *                 "es": {
+     *                     "question": "¿Qué tan satisfecho estás?",
+     *                     "lowerBoundLabel": "No satisfecho",
+     *                     "upperBoundLabel": "Muy satisfecho"
+     *                 },
+     *                 "fr": {
+     *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+     *                 }
+     *             }
+     *         }
+     *         ```
+     *
      * @nullable
      */
     questions?: SurveyQuestionInputSchemaApi[] | null
@@ -2132,9 +2132,9 @@ export type SurveysListParams = {
     search?: string
     /**
      * * `popover` - popover
-     * `widget` - widget
-     * `external_survey` - external survey
-     * `api` - api
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api
      */
     type?: SurveysListType
 }

--- a/products/surveys/frontend/generated/api.ts
+++ b/products/surveys/frontend/generated/api.ts
@@ -50,7 +50,7 @@ export const getSurveysListUrl = (projectId: string, params?: SurveysListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -164,9 +164,9 @@ export const getSurveysArchivedResponseUuidsRetrieveUrl = (projectId: string, id
 
 /**
  * Get list of archived response UUIDs for HogQL filtering.
-
-Returns list of UUIDs that the frontend can use to filter out archived responses
-in HogQL queries.
+ *
+ * Returns list of UUIDs that the frontend can use to filter out archived responses
+ * in HogQL queries.
  */
 export const surveysArchivedResponseUuidsRetrieve = async (
     projectId: string,
@@ -185,9 +185,9 @@ export const getSurveysDuplicateToProjectsCreateUrl = (projectId: string, id: st
 
 /**
  * Duplicate a survey to multiple projects in a single transaction.
-
-Accepts a list of target team IDs and creates a copy of the survey in each project.
-Uses an all-or-nothing approach - if any duplication fails, all changes are rolled back.
+ *
+ * Accepts a list of target team IDs and creates a copy of the survey in each project.
+ * Uses an all-or-nothing approach - if any duplication fails, all changes are rolled back.
  */
 export const surveysDuplicateToProjectsCreate = async (
     projectId: string,
@@ -240,7 +240,7 @@ export const getSurveysResponsesListUrl = (projectId: string, id: string, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -315,7 +315,7 @@ export const getSurveysStatsRetrieveUrl = (projectId: string, id: string, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -328,15 +328,15 @@ export const getSurveysStatsRetrieveUrl = (projectId: string, id: string, params
 
 /**
  * Get survey response statistics for a specific survey.
-
-Args:
-    date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
-    date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
-    exclude_archived: Optional boolean to exclude archived responses (default: false, includes archived)
-    include_per_question_stats: Optional boolean to include per-question response counts and distributions
-
-Returns:
-    Survey statistics including event counts, unique respondents, and conversion rates
+ *
+ * Args:
+ *     date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
+ *     date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
+ *     exclude_archived: Optional boolean to exclude archived responses (default: false, includes archived)
+ *     include_per_question_stats: Optional boolean to include per-question response counts and distributions
+ *
+ * Returns:
+ *     Survey statistics including event counts, unique respondents, and conversion rates
  */
 export const surveysStatsRetrieve = async (
     projectId: string,
@@ -373,7 +373,7 @@ export const getSurveysSummarizeResponsesCreateUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -454,13 +454,13 @@ export const getSurveysResponsesCountRetrieveUrl = (projectId: string) => {
 
 /**
  * Get response counts for all surveys.
-
-Args:
-    exclude_archived: Optional boolean to exclude archived responses (default: false, includes archived)
-    survey_ids: Optional comma-separated list of survey IDs to filter by
-
-Returns:
-    Dictionary mapping survey IDs to response counts
+ *
+ * Args:
+ *     exclude_archived: Optional boolean to exclude archived responses (default: false, includes archived)
+ *     survey_ids: Optional comma-separated list of survey IDs to filter by
+ *
+ * Returns:
+ *     Dictionary mapping survey IDs to response counts
  */
 export const surveysResponsesCountRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysResponsesCountRetrieveUrl(projectId), {
@@ -474,7 +474,7 @@ export const getSurveysGlobalStatsRetrieveUrl = (projectId: string, params?: Sur
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -487,13 +487,13 @@ export const getSurveysGlobalStatsRetrieveUrl = (projectId: string, params?: Sur
 
 /**
  * Get aggregated response statistics across all surveys.
-
-Args:
-    date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
-    date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
-
-Returns:
-    Aggregated statistics across all surveys including total counts and rates
+ *
+ * Args:
+ *     date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
+ *     date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
+ *
+ * Returns:
+ *     Aggregated statistics across all surveys including total counts and rates
  */
 export const surveysGlobalStatsRetrieve = async (
     projectId: string,

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -1691,9 +1691,9 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Duplicate a survey to multiple projects in a single transaction.
-
-Accepts a list of target team IDs and creates a copy of the survey in each project.
-Uses an all-or-nothing approach - if any duplication fails, all changes are rolled back.
+ *
+ * Accepts a list of target team IDs and creates a copy of the survey in each project.
+ * Uses an all-or-nothing approach - if any duplication fails, all changes are rolled back.
  */
 export const surveysDuplicateToProjectsCreateBodyNameMax = 400
 

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -14,7 +14,7 @@ export interface CodeInviteRedeemRequestApi {
 
 /**
  * * `burst` - burst
- * `sustained` - sustained
+ * * `sustained` - sustained
  */
 export type LimitTypeEnumApi = (typeof LimitTypeEnumApi)[keyof typeof LimitTypeEnumApi]
 
@@ -37,9 +37,9 @@ export interface TaskRunErrorResponseApi {
     /** Artifact ids that could not be resolved for the run */
     missing_artifact_ids?: string[]
     /** Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)
-
-  * `burst` - burst
-  * `sustained` - sustained */
+     *
+     * * `burst` - burst
+     * * `sustained` - sustained */
     limit_type?: LimitTypeEnumApi
     /** ISO 8601 timestamp when the hit usage limit resets, when known */
     reset_at?: string
@@ -49,8 +49,8 @@ export interface TaskRunErrorResponseApi {
 
 /**
  * * `trusted` - Trusted
- * `full` - Full
- * `custom` - Custom
+ * * `full` - Full
+ * * `custom` - Custom
  */
 export type NetworkAccessLevelEnumApi = (typeof NetworkAccessLevelEnumApi)[keyof typeof NetworkAccessLevelEnumApi]
 
@@ -62,13 +62,13 @@ export const NetworkAccessLevelEnumApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -120,9 +120,15 @@ export interface SandboxEnvironmentListApi {
     /** @maxLength 255 */
     name: string
     network_access_level?: NetworkAccessLevelEnumApi
-    /** List of allowed domains for custom network access */
+    /**
+     * List of allowed domains for custom network access
+     * @items.maxLength 255
+     */
     allowed_domains?: string[]
-    /** List of repositories this environment applies to (format: org/repo) */
+    /**
+     * List of repositories this environment applies to (format: org/repo)
+     * @items.maxLength 255
+     */
     repositories?: string[]
     /** If true, only the creator can see this environment. Otherwise visible to whole team. */
     private?: boolean
@@ -147,11 +153,17 @@ export interface SandboxEnvironmentApi {
     /** @maxLength 255 */
     name: string
     network_access_level?: NetworkAccessLevelEnumApi
-    /** List of allowed domains for custom network access */
+    /**
+     * List of allowed domains for custom network access
+     * @items.maxLength 255
+     */
     allowed_domains?: string[]
     /** Whether to include default trusted domains (GitHub, npm, PyPI) */
     include_default_domains?: boolean
-    /** List of repositories this environment applies to (format: org/repo) */
+    /**
+     * List of repositories this environment applies to (format: org/repo)
+     * @items.maxLength 255
+     */
     repositories?: string[]
     /** Encrypted environment variables (write-only, never returned in responses) */
     environment_variables?: unknown
@@ -173,11 +185,17 @@ export interface PatchedSandboxEnvironmentApi {
     /** @maxLength 255 */
     name?: string
     network_access_level?: NetworkAccessLevelEnumApi
-    /** List of allowed domains for custom network access */
+    /**
+     * List of allowed domains for custom network access
+     * @items.maxLength 255
+     */
     allowed_domains?: string[]
     /** Whether to include default trusted domains (GitHub, npm, PyPI) */
     include_default_domains?: boolean
-    /** List of repositories this environment applies to (format: org/repo) */
+    /**
+     * List of repositories this environment applies to (format: org/repo)
+     * @items.maxLength 255
+     */
     repositories?: string[]
     /** Encrypted environment variables (write-only, never returned in responses) */
     environment_variables?: unknown
@@ -271,14 +289,14 @@ export interface PatchedTaskAutomationApi {
 
 /**
  * * `error_tracking` - Error Tracking
- * `eval_clusters` - Eval Clusters
- * `user_created` - User Created
- * `automation` - Automation
- * `slack` - Slack
- * `support_queue` - Support Queue
- * `session_summaries` - Session Summaries
- * `signal_report` - Signal Report
- * `signals_scout` - Signals Scout
+ * * `eval_clusters` - Eval Clusters
+ * * `user_created` - User Created
+ * * `automation` - Automation
+ * * `slack` - Slack
+ * * `support_queue` - Support Queue
+ * * `session_summaries` - Session Summaries
+ * * `signal_report` - Signal Report
+ * * `signals_scout` - Signals Scout
  */
 export type OriginProductEnumApi = (typeof OriginProductEnumApi)[keyof typeof OriginProductEnumApi]
 
@@ -324,16 +342,16 @@ export interface TaskApi {
     /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
     /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-
-  * `error_tracking` - Error Tracking
-  * `eval_clusters` - Eval Clusters
-  * `user_created` - User Created
-  * `automation` - Automation
-  * `slack` - Slack
-  * `support_queue` - Support Queue
-  * `session_summaries` - Session Summaries
-  * `signal_report` - Signal Report
-  * `signals_scout` - Signals Scout */
+     *
+     * * `error_tracking` - Error Tracking
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `automation` - Automation
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout */
     origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -406,16 +424,16 @@ export interface PatchedTaskApi {
     /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
     /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-
-  * `error_tracking` - Error Tracking
-  * `eval_clusters` - Eval Clusters
-  * `user_created` - User Created
-  * `automation` - Automation
-  * `slack` - Slack
-  * `support_queue` - Support Queue
-  * `session_summaries` - Session Summaries
-  * `signal_report` - Signal Report
-  * `signals_scout` - Signals Scout */
+     *
+     * * `error_tracking` - Error Tracking
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `automation` - Automation
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout */
     origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -479,13 +497,13 @@ export interface TaskFileResponseApi {
 
 /**
  * Request body for the presence beacon and beacon-leave endpoints.
-
-`device_id` is the UUID of the caller's `UserPushToken` row, which the
-client received when it registered for push via `/api/users/@me/push_tokens/`.
-The client is expected to use the same identifier on the beacon and leave
-calls; if the user has unregistered the underlying push token, the value
-won't resolve and the call returns 404 — at which point pushes were
-already not going there anyway.
+ *
+ * `device_id` is the UUID of the caller's `UserPushToken` row, which the
+ * client received when it registered for push via `/api/users/@me/push_tokens/`.
+ * The client is expected to use the same identifier on the beacon and leave
+ * calls; if the user has unregistered the underlying push token, the value
+ * won't resolve and the call returns 404 — at which point pushes were
+ * already not going there anyway.
  */
 export interface TaskPresenceBeaconRequestApi {
     /** UUID of the caller's UserPushToken (returned by `/api/users/@me/push_tokens/` on register). */
@@ -494,7 +512,7 @@ export interface TaskPresenceBeaconRequestApi {
 
 /**
  * * `interactive` - interactive
- * `background` - background
+ * * `background` - background
  */
 export type TaskExecutionModeEnumApi = (typeof TaskExecutionModeEnumApi)[keyof typeof TaskExecutionModeEnumApi]
 
@@ -505,7 +523,7 @@ export const TaskExecutionModeEnumApi = {
 
 /**
  * * `user` - user
- * `bot` - bot
+ * * `bot` - bot
  */
 export type PrAuthorshipModeEnumApi = (typeof PrAuthorshipModeEnumApi)[keyof typeof PrAuthorshipModeEnumApi]
 
@@ -516,7 +534,7 @@ export const PrAuthorshipModeEnumApi = {
 
 /**
  * * `manual` - manual
- * `signal_report` - signal_report
+ * * `signal_report` - signal_report
  */
 export type RunSourceEnumApi = (typeof RunSourceEnumApi)[keyof typeof RunSourceEnumApi]
 
@@ -536,10 +554,10 @@ export const ClaudeRuntimeAdapterEnumApi = {
 
 /**
  * * `low` - low
- * `medium` - medium
- * `high` - high
- * `xhigh` - xhigh
- * `max` - max
+ * * `medium` - medium
+ * * `high` - high
+ * * `xhigh` - xhigh
+ * * `max` - max
  */
 export type ReasoningEffortEnumApi = (typeof ReasoningEffortEnumApi)[keyof typeof ReasoningEffortEnumApi]
 
@@ -553,10 +571,10 @@ export const ReasoningEffortEnumApi = {
 
 /**
  * * `default` - default
- * `acceptEdits` - acceptEdits
- * `plan` - plan
- * `bypassPermissions` - bypassPermissions
- * `auto` - auto
+ * * `acceptEdits` - acceptEdits
+ * * `plan` - plan
+ * * `bypassPermissions` - bypassPermissions
+ * * `auto` - auto
  */
 export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi =
     (typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi)[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi]
@@ -574,9 +592,9 @@ export const ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi = {
  */
 export interface ClaudeTaskRunCreateSchemaApi {
     /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-  * `interactive` - interactive
-  * `background` - background */
+     *
+     * * `interactive` - interactive
+     * * `background` - background */
     mode?: TaskExecutionModeEnumApi
     /**
      * Git branch to checkout in the sandbox
@@ -588,45 +606,48 @@ export interface ClaudeTaskRunCreateSchemaApi {
     resume_from_run_id?: string
     /** Initial or follow-up user message to include in the run prompt. */
     pending_user_message?: string
-    /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
+    /**
+     * Identifiers for staged task artifacts that should be attached to the initial run prompt.
+     * @items.maxLength 128
+     */
     pending_user_artifact_ids?: string[]
     /** Optional sandbox environment to apply for this cloud run. */
     sandbox_environment_id?: string
     /** Whether pull requests for this run should be authored by the user or the bot.
-
-  * `user` - user
-  * `bot` - bot */
+     *
+     * * `user` - user
+     * * `bot` - bot */
     pr_authorship_mode?: PrAuthorshipModeEnumApi
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-  * `manual` - manual
-  * `signal_report` - signal_report */
+     *
+     * * `manual` - manual
+     * * `signal_report` - signal_report */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
     /** Agent runtime adapter to launch for this run. Must be 'claude' for Claude runtimes.
-
-  * `claude` - claude */
+     *
+     * * `claude` - claude */
     runtime_adapter: ClaudeRuntimeAdapterEnumApi
     /** LLM model identifier to run in the Claude runtime. */
     model: string
     /** Reasoning effort to request for models that expose an effort control.
-
-  * `low` - low
-  * `medium` - medium
-  * `high` - high
-  * `xhigh` - xhigh
-  * `max` - max */
+     *
+     * * `low` - low
+     * * `medium` - medium
+     * * `high` - high
+     * * `xhigh` - xhigh
+     * * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
     /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
     github_user_token?: string
     /** Initial permission mode for Claude runtimes.
-
-  * `default` - default
-  * `acceptEdits` - acceptEdits
-  * `plan` - plan
-  * `bypassPermissions` - bypassPermissions
-  * `auto` - auto */
+     *
+     * * `default` - default
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto */
     initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi
 }
 
@@ -641,8 +662,8 @@ export const CodexRuntimeAdapterEnumApi = {
 
 /**
  * * `auto` - auto
- * `read-only` - read-only
- * `full-access` - full-access
+ * * `read-only` - read-only
+ * * `full-access` - full-access
  */
 export type CodexTaskRunCreateSchemaInitialPermissionModeEnumApi =
     (typeof CodexTaskRunCreateSchemaInitialPermissionModeEnumApi)[keyof typeof CodexTaskRunCreateSchemaInitialPermissionModeEnumApi]
@@ -658,9 +679,9 @@ export const CodexTaskRunCreateSchemaInitialPermissionModeEnumApi = {
  */
 export interface CodexTaskRunCreateSchemaApi {
     /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-  * `interactive` - interactive
-  * `background` - background */
+     *
+     * * `interactive` - interactive
+     * * `background` - background */
     mode?: TaskExecutionModeEnumApi
     /**
      * Git branch to checkout in the sandbox
@@ -672,51 +693,54 @@ export interface CodexTaskRunCreateSchemaApi {
     resume_from_run_id?: string
     /** Initial or follow-up user message to include in the run prompt. */
     pending_user_message?: string
-    /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
+    /**
+     * Identifiers for staged task artifacts that should be attached to the initial run prompt.
+     * @items.maxLength 128
+     */
     pending_user_artifact_ids?: string[]
     /** Optional sandbox environment to apply for this cloud run. */
     sandbox_environment_id?: string
     /** Whether pull requests for this run should be authored by the user or the bot.
-
-  * `user` - user
-  * `bot` - bot */
+     *
+     * * `user` - user
+     * * `bot` - bot */
     pr_authorship_mode?: PrAuthorshipModeEnumApi
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-  * `manual` - manual
-  * `signal_report` - signal_report */
+     *
+     * * `manual` - manual
+     * * `signal_report` - signal_report */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
     /** Agent runtime adapter to launch for this run. Must be 'codex' for Codex runtimes.
-
-  * `codex` - codex */
+     *
+     * * `codex` - codex */
     runtime_adapter: CodexRuntimeAdapterEnumApi
     /** LLM model identifier to run in the Codex runtime. */
     model: string
     /** Reasoning effort to request for models that expose an effort control.
-
-  * `low` - low
-  * `medium` - medium
-  * `high` - high
-  * `xhigh` - xhigh
-  * `max` - max */
+     *
+     * * `low` - low
+     * * `medium` - medium
+     * * `high` - high
+     * * `xhigh` - xhigh
+     * * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
     /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
     github_user_token?: string
     /** Initial permission mode for Codex runtimes.
-
-  * `auto` - auto
-  * `read-only` - read-only
-  * `full-access` - full-access */
+     *
+     * * `auto` - auto
+     * * `read-only` - read-only
+     * * `full-access` - full-access */
     initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnumApi
 }
 
 export interface TaskRunResumeRequestSchemaApi {
     /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-  * `interactive` - interactive
-  * `background` - background */
+     *
+     * * `interactive` - interactive
+     * * `background` - background */
     mode?: TaskExecutionModeEnumApi
     /**
      * Git branch to checkout in the sandbox
@@ -731,14 +755,14 @@ export interface TaskRunResumeRequestSchemaApi {
     /** Optional sandbox environment to apply for this cloud run. */
     sandbox_environment_id?: string
     /** Whether pull requests for this run should be authored by the user or the bot.
-
-  * `user` - user
-  * `bot` - bot */
+     *
+     * * `user` - user
+     * * `bot` - bot */
     pr_authorship_mode?: PrAuthorshipModeEnumApi
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-  * `manual` - manual
-  * `signal_report` - signal_report */
+     *
+     * * `manual` - manual
+     * * `signal_report` - signal_report */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
@@ -753,12 +777,12 @@ export type TaskRunCreateRequestSchemaApi =
 
 /**
  * * `plan` - plan
- * `context` - context
- * `reference` - reference
- * `output` - output
- * `artifact` - artifact
- * `tree_snapshot` - tree_snapshot
- * `user_attachment` - user_attachment
+ * * `context` - context
+ * * `reference` - reference
+ * * `output` - output
+ * * `artifact` - artifact
+ * * `tree_snapshot` - tree_snapshot
+ * * `user_attachment` - user_attachment
  */
 export type TaskRunArtifactTypeEnumApi = (typeof TaskRunArtifactTypeEnumApi)[keyof typeof TaskRunArtifactTypeEnumApi]
 
@@ -781,14 +805,14 @@ export interface TaskStagedArtifactFinalizeUploadApi {
      */
     name: string
     /** Classification for the artifact
-
-  * `plan` - plan
-  * `context` - context
-  * `reference` - reference
-  * `output` - output
-  * `artifact` - artifact
-  * `tree_snapshot` - tree_snapshot
-  * `user_attachment` - user_attachment */
+     *
+     * * `plan` - plan
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment */
     type: TaskRunArtifactTypeEnumApi
     /**
      * Optional source label for the artifact, such as agent_output or user_attachment
@@ -843,14 +867,14 @@ export interface TaskStagedArtifactPrepareUploadApi {
      */
     name: string
     /** Classification for the artifact
-
-  * `plan` - plan
-  * `context` - context
-  * `reference` - reference
-  * `output` - output
-  * `artifact` - artifact
-  * `tree_snapshot` - tree_snapshot
-  * `user_attachment` - user_attachment */
+     *
+     * * `plan` - plan
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment */
     type: TaskRunArtifactTypeEnumApi
     /**
      * Optional source label for the artifact, such as agent_output or user_attachment
@@ -915,11 +939,11 @@ export interface TaskStagedArtifactsPrepareUploadResponseApi {
 
 /**
  * * `not_started` - Not Started
- * `queued` - Queued
- * `in_progress` - In Progress
- * `completed` - Completed
- * `failed` - Failed
- * `cancelled` - Cancelled
+ * * `queued` - Queued
+ * * `in_progress` - In Progress
+ * * `completed` - Completed
+ * * `failed` - Failed
+ * * `cancelled` - Cancelled
  */
 export type TaskRunStatusEnumApi = (typeof TaskRunStatusEnumApi)[keyof typeof TaskRunStatusEnumApi]
 
@@ -934,7 +958,7 @@ export const TaskRunStatusEnumApi = {
 
 /**
  * * `local` - Local
- * `cloud` - Cloud
+ * * `cloud` - Cloud
  */
 export type TaskRunEnvironmentEnumApi = (typeof TaskRunEnvironmentEnumApi)[keyof typeof TaskRunEnvironmentEnumApi]
 
@@ -945,7 +969,7 @@ export const TaskRunEnvironmentEnumApi = {
 
 /**
  * * `claude` - claude
- * `codex` - codex
+ * * `codex` - codex
  */
 export type RuntimeAdapterEnumApi = (typeof RuntimeAdapterEnumApi)[keyof typeof RuntimeAdapterEnumApi]
 
@@ -979,9 +1003,9 @@ export interface TaskRunDetailApi {
     branch?: string | null
     status?: TaskRunStatusEnumApi
     /** Execution environment
-
-  * `local` - Local
-  * `cloud` - Cloud */
+     *
+     * * `local` - Local
+     * * `cloud` - Cloud */
     environment?: TaskRunEnvironmentEnumApi
     /** Configured runtime adapter for this run, such as 'claude' or 'codex'. */
     readonly runtime_adapter: RuntimeAdapterEnumApi | null
@@ -1026,7 +1050,7 @@ export interface PaginatedTaskRunDetailListApi {
 
 /**
  * * `local` - local
- * `cloud` - cloud
+ * * `cloud` - cloud
  */
 export type TaskRunBootstrapCreateRequestEnvironmentEnumApi =
     (typeof TaskRunBootstrapCreateRequestEnvironmentEnumApi)[keyof typeof TaskRunBootstrapCreateRequestEnvironmentEnumApi]
@@ -1038,12 +1062,12 @@ export const TaskRunBootstrapCreateRequestEnvironmentEnumApi = {
 
 /**
  * * `default` - default
- * `acceptEdits` - acceptEdits
- * `plan` - plan
- * `bypassPermissions` - bypassPermissions
- * `auto` - auto
- * `read-only` - read-only
- * `full-access` - full-access
+ * * `acceptEdits` - acceptEdits
+ * * `plan` - plan
+ * * `bypassPermissions` - bypassPermissions
+ * * `auto` - auto
+ * * `read-only` - read-only
+ * * `full-access` - full-access
  */
 export type TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi =
     (typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi)[keyof typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi]
@@ -1063,14 +1087,14 @@ export const TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi = {
  */
 export interface TaskRunBootstrapCreateRequestApi {
     /** Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.
-
-  * `local` - local
-  * `cloud` - cloud */
+     *
+     * * `local` - local
+     * * `cloud` - cloud */
     environment?: TaskRunBootstrapCreateRequestEnvironmentEnumApi
     /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-  * `interactive` - interactive
-  * `background` - background */
+     *
+     * * `interactive` - interactive
+     * * `background` - background */
     mode?: TaskExecutionModeEnumApi
     /**
      * Git branch to checkout in the sandbox
@@ -1081,53 +1105,53 @@ export interface TaskRunBootstrapCreateRequestApi {
     /** Optional sandbox environment to apply for this cloud run. */
     sandbox_environment_id?: string
     /** Whether pull requests for this run should be authored by the user or the bot.
-
-  * `user` - user
-  * `bot` - bot */
+     *
+     * * `user` - user
+     * * `bot` - bot */
     pr_authorship_mode?: PrAuthorshipModeEnumApi
     /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-  * `manual` - manual
-  * `signal_report` - signal_report */
+     *
+     * * `manual` - manual
+     * * `signal_report` - signal_report */
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
     /** Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.
-
-  * `claude` - claude
-  * `codex` - codex */
+     *
+     * * `claude` - claude
+     * * `codex` - codex */
     runtime_adapter?: RuntimeAdapterEnumApi
     /** LLM model identifier to run in the selected runtime. */
     model?: string
     /** Reasoning effort to request for models that expose an effort control.
-
-  * `low` - low
-  * `medium` - medium
-  * `high` - high
-  * `xhigh` - xhigh
-  * `max` - max */
+     *
+     * * `low` - low
+     * * `medium` - medium
+     * * `high` - high
+     * * `xhigh` - xhigh
+     * * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
     /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
     github_user_token?: string
     /** Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.
-
-  * `default` - default
-  * `acceptEdits` - acceptEdits
-  * `plan` - plan
-  * `bypassPermissions` - bypassPermissions
-  * `auto` - auto
-  * `read-only` - read-only
-  * `full-access` - full-access */
+     *
+     * * `default` - default
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto
+     * * `read-only` - read-only
+     * * `full-access` - full-access */
     initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi
 }
 
 /**
  * * `not_started` - not_started
- * `queued` - queued
- * `in_progress` - in_progress
- * `completed` - completed
- * `failed` - failed
- * `cancelled` - cancelled
+ * * `queued` - queued
+ * * `in_progress` - in_progress
+ * * `completed` - completed
+ * * `failed` - failed
+ * * `cancelled` - cancelled
  */
 export type TaskRunUpdateStatusEnumApi = (typeof TaskRunUpdateStatusEnumApi)[keyof typeof TaskRunUpdateStatusEnumApi]
 
@@ -1152,13 +1176,13 @@ export const TaskRunUpdateEnvironmentEnumApi = {
 
 export interface PatchedTaskRunUpdateApi {
     /** Current execution status
-
-  * `not_started` - not_started
-  * `queued` - queued
-  * `in_progress` - in_progress
-  * `completed` - completed
-  * `failed` - failed
-  * `cancelled` - cancelled */
+     *
+     * * `not_started` - not_started
+     * * `queued` - queued
+     * * `in_progress` - in_progress
+     * * `completed` - completed
+     * * `failed` - failed
+     * * `cancelled` - cancelled */
     status?: TaskRunUpdateStatusEnumApi
     /**
      * Git branch name to associate with the task
@@ -1182,8 +1206,8 @@ export interface PatchedTaskRunUpdateApi {
      */
     error_message?: string | null
     /** Transition a cloud run to local. Use the resume_in_cloud action to move a run into cloud.
-
-  * `local` - local */
+     *
+     * * `local` - local */
     environment?: TaskRunUpdateEnvironmentEnumApi
 }
 
@@ -1196,7 +1220,7 @@ export interface TaskRunAppendLogRequestApi {
 
 /**
  * * `utf-8` - utf-8
- * `base64` - base64
+ * * `base64` - base64
  */
 export type ContentEncodingEnumApi = (typeof ContentEncodingEnumApi)[keyof typeof ContentEncodingEnumApi]
 
@@ -1212,14 +1236,14 @@ export interface TaskRunArtifactUploadApi {
      */
     name: string
     /** Classification for the artifact
-
-  * `plan` - plan
-  * `context` - context
-  * `reference` - reference
-  * `output` - output
-  * `artifact` - artifact
-  * `tree_snapshot` - tree_snapshot
-  * `user_attachment` - user_attachment */
+     *
+     * * `plan` - plan
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment */
     type: TaskRunArtifactTypeEnumApi
     /**
      * Optional source label for the artifact, such as agent_output or user_attachment
@@ -1229,9 +1253,9 @@ export interface TaskRunArtifactUploadApi {
     /** Artifact contents encoded according to content_encoding */
     content: string
     /** Encoding used for content. Use base64 for binary files and utf-8 for text payloads.
-
-  * `utf-8` - utf-8
-  * `base64` - base64 */
+     *
+     * * `utf-8` - utf-8
+     * * `base64` - base64 */
     content_encoding?: ContentEncodingEnumApi
     /**
      * Optional MIME type for the artifact
@@ -1267,14 +1291,14 @@ export interface TaskRunArtifactFinalizeUploadApi {
      */
     name: string
     /** Classification for the artifact
-
-  * `plan` - plan
-  * `context` - context
-  * `reference` - reference
-  * `output` - output
-  * `artifact` - artifact
-  * `tree_snapshot` - tree_snapshot
-  * `user_attachment` - user_attachment */
+     *
+     * * `plan` - plan
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment */
     type: TaskRunArtifactTypeEnumApi
     /**
      * Optional source label for the artifact, such as agent_output or user_attachment
@@ -1310,14 +1334,14 @@ export interface TaskRunArtifactPrepareUploadApi {
      */
     name: string
     /** Classification for the artifact
-
-  * `plan` - plan
-  * `context` - context
-  * `reference` - reference
-  * `output` - output
-  * `artifact` - artifact
-  * `tree_snapshot` - tree_snapshot
-  * `user_attachment` - user_attachment */
+     *
+     * * `plan` - plan
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment */
     type: TaskRunArtifactTypeEnumApi
     /**
      * Optional source label for the artifact, such as agent_output or user_attachment
@@ -1391,10 +1415,10 @@ export const JsonrpcEnumApi = {
 
 /**
  * * `user_message` - user_message
- * `cancel` - cancel
- * `close` - close
- * `permission_response` - permission_response
- * `set_config_option` - set_config_option
+ * * `cancel` - cancel
+ * * `close` - close
+ * * `permission_response` - permission_response
+ * * `set_config_option` - set_config_option
  */
 export type MethodEnumApi = (typeof MethodEnumApi)[keyof typeof MethodEnumApi]
 
@@ -1411,16 +1435,16 @@ export const MethodEnumApi = {
  */
 export interface TaskRunCommandRequestApi {
     /** JSON-RPC version, must be '2.0'
-
-  * `2.0` - 2.0 */
+     *
+     * * `2.0` - 2.0 */
     jsonrpc: JsonrpcEnumApi
     /** Command method to execute on the agent server
-
-  * `user_message` - user_message
-  * `cancel` - cancel
-  * `close` - close
-  * `permission_response` - permission_response
-  * `set_config_option` - set_config_option */
+     *
+     * * `user_message` - user_message
+     * * `cancel` - cancel
+     * * `close` - close
+     * * `permission_response` - permission_response
+     * * `set_config_option` - set_config_option */
     method: MethodEnumApi
     /** Parameters for the command */
     params?: TaskRunCommandRequestApiParams
@@ -1480,7 +1504,10 @@ export interface PatchedTaskRunSetOutputRequestApi {
 export interface TaskRunStartRequestApi {
     /** Initial or follow-up user message to include in the run prompt. */
     pending_user_message?: string
-    /** Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox. */
+    /**
+     * Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.
+     * @items.maxLength 128
+     */
     pending_user_artifact_ids?: string[]
 }
 
@@ -1491,11 +1518,11 @@ export interface TaskRepositoriesResponseApi {
 
 /**
  * * `needs_setup` - needs_setup
- * `detected` - detected
- * `waiting_for_data` - waiting_for_data
- * `ready` - ready
- * `not_applicable` - not_applicable
- * `unknown` - unknown
+ * * `detected` - detected
+ * * `waiting_for_data` - waiting_for_data
+ * * `ready` - ready
+ * * `not_applicable` - not_applicable
+ * * `unknown` - unknown
  */
 export type CapabilityStateStateEnumApi = (typeof CapabilityStateStateEnumApi)[keyof typeof CapabilityStateStateEnumApi]
 
@@ -1515,13 +1542,13 @@ export type CapabilityStateApiEvidence = { [key: string]: unknown }
 
 export interface CapabilityStateApi {
     /** Current state of the capability
-
-  * `needs_setup` - needs_setup
-  * `detected` - detected
-  * `waiting_for_data` - waiting_for_data
-  * `ready` - ready
-  * `not_applicable` - not_applicable
-  * `unknown` - unknown */
+     *
+     * * `needs_setup` - needs_setup
+     * * `detected` - detected
+     * * `waiting_for_data` - waiting_for_data
+     * * `ready` - ready
+     * * `not_applicable` - not_applicable
+     * * `unknown` - unknown */
     state: CapabilityStateStateEnumApi
     /** Whether the state is estimated from static analysis */
     estimated: boolean
@@ -1620,10 +1647,10 @@ export interface SlackThreadContextTaskApi {
 
 /**
  * The internal sandbox run the discovery agent used to pick this run's repo.
-
-Only present when the originating mention was ambiguous (multiple candidate
-repos, no explicit mention) — that's the only path that spins up a research
-sandbox. Null otherwise.
+ *
+ * Only present when the originating mention was ambiguous (multiple candidate
+ * repos, no explicit mention) — that's the only path that spins up a research
+ * sandbox. Null otherwise.
  */
 export interface SlackThreadContextRepoResearchApi {
     /** UUID of the internal repo-research Task. */
@@ -1782,13 +1809,13 @@ export type TaskAutomationsListParams = {
 
 export type TasksListParams = {
     /**
- * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
-
-* `true` - true
-* `false` - false
-* `all` - all
- * @minLength 1
- */
+     * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
+     *
+     * * `true` - true
+     * * `false` - false
+     * * `all` - all
+     * @minLength 1
+     */
     archived?: TasksListArchived
     /**
      * Filter by creator user ID
@@ -1834,16 +1861,16 @@ export type TasksListParams = {
      */
     stage?: string
     /**
- * Filter tasks by the status of their most recent run.
-
-* `not_started` - not_started
-* `queued` - queued
-* `in_progress` - in_progress
-* `completed` - completed
-* `failed` - failed
-* `cancelled` - cancelled
- * @minLength 1
- */
+     * Filter tasks by the status of their most recent run.
+     *
+     * * `not_started` - not_started
+     * * `queued` - queued
+     * * `in_progress` - in_progress
+     * * `completed` - completed
+     * * `failed` - failed
+     * * `cancelled` - cancelled
+     * @minLength 1
+     */
     status?: TasksListStatus
 }
 

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -119,7 +119,7 @@ export const getSandboxListUrl = (projectId: string, params?: SandboxListParams)
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -222,7 +222,7 @@ export const getTaskAutomationsListUrl = (projectId: string, params?: TaskAutoma
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -346,7 +346,7 @@ export const getTasksListUrl = (projectId: string, params?: TasksListParams) => 
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -613,7 +613,7 @@ export const getTasksRunsListUrl = (projectId: string, taskId: string, params?: 
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -944,7 +944,7 @@ export const getTasksRunsSessionLogsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1063,7 +1063,7 @@ export const getTasksRepositoryReadinessRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1097,7 +1097,7 @@ export const getTasksSlackThreadContextRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -1128,7 +1128,7 @@ export const getTasksSummariesCreateUrl = (projectId: string, params?: TasksSumm
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -32,8 +32,8 @@ export interface _CompareFilterApi {
 
 /**
  * * `span` - span
- * `span_attribute` - span_attribute
- * `span_resource_attribute` - span_resource_attribute
+ * * `span_attribute` - span_attribute
+ * * `span_resource_attribute` - span_resource_attribute
  */
 export type _SpanPropertyFilterTypeEnumApi =
     (typeof _SpanPropertyFilterTypeEnumApi)[keyof typeof _SpanPropertyFilterTypeEnumApi]
@@ -46,15 +46,15 @@ export const _SpanPropertyFilterTypeEnumApi = {
 
 /**
  * * `exact` - exact
- * `is_not` - is_not
- * `icontains` - icontains
- * `not_icontains` - not_icontains
- * `regex` - regex
- * `not_regex` - not_regex
- * `gt` - gt
- * `lt` - lt
- * `is_set` - is_set
- * `is_not_set` - is_not_set
+ * * `is_not` - is_not
+ * * `icontains` - icontains
+ * * `not_icontains` - not_icontains
+ * * `regex` - regex
+ * * `not_regex` - not_regex
+ * * `gt` - gt
+ * * `lt` - lt
+ * * `is_set` - is_set
+ * * `is_not_set` - is_not_set
  */
 export type _SpanPropertyFilterOperatorEnumApi =
     (typeof _SpanPropertyFilterOperatorEnumApi)[keyof typeof _SpanPropertyFilterOperatorEnumApi]
@@ -76,23 +76,23 @@ export interface _SpanPropertyFilterApi {
     /** Attribute key. For type "span", use built-in fields (trace_id, span_id, duration, name, kind, status_code). For "span_attribute"/"span_resource_attribute", use the attribute key (e.g. "http.method"). */
     key: string
     /** "span" filters built-in span fields. "span_attribute" filters span-level attributes. "span_resource_attribute" filters resource-level attributes.
-
-  * `span` - span
-  * `span_attribute` - span_attribute
-  * `span_resource_attribute` - span_resource_attribute */
+     *
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute */
     type: _SpanPropertyFilterTypeEnumApi
     /** Comparison operator.
-
-  * `exact` - exact
-  * `is_not` - is_not
-  * `icontains` - icontains
-  * `not_icontains` - not_icontains
-  * `regex` - regex
-  * `not_regex` - not_regex
-  * `gt` - gt
-  * `lt` - lt
-  * `is_set` - is_set
-  * `is_not_set` - is_not_set */
+     *
+     * * `exact` - exact
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set */
     operator: _SpanPropertyFilterOperatorEnumApi
     /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
     value?: unknown
@@ -142,7 +142,7 @@ export interface _HasSpansResponseApi {
 
 /**
  * * `latest` - latest
- * `earliest` - earliest
+ * * `earliest` - earliest
  */
 export type OrderByEnumApi = (typeof OrderByEnumApi)[keyof typeof OrderByEnumApi]
 
@@ -159,9 +159,9 @@ export interface _TracingQueryBodyApi {
     /** Filter by HTTP status codes. */
     statusCodes?: number[]
     /** Order results by timestamp. Defaults to latest.
-
-  * `latest` - latest
-  * `earliest` - earliest */
+     *
+     * * `latest` - latest
+     * * `earliest` - earliest */
     orderBy?: OrderByEnumApi
     /** Property filters for the query. */
     filterGroup?: _SpanPropertyFilterApi[]
@@ -213,12 +213,12 @@ export interface _TracingTreeRequestApi {
 
 export type TracingSpansAttributesRetrieveParams = {
     /**
- * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-* `span_attribute` - span_attribute
-* `span_resource_attribute` - span_resource_attribute
- * @minLength 1
- */
+     * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
+     *
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * @minLength 1
+     */
     attribute_type?: TracingSpansAttributesRetrieveAttributeType
     /**
      * Max results (default: 100).
@@ -261,13 +261,13 @@ export type TracingSpansServiceNamesRetrieveParams = {
 
 export type TracingSpansValuesRetrieveParams = {
     /**
- * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-* `span` - span
-* `span_attribute` - span_attribute
-* `span_resource_attribute` - span_resource_attribute
- * @minLength 1
- */
+     * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
+     *
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * @minLength 1
+     */
     attribute_type?: TracingSpansValuesRetrieveAttributeType
     /**
      * The attribute key to get values for.

--- a/products/tracing/frontend/generated/api.ts
+++ b/products/tracing/frontend/generated/api.ts
@@ -46,7 +46,7 @@ export const getTracingSpansAttributesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -124,7 +124,7 @@ export const getTracingSpansServiceNamesRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -203,7 +203,7 @@ export const getTracingSpansValuesRetrieveUrl = (projectId: string, params: Trac
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/user_interviews/frontend/generated/api.schemas.ts
+++ b/products/user_interviews/frontend/generated/api.schemas.ts
@@ -9,13 +9,13 @@
  */
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -66,9 +66,15 @@ export interface UserInterviewTopicApi {
     readonly id: string
     readonly created_by: UserBasicApi
     readonly created_at: string
-    /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
+    /**
+     * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
+     * @items.maxLength 254
+     */
     interviewee_emails?: string[]
-    /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
+    /**
+     * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
+     * @items.maxLength 400
+     */
     interviewee_distinct_ids?: string[]
     /** The product, feature, or idea you want to ask interviewees about. */
     topic: string
@@ -101,9 +107,15 @@ export interface PatchedUserInterviewTopicApi {
     readonly id?: string
     readonly created_by?: UserBasicApi
     readonly created_at?: string
-    /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
+    /**
+     * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
+     * @items.maxLength 254
+     */
     interviewee_emails?: string[]
-    /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
+    /**
+     * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
+     * @items.maxLength 400
+     */
     interviewee_distinct_ids?: string[]
     /** The product, feature, or idea you want to ask interviewees about. */
     topic?: string
@@ -307,7 +319,7 @@ export interface BulkIntervieweeContextResponseApi {
 
 /**
  * * `abandoned` - Abandoned
- * `off-topic` - Off-topic
+ * * `off-topic` - Off-topic
  */
 export type ClassificationsEnumApi = (typeof ClassificationsEnumApi)[keyof typeof ClassificationsEnumApi]
 
@@ -320,6 +332,7 @@ export interface UserInterviewApi {
     readonly id: string
     readonly created_by: UserBasicApi
     readonly created_at: string
+    /** @items.maxLength 254 */
     interviewee_emails?: string[]
     readonly interviewee_identifier: string
     /** @nullable */
@@ -344,6 +357,7 @@ export interface PatchedUserInterviewApi {
     readonly id?: string
     readonly created_by?: UserBasicApi
     readonly created_at?: string
+    /** @items.maxLength 254 */
     interviewee_emails?: string[]
     readonly interviewee_identifier?: string
     /** @nullable */
@@ -357,7 +371,7 @@ export interface PatchedUserInterviewApi {
 
 /**
  * * `transcript` - transcript
- * `summary` - summary
+ * * `summary` - summary
  */
 export type UserInterviewSearchDocumentTypeEnumApi =
     (typeof UserInterviewSearchDocumentTypeEnumApi)[keyof typeof UserInterviewSearchDocumentTypeEnumApi]
@@ -400,9 +414,9 @@ export interface UserInterviewSearchResultApi {
     /** ID of the matched UserInterview. */
     interview_id: string
     /** Which document type matched — `transcript` is the raw conversation, `summary` is the AI-generated abstract.
-
-  * `transcript` - transcript
-  * `summary` - summary */
+     *
+     * * `transcript` - transcript
+     * * `summary` - summary */
     document_type: UserInterviewSearchDocumentTypeEnumApi
     /** Cosine similarity in [0, 1]; higher is closer to the query. Computed as `1 - cosineDistance`. */
     similarity: number

--- a/products/user_interviews/frontend/generated/api.ts
+++ b/products/user_interviews/frontend/generated/api.ts
@@ -56,7 +56,7 @@ export const getUserInterviewTopicsListUrl = (projectId: string, params?: UserIn
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -329,7 +329,7 @@ export const getUserInterviewTopicsIntervieweesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -493,7 +493,7 @@ export const getUserInterviewsListUrl = (projectId: string, params?: UserIntervi
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/visual_review/frontend/generated/api.ts
+++ b/products/visual_review/frontend/generated/api.ts
@@ -48,7 +48,7 @@ export const getVisualReviewReposListUrl = (projectId: string, params?: VisualRe
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -159,7 +159,7 @@ export const getVisualReviewReposQuarantineListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -260,7 +260,7 @@ export const getVisualReviewReposRunsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -315,7 +315,7 @@ export const getVisualReviewReposSnapshotsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -351,7 +351,7 @@ export const getVisualReviewRunsListUrl = (projectId: string, params?: VisualRev
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -441,9 +441,9 @@ export const getVisualReviewRunsApproveCreateUrl = (projectId: string, id: strin
 
 /**
  * Mark snapshots reviewed (DB only).
-
-Records the per-snapshot "Accept change" decision. Does not commit the baseline
-or change the GitHub gate — call finalize to ship the run.
+ *
+ * Records the per-snapshot "Accept change" decision. Does not commit the baseline
+ * or change the GitHub gate — call finalize to ship the run.
  */
 export const visualReviewRunsApproveCreate = async (
     projectId: string,
@@ -483,11 +483,11 @@ export const getVisualReviewRunsFinalizeCreateUrl = (projectId: string, id: stri
 
 /**
  * Finalize a fully-reviewed run: commit the approved baseline and green the gate.
-
-Commits exactly the snapshots approved in the DB (tolerated ones keep their baseline)
-and only succeeds once every changed/new snapshot is resolved. With approve_all=true,
-any still-pending changed/new snapshot is approved first. With commit_to_github=false
-the server returns the signed baseline YAML instead of committing it.
+ *
+ * Commits exactly the snapshots approved in the DB (tolerated ones keep their baseline)
+ * and only succeeds once every changed/new snapshot is resolved. With approve_all=true,
+ * any still-pending changed/new snapshot is approved first. With commit_to_github=false
+ * the server returns the signed baseline YAML instead of committing it.
  */
 export const visualReviewRunsFinalizeCreate = async (
     projectId: string,
@@ -530,7 +530,7 @@ export const getVisualReviewRunsSnapshotHistoryListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -568,7 +568,7 @@ export const getVisualReviewRunsSnapshotsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -624,7 +624,7 @@ export const getVisualReviewRunsToleratedHashesListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/visual_review/frontend/generated/api.zod.ts
+++ b/products/visual_review/frontend/generated/api.zod.ts
@@ -118,9 +118,9 @@ export const VisualReviewRunsAddSnapshotsCreateBody = /* @__PURE__ */ zod.object
 
 /**
  * Mark snapshots reviewed (DB only).
-
-Records the per-snapshot "Accept change" decision. Does not commit the baseline
-or change the GitHub gate — call finalize to ship the run.
+ *
+ * Records the per-snapshot "Accept change" decision. Does not commit the baseline
+ * or change the GitHub gate — call finalize to ship the run.
  */
 export const VisualReviewRunsApproveCreateBody = /* @__PURE__ */ zod.object({
     snapshots: zod
@@ -141,11 +141,11 @@ export const VisualReviewRunsApproveCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Finalize a fully-reviewed run: commit the approved baseline and green the gate.
-
-Commits exactly the snapshots approved in the DB (tolerated ones keep their baseline)
-and only succeeds once every changed/new snapshot is resolved. With approve_all=true,
-any still-pending changed/new snapshot is approved first. With commit_to_github=false
-the server returns the signed baseline YAML instead of committing it.
+ *
+ * Commits exactly the snapshots approved in the DB (tolerated ones keep their baseline)
+ * and only succeeds once every changed/new snapshot is resolved. With approve_all=true,
+ * any still-pending changed/new snapshot is approved first. With commit_to_github=false
+ * the server returns the signed baseline YAML instead of committing it.
  */
 export const visualReviewRunsFinalizeCreateBodyApproveAllDefault = false
 export const visualReviewRunsFinalizeCreateBodyCommitToGithubDefault = true

--- a/products/web_analytics/frontend/generated/api.schemas.ts
+++ b/products/web_analytics/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `screenshot` - Screenshot
- * `iframe` - Iframe
- * `recording` - Recording
+ * * `iframe` - Iframe
+ * * `recording` - Recording
  */
 export type HeatmapTypeApi = (typeof HeatmapTypeApi)[keyof typeof HeatmapTypeApi]
 
@@ -22,8 +22,8 @@ export const HeatmapTypeApi = {
 
 /**
  * * `processing` - Processing
- * `completed` - Completed
- * `failed` - Failed
+ * * `completed` - Completed
+ * * `failed` - Failed
  */
 export type HeatmapScreenshotResponseStatusEnumApi =
     (typeof HeatmapScreenshotResponseStatusEnumApi)[keyof typeof HeatmapScreenshotResponseStatusEnumApi]
@@ -43,13 +43,13 @@ export interface HeatmapSnapshotMetadataApi {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -120,16 +120,16 @@ export interface HeatmapScreenshotResponseApi {
     /** Viewport widths (CSS pixels) the screenshot is rendered at. */
     target_widths?: unknown
     /** Render mode: 'screenshot', 'iframe', or 'recording'.
-
-  * `screenshot` - Screenshot
-  * `iframe` - Iframe
-  * `recording` - Recording */
+     *
+     * * `screenshot` - Screenshot
+     * * `iframe` - Iframe
+     * * `recording` - Recording */
     type?: HeatmapTypeApi
     /** Screenshot generation status: 'processing', 'completed', or 'failed'.
-
-  * `processing` - Processing
-  * `completed` - Completed
-  * `failed` - Failed */
+     *
+     * * `processing` - Processing
+     * * `completed` - Completed
+     * * `failed` - Failed */
     readonly status: HeatmapScreenshotResponseStatusEnumApi
     /** Whether at least one rendered image is ready to fetch. */
     readonly has_content: boolean
@@ -218,13 +218,15 @@ export interface SavedHeatmapRequestApi {
     /**
      * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
      * @maxItems 16
+     * @items.minimum 100
+     * @items.maximum 3000
      */
     widths?: number[]
     /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-
-  * `screenshot` - Screenshot
-  * `iframe` - Iframe
-  * `recording` - Recording */
+     *
+     * * `screenshot` - Screenshot
+     * * `iframe` - Iframe
+     * * `recording` - Recording */
     type?: HeatmapTypeApi
     /** Set true to soft-delete the saved heatmap. */
     deleted?: boolean
@@ -251,13 +253,15 @@ export interface PatchedSavedHeatmapRequestApi {
     /**
      * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
      * @maxItems 16
+     * @items.minimum 100
+     * @items.maximum 3000
      */
     widths?: number[]
     /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-
-  * `screenshot` - Screenshot
-  * `iframe` - Iframe
-  * `recording` - Recording */
+     *
+     * * `screenshot` - Screenshot
+     * * `iframe` - Iframe
+     * * `recording` - Recording */
     type?: HeatmapTypeApi
     /** Set true to soft-delete the saved heatmap. */
     deleted?: boolean
@@ -265,7 +269,7 @@ export interface PatchedSavedHeatmapRequestApi {
 
 /**
  * * `Up` - Up
- * `Down` - Down
+ * * `Down` - Down
  */
 export type DirectionEnumApi = (typeof DirectionEnumApi)[keyof typeof DirectionEnumApi]
 
@@ -278,9 +282,9 @@ export interface WoWChangeApi {
     /** Absolute percentage change, rounded to nearest integer. */
     percent: number
     /** Direction of the change relative to the prior period.
-
-  * `Up` - Up
-  * `Down` - Down */
+     *
+     * * `Up` - Up
+     * * `Down` - Down */
     direction: DirectionEnumApi
     /** Hex color indicating whether the change is a positive or negative signal. */
     color: string
@@ -412,12 +416,12 @@ export type HeatmapScreenshotsContentRetrieveParams = {
 
 export type HeatmapsListParams = {
     /**
- * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-* `unique_visitors` - unique_visitors
-* `total_count` - total_count
- * @minLength 1
- */
+     * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
+     * @minLength 1
+     */
     aggregation?: HeatmapsListAggregation
     /**
      * JSON array of cohort IDs (e.g. '[123, 456]') to restrict results to people in those cohorts. Feature-flagged; ignored when the cohort filter is not enabled for the caller.
@@ -477,12 +481,12 @@ export const HeatmapsListAggregation = {
 
 export type HeatmapsEventsRetrieveParams = {
     /**
- * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-* `unique_visitors` - unique_visitors
-* `total_count` - total_count
- * @minLength 1
- */
+     * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
+     * @minLength 1
+     */
     aggregation?: HeatmapsEventsRetrieveAggregation
     /**
      * JSON array of cohort IDs (e.g. '[123, 456]') to restrict results to people in those cohorts. Feature-flagged; ignored when the cohort filter is not enabled for the caller.

--- a/products/web_analytics/frontend/generated/api.ts
+++ b/products/web_analytics/frontend/generated/api.ts
@@ -53,7 +53,7 @@ export const getHeatmapScreenshotsContentRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -87,7 +87,7 @@ export const getHeatmapsListUrl = (projectId: string, params?: HeatmapsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -117,7 +117,7 @@ export const getHeatmapsEventsRetrieveUrl = (projectId: string, params: Heatmaps
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -147,7 +147,7 @@ export const getSavedListUrl = (projectId: string, params?: SavedListParams) => 
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -268,7 +268,7 @@ export const getWebAnalyticsWeeklyDigestUrl = (projectId: string, params?: WebAn
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -302,7 +302,7 @@ export const getWebAnalyticsFilterPresetsListUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 

--- a/products/wizard/frontend/generated/api.schemas.ts
+++ b/products/wizard/frontend/generated/api.schemas.ts
@@ -9,9 +9,9 @@
  */
 /**
  * * `idle` - IDLE
- * `running` - RUNNING
- * `completed` - COMPLETED
- * `error` - ERROR
+ * * `running` - RUNNING
+ * * `completed` - COMPLETED
+ * * `error` - ERROR
  */
 export type RunPhaseEnumApi = (typeof RunPhaseEnumApi)[keyof typeof RunPhaseEnumApi]
 
@@ -24,10 +24,10 @@ export const RunPhaseEnumApi = {
 
 /**
  * * `pending` - PENDING
- * `in_progress` - IN_PROGRESS
- * `completed` - COMPLETED
- * `failed` - FAILED
- * `canceled` - CANCELED
+ * * `in_progress` - IN_PROGRESS
+ * * `completed` - COMPLETED
+ * * `failed` - FAILED
+ * * `canceled` - CANCELED
  */
 export type WizardTaskDTOStatusEnumApi = (typeof WizardTaskDTOStatusEnumApi)[keyof typeof WizardTaskDTOStatusEnumApi]
 
@@ -118,11 +118,11 @@ export interface UpsertWizardSessionRequestApi {
     /** UTC timestamp when the wizard started this run. Matches the timestamp encoded in session_id. */
     started_at: string
     /** Lifecycle stage of the wizard run.
-
-  * `idle` - IDLE
-  * `running` - RUNNING
-  * `completed` - COMPLETED
-  * `error` - ERROR */
+     *
+     * * `idle` - IDLE
+     * * `running` - RUNNING
+     * * `completed` - COMPLETED
+     * * `error` - ERROR */
     run_phase: RunPhaseEnumApi
     tasks: WizardTaskDTOApi[]
     /**

--- a/products/wizard/frontend/generated/api.ts
+++ b/products/wizard/frontend/generated/api.ts
@@ -21,7 +21,7 @@ export const getWizardSessionsListUrl = (projectId: string, params?: WizardSessi
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -89,7 +89,7 @@ export const getWizardSessionsStreamRetrieveUrl = (projectId: string, params: Wi
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -102,8 +102,8 @@ export const getWizardSessionsStreamRetrieveUrl = (projectId: string, params: Wi
 
 /**
  * Server-Sent Events stream of wizard session updates for a (workflow_id, skill_id) pair. On connect, the current latest session (if any) is emitted as the first event; subsequent upserts are streamed in real time. The server closes the connection after 1800 seconds with an `event: end` line so the client (EventSource) can reconnect.
-
-**SDK consumers**: do not call the generated fetch wrapper for this path — it will buffer the entire infinite stream. Use the URL builder (`getWizardSessionsStreamRetrieveUrl`) with the browser's `EventSource` API instead.
+ *
+ * **SDK consumers**: do not call the generated fetch wrapper for this path — it will buffer the entire infinite stream. Use the URL builder (`getWizardSessionsStreamRetrieveUrl`) with the browser's `EventSource` API instead.
  */
 export const wizardSessionsStreamRetrieve = async (
     projectId: string,

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -9,8 +9,8 @@
  */
 /**
  * * `team` - Only team
- * `organization` - Organization
- * `global` - Global
+ * * `organization` - Organization
+ * * `global` - Global
  */
 export type HogFlowTemplateScopeEnumApi = (typeof HogFlowTemplateScopeEnumApi)[keyof typeof HogFlowTemplateScopeEnumApi]
 
@@ -41,9 +41,9 @@ export interface HogFlowMaskingApi {
 
 /**
  * * `exit_on_conversion` - Conversion
- * `exit_on_trigger_not_matched` - Trigger Not Matched
- * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
- * `exit_only_at_end` - Only At End
+ * * `exit_on_trigger_not_matched` - Trigger Not Matched
+ * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+ * * `exit_only_at_end` - Only At End
  */
 export type ExitConditionEnumApi = (typeof ExitConditionEnumApi)[keyof typeof ExitConditionEnumApi]
 
@@ -56,9 +56,9 @@ export const ExitConditionEnumApi = {
 
 /**
  * * `continue` - continue
- * `abort` - abort
- * `complete` - complete
- * `branch` - branch
+ * * `abort` - abort
+ * * `complete` - complete
+ * * `branch` - branch
  */
 export type OnErrorEnumApi = (typeof OnErrorEnumApi)[keyof typeof OnErrorEnumApi]
 
@@ -71,8 +71,8 @@ export const OnErrorEnumApi = {
 
 /**
  * * `events` - events
- * `person-updates` - person-updates
- * `data-warehouse-table` - data-warehouse-table
+ * * `person-updates` - person-updates
+ * * `data-warehouse-table` - data-warehouse-table
  */
 export type HogFunctionFiltersSourceEnumApi =
     (typeof HogFunctionFiltersSourceEnumApi)[keyof typeof HogFunctionFiltersSourceEnumApi]
@@ -105,7 +105,7 @@ export interface HogFunctionFiltersApi {
 
 /**
  * Custom action serializer for templates that skips input validation
-(since templates should have default/empty values).
+ * (since templates should have default/empty values).
  */
 export interface HogFlowTemplateActionApi {
     id: string
@@ -134,7 +134,7 @@ export type HogFlowTemplateApiVariablesItem = { [key: string]: string }
 
 /**
  * Serializer for creating hog flow templates.
-Validates and sanitizes the workflow before creating it as a template.
+ * Validates and sanitizes the workflow before creating it as a template.
  */
 export interface HogFlowTemplateApi {
     readonly id: string
@@ -187,7 +187,7 @@ export type PatchedHogFlowTemplateApiVariablesItem = { [key: string]: string }
 
 /**
  * Serializer for creating hog flow templates.
-Validates and sanitizes the workflow before creating it as a template.
+ * Validates and sanitizes the workflow before creating it as a template.
  */
 export interface PatchedHogFlowTemplateApi {
     readonly id?: string
@@ -221,8 +221,8 @@ export interface PatchedHogFlowTemplateApi {
 
 /**
  * * `draft` - Draft
- * `active` - Active
- * `archived` - Archived
+ * * `active` - Active
+ * * `archived` - Archived
  */
 export type HogFlowStatusEnumApi = (typeof HogFlowStatusEnumApi)[keyof typeof HogFlowStatusEnumApi]
 
@@ -234,13 +234,13 @@ export const HogFlowStatusEnumApi = {
 
 /**
  * * `engineering` - Engineering
- * `data` - Data
- * `product` - Product Management
- * `founder` - Founder
- * `leadership` - Leadership
- * `marketing` - Marketing
- * `sales` - Sales / Success
- * `other` - Other
+ * * `data` - Data
+ * * `product` - Product Management
+ * * `founder` - Founder
+ * * `leadership` - Leadership
+ * * `marketing` - Marketing
+ * * `sales` - Sales / Success
+ * * `other` - Other
  */
 export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
 
@@ -325,7 +325,7 @@ export type HogFlowApiVariablesItem = { [key: string]: string }
 
 /**
  * * `continue` - continue
- * `branch` - branch
+ * * `branch` - branch
  */
 export type HogFlowEdgeTypeEnumApi = (typeof HogFlowEdgeTypeEnumApi)[keyof typeof HogFlowEdgeTypeEnumApi]
 
@@ -338,9 +338,9 @@ export interface HogFlowEdgeApi {
     /** Target action id. */
     to: string
     /** continue: fall-through (sequential or the no-match path of conditional_branch). branch: requires 'index' matching config.conditions[index].
-
-  * `continue` - continue
-  * `branch` - branch */
+     *
+     * * `continue` - continue
+     * * `branch` - branch */
     type: HogFlowEdgeTypeEnumApi
     /** Required for type='branch'. Index into config.conditions on conditional_branch / wait_until_condition. */
     index?: number
@@ -359,11 +359,11 @@ export interface HogFlowActionApi {
     /** Optional description. */
     description?: string
     /** On failure: continue (skip), abort (stop), complete (mark done), branch (follow error edge).
-
-  * `continue` - continue
-  * `abort` - abort
-  * `complete` - complete
-  * `branch` - branch */
+     *
+     * * `continue` - continue
+     * * `abort` - abort
+     * * `complete` - complete
+     * * `branch` - branch */
     on_error?: OnErrorEnumApi | null
     /** Created at (epoch ms). Frontend-managed. */
     created_at?: number
@@ -384,8 +384,8 @@ export interface HogFlowActionApi {
 
 /**
  * * `active` - Active
- * `paused` - Paused
- * `completed` - Completed
+ * * `paused` - Paused
+ * * `completed` - Completed
  */
 export type HogFlowScheduleStatusEnumApi =
     (typeof HogFlowScheduleStatusEnumApi)[keyof typeof HogFlowScheduleStatusEnumApi]
@@ -410,10 +410,10 @@ export interface HogFlowScheduleApi {
     /** Variable value overrides merged with the workflow defaults on each run. */
     variables?: unknown
     /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-
-  * `active` - Active
-  * `paused` - Paused
-  * `completed` - Completed */
+     *
+     * * `active` - Active
+     * * `paused` - Paused
+     * * `completed` - Completed */
     readonly status: HogFlowScheduleStatusEnumApi
     /**
      * Next scheduled fire time, computed by the scheduler.
@@ -436,10 +436,10 @@ export interface HogFlowApi {
     description?: string
     readonly version: number
     /** draft (no execution), active (live), archived (disabled).
-
-  * `draft` - Draft
-  * `active` - Active
-  * `archived` - Archived */
+     *
+     * * `draft` - Draft
+     * * `active` - Active
+     * * `archived` - Archived */
     status?: HogFlowStatusEnumApi
     readonly created_at: string
     readonly created_by: UserBasicApi
@@ -450,11 +450,11 @@ export interface HogFlowApi {
     /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
     conversion?: unknown
     /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-
-  * `exit_on_conversion` - Conversion
-  * `exit_on_trigger_not_matched` - Trigger Not Matched
-  * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-  * `exit_only_at_end` - Only At End */
+     *
+     * * `exit_on_conversion` - Conversion
+     * * `exit_on_trigger_not_matched` - Trigger Not Matched
+     * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+     * * `exit_only_at_end` - Only At End */
     exit_condition?: ExitConditionEnumApi
     /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
     edges?: HogFlowEdgeApi[]
@@ -486,10 +486,10 @@ export interface PatchedHogFlowApi {
     description?: string
     readonly version?: number
     /** draft (no execution), active (live), archived (disabled).
-
-  * `draft` - Draft
-  * `active` - Active
-  * `archived` - Archived */
+     *
+     * * `draft` - Draft
+     * * `active` - Active
+     * * `archived` - Archived */
     status?: HogFlowStatusEnumApi
     readonly created_at?: string
     readonly created_by?: UserBasicApi
@@ -500,11 +500,11 @@ export interface PatchedHogFlowApi {
     /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
     conversion?: unknown
     /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-
-  * `exit_on_conversion` - Conversion
-  * `exit_on_trigger_not_matched` - Trigger Not Matched
-  * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-  * `exit_only_at_end` - Only At End */
+     *
+     * * `exit_on_conversion` - Conversion
+     * * `exit_on_trigger_not_matched` - Trigger Not Matched
+     * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+     * * `exit_only_at_end` - Only At End */
     exit_condition?: ExitConditionEnumApi
     /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
     edges?: HogFlowEdgeApi[]
@@ -521,11 +521,11 @@ export interface PatchedHogFlowApi {
 
 /**
  * * `waiting` - Waiting
- * `queued` - Queued
- * `active` - Active
- * `completed` - Completed
- * `cancelled` - Cancelled
- * `failed` - Failed
+ * * `queued` - Queued
+ * * `active` - Active
+ * * `completed` - Completed
+ * * `cancelled` - Cancelled
+ * * `failed` - Failed
  */
 export type HogFlowBatchJobStatusEnumApi =
     (typeof HogFlowBatchJobStatusEnumApi)[keyof typeof HogFlowBatchJobStatusEnumApi]
@@ -542,13 +542,13 @@ export const HogFlowBatchJobStatusEnumApi = {
 export interface HogFlowBatchJobApi {
     readonly id: string
     /** Not currently tracked — stays at its initial value. Use the workflow logs/metrics endpoints for run outcome.
-
-  * `waiting` - Waiting
-  * `queued` - Queued
-  * `active` - Active
-  * `completed` - Completed
-  * `cancelled` - Cancelled
-  * `failed` - Failed */
+     *
+     * * `waiting` - Waiting
+     * * `queued` - Queued
+     * * `active` - Active
+     * * `completed` - Completed
+     * * `cancelled` - Cancelled
+     * * `failed` - Failed */
     status?: HogFlowBatchJobStatusEnumApi
     /** ID of the workflow this batch run belongs to. */
     hog_flow: string
@@ -650,10 +650,10 @@ export interface PatchedHogFlowScheduleApi {
     /** Variable value overrides merged with the workflow defaults on each run. */
     variables?: unknown
     /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-
-  * `active` - Active
-  * `paused` - Paused
-  * `completed` - Completed */
+     *
+     * * `active` - Active
+     * * `paused` - Paused
+     * * `completed` - Completed */
     readonly status?: HogFlowScheduleStatusEnumApi
     /**
      * Next scheduled fire time, computed by the scheduler.
@@ -752,8 +752,8 @@ export type HogFlowsListParams = {
     offset?: number
     /**
      * * `draft` - Draft
-     * `active` - Active
-     * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     status?: HogFlowsListStatus
     updated_at?: string
@@ -840,12 +840,12 @@ export type HogFlowsMetricsRetrieveParams = {
      */
     before?: string
     /**
- * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-* `name` - name
-* `kind` - kind
- * @minLength 1
- */
+     * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
+     *
+     * * `name` - name
+     * * `kind` - kind
+     * @minLength 1
+     */
     breakdown_by?: HogFlowsMetricsRetrieveBreakdownBy
     /**
      * Filter metrics to a specific execution instance.
@@ -853,13 +853,13 @@ export type HogFlowsMetricsRetrieveParams = {
      */
     instance_id?: string
     /**
- * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-* `hour` - hour
-* `day` - day
-* `week` - week
- * @minLength 1
- */
+     * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * @minLength 1
+     */
     interval?: HogFlowsMetricsRetrieveInterval
     /**
      * Comma-separated metric kinds to filter by, e.g. 'success,failure'.
@@ -902,12 +902,12 @@ export type HogFlowsMetricsTotalsRetrieveParams = {
      */
     before?: string
     /**
- * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-* `name` - name
-* `kind` - kind
- * @minLength 1
- */
+     * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
+     *
+     * * `name` - name
+     * * `kind` - kind
+     * @minLength 1
+     */
     breakdown_by?: HogFlowsMetricsTotalsRetrieveBreakdownBy
     /**
      * Filter metrics to a specific execution instance.
@@ -915,13 +915,13 @@ export type HogFlowsMetricsTotalsRetrieveParams = {
      */
     instance_id?: string
     /**
- * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-* `hour` - hour
-* `day` - day
-* `week` - week
- * @minLength 1
- */
+     * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
+     * @minLength 1
+     */
     interval?: HogFlowsMetricsTotalsRetrieveInterval
     /**
      * Comma-separated metric kinds to filter by, e.g. 'success,failure'.

--- a/products/workflows/frontend/generated/api.ts
+++ b/products/workflows/frontend/generated/api.ts
@@ -59,7 +59,7 @@ export const getInternalHogFlowsProcessDueSchedulesCreateUrl = () => {
 
 /**
  * Internal endpoint called by the scheduler service to process due schedules.
-Handles both executing due schedules and initializing next_run_at for new ones.
+ * Handles both executing due schedules and initializing next_run_at for new ones.
  */
 export const internalHogFlowsProcessDueSchedulesCreate = async (options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getInternalHogFlowsProcessDueSchedulesCreateUrl(), {
@@ -73,7 +73,7 @@ export const getHogFlowTemplatesListUrl = (projectId: string, params?: HogFlowTe
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -121,7 +121,7 @@ export const getHogFlowTemplatesRetrieveUrl = (projectId: string, id: string) =>
 
 /**
  * Check file-based global templates first, then DB team templates.
-The queryset excludes all global templates from DB, so this only returns team templates from DB.
+ * The queryset excludes all global templates from DB, so this only returns team templates from DB.
  */
 export const hogFlowTemplatesRetrieve = async (
     projectId: string,
@@ -190,7 +190,7 @@ export const getHogFlowTemplatesLogsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -218,7 +218,7 @@ export const getHogFlowsListUrl = (projectId: string, params?: HogFlowsListParam
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -357,7 +357,7 @@ export const getHogFlowsInvocationResultsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -406,7 +406,7 @@ export const getHogFlowsInvocationsCreateUrl = (projectId: string, id: string) =
 export const hogFlowsInvocationsCreate = async (
     projectId: string,
     id: string,
-    hogFlowInvocationApi?: HogFlowInvocationApi,
+    hogFlowInvocationApi?: NonReadonly<HogFlowInvocationApi>,
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getHogFlowsInvocationsCreateUrl(projectId, id), {
@@ -422,7 +422,7 @@ export const getHogFlowsLogsRetrieveUrl = (projectId: string, id: string, params
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -454,7 +454,7 @@ export const getHogFlowsMetricsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -486,7 +486,7 @@ export const getHogFlowsMetricsTotalsRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -602,7 +602,7 @@ export const getHogFlowsMetricsGlobalRetrieveUrl = (
 
     Object.entries(params || {}).forEach(([key, value]) => {
         if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
+            normalizedParams.append(key, value === null ? 'null' : String(value))
         }
     })
 
@@ -647,7 +647,7 @@ export const getInternalHogFlowsUserBlastRadiusCreateUrl = (teamId: string) => {
 
 /**
  * Internal endpoint for Node.js services to query user blast radius.
-Requires Bearer token authentication via INTERNAL_API_SECRET.
+ * Requires Bearer token authentication via INTERNAL_API_SECRET.
  */
 export const internalHogFlowsUserBlastRadiusCreate = async (teamId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getInternalHogFlowsUserBlastRadiusCreateUrl(teamId), {
@@ -662,7 +662,7 @@ export const getInternalHogFlowsUserBlastRadiusPersonsCreateUrl = (teamId: strin
 
 /**
  * Internal endpoint for Node.js services to query user blast radius persons with pagination.
-Requires Bearer token authentication via INTERNAL_API_SECRET.
+ * Requires Bearer token authentication via INTERNAL_API_SECRET.
  */
 export const internalHogFlowsUserBlastRadiusPersonsCreate = async (
     teamId: string,

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33,8 +33,8 @@ export namespace Schemas {
 
     /**
      * * `read_write` - read_write
-    * `read` - read
-    * `none` - none
+     * * `read` - read
+     * * `none` - none
      */
     export type AccessLevelEnum = typeof AccessLevelEnum[keyof typeof AccessLevelEnum];
 
@@ -47,7 +47,7 @@ export namespace Schemas {
 
     /**
      * * `warehouse` - warehouse
-    * `direct` - direct
+     * * `direct` - direct
      */
     export type AccessMethodEnum = typeof AccessMethodEnum[keyof typeof AccessMethodEnum];
 
@@ -127,13 +127,13 @@ export namespace Schemas {
 
     /**
      * * `engineering` - Engineering
-    * `data` - Data
-    * `product` - Product Management
-    * `founder` - Founder
-    * `leadership` - Leadership
-    * `marketing` - Marketing
-    * `sales` - Sales / Success
-    * `other` - Other
+     * * `data` - Data
+     * * `product` - Product Management
+     * * `founder` - Founder
+     * * `leadership` - Leadership
+     * * `marketing` - Marketing
+     * * `sales` - Sales / Success
+     * * `other` - Other
      */
     export type RoleAtOrganizationEnum = typeof RoleAtOrganizationEnum[keyof typeof RoleAtOrganizationEnum];
 
@@ -537,32 +537,32 @@ export namespace Schemas {
 
     /**
      * * `event` - event
-    * `event_metadata` - event_metadata
-    * `feature` - feature
-    * `person` - person
-    * `cohort` - cohort
-    * `element` - element
-    * `static-cohort` - static-cohort
-    * `dynamic-cohort` - dynamic-cohort
-    * `precalculated-cohort` - precalculated-cohort
-    * `group` - group
-    * `recording` - recording
-    * `log_entry` - log_entry
-    * `behavioral` - behavioral
-    * `session` - session
-    * `hogql` - hogql
-    * `data_warehouse` - data_warehouse
-    * `data_warehouse_person_property` - data_warehouse_person_property
-    * `error_tracking_issue` - error_tracking_issue
-    * `log` - log
-    * `log_attribute` - log_attribute
-    * `log_resource_attribute` - log_resource_attribute
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
-    * `revenue_analytics` - revenue_analytics
-    * `flag` - flag
-    * `workflow_variable` - workflow_variable
+     * * `event_metadata` - event_metadata
+     * * `feature` - feature
+     * * `person` - person
+     * * `cohort` - cohort
+     * * `element` - element
+     * * `static-cohort` - static-cohort
+     * * `dynamic-cohort` - dynamic-cohort
+     * * `precalculated-cohort` - precalculated-cohort
+     * * `group` - group
+     * * `recording` - recording
+     * * `log_entry` - log_entry
+     * * `behavioral` - behavioral
+     * * `session` - session
+     * * `hogql` - hogql
+     * * `data_warehouse` - data_warehouse
+     * * `data_warehouse_person_property` - data_warehouse_person_property
+     * * `error_tracking_issue` - error_tracking_issue
+     * * `log` - log
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
+     * * `revenue_analytics` - revenue_analytics
+     * * `flag` - flag
+     * * `workflow_variable` - workflow_variable
      */
     export type PropertyFilterTypeEnum = typeof PropertyFilterTypeEnum[keyof typeof PropertyFilterTypeEnum];
 
@@ -599,11 +599,11 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
      */
     export type StringMatchOperatorEnum = typeof StringMatchOperatorEnum[keyof typeof StringMatchOperatorEnum];
 
@@ -624,55 +624,55 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** String value to match against. */
       value: string;
       /** String comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex */
       operator?: StringMatchOperatorEnum;
     }
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `gt` - gt
-    * `lt` - lt
-    * `gte` - gte
-    * `lte` - lte
+     * * `is_not` - is_not
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `gte` - gte
+     * * `lte` - lte
      */
     export type NumericPropertyFilterOperatorEnum = typeof NumericPropertyFilterOperatorEnum[keyof typeof NumericPropertyFilterOperatorEnum];
 
@@ -693,53 +693,53 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Numeric value to compare against. */
       value: number;
       /** Numeric comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `gt` - gt
-      * `lt` - lt
-      * `gte` - gte
-      * `lte` - lte */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `gt` - gt
+       * * `lt` - lt
+       * * `gte` - gte
+       * * `lte` - lte */
       operator?: NumericPropertyFilterOperatorEnum;
     }
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `in` - in
-    * `not_in` - not_in
+     * * `is_not` - is_not
+     * * `in` - in
+     * * `not_in` - not_in
      */
     export type ArrayPropertyFilterOperatorEnum = typeof ArrayPropertyFilterOperatorEnum[keyof typeof ArrayPropertyFilterOperatorEnum];
 
@@ -758,50 +758,50 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** List of values to match. For example `["test@example.com", "ok@example.com"]`. */
       value: string[];
       /** Array comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `in` - in
-      * `not_in` - not_in */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `in` - in
+       * * `not_in` - not_in */
       operator?: ArrayPropertyFilterOperatorEnum;
     }
 
     /**
      * * `is_date_exact` - is_date_exact
-    * `is_date_before` - is_date_before
-    * `is_date_after` - is_date_after
+     * * `is_date_before` - is_date_before
+     * * `is_date_after` - is_date_after
      */
     export type DateOperatorEnum = typeof DateOperatorEnum[keyof typeof DateOperatorEnum];
 
@@ -819,48 +819,48 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Date or datetime string in ISO 8601 format (e.g. '2024-01-15' or '2024-01-15T10:30:00Z'). */
       value: string;
       /** Date comparison operator.
-
-      * `is_date_exact` - is_date_exact
-      * `is_date_before` - is_date_before
-      * `is_date_after` - is_date_after */
+       *
+       * * `is_date_exact` - is_date_exact
+       * * `is_date_before` - is_date_before
+       * * `is_date_after` - is_date_after */
       operator?: DateOperatorEnum;
     }
 
     /**
      * * `is_set` - is_set
-    * `is_not_set` - is_not_set
+     * * `is_not_set` - is_not_set
      */
     export type ExistenceOperatorEnum = typeof ExistenceOperatorEnum[keyof typeof ExistenceOperatorEnum];
 
@@ -877,39 +877,39 @@ export namespace Schemas {
       /** Key of the property you're filtering on. For example `email` or `$current_url`. */
       key: string;
       /** Property type (event, person, session, etc.).
-
-      * `event` - event
-      * `event_metadata` - event_metadata
-      * `feature` - feature
-      * `person` - person
-      * `cohort` - cohort
-      * `element` - element
-      * `static-cohort` - static-cohort
-      * `dynamic-cohort` - dynamic-cohort
-      * `precalculated-cohort` - precalculated-cohort
-      * `group` - group
-      * `recording` - recording
-      * `log_entry` - log_entry
-      * `behavioral` - behavioral
-      * `session` - session
-      * `hogql` - hogql
-      * `data_warehouse` - data_warehouse
-      * `data_warehouse_person_property` - data_warehouse_person_property
-      * `error_tracking_issue` - error_tracking_issue
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute
-      * `revenue_analytics` - revenue_analytics
-      * `flag` - flag
-      * `workflow_variable` - workflow_variable */
+       *
+       * * `event` - event
+       * * `event_metadata` - event_metadata
+       * * `feature` - feature
+       * * `person` - person
+       * * `cohort` - cohort
+       * * `element` - element
+       * * `static-cohort` - static-cohort
+       * * `dynamic-cohort` - dynamic-cohort
+       * * `precalculated-cohort` - precalculated-cohort
+       * * `group` - group
+       * * `recording` - recording
+       * * `log_entry` - log_entry
+       * * `behavioral` - behavioral
+       * * `session` - session
+       * * `hogql` - hogql
+       * * `data_warehouse` - data_warehouse
+       * * `data_warehouse_person_property` - data_warehouse_person_property
+       * * `error_tracking_issue` - error_tracking_issue
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute
+       * * `revenue_analytics` - revenue_analytics
+       * * `flag` - flag
+       * * `workflow_variable` - workflow_variable */
       type?: PropertyFilterTypeEnum;
       /** Existence check operator.
-
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: ExistenceOperatorEnum;
     }
 
@@ -917,8 +917,8 @@ export namespace Schemas {
 
     /**
      * * `contains` - contains
-    * `regex` - regex
-    * `exact` - exact
+     * * `regex` - regex
+     * * `exact` - exact
      */
     export type ActionStepMatchingEnum = typeof ActionStepMatchingEnum[keyof typeof ActionStepMatchingEnum];
 
@@ -958,10 +958,10 @@ export namespace Schemas {
          */
       text?: string | null;
       /** How to match the text value. Defaults to exact.
-
-      * `contains` - contains
-      * `regex` - regex
-      * `exact` - exact */
+       *
+       * * `contains` - contains
+       * * `regex` - regex
+       * * `exact` - exact */
       text_matching?: ActionStepMatchingEnum | null;
       /**
          * Link href attribute to match.
@@ -969,10 +969,10 @@ export namespace Schemas {
          */
       href?: string | null;
       /** How to match the href value. Defaults to exact.
-
-      * `contains` - contains
-      * `regex` - regex
-      * `exact` - exact */
+       *
+       * * `contains` - contains
+       * * `regex` - regex
+       * * `exact` - exact */
       href_matching?: ActionStepMatchingEnum | null;
       /**
          * Page URL to match.
@@ -980,10 +980,10 @@ export namespace Schemas {
          */
       url?: string | null;
       /** How to match the URL value. Defaults to contains.
-
-      * `contains` - contains
-      * `regex` - regex
-      * `exact` - exact */
+       *
+       * * `contains` - contains
+       * * `regex` - regex
+       * * `exact` - exact */
       url_matching?: ActionStepMatchingEnum | null;
     }
 
@@ -1040,8 +1040,8 @@ export namespace Schemas {
 
     /**
      * * `add` - add
-    * `remove` - remove
-    * `set` - set
+     * * `remove` - remove
+     * * `set` - set
      */
     export type ActionEnum = typeof ActionEnum[keyof typeof ActionEnum];
 
@@ -1626,8 +1626,8 @@ export namespace Schemas {
 
     /**
      * * `true` - true
-    * `false` - false
-    * `STALE` - STALE
+     * * `false` - false
+     * * `STALE` - STALE
      */
     export type ActiveEnum = typeof ActiveEnum[keyof typeof ActiveEnum];
 
@@ -1880,7 +1880,7 @@ export namespace Schemas {
 
     export interface DateRange {
       /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-      -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
+       * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
       date_from?: string | null;
       /** End of the date range. Same format as date_from. Omit or null for "now". */
       date_to?: string | null;
@@ -2152,14 +2152,14 @@ export namespace Schemas {
 
     export interface TrendsFilter {
       /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-
-      - `numeric` (default): raw numbers, e.g. `1,234`.
-      - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-      - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-      - `percentage`: values are already in the 0-100 range; appends `%`.
-      - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-      - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-      - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
+       *
+       * - `numeric` (default): raw numbers, e.g. `1,234`.
+       * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
+       * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
+       * - `percentage`: values are already in the 0-100 range; appends `%`.
+       * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
+       * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
+       * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
       aggregationAxisFormat?: AggregationAxisFormat | null;
       /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
       aggregationAxisPostfix?: string | null;
@@ -3832,10 +3832,10 @@ export namespace Schemas {
 
     /**
      * * `last_seen` - last_seen
-    * `first_seen` - first_seen
-    * `occurrences` - occurrences
-    * `users` - users
-    * `sessions` - sessions
+     * * `first_seen` - first_seen
+     * * `occurrences` - occurrences
+     * * `users` - users
+     * * `sessions` - sessions
      */
     export type ErrorTrackingIssueOrderByEnum = typeof ErrorTrackingIssueOrderByEnum[keyof typeof ErrorTrackingIssueOrderByEnum];
 
@@ -3850,7 +3850,7 @@ export namespace Schemas {
 
     /**
      * * `ASC` - ASC
-    * `DESC` - DESC
+     * * `DESC` - DESC
      */
     export type OrderDirectionEnum = typeof OrderDirectionEnum[keyof typeof OrderDirectionEnum];
 
@@ -3862,11 +3862,11 @@ export namespace Schemas {
 
     /**
      * * `archived` - archived
-    * `active` - active
-    * `resolved` - resolved
-    * `pending_release` - pending_release
-    * `suppressed` - suppressed
-    * `all` - all
+     * * `active` - active
+     * * `resolved` - resolved
+     * * `pending_release` - pending_release
+     * * `suppressed` - suppressed
+     * * `all` - all
      */
     export type ErrorTrackingIssueStatusEnum = typeof ErrorTrackingIssueStatusEnum[keyof typeof ErrorTrackingIssueStatusEnum];
 
@@ -3882,7 +3882,7 @@ export namespace Schemas {
 
     /**
      * * `user` - user
-    * `role` - role
+     * * `role` - role
      */
     export type AssigneeTypeEnum = typeof AssigneeTypeEnum[keyof typeof AssigneeTypeEnum];
 
@@ -3896,9 +3896,9 @@ export namespace Schemas {
       /** User ID or role UUID to filter by. */
       id: string | number | null;
       /** Assignee target type: user or role.
-
-      * `user` - user
-      * `role` - role */
+       *
+       * * `user` - user
+       * * `role` - role */
       type: AssigneeTypeEnum;
     }
 
@@ -3917,12 +3917,12 @@ export namespace Schemas {
 
     /**
      * * `-14d` - -14d
-    * `-1h` - -1h
-    * `-24h` - -24h
-    * `-30d` - -30d
-    * `-3h` - -3h
-    * `-7d` - -7d
-    * `-90d` - -90d
+     * * `-1h` - -1h
+     * * `-24h` - -24h
+     * * `-30d` - -30d
+     * * `-3h` - -3h
+     * * `-7d` - -7d
+     * * `-90d` - -90d
      */
     export type DateFromEnum = typeof DateFromEnum[keyof typeof DateFromEnum];
 
@@ -3939,14 +3939,14 @@ export namespace Schemas {
 
     export interface WidgetDateRange {
       /** Relative lookback window (for example '-7d'). Omit to use the project default range.
-
-      * `-14d` - -14d
-      * `-1h` - -1h
-      * `-24h` - -24h
-      * `-30d` - -30d
-      * `-3h` - -3h
-      * `-7d` - -7d
-      * `-90d` - -90d */
+       *
+       * * `-14d` - -14d
+       * * `-1h` - -1h
+       * * `-24h` - -24h
+       * * `-30d` - -30d
+       * * `-3h` - -3h
+       * * `-7d` - -7d
+       * * `-90d` - -90d */
       date_from?: DateFromEnum | null;
     }
 
@@ -3963,26 +3963,26 @@ export namespace Schemas {
          */
       limit?: number;
       /** Issue ranking column.
-
-      * `first_seen` - first_seen
-      * `last_seen` - last_seen
-      * `occurrences` - occurrences
-      * `sessions` - sessions
-      * `users` - users */
+       *
+       * * `first_seen` - first_seen
+       * * `last_seen` - last_seen
+       * * `occurrences` - occurrences
+       * * `sessions` - sessions
+       * * `users` - users */
       orderBy?: ErrorTrackingIssueOrderByEnum;
       /** Sort direction for orderBy.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /** Issue status filter.
-
-      * `archived` - archived
-      * `active` - active
-      * `resolved` - resolved
-      * `pending_release` - pending_release
-      * `suppressed` - suppressed
-      * `all` - all */
+       *
+       * * `archived` - archived
+       * * `active` - active
+       * * `resolved` - resolved
+       * * `pending_release` - pending_release
+       * * `suppressed` - suppressed
+       * * `all` - all */
       status?: ErrorTrackingIssueStatusEnum;
       /** Filter by assignee ({type: user|role, id}). Omit for any assignee. */
       assignee?: ErrorTrackingAssignee | null;
@@ -4021,11 +4021,11 @@ export namespace Schemas {
 
     /**
      * * `activity_score` - activity_score
-    * `click_count` - click_count
-    * `console_error_count` - console_error_count
-    * `duration` - duration
-    * `recording_duration` - recording_duration
-    * `start_time` - start_time
+     * * `click_count` - click_count
+     * * `console_error_count` - console_error_count
+     * * `duration` - duration
+     * * `recording_duration` - recording_duration
+     * * `start_time` - start_time
      */
     export type SessionReplayListWidgetConfigOrderByEnum = typeof SessionReplayListWidgetConfigOrderByEnum[keyof typeof SessionReplayListWidgetConfigOrderByEnum];
 
@@ -4052,18 +4052,18 @@ export namespace Schemas {
          */
       limit?: number;
       /** Recording ranking column.
-
-      * `activity_score` - activity_score
-      * `click_count` - click_count
-      * `console_error_count` - console_error_count
-      * `duration` - duration
-      * `recording_duration` - recording_duration
-      * `start_time` - start_time */
+       *
+       * * `activity_score` - activity_score
+       * * `click_count` - click_count
+       * * `console_error_count` - console_error_count
+       * * `duration` - duration
+       * * `recording_duration` - recording_duration
+       * * `start_time` - start_time */
       orderBy?: SessionReplayListWidgetConfigOrderByEnum;
       /** Sort direction for orderBy.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /** Optional relative date range override. */
       dateRange?: WidgetDateRange | null;
@@ -6888,10 +6888,10 @@ export namespace Schemas {
 
     /**
      * The query definition for this insight. The `kind` field determines the query type:
-    - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
-    - `DataVisualizationNode` — SQL insights using HogQL
-    - `DataTableNode` — raw data tables
-    - `HogQuery` — Hog language queries
+     * - `InsightVizNode` — product analytics (trends, funnels, retention, paths, stickiness, lifecycle)
+     * - `DataVisualizationNode` — SQL insights using HogQL
+     * - `DataTableNode` — raw data tables
+     * - `HogQuery` — Hog language queries
      */
     export type _InsightQuerySchema = InsightVizNode | DataTableNode | DataVisualizationNode | HogQuery;
 
@@ -6951,21 +6951,21 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
-              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-              A dashboard ID for each of the dashboards that this insight is displayed on.
-               */
+       *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+       *         A dashboard ID for each of the dashboards that this insight is displayed on.
+       *          */
       dashboards?: number[];
       /**
-          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-           */
+       *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+       *      */
       readonly dashboard_tiles: readonly DashboardTileBasic[];
       /**
          *
-          The datetime this insight's results were generated.
-          If added to one or more dashboards the insight can be refreshed separately on each.
-          Returns the appropriate last_refresh datetime for the context the insight is viewed in
-          (see from_dashboard query parameter).
-
+       *     The datetime this insight's results were generated.
+       *     If added to one or more dashboards the insight can be refreshed separately on each.
+       *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+       *     (see from_dashboard query parameter).
+       *
          * @nullable
          */
       readonly last_refresh: string | null;
@@ -6976,9 +6976,9 @@ export namespace Schemas {
       readonly cache_target_age: string | null;
       /**
          *
-          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-          by querying the database.
-
+       *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+       *     by querying the database.
+       *
          * @nullable
          */
       readonly next_allowed_client_refresh: string | null;
@@ -7045,7 +7045,7 @@ export namespace Schemas {
 
     /**
      * * `left` - left
-    * `right` - right
+     * * `right` - right
      */
     export type PlacementEnum = typeof PlacementEnum[keyof typeof PlacementEnum];
 
@@ -7057,7 +7057,7 @@ export namespace Schemas {
 
     /**
      * * `primary` - Primary
-    * `secondary` - Secondary
+     * * `secondary` - Secondary
      */
     export type StyleEnum = typeof StyleEnum[keyof typeof StyleEnum];
 
@@ -7176,17 +7176,17 @@ export namespace Schemas {
 
     /**
      * * `product_analytics` - product_analytics
-    * `sql` - sql
-    * `session_replay` - session_replay
-    * `error_tracking` - error_tracking
-    * `plan` - plan
-    * `execution` - execution
-    * `survey` - survey
-    * `research` - research
-    * `flags` - flags
-    * `llm_analytics` - llm_analytics
-    * `sandbox` - sandbox
-    * `user_interview` - user_interview
+     * * `sql` - sql
+     * * `session_replay` - session_replay
+     * * `error_tracking` - error_tracking
+     * * `plan` - plan
+     * * `execution` - execution
+     * * `survey` - survey
+     * * `research` - research
+     * * `flags` - flags
+     * * `llm_analytics` - llm_analytics
+     * * `sandbox` - sandbox
+     * * `user_interview` - user_interview
      */
     export type AgentModeEnum = typeof AgentModeEnum[keyof typeof AgentModeEnum];
 
@@ -7219,9 +7219,9 @@ export namespace Schemas {
 
     /**
      * * `sum` - sum
-    * `avg` - avg
-    * `count` - count
-    * `p95` - p95
+     * * `avg` - avg
+     * * `count` - count
+     * * `p95` - p95
      */
     export type AggregationEnum = typeof AggregationEnum[keyof typeof AggregationEnum];
 
@@ -7278,9 +7278,9 @@ export namespace Schemas {
 
     /**
      * * `Firing` - Firing
-    * `Not firing` - Not firing
-    * `Errored` - Errored
-    * `Snoozed` - Snoozed
+     * * `Not firing` - Not firing
+     * * `Errored` - Errored
+     * * `Snoozed` - Snoozed
      */
     export type AlertCheckStateEnum = typeof AlertCheckStateEnum[keyof typeof AlertCheckStateEnum];
 
@@ -7294,10 +7294,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - pending
-    * `running` - running
-    * `done` - done
-    * `failed` - failed
-    * `skipped` - skipped
+     * * `running` - running
+     * * `done` - done
+     * * `failed` - failed
+     * * `skipped` - skipped
      */
     export type InvestigationStatusEnum = typeof InvestigationStatusEnum[keyof typeof InvestigationStatusEnum];
 
@@ -7312,8 +7312,8 @@ export namespace Schemas {
 
     /**
      * * `true_positive` - true_positive
-    * `false_positive` - false_positive
-    * `inconclusive` - inconclusive
+     * * `false_positive` - false_positive
+     * * `inconclusive` - inconclusive
      */
     export type InvestigationVerdictEnum = typeof InvestigationVerdictEnum[keyof typeof InvestigationVerdictEnum];
 
@@ -7534,10 +7534,10 @@ export namespace Schemas {
 
     /**
      * * `every_15_minutes` - every_15_minutes
-    * `hourly` - hourly
-    * `daily` - daily
-    * `weekly` - weekly
-    * `monthly` - monthly
+     * * `hourly` - hourly
+     * * `daily` - daily
+     * * `weekly` - weekly
+     * * `monthly` - monthly
      */
     export type CalculationIntervalEnum = typeof CalculationIntervalEnum[keyof typeof CalculationIntervalEnum];
 
@@ -7564,7 +7564,7 @@ export namespace Schemas {
 
     /**
      * * `notify` - Notify
-    * `suppress` - Suppress
+     * * `suppress` - Suppress
      */
     export type InvestigationInconclusiveActionEnum = typeof InvestigationInconclusiveActionEnum[keyof typeof InvestigationInconclusiveActionEnum];
 
@@ -7609,12 +7609,12 @@ export namespace Schemas {
       config?: TrendsAlertConfig | null;
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-
-      * `every_15_minutes` - every_15_minutes
-      * `hourly` - hourly
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly */
+       *
+       * * `every_15_minutes` - every_15_minutes
+       * * `hourly` - hourly
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly */
       calculation_interval?: CalculationIntervalEnum;
       /**
          * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -7638,9 +7638,9 @@ export namespace Schemas {
       /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
       investigation_gates_notifications?: boolean;
       /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-
-      * `notify` - Notify
-      * `suppress` - Suppress */
+       *
+       * * `notify` - Notify
+       * * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
     }
 
@@ -7711,7 +7711,7 @@ export namespace Schemas {
 
     /**
      * * `USR` - user
-    * `GIT` - GitHub
+     * * `GIT` - GitHub
      */
     export type CreationTypeEnum = typeof CreationTypeEnum[keyof typeof CreationTypeEnum];
 
@@ -7723,10 +7723,10 @@ export namespace Schemas {
 
     /**
      * * `dashboard_item` - insight
-    * `dashboard` - dashboard
-    * `project` - project
-    * `organization` - organization
-    * `recording` - recording
+     * * `dashboard` - dashboard
+     * * `project` - project
+     * * `organization` - organization
+     * * `recording` - recording
      */
     export type AnnotationScopeEnum = typeof AnnotationScopeEnum[keyof typeof AnnotationScopeEnum];
 
@@ -7753,9 +7753,9 @@ export namespace Schemas {
          */
       date_marker?: string | null;
       /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-
-      * `USR` - user
-      * `GIT` - GitHub */
+       *
+       * * `USR` - user
+       * * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -7776,12 +7776,12 @@ export namespace Schemas {
       /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
       /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-
-      * `dashboard_item` - insight
-      * `dashboard` - dashboard
-      * `project` - project
-      * `organization` - organization
-      * `recording` - recording */
+       *
+       * * `dashboard_item` - insight
+       * * `dashboard` - dashboard
+       * * `project` - project
+       * * `organization` - organization
+       * * `recording` - recording */
       scope?: AnnotationScopeEnum;
       /**
          * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -7930,10 +7930,10 @@ export namespace Schemas {
 
     /**
      * * `first_touch` - First Touch
-    * `last_touch` - Last Touch
-    * `linear` - Linear
-    * `time_decay` - Time Decay
-    * `position_based` - Position Based
+     * * `last_touch` - Last Touch
+     * * `linear` - Linear
+     * * `time_decay` - Time Decay
+     * * `position_based` - Position Based
      */
     export type AttributionModeEnum = typeof AttributionModeEnum[keyof typeof AttributionModeEnum];
 
@@ -8006,10 +8006,10 @@ export namespace Schemas {
 
     /**
      * * `P0` - P0
-    * `P1` - P1
-    * `P2` - P2
-    * `P3` - P3
-    * `P4` - P4
+     * * `P1` - P1
+     * * `P2` - P2
+     * * `P3` - P3
+     * * `P4` - P4
      */
     export type AutonomyPriorityEnum = typeof AutonomyPriorityEnum[keyof typeof AutonomyPriorityEnum];
 
@@ -8055,70 +8055,70 @@ export namespace Schemas {
 
     /**
      * * `ingest_first_event` - ingest_first_event
-    * `set_up_reverse_proxy` - set_up_reverse_proxy
-    * `create_first_insight` - create_first_insight
-    * `create_first_dashboard` - create_first_dashboard
-    * `track_custom_events` - track_custom_events
-    * `define_actions` - define_actions
-    * `set_up_cohorts` - set_up_cohorts
-    * `explore_trends_insight` - explore_trends_insight
-    * `create_funnel` - create_funnel
-    * `explore_retention_insight` - explore_retention_insight
-    * `explore_paths_insight` - explore_paths_insight
-    * `explore_stickiness_insight` - explore_stickiness_insight
-    * `explore_lifecycle_insight` - explore_lifecycle_insight
-    * `add_authorized_domain` - add_authorized_domain
-    * `set_up_web_vitals` - set_up_web_vitals
-    * `review_web_analytics_dashboard` - review_web_analytics_dashboard
-    * `filter_web_analytics` - filter_web_analytics
-    * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
-    * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
-    * `setup_session_recordings` - setup_session_recordings
-    * `watch_session_recording` - watch_session_recording
-    * `configure_recording_settings` - configure_recording_settings
-    * `create_recording_playlist` - create_recording_playlist
-    * `enable_console_logs` - enable_console_logs
-    * `create_feature_flag` - create_feature_flag
-    * `implement_flag_in_code` - implement_flag_in_code
-    * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
-    * `create_multivariate_flag` - create_multivariate_flag
-    * `set_up_flag_payloads` - set_up_flag_payloads
-    * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
-    * `create_experiment` - create_experiment
-    * `implement_experiment_variants` - implement_experiment_variants
-    * `launch_experiment` - launch_experiment
-    * `review_experiment_results` - review_experiment_results
-    * `create_survey` - create_survey
-    * `launch_survey` - launch_survey
-    * `collect_survey_responses` - collect_survey_responses
-    * `connect_source` - connect_source
-    * `run_first_query` - run_first_query
-    * `join_external_data` - join_external_data
-    * `create_saved_view` - create_saved_view
-    * `enable_error_tracking` - enable_error_tracking
-    * `upload_source_maps` - upload_source_maps
-    * `view_first_error` - view_first_error
-    * `resolve_first_error` - resolve_first_error
-    * `ingest_first_llm_event` - ingest_first_llm_event
-    * `view_first_trace` - view_first_trace
-    * `track_costs` - track_costs
-    * `set_up_llm_evaluation` - set_up_llm_evaluation
-    * `run_ai_playground` - run_ai_playground
-    * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
-    * `connect_revenue_source` - connect_revenue_source
-    * `set_up_revenue_goal` - set_up_revenue_goal
-    * `enable_log_capture` - enable_log_capture
-    * `view_first_logs` - view_first_logs
-    * `create_first_workflow` - create_first_workflow
-    * `set_up_first_workflow_channel` - set_up_first_workflow_channel
-    * `configure_workflow_trigger` - configure_workflow_trigger
-    * `add_workflow_action` - add_workflow_action
-    * `launch_workflow` - launch_workflow
-    * `create_first_endpoint` - create_first_endpoint
-    * `configure_endpoint` - configure_endpoint
-    * `test_endpoint` - test_endpoint
-    * `create_early_access_feature` - create_early_access_feature
-    * `update_feature_stage` - update_feature_stage
+     * * `set_up_reverse_proxy` - set_up_reverse_proxy
+     * * `create_first_insight` - create_first_insight
+     * * `create_first_dashboard` - create_first_dashboard
+     * * `track_custom_events` - track_custom_events
+     * * `define_actions` - define_actions
+     * * `set_up_cohorts` - set_up_cohorts
+     * * `explore_trends_insight` - explore_trends_insight
+     * * `create_funnel` - create_funnel
+     * * `explore_retention_insight` - explore_retention_insight
+     * * `explore_paths_insight` - explore_paths_insight
+     * * `explore_stickiness_insight` - explore_stickiness_insight
+     * * `explore_lifecycle_insight` - explore_lifecycle_insight
+     * * `add_authorized_domain` - add_authorized_domain
+     * * `set_up_web_vitals` - set_up_web_vitals
+     * * `review_web_analytics_dashboard` - review_web_analytics_dashboard
+     * * `filter_web_analytics` - filter_web_analytics
+     * * `set_up_web_analytics_conversion_goals` - set_up_web_analytics_conversion_goals
+     * * `visit_web_vitals_dashboard` - visit_web_vitals_dashboard
+     * * `setup_session_recordings` - setup_session_recordings
+     * * `watch_session_recording` - watch_session_recording
+     * * `configure_recording_settings` - configure_recording_settings
+     * * `create_recording_playlist` - create_recording_playlist
+     * * `enable_console_logs` - enable_console_logs
+     * * `create_feature_flag` - create_feature_flag
+     * * `implement_flag_in_code` - implement_flag_in_code
+     * * `update_feature_flag_release_conditions` - update_feature_flag_release_conditions
+     * * `create_multivariate_flag` - create_multivariate_flag
+     * * `set_up_flag_payloads` - set_up_flag_payloads
+     * * `set_up_flag_evaluation_runtimes` - set_up_flag_evaluation_runtimes
+     * * `create_experiment` - create_experiment
+     * * `implement_experiment_variants` - implement_experiment_variants
+     * * `launch_experiment` - launch_experiment
+     * * `review_experiment_results` - review_experiment_results
+     * * `create_survey` - create_survey
+     * * `launch_survey` - launch_survey
+     * * `collect_survey_responses` - collect_survey_responses
+     * * `connect_source` - connect_source
+     * * `run_first_query` - run_first_query
+     * * `join_external_data` - join_external_data
+     * * `create_saved_view` - create_saved_view
+     * * `enable_error_tracking` - enable_error_tracking
+     * * `upload_source_maps` - upload_source_maps
+     * * `view_first_error` - view_first_error
+     * * `resolve_first_error` - resolve_first_error
+     * * `ingest_first_llm_event` - ingest_first_llm_event
+     * * `view_first_trace` - view_first_trace
+     * * `track_costs` - track_costs
+     * * `set_up_llm_evaluation` - set_up_llm_evaluation
+     * * `run_ai_playground` - run_ai_playground
+     * * `enable_revenue_analytics_viewset` - enable_revenue_analytics_viewset
+     * * `connect_revenue_source` - connect_revenue_source
+     * * `set_up_revenue_goal` - set_up_revenue_goal
+     * * `enable_log_capture` - enable_log_capture
+     * * `view_first_logs` - view_first_logs
+     * * `create_first_workflow` - create_first_workflow
+     * * `set_up_first_workflow_channel` - set_up_first_workflow_channel
+     * * `configure_workflow_trigger` - configure_workflow_trigger
+     * * `add_workflow_action` - add_workflow_action
+     * * `launch_workflow` - launch_workflow
+     * * `create_first_endpoint` - create_first_endpoint
+     * * `configure_endpoint` - configure_endpoint
+     * * `test_endpoint` - test_endpoint
+     * * `create_early_access_feature` - create_early_access_feature
+     * * `update_feature_stage` - update_feature_stage
      */
     export type AvailableSetupTaskIdsEnum = typeof AvailableSetupTaskIdsEnum[keyof typeof AvailableSetupTaskIdsEnum];
 
@@ -8200,10 +8200,10 @@ export namespace Schemas {
 
     /**
      * * `brotli` - brotli
-    * `gzip` - gzip
-    * `lz4` - lz4
-    * `snappy` - snappy
-    * `zstd` - zstd
+     * * `gzip` - gzip
+     * * `lz4` - lz4
+     * * `snappy` - snappy
+     * * `zstd` - zstd
      */
     export type CompressionEnum = typeof CompressionEnum[keyof typeof CompressionEnum];
 
@@ -8218,7 +8218,7 @@ export namespace Schemas {
 
     /**
      * * `JSONLines` - JSONLines
-    * `Parquet` - Parquet
+     * * `Parquet` - Parquet
      */
     export type FileFormatEnum = typeof FileFormatEnum[keyof typeof FileFormatEnum];
 
@@ -8230,9 +8230,9 @@ export namespace Schemas {
 
     /**
      * Typed configuration for an Azure Blob Storage batch-export destination.
-
-    Credentials live in the linked Integration, not in this config. Mirrors
-    `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
+     *
+     * Credentials live in the linked Integration, not in this config. Mirrors
+     * `AzureBlobBatchExportInputs` in `products/batch_exports/backend/service.py`.
      */
     export interface AzureBlobDestinationConfig {
       /** Azure Blob Storage container name. */
@@ -8240,17 +8240,17 @@ export namespace Schemas {
       /** Object key prefix applied to every exported file. */
       prefix?: string;
       /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
-
-      * `brotli` - brotli
-      * `gzip` - gzip
-      * `lz4` - lz4
-      * `snappy` - snappy
-      * `zstd` - zstd */
+       *
+       * * `brotli` - brotli
+       * * `gzip` - gzip
+       * * `lz4` - lz4
+       * * `snappy` - snappy
+       * * `zstd` - zstd */
       compression?: CompressionEnum | null;
       /** File format used for exported objects.
-
-      * `JSONLines` - JSONLines
-      * `Parquet` - Parquet */
+       *
+       * * `JSONLines` - JSONLines
+       * * `Parquet` - Parquet */
       file_format?: FileFormatEnum;
       /**
          * If set, rolls to a new file once the current file exceeds this size in MB.
@@ -8289,157 +8289,157 @@ export namespace Schemas {
 
     /**
      * * `AED` - AED
-    * `AFN` - AFN
-    * `ALL` - ALL
-    * `AMD` - AMD
-    * `ANG` - ANG
-    * `AOA` - AOA
-    * `ARS` - ARS
-    * `AUD` - AUD
-    * `AWG` - AWG
-    * `AZN` - AZN
-    * `BAM` - BAM
-    * `BBD` - BBD
-    * `BDT` - BDT
-    * `BGN` - BGN
-    * `BHD` - BHD
-    * `BIF` - BIF
-    * `BMD` - BMD
-    * `BND` - BND
-    * `BOB` - BOB
-    * `BRL` - BRL
-    * `BSD` - BSD
-    * `BTC` - BTC
-    * `BTN` - BTN
-    * `BWP` - BWP
-    * `BYN` - BYN
-    * `BZD` - BZD
-    * `CAD` - CAD
-    * `CDF` - CDF
-    * `CHF` - CHF
-    * `CLP` - CLP
-    * `CNY` - CNY
-    * `COP` - COP
-    * `CRC` - CRC
-    * `CVE` - CVE
-    * `CZK` - CZK
-    * `DJF` - DJF
-    * `DKK` - DKK
-    * `DOP` - DOP
-    * `DZD` - DZD
-    * `EGP` - EGP
-    * `ERN` - ERN
-    * `ETB` - ETB
-    * `EUR` - EUR
-    * `FJD` - FJD
-    * `GBP` - GBP
-    * `GEL` - GEL
-    * `GHS` - GHS
-    * `GIP` - GIP
-    * `GMD` - GMD
-    * `GNF` - GNF
-    * `GTQ` - GTQ
-    * `GYD` - GYD
-    * `HKD` - HKD
-    * `HNL` - HNL
-    * `HRK` - HRK
-    * `HTG` - HTG
-    * `HUF` - HUF
-    * `IDR` - IDR
-    * `ILS` - ILS
-    * `INR` - INR
-    * `IQD` - IQD
-    * `IRR` - IRR
-    * `ISK` - ISK
-    * `JMD` - JMD
-    * `JOD` - JOD
-    * `JPY` - JPY
-    * `KES` - KES
-    * `KGS` - KGS
-    * `KHR` - KHR
-    * `KMF` - KMF
-    * `KRW` - KRW
-    * `KWD` - KWD
-    * `KYD` - KYD
-    * `KZT` - KZT
-    * `LAK` - LAK
-    * `LBP` - LBP
-    * `LKR` - LKR
-    * `LRD` - LRD
-    * `LTL` - LTL
-    * `LVL` - LVL
-    * `LSL` - LSL
-    * `LYD` - LYD
-    * `MAD` - MAD
-    * `MDL` - MDL
-    * `MGA` - MGA
-    * `MKD` - MKD
-    * `MMK` - MMK
-    * `MNT` - MNT
-    * `MOP` - MOP
-    * `MRU` - MRU
-    * `MTL` - MTL
-    * `MUR` - MUR
-    * `MVR` - MVR
-    * `MWK` - MWK
-    * `MXN` - MXN
-    * `MYR` - MYR
-    * `MZN` - MZN
-    * `NAD` - NAD
-    * `NGN` - NGN
-    * `NIO` - NIO
-    * `NOK` - NOK
-    * `NPR` - NPR
-    * `NZD` - NZD
-    * `OMR` - OMR
-    * `PAB` - PAB
-    * `PEN` - PEN
-    * `PGK` - PGK
-    * `PHP` - PHP
-    * `PKR` - PKR
-    * `PLN` - PLN
-    * `PYG` - PYG
-    * `QAR` - QAR
-    * `RON` - RON
-    * `RSD` - RSD
-    * `RUB` - RUB
-    * `RWF` - RWF
-    * `SAR` - SAR
-    * `SBD` - SBD
-    * `SCR` - SCR
-    * `SDG` - SDG
-    * `SEK` - SEK
-    * `SGD` - SGD
-    * `SRD` - SRD
-    * `SSP` - SSP
-    * `STN` - STN
-    * `SYP` - SYP
-    * `SZL` - SZL
-    * `THB` - THB
-    * `TJS` - TJS
-    * `TMT` - TMT
-    * `TND` - TND
-    * `TOP` - TOP
-    * `TRY` - TRY
-    * `TTD` - TTD
-    * `TWD` - TWD
-    * `TZS` - TZS
-    * `UAH` - UAH
-    * `UGX` - UGX
-    * `USD` - USD
-    * `UYU` - UYU
-    * `UZS` - UZS
-    * `VES` - VES
-    * `VND` - VND
-    * `VUV` - VUV
-    * `WST` - WST
-    * `XAF` - XAF
-    * `XCD` - XCD
-    * `XOF` - XOF
-    * `XPF` - XPF
-    * `YER` - YER
-    * `ZAR` - ZAR
-    * `ZMW` - ZMW
+     * * `AFN` - AFN
+     * * `ALL` - ALL
+     * * `AMD` - AMD
+     * * `ANG` - ANG
+     * * `AOA` - AOA
+     * * `ARS` - ARS
+     * * `AUD` - AUD
+     * * `AWG` - AWG
+     * * `AZN` - AZN
+     * * `BAM` - BAM
+     * * `BBD` - BBD
+     * * `BDT` - BDT
+     * * `BGN` - BGN
+     * * `BHD` - BHD
+     * * `BIF` - BIF
+     * * `BMD` - BMD
+     * * `BND` - BND
+     * * `BOB` - BOB
+     * * `BRL` - BRL
+     * * `BSD` - BSD
+     * * `BTC` - BTC
+     * * `BTN` - BTN
+     * * `BWP` - BWP
+     * * `BYN` - BYN
+     * * `BZD` - BZD
+     * * `CAD` - CAD
+     * * `CDF` - CDF
+     * * `CHF` - CHF
+     * * `CLP` - CLP
+     * * `CNY` - CNY
+     * * `COP` - COP
+     * * `CRC` - CRC
+     * * `CVE` - CVE
+     * * `CZK` - CZK
+     * * `DJF` - DJF
+     * * `DKK` - DKK
+     * * `DOP` - DOP
+     * * `DZD` - DZD
+     * * `EGP` - EGP
+     * * `ERN` - ERN
+     * * `ETB` - ETB
+     * * `EUR` - EUR
+     * * `FJD` - FJD
+     * * `GBP` - GBP
+     * * `GEL` - GEL
+     * * `GHS` - GHS
+     * * `GIP` - GIP
+     * * `GMD` - GMD
+     * * `GNF` - GNF
+     * * `GTQ` - GTQ
+     * * `GYD` - GYD
+     * * `HKD` - HKD
+     * * `HNL` - HNL
+     * * `HRK` - HRK
+     * * `HTG` - HTG
+     * * `HUF` - HUF
+     * * `IDR` - IDR
+     * * `ILS` - ILS
+     * * `INR` - INR
+     * * `IQD` - IQD
+     * * `IRR` - IRR
+     * * `ISK` - ISK
+     * * `JMD` - JMD
+     * * `JOD` - JOD
+     * * `JPY` - JPY
+     * * `KES` - KES
+     * * `KGS` - KGS
+     * * `KHR` - KHR
+     * * `KMF` - KMF
+     * * `KRW` - KRW
+     * * `KWD` - KWD
+     * * `KYD` - KYD
+     * * `KZT` - KZT
+     * * `LAK` - LAK
+     * * `LBP` - LBP
+     * * `LKR` - LKR
+     * * `LRD` - LRD
+     * * `LTL` - LTL
+     * * `LVL` - LVL
+     * * `LSL` - LSL
+     * * `LYD` - LYD
+     * * `MAD` - MAD
+     * * `MDL` - MDL
+     * * `MGA` - MGA
+     * * `MKD` - MKD
+     * * `MMK` - MMK
+     * * `MNT` - MNT
+     * * `MOP` - MOP
+     * * `MRU` - MRU
+     * * `MTL` - MTL
+     * * `MUR` - MUR
+     * * `MVR` - MVR
+     * * `MWK` - MWK
+     * * `MXN` - MXN
+     * * `MYR` - MYR
+     * * `MZN` - MZN
+     * * `NAD` - NAD
+     * * `NGN` - NGN
+     * * `NIO` - NIO
+     * * `NOK` - NOK
+     * * `NPR` - NPR
+     * * `NZD` - NZD
+     * * `OMR` - OMR
+     * * `PAB` - PAB
+     * * `PEN` - PEN
+     * * `PGK` - PGK
+     * * `PHP` - PHP
+     * * `PKR` - PKR
+     * * `PLN` - PLN
+     * * `PYG` - PYG
+     * * `QAR` - QAR
+     * * `RON` - RON
+     * * `RSD` - RSD
+     * * `RUB` - RUB
+     * * `RWF` - RWF
+     * * `SAR` - SAR
+     * * `SBD` - SBD
+     * * `SCR` - SCR
+     * * `SDG` - SDG
+     * * `SEK` - SEK
+     * * `SGD` - SGD
+     * * `SRD` - SRD
+     * * `SSP` - SSP
+     * * `STN` - STN
+     * * `SYP` - SYP
+     * * `SZL` - SZL
+     * * `THB` - THB
+     * * `TJS` - TJS
+     * * `TMT` - TMT
+     * * `TND` - TND
+     * * `TOP` - TOP
+     * * `TRY` - TRY
+     * * `TTD` - TTD
+     * * `TWD` - TWD
+     * * `TZS` - TZS
+     * * `UAH` - UAH
+     * * `UGX` - UGX
+     * * `USD` - USD
+     * * `UYU` - UYU
+     * * `UZS` - UZS
+     * * `VES` - VES
+     * * `VND` - VND
+     * * `VUV` - VUV
+     * * `WST` - WST
+     * * `XAF` - XAF
+     * * `XCD` - XCD
+     * * `XOF` - XOF
+     * * `XPF` - XPF
+     * * `YER` - YER
+     * * `ZAR` - ZAR
+     * * `ZMW` - ZMW
      */
     export type BaseCurrencyEnum = typeof BaseCurrencyEnum[keyof typeof BaseCurrencyEnum];
 
@@ -8665,7 +8665,7 @@ export namespace Schemas {
 
     /**
      * * `minimal` - minimal
-    * `detailed` - detailed
+     * * `detailed` - detailed
      */
     export type DetailModeValueEnum = typeof DetailModeValueEnum[keyof typeof DetailModeValueEnum];
 
@@ -8682,9 +8682,9 @@ export namespace Schemas {
          */
       trace_ids: string[];
       /** Summary detail level to check for
-
-      * `minimal` - minimal
-      * `detailed` - detailed */
+       *
+       * * `minimal` - minimal
+       * * `detailed` - detailed */
       mode?: DetailModeValueEnum;
       /**
          * LLM model used for cached summaries
@@ -8705,8 +8705,8 @@ export namespace Schemas {
 
     /**
      * * `events` - Events
-    * `persons` - Persons
-    * `sessions` - Sessions
+     * * `persons` - Persons
+     * * `sessions` - Sessions
      */
     export type ModelEnum = typeof ModelEnum[keyof typeof ModelEnum];
 
@@ -8719,18 +8719,18 @@ export namespace Schemas {
 
     /**
      * * `S3` - S3
-    * `AwsS3` - Aws S3
-    * `S3Compatible` - S3 Compatible
-    * `Snowflake` - Snowflake
-    * `Postgres` - Postgres
-    * `Redshift` - Redshift
-    * `BigQuery` - Bigquery
-    * `Databricks` - Databricks
-    * `AzureBlob` - Azure Blob
-    * `Workflows` - Workflows
-    * `HTTP` - Http
-    * `NoOp` - Noop
-    * `FileDownload` - File Download
+     * * `AwsS3` - Aws S3
+     * * `S3Compatible` - S3 Compatible
+     * * `Snowflake` - Snowflake
+     * * `Postgres` - Postgres
+     * * `Redshift` - Redshift
+     * * `BigQuery` - Bigquery
+     * * `Databricks` - Databricks
+     * * `AzureBlob` - Azure Blob
+     * * `Workflows` - Workflows
+     * * `HTTP` - Http
+     * * `NoOp` - Noop
+     * * `FileDownload` - File Download
      */
     export type BatchExportDestinationTypeEnum = typeof BatchExportDestinationTypeEnum[keyof typeof BatchExportDestinationTypeEnum];
 
@@ -8760,9 +8760,9 @@ export namespace Schemas {
 
     /**
      * Typed configuration for a Databricks batch-export destination.
-
-    Credentials live in the linked Integration, not in this config. Mirrors
-    `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
+     *
+     * Credentials live in the linked Integration, not in this config. Mirrors
+     * `DatabricksBatchExportInputs` in `products/batch_exports/backend/service.py`.
      */
     export interface DatabricksDestinationConfig {
       /** Databricks SQL warehouse HTTP path. */
@@ -8789,10 +8789,10 @@ export namespace Schemas {
 
     /**
      * Typed configuration for a BigQuery batch-export destination.
-
-    Credentials live in the linked Integration, not in this config. Mirrors the
-    non-credential fields of `BigQueryBatchExportInputs` in
-    `products/batch_exports/backend/service.py`.
+     *
+     * Credentials live in the linked Integration, not in this config. Mirrors the
+     * non-credential fields of `BigQueryBatchExportInputs` in
+     * `products/batch_exports/backend/service.py`.
      */
     export interface BigQueryDestinationConfig {
       /** BigQuery dataset ID to write to. */
@@ -8808,28 +8808,28 @@ export namespace Schemas {
 
     /**
      * Serializer for an BatchExportDestination model.
-
-    The `config` field is polymorphic and typed only for destinations that keep
-    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
-    Other destination types accept the same JSON shape but without a typed
-    OpenAPI schema. Secret fields are stripped from `config` on read.
+     *
+     * The `config` field is polymorphic and typed only for destinations that keep
+     * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery).
+     * Other destination types accept the same JSON shape but without a typed
+     * OpenAPI schema. Secret fields are stripped from `config` on read.
      */
     export interface BatchExportDestination {
       /** A choice of supported BatchExportDestination types.
-
-      * `S3` - S3
-      * `AwsS3` - Aws S3
-      * `S3Compatible` - S3 Compatible
-      * `Snowflake` - Snowflake
-      * `Postgres` - Postgres
-      * `Redshift` - Redshift
-      * `BigQuery` - Bigquery
-      * `Databricks` - Databricks
-      * `AzureBlob` - Azure Blob
-      * `Workflows` - Workflows
-      * `HTTP` - Http
-      * `NoOp` - Noop
-      * `FileDownload` - File Download */
+       *
+       * * `S3` - S3
+       * * `AwsS3` - Aws S3
+       * * `S3Compatible` - S3 Compatible
+       * * `Snowflake` - Snowflake
+       * * `Postgres` - Postgres
+       * * `Redshift` - Redshift
+       * * `BigQuery` - Bigquery
+       * * `Databricks` - Databricks
+       * * `AzureBlob` - Azure Blob
+       * * `Workflows` - Workflows
+       * * `HTTP` - Http
+       * * `NoOp` - Noop
+       * * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
       /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
@@ -8847,10 +8847,10 @@ export namespace Schemas {
 
     /**
      * * `hour` - hour
-    * `day` - day
-    * `week` - week
-    * `every 5 minutes` - every 5 minutes
-    * `every 15 minutes` - every 15 minutes
+     * * `day` - day
+     * * `week` - week
+     * * `every 5 minutes` - every 5 minutes
+     * * `every 15 minutes` - every 15 minutes
      */
     export type IntervalEnum = typeof IntervalEnum[keyof typeof IntervalEnum];
 
@@ -8865,15 +8865,15 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `ContinuedAsNew` - Continued As New
-    * `Failed` - Failed
-    * `FailedRetryable` - Failed Retryable
-    * `FailedBilling` - Failed Billing
-    * `Terminated` - Terminated
-    * `TimedOut` - Timedout
-    * `Running` - Running
-    * `Starting` - Starting
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `FailedBilling` - Failed Billing
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting
      */
     export type BatchExportRunStatusEnum = typeof BatchExportRunStatusEnum[keyof typeof BatchExportRunStatusEnum];
 
@@ -8897,17 +8897,17 @@ export namespace Schemas {
     export interface BatchExportRun {
       readonly id: string;
       /** The status of this run.
-
-      * `Cancelled` - Cancelled
-      * `Completed` - Completed
-      * `ContinuedAsNew` - Continued As New
-      * `Failed` - Failed
-      * `FailedRetryable` - Failed Retryable
-      * `FailedBilling` - Failed Billing
-      * `Terminated` - Terminated
-      * `TimedOut` - Timedout
-      * `Running` - Running
-      * `Starting` - Starting */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Completed` - Completed
+       * * `ContinuedAsNew` - Continued As New
+       * * `Failed` - Failed
+       * * `FailedRetryable` - Failed Retryable
+       * * `FailedBilling` - Failed Billing
+       * * `Terminated` - Terminated
+       * * `TimedOut` - Timedout
+       * * `Running` - Running
+       * * `Starting` - Starting */
       status: BatchExportRunStatusEnum;
       /**
          * The number of records that have been exported.
@@ -8990,20 +8990,20 @@ export namespace Schemas {
       /** A human-readable name for this BatchExport. */
       name: string;
       /** Which model this BatchExport is exporting.
-
-      * `events` - Events
-      * `persons` - Persons
-      * `sessions` - Sessions */
+       *
+       * * `events` - Events
+       * * `persons` - Persons
+       * * `sessions` - Sessions */
       model?: ModelEnum | BlankEnum | null;
       /** Destination configuration (type, config, and optional integration). */
       destination: BatchExportDestination;
       /** How often the batch export should run.
-
-      * `hour` - hour
-      * `day` - day
-      * `week` - week
-      * `every 5 minutes` - every 5 minutes
-      * `every 15 minutes` - every 15 minutes */
+       *
+       * * `hour` - hour
+       * * `day` - day
+       * * `week` - week
+       * * `every 5 minutes` - every 5 minutes
+       * * `every 15 minutes` - every 15 minutes */
       interval: IntervalEnum;
       /** Whether this BatchExport is paused or not. */
       paused?: boolean;
@@ -9034,603 +9034,603 @@ export namespace Schemas {
       readonly schema: unknown;
       filters?: unknown;
       /** IANA timezone name controlling daily and weekly interval boundaries. Defaults to UTC.
-
-      * `Africa/Abidjan` - Africa/Abidjan
-      * `Africa/Accra` - Africa/Accra
-      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-      * `Africa/Algiers` - Africa/Algiers
-      * `Africa/Asmara` - Africa/Asmara
-      * `Africa/Asmera` - Africa/Asmera
-      * `Africa/Bamako` - Africa/Bamako
-      * `Africa/Bangui` - Africa/Bangui
-      * `Africa/Banjul` - Africa/Banjul
-      * `Africa/Bissau` - Africa/Bissau
-      * `Africa/Blantyre` - Africa/Blantyre
-      * `Africa/Brazzaville` - Africa/Brazzaville
-      * `Africa/Bujumbura` - Africa/Bujumbura
-      * `Africa/Cairo` - Africa/Cairo
-      * `Africa/Casablanca` - Africa/Casablanca
-      * `Africa/Ceuta` - Africa/Ceuta
-      * `Africa/Conakry` - Africa/Conakry
-      * `Africa/Dakar` - Africa/Dakar
-      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-      * `Africa/Djibouti` - Africa/Djibouti
-      * `Africa/Douala` - Africa/Douala
-      * `Africa/El_Aaiun` - Africa/El_Aaiun
-      * `Africa/Freetown` - Africa/Freetown
-      * `Africa/Gaborone` - Africa/Gaborone
-      * `Africa/Harare` - Africa/Harare
-      * `Africa/Johannesburg` - Africa/Johannesburg
-      * `Africa/Juba` - Africa/Juba
-      * `Africa/Kampala` - Africa/Kampala
-      * `Africa/Khartoum` - Africa/Khartoum
-      * `Africa/Kigali` - Africa/Kigali
-      * `Africa/Kinshasa` - Africa/Kinshasa
-      * `Africa/Lagos` - Africa/Lagos
-      * `Africa/Libreville` - Africa/Libreville
-      * `Africa/Lome` - Africa/Lome
-      * `Africa/Luanda` - Africa/Luanda
-      * `Africa/Lubumbashi` - Africa/Lubumbashi
-      * `Africa/Lusaka` - Africa/Lusaka
-      * `Africa/Malabo` - Africa/Malabo
-      * `Africa/Maputo` - Africa/Maputo
-      * `Africa/Maseru` - Africa/Maseru
-      * `Africa/Mbabane` - Africa/Mbabane
-      * `Africa/Mogadishu` - Africa/Mogadishu
-      * `Africa/Monrovia` - Africa/Monrovia
-      * `Africa/Nairobi` - Africa/Nairobi
-      * `Africa/Ndjamena` - Africa/Ndjamena
-      * `Africa/Niamey` - Africa/Niamey
-      * `Africa/Nouakchott` - Africa/Nouakchott
-      * `Africa/Ouagadougou` - Africa/Ouagadougou
-      * `Africa/Porto-Novo` - Africa/Porto-Novo
-      * `Africa/Sao_Tome` - Africa/Sao_Tome
-      * `Africa/Timbuktu` - Africa/Timbuktu
-      * `Africa/Tripoli` - Africa/Tripoli
-      * `Africa/Tunis` - Africa/Tunis
-      * `Africa/Windhoek` - Africa/Windhoek
-      * `America/Adak` - America/Adak
-      * `America/Anchorage` - America/Anchorage
-      * `America/Anguilla` - America/Anguilla
-      * `America/Antigua` - America/Antigua
-      * `America/Araguaina` - America/Araguaina
-      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-      * `America/Argentina/Salta` - America/Argentina/Salta
-      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-      * `America/Aruba` - America/Aruba
-      * `America/Asuncion` - America/Asuncion
-      * `America/Atikokan` - America/Atikokan
-      * `America/Atka` - America/Atka
-      * `America/Bahia` - America/Bahia
-      * `America/Bahia_Banderas` - America/Bahia_Banderas
-      * `America/Barbados` - America/Barbados
-      * `America/Belem` - America/Belem
-      * `America/Belize` - America/Belize
-      * `America/Blanc-Sablon` - America/Blanc-Sablon
-      * `America/Boa_Vista` - America/Boa_Vista
-      * `America/Bogota` - America/Bogota
-      * `America/Boise` - America/Boise
-      * `America/Buenos_Aires` - America/Buenos_Aires
-      * `America/Cambridge_Bay` - America/Cambridge_Bay
-      * `America/Campo_Grande` - America/Campo_Grande
-      * `America/Cancun` - America/Cancun
-      * `America/Caracas` - America/Caracas
-      * `America/Catamarca` - America/Catamarca
-      * `America/Cayenne` - America/Cayenne
-      * `America/Cayman` - America/Cayman
-      * `America/Chicago` - America/Chicago
-      * `America/Chihuahua` - America/Chihuahua
-      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-      * `America/Coral_Harbour` - America/Coral_Harbour
-      * `America/Cordoba` - America/Cordoba
-      * `America/Costa_Rica` - America/Costa_Rica
-      * `America/Creston` - America/Creston
-      * `America/Cuiaba` - America/Cuiaba
-      * `America/Curacao` - America/Curacao
-      * `America/Danmarkshavn` - America/Danmarkshavn
-      * `America/Dawson` - America/Dawson
-      * `America/Dawson_Creek` - America/Dawson_Creek
-      * `America/Denver` - America/Denver
-      * `America/Detroit` - America/Detroit
-      * `America/Dominica` - America/Dominica
-      * `America/Edmonton` - America/Edmonton
-      * `America/Eirunepe` - America/Eirunepe
-      * `America/El_Salvador` - America/El_Salvador
-      * `America/Ensenada` - America/Ensenada
-      * `America/Fort_Nelson` - America/Fort_Nelson
-      * `America/Fort_Wayne` - America/Fort_Wayne
-      * `America/Fortaleza` - America/Fortaleza
-      * `America/Glace_Bay` - America/Glace_Bay
-      * `America/Godthab` - America/Godthab
-      * `America/Goose_Bay` - America/Goose_Bay
-      * `America/Grand_Turk` - America/Grand_Turk
-      * `America/Grenada` - America/Grenada
-      * `America/Guadeloupe` - America/Guadeloupe
-      * `America/Guatemala` - America/Guatemala
-      * `America/Guayaquil` - America/Guayaquil
-      * `America/Guyana` - America/Guyana
-      * `America/Halifax` - America/Halifax
-      * `America/Havana` - America/Havana
-      * `America/Hermosillo` - America/Hermosillo
-      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-      * `America/Indiana/Knox` - America/Indiana/Knox
-      * `America/Indiana/Marengo` - America/Indiana/Marengo
-      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-      * `America/Indiana/Vevay` - America/Indiana/Vevay
-      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-      * `America/Indiana/Winamac` - America/Indiana/Winamac
-      * `America/Indianapolis` - America/Indianapolis
-      * `America/Inuvik` - America/Inuvik
-      * `America/Iqaluit` - America/Iqaluit
-      * `America/Jamaica` - America/Jamaica
-      * `America/Jujuy` - America/Jujuy
-      * `America/Juneau` - America/Juneau
-      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-      * `America/Knox_IN` - America/Knox_IN
-      * `America/Kralendijk` - America/Kralendijk
-      * `America/La_Paz` - America/La_Paz
-      * `America/Lima` - America/Lima
-      * `America/Los_Angeles` - America/Los_Angeles
-      * `America/Louisville` - America/Louisville
-      * `America/Lower_Princes` - America/Lower_Princes
-      * `America/Maceio` - America/Maceio
-      * `America/Managua` - America/Managua
-      * `America/Manaus` - America/Manaus
-      * `America/Marigot` - America/Marigot
-      * `America/Martinique` - America/Martinique
-      * `America/Matamoros` - America/Matamoros
-      * `America/Mazatlan` - America/Mazatlan
-      * `America/Mendoza` - America/Mendoza
-      * `America/Menominee` - America/Menominee
-      * `America/Merida` - America/Merida
-      * `America/Metlakatla` - America/Metlakatla
-      * `America/Mexico_City` - America/Mexico_City
-      * `America/Miquelon` - America/Miquelon
-      * `America/Moncton` - America/Moncton
-      * `America/Monterrey` - America/Monterrey
-      * `America/Montevideo` - America/Montevideo
-      * `America/Montreal` - America/Montreal
-      * `America/Montserrat` - America/Montserrat
-      * `America/Nassau` - America/Nassau
-      * `America/New_York` - America/New_York
-      * `America/Nipigon` - America/Nipigon
-      * `America/Nome` - America/Nome
-      * `America/Noronha` - America/Noronha
-      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-      * `America/North_Dakota/Center` - America/North_Dakota/Center
-      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-      * `America/Nuuk` - America/Nuuk
-      * `America/Ojinaga` - America/Ojinaga
-      * `America/Panama` - America/Panama
-      * `America/Pangnirtung` - America/Pangnirtung
-      * `America/Paramaribo` - America/Paramaribo
-      * `America/Phoenix` - America/Phoenix
-      * `America/Port-au-Prince` - America/Port-au-Prince
-      * `America/Port_of_Spain` - America/Port_of_Spain
-      * `America/Porto_Acre` - America/Porto_Acre
-      * `America/Porto_Velho` - America/Porto_Velho
-      * `America/Puerto_Rico` - America/Puerto_Rico
-      * `America/Punta_Arenas` - America/Punta_Arenas
-      * `America/Rainy_River` - America/Rainy_River
-      * `America/Rankin_Inlet` - America/Rankin_Inlet
-      * `America/Recife` - America/Recife
-      * `America/Regina` - America/Regina
-      * `America/Resolute` - America/Resolute
-      * `America/Rio_Branco` - America/Rio_Branco
-      * `America/Rosario` - America/Rosario
-      * `America/Santa_Isabel` - America/Santa_Isabel
-      * `America/Santarem` - America/Santarem
-      * `America/Santiago` - America/Santiago
-      * `America/Santo_Domingo` - America/Santo_Domingo
-      * `America/Sao_Paulo` - America/Sao_Paulo
-      * `America/Scoresbysund` - America/Scoresbysund
-      * `America/Shiprock` - America/Shiprock
-      * `America/Sitka` - America/Sitka
-      * `America/St_Barthelemy` - America/St_Barthelemy
-      * `America/St_Johns` - America/St_Johns
-      * `America/St_Kitts` - America/St_Kitts
-      * `America/St_Lucia` - America/St_Lucia
-      * `America/St_Thomas` - America/St_Thomas
-      * `America/St_Vincent` - America/St_Vincent
-      * `America/Swift_Current` - America/Swift_Current
-      * `America/Tegucigalpa` - America/Tegucigalpa
-      * `America/Thule` - America/Thule
-      * `America/Thunder_Bay` - America/Thunder_Bay
-      * `America/Tijuana` - America/Tijuana
-      * `America/Toronto` - America/Toronto
-      * `America/Tortola` - America/Tortola
-      * `America/Vancouver` - America/Vancouver
-      * `America/Virgin` - America/Virgin
-      * `America/Whitehorse` - America/Whitehorse
-      * `America/Winnipeg` - America/Winnipeg
-      * `America/Yakutat` - America/Yakutat
-      * `America/Yellowknife` - America/Yellowknife
-      * `Antarctica/Casey` - Antarctica/Casey
-      * `Antarctica/Davis` - Antarctica/Davis
-      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-      * `Antarctica/Macquarie` - Antarctica/Macquarie
-      * `Antarctica/Mawson` - Antarctica/Mawson
-      * `Antarctica/McMurdo` - Antarctica/McMurdo
-      * `Antarctica/Palmer` - Antarctica/Palmer
-      * `Antarctica/Rothera` - Antarctica/Rothera
-      * `Antarctica/South_Pole` - Antarctica/South_Pole
-      * `Antarctica/Syowa` - Antarctica/Syowa
-      * `Antarctica/Troll` - Antarctica/Troll
-      * `Antarctica/Vostok` - Antarctica/Vostok
-      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-      * `Asia/Aden` - Asia/Aden
-      * `Asia/Almaty` - Asia/Almaty
-      * `Asia/Amman` - Asia/Amman
-      * `Asia/Anadyr` - Asia/Anadyr
-      * `Asia/Aqtau` - Asia/Aqtau
-      * `Asia/Aqtobe` - Asia/Aqtobe
-      * `Asia/Ashgabat` - Asia/Ashgabat
-      * `Asia/Ashkhabad` - Asia/Ashkhabad
-      * `Asia/Atyrau` - Asia/Atyrau
-      * `Asia/Baghdad` - Asia/Baghdad
-      * `Asia/Bahrain` - Asia/Bahrain
-      * `Asia/Baku` - Asia/Baku
-      * `Asia/Bangkok` - Asia/Bangkok
-      * `Asia/Barnaul` - Asia/Barnaul
-      * `Asia/Beirut` - Asia/Beirut
-      * `Asia/Bishkek` - Asia/Bishkek
-      * `Asia/Brunei` - Asia/Brunei
-      * `Asia/Calcutta` - Asia/Calcutta
-      * `Asia/Chita` - Asia/Chita
-      * `Asia/Choibalsan` - Asia/Choibalsan
-      * `Asia/Chongqing` - Asia/Chongqing
-      * `Asia/Chungking` - Asia/Chungking
-      * `Asia/Colombo` - Asia/Colombo
-      * `Asia/Dacca` - Asia/Dacca
-      * `Asia/Damascus` - Asia/Damascus
-      * `Asia/Dhaka` - Asia/Dhaka
-      * `Asia/Dili` - Asia/Dili
-      * `Asia/Dubai` - Asia/Dubai
-      * `Asia/Dushanbe` - Asia/Dushanbe
-      * `Asia/Famagusta` - Asia/Famagusta
-      * `Asia/Gaza` - Asia/Gaza
-      * `Asia/Harbin` - Asia/Harbin
-      * `Asia/Hebron` - Asia/Hebron
-      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-      * `Asia/Hong_Kong` - Asia/Hong_Kong
-      * `Asia/Hovd` - Asia/Hovd
-      * `Asia/Irkutsk` - Asia/Irkutsk
-      * `Asia/Istanbul` - Asia/Istanbul
-      * `Asia/Jakarta` - Asia/Jakarta
-      * `Asia/Jayapura` - Asia/Jayapura
-      * `Asia/Jerusalem` - Asia/Jerusalem
-      * `Asia/Kabul` - Asia/Kabul
-      * `Asia/Kamchatka` - Asia/Kamchatka
-      * `Asia/Karachi` - Asia/Karachi
-      * `Asia/Kashgar` - Asia/Kashgar
-      * `Asia/Kathmandu` - Asia/Kathmandu
-      * `Asia/Katmandu` - Asia/Katmandu
-      * `Asia/Khandyga` - Asia/Khandyga
-      * `Asia/Kolkata` - Asia/Kolkata
-      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-      * `Asia/Kuching` - Asia/Kuching
-      * `Asia/Kuwait` - Asia/Kuwait
-      * `Asia/Macao` - Asia/Macao
-      * `Asia/Macau` - Asia/Macau
-      * `Asia/Magadan` - Asia/Magadan
-      * `Asia/Makassar` - Asia/Makassar
-      * `Asia/Manila` - Asia/Manila
-      * `Asia/Muscat` - Asia/Muscat
-      * `Asia/Nicosia` - Asia/Nicosia
-      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-      * `Asia/Novosibirsk` - Asia/Novosibirsk
-      * `Asia/Omsk` - Asia/Omsk
-      * `Asia/Oral` - Asia/Oral
-      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-      * `Asia/Pontianak` - Asia/Pontianak
-      * `Asia/Pyongyang` - Asia/Pyongyang
-      * `Asia/Qatar` - Asia/Qatar
-      * `Asia/Qostanay` - Asia/Qostanay
-      * `Asia/Qyzylorda` - Asia/Qyzylorda
-      * `Asia/Rangoon` - Asia/Rangoon
-      * `Asia/Riyadh` - Asia/Riyadh
-      * `Asia/Saigon` - Asia/Saigon
-      * `Asia/Sakhalin` - Asia/Sakhalin
-      * `Asia/Samarkand` - Asia/Samarkand
-      * `Asia/Seoul` - Asia/Seoul
-      * `Asia/Shanghai` - Asia/Shanghai
-      * `Asia/Singapore` - Asia/Singapore
-      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-      * `Asia/Taipei` - Asia/Taipei
-      * `Asia/Tashkent` - Asia/Tashkent
-      * `Asia/Tbilisi` - Asia/Tbilisi
-      * `Asia/Tehran` - Asia/Tehran
-      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-      * `Asia/Thimbu` - Asia/Thimbu
-      * `Asia/Thimphu` - Asia/Thimphu
-      * `Asia/Tokyo` - Asia/Tokyo
-      * `Asia/Tomsk` - Asia/Tomsk
-      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-      * `Asia/Urumqi` - Asia/Urumqi
-      * `Asia/Ust-Nera` - Asia/Ust-Nera
-      * `Asia/Vientiane` - Asia/Vientiane
-      * `Asia/Vladivostok` - Asia/Vladivostok
-      * `Asia/Yakutsk` - Asia/Yakutsk
-      * `Asia/Yangon` - Asia/Yangon
-      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-      * `Asia/Yerevan` - Asia/Yerevan
-      * `Atlantic/Azores` - Atlantic/Azores
-      * `Atlantic/Bermuda` - Atlantic/Bermuda
-      * `Atlantic/Canary` - Atlantic/Canary
-      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-      * `Atlantic/Faeroe` - Atlantic/Faeroe
-      * `Atlantic/Faroe` - Atlantic/Faroe
-      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-      * `Atlantic/Madeira` - Atlantic/Madeira
-      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-      * `Atlantic/St_Helena` - Atlantic/St_Helena
-      * `Atlantic/Stanley` - Atlantic/Stanley
-      * `Australia/ACT` - Australia/ACT
-      * `Australia/Adelaide` - Australia/Adelaide
-      * `Australia/Brisbane` - Australia/Brisbane
-      * `Australia/Broken_Hill` - Australia/Broken_Hill
-      * `Australia/Canberra` - Australia/Canberra
-      * `Australia/Currie` - Australia/Currie
-      * `Australia/Darwin` - Australia/Darwin
-      * `Australia/Eucla` - Australia/Eucla
-      * `Australia/Hobart` - Australia/Hobart
-      * `Australia/LHI` - Australia/LHI
-      * `Australia/Lindeman` - Australia/Lindeman
-      * `Australia/Lord_Howe` - Australia/Lord_Howe
-      * `Australia/Melbourne` - Australia/Melbourne
-      * `Australia/NSW` - Australia/NSW
-      * `Australia/North` - Australia/North
-      * `Australia/Perth` - Australia/Perth
-      * `Australia/Queensland` - Australia/Queensland
-      * `Australia/South` - Australia/South
-      * `Australia/Sydney` - Australia/Sydney
-      * `Australia/Tasmania` - Australia/Tasmania
-      * `Australia/Victoria` - Australia/Victoria
-      * `Australia/West` - Australia/West
-      * `Australia/Yancowinna` - Australia/Yancowinna
-      * `Brazil/Acre` - Brazil/Acre
-      * `Brazil/DeNoronha` - Brazil/DeNoronha
-      * `Brazil/East` - Brazil/East
-      * `Brazil/West` - Brazil/West
-      * `CET` - CET
-      * `CST6CDT` - CST6CDT
-      * `Canada/Atlantic` - Canada/Atlantic
-      * `Canada/Central` - Canada/Central
-      * `Canada/Eastern` - Canada/Eastern
-      * `Canada/Mountain` - Canada/Mountain
-      * `Canada/Newfoundland` - Canada/Newfoundland
-      * `Canada/Pacific` - Canada/Pacific
-      * `Canada/Saskatchewan` - Canada/Saskatchewan
-      * `Canada/Yukon` - Canada/Yukon
-      * `Chile/Continental` - Chile/Continental
-      * `Chile/EasterIsland` - Chile/EasterIsland
-      * `Cuba` - Cuba
-      * `EET` - EET
-      * `EST` - EST
-      * `EST5EDT` - EST5EDT
-      * `Egypt` - Egypt
-      * `Eire` - Eire
-      * `Etc/GMT` - Etc/GMT
-      * `Etc/GMT+0` - Etc/GMT+0
-      * `Etc/GMT+1` - Etc/GMT+1
-      * `Etc/GMT+10` - Etc/GMT+10
-      * `Etc/GMT+11` - Etc/GMT+11
-      * `Etc/GMT+12` - Etc/GMT+12
-      * `Etc/GMT+2` - Etc/GMT+2
-      * `Etc/GMT+3` - Etc/GMT+3
-      * `Etc/GMT+4` - Etc/GMT+4
-      * `Etc/GMT+5` - Etc/GMT+5
-      * `Etc/GMT+6` - Etc/GMT+6
-      * `Etc/GMT+7` - Etc/GMT+7
-      * `Etc/GMT+8` - Etc/GMT+8
-      * `Etc/GMT+9` - Etc/GMT+9
-      * `Etc/GMT-0` - Etc/GMT-0
-      * `Etc/GMT-1` - Etc/GMT-1
-      * `Etc/GMT-10` - Etc/GMT-10
-      * `Etc/GMT-11` - Etc/GMT-11
-      * `Etc/GMT-12` - Etc/GMT-12
-      * `Etc/GMT-13` - Etc/GMT-13
-      * `Etc/GMT-14` - Etc/GMT-14
-      * `Etc/GMT-2` - Etc/GMT-2
-      * `Etc/GMT-3` - Etc/GMT-3
-      * `Etc/GMT-4` - Etc/GMT-4
-      * `Etc/GMT-5` - Etc/GMT-5
-      * `Etc/GMT-6` - Etc/GMT-6
-      * `Etc/GMT-7` - Etc/GMT-7
-      * `Etc/GMT-8` - Etc/GMT-8
-      * `Etc/GMT-9` - Etc/GMT-9
-      * `Etc/GMT0` - Etc/GMT0
-      * `Etc/Greenwich` - Etc/Greenwich
-      * `Etc/UCT` - Etc/UCT
-      * `Etc/UTC` - Etc/UTC
-      * `Etc/Universal` - Etc/Universal
-      * `Etc/Zulu` - Etc/Zulu
-      * `Europe/Amsterdam` - Europe/Amsterdam
-      * `Europe/Andorra` - Europe/Andorra
-      * `Europe/Astrakhan` - Europe/Astrakhan
-      * `Europe/Athens` - Europe/Athens
-      * `Europe/Belfast` - Europe/Belfast
-      * `Europe/Belgrade` - Europe/Belgrade
-      * `Europe/Berlin` - Europe/Berlin
-      * `Europe/Bratislava` - Europe/Bratislava
-      * `Europe/Brussels` - Europe/Brussels
-      * `Europe/Bucharest` - Europe/Bucharest
-      * `Europe/Budapest` - Europe/Budapest
-      * `Europe/Busingen` - Europe/Busingen
-      * `Europe/Chisinau` - Europe/Chisinau
-      * `Europe/Copenhagen` - Europe/Copenhagen
-      * `Europe/Dublin` - Europe/Dublin
-      * `Europe/Gibraltar` - Europe/Gibraltar
-      * `Europe/Guernsey` - Europe/Guernsey
-      * `Europe/Helsinki` - Europe/Helsinki
-      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-      * `Europe/Istanbul` - Europe/Istanbul
-      * `Europe/Jersey` - Europe/Jersey
-      * `Europe/Kaliningrad` - Europe/Kaliningrad
-      * `Europe/Kiev` - Europe/Kiev
-      * `Europe/Kirov` - Europe/Kirov
-      * `Europe/Kyiv` - Europe/Kyiv
-      * `Europe/Lisbon` - Europe/Lisbon
-      * `Europe/Ljubljana` - Europe/Ljubljana
-      * `Europe/London` - Europe/London
-      * `Europe/Luxembourg` - Europe/Luxembourg
-      * `Europe/Madrid` - Europe/Madrid
-      * `Europe/Malta` - Europe/Malta
-      * `Europe/Mariehamn` - Europe/Mariehamn
-      * `Europe/Minsk` - Europe/Minsk
-      * `Europe/Monaco` - Europe/Monaco
-      * `Europe/Moscow` - Europe/Moscow
-      * `Europe/Nicosia` - Europe/Nicosia
-      * `Europe/Oslo` - Europe/Oslo
-      * `Europe/Paris` - Europe/Paris
-      * `Europe/Podgorica` - Europe/Podgorica
-      * `Europe/Prague` - Europe/Prague
-      * `Europe/Riga` - Europe/Riga
-      * `Europe/Rome` - Europe/Rome
-      * `Europe/Samara` - Europe/Samara
-      * `Europe/San_Marino` - Europe/San_Marino
-      * `Europe/Sarajevo` - Europe/Sarajevo
-      * `Europe/Saratov` - Europe/Saratov
-      * `Europe/Simferopol` - Europe/Simferopol
-      * `Europe/Skopje` - Europe/Skopje
-      * `Europe/Sofia` - Europe/Sofia
-      * `Europe/Stockholm` - Europe/Stockholm
-      * `Europe/Tallinn` - Europe/Tallinn
-      * `Europe/Tirane` - Europe/Tirane
-      * `Europe/Tiraspol` - Europe/Tiraspol
-      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-      * `Europe/Uzhgorod` - Europe/Uzhgorod
-      * `Europe/Vaduz` - Europe/Vaduz
-      * `Europe/Vatican` - Europe/Vatican
-      * `Europe/Vienna` - Europe/Vienna
-      * `Europe/Vilnius` - Europe/Vilnius
-      * `Europe/Volgograd` - Europe/Volgograd
-      * `Europe/Warsaw` - Europe/Warsaw
-      * `Europe/Zagreb` - Europe/Zagreb
-      * `Europe/Zaporozhye` - Europe/Zaporozhye
-      * `Europe/Zurich` - Europe/Zurich
-      * `GB` - GB
-      * `GB-Eire` - GB-Eire
-      * `GMT` - GMT
-      * `GMT+0` - GMT+0
-      * `GMT-0` - GMT-0
-      * `GMT0` - GMT0
-      * `Greenwich` - Greenwich
-      * `HST` - HST
-      * `Hongkong` - Hongkong
-      * `Iceland` - Iceland
-      * `Indian/Antananarivo` - Indian/Antananarivo
-      * `Indian/Chagos` - Indian/Chagos
-      * `Indian/Christmas` - Indian/Christmas
-      * `Indian/Cocos` - Indian/Cocos
-      * `Indian/Comoro` - Indian/Comoro
-      * `Indian/Kerguelen` - Indian/Kerguelen
-      * `Indian/Mahe` - Indian/Mahe
-      * `Indian/Maldives` - Indian/Maldives
-      * `Indian/Mauritius` - Indian/Mauritius
-      * `Indian/Mayotte` - Indian/Mayotte
-      * `Indian/Reunion` - Indian/Reunion
-      * `Iran` - Iran
-      * `Israel` - Israel
-      * `Jamaica` - Jamaica
-      * `Japan` - Japan
-      * `Kwajalein` - Kwajalein
-      * `Libya` - Libya
-      * `MET` - MET
-      * `MST` - MST
-      * `MST7MDT` - MST7MDT
-      * `Mexico/BajaNorte` - Mexico/BajaNorte
-      * `Mexico/BajaSur` - Mexico/BajaSur
-      * `Mexico/General` - Mexico/General
-      * `NZ` - NZ
-      * `NZ-CHAT` - NZ-CHAT
-      * `Navajo` - Navajo
-      * `PRC` - PRC
-      * `PST8PDT` - PST8PDT
-      * `Pacific/Apia` - Pacific/Apia
-      * `Pacific/Auckland` - Pacific/Auckland
-      * `Pacific/Bougainville` - Pacific/Bougainville
-      * `Pacific/Chatham` - Pacific/Chatham
-      * `Pacific/Chuuk` - Pacific/Chuuk
-      * `Pacific/Easter` - Pacific/Easter
-      * `Pacific/Efate` - Pacific/Efate
-      * `Pacific/Enderbury` - Pacific/Enderbury
-      * `Pacific/Fakaofo` - Pacific/Fakaofo
-      * `Pacific/Fiji` - Pacific/Fiji
-      * `Pacific/Funafuti` - Pacific/Funafuti
-      * `Pacific/Galapagos` - Pacific/Galapagos
-      * `Pacific/Gambier` - Pacific/Gambier
-      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-      * `Pacific/Guam` - Pacific/Guam
-      * `Pacific/Honolulu` - Pacific/Honolulu
-      * `Pacific/Johnston` - Pacific/Johnston
-      * `Pacific/Kanton` - Pacific/Kanton
-      * `Pacific/Kiritimati` - Pacific/Kiritimati
-      * `Pacific/Kosrae` - Pacific/Kosrae
-      * `Pacific/Kwajalein` - Pacific/Kwajalein
-      * `Pacific/Majuro` - Pacific/Majuro
-      * `Pacific/Marquesas` - Pacific/Marquesas
-      * `Pacific/Midway` - Pacific/Midway
-      * `Pacific/Nauru` - Pacific/Nauru
-      * `Pacific/Niue` - Pacific/Niue
-      * `Pacific/Norfolk` - Pacific/Norfolk
-      * `Pacific/Noumea` - Pacific/Noumea
-      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-      * `Pacific/Palau` - Pacific/Palau
-      * `Pacific/Pitcairn` - Pacific/Pitcairn
-      * `Pacific/Pohnpei` - Pacific/Pohnpei
-      * `Pacific/Ponape` - Pacific/Ponape
-      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-      * `Pacific/Rarotonga` - Pacific/Rarotonga
-      * `Pacific/Saipan` - Pacific/Saipan
-      * `Pacific/Samoa` - Pacific/Samoa
-      * `Pacific/Tahiti` - Pacific/Tahiti
-      * `Pacific/Tarawa` - Pacific/Tarawa
-      * `Pacific/Tongatapu` - Pacific/Tongatapu
-      * `Pacific/Truk` - Pacific/Truk
-      * `Pacific/Wake` - Pacific/Wake
-      * `Pacific/Wallis` - Pacific/Wallis
-      * `Pacific/Yap` - Pacific/Yap
-      * `Poland` - Poland
-      * `Portugal` - Portugal
-      * `ROC` - ROC
-      * `ROK` - ROK
-      * `Singapore` - Singapore
-      * `Turkey` - Turkey
-      * `UCT` - UCT
-      * `US/Alaska` - US/Alaska
-      * `US/Aleutian` - US/Aleutian
-      * `US/Arizona` - US/Arizona
-      * `US/Central` - US/Central
-      * `US/East-Indiana` - US/East-Indiana
-      * `US/Eastern` - US/Eastern
-      * `US/Hawaii` - US/Hawaii
-      * `US/Indiana-Starke` - US/Indiana-Starke
-      * `US/Michigan` - US/Michigan
-      * `US/Mountain` - US/Mountain
-      * `US/Pacific` - US/Pacific
-      * `US/Samoa` - US/Samoa
-      * `UTC` - UTC
-      * `Universal` - Universal
-      * `W-SU` - W-SU
-      * `WET` - WET
-      * `Zulu` - Zulu */
+       *
+       * * `Africa/Abidjan` - Africa/Abidjan
+       * * `Africa/Accra` - Africa/Accra
+       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+       * * `Africa/Algiers` - Africa/Algiers
+       * * `Africa/Asmara` - Africa/Asmara
+       * * `Africa/Asmera` - Africa/Asmera
+       * * `Africa/Bamako` - Africa/Bamako
+       * * `Africa/Bangui` - Africa/Bangui
+       * * `Africa/Banjul` - Africa/Banjul
+       * * `Africa/Bissau` - Africa/Bissau
+       * * `Africa/Blantyre` - Africa/Blantyre
+       * * `Africa/Brazzaville` - Africa/Brazzaville
+       * * `Africa/Bujumbura` - Africa/Bujumbura
+       * * `Africa/Cairo` - Africa/Cairo
+       * * `Africa/Casablanca` - Africa/Casablanca
+       * * `Africa/Ceuta` - Africa/Ceuta
+       * * `Africa/Conakry` - Africa/Conakry
+       * * `Africa/Dakar` - Africa/Dakar
+       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+       * * `Africa/Djibouti` - Africa/Djibouti
+       * * `Africa/Douala` - Africa/Douala
+       * * `Africa/El_Aaiun` - Africa/El_Aaiun
+       * * `Africa/Freetown` - Africa/Freetown
+       * * `Africa/Gaborone` - Africa/Gaborone
+       * * `Africa/Harare` - Africa/Harare
+       * * `Africa/Johannesburg` - Africa/Johannesburg
+       * * `Africa/Juba` - Africa/Juba
+       * * `Africa/Kampala` - Africa/Kampala
+       * * `Africa/Khartoum` - Africa/Khartoum
+       * * `Africa/Kigali` - Africa/Kigali
+       * * `Africa/Kinshasa` - Africa/Kinshasa
+       * * `Africa/Lagos` - Africa/Lagos
+       * * `Africa/Libreville` - Africa/Libreville
+       * * `Africa/Lome` - Africa/Lome
+       * * `Africa/Luanda` - Africa/Luanda
+       * * `Africa/Lubumbashi` - Africa/Lubumbashi
+       * * `Africa/Lusaka` - Africa/Lusaka
+       * * `Africa/Malabo` - Africa/Malabo
+       * * `Africa/Maputo` - Africa/Maputo
+       * * `Africa/Maseru` - Africa/Maseru
+       * * `Africa/Mbabane` - Africa/Mbabane
+       * * `Africa/Mogadishu` - Africa/Mogadishu
+       * * `Africa/Monrovia` - Africa/Monrovia
+       * * `Africa/Nairobi` - Africa/Nairobi
+       * * `Africa/Ndjamena` - Africa/Ndjamena
+       * * `Africa/Niamey` - Africa/Niamey
+       * * `Africa/Nouakchott` - Africa/Nouakchott
+       * * `Africa/Ouagadougou` - Africa/Ouagadougou
+       * * `Africa/Porto-Novo` - Africa/Porto-Novo
+       * * `Africa/Sao_Tome` - Africa/Sao_Tome
+       * * `Africa/Timbuktu` - Africa/Timbuktu
+       * * `Africa/Tripoli` - Africa/Tripoli
+       * * `Africa/Tunis` - Africa/Tunis
+       * * `Africa/Windhoek` - Africa/Windhoek
+       * * `America/Adak` - America/Adak
+       * * `America/Anchorage` - America/Anchorage
+       * * `America/Anguilla` - America/Anguilla
+       * * `America/Antigua` - America/Antigua
+       * * `America/Araguaina` - America/Araguaina
+       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+       * * `America/Argentina/Salta` - America/Argentina/Salta
+       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+       * * `America/Aruba` - America/Aruba
+       * * `America/Asuncion` - America/Asuncion
+       * * `America/Atikokan` - America/Atikokan
+       * * `America/Atka` - America/Atka
+       * * `America/Bahia` - America/Bahia
+       * * `America/Bahia_Banderas` - America/Bahia_Banderas
+       * * `America/Barbados` - America/Barbados
+       * * `America/Belem` - America/Belem
+       * * `America/Belize` - America/Belize
+       * * `America/Blanc-Sablon` - America/Blanc-Sablon
+       * * `America/Boa_Vista` - America/Boa_Vista
+       * * `America/Bogota` - America/Bogota
+       * * `America/Boise` - America/Boise
+       * * `America/Buenos_Aires` - America/Buenos_Aires
+       * * `America/Cambridge_Bay` - America/Cambridge_Bay
+       * * `America/Campo_Grande` - America/Campo_Grande
+       * * `America/Cancun` - America/Cancun
+       * * `America/Caracas` - America/Caracas
+       * * `America/Catamarca` - America/Catamarca
+       * * `America/Cayenne` - America/Cayenne
+       * * `America/Cayman` - America/Cayman
+       * * `America/Chicago` - America/Chicago
+       * * `America/Chihuahua` - America/Chihuahua
+       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+       * * `America/Coral_Harbour` - America/Coral_Harbour
+       * * `America/Cordoba` - America/Cordoba
+       * * `America/Costa_Rica` - America/Costa_Rica
+       * * `America/Creston` - America/Creston
+       * * `America/Cuiaba` - America/Cuiaba
+       * * `America/Curacao` - America/Curacao
+       * * `America/Danmarkshavn` - America/Danmarkshavn
+       * * `America/Dawson` - America/Dawson
+       * * `America/Dawson_Creek` - America/Dawson_Creek
+       * * `America/Denver` - America/Denver
+       * * `America/Detroit` - America/Detroit
+       * * `America/Dominica` - America/Dominica
+       * * `America/Edmonton` - America/Edmonton
+       * * `America/Eirunepe` - America/Eirunepe
+       * * `America/El_Salvador` - America/El_Salvador
+       * * `America/Ensenada` - America/Ensenada
+       * * `America/Fort_Nelson` - America/Fort_Nelson
+       * * `America/Fort_Wayne` - America/Fort_Wayne
+       * * `America/Fortaleza` - America/Fortaleza
+       * * `America/Glace_Bay` - America/Glace_Bay
+       * * `America/Godthab` - America/Godthab
+       * * `America/Goose_Bay` - America/Goose_Bay
+       * * `America/Grand_Turk` - America/Grand_Turk
+       * * `America/Grenada` - America/Grenada
+       * * `America/Guadeloupe` - America/Guadeloupe
+       * * `America/Guatemala` - America/Guatemala
+       * * `America/Guayaquil` - America/Guayaquil
+       * * `America/Guyana` - America/Guyana
+       * * `America/Halifax` - America/Halifax
+       * * `America/Havana` - America/Havana
+       * * `America/Hermosillo` - America/Hermosillo
+       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+       * * `America/Indiana/Knox` - America/Indiana/Knox
+       * * `America/Indiana/Marengo` - America/Indiana/Marengo
+       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+       * * `America/Indiana/Vevay` - America/Indiana/Vevay
+       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+       * * `America/Indiana/Winamac` - America/Indiana/Winamac
+       * * `America/Indianapolis` - America/Indianapolis
+       * * `America/Inuvik` - America/Inuvik
+       * * `America/Iqaluit` - America/Iqaluit
+       * * `America/Jamaica` - America/Jamaica
+       * * `America/Jujuy` - America/Jujuy
+       * * `America/Juneau` - America/Juneau
+       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+       * * `America/Knox_IN` - America/Knox_IN
+       * * `America/Kralendijk` - America/Kralendijk
+       * * `America/La_Paz` - America/La_Paz
+       * * `America/Lima` - America/Lima
+       * * `America/Los_Angeles` - America/Los_Angeles
+       * * `America/Louisville` - America/Louisville
+       * * `America/Lower_Princes` - America/Lower_Princes
+       * * `America/Maceio` - America/Maceio
+       * * `America/Managua` - America/Managua
+       * * `America/Manaus` - America/Manaus
+       * * `America/Marigot` - America/Marigot
+       * * `America/Martinique` - America/Martinique
+       * * `America/Matamoros` - America/Matamoros
+       * * `America/Mazatlan` - America/Mazatlan
+       * * `America/Mendoza` - America/Mendoza
+       * * `America/Menominee` - America/Menominee
+       * * `America/Merida` - America/Merida
+       * * `America/Metlakatla` - America/Metlakatla
+       * * `America/Mexico_City` - America/Mexico_City
+       * * `America/Miquelon` - America/Miquelon
+       * * `America/Moncton` - America/Moncton
+       * * `America/Monterrey` - America/Monterrey
+       * * `America/Montevideo` - America/Montevideo
+       * * `America/Montreal` - America/Montreal
+       * * `America/Montserrat` - America/Montserrat
+       * * `America/Nassau` - America/Nassau
+       * * `America/New_York` - America/New_York
+       * * `America/Nipigon` - America/Nipigon
+       * * `America/Nome` - America/Nome
+       * * `America/Noronha` - America/Noronha
+       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+       * * `America/North_Dakota/Center` - America/North_Dakota/Center
+       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+       * * `America/Nuuk` - America/Nuuk
+       * * `America/Ojinaga` - America/Ojinaga
+       * * `America/Panama` - America/Panama
+       * * `America/Pangnirtung` - America/Pangnirtung
+       * * `America/Paramaribo` - America/Paramaribo
+       * * `America/Phoenix` - America/Phoenix
+       * * `America/Port-au-Prince` - America/Port-au-Prince
+       * * `America/Port_of_Spain` - America/Port_of_Spain
+       * * `America/Porto_Acre` - America/Porto_Acre
+       * * `America/Porto_Velho` - America/Porto_Velho
+       * * `America/Puerto_Rico` - America/Puerto_Rico
+       * * `America/Punta_Arenas` - America/Punta_Arenas
+       * * `America/Rainy_River` - America/Rainy_River
+       * * `America/Rankin_Inlet` - America/Rankin_Inlet
+       * * `America/Recife` - America/Recife
+       * * `America/Regina` - America/Regina
+       * * `America/Resolute` - America/Resolute
+       * * `America/Rio_Branco` - America/Rio_Branco
+       * * `America/Rosario` - America/Rosario
+       * * `America/Santa_Isabel` - America/Santa_Isabel
+       * * `America/Santarem` - America/Santarem
+       * * `America/Santiago` - America/Santiago
+       * * `America/Santo_Domingo` - America/Santo_Domingo
+       * * `America/Sao_Paulo` - America/Sao_Paulo
+       * * `America/Scoresbysund` - America/Scoresbysund
+       * * `America/Shiprock` - America/Shiprock
+       * * `America/Sitka` - America/Sitka
+       * * `America/St_Barthelemy` - America/St_Barthelemy
+       * * `America/St_Johns` - America/St_Johns
+       * * `America/St_Kitts` - America/St_Kitts
+       * * `America/St_Lucia` - America/St_Lucia
+       * * `America/St_Thomas` - America/St_Thomas
+       * * `America/St_Vincent` - America/St_Vincent
+       * * `America/Swift_Current` - America/Swift_Current
+       * * `America/Tegucigalpa` - America/Tegucigalpa
+       * * `America/Thule` - America/Thule
+       * * `America/Thunder_Bay` - America/Thunder_Bay
+       * * `America/Tijuana` - America/Tijuana
+       * * `America/Toronto` - America/Toronto
+       * * `America/Tortola` - America/Tortola
+       * * `America/Vancouver` - America/Vancouver
+       * * `America/Virgin` - America/Virgin
+       * * `America/Whitehorse` - America/Whitehorse
+       * * `America/Winnipeg` - America/Winnipeg
+       * * `America/Yakutat` - America/Yakutat
+       * * `America/Yellowknife` - America/Yellowknife
+       * * `Antarctica/Casey` - Antarctica/Casey
+       * * `Antarctica/Davis` - Antarctica/Davis
+       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+       * * `Antarctica/Macquarie` - Antarctica/Macquarie
+       * * `Antarctica/Mawson` - Antarctica/Mawson
+       * * `Antarctica/McMurdo` - Antarctica/McMurdo
+       * * `Antarctica/Palmer` - Antarctica/Palmer
+       * * `Antarctica/Rothera` - Antarctica/Rothera
+       * * `Antarctica/South_Pole` - Antarctica/South_Pole
+       * * `Antarctica/Syowa` - Antarctica/Syowa
+       * * `Antarctica/Troll` - Antarctica/Troll
+       * * `Antarctica/Vostok` - Antarctica/Vostok
+       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+       * * `Asia/Aden` - Asia/Aden
+       * * `Asia/Almaty` - Asia/Almaty
+       * * `Asia/Amman` - Asia/Amman
+       * * `Asia/Anadyr` - Asia/Anadyr
+       * * `Asia/Aqtau` - Asia/Aqtau
+       * * `Asia/Aqtobe` - Asia/Aqtobe
+       * * `Asia/Ashgabat` - Asia/Ashgabat
+       * * `Asia/Ashkhabad` - Asia/Ashkhabad
+       * * `Asia/Atyrau` - Asia/Atyrau
+       * * `Asia/Baghdad` - Asia/Baghdad
+       * * `Asia/Bahrain` - Asia/Bahrain
+       * * `Asia/Baku` - Asia/Baku
+       * * `Asia/Bangkok` - Asia/Bangkok
+       * * `Asia/Barnaul` - Asia/Barnaul
+       * * `Asia/Beirut` - Asia/Beirut
+       * * `Asia/Bishkek` - Asia/Bishkek
+       * * `Asia/Brunei` - Asia/Brunei
+       * * `Asia/Calcutta` - Asia/Calcutta
+       * * `Asia/Chita` - Asia/Chita
+       * * `Asia/Choibalsan` - Asia/Choibalsan
+       * * `Asia/Chongqing` - Asia/Chongqing
+       * * `Asia/Chungking` - Asia/Chungking
+       * * `Asia/Colombo` - Asia/Colombo
+       * * `Asia/Dacca` - Asia/Dacca
+       * * `Asia/Damascus` - Asia/Damascus
+       * * `Asia/Dhaka` - Asia/Dhaka
+       * * `Asia/Dili` - Asia/Dili
+       * * `Asia/Dubai` - Asia/Dubai
+       * * `Asia/Dushanbe` - Asia/Dushanbe
+       * * `Asia/Famagusta` - Asia/Famagusta
+       * * `Asia/Gaza` - Asia/Gaza
+       * * `Asia/Harbin` - Asia/Harbin
+       * * `Asia/Hebron` - Asia/Hebron
+       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+       * * `Asia/Hong_Kong` - Asia/Hong_Kong
+       * * `Asia/Hovd` - Asia/Hovd
+       * * `Asia/Irkutsk` - Asia/Irkutsk
+       * * `Asia/Istanbul` - Asia/Istanbul
+       * * `Asia/Jakarta` - Asia/Jakarta
+       * * `Asia/Jayapura` - Asia/Jayapura
+       * * `Asia/Jerusalem` - Asia/Jerusalem
+       * * `Asia/Kabul` - Asia/Kabul
+       * * `Asia/Kamchatka` - Asia/Kamchatka
+       * * `Asia/Karachi` - Asia/Karachi
+       * * `Asia/Kashgar` - Asia/Kashgar
+       * * `Asia/Kathmandu` - Asia/Kathmandu
+       * * `Asia/Katmandu` - Asia/Katmandu
+       * * `Asia/Khandyga` - Asia/Khandyga
+       * * `Asia/Kolkata` - Asia/Kolkata
+       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+       * * `Asia/Kuching` - Asia/Kuching
+       * * `Asia/Kuwait` - Asia/Kuwait
+       * * `Asia/Macao` - Asia/Macao
+       * * `Asia/Macau` - Asia/Macau
+       * * `Asia/Magadan` - Asia/Magadan
+       * * `Asia/Makassar` - Asia/Makassar
+       * * `Asia/Manila` - Asia/Manila
+       * * `Asia/Muscat` - Asia/Muscat
+       * * `Asia/Nicosia` - Asia/Nicosia
+       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+       * * `Asia/Novosibirsk` - Asia/Novosibirsk
+       * * `Asia/Omsk` - Asia/Omsk
+       * * `Asia/Oral` - Asia/Oral
+       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+       * * `Asia/Pontianak` - Asia/Pontianak
+       * * `Asia/Pyongyang` - Asia/Pyongyang
+       * * `Asia/Qatar` - Asia/Qatar
+       * * `Asia/Qostanay` - Asia/Qostanay
+       * * `Asia/Qyzylorda` - Asia/Qyzylorda
+       * * `Asia/Rangoon` - Asia/Rangoon
+       * * `Asia/Riyadh` - Asia/Riyadh
+       * * `Asia/Saigon` - Asia/Saigon
+       * * `Asia/Sakhalin` - Asia/Sakhalin
+       * * `Asia/Samarkand` - Asia/Samarkand
+       * * `Asia/Seoul` - Asia/Seoul
+       * * `Asia/Shanghai` - Asia/Shanghai
+       * * `Asia/Singapore` - Asia/Singapore
+       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+       * * `Asia/Taipei` - Asia/Taipei
+       * * `Asia/Tashkent` - Asia/Tashkent
+       * * `Asia/Tbilisi` - Asia/Tbilisi
+       * * `Asia/Tehran` - Asia/Tehran
+       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+       * * `Asia/Thimbu` - Asia/Thimbu
+       * * `Asia/Thimphu` - Asia/Thimphu
+       * * `Asia/Tokyo` - Asia/Tokyo
+       * * `Asia/Tomsk` - Asia/Tomsk
+       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+       * * `Asia/Urumqi` - Asia/Urumqi
+       * * `Asia/Ust-Nera` - Asia/Ust-Nera
+       * * `Asia/Vientiane` - Asia/Vientiane
+       * * `Asia/Vladivostok` - Asia/Vladivostok
+       * * `Asia/Yakutsk` - Asia/Yakutsk
+       * * `Asia/Yangon` - Asia/Yangon
+       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+       * * `Asia/Yerevan` - Asia/Yerevan
+       * * `Atlantic/Azores` - Atlantic/Azores
+       * * `Atlantic/Bermuda` - Atlantic/Bermuda
+       * * `Atlantic/Canary` - Atlantic/Canary
+       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+       * * `Atlantic/Faeroe` - Atlantic/Faeroe
+       * * `Atlantic/Faroe` - Atlantic/Faroe
+       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+       * * `Atlantic/Madeira` - Atlantic/Madeira
+       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+       * * `Atlantic/St_Helena` - Atlantic/St_Helena
+       * * `Atlantic/Stanley` - Atlantic/Stanley
+       * * `Australia/ACT` - Australia/ACT
+       * * `Australia/Adelaide` - Australia/Adelaide
+       * * `Australia/Brisbane` - Australia/Brisbane
+       * * `Australia/Broken_Hill` - Australia/Broken_Hill
+       * * `Australia/Canberra` - Australia/Canberra
+       * * `Australia/Currie` - Australia/Currie
+       * * `Australia/Darwin` - Australia/Darwin
+       * * `Australia/Eucla` - Australia/Eucla
+       * * `Australia/Hobart` - Australia/Hobart
+       * * `Australia/LHI` - Australia/LHI
+       * * `Australia/Lindeman` - Australia/Lindeman
+       * * `Australia/Lord_Howe` - Australia/Lord_Howe
+       * * `Australia/Melbourne` - Australia/Melbourne
+       * * `Australia/NSW` - Australia/NSW
+       * * `Australia/North` - Australia/North
+       * * `Australia/Perth` - Australia/Perth
+       * * `Australia/Queensland` - Australia/Queensland
+       * * `Australia/South` - Australia/South
+       * * `Australia/Sydney` - Australia/Sydney
+       * * `Australia/Tasmania` - Australia/Tasmania
+       * * `Australia/Victoria` - Australia/Victoria
+       * * `Australia/West` - Australia/West
+       * * `Australia/Yancowinna` - Australia/Yancowinna
+       * * `Brazil/Acre` - Brazil/Acre
+       * * `Brazil/DeNoronha` - Brazil/DeNoronha
+       * * `Brazil/East` - Brazil/East
+       * * `Brazil/West` - Brazil/West
+       * * `CET` - CET
+       * * `CST6CDT` - CST6CDT
+       * * `Canada/Atlantic` - Canada/Atlantic
+       * * `Canada/Central` - Canada/Central
+       * * `Canada/Eastern` - Canada/Eastern
+       * * `Canada/Mountain` - Canada/Mountain
+       * * `Canada/Newfoundland` - Canada/Newfoundland
+       * * `Canada/Pacific` - Canada/Pacific
+       * * `Canada/Saskatchewan` - Canada/Saskatchewan
+       * * `Canada/Yukon` - Canada/Yukon
+       * * `Chile/Continental` - Chile/Continental
+       * * `Chile/EasterIsland` - Chile/EasterIsland
+       * * `Cuba` - Cuba
+       * * `EET` - EET
+       * * `EST` - EST
+       * * `EST5EDT` - EST5EDT
+       * * `Egypt` - Egypt
+       * * `Eire` - Eire
+       * * `Etc/GMT` - Etc/GMT
+       * * `Etc/GMT+0` - Etc/GMT+0
+       * * `Etc/GMT+1` - Etc/GMT+1
+       * * `Etc/GMT+10` - Etc/GMT+10
+       * * `Etc/GMT+11` - Etc/GMT+11
+       * * `Etc/GMT+12` - Etc/GMT+12
+       * * `Etc/GMT+2` - Etc/GMT+2
+       * * `Etc/GMT+3` - Etc/GMT+3
+       * * `Etc/GMT+4` - Etc/GMT+4
+       * * `Etc/GMT+5` - Etc/GMT+5
+       * * `Etc/GMT+6` - Etc/GMT+6
+       * * `Etc/GMT+7` - Etc/GMT+7
+       * * `Etc/GMT+8` - Etc/GMT+8
+       * * `Etc/GMT+9` - Etc/GMT+9
+       * * `Etc/GMT-0` - Etc/GMT-0
+       * * `Etc/GMT-1` - Etc/GMT-1
+       * * `Etc/GMT-10` - Etc/GMT-10
+       * * `Etc/GMT-11` - Etc/GMT-11
+       * * `Etc/GMT-12` - Etc/GMT-12
+       * * `Etc/GMT-13` - Etc/GMT-13
+       * * `Etc/GMT-14` - Etc/GMT-14
+       * * `Etc/GMT-2` - Etc/GMT-2
+       * * `Etc/GMT-3` - Etc/GMT-3
+       * * `Etc/GMT-4` - Etc/GMT-4
+       * * `Etc/GMT-5` - Etc/GMT-5
+       * * `Etc/GMT-6` - Etc/GMT-6
+       * * `Etc/GMT-7` - Etc/GMT-7
+       * * `Etc/GMT-8` - Etc/GMT-8
+       * * `Etc/GMT-9` - Etc/GMT-9
+       * * `Etc/GMT0` - Etc/GMT0
+       * * `Etc/Greenwich` - Etc/Greenwich
+       * * `Etc/UCT` - Etc/UCT
+       * * `Etc/UTC` - Etc/UTC
+       * * `Etc/Universal` - Etc/Universal
+       * * `Etc/Zulu` - Etc/Zulu
+       * * `Europe/Amsterdam` - Europe/Amsterdam
+       * * `Europe/Andorra` - Europe/Andorra
+       * * `Europe/Astrakhan` - Europe/Astrakhan
+       * * `Europe/Athens` - Europe/Athens
+       * * `Europe/Belfast` - Europe/Belfast
+       * * `Europe/Belgrade` - Europe/Belgrade
+       * * `Europe/Berlin` - Europe/Berlin
+       * * `Europe/Bratislava` - Europe/Bratislava
+       * * `Europe/Brussels` - Europe/Brussels
+       * * `Europe/Bucharest` - Europe/Bucharest
+       * * `Europe/Budapest` - Europe/Budapest
+       * * `Europe/Busingen` - Europe/Busingen
+       * * `Europe/Chisinau` - Europe/Chisinau
+       * * `Europe/Copenhagen` - Europe/Copenhagen
+       * * `Europe/Dublin` - Europe/Dublin
+       * * `Europe/Gibraltar` - Europe/Gibraltar
+       * * `Europe/Guernsey` - Europe/Guernsey
+       * * `Europe/Helsinki` - Europe/Helsinki
+       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+       * * `Europe/Istanbul` - Europe/Istanbul
+       * * `Europe/Jersey` - Europe/Jersey
+       * * `Europe/Kaliningrad` - Europe/Kaliningrad
+       * * `Europe/Kiev` - Europe/Kiev
+       * * `Europe/Kirov` - Europe/Kirov
+       * * `Europe/Kyiv` - Europe/Kyiv
+       * * `Europe/Lisbon` - Europe/Lisbon
+       * * `Europe/Ljubljana` - Europe/Ljubljana
+       * * `Europe/London` - Europe/London
+       * * `Europe/Luxembourg` - Europe/Luxembourg
+       * * `Europe/Madrid` - Europe/Madrid
+       * * `Europe/Malta` - Europe/Malta
+       * * `Europe/Mariehamn` - Europe/Mariehamn
+       * * `Europe/Minsk` - Europe/Minsk
+       * * `Europe/Monaco` - Europe/Monaco
+       * * `Europe/Moscow` - Europe/Moscow
+       * * `Europe/Nicosia` - Europe/Nicosia
+       * * `Europe/Oslo` - Europe/Oslo
+       * * `Europe/Paris` - Europe/Paris
+       * * `Europe/Podgorica` - Europe/Podgorica
+       * * `Europe/Prague` - Europe/Prague
+       * * `Europe/Riga` - Europe/Riga
+       * * `Europe/Rome` - Europe/Rome
+       * * `Europe/Samara` - Europe/Samara
+       * * `Europe/San_Marino` - Europe/San_Marino
+       * * `Europe/Sarajevo` - Europe/Sarajevo
+       * * `Europe/Saratov` - Europe/Saratov
+       * * `Europe/Simferopol` - Europe/Simferopol
+       * * `Europe/Skopje` - Europe/Skopje
+       * * `Europe/Sofia` - Europe/Sofia
+       * * `Europe/Stockholm` - Europe/Stockholm
+       * * `Europe/Tallinn` - Europe/Tallinn
+       * * `Europe/Tirane` - Europe/Tirane
+       * * `Europe/Tiraspol` - Europe/Tiraspol
+       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+       * * `Europe/Uzhgorod` - Europe/Uzhgorod
+       * * `Europe/Vaduz` - Europe/Vaduz
+       * * `Europe/Vatican` - Europe/Vatican
+       * * `Europe/Vienna` - Europe/Vienna
+       * * `Europe/Vilnius` - Europe/Vilnius
+       * * `Europe/Volgograd` - Europe/Volgograd
+       * * `Europe/Warsaw` - Europe/Warsaw
+       * * `Europe/Zagreb` - Europe/Zagreb
+       * * `Europe/Zaporozhye` - Europe/Zaporozhye
+       * * `Europe/Zurich` - Europe/Zurich
+       * * `GB` - GB
+       * * `GB-Eire` - GB-Eire
+       * * `GMT` - GMT
+       * * `GMT+0` - GMT+0
+       * * `GMT-0` - GMT-0
+       * * `GMT0` - GMT0
+       * * `Greenwich` - Greenwich
+       * * `HST` - HST
+       * * `Hongkong` - Hongkong
+       * * `Iceland` - Iceland
+       * * `Indian/Antananarivo` - Indian/Antananarivo
+       * * `Indian/Chagos` - Indian/Chagos
+       * * `Indian/Christmas` - Indian/Christmas
+       * * `Indian/Cocos` - Indian/Cocos
+       * * `Indian/Comoro` - Indian/Comoro
+       * * `Indian/Kerguelen` - Indian/Kerguelen
+       * * `Indian/Mahe` - Indian/Mahe
+       * * `Indian/Maldives` - Indian/Maldives
+       * * `Indian/Mauritius` - Indian/Mauritius
+       * * `Indian/Mayotte` - Indian/Mayotte
+       * * `Indian/Reunion` - Indian/Reunion
+       * * `Iran` - Iran
+       * * `Israel` - Israel
+       * * `Jamaica` - Jamaica
+       * * `Japan` - Japan
+       * * `Kwajalein` - Kwajalein
+       * * `Libya` - Libya
+       * * `MET` - MET
+       * * `MST` - MST
+       * * `MST7MDT` - MST7MDT
+       * * `Mexico/BajaNorte` - Mexico/BajaNorte
+       * * `Mexico/BajaSur` - Mexico/BajaSur
+       * * `Mexico/General` - Mexico/General
+       * * `NZ` - NZ
+       * * `NZ-CHAT` - NZ-CHAT
+       * * `Navajo` - Navajo
+       * * `PRC` - PRC
+       * * `PST8PDT` - PST8PDT
+       * * `Pacific/Apia` - Pacific/Apia
+       * * `Pacific/Auckland` - Pacific/Auckland
+       * * `Pacific/Bougainville` - Pacific/Bougainville
+       * * `Pacific/Chatham` - Pacific/Chatham
+       * * `Pacific/Chuuk` - Pacific/Chuuk
+       * * `Pacific/Easter` - Pacific/Easter
+       * * `Pacific/Efate` - Pacific/Efate
+       * * `Pacific/Enderbury` - Pacific/Enderbury
+       * * `Pacific/Fakaofo` - Pacific/Fakaofo
+       * * `Pacific/Fiji` - Pacific/Fiji
+       * * `Pacific/Funafuti` - Pacific/Funafuti
+       * * `Pacific/Galapagos` - Pacific/Galapagos
+       * * `Pacific/Gambier` - Pacific/Gambier
+       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+       * * `Pacific/Guam` - Pacific/Guam
+       * * `Pacific/Honolulu` - Pacific/Honolulu
+       * * `Pacific/Johnston` - Pacific/Johnston
+       * * `Pacific/Kanton` - Pacific/Kanton
+       * * `Pacific/Kiritimati` - Pacific/Kiritimati
+       * * `Pacific/Kosrae` - Pacific/Kosrae
+       * * `Pacific/Kwajalein` - Pacific/Kwajalein
+       * * `Pacific/Majuro` - Pacific/Majuro
+       * * `Pacific/Marquesas` - Pacific/Marquesas
+       * * `Pacific/Midway` - Pacific/Midway
+       * * `Pacific/Nauru` - Pacific/Nauru
+       * * `Pacific/Niue` - Pacific/Niue
+       * * `Pacific/Norfolk` - Pacific/Norfolk
+       * * `Pacific/Noumea` - Pacific/Noumea
+       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+       * * `Pacific/Palau` - Pacific/Palau
+       * * `Pacific/Pitcairn` - Pacific/Pitcairn
+       * * `Pacific/Pohnpei` - Pacific/Pohnpei
+       * * `Pacific/Ponape` - Pacific/Ponape
+       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+       * * `Pacific/Rarotonga` - Pacific/Rarotonga
+       * * `Pacific/Saipan` - Pacific/Saipan
+       * * `Pacific/Samoa` - Pacific/Samoa
+       * * `Pacific/Tahiti` - Pacific/Tahiti
+       * * `Pacific/Tarawa` - Pacific/Tarawa
+       * * `Pacific/Tongatapu` - Pacific/Tongatapu
+       * * `Pacific/Truk` - Pacific/Truk
+       * * `Pacific/Wake` - Pacific/Wake
+       * * `Pacific/Wallis` - Pacific/Wallis
+       * * `Pacific/Yap` - Pacific/Yap
+       * * `Poland` - Poland
+       * * `Portugal` - Portugal
+       * * `ROC` - ROC
+       * * `ROK` - ROK
+       * * `Singapore` - Singapore
+       * * `Turkey` - Turkey
+       * * `UCT` - UCT
+       * * `US/Alaska` - US/Alaska
+       * * `US/Aleutian` - US/Aleutian
+       * * `US/Arizona` - US/Arizona
+       * * `US/Central` - US/Central
+       * * `US/East-Indiana` - US/East-Indiana
+       * * `US/Eastern` - US/Eastern
+       * * `US/Hawaii` - US/Hawaii
+       * * `US/Indiana-Starke` - US/Indiana-Starke
+       * * `US/Michigan` - US/Michigan
+       * * `US/Mountain` - US/Mountain
+       * * `US/Pacific` - US/Pacific
+       * * `US/Samoa` - US/Samoa
+       * * `UTC` - UTC
+       * * `Universal` - Universal
+       * * `W-SU` - W-SU
+       * * `WET` - WET
+       * * `Zulu` - Zulu */
       timezone?: string | null;
       /**
          * Day-of-week offset for weekly intervals (0=Sunday, 6=Saturday). Only valid when interval is 'week'.
@@ -9662,14 +9662,14 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `ContinuedAsNew` - Continued As New
-    * `Failed` - Failed
-    * `FailedRetryable` - Failed Retryable
-    * `Terminated` - Terminated
-    * `TimedOut` - Timedout
-    * `Running` - Running
-    * `Starting` - Starting
+     * * `Completed` - Completed
+     * * `ContinuedAsNew` - Continued As New
+     * * `Failed` - Failed
+     * * `FailedRetryable` - Failed Retryable
+     * * `Terminated` - Terminated
+     * * `TimedOut` - Timedout
+     * * `Running` - Running
+     * * `Starting` - Starting
      */
     export type BatchExportBackfillStatusEnum = typeof BatchExportBackfillStatusEnum[keyof typeof BatchExportBackfillStatusEnum];
 
@@ -9701,16 +9701,16 @@ export namespace Schemas {
          */
       end_at?: string | null;
       /** The status of this backfill.
-
-      * `Cancelled` - Cancelled
-      * `Completed` - Completed
-      * `ContinuedAsNew` - Continued As New
-      * `Failed` - Failed
-      * `FailedRetryable` - Failed Retryable
-      * `Terminated` - Terminated
-      * `TimedOut` - Timedout
-      * `Running` - Running
-      * `Starting` - Starting */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Completed` - Completed
+       * * `ContinuedAsNew` - Continued As New
+       * * `Failed` - Failed
+       * * `FailedRetryable` - Failed Retryable
+       * * `Terminated` - Terminated
+       * * `TimedOut` - Timedout
+       * * `Running` - Running
+       * * `Starting` - Starting */
       status: BatchExportBackfillStatusEnum;
       /** The timestamp at which this BatchExportBackfill was created. */
       readonly created_at: string;
@@ -9777,29 +9777,29 @@ export namespace Schemas {
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
-
-    Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-    `destination` schema so integration_id is marked required on the types that need
-    it. Responses continue to use `BatchExportSerializer`.
+     *
+     * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+     * `destination` schema so integration_id is marked required on the types that need
+     * it. Responses continue to use `BatchExportSerializer`.
      */
     export interface BatchExportRequest {
       /** Human-readable name for the batch export. */
       name: string;
       /** Which data model to export (events, persons, sessions).
-
-      * `events` - Events
-      * `persons` - Persons
-      * `sessions` - Sessions */
+       *
+       * * `events` - Events
+       * * `persons` - Persons
+       * * `sessions` - Sessions */
       model?: ModelEnum;
       /** Destination configuration. Required integration_id is enforced per destination type. */
       destination: BatchExportDestinationRequest;
       /** How often the batch export should run.
-
-      * `hour` - hour
-      * `day` - day
-      * `week` - week
-      * `every 5 minutes` - every 5 minutes
-      * `every 15 minutes` - every 15 minutes */
+       *
+       * * `hour` - hour
+       * * `day` - day
+       * * `week` - week
+       * * `every 5 minutes` - every 5 minutes
+       * * `every 15 minutes` - every 15 minutes */
       interval: IntervalEnum;
       /** Whether the batch export is paused. */
       paused?: boolean;
@@ -9834,9 +9834,9 @@ export namespace Schemas {
 
     /**
      * * `completed` - Completed
-    * `failed` - Failed
-    * `paused` - Paused
-    * `running` - Running
+     * * `failed` - Failed
+     * * `paused` - Paused
+     * * `running` - Running
      */
     export type BatchImportStatusEnum = typeof BatchImportStatusEnum[keyof typeof BatchImportStatusEnum];
 
@@ -10005,7 +10005,7 @@ export namespace Schemas {
 
     /**
      * * `distinct_id` - User ID (default)
-    * `device_id` - Device ID
+     * * `device_id` - Device ID
      */
     export type BucketingIdentifierEnum = typeof BucketingIdentifierEnum[keyof typeof BucketingIdentifierEnum];
 
@@ -10017,8 +10017,8 @@ export namespace Schemas {
 
     /**
      * * `fully_rolled_out` - fully_rolled_out
-    * `not_rolled_out` - not_rolled_out
-    * `partial` - partial
+     * * `not_rolled_out` - not_rolled_out
+     * * `partial` - partial
      */
     export type RolloutStateEnum = typeof RolloutStateEnum[keyof typeof RolloutStateEnum];
 
@@ -10035,10 +10035,10 @@ export namespace Schemas {
       /** The flag key at the time of deletion. */
       key: string;
       /** Rollout state captured before deletion.
-
-      * `fully_rolled_out` - fully_rolled_out
-      * `not_rolled_out` - not_rolled_out
-      * `partial` - partial */
+       *
+       * * `fully_rolled_out` - fully_rolled_out
+       * * `not_rolled_out` - not_rolled_out
+       * * `partial` - partial */
       rollout_state: RolloutStateEnum;
       /**
          * Variant key when a multivariate flag was fully rolled out to a single variant; otherwise null.
@@ -10058,9 +10058,9 @@ export namespace Schemas {
 
     /**
      * * `boolean` - boolean
-    * `multivariant` - multivariant
-    * `experiment` - experiment
-    * `remote_config` - remote_config
+     * * `multivariant` - multivariant
+     * * `experiment` - experiment
+     * * `remote_config` - remote_config
      */
     export type BulkDeleteFiltersTypeEnum = typeof BulkDeleteFiltersTypeEnum[keyof typeof BulkDeleteFiltersTypeEnum];
 
@@ -10074,8 +10074,8 @@ export namespace Schemas {
 
     /**
      * * `server` - Server
-    * `client` - Client
-    * `all` - All
+     * * `client` - Client
+     * * `all` - All
      */
     export type EvaluationRuntimeEnum = typeof EvaluationRuntimeEnum[keyof typeof EvaluationRuntimeEnum];
 
@@ -10091,27 +10091,27 @@ export namespace Schemas {
      */
     export interface BulkDeleteFilters {
       /** Filter by active state.
-
-      * `true` - true
-      * `false` - false
-      * `STALE` - STALE */
+       *
+       * * `true` - true
+       * * `false` - false
+       * * `STALE` - STALE */
       active?: ActiveEnum;
       /** Filter to flags created by a specific user ID. */
       created_by_id?: number;
       /** Search by feature flag key or name (case-insensitive). */
       search?: string;
       /** Filter by flag type.
-
-      * `boolean` - boolean
-      * `multivariant` - multivariant
-      * `experiment` - experiment
-      * `remote_config` - remote_config */
+       *
+       * * `boolean` - boolean
+       * * `multivariant` - multivariant
+       * * `experiment` - experiment
+       * * `remote_config` - remote_config */
       type?: BulkDeleteFiltersTypeEnum;
       /** Filter by evaluation runtime.
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum;
       /** JSON-encoded property filter to exclude. Same shape as the list endpoint. */
       excluded_properties?: string;
@@ -10124,17 +10124,20 @@ export namespace Schemas {
     export interface BulkDeleteRequest {
       /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to bulk-delete by search/active/tags/etc. instead of supplying explicit IDs. */
       filters?: BulkDeleteFilters;
-      /** Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`. */
+      /**
+         * Explicit feature flag IDs to soft-delete. Mutually exclusive with `filters`.
+         * @items.minimum 1
+         */
       ids?: number[];
     }
 
     /**
      * Schema-only — referenced from ``@extend_schema(responses=...)`` to describe the wire format.
-    Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
-    declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
-    so accessing ``serializer.errors`` would return this field descriptor instead of validation
-    errors. The handler builds the response dict directly; this class exists only so drf-spectacular
-    can render the response in the OpenAPI spec and downstream generated clients.
+     * Never instantiate this for validation or call ``.is_valid()`` / ``.errors`` on it: the
+     * declared ``errors`` field shadows DRF's inherited ``Serializer.errors`` ReturnDict property,
+     * so accessing ``serializer.errors`` would return this field descriptor instead of validation
+     * errors. The handler builds the response dict directly; this class exists only so drf-spectacular
+     * can render the response in the OpenAPI spec and downstream generated clients.
      */
     export interface BulkDeleteResponse {
       /** Flags successfully soft-deleted. */
@@ -10197,10 +10200,10 @@ export namespace Schemas {
 
     /**
      * * `new` - New
-    * `open` - Open
-    * `pending` - Pending
-    * `on_hold` - On hold
-    * `resolved` - Resolved
+     * * `open` - Open
+     * * `pending` - Pending
+     * * `on_hold` - On hold
+     * * `resolved` - Resolved
      */
     export type TicketStatusEnum = typeof TicketStatusEnum[keyof typeof TicketStatusEnum];
 
@@ -10220,12 +10223,12 @@ export namespace Schemas {
          */
       ids: string[];
       /** New status to apply to all selected tickets: new, open, pending, on_hold, or resolved.
-
-      * `new` - New
-      * `open` - Open
-      * `pending` - Pending
-      * `on_hold` - On hold
-      * `resolved` - Resolved */
+       *
+       * * `new` - New
+       * * `open` - Open
+       * * `pending` - Pending
+       * * `on_hold` - On hold
+       * * `resolved` - Resolved */
       status: TicketStatusEnum;
     }
 
@@ -10253,10 +10256,10 @@ export namespace Schemas {
          */
       ids: number[];
       /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
-
-      * `add` - add
-      * `remove` - remove
-      * `set` - set */
+       *
+       * * `add` - add
+       * * `remove` - remove
+       * * `set` - set */
       action: ActionEnum;
       /** Tag names to add, remove, or set. */
       tags: string[];
@@ -10269,8 +10272,8 @@ export namespace Schemas {
 
     /**
      * * `b2b` - B2B
-    * `b2c` - B2C
-    * `other` - Other
+     * * `b2c` - B2C
+     * * `other` - Other
      */
     export type BusinessModelEnum = typeof BusinessModelEnum[keyof typeof BusinessModelEnum];
 
@@ -10306,9 +10309,9 @@ export namespace Schemas {
 
     /**
      * Create-response variant that includes the plaintext token.
-
-    Only emitted from the create endpoint - storage-side we only persist the
-    hash, so subsequent reads use the base serializer.
+     *
+     * Only emitted from the create endpoint - storage-side we only persist the
+     * hash, so subsequent reads use the base serializer.
      */
     export interface CIMDVerificationTokenWithValue {
       readonly id: string;
@@ -10413,7 +10416,7 @@ export namespace Schemas {
 
     /**
      * * `error` - error
-    * `warning` - warning
+     * * `warning` - warning
      */
     export type UtmIssueSeverityEnum = typeof UtmIssueSeverityEnum[keyof typeof UtmIssueSeverityEnum];
 
@@ -10427,9 +10430,9 @@ export namespace Schemas {
       /** The UTM field with the issue (e.g. utm_campaign, utm_source) */
       field: string;
       /** Issue severity level
-
-      * `error` - error
-      * `warning` - warning */
+       *
+       * * `error` - error
+       * * `warning` - warning */
       severity: UtmIssueSeverityEnum;
       /** Human-readable description of the issue */
       message: string;
@@ -10484,7 +10487,11 @@ export namespace Schemas {
       pct_with_utm_source: number;
       /** Percentage of events that carry a utm_campaign */
       pct_with_utm_campaign: number;
-      /** List of [utm_source, count] pairs */
+      /**
+         * List of [utm_source, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       top_utm_sources: [string, number][];
       /** Whether this event is already configured as a goal */
       is_already_a_goal: boolean;
@@ -10501,11 +10508,11 @@ export namespace Schemas {
 
     /**
      * * `needs_setup` - needs_setup
-    * `detected` - detected
-    * `waiting_for_data` - waiting_for_data
-    * `ready` - ready
-    * `not_applicable` - not_applicable
-    * `unknown` - unknown
+     * * `detected` - detected
+     * * `waiting_for_data` - waiting_for_data
+     * * `ready` - ready
+     * * `not_applicable` - not_applicable
+     * * `unknown` - unknown
      */
     export type CapabilityStateStateEnum = typeof CapabilityStateStateEnum[keyof typeof CapabilityStateStateEnum];
 
@@ -10521,13 +10528,13 @@ export namespace Schemas {
 
     export interface CapabilityState {
       /** Current state of the capability
-
-      * `needs_setup` - needs_setup
-      * `detected` - detected
-      * `waiting_for_data` - waiting_for_data
-      * `ready` - ready
-      * `not_applicable` - not_applicable
-      * `unknown` - unknown */
+       *
+       * * `needs_setup` - needs_setup
+       * * `detected` - detected
+       * * `waiting_for_data` - waiting_for_data
+       * * `ready` - ready
+       * * `not_applicable` - not_applicable
+       * * `unknown` - unknown */
       state: CapabilityStateStateEnum;
       /** Whether the state is estimated from static analysis */
       estimated: boolean;
@@ -10574,7 +10581,7 @@ export namespace Schemas {
 
     /**
      * * `single` - single
-    * `multiple` - multiple
+     * * `multiple` - multiple
      */
     export type SelectionModeEnum = typeof SelectionModeEnum[keyof typeof SelectionModeEnum];
 
@@ -10588,9 +10595,9 @@ export namespace Schemas {
       /** Ordered categorical options available to the scorer. */
       options: CategoricalScoreOption[];
       /** Whether reviewers can select one option or multiple options. Defaults to `single`.
-
-      * `single` - single
-      * `multiple` - multiple */
+       *
+       * * `single` - single
+       * * `multiple` - multiple */
       selection_mode?: SelectionModeEnum;
       /**
          * Optional minimum number of options that can be selected when `selection_mode` is `multiple`.
@@ -10608,7 +10615,7 @@ export namespace Schemas {
 
     /**
      * * `marketing` - Marketing
-    * `transactional` - Transactional
+     * * `transactional` - Transactional
      */
     export type CategoryTypeEnum = typeof CategoryTypeEnum[keyof typeof CategoryTypeEnum];
 
@@ -10620,8 +10627,8 @@ export namespace Schemas {
 
     /**
      * * `consolidated` - consolidated
-    * `cdc_only` - cdc_only
-    * `both` - both
+     * * `cdc_only` - cdc_only
+     * * `both` - both
      */
     export type CdcTableModeEnum = typeof CdcTableModeEnum[keyof typeof CdcTableModeEnum];
 
@@ -10636,9 +10643,9 @@ export namespace Schemas {
 
     /**
      * * `valid` - Valid
-    * `invalid` - Invalid
-    * `expired` - Expired
-    * `stale` - Stale (resource changed)
+     * * `invalid` - Invalid
+     * * `expired` - Expired
+     * * `stale` - Stale (resource changed)
      */
     export type ValidationStatusEnum = typeof ValidationStatusEnum[keyof typeof ValidationStatusEnum];
 
@@ -10652,11 +10659,11 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `approved` - Approved (awaiting application)
-    * `applied` - Applied
-    * `rejected` - Rejected
-    * `expired` - Expired
-    * `failed` - Failed to apply
+     * * `approved` - Approved (awaiting application)
+     * * `applied` - Applied
+     * * `rejected` - Rejected
+     * * `expired` - Expired
+     * * `failed` - Failed to apply
      */
     export type ChangeRequestStateEnum = typeof ChangeRequestStateEnum[keyof typeof ChangeRequestStateEnum];
 
@@ -10710,13 +10717,13 @@ export namespace Schemas {
 
     /**
      * * `slack_channel_message` - Channel message
-    * `slack_bot_mention` - Bot mention
-    * `slack_emoji_reaction` - Emoji reaction
-    * `teams_channel_message` - Teams channel message
-    * `teams_bot_mention` - Teams bot mention
-    * `widget_embedded` - Widget
-    * `widget_api` - API
-    * `github_issue` - GitHub issue
+     * * `slack_bot_mention` - Bot mention
+     * * `slack_emoji_reaction` - Emoji reaction
+     * * `teams_channel_message` - Teams channel message
+     * * `teams_bot_mention` - Teams bot mention
+     * * `widget_embedded` - Widget
+     * * `widget_api` - API
+     * * `github_issue` - GitHub issue
      */
     export type ChannelDetailEnum = typeof ChannelDetailEnum[keyof typeof ChannelDetailEnum];
 
@@ -10734,10 +10741,10 @@ export namespace Schemas {
 
     /**
      * * `widget` - Widget
-    * `email` - Email
-    * `slack` - Slack
-    * `teams` - Microsoft Teams
-    * `github` - GitHub
+     * * `email` - Email
+     * * `slack` - Slack
+     * * `teams` - Microsoft Teams
+     * * `github` - GitHub
      */
     export type ChannelSourceEnum = typeof ChannelSourceEnum[keyof typeof ChannelSourceEnum];
 
@@ -10757,7 +10764,7 @@ export namespace Schemas {
 
     /**
      * * `abandoned` - Abandoned
-    * `off-topic` - Off-topic
+     * * `off-topic` - Off-topic
      */
     export type ClassificationsEnum = typeof ClassificationsEnum[keyof typeof ClassificationsEnum];
 
@@ -10795,7 +10802,7 @@ export namespace Schemas {
 
     /**
      * * `interactive` - interactive
-    * `background` - background
+     * * `background` - background
      */
     export type TaskExecutionModeEnum = typeof TaskExecutionModeEnum[keyof typeof TaskExecutionModeEnum];
 
@@ -10807,7 +10814,7 @@ export namespace Schemas {
 
     /**
      * * `user` - user
-    * `bot` - bot
+     * * `bot` - bot
      */
     export type PrAuthorshipModeEnum = typeof PrAuthorshipModeEnum[keyof typeof PrAuthorshipModeEnum];
 
@@ -10819,7 +10826,7 @@ export namespace Schemas {
 
     /**
      * * `manual` - manual
-    * `signal_report` - signal_report
+     * * `signal_report` - signal_report
      */
     export type RunSourceEnum = typeof RunSourceEnum[keyof typeof RunSourceEnum];
 
@@ -10831,10 +10838,10 @@ export namespace Schemas {
 
     /**
      * * `low` - low
-    * `medium` - medium
-    * `high` - high
-    * `xhigh` - xhigh
-    * `max` - max
+     * * `medium` - medium
+     * * `high` - high
+     * * `xhigh` - xhigh
+     * * `max` - max
      */
     export type ReasoningEffortEnum = typeof ReasoningEffortEnum[keyof typeof ReasoningEffortEnum];
 
@@ -10849,10 +10856,10 @@ export namespace Schemas {
 
     /**
      * * `default` - default
-    * `acceptEdits` - acceptEdits
-    * `plan` - plan
-    * `bypassPermissions` - bypassPermissions
-    * `auto` - auto
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto
      */
     export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnum = typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -10870,9 +10877,9 @@ export namespace Schemas {
      */
     export interface ClaudeTaskRunCreateSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -10884,45 +10891,48 @@ export namespace Schemas {
       resume_from_run_id?: string;
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
+      /**
+         * Identifiers for staged task artifacts that should be attached to the initial run prompt.
+         * @items.maxLength 128
+         */
       pending_user_artifact_ids?: string[];
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Must be 'claude' for Claude runtimes.
-
-      * `claude` - claude */
+       *
+       * * `claude` - claude */
       runtime_adapter: ClaudeRuntimeAdapterEnum;
       /** LLM model identifier to run in the Claude runtime. */
       model: string;
       /** Reasoning effort to request for models that expose an effort control.
-
-      * `low` - low
-      * `medium` - medium
-      * `high` - high
-      * `xhigh` - xhigh
-      * `max` - max */
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high
+       * * `xhigh` - xhigh
+       * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Claude runtimes.
-
-      * `default` - default
-      * `acceptEdits` - acceptEdits
-      * `plan` - plan
-      * `bypassPermissions` - bypassPermissions
-      * `auto` - auto */
+       *
+       * * `default` - default
+       * * `acceptEdits` - acceptEdits
+       * * `plan` - plan
+       * * `bypassPermissions` - bypassPermissions
+       * * `auto` - auto */
       initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 
@@ -10945,7 +10955,10 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -11008,8 +11021,8 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `generation` - generation
-    * `evaluation` - evaluation
+     * * `generation` - generation
+     * * `evaluation` - evaluation
      */
     export type ClusteringJobAnalysisLevelEnum = typeof ClusteringJobAnalysisLevelEnum[keyof typeof ClusteringJobAnalysisLevelEnum];
 
@@ -11033,7 +11046,7 @@ export namespace Schemas {
 
     /**
      * * `hdbscan` - hdbscan
-    * `kmeans` - kmeans
+     * * `kmeans` - kmeans
      */
     export type ClusteringMethodEnum = typeof ClusteringMethodEnum[keyof typeof ClusteringMethodEnum];
 
@@ -11047,7 +11060,7 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `l2` - l2
+     * * `l2` - l2
      */
     export type EmbeddingNormalizationEnum = typeof EmbeddingNormalizationEnum[keyof typeof EmbeddingNormalizationEnum];
 
@@ -11059,8 +11072,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `umap` - umap
-    * `pca` - pca
+     * * `umap` - umap
+     * * `pca` - pca
      */
     export type DimensionalityReductionMethodEnum = typeof DimensionalityReductionMethodEnum[keyof typeof DimensionalityReductionMethodEnum];
 
@@ -11073,8 +11086,8 @@ export namespace Schemas {
 
     /**
      * * `umap` - umap
-    * `pca` - pca
-    * `tsne` - tsne
+     * * `pca` - pca
+     * * `tsne` - tsne
      */
     export type VisualizationMethodEnum = typeof VisualizationMethodEnum[keyof typeof VisualizationMethodEnum];
 
@@ -11102,15 +11115,15 @@ export namespace Schemas {
          */
       max_samples?: number;
       /** Embedding normalization method: 'none' (raw embeddings) or 'l2' (L2 normalize before clustering)
-
-      * `none` - none
-      * `l2` - l2 */
+       *
+       * * `none` - none
+       * * `l2` - l2 */
       embedding_normalization?: EmbeddingNormalizationEnum;
       /** Dimensionality reduction method: 'none' (cluster on raw), 'umap', or 'pca'
-
-      * `none` - none
-      * `umap` - umap
-      * `pca` - pca */
+       *
+       * * `none` - none
+       * * `umap` - umap
+       * * `pca` - pca */
       dimensionality_reduction_method?: DimensionalityReductionMethodEnum;
       /**
          * Target dimensions for dimensionality reduction (ignored if method is 'none')
@@ -11119,9 +11132,9 @@ export namespace Schemas {
          */
       dimensionality_reduction_ndims?: number;
       /** Clustering algorithm: 'hdbscan' (density-based, auto-determines k) or 'kmeans' (centroid-based)
-
-      * `hdbscan` - hdbscan
-      * `kmeans` - kmeans */
+       *
+       * * `hdbscan` - hdbscan
+       * * `kmeans` - kmeans */
       clustering_method?: ClusteringMethodEnum;
       /**
          * Minimum cluster size as fraction of total samples (e.g., 0.02 = 2%)
@@ -11153,10 +11166,10 @@ export namespace Schemas {
          */
       run_label?: string;
       /** Method for 2D scatter plot visualization: 'umap', 'pca', or 'tsne'
-
-      * `umap` - umap
-      * `pca` - pca
-      * `tsne` - tsne */
+       *
+       * * `umap` - umap
+       * * `pca` - pca
+       * * `tsne` - tsne */
       visualization_method?: VisualizationMethodEnum;
       /** Property filters to scope which traces are included in clustering (PostHog standard format) */
       event_filters?: ClusteringRunRequestEventFiltersItem[];
@@ -11184,8 +11197,8 @@ export namespace Schemas {
 
     /**
      * * `auto` - auto
-    * `read-only` - read-only
-    * `full-access` - full-access
+     * * `read-only` - read-only
+     * * `full-access` - full-access
      */
     export type CodexTaskRunCreateSchemaInitialPermissionModeEnum = typeof CodexTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof CodexTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -11201,9 +11214,9 @@ export namespace Schemas {
      */
     export interface CodexTaskRunCreateSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -11215,43 +11228,46 @@ export namespace Schemas {
       resume_from_run_id?: string;
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /** Identifiers for staged task artifacts that should be attached to the initial run prompt. */
+      /**
+         * Identifiers for staged task artifacts that should be attached to the initial run prompt.
+         * @items.maxLength 128
+         */
       pending_user_artifact_ids?: string[];
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Must be 'codex' for Codex runtimes.
-
-      * `codex` - codex */
+       *
+       * * `codex` - codex */
       runtime_adapter: CodexRuntimeAdapterEnum;
       /** LLM model identifier to run in the Codex runtime. */
       model: string;
       /** Reasoning effort to request for models that expose an effort control.
-
-      * `low` - low
-      * `medium` - medium
-      * `high` - high
-      * `xhigh` - xhigh
-      * `max` - max */
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high
+       * * `xhigh` - xhigh
+       * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Codex runtimes.
-
-      * `auto` - auto
-      * `read-only` - read-only
-      * `full-access` - full-access */
+       *
+       * * `auto` - auto
+       * * `read-only` - read-only
+       * * `full-access` - full-access */
       initial_permission_mode?: CodexTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 
@@ -11298,10 +11314,10 @@ export namespace Schemas {
 
     /**
      * * `static` - static
-    * `person_property` - person_property
-    * `behavioral` - behavioral
-    * `realtime` - realtime
-    * `analytical` - analytical
+     * * `person_property` - person_property
+     * * `behavioral` - behavioral
+     * * `realtime` - realtime
+     * * `analytical` - analytical
      */
     export type CohortTypeEnum = typeof CohortTypeEnum[keyof typeof CohortTypeEnum];
 
@@ -11346,12 +11362,12 @@ export namespace Schemas {
       readonly count: number | null;
       is_static?: boolean;
       /** Type of cohort based on filter complexity
-
-      * `static` - static
-      * `person_property` - person_property
-      * `behavioral` - behavioral
-      * `realtime` - realtime
-      * `analytical` - analytical */
+       *
+       * * `static` - static
+       * * `person_property` - person_property
+       * * `behavioral` - behavioral
+       * * `realtime` - realtime
+       * * `analytical` - analytical */
       cohort_type?: CohortTypeEnum | BlankEnum | null;
       readonly experiment_set: readonly number[];
       _create_in_folder?: string;
@@ -11400,7 +11416,7 @@ export namespace Schemas {
 
     /**
      * * `private` - Private (only visible to creator)
-    * `shared` - Shared with team
+     * * `shared` - Shared with team
      */
     export type VisibilityEnum = typeof VisibilityEnum[keyof typeof VisibilityEnum];
 
@@ -11501,10 +11517,10 @@ export namespace Schemas {
 
     /**
      * * `won` - won
-    * `lost` - lost
-    * `inconclusive` - inconclusive
-    * `stopped_early` - stopped_early
-    * `invalid` - invalid
+     * * `lost` - lost
+     * * `inconclusive` - inconclusive
+     * * `stopped_early` - stopped_early
+     * * `invalid` - invalid
      */
     export type ConclusionEnum = typeof ConclusionEnum[keyof typeof ConclusionEnum];
 
@@ -11527,7 +11543,7 @@ export namespace Schemas {
 
     /**
      * * `utf-8` - utf-8
-    * `base64` - base64
+     * * `base64` - base64
      */
     export type ContentEncodingEnum = typeof ContentEncodingEnum[keyof typeof ContentEncodingEnum];
 
@@ -11543,8 +11559,8 @@ export namespace Schemas {
 
     /**
      * * `idle` - Idle
-    * `in_progress` - In progress
-    * `canceling` - Canceling
+     * * `in_progress` - In progress
+     * * `canceling` - Canceling
      */
     export type ConversationStatus = typeof ConversationStatus[keyof typeof ConversationStatus];
 
@@ -11557,9 +11573,9 @@ export namespace Schemas {
 
     /**
      * * `assistant` - Assistant
-    * `tool_call` - Tool call
-    * `deep_research` - Deep research
-    * `slack` - Slack
+     * * `tool_call` - Tool call
+     * * `deep_research` - Deep research
+     * * `slack` - Slack
      */
     export type ConversationType = typeof ConversationType[keyof typeof ConversationType];
 
@@ -11606,9 +11622,9 @@ export namespace Schemas {
       readonly agent_mode: string | null;
       readonly is_sandbox: boolean;
       /** Return pending approval cards as structured data.
-
-      Combines metadata from conversation.approval_decisions with payload from checkpoint
-      interrupts (single source of truth for payload data). */
+       *
+       * Combines metadata from conversation.approval_decisions with payload from checkpoint
+       * interrupts (single source of truth for payload data). */
       readonly pending_approvals: readonly ConversationPendingApprovalsItem[];
     }
 
@@ -11708,8 +11724,8 @@ export namespace Schemas {
 
     /**
      * * `0` - Disabled
-    * `1` - Stateless
-    * `2` - Stateful
+     * * `1` - Stateless
+     * * `2` - Stateful
      */
     export type CookielessServerHashModeEnum = typeof CookielessServerHashModeEnum[keyof typeof CookielessServerHashModeEnum];
 
@@ -11786,13 +11802,13 @@ export namespace Schemas {
 
     /**
      * * `acquisition` - Acquisition
-    * `activation` - Activation
-    * `monetization` - Monetization
-    * `expansion` - Expansion
-    * `referral` - Referral
-    * `retention` - Retention
-    * `churn` - Churn
-    * `reactivation` - Reactivation
+     * * `activation` - Activation
+     * * `monetization` - Monetization
+     * * `expansion` - Expansion
+     * * `referral` - Referral
+     * * `retention` - Retention
+     * * `churn` - Churn
+     * * `reactivation` - Reactivation
      */
     export type CoreEventCategoryEnum = typeof CoreEventCategoryEnum[keyof typeof CoreEventCategoryEnum];
 
@@ -11818,15 +11834,15 @@ export namespace Schemas {
       /** Optional description */
       description?: string;
       /** Lifecycle category for this core event
-
-      * `acquisition` - Acquisition
-      * `activation` - Activation
-      * `monetization` - Monetization
-      * `expansion` - Expansion
-      * `referral` - Referral
-      * `retention` - Retention
-      * `churn` - Churn
-      * `reactivation` - Reactivation */
+       *
+       * * `acquisition` - Acquisition
+       * * `activation` - Activation
+       * * `monetization` - Monetization
+       * * `expansion` - Expansion
+       * * `referral` - Referral
+       * * `retention` - Retention
+       * * `churn` - Churn
+       * * `reactivation` - Reactivation */
       category: CoreEventCategoryEnum;
       /** Filter configuration - event, action, or data warehouse node */
       filter: unknown;
@@ -11845,9 +11861,9 @@ export namespace Schemas {
 
     /**
      * * `single` - Single page
-    * `sitemap` - Sitemap
-    * `same_origin` - Same origin crawl
-    * `github_repo` - GitHub repository
+     * * `sitemap` - Sitemap
+     * * `same_origin` - Same origin crawl
+     * * `github_repo` - GitHub repository
      */
     export type CrawlModeEnum = typeof CrawlModeEnum[keyof typeof CrawlModeEnum];
 
@@ -11864,17 +11880,17 @@ export namespace Schemas {
      */
     export interface FileDownloadDestinationFileConfig {
       /** File format
-
-      * `Parquet` - Parquet
-      * `JSONLines` - JSONLines */
+       *
+       * * `Parquet` - Parquet
+       * * `JSONLines` - JSONLines */
       format?: FileFormatEnum;
       /** Compress the file with a supported compression format
-
-      * `zstd` - zstd
-      * `gzip` - gzip
-      * `brotli` - brotli
-      * `lz4` - lz4
-      * `snappy` - snappy */
+       *
+       * * `zstd` - zstd
+       * * `gzip` - gzip
+       * * `brotli` - brotli
+       * * `lz4` - lz4
+       * * `snappy` - snappy */
       compression?: CompressionEnum | null;
       /**
          * Split download into multiple files of at most this size in MB
@@ -11941,8 +11957,8 @@ export namespace Schemas {
 
     /**
      * * `cost` - cost
-    * `latency` - latency
-    * `eval_pass_rate` - eval_pass_rate
+     * * `latency` - latency
+     * * `eval_pass_rate` - eval_pass_rate
      */
     export type TemplatesEnum = typeof TemplatesEnum[keyof typeof TemplatesEnum];
 
@@ -11960,6 +11976,7 @@ export namespace Schemas {
          * Ordered list of prompt version numbers to assign to experiment variants. The first entry is the control variant. Must contain between 2 and 10 distinct versions.
          * @minItems 2
          * @maxItems 10
+         * @items.minimum 1
          */
       versions: number[];
       /**
@@ -11989,7 +12006,7 @@ export namespace Schemas {
 
     /**
      * * `BAA` - BAA
-    * `DPA` - DPA
+     * * `DPA` - DPA
      */
     export type CreateLegalDocumentDocumentTypeEnum = typeof CreateLegalDocumentDocumentTypeEnum[keyof typeof CreateLegalDocumentDocumentTypeEnum];
 
@@ -12001,14 +12018,14 @@ export namespace Schemas {
 
     /**
      * Input serializer for POST. Mirrors the submittable fields on the model plus
-    cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
-    organization and submitting user.
+     * cross-field rules (BAA addon, DPA mode, uniqueness). The view supplies the
+     * organization and submitting user.
      */
     export interface CreateLegalDocument {
       /** Either 'BAA' or 'DPA'.
-
-      * `BAA` - BAA
-      * `DPA` - DPA */
+       *
+       * * `BAA` - BAA
+       * * `DPA` - DPA */
       document_type: CreateLegalDocumentDocumentTypeEnum;
       /**
          * The customer legal entity entering the agreement (PandaDoc's Client.Company).
@@ -12033,10 +12050,10 @@ export namespace Schemas {
 
     /**
      * * `zoom` - zoom
-    * `teams` - teams
-    * `meet` - meet
-    * `desktop_audio` - desktop_audio
-    * `slack` - slack
+     * * `teams` - teams
+     * * `meet` - meet
+     * * `desktop_audio` - desktop_audio
+     * * `slack` - slack
      */
     export type CreateRecordingRequestPlatformEnum = typeof CreateRecordingRequestPlatformEnum[keyof typeof CreateRecordingRequestPlatformEnum];
 
@@ -12054,21 +12071,21 @@ export namespace Schemas {
      */
     export interface CreateRecordingRequest {
       /** Meeting platform being recorded
-
-      * `zoom` - zoom
-      * `teams` - teams
-      * `meet` - meet
-      * `desktop_audio` - desktop_audio
-      * `slack` - slack */
+       *
+       * * `zoom` - zoom
+       * * `teams` - teams
+       * * `meet` - meet
+       * * `desktop_audio` - desktop_audio
+       * * `slack` - slack */
       platform?: CreateRecordingRequestPlatformEnum;
     }
 
     /**
      * * `zoom` - Zoom
-    * `teams` - Microsoft Teams
-    * `meet` - Google Meet
-    * `desktop_audio` - Desktop audio
-    * `slack` - Slack huddle
+     * * `teams` - Microsoft Teams
+     * * `meet` - Google Meet
+     * * `desktop_audio` - Desktop audio
+     * * `slack` - Slack huddle
      */
     export type MeetingPlatformEnum = typeof MeetingPlatformEnum[keyof typeof MeetingPlatformEnum];
 
@@ -12083,10 +12100,10 @@ export namespace Schemas {
 
     /**
      * * `recording` - Recording
-    * `uploading` - Uploading
-    * `processing` - Processing
-    * `ready` - Ready
-    * `error` - Error
+     * * `uploading` - Uploading
+     * * `processing` - Processing
+     * * `ready` - Ready
+     * * `error` - Error
      */
     export type DesktopRecordingStatusEnum = typeof DesktopRecordingStatusEnum[keyof typeof DesktopRecordingStatusEnum];
 
@@ -12252,8 +12269,8 @@ export namespace Schemas {
 
     /**
      * * `web` - web
-    * `api` - api
-    * `mcp` - mcp
+     * * `api` - api
+     * * `mcp` - mcp
      */
     export type CreatedViaEnum = typeof CreatedViaEnum[keyof typeof CreatedViaEnum];
 
@@ -12266,9 +12283,9 @@ export namespace Schemas {
 
     /**
      * * `default` - Default
-    * `template` - Template
-    * `duplicate` - Duplicate
-    * `unlisted` - Unlisted (product-embedded)
+     * * `template` - Template
+     * * `duplicate` - Duplicate
+     * * `unlisted` - Unlisted (product-embedded)
      */
     export type CreationModeEnum = typeof CreationModeEnum[keyof typeof CreationModeEnum];
 
@@ -12317,11 +12334,11 @@ export namespace Schemas {
 
     /**
      * * `person` - Person
-    * `group_0` - Group 0
-    * `group_1` - Group 1
-    * `group_2` - Group 2
-    * `group_3` - Group 3
-    * `group_4` - Group 4
+     * * `group_0` - Group 0
+     * * `group_1` - Group 1
+     * * `group_2` - Group 2
+     * * `group_3` - Group 3
+     * * `group_4` - Group 4
      */
     export type CustomerProfileConfigScopeEnum = typeof CustomerProfileConfigScopeEnum[keyof typeof CustomerProfileConfigScopeEnum];
 
@@ -12386,7 +12403,7 @@ export namespace Schemas {
 
     /**
      * * `21` - Everyone in the project can edit
-    * `37` - Only those invited to this dashboard can edit
+     * * `37` - Only those invited to this dashboard can edit
      */
     export type RestrictionLevelEnum = typeof RestrictionLevelEnum[keyof typeof RestrictionLevelEnum];
 
@@ -12488,9 +12505,9 @@ export namespace Schemas {
       readonly creation_mode: CreationModeEnum;
       tags?: unknown[];
       /** Controls who can edit the dashboard.
-
-      * `21` - Everyone in the project can edit
-      * `37` - Only those invited to this dashboard can edit */
+       *
+       * * `21` - Everyone in the project can edit
+       * * `37` - Only those invited to this dashboard can edit */
       readonly restriction_level: RestrictionLevelEnum;
       readonly effective_restriction_level: EffectivePrivilegeLevelEnum;
       readonly effective_privilege_level: EffectivePrivilegeLevelEnum;
@@ -12525,8 +12542,8 @@ export namespace Schemas {
 
     /**
      * * `team` - Only team
-    * `global` - Global
-    * `feature_flag` - Feature Flag
+     * * `global` - Global
+     * * `feature_flag` - Feature Flag
      */
     export type DashboardTemplateScopeEnum = typeof DashboardTemplateScopeEnum[keyof typeof DashboardTemplateScopeEnum];
 
@@ -12550,7 +12567,10 @@ export namespace Schemas {
          */
       dashboard_description?: string | null;
       dashboard_filters?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       tags?: string[] | null;
       tiles?: unknown;
       variables?: unknown;
@@ -12567,7 +12587,10 @@ export namespace Schemas {
       /** @nullable */
       readonly team_id: number | null;
       scope?: DashboardTemplateScopeEnum | BlankEnum | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       availability_contexts?: string[] | null;
       /** Manually curated; used to highlight templates in the UI. */
       is_featured?: boolean;
@@ -12624,9 +12647,9 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Completed` - Completed
-    * `Failed` - Failed
-    * `Running` - Running
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running
      */
     export type DataModelingJobStatusEnum = typeof DataModelingJobStatusEnum[keyof typeof DataModelingJobStatusEnum];
 
@@ -12771,10 +12794,10 @@ export namespace Schemas {
 
     /**
      * * `Cancelled` - Cancelled
-    * `Modified` - Modified
-    * `Completed` - Completed
-    * `Failed` - Failed
-    * `Running` - Running
+     * * `Modified` - Modified
+     * * `Completed` - Completed
+     * * `Failed` - Failed
+     * * `Running` - Running
      */
     export type SavedQueryStatusEnum = typeof SavedQueryStatusEnum[keyof typeof SavedQueryStatusEnum];
 
@@ -12789,8 +12812,8 @@ export namespace Schemas {
 
     /**
      * * `data_warehouse` - Data Warehouse
-    * `endpoint` - Endpoint
-    * `managed_viewset` - Managed Viewset
+     * * `endpoint` - Endpoint
+     * * `managed_viewset` - Managed Viewset
      */
     export type OriginEnum = typeof OriginEnum[keyof typeof OriginEnum];
 
@@ -12803,8 +12826,8 @@ export namespace Schemas {
 
     /**
      * Shared methods for DataWarehouseSavedQuery serializers.
-
-    This mixin is intended to be used with serializers.ModelSerializer subclasses.
+     *
+     * This mixin is intended to be used with serializers.ModelSerializer subclasses.
      */
     export interface DataWarehouseSavedQuery {
       readonly id: string;
@@ -12823,12 +12846,12 @@ export namespace Schemas {
       readonly sync_frequency: string | null;
       readonly columns: readonly DataWarehouseSavedQueryColumnsItem[];
       /** The status of when this SavedQuery last ran.
-
-      * `Cancelled` - Cancelled
-      * `Modified` - Modified
-      * `Completed` - Completed
-      * `Failed` - Failed
-      * `Running` - Running */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Modified` - Modified
+       * * `Completed` - Completed
+       * * `Failed` - Failed
+       * * `Running` - Running */
       readonly status: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -12866,10 +12889,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized: boolean | null;
       /** Where this SavedQuery is created.
-
-      * `data_warehouse` - Data Warehouse
-      * `endpoint` - Endpoint
-      * `managed_viewset` - Managed Viewset */
+       *
+       * * `data_warehouse` - Data Warehouse
+       * * `endpoint` - Endpoint
+       * * `managed_viewset` - Managed Viewset */
       readonly origin: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       is_test?: boolean;
@@ -12940,12 +12963,12 @@ export namespace Schemas {
       readonly sync_frequency: string | null;
       readonly columns: readonly DataWarehouseSavedQueryMinimalColumnsItem[];
       /** The status of when this SavedQuery last ran.
-
-      * `Cancelled` - Cancelled
-      * `Modified` - Modified
-      * `Completed` - Completed
-      * `Failed` - Failed
-      * `Running` - Running */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Modified` - Modified
+       * * `Completed` - Completed
+       * * `Failed` - Failed
+       * * `Running` - Running */
       readonly status: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -12960,10 +12983,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized: boolean | null;
       /** Where this SavedQuery is created.
-
-      * `data_warehouse` - Data Warehouse
-      * `endpoint` - Endpoint
-      * `managed_viewset` - Managed Viewset */
+       *
+       * * `data_warehouse` - Data Warehouse
+       * * `endpoint` - Endpoint
+       * * `managed_viewset` - Managed Viewset */
       readonly origin: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       readonly is_test: boolean;
@@ -13237,153 +13260,153 @@ export namespace Schemas {
 
     /**
      * * `Ashby` - Ashby
-    * `Supabase` - Supabase
-    * `CustomerIO` - CustomerIO
-    * `Github` - Github
-    * `Stripe` - Stripe
-    * `Hubspot` - Hubspot
-    * `Postgres` - Postgres
-    * `Zendesk` - Zendesk
-    * `Snowflake` - Snowflake
-    * `Salesforce` - Salesforce
-    * `MySQL` - MySQL
-    * `MongoDB` - MongoDB
-    * `MSSQL` - MSSQL
-    * `Vitally` - Vitally
-    * `BigQuery` - BigQuery
-    * `Chargebee` - Chargebee
-    * `Clerk` - Clerk
-    * `GoogleAds` - GoogleAds
-    * `GoogleSearchConsole` - GoogleSearchConsole
-    * `TemporalIO` - TemporalIO
-    * `DoIt` - DoIt
-    * `GoogleSheets` - GoogleSheets
-    * `MetaAds` - MetaAds
-    * `Klaviyo` - Klaviyo
-    * `Mailchimp` - Mailchimp
-    * `Braze` - Braze
-    * `Mailjet` - Mailjet
-    * `Redshift` - Redshift
-    * `Polar` - Polar
-    * `RevenueCat` - RevenueCat
-    * `LinkedinAds` - LinkedinAds
-    * `RedditAds` - RedditAds
-    * `TikTokAds` - TikTokAds
-    * `BingAds` - BingAds
-    * `Shopify` - Shopify
-    * `Attio` - Attio
-    * `SnapchatAds` - SnapchatAds
-    * `Linear` - Linear
-    * `Intercom` - Intercom
-    * `Amplitude` - Amplitude
-    * `Mixpanel` - Mixpanel
-    * `Jira` - Jira
-    * `ActiveCampaign` - ActiveCampaign
-    * `Marketo` - Marketo
-    * `Adjust` - Adjust
-    * `AppsFlyer` - AppsFlyer
-    * `Freshdesk` - Freshdesk
-    * `GoogleAnalytics` - GoogleAnalytics
-    * `Pipedrive` - Pipedrive
-    * `SendGrid` - SendGrid
-    * `Slack` - Slack
-    * `PagerDuty` - PagerDuty
-    * `Asana` - Asana
-    * `Notion` - Notion
-    * `Airtable` - Airtable
-    * `Greenhouse` - Greenhouse
-    * `BambooHR` - BambooHR
-    * `Lever` - Lever
-    * `GitLab` - GitLab
-    * `Datadog` - Datadog
-    * `Sentry` - Sentry
-    * `Pendo` - Pendo
-    * `FullStory` - FullStory
-    * `AmazonAds` - AmazonAds
-    * `PinterestAds` - PinterestAds
-    * `AppleSearchAds` - AppleSearchAds
-    * `QuickBooks` - QuickBooks
-    * `Xero` - Xero
-    * `NetSuite` - NetSuite
-    * `WooCommerce` - WooCommerce
-    * `BigCommerce` - BigCommerce
-    * `PayPal` - PayPal
-    * `Square` - Square
-    * `Zoom` - Zoom
-    * `Trello` - Trello
-    * `Monday` - Monday
-    * `ClickUp` - ClickUp
-    * `Confluence` - Confluence
-    * `Recurly` - Recurly
-    * `SalesLoft` - SalesLoft
-    * `Outreach` - Outreach
-    * `Gong` - Gong
-    * `Calendly` - Calendly
-    * `Typeform` - Typeform
-    * `Iterable` - Iterable
-    * `ZohoCRM` - ZohoCRM
-    * `Close` - Close
-    * `Oracle` - Oracle
-    * `DynamoDB` - DynamoDB
-    * `Elasticsearch` - Elasticsearch
-    * `Kafka` - Kafka
-    * `LaunchDarkly` - LaunchDarkly
-    * `Braintree` - Braintree
-    * `Recharge` - Recharge
-    * `HelpScout` - HelpScout
-    * `Gorgias` - Gorgias
-    * `Instagram` - Instagram
-    * `YouTubeAnalytics` - YouTubeAnalytics
-    * `FacebookPages` - FacebookPages
-    * `TwitterAds` - TwitterAds
-    * `Workday` - Workday
-    * `ServiceNow` - ServiceNow
-    * `Pardot` - Pardot
-    * `Copper` - Copper
-    * `Front` - Front
-    * `ChartMogul` - ChartMogul
-    * `Zuora` - Zuora
-    * `Paddle` - Paddle
-    * `CircleCI` - CircleCI
-    * `CockroachDB` - CockroachDB
-    * `Firebase` - Firebase
-    * `AzureBlob` - AzureBlob
-    * `GoogleDrive` - GoogleDrive
-    * `OneDrive` - OneDrive
-    * `SharePoint` - SharePoint
-    * `Box` - Box
-    * `SFTP` - SFTP
-    * `MicrosoftTeams` - MicrosoftTeams
-    * `Aircall` - Aircall
-    * `Webflow` - Webflow
-    * `Okta` - Okta
-    * `Auth0` - Auth0
-    * `Productboard` - Productboard
-    * `Smartsheet` - Smartsheet
-    * `Wrike` - Wrike
-    * `Plaid` - Plaid
-    * `SurveyMonkey` - SurveyMonkey
-    * `Eventbrite` - Eventbrite
-    * `RingCentral` - RingCentral
-    * `Twilio` - Twilio
-    * `Freshsales` - Freshsales
-    * `Shortcut` - Shortcut
-    * `ConvertKit` - ConvertKit
-    * `Drip` - Drip
-    * `CampaignMonitor` - CampaignMonitor
-    * `MailerLite` - MailerLite
-    * `Omnisend` - Omnisend
-    * `Brevo` - Brevo
-    * `Postmark` - Postmark
-    * `Granola` - Granola
-    * `BuildBetter` - BuildBetter
-    * `Convex` - Convex
-    * `ClickHouse` - ClickHouse
-    * `Plain` - Plain
-    * `Resend` - Resend
-    * `PgAnalyze` - PgAnalyze
-    * `WorkOS` - WorkOS
-    * `Custom` - Custom
+     * * `Supabase` - Supabase
+     * * `CustomerIO` - CustomerIO
+     * * `Github` - Github
+     * * `Stripe` - Stripe
+     * * `Hubspot` - Hubspot
+     * * `Postgres` - Postgres
+     * * `Zendesk` - Zendesk
+     * * `Snowflake` - Snowflake
+     * * `Salesforce` - Salesforce
+     * * `MySQL` - MySQL
+     * * `MongoDB` - MongoDB
+     * * `MSSQL` - MSSQL
+     * * `Vitally` - Vitally
+     * * `BigQuery` - BigQuery
+     * * `Chargebee` - Chargebee
+     * * `Clerk` - Clerk
+     * * `GoogleAds` - GoogleAds
+     * * `GoogleSearchConsole` - GoogleSearchConsole
+     * * `TemporalIO` - TemporalIO
+     * * `DoIt` - DoIt
+     * * `GoogleSheets` - GoogleSheets
+     * * `MetaAds` - MetaAds
+     * * `Klaviyo` - Klaviyo
+     * * `Mailchimp` - Mailchimp
+     * * `Braze` - Braze
+     * * `Mailjet` - Mailjet
+     * * `Redshift` - Redshift
+     * * `Polar` - Polar
+     * * `RevenueCat` - RevenueCat
+     * * `LinkedinAds` - LinkedinAds
+     * * `RedditAds` - RedditAds
+     * * `TikTokAds` - TikTokAds
+     * * `BingAds` - BingAds
+     * * `Shopify` - Shopify
+     * * `Attio` - Attio
+     * * `SnapchatAds` - SnapchatAds
+     * * `Linear` - Linear
+     * * `Intercom` - Intercom
+     * * `Amplitude` - Amplitude
+     * * `Mixpanel` - Mixpanel
+     * * `Jira` - Jira
+     * * `ActiveCampaign` - ActiveCampaign
+     * * `Marketo` - Marketo
+     * * `Adjust` - Adjust
+     * * `AppsFlyer` - AppsFlyer
+     * * `Freshdesk` - Freshdesk
+     * * `GoogleAnalytics` - GoogleAnalytics
+     * * `Pipedrive` - Pipedrive
+     * * `SendGrid` - SendGrid
+     * * `Slack` - Slack
+     * * `PagerDuty` - PagerDuty
+     * * `Asana` - Asana
+     * * `Notion` - Notion
+     * * `Airtable` - Airtable
+     * * `Greenhouse` - Greenhouse
+     * * `BambooHR` - BambooHR
+     * * `Lever` - Lever
+     * * `GitLab` - GitLab
+     * * `Datadog` - Datadog
+     * * `Sentry` - Sentry
+     * * `Pendo` - Pendo
+     * * `FullStory` - FullStory
+     * * `AmazonAds` - AmazonAds
+     * * `PinterestAds` - PinterestAds
+     * * `AppleSearchAds` - AppleSearchAds
+     * * `QuickBooks` - QuickBooks
+     * * `Xero` - Xero
+     * * `NetSuite` - NetSuite
+     * * `WooCommerce` - WooCommerce
+     * * `BigCommerce` - BigCommerce
+     * * `PayPal` - PayPal
+     * * `Square` - Square
+     * * `Zoom` - Zoom
+     * * `Trello` - Trello
+     * * `Monday` - Monday
+     * * `ClickUp` - ClickUp
+     * * `Confluence` - Confluence
+     * * `Recurly` - Recurly
+     * * `SalesLoft` - SalesLoft
+     * * `Outreach` - Outreach
+     * * `Gong` - Gong
+     * * `Calendly` - Calendly
+     * * `Typeform` - Typeform
+     * * `Iterable` - Iterable
+     * * `ZohoCRM` - ZohoCRM
+     * * `Close` - Close
+     * * `Oracle` - Oracle
+     * * `DynamoDB` - DynamoDB
+     * * `Elasticsearch` - Elasticsearch
+     * * `Kafka` - Kafka
+     * * `LaunchDarkly` - LaunchDarkly
+     * * `Braintree` - Braintree
+     * * `Recharge` - Recharge
+     * * `HelpScout` - HelpScout
+     * * `Gorgias` - Gorgias
+     * * `Instagram` - Instagram
+     * * `YouTubeAnalytics` - YouTubeAnalytics
+     * * `FacebookPages` - FacebookPages
+     * * `TwitterAds` - TwitterAds
+     * * `Workday` - Workday
+     * * `ServiceNow` - ServiceNow
+     * * `Pardot` - Pardot
+     * * `Copper` - Copper
+     * * `Front` - Front
+     * * `ChartMogul` - ChartMogul
+     * * `Zuora` - Zuora
+     * * `Paddle` - Paddle
+     * * `CircleCI` - CircleCI
+     * * `CockroachDB` - CockroachDB
+     * * `Firebase` - Firebase
+     * * `AzureBlob` - AzureBlob
+     * * `GoogleDrive` - GoogleDrive
+     * * `OneDrive` - OneDrive
+     * * `SharePoint` - SharePoint
+     * * `Box` - Box
+     * * `SFTP` - SFTP
+     * * `MicrosoftTeams` - MicrosoftTeams
+     * * `Aircall` - Aircall
+     * * `Webflow` - Webflow
+     * * `Okta` - Okta
+     * * `Auth0` - Auth0
+     * * `Productboard` - Productboard
+     * * `Smartsheet` - Smartsheet
+     * * `Wrike` - Wrike
+     * * `Plaid` - Plaid
+     * * `SurveyMonkey` - SurveyMonkey
+     * * `Eventbrite` - Eventbrite
+     * * `RingCentral` - RingCentral
+     * * `Twilio` - Twilio
+     * * `Freshsales` - Freshsales
+     * * `Shortcut` - Shortcut
+     * * `ConvertKit` - ConvertKit
+     * * `Drip` - Drip
+     * * `CampaignMonitor` - CampaignMonitor
+     * * `MailerLite` - MailerLite
+     * * `Omnisend` - Omnisend
+     * * `Brevo` - Brevo
+     * * `Postmark` - Postmark
+     * * `Granola` - Granola
+     * * `BuildBetter` - BuildBetter
+     * * `Convex` - Convex
+     * * `ClickHouse` - ClickHouse
+     * * `Plain` - Plain
+     * * `Resend` - Resend
+     * * `PgAnalyze` - PgAnalyze
+     * * `WorkOS` - WorkOS
+     * * `Custom` - Custom
      */
     export type ExternalDataSourceTypeEnum = typeof ExternalDataSourceTypeEnum[keyof typeof ExternalDataSourceTypeEnum];
 
@@ -13541,162 +13564,162 @@ export namespace Schemas {
 
     /**
      * Validate credentials and preview available tables from a remote database.
-
-    The request body contains source_type plus flat source-specific credential fields
-    (e.g. host, port, database, user, password, schema for Postgres). The credential
-    fields vary per source_type and are validated dynamically by the source registry.
+     *
+     * The request body contains source_type plus flat source-specific credential fields
+     * (e.g. host, port, database, user, password, schema for Postgres). The credential
+     * fields vary per source_type and are validated dynamically by the source registry.
      */
     export interface DatabaseSchemaRequest {
       /** The source type to validate against.
-
-      * `Ashby` - Ashby
-      * `Supabase` - Supabase
-      * `CustomerIO` - CustomerIO
-      * `Github` - Github
-      * `Stripe` - Stripe
-      * `Hubspot` - Hubspot
-      * `Postgres` - Postgres
-      * `Zendesk` - Zendesk
-      * `Snowflake` - Snowflake
-      * `Salesforce` - Salesforce
-      * `MySQL` - MySQL
-      * `MongoDB` - MongoDB
-      * `MSSQL` - MSSQL
-      * `Vitally` - Vitally
-      * `BigQuery` - BigQuery
-      * `Chargebee` - Chargebee
-      * `Clerk` - Clerk
-      * `GoogleAds` - GoogleAds
-      * `GoogleSearchConsole` - GoogleSearchConsole
-      * `TemporalIO` - TemporalIO
-      * `DoIt` - DoIt
-      * `GoogleSheets` - GoogleSheets
-      * `MetaAds` - MetaAds
-      * `Klaviyo` - Klaviyo
-      * `Mailchimp` - Mailchimp
-      * `Braze` - Braze
-      * `Mailjet` - Mailjet
-      * `Redshift` - Redshift
-      * `Polar` - Polar
-      * `RevenueCat` - RevenueCat
-      * `LinkedinAds` - LinkedinAds
-      * `RedditAds` - RedditAds
-      * `TikTokAds` - TikTokAds
-      * `BingAds` - BingAds
-      * `Shopify` - Shopify
-      * `Attio` - Attio
-      * `SnapchatAds` - SnapchatAds
-      * `Linear` - Linear
-      * `Intercom` - Intercom
-      * `Amplitude` - Amplitude
-      * `Mixpanel` - Mixpanel
-      * `Jira` - Jira
-      * `ActiveCampaign` - ActiveCampaign
-      * `Marketo` - Marketo
-      * `Adjust` - Adjust
-      * `AppsFlyer` - AppsFlyer
-      * `Freshdesk` - Freshdesk
-      * `GoogleAnalytics` - GoogleAnalytics
-      * `Pipedrive` - Pipedrive
-      * `SendGrid` - SendGrid
-      * `Slack` - Slack
-      * `PagerDuty` - PagerDuty
-      * `Asana` - Asana
-      * `Notion` - Notion
-      * `Airtable` - Airtable
-      * `Greenhouse` - Greenhouse
-      * `BambooHR` - BambooHR
-      * `Lever` - Lever
-      * `GitLab` - GitLab
-      * `Datadog` - Datadog
-      * `Sentry` - Sentry
-      * `Pendo` - Pendo
-      * `FullStory` - FullStory
-      * `AmazonAds` - AmazonAds
-      * `PinterestAds` - PinterestAds
-      * `AppleSearchAds` - AppleSearchAds
-      * `QuickBooks` - QuickBooks
-      * `Xero` - Xero
-      * `NetSuite` - NetSuite
-      * `WooCommerce` - WooCommerce
-      * `BigCommerce` - BigCommerce
-      * `PayPal` - PayPal
-      * `Square` - Square
-      * `Zoom` - Zoom
-      * `Trello` - Trello
-      * `Monday` - Monday
-      * `ClickUp` - ClickUp
-      * `Confluence` - Confluence
-      * `Recurly` - Recurly
-      * `SalesLoft` - SalesLoft
-      * `Outreach` - Outreach
-      * `Gong` - Gong
-      * `Calendly` - Calendly
-      * `Typeform` - Typeform
-      * `Iterable` - Iterable
-      * `ZohoCRM` - ZohoCRM
-      * `Close` - Close
-      * `Oracle` - Oracle
-      * `DynamoDB` - DynamoDB
-      * `Elasticsearch` - Elasticsearch
-      * `Kafka` - Kafka
-      * `LaunchDarkly` - LaunchDarkly
-      * `Braintree` - Braintree
-      * `Recharge` - Recharge
-      * `HelpScout` - HelpScout
-      * `Gorgias` - Gorgias
-      * `Instagram` - Instagram
-      * `YouTubeAnalytics` - YouTubeAnalytics
-      * `FacebookPages` - FacebookPages
-      * `TwitterAds` - TwitterAds
-      * `Workday` - Workday
-      * `ServiceNow` - ServiceNow
-      * `Pardot` - Pardot
-      * `Copper` - Copper
-      * `Front` - Front
-      * `ChartMogul` - ChartMogul
-      * `Zuora` - Zuora
-      * `Paddle` - Paddle
-      * `CircleCI` - CircleCI
-      * `CockroachDB` - CockroachDB
-      * `Firebase` - Firebase
-      * `AzureBlob` - AzureBlob
-      * `GoogleDrive` - GoogleDrive
-      * `OneDrive` - OneDrive
-      * `SharePoint` - SharePoint
-      * `Box` - Box
-      * `SFTP` - SFTP
-      * `MicrosoftTeams` - MicrosoftTeams
-      * `Aircall` - Aircall
-      * `Webflow` - Webflow
-      * `Okta` - Okta
-      * `Auth0` - Auth0
-      * `Productboard` - Productboard
-      * `Smartsheet` - Smartsheet
-      * `Wrike` - Wrike
-      * `Plaid` - Plaid
-      * `SurveyMonkey` - SurveyMonkey
-      * `Eventbrite` - Eventbrite
-      * `RingCentral` - RingCentral
-      * `Twilio` - Twilio
-      * `Freshsales` - Freshsales
-      * `Shortcut` - Shortcut
-      * `ConvertKit` - ConvertKit
-      * `Drip` - Drip
-      * `CampaignMonitor` - CampaignMonitor
-      * `MailerLite` - MailerLite
-      * `Omnisend` - Omnisend
-      * `Brevo` - Brevo
-      * `Postmark` - Postmark
-      * `Granola` - Granola
-      * `BuildBetter` - BuildBetter
-      * `Convex` - Convex
-      * `ClickHouse` - ClickHouse
-      * `Plain` - Plain
-      * `Resend` - Resend
-      * `PgAnalyze` - PgAnalyze
-      * `WorkOS` - WorkOS
-      * `Custom` - Custom */
+       *
+       * * `Ashby` - Ashby
+       * * `Supabase` - Supabase
+       * * `CustomerIO` - CustomerIO
+       * * `Github` - Github
+       * * `Stripe` - Stripe
+       * * `Hubspot` - Hubspot
+       * * `Postgres` - Postgres
+       * * `Zendesk` - Zendesk
+       * * `Snowflake` - Snowflake
+       * * `Salesforce` - Salesforce
+       * * `MySQL` - MySQL
+       * * `MongoDB` - MongoDB
+       * * `MSSQL` - MSSQL
+       * * `Vitally` - Vitally
+       * * `BigQuery` - BigQuery
+       * * `Chargebee` - Chargebee
+       * * `Clerk` - Clerk
+       * * `GoogleAds` - GoogleAds
+       * * `GoogleSearchConsole` - GoogleSearchConsole
+       * * `TemporalIO` - TemporalIO
+       * * `DoIt` - DoIt
+       * * `GoogleSheets` - GoogleSheets
+       * * `MetaAds` - MetaAds
+       * * `Klaviyo` - Klaviyo
+       * * `Mailchimp` - Mailchimp
+       * * `Braze` - Braze
+       * * `Mailjet` - Mailjet
+       * * `Redshift` - Redshift
+       * * `Polar` - Polar
+       * * `RevenueCat` - RevenueCat
+       * * `LinkedinAds` - LinkedinAds
+       * * `RedditAds` - RedditAds
+       * * `TikTokAds` - TikTokAds
+       * * `BingAds` - BingAds
+       * * `Shopify` - Shopify
+       * * `Attio` - Attio
+       * * `SnapchatAds` - SnapchatAds
+       * * `Linear` - Linear
+       * * `Intercom` - Intercom
+       * * `Amplitude` - Amplitude
+       * * `Mixpanel` - Mixpanel
+       * * `Jira` - Jira
+       * * `ActiveCampaign` - ActiveCampaign
+       * * `Marketo` - Marketo
+       * * `Adjust` - Adjust
+       * * `AppsFlyer` - AppsFlyer
+       * * `Freshdesk` - Freshdesk
+       * * `GoogleAnalytics` - GoogleAnalytics
+       * * `Pipedrive` - Pipedrive
+       * * `SendGrid` - SendGrid
+       * * `Slack` - Slack
+       * * `PagerDuty` - PagerDuty
+       * * `Asana` - Asana
+       * * `Notion` - Notion
+       * * `Airtable` - Airtable
+       * * `Greenhouse` - Greenhouse
+       * * `BambooHR` - BambooHR
+       * * `Lever` - Lever
+       * * `GitLab` - GitLab
+       * * `Datadog` - Datadog
+       * * `Sentry` - Sentry
+       * * `Pendo` - Pendo
+       * * `FullStory` - FullStory
+       * * `AmazonAds` - AmazonAds
+       * * `PinterestAds` - PinterestAds
+       * * `AppleSearchAds` - AppleSearchAds
+       * * `QuickBooks` - QuickBooks
+       * * `Xero` - Xero
+       * * `NetSuite` - NetSuite
+       * * `WooCommerce` - WooCommerce
+       * * `BigCommerce` - BigCommerce
+       * * `PayPal` - PayPal
+       * * `Square` - Square
+       * * `Zoom` - Zoom
+       * * `Trello` - Trello
+       * * `Monday` - Monday
+       * * `ClickUp` - ClickUp
+       * * `Confluence` - Confluence
+       * * `Recurly` - Recurly
+       * * `SalesLoft` - SalesLoft
+       * * `Outreach` - Outreach
+       * * `Gong` - Gong
+       * * `Calendly` - Calendly
+       * * `Typeform` - Typeform
+       * * `Iterable` - Iterable
+       * * `ZohoCRM` - ZohoCRM
+       * * `Close` - Close
+       * * `Oracle` - Oracle
+       * * `DynamoDB` - DynamoDB
+       * * `Elasticsearch` - Elasticsearch
+       * * `Kafka` - Kafka
+       * * `LaunchDarkly` - LaunchDarkly
+       * * `Braintree` - Braintree
+       * * `Recharge` - Recharge
+       * * `HelpScout` - HelpScout
+       * * `Gorgias` - Gorgias
+       * * `Instagram` - Instagram
+       * * `YouTubeAnalytics` - YouTubeAnalytics
+       * * `FacebookPages` - FacebookPages
+       * * `TwitterAds` - TwitterAds
+       * * `Workday` - Workday
+       * * `ServiceNow` - ServiceNow
+       * * `Pardot` - Pardot
+       * * `Copper` - Copper
+       * * `Front` - Front
+       * * `ChartMogul` - ChartMogul
+       * * `Zuora` - Zuora
+       * * `Paddle` - Paddle
+       * * `CircleCI` - CircleCI
+       * * `CockroachDB` - CockroachDB
+       * * `Firebase` - Firebase
+       * * `AzureBlob` - AzureBlob
+       * * `GoogleDrive` - GoogleDrive
+       * * `OneDrive` - OneDrive
+       * * `SharePoint` - SharePoint
+       * * `Box` - Box
+       * * `SFTP` - SFTP
+       * * `MicrosoftTeams` - MicrosoftTeams
+       * * `Aircall` - Aircall
+       * * `Webflow` - Webflow
+       * * `Okta` - Okta
+       * * `Auth0` - Auth0
+       * * `Productboard` - Productboard
+       * * `Smartsheet` - Smartsheet
+       * * `Wrike` - Wrike
+       * * `Plaid` - Plaid
+       * * `SurveyMonkey` - SurveyMonkey
+       * * `Eventbrite` - Eventbrite
+       * * `RingCentral` - RingCentral
+       * * `Twilio` - Twilio
+       * * `Freshsales` - Freshsales
+       * * `Shortcut` - Shortcut
+       * * `ConvertKit` - ConvertKit
+       * * `Drip` - Drip
+       * * `CampaignMonitor` - CampaignMonitor
+       * * `MailerLite` - MailerLite
+       * * `Omnisend` - Omnisend
+       * * `Brevo` - Brevo
+       * * `Postmark` - Postmark
+       * * `Granola` - Granola
+       * * `BuildBetter` - BuildBetter
+       * * `Convex` - Convex
+       * * `ClickHouse` - ClickHouse
+       * * `Plain` - Plain
+       * * `Resend` - Resend
+       * * `PgAnalyze` - PgAnalyze
+       * * `WorkOS` - WorkOS
+       * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
     }
 
@@ -13760,7 +13783,7 @@ export namespace Schemas {
 
     /**
      * * `bayesian` - Bayesian
-    * `frequentist` - Frequentist
+     * * `frequentist` - Frequentist
      */
     export type DefaultExperimentStatsMethodEnum = typeof DefaultExperimentStatsMethodEnum[keyof typeof DefaultExperimentStatsMethodEnum];
 
@@ -13777,9 +13800,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `delivered` - Delivered
-    * `partial_failure` - Partial Failure
-    * `failed` - Failed
+     * * `delivered` - Delivered
+     * * `partial_failure` - Partial Failure
+     * * `failed` - Failed
      */
     export type DeliveryStatusEnum = typeof DeliveryStatusEnum[keyof typeof DeliveryStatusEnum];
 
@@ -13807,7 +13830,7 @@ export namespace Schemas {
 
     /**
      * * `html` - html
-    * `text` - text
+     * * `text` - text
      */
     export type DescriptionContentTypeEnum = typeof DescriptionContentTypeEnum[keyof typeof DescriptionContentTypeEnum];
 
@@ -13880,8 +13903,8 @@ export namespace Schemas {
 
     /**
      * * `Desktop` - Desktop
-    * `Mobile` - Mobile
-    * `Tablet` - Tablet
+     * * `Mobile` - Mobile
+     * * `Tablet` - Tablet
      */
     export type DeviceTypesEnum = typeof DeviceTypesEnum[keyof typeof DeviceTypesEnum];
 
@@ -13894,9 +13917,9 @@ export namespace Schemas {
 
     /**
      * * `passed` - passed
-    * `warned` - warned
-    * `failed` - failed
-    * `skipped` - skipped
+     * * `warned` - warned
+     * * `failed` - failed
+     * * `skipped` - skipped
      */
     export type DiagnosticCheckResultStatusEnum = typeof DiagnosticCheckResultStatusEnum[keyof typeof DiagnosticCheckResultStatusEnum];
 
@@ -13910,9 +13933,9 @@ export namespace Schemas {
 
     /**
      * * `dns` - dns
-    * `config` - config
-    * `wait` - wait
-    * `retry` - retry
+     * * `config` - config
+     * * `wait` - wait
+     * * `retry` - retry
      */
     export type DiagnosticRemediationTypeEnum = typeof DiagnosticRemediationTypeEnum[keyof typeof DiagnosticRemediationTypeEnum];
 
@@ -13935,11 +13958,11 @@ export namespace Schemas {
 
     export interface DiagnosticRemediation {
       /** Category of fix. dns: customer must change DNS records. config: customer must adjust their server config (e.g. allow port 80). wait: no action — the system will resolve on its own. retry: hit Retry.
-
-      * `dns` - dns
-      * `config` - config
-      * `wait` - wait
-      * `retry` - retry */
+       *
+       * * `dns` - dns
+       * * `config` - config
+       * * `wait` - wait
+       * * `retry` - retry */
       type: DiagnosticRemediationTypeEnum;
       /** One-line, action-oriented summary of what to do. */
       summary: string;
@@ -13953,11 +13976,11 @@ export namespace Schemas {
       /** Human-readable check name. */
       name: string;
       /** passed: ok. warned: degraded but not blocking. failed: blocking. skipped: not run for this state.
-
-      * `passed` - passed
-      * `warned` - warned
-      * `failed` - failed
-      * `skipped` - skipped */
+       *
+       * * `passed` - passed
+       * * `warned` - warned
+       * * `failed` - failed
+       * * `skipped` - skipped */
       status: DiagnosticCheckResultStatusEnum;
       /** Customer-facing explanation of the check's outcome. */
       detail: string;
@@ -13967,8 +13990,8 @@ export namespace Schemas {
 
     /**
      * * `healthy` - healthy
-    * `warn` - warn
-    * `fail` - fail
+     * * `warn` - warn
+     * * `fail` - fail
      */
     export type DiagnosticReportSummaryStatusEnum = typeof DiagnosticReportSummaryStatusEnum[keyof typeof DiagnosticReportSummaryStatusEnum];
 
@@ -13981,10 +14004,10 @@ export namespace Schemas {
 
     export interface DiagnosticReportSummary {
       /** Overall outcome: healthy if the proxy is serving requests, warn for non-blocking issues, fail otherwise.
-
-      * `healthy` - healthy
-      * `warn` - warn
-      * `fail` - fail */
+       *
+       * * `healthy` - healthy
+       * * `warn` - warn
+       * * `fail` - fail */
       status: DiagnosticReportSummaryStatusEnum;
       /**
          * Check id of the most actionable failure, if any. Null when status is healthy.
@@ -14009,7 +14032,7 @@ export namespace Schemas {
 
     /**
      * * `Up` - Up
-    * `Down` - Down
+     * * `Down` - Down
      */
     export type DirectionEnum = typeof DirectionEnum[keyof typeof DirectionEnum];
 
@@ -14138,9 +14161,9 @@ export namespace Schemas {
       /** Absolute percentage change, rounded to nearest integer. */
       percent: number;
       /** Direction of the change relative to the prior period.
-
-      * `Up` - Up
-      * `Down` - Down */
+       *
+       * * `Up` - Up
+       * * `Down` - Down */
       direction: DirectionEnum;
       /** Hex color indicating whether the change is a positive or negative signal. */
       color: string;
@@ -14187,26 +14210,26 @@ export namespace Schemas {
          */
       version?: number | null;
       /** Specifies where this feature flag should be evaluated
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-
-      * `distinct_id` - User ID (default)
-      * `device_id` - Device ID */
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       readonly evaluation_contexts: readonly string[];
     }
 
     /**
      * * `draft` - draft
-    * `concept` - concept
-    * `alpha` - alpha
-    * `beta` - beta
-    * `general-availability` - general availability
-    * `archived` - archived
+     * * `concept` - concept
+     * * `alpha` - alpha
+     * * `beta` - beta
+     * * `general-availability` - general availability
+     * * `archived` - archived
      */
     export type StageEnum = typeof StageEnum[keyof typeof StageEnum];
 
@@ -14231,13 +14254,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-      * `draft` - draft
-      * `concept` - concept
-      * `alpha` - alpha
-      * `beta` - beta
-      * `general-availability` - general availability
-      * `archived` - archived */
+       *
+       * * `draft` - draft
+       * * `concept` - concept
+       * * `alpha` - alpha
+       * * `beta` - beta
+       * * `general-availability` - general availability
+       * * `archived` - archived */
       stage: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -14259,13 +14282,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-      * `draft` - draft
-      * `concept` - concept
-      * `alpha` - alpha
-      * `beta` - beta
-      * `general-availability` - general availability
-      * `archived` - archived */
+       *
+       * * `draft` - draft
+       * * `concept` - concept
+       * * `alpha` - alpha
+       * * `beta` - beta
+       * * `general-availability` - general availability
+       * * `archived` - archived */
       stage: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -14313,7 +14336,10 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -14415,12 +14441,12 @@ export namespace Schemas {
          */
       hypothesis?: string | null;
       /** Optional severity tag — one of P0, P1, P2, P3, P4. Informational only.
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
+       *
+       * * `P0` - P0
+       * * `P1` - P1
+       * * `P2` - P2
+       * * `P3` - P3
+       * * `P4` - P4 */
       severity?: AutonomyPriorityEnum | null;
       /** Optional keys for downstream dedupe (e.g. `error_tracking_issue:<id>`). */
       dedupe_keys?: string[];
@@ -14453,12 +14479,12 @@ export namespace Schemas {
 
     export interface EndExperiment {
       /** The conclusion of the experiment.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
@@ -14662,14 +14688,14 @@ export namespace Schemas {
 
     /**
      * Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-
-    For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-
-    For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-
-    For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-
-    Unknown variable names will return a 400 error.
+     *
+     * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+     *
+     * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+     *
+     * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+     *
+     * Unknown variable names will return a 400 error.
      */
     export type EndpointRunRequestVariables = { [key: string]: unknown } | null;
 
@@ -14685,14 +14711,14 @@ export namespace Schemas {
       offset?: number | null;
       refresh?: EndpointRefreshMode | null;
       /** Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-
-      For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-
-      For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-
-      For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-
-      Unknown variable names will return a 400 error. */
+       *
+       * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
+       *
+       * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
+       *
+       * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
+       *
+       * Unknown variable names will return a 400 error. */
       variables?: EndpointRunRequestVariables;
       /** Specific endpoint version to execute. If not provided, the latest version is used. */
       version?: number | null;
@@ -14922,7 +14948,7 @@ export namespace Schemas {
 
     /**
      * * `allow` - Allow
-    * `reject` - Reject
+     * * `reject` - Reject
      */
     export type EnforcementModeEnum = typeof EnforcementModeEnum[keyof typeof EnforcementModeEnum];
 
@@ -14934,7 +14960,7 @@ export namespace Schemas {
 
     /**
      * * `duckdb` - duckdb
-    * `postgres` - postgres
+     * * `postgres` - postgres
      */
     export type EngineEnum = typeof EngineEnum[keyof typeof EngineEnum];
 
@@ -14946,8 +14972,8 @@ export namespace Schemas {
 
     /**
      * * `open` - OPEN
-    * `closed` - CLOSED
-    * `merged` - MERGED
+     * * `closed` - CLOSED
+     * * `merged` - MERGED
      */
     export type EngineeringAnalyticsPRStateEnum = typeof EngineeringAnalyticsPRStateEnum[keyof typeof EngineeringAnalyticsPRStateEnum];
 
@@ -15002,10 +15028,10 @@ export namespace Schemas {
 
     /**
      * * `DateTime` - DateTime
-    * `String` - String
-    * `Numeric` - Numeric
-    * `Boolean` - Boolean
-    * `Duration` - Duration
+     * * `String` - String
+     * * `Numeric` - Numeric
+     * * `Boolean` - Boolean
+     * * `Duration` - Duration
      */
     export type PropertyDefinitionTypeEnum = typeof PropertyDefinitionTypeEnum[keyof typeof PropertyDefinitionTypeEnum];
 
@@ -15104,9 +15130,9 @@ export namespace Schemas {
 
     export interface ErrorTrackingAssignmentRuleAssigneeRequest {
       /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-
-      * `user` - user
-      * `role` - role */
+       *
+       * * `user` - user
+       * * `role` - role */
       type: AssigneeTypeEnum;
       /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
       id: number | string;
@@ -15254,9 +15280,9 @@ export namespace Schemas {
 
     export interface ErrorTrackingGroupingRuleAssigneeRequest {
       /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
-
-      * `user` - user
-      * `role` - role */
+       *
+       * * `user` - user
+       * * `role` - role */
       type: AssigneeTypeEnum;
       /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
       id: number | string;
@@ -15381,22 +15407,22 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `gte` - gte
-    * `lte` - lte
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
-    * `is_date_exact` - is_date_exact
-    * `is_date_after` - is_date_after
-    * `is_date_before` - is_date_before
-    * `in` - in
-    * `not_in` - not_in
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `gte` - gte
+     * * `lte` - lte
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_after` - is_date_after
+     * * `is_date_before` - is_date_before
+     * * `in` - in
+     * * `not_in` - not_in
      */
     export type PropertyItemOperatorEnum = typeof PropertyItemOperatorEnum[keyof typeof PropertyItemOperatorEnum];
 
@@ -15433,8 +15459,8 @@ export namespace Schemas {
 
     /**
      * * `summary` - summary
-    * `stack` - stack
-    * `raw` - raw
+     * * `stack` - stack
+     * * `raw` - raw
      */
     export type VerbosityEnum = typeof VerbosityEnum[keyof typeof VerbosityEnum];
 
@@ -15460,9 +15486,9 @@ export namespace Schemas {
          */
       searchQuery?: string;
       /** Timestamp sort direction. Defaults to DESC.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /**
          * Page size.
@@ -15476,10 +15502,10 @@ export namespace Schemas {
          */
       offset?: number;
       /** Controls exception detail size: summary, stack, or raw. Defaults to summary.
-
-      * `summary` - summary
-      * `stack` - stack
-      * `raw` - raw */
+       *
+       * * `summary` - summary
+       * * `stack` - stack
+       * * `raw` - raw */
       verbosity?: VerbosityEnum;
       /** When true, include only stack frames marked in_app. Defaults to true. */
       onlyAppFrames?: boolean;
@@ -15508,10 +15534,10 @@ export namespace Schemas {
 
     /**
      * * `archived` - Archived
-    * `active` - Active
-    * `resolved` - Resolved
-    * `pending_release` - Pending release
-    * `suppressed` - Suppressed
+     * * `active` - Active
+     * * `resolved` - Resolved
+     * * `pending_release` - Pending release
+     * * `suppressed` - Suppressed
      */
     export type ErrorTrackingIssueFullStatusEnum = typeof ErrorTrackingIssueFullStatusEnum[keyof typeof ErrorTrackingIssueFullStatusEnum];
 
@@ -15631,13 +15657,13 @@ export namespace Schemas {
       /** Date range for issue aggregates. Defaults to the last 7 days. */
       dateRange?: ErrorTrackingDateRange;
       /** Filter by issue status. Defaults to active.
-
-      * `archived` - archived
-      * `active` - active
-      * `resolved` - resolved
-      * `pending_release` - pending_release
-      * `suppressed` - suppressed
-      * `all` - all */
+       *
+       * * `archived` - archived
+       * * `active` - active
+       * * `resolved` - resolved
+       * * `pending_release` - pending_release
+       * * `suppressed` - suppressed
+       * * `all` - all */
       status?: ErrorTrackingIssueStatusEnum;
       /** Filter by issue assignee. Omit to include all assignees. */
       assignee?: ErrorTrackingAssignee | null;
@@ -15651,17 +15677,17 @@ export namespace Schemas {
       /** Advanced flat AND property filters. Prefer typed shortcut fields when they fit. HogQL filters are rejected. */
       filterGroup?: PropertyItem[];
       /** Field used to sort issues. Defaults to occurrences.
-
-      * `last_seen` - last_seen
-      * `first_seen` - first_seen
-      * `occurrences` - occurrences
-      * `users` - users
-      * `sessions` - sessions */
+       *
+       * * `last_seen` - last_seen
+       * * `first_seen` - first_seen
+       * * `occurrences` - occurrences
+       * * `users` - users
+       * * `sessions` - sessions */
       orderBy?: ErrorTrackingIssueOrderByEnum;
       /** Sort direction. Defaults to DESC.
-
-      * `ASC` - ASC
-      * `DESC` - DESC */
+       *
+       * * `ASC` - ASC
+       * * `DESC` - DESC */
       orderDirection?: OrderDirectionEnum;
       /**
          * Page size.
@@ -15738,7 +15764,7 @@ export namespace Schemas {
 
     /**
      * * `ready` - Ready
-    * `computing` - Computing
+     * * `computing` - Computing
      */
     export type ErrorTrackingRecommendationStatusEnum = typeof ErrorTrackingRecommendationStatusEnum[keyof typeof ErrorTrackingRecommendationStatusEnum];
 
@@ -15758,9 +15784,9 @@ export namespace Schemas {
       /** Whether the recommendation's recommended action has been satisfied. */
       readonly completed: boolean;
       /** 'ready' if meta is fresh, 'computing' if a refresh is in progress.
-
-      * `ready` - Ready
-      * `computing` - Computing */
+       *
+       * * `ready` - Ready
+       * * `computing` - Computing */
       readonly status: ErrorTrackingRecommendationStatusEnum;
       /**
          * Timestamp meta was last successfully computed.
@@ -16087,8 +16113,8 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-    * `paused` - Paused
-    * `error` - Error
+     * * `paused` - Paused
+     * * `error` - Error
      */
     export type EvaluationStatusEnum = typeof EvaluationStatusEnum[keyof typeof EvaluationStatusEnum];
 
@@ -16101,8 +16127,8 @@ export namespace Schemas {
 
     /**
      * * `trial_limit_reached` - Trial evaluation limit reached
-    * `model_not_allowed` - Model not available on the trial plan
-    * `provider_key_deleted` - Provider API key was deleted
+     * * `model_not_allowed` - Model not available on the trial plan
+     * * `provider_key_deleted` - Provider API key was deleted
      */
     export type StatusReasonEnum = typeof StatusReasonEnum[keyof typeof StatusReasonEnum];
 
@@ -16115,7 +16141,7 @@ export namespace Schemas {
 
     /**
      * * `llm_judge` - LLM as a judge
-    * `hog` - Hog
+     * * `hog` - Hog
      */
     export type EvaluationTypeEnum = typeof EvaluationTypeEnum[keyof typeof EvaluationTypeEnum];
 
@@ -16158,12 +16184,12 @@ export namespace Schemas {
 
     /**
      * * `openai` - Openai
-    * `anthropic` - Anthropic
-    * `gemini` - Gemini
-    * `openrouter` - Openrouter
-    * `fireworks` - Fireworks
-    * `azure_openai` - Azure OpenAI
-    * `together_ai` - Together AI
+     * * `anthropic` - Anthropic
+     * * `gemini` - Gemini
+     * * `openrouter` - Openrouter
+     * * `fireworks` - Fireworks
+     * * `azure_openai` - Azure OpenAI
+     * * `together_ai` - Together AI
      */
     export type LLMProviderEnum = typeof LLMProviderEnum[keyof typeof LLMProviderEnum];
 
@@ -16205,15 +16231,15 @@ export namespace Schemas {
       readonly status: EvaluationStatusEnum;
       readonly status_reason: StatusReasonEnum | null;
       /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-
-      * `llm_judge` - LLM as a judge
-      * `hog` - Hog */
+       *
+       * * `llm_judge` - LLM as a judge
+       * * `hog` - Hog */
       evaluation_type: EvaluationTypeEnum;
       /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
       evaluation_config?: EvaluationEvaluationConfig;
       /** Output format. Currently only 'boolean' is supported.
-
-      * `boolean` - Boolean (Pass/Fail) */
+       *
+       * * `boolean` - Boolean (Pass/Fail) */
       output_type: OutputTypeEnum;
       /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
       output_config?: EvaluationOutputConfig;
@@ -16229,9 +16255,9 @@ export namespace Schemas {
 
     /**
      * * `unknown` - Unknown
-    * `ok` - Ok
-    * `invalid` - Invalid
-    * `error` - Error
+     * * `ok` - Ok
+     * * `invalid` - Invalid
+     * * `error` - Error
      */
     export type LLMProviderKeyStateEnum = typeof LLMProviderKeyStateEnum[keyof typeof LLMProviderKeyStateEnum];
 
@@ -16306,7 +16332,7 @@ export namespace Schemas {
 
     /**
      * * `scheduled` - Scheduled
-    * `every_n` - Every N
+     * * `every_n` - Every N
      */
     export type EvaluationReportFrequencyEnum = typeof EvaluationReportFrequencyEnum[keyof typeof EvaluationReportFrequencyEnum];
 
@@ -16321,9 +16347,9 @@ export namespace Schemas {
       /** UUID of the evaluation this report config belongs to. */
       evaluation: string;
       /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-
-      * `scheduled` - Scheduled
-      * `every_n` - Every N */
+       *
+       * * `scheduled` - Scheduled
+       * * `every_n` - Every N */
       frequency?: EvaluationReportFrequencyEnum;
       /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
       rrule?: string;
@@ -16393,11 +16419,11 @@ export namespace Schemas {
       /** End of the evaluation window covered by this report. */
       readonly period_end: string;
       /** 'pending', 'delivered', or 'failed'.
-
-      * `pending` - Pending
-      * `delivered` - Delivered
-      * `partial_failure` - Partial Failure
-      * `failed` - Failed */
+       *
+       * * `pending` - Pending
+       * * `delivered` - Delivered
+       * * `partial_failure` - Partial Failure
+       * * `failed` - Failed */
       readonly delivery_status: DeliveryStatusEnum;
       /** List of delivery error messages if delivery failed. */
       readonly delivery_errors: unknown;
@@ -16422,9 +16448,9 @@ export namespace Schemas {
 
     /**
      * * `all` - all
-    * `pass` - pass
-    * `fail` - fail
-    * `na` - na
+     * * `pass` - pass
+     * * `fail` - fail
+     * * `na` - na
      */
     export type FilterEnum = typeof FilterEnum[keyof typeof FilterEnum];
 
@@ -16443,11 +16469,11 @@ export namespace Schemas {
       /** UUID of the evaluation config to summarize */
       evaluation_id: string;
       /** Filter type to apply ('all', 'pass', 'fail', or 'na')
-
-      * `all` - all
-      * `pass` - pass
-      * `fail` - fail
-      * `na` - na */
+       *
+       * * `all` - all
+       * * `pass` - pass
+       * * `fail` - fail
+       * * `na` - na */
       filter?: FilterEnum;
       /**
          * Optional: specific generation IDs to include in summary (max 250)
@@ -16509,8 +16535,8 @@ export namespace Schemas {
 
     /**
      * * `disabled` - Disabled
-    * `dry_run` - Dry Run
-    * `live` - Live
+     * * `dry_run` - Dry Run
+     * * `live` - Live
      */
     export type EventFilterConfigModeEnum = typeof EventFilterConfigModeEnum[keyof typeof EventFilterConfigModeEnum];
 
@@ -16534,10 +16560,10 @@ export namespace Schemas {
 
     /**
      * * `DateTime` - DateTime
-    * `String` - String
-    * `Numeric` - Numeric
-    * `Boolean` - Boolean
-    * `Object` - Object
+     * * `String` - String
+     * * `Numeric` - Numeric
+     * * `Boolean` - Boolean
+     * * `Object` - Object
      */
     export type SchemaPropertyGroupPropertyPropertyTypeEnum = typeof SchemaPropertyGroupPropertyPropertyTypeEnum[keyof typeof SchemaPropertyGroupPropertyPropertyTypeEnum];
 
@@ -16665,9 +16691,9 @@ export namespace Schemas {
 
     /**
      * * `$ai_generation` - $ai_generation
-    * `$ai_span` - $ai_span
-    * `$ai_embedding` - $ai_embedding
-    * `$ai_trace` - $ai_trace
+     * * `$ai_span` - $ai_span
+     * * `$ai_embedding` - $ai_embedding
+     * * `$ai_trace` - $ai_trace
      */
     export type EventTypeEnum = typeof EventTypeEnum[keyof typeof EventTypeEnum];
 
@@ -16736,9 +16762,9 @@ export namespace Schemas {
 
     /**
      * * `exit_on_conversion` - Conversion
-    * `exit_on_trigger_not_matched` - Trigger Not Matched
-    * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-    * `exit_only_at_end` - Only At End
+     * * `exit_on_trigger_not_matched` - Trigger Not Matched
+     * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+     * * `exit_only_at_end` - Only At End
      */
     export type ExitConditionEnum = typeof ExitConditionEnum[keyof typeof ExitConditionEnum];
 
@@ -16798,7 +16824,7 @@ export namespace Schemas {
 
     /**
      * * `web` - web
-    * `product` - product
+     * * `product` - product
      */
     export type ExperimentTypeEnum = typeof ExperimentTypeEnum[keyof typeof ExperimentTypeEnum];
 
@@ -16971,9 +16997,9 @@ export namespace Schemas {
       readonly created_at: string;
       readonly updated_at: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
-
-      * `web` - web
-      * `product` - product */
+       *
+       * * `web` - web
+       * * `product` - product */
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
@@ -16987,12 +17013,12 @@ export namespace Schemas {
       allow_unknown_events?: boolean;
       _create_in_folder?: string;
       /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
@@ -17086,8 +17112,8 @@ export namespace Schemas {
 
     /**
      * * `categorical` - categorical
-    * `numeric` - numeric
-    * `boolean` - boolean
+     * * `numeric` - numeric
+     * * `boolean` - boolean
      */
     export type ExperimentMetricKindEnum = typeof ExperimentMetricKindEnum[keyof typeof ExperimentMetricKindEnum];
 
@@ -17138,13 +17164,13 @@ export namespace Schemas {
 
     /**
      * * `image/png` - image/png
-    * `application/pdf` - application/pdf
-    * `text/csv` - text/csv
-    * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-    * `video/webm` - video/webm
-    * `video/mp4` - video/mp4
-    * `image/gif` - image/gif
-    * `application/json` - application/json
+     * * `application/pdf` - application/pdf
+     * * `text/csv` - text/csv
+     * * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+     * * `video/webm` - video/webm
+     * * `video/mp4` - video/mp4
+     * * `image/gif` - image/gif
+     * * `application/json` - application/json
      */
     export type ExportFormatEnum = typeof ExportFormatEnum[keyof typeof ExportFormatEnum];
 
@@ -17205,10 +17231,10 @@ export namespace Schemas {
 
     /**
      * * `full_refresh` - full_refresh
-    * `incremental` - incremental
-    * `append` - append
-    * `webhook` - webhook
-    * `cdc` - cdc
+     * * `incremental` - incremental
+     * * `append` - append
+     * * `webhook` - webhook
+     * * `cdc` - cdc
      */
     export type SyncTypeEnum = typeof SyncTypeEnum[keyof typeof SyncTypeEnum];
 
@@ -17223,11 +17249,11 @@ export namespace Schemas {
 
     /**
      * * `integer` - integer
-    * `numeric` - numeric
-    * `datetime` - datetime
-    * `date` - date
-    * `timestamp` - timestamp
-    * `objectid` - objectid
+     * * `numeric` - numeric
+     * * `datetime` - datetime
+     * * `date` - date
+     * * `timestamp` - timestamp
+     * * `objectid` - objectid
      */
     export type IncrementalFieldTypeEnum = typeof IncrementalFieldTypeEnum[keyof typeof IncrementalFieldTypeEnum];
 
@@ -17243,16 +17269,16 @@ export namespace Schemas {
 
     /**
      * * `never` - never
-    * `1min` - 1min
-    * `5min` - 5min
-    * `15min` - 15min
-    * `30min` - 30min
-    * `1hour` - 1hour
-    * `6hour` - 6hour
-    * `12hour` - 12hour
-    * `24hour` - 24hour
-    * `7day` - 7day
-    * `30day` - 30day
+     * * `1min` - 1min
+     * * `5min` - 5min
+     * * `15min` - 15min
+     * * `30min` - 30min
+     * * `1hour` - 1hour
+     * * `6hour` - 6hour
+     * * `12hour` - 12hour
+     * * `24hour` - 24hour
+     * * `7day` - 7day
+     * * `30day` - 30day
      */
     export type SyncFrequencyEnum = typeof SyncFrequencyEnum[keyof typeof SyncFrequencyEnum];
 
@@ -17290,12 +17316,12 @@ export namespace Schemas {
       /** @nullable */
       readonly status: string | null;
       /** Sync strategy: incremental, full_refresh, append, or cdc.
-
-      * `full_refresh` - full_refresh
-      * `incremental` - incremental
-      * `append` - append
-      * `webhook` - webhook
-      * `cdc` - cdc */
+       *
+       * * `full_refresh` - full_refresh
+       * * `incremental` - incremental
+       * * `append` - append
+       * * `webhook` - webhook
+       * * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Column name used to track sync progress.
@@ -17303,27 +17329,27 @@ export namespace Schemas {
          */
       incremental_field?: string | null;
       /** Data type of the incremental field.
-
-      * `integer` - integer
-      * `numeric` - numeric
-      * `datetime` - datetime
-      * `date` - date
-      * `timestamp` - timestamp
-      * `objectid` - objectid */
+       *
+       * * `integer` - integer
+       * * `numeric` - numeric
+       * * `datetime` - datetime
+       * * `date` - date
+       * * `timestamp` - timestamp
+       * * `objectid` - objectid */
       incremental_field_type?: IncrementalFieldTypeEnum | null;
       /** How often to sync.
-
-      * `never` - never
-      * `1min` - 1min
-      * `5min` - 5min
-      * `15min` - 15min
-      * `30min` - 30min
-      * `1hour` - 1hour
-      * `6hour` - 6hour
-      * `12hour` - 12hour
-      * `24hour` - 24hour
-      * `7day` - 7day
-      * `30day` - 30day */
+       *
+       * * `never` - never
+       * * `1min` - 1min
+       * * `5min` - 5min
+       * * `15min` - 15min
+       * * `30min` - 30min
+       * * `1hour` - 1hour
+       * * `6hour` - 6hour
+       * * `12hour` - 12hour
+       * * `24hour` - 24hour
+       * * `7day` - 7day
+       * * `30day` - 30day */
       sync_frequency?: SyncFrequencyEnum | null;
       /**
          * UTC time of day to run the sync (HH:MM:SS).
@@ -17338,10 +17364,10 @@ export namespace Schemas {
          */
       primary_key_columns?: string[] | null;
       /** For CDC syncs: consolidated, cdc_only, or both.
-
-      * `consolidated` - consolidated
-      * `cdc_only` - cdc_only
-      * `both` - both */
+       *
+       * * `consolidated` - consolidated
+       * * `cdc_only` - cdc_only
+       * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -17363,12 +17389,12 @@ export namespace Schemas {
       /** Whether the schema should be queryable/synced. */
       should_sync?: boolean;
       /** Requested sync mode for the schema.
-
-      * `full_refresh` - full_refresh
-      * `incremental` - incremental
-      * `append` - append
-      * `webhook` - webhook
-      * `cdc` - cdc */
+       *
+       * * `full_refresh` - full_refresh
+       * * `incremental` - incremental
+       * * `append` - append
+       * * `webhook` - webhook
+       * * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Incremental cursor field for incremental or append syncs.
@@ -17391,10 +17417,10 @@ export namespace Schemas {
          */
       sync_time_of_day?: string | null;
       /** How CDC-backed tables should be exposed.
-
-      * `consolidated` - consolidated
-      * `cdc_only` - cdc_only
-      * `both` - both */
+       *
+       * * `consolidated` - consolidated
+       * * `cdc_only` - cdc_only
+       * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Columns to sync. Null means sync all columns.
@@ -17408,9 +17434,9 @@ export namespace Schemas {
       /** @nullable */
       readonly prefix: string | null;
       /** Backend engine detected for the direct connection.
-
-      * `duckdb` - duckdb
-      * `postgres` - postgres */
+       *
+       * * `duckdb` - duckdb
+       * * `postgres` - postgres */
       readonly engine: EngineEnum | null;
     }
 
@@ -17421,155 +17447,155 @@ export namespace Schemas {
 
     export interface ExternalDataSourceCreate {
       /** The source type (e.g. 'Postgres', 'Stripe').
-
-      * `Ashby` - Ashby
-      * `Supabase` - Supabase
-      * `CustomerIO` - CustomerIO
-      * `Github` - Github
-      * `Stripe` - Stripe
-      * `Hubspot` - Hubspot
-      * `Postgres` - Postgres
-      * `Zendesk` - Zendesk
-      * `Snowflake` - Snowflake
-      * `Salesforce` - Salesforce
-      * `MySQL` - MySQL
-      * `MongoDB` - MongoDB
-      * `MSSQL` - MSSQL
-      * `Vitally` - Vitally
-      * `BigQuery` - BigQuery
-      * `Chargebee` - Chargebee
-      * `Clerk` - Clerk
-      * `GoogleAds` - GoogleAds
-      * `GoogleSearchConsole` - GoogleSearchConsole
-      * `TemporalIO` - TemporalIO
-      * `DoIt` - DoIt
-      * `GoogleSheets` - GoogleSheets
-      * `MetaAds` - MetaAds
-      * `Klaviyo` - Klaviyo
-      * `Mailchimp` - Mailchimp
-      * `Braze` - Braze
-      * `Mailjet` - Mailjet
-      * `Redshift` - Redshift
-      * `Polar` - Polar
-      * `RevenueCat` - RevenueCat
-      * `LinkedinAds` - LinkedinAds
-      * `RedditAds` - RedditAds
-      * `TikTokAds` - TikTokAds
-      * `BingAds` - BingAds
-      * `Shopify` - Shopify
-      * `Attio` - Attio
-      * `SnapchatAds` - SnapchatAds
-      * `Linear` - Linear
-      * `Intercom` - Intercom
-      * `Amplitude` - Amplitude
-      * `Mixpanel` - Mixpanel
-      * `Jira` - Jira
-      * `ActiveCampaign` - ActiveCampaign
-      * `Marketo` - Marketo
-      * `Adjust` - Adjust
-      * `AppsFlyer` - AppsFlyer
-      * `Freshdesk` - Freshdesk
-      * `GoogleAnalytics` - GoogleAnalytics
-      * `Pipedrive` - Pipedrive
-      * `SendGrid` - SendGrid
-      * `Slack` - Slack
-      * `PagerDuty` - PagerDuty
-      * `Asana` - Asana
-      * `Notion` - Notion
-      * `Airtable` - Airtable
-      * `Greenhouse` - Greenhouse
-      * `BambooHR` - BambooHR
-      * `Lever` - Lever
-      * `GitLab` - GitLab
-      * `Datadog` - Datadog
-      * `Sentry` - Sentry
-      * `Pendo` - Pendo
-      * `FullStory` - FullStory
-      * `AmazonAds` - AmazonAds
-      * `PinterestAds` - PinterestAds
-      * `AppleSearchAds` - AppleSearchAds
-      * `QuickBooks` - QuickBooks
-      * `Xero` - Xero
-      * `NetSuite` - NetSuite
-      * `WooCommerce` - WooCommerce
-      * `BigCommerce` - BigCommerce
-      * `PayPal` - PayPal
-      * `Square` - Square
-      * `Zoom` - Zoom
-      * `Trello` - Trello
-      * `Monday` - Monday
-      * `ClickUp` - ClickUp
-      * `Confluence` - Confluence
-      * `Recurly` - Recurly
-      * `SalesLoft` - SalesLoft
-      * `Outreach` - Outreach
-      * `Gong` - Gong
-      * `Calendly` - Calendly
-      * `Typeform` - Typeform
-      * `Iterable` - Iterable
-      * `ZohoCRM` - ZohoCRM
-      * `Close` - Close
-      * `Oracle` - Oracle
-      * `DynamoDB` - DynamoDB
-      * `Elasticsearch` - Elasticsearch
-      * `Kafka` - Kafka
-      * `LaunchDarkly` - LaunchDarkly
-      * `Braintree` - Braintree
-      * `Recharge` - Recharge
-      * `HelpScout` - HelpScout
-      * `Gorgias` - Gorgias
-      * `Instagram` - Instagram
-      * `YouTubeAnalytics` - YouTubeAnalytics
-      * `FacebookPages` - FacebookPages
-      * `TwitterAds` - TwitterAds
-      * `Workday` - Workday
-      * `ServiceNow` - ServiceNow
-      * `Pardot` - Pardot
-      * `Copper` - Copper
-      * `Front` - Front
-      * `ChartMogul` - ChartMogul
-      * `Zuora` - Zuora
-      * `Paddle` - Paddle
-      * `CircleCI` - CircleCI
-      * `CockroachDB` - CockroachDB
-      * `Firebase` - Firebase
-      * `AzureBlob` - AzureBlob
-      * `GoogleDrive` - GoogleDrive
-      * `OneDrive` - OneDrive
-      * `SharePoint` - SharePoint
-      * `Box` - Box
-      * `SFTP` - SFTP
-      * `MicrosoftTeams` - MicrosoftTeams
-      * `Aircall` - Aircall
-      * `Webflow` - Webflow
-      * `Okta` - Okta
-      * `Auth0` - Auth0
-      * `Productboard` - Productboard
-      * `Smartsheet` - Smartsheet
-      * `Wrike` - Wrike
-      * `Plaid` - Plaid
-      * `SurveyMonkey` - SurveyMonkey
-      * `Eventbrite` - Eventbrite
-      * `RingCentral` - RingCentral
-      * `Twilio` - Twilio
-      * `Freshsales` - Freshsales
-      * `Shortcut` - Shortcut
-      * `ConvertKit` - ConvertKit
-      * `Drip` - Drip
-      * `CampaignMonitor` - CampaignMonitor
-      * `MailerLite` - MailerLite
-      * `Omnisend` - Omnisend
-      * `Brevo` - Brevo
-      * `Postmark` - Postmark
-      * `Granola` - Granola
-      * `BuildBetter` - BuildBetter
-      * `Convex` - Convex
-      * `ClickHouse` - ClickHouse
-      * `Plain` - Plain
-      * `Resend` - Resend
-      * `PgAnalyze` - PgAnalyze
-      * `WorkOS` - WorkOS
-      * `Custom` - Custom */
+       *
+       * * `Ashby` - Ashby
+       * * `Supabase` - Supabase
+       * * `CustomerIO` - CustomerIO
+       * * `Github` - Github
+       * * `Stripe` - Stripe
+       * * `Hubspot` - Hubspot
+       * * `Postgres` - Postgres
+       * * `Zendesk` - Zendesk
+       * * `Snowflake` - Snowflake
+       * * `Salesforce` - Salesforce
+       * * `MySQL` - MySQL
+       * * `MongoDB` - MongoDB
+       * * `MSSQL` - MSSQL
+       * * `Vitally` - Vitally
+       * * `BigQuery` - BigQuery
+       * * `Chargebee` - Chargebee
+       * * `Clerk` - Clerk
+       * * `GoogleAds` - GoogleAds
+       * * `GoogleSearchConsole` - GoogleSearchConsole
+       * * `TemporalIO` - TemporalIO
+       * * `DoIt` - DoIt
+       * * `GoogleSheets` - GoogleSheets
+       * * `MetaAds` - MetaAds
+       * * `Klaviyo` - Klaviyo
+       * * `Mailchimp` - Mailchimp
+       * * `Braze` - Braze
+       * * `Mailjet` - Mailjet
+       * * `Redshift` - Redshift
+       * * `Polar` - Polar
+       * * `RevenueCat` - RevenueCat
+       * * `LinkedinAds` - LinkedinAds
+       * * `RedditAds` - RedditAds
+       * * `TikTokAds` - TikTokAds
+       * * `BingAds` - BingAds
+       * * `Shopify` - Shopify
+       * * `Attio` - Attio
+       * * `SnapchatAds` - SnapchatAds
+       * * `Linear` - Linear
+       * * `Intercom` - Intercom
+       * * `Amplitude` - Amplitude
+       * * `Mixpanel` - Mixpanel
+       * * `Jira` - Jira
+       * * `ActiveCampaign` - ActiveCampaign
+       * * `Marketo` - Marketo
+       * * `Adjust` - Adjust
+       * * `AppsFlyer` - AppsFlyer
+       * * `Freshdesk` - Freshdesk
+       * * `GoogleAnalytics` - GoogleAnalytics
+       * * `Pipedrive` - Pipedrive
+       * * `SendGrid` - SendGrid
+       * * `Slack` - Slack
+       * * `PagerDuty` - PagerDuty
+       * * `Asana` - Asana
+       * * `Notion` - Notion
+       * * `Airtable` - Airtable
+       * * `Greenhouse` - Greenhouse
+       * * `BambooHR` - BambooHR
+       * * `Lever` - Lever
+       * * `GitLab` - GitLab
+       * * `Datadog` - Datadog
+       * * `Sentry` - Sentry
+       * * `Pendo` - Pendo
+       * * `FullStory` - FullStory
+       * * `AmazonAds` - AmazonAds
+       * * `PinterestAds` - PinterestAds
+       * * `AppleSearchAds` - AppleSearchAds
+       * * `QuickBooks` - QuickBooks
+       * * `Xero` - Xero
+       * * `NetSuite` - NetSuite
+       * * `WooCommerce` - WooCommerce
+       * * `BigCommerce` - BigCommerce
+       * * `PayPal` - PayPal
+       * * `Square` - Square
+       * * `Zoom` - Zoom
+       * * `Trello` - Trello
+       * * `Monday` - Monday
+       * * `ClickUp` - ClickUp
+       * * `Confluence` - Confluence
+       * * `Recurly` - Recurly
+       * * `SalesLoft` - SalesLoft
+       * * `Outreach` - Outreach
+       * * `Gong` - Gong
+       * * `Calendly` - Calendly
+       * * `Typeform` - Typeform
+       * * `Iterable` - Iterable
+       * * `ZohoCRM` - ZohoCRM
+       * * `Close` - Close
+       * * `Oracle` - Oracle
+       * * `DynamoDB` - DynamoDB
+       * * `Elasticsearch` - Elasticsearch
+       * * `Kafka` - Kafka
+       * * `LaunchDarkly` - LaunchDarkly
+       * * `Braintree` - Braintree
+       * * `Recharge` - Recharge
+       * * `HelpScout` - HelpScout
+       * * `Gorgias` - Gorgias
+       * * `Instagram` - Instagram
+       * * `YouTubeAnalytics` - YouTubeAnalytics
+       * * `FacebookPages` - FacebookPages
+       * * `TwitterAds` - TwitterAds
+       * * `Workday` - Workday
+       * * `ServiceNow` - ServiceNow
+       * * `Pardot` - Pardot
+       * * `Copper` - Copper
+       * * `Front` - Front
+       * * `ChartMogul` - ChartMogul
+       * * `Zuora` - Zuora
+       * * `Paddle` - Paddle
+       * * `CircleCI` - CircleCI
+       * * `CockroachDB` - CockroachDB
+       * * `Firebase` - Firebase
+       * * `AzureBlob` - AzureBlob
+       * * `GoogleDrive` - GoogleDrive
+       * * `OneDrive` - OneDrive
+       * * `SharePoint` - SharePoint
+       * * `Box` - Box
+       * * `SFTP` - SFTP
+       * * `MicrosoftTeams` - MicrosoftTeams
+       * * `Aircall` - Aircall
+       * * `Webflow` - Webflow
+       * * `Okta` - Okta
+       * * `Auth0` - Auth0
+       * * `Productboard` - Productboard
+       * * `Smartsheet` - Smartsheet
+       * * `Wrike` - Wrike
+       * * `Plaid` - Plaid
+       * * `SurveyMonkey` - SurveyMonkey
+       * * `Eventbrite` - Eventbrite
+       * * `RingCentral` - RingCentral
+       * * `Twilio` - Twilio
+       * * `Freshsales` - Freshsales
+       * * `Shortcut` - Shortcut
+       * * `ConvertKit` - ConvertKit
+       * * `Drip` - Drip
+       * * `CampaignMonitor` - CampaignMonitor
+       * * `MailerLite` - MailerLite
+       * * `Omnisend` - Omnisend
+       * * `Brevo` - Brevo
+       * * `Postmark` - Postmark
+       * * `Granola` - Granola
+       * * `BuildBetter` - BuildBetter
+       * * `Convex` - Convex
+       * * `ClickHouse` - ClickHouse
+       * * `Plain` - Plain
+       * * `Resend` - Resend
+       * * `PgAnalyze` - PgAnalyze
+       * * `WorkOS` - WorkOS
+       * * `Custom` - Custom */
       source_type: ExternalDataSourceTypeEnum;
       /** Connection credentials and a 'schemas' array. Keys depend on source_type. */
       payload: ExternalDataSourceCreatePayload;
@@ -17586,15 +17612,15 @@ export namespace Schemas {
          */
       description?: string | null;
       /** Connection mode: 'warehouse' (import) or 'direct' (live query).
-
-      * `warehouse` - warehouse
-      * `direct` - direct */
+       *
+       * * `warehouse` - warehouse
+       * * `direct` - direct */
       access_method?: AccessMethodEnum;
       /** Where the request came from
-
-      * `web` - web
-      * `api` - api
-      * `mcp` - mcp */
+       *
+       * * `web` - web
+       * * `api` - api
+       * * `mcp` - mcp */
       created_via?: CreatedViaEnum;
     }
 
@@ -17631,10 +17657,10 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by: string | null;
       /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-
-      * `web` - web
-      * `api` - api
-      * `mcp` - mcp */
+       *
+       * * `web` - web
+       * * `api` - api
+       * * `mcp` - mcp */
       created_via?: CreatedViaEnum | null;
       readonly status: string;
       client_secret: string;
@@ -17654,9 +17680,9 @@ export namespace Schemas {
       description?: string | null;
       readonly access_method: AccessMethodEnum;
       /** Backend engine detected for the direct connection.
-
-      * `duckdb` - duckdb
-      * `postgres` - postgres */
+       *
+       * * `duckdb` - duckdb
+       * * `postgres` - postgres */
       readonly engine: EngineEnum | null;
       /** @nullable */
       readonly last_run_at: string | null;
@@ -17704,11 +17730,11 @@ export namespace Schemas {
 
     /**
      * * `feature_flags` - feature_flags
-    * `experiments` - experiments
-    * `surveys` - surveys
-    * `early_access_features` - early_access_features
-    * `web_experiments` - web_experiments
-    * `product_tours` - product_tours
+     * * `experiments` - experiments
+     * * `surveys` - surveys
+     * * `early_access_features` - early_access_features
+     * * `web_experiments` - web_experiments
+     * * `product_tours` - product_tours
      */
     export type FeatureFlagCreationContextEnum = typeof FeatureFlagCreationContextEnum[keyof typeof FeatureFlagCreationContextEnum];
 
@@ -17762,13 +17788,13 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       /** Indicates the origin product of the feature flag. Choices: 'feature_flags', 'experiments', 'surveys', 'early_access_features', 'web_experiments', 'product_tours'.
-
-      * `feature_flags` - feature_flags
-      * `experiments` - experiments
-      * `surveys` - surveys
-      * `early_access_features` - early_access_features
-      * `web_experiments` - web_experiments
-      * `product_tours` - product_tours */
+       *
+       * * `feature_flags` - feature_flags
+       * * `experiments` - experiments
+       * * `surveys` - surveys
+       * * `early_access_features` - early_access_features
+       * * `web_experiments` - web_experiments
+       * * `product_tours` - product_tours */
       creation_context?: FeatureFlagCreationContextEnum;
       /** @nullable */
       is_remote_configuration?: boolean | null;
@@ -17776,15 +17802,15 @@ export namespace Schemas {
       has_encrypted_payloads?: boolean | null;
       readonly status: string;
       /** Specifies where this feature flag should be evaluated
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-
-      * `distinct_id` - User ID (default)
-      * `device_id` - Device ID */
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       /**
          * Last time this feature flag was called (from $feature_flag_called events)
@@ -17838,8 +17864,8 @@ export namespace Schemas {
 
     /**
      * * `cohort` - cohort
-    * `person` - person
-    * `group` - group
+     * * `person` - person
+     * * `group` - group
      */
     export type PropertyGroupTypeEnum = typeof PropertyGroupTypeEnum[keyof typeof PropertyGroupTypeEnum];
 
@@ -17852,15 +17878,15 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `gte` - gte
-    * `lt` - lt
-    * `lte` - lte
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `gte` - gte
+     * * `lt` - lt
+     * * `lte` - lte
      */
     export type FeatureFlagFilterPropertyGenericSchemaOperatorEnum = typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyGenericSchemaOperatorEnum];
 
@@ -17882,10 +17908,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -17900,17 +17926,17 @@ export namespace Schemas {
       /** Comparison value for the property filter. Supports strings, numbers, booleans, and arrays. */
       value: unknown;
       /** Operator used to compare the property value.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `gt` - gt
-      * `gte` - gte
-      * `lt` - lt
-      * `lte` - lte */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `gt` - gt
+       * * `gte` - gte
+       * * `lt` - lt
+       * * `lte` - lte */
       operator: FeatureFlagFilterPropertyGenericSchemaOperatorEnum;
     }
 
@@ -17918,10 +17944,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -17934,9 +17960,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Existence operator.
-
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: ExistenceOperatorEnum;
       /** Optional value. Runtime behavior determines whether this is ignored. */
       value?: unknown;
@@ -17946,10 +17972,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -17962,10 +17988,10 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Date comparison operator.
-
-      * `is_date_exact` - is_date_exact
-      * `is_date_after` - is_date_after
-      * `is_date_before` - is_date_before */
+       *
+       * * `is_date_exact` - is_date_exact
+       * * `is_date_after` - is_date_after
+       * * `is_date_before` - is_date_before */
       operator: DateOperatorEnum;
       /** Date value in ISO format or relative date expression. */
       value: string;
@@ -17973,14 +17999,14 @@ export namespace Schemas {
 
     /**
      * * `semver_gt` - semver_gt
-    * `semver_gte` - semver_gte
-    * `semver_lt` - semver_lt
-    * `semver_lte` - semver_lte
-    * `semver_eq` - semver_eq
-    * `semver_neq` - semver_neq
-    * `semver_tilde` - semver_tilde
-    * `semver_caret` - semver_caret
-    * `semver_wildcard` - semver_wildcard
+     * * `semver_gte` - semver_gte
+     * * `semver_lt` - semver_lt
+     * * `semver_lte` - semver_lte
+     * * `semver_eq` - semver_eq
+     * * `semver_neq` - semver_neq
+     * * `semver_tilde` - semver_tilde
+     * * `semver_caret` - semver_caret
+     * * `semver_wildcard` - semver_wildcard
      */
     export type FeatureFlagFilterPropertySemverSchemaOperatorEnum = typeof FeatureFlagFilterPropertySemverSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertySemverSchemaOperatorEnum];
 
@@ -18001,10 +18027,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18017,16 +18043,16 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Semantic version comparison operator.
-
-      * `semver_gt` - semver_gt
-      * `semver_gte` - semver_gte
-      * `semver_lt` - semver_lt
-      * `semver_lte` - semver_lte
-      * `semver_eq` - semver_eq
-      * `semver_neq` - semver_neq
-      * `semver_tilde` - semver_tilde
-      * `semver_caret` - semver_caret
-      * `semver_wildcard` - semver_wildcard */
+       *
+       * * `semver_gt` - semver_gt
+       * * `semver_gte` - semver_gte
+       * * `semver_lt` - semver_lt
+       * * `semver_lte` - semver_lte
+       * * `semver_eq` - semver_eq
+       * * `semver_neq` - semver_neq
+       * * `semver_tilde` - semver_tilde
+       * * `semver_caret` - semver_caret
+       * * `semver_wildcard` - semver_wildcard */
       operator: FeatureFlagFilterPropertySemverSchemaOperatorEnum;
       /** Semantic version string. */
       value: string;
@@ -18034,7 +18060,7 @@ export namespace Schemas {
 
     /**
      * * `icontains_multi` - icontains_multi
-    * `not_icontains_multi` - not_icontains_multi
+     * * `not_icontains_multi` - not_icontains_multi
      */
     export type FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum = typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum];
 
@@ -18048,10 +18074,10 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Property filter type. Common values are 'person' and 'cohort'.
-
-      * `cohort` - cohort
-      * `person` - person
-      * `group` - group */
+       *
+       * * `cohort` - cohort
+       * * `person` - person
+       * * `group` - group */
       type?: PropertyGroupTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18064,9 +18090,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Multi-contains operator.
-
-      * `icontains_multi` - icontains_multi
-      * `not_icontains_multi` - not_icontains_multi */
+       *
+       * * `icontains_multi` - icontains_multi
+       * * `not_icontains_multi` - not_icontains_multi */
       operator: FeatureFlagFilterPropertyMultiContainsSchemaOperatorEnum;
       /** List of strings to evaluate against. */
       value: string[];
@@ -18084,7 +18110,7 @@ export namespace Schemas {
 
     /**
      * * `in` - in
-    * `not_in` - not_in
+     * * `not_in` - not_in
      */
     export type FeatureFlagFilterPropertyCohortInSchemaOperatorEnum = typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnum[keyof typeof FeatureFlagFilterPropertyCohortInSchemaOperatorEnum];
 
@@ -18098,8 +18124,8 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Cohort property type required for in/not_in operators.
-
-      * `cohort` - cohort */
+       *
+       * * `cohort` - cohort */
       type: FeatureFlagFilterPropertyCohortInSchemaTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18112,9 +18138,9 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Membership operator for cohort properties.
-
-      * `in` - in
-      * `not_in` - not_in */
+       *
+       * * `in` - in
+       * * `not_in` - not_in */
       operator: FeatureFlagFilterPropertyCohortInSchemaOperatorEnum;
       /** Cohort comparison value (single or list, depending on usage). */
       value: unknown;
@@ -18144,8 +18170,8 @@ export namespace Schemas {
       /** Property key used in this feature flag condition. */
       key: string;
       /** Flag property type required for flag dependency checks.
-
-      * `flag` - flag */
+       *
+       * * `flag` - flag */
       type: FeatureFlagFilterPropertyFlagEvaluatesSchemaTypeEnum;
       /**
          * Resolved cohort name for cohort-type filters.
@@ -18158,8 +18184,8 @@ export namespace Schemas {
          */
       group_type_index?: number | null;
       /** Operator for feature flag dependency evaluation.
-
-      * `flag_evaluates_to` - flag_evaluates_to */
+       *
+       * * `flag_evaluates_to` - flag_evaluates_to */
       operator: FeatureFlagFilterPropertyFlagEvaluatesSchemaOperatorEnum;
       /** Value to compare flag evaluation against. */
       value: unknown;
@@ -18321,15 +18347,15 @@ export namespace Schemas {
       /** @nullable */
       has_encrypted_payloads?: boolean | null;
       /** Specifies where this feature flag should be evaluated
-
-      * `server` - Server
-      * `client` - Client
-      * `all` - All */
+       *
+       * * `server` - Server
+       * * `client` - Client
+       * * `all` - All */
       evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | null;
       /** Identifier used for bucketing users into rollout and variants
-
-      * `distinct_id` - User ID (default)
-      * `device_id` - Device ID */
+       *
+       * * `distinct_id` - User ID (default)
+       * * `device_id` - Device ID */
       bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | null;
       /**
          * Last time this feature flag was called (from $feature_flag_called events)
@@ -18352,8 +18378,8 @@ export namespace Schemas {
 
     /**
      * * `events` - events
-    * `persons` - persons
-    * `sessions` - sessions
+     * * `persons` - persons
+     * * `sessions` - sessions
      */
     export type FileDownloadBatchExportOnDemandModelEnum = typeof FileDownloadBatchExportOnDemandModelEnum[keyof typeof FileDownloadBatchExportOnDemandModelEnum];
 
@@ -18800,11 +18826,23 @@ export namespace Schemas {
          * @nullable
          */
       non_integrated_count: number | null;
-      /** List of [event_name, count] pairs */
+      /**
+         * List of [event_name, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       by_event: [string, number][];
-      /** List of [utm_source, count] pairs */
+      /**
+         * List of [utm_source, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       by_utm_source: [string, number][];
-      /** List of [integration, count] pairs */
+      /**
+         * List of [integration, count] pairs
+         * @items.minItems 2
+         * @items.maxItems 2
+         */
       by_matched_integration: [string, number][];
       /** A small sample of matching events */
       samples: GoalEventSample[];
@@ -18847,16 +18885,16 @@ export namespace Schemas {
 
     /**
      * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-    **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-    **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+     *
+     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+     *
+     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
      */
     export type GroupUsageMetricFilters = { [key: string]: unknown };
 
     /**
      * * `numeric` - numeric
-    * `currency` - currency
+     * * `currency` - currency
      */
     export type GroupUsageMetricFormatEnum = typeof GroupUsageMetricFormatEnum[keyof typeof GroupUsageMetricFormatEnum];
 
@@ -18868,7 +18906,7 @@ export namespace Schemas {
 
     /**
      * * `number` - number
-    * `sparkline` - sparkline
+     * * `sparkline` - sparkline
      */
     export type GroupUsageMetricDisplayEnum = typeof GroupUsageMetricDisplayEnum[keyof typeof GroupUsageMetricDisplayEnum];
 
@@ -18880,7 +18918,7 @@ export namespace Schemas {
 
     /**
      * * `count` - count
-    * `sum` - sum
+     * * `sum` - sum
      */
     export type MathEnum = typeof MathEnum[keyof typeof MathEnum];
 
@@ -18898,27 +18936,27 @@ export namespace Schemas {
          */
       name: string;
       /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-
-      * `numeric` - numeric
-      * `currency` - currency */
+       *
+       * * `numeric` - numeric
+       * * `currency` - currency */
       format?: GroupUsageMetricFormatEnum;
       /** Rolling time window in days used to compute the metric. Defaults to 7. */
       interval?: number;
       /** Visual representation in the UI. One of `number` or `sparkline`.
-
-      * `number` - number
-      * `sparkline` - sparkline */
+       *
+       * * `number` - number
+       * * `sparkline` - sparkline */
       display?: GroupUsageMetricDisplayEnum;
       /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-      **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-      **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+       *
+       * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+       *
+       * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
       filters: GroupUsageMetricFilters;
       /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-
-      * `count` - count
-      * `sum` - sum */
+       *
+       * * `count` - count
+       * * `sum` - sum */
       math?: MathEnum;
       /**
          * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -18930,8 +18968,8 @@ export namespace Schemas {
 
     /**
      * * `success` - success
-    * `warning` - warning
-    * `danger` - danger
+     * * `warning` - warning
+     * * `danger` - danger
      */
     export type HealthEnum = typeof HealthEnum[keyof typeof HealthEnum];
 
@@ -18949,8 +18987,8 @@ export namespace Schemas {
 
     /**
      * * `critical` - Critical
-    * `warning` - Warning
-    * `info` - Info
+     * * `warning` - Warning
+     * * `info` - Info
      */
     export type HealthIssueSeverityEnum = typeof HealthIssueSeverityEnum[keyof typeof HealthIssueSeverityEnum];
 
@@ -18963,7 +19001,7 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-    * `resolved` - Resolved
+     * * `resolved` - Resolved
      */
     export type HealthIssueStatusEnum = typeof HealthIssueStatusEnum[keyof typeof HealthIssueStatusEnum];
 
@@ -18979,15 +19017,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-
-      * `critical` - Critical
-      * `warning` - Warning
-      * `info` - Info */
+       *
+       * * `critical` - Critical
+       * * `warning` - Warning
+       * * `info` - Info */
       readonly severity: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-
-      * `active` - Active
-      * `resolved` - Resolved */
+       *
+       * * `active` - Active
+       * * `resolved` - Resolved */
       readonly status: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -19018,11 +19056,11 @@ export namespace Schemas {
 
     /**
      * Single-issue view that adds the rendered, human-readable explanation.
-
-    `render_alert` produces the per-issue title/summary/link; `remediation` is
-    the static, kind-level fix-it guide (split into a human and an agent half).
-    Together they let the detail view explain what's wrong and how to fix it
-    without the caller having to interpret the raw payload.
+     *
+     * `render_alert` produces the per-issue title/summary/link; `remediation` is
+     * the static, kind-level fix-it guide (split into a human and an agent half).
+     * Together they let the detail view explain what's wrong and how to fix it
+     * without the caller having to interpret the raw payload.
      */
     export interface HealthIssueDetail {
       /** Unique identifier for the health issue. */
@@ -19030,15 +19068,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-
-      * `critical` - Critical
-      * `warning` - Warning
-      * `info` - Info */
+       *
+       * * `critical` - Critical
+       * * `warning` - Warning
+       * * `info` - Info */
       readonly severity: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-
-      * `active` - Active
-      * `resolved` - Resolved */
+       *
+       * * `active` - Active
+       * * `resolved` - Resolved */
       readonly status: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -19122,8 +19160,8 @@ export namespace Schemas {
 
     /**
      * * `screenshot` - Screenshot
-    * `iframe` - Iframe
-    * `recording` - Recording
+     * * `iframe` - Iframe
+     * * `recording` - Recording
      */
     export type HeatmapType = typeof HeatmapType[keyof typeof HeatmapType];
 
@@ -19136,8 +19174,8 @@ export namespace Schemas {
 
     /**
      * * `processing` - Processing
-    * `completed` - Completed
-    * `failed` - Failed
+     * * `completed` - Completed
+     * * `failed` - Failed
      */
     export type HeatmapScreenshotResponseStatusEnum = typeof HeatmapScreenshotResponseStatusEnum[keyof typeof HeatmapScreenshotResponseStatusEnum];
 
@@ -19179,16 +19217,16 @@ export namespace Schemas {
       /** Viewport widths (CSS pixels) the screenshot is rendered at. */
       target_widths?: unknown;
       /** Render mode: 'screenshot', 'iframe', or 'recording'.
-
-      * `screenshot` - Screenshot
-      * `iframe` - Iframe
-      * `recording` - Recording */
+       *
+       * * `screenshot` - Screenshot
+       * * `iframe` - Iframe
+       * * `recording` - Recording */
       type?: HeatmapType;
       /** Screenshot generation status: 'processing', 'completed', or 'failed'.
-
-      * `processing` - Processing
-      * `completed` - Completed
-      * `failed` - Failed */
+       *
+       * * `processing` - Processing
+       * * `completed` - Completed
+       * * `failed` - Failed */
       readonly status: HeatmapScreenshotResponseStatusEnum;
       /** Whether at least one rendered image is ready to fetch. */
       readonly has_content: boolean;
@@ -19227,8 +19265,8 @@ export namespace Schemas {
 
     /**
      * * `draft` - Draft
-    * `active` - Active
-    * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     export type HogFlowStatusEnum = typeof HogFlowStatusEnum[keyof typeof HogFlowStatusEnum];
 
@@ -19260,7 +19298,7 @@ export namespace Schemas {
 
     /**
      * * `continue` - continue
-    * `branch` - branch
+     * * `branch` - branch
      */
     export type HogFlowEdgeTypeEnum = typeof HogFlowEdgeTypeEnum[keyof typeof HogFlowEdgeTypeEnum];
 
@@ -19274,9 +19312,9 @@ export namespace Schemas {
       /** Target action id. */
       to: string;
       /** continue: fall-through (sequential or the no-match path of conditional_branch). branch: requires 'index' matching config.conditions[index].
-
-      * `continue` - continue
-      * `branch` - branch */
+       *
+       * * `continue` - continue
+       * * `branch` - branch */
       type: HogFlowEdgeTypeEnum;
       /** Required for type='branch'. Index into config.conditions on conditional_branch / wait_until_condition. */
       index?: number;
@@ -19286,9 +19324,9 @@ export namespace Schemas {
 
     /**
      * * `continue` - continue
-    * `abort` - abort
-    * `complete` - complete
-    * `branch` - branch
+     * * `abort` - abort
+     * * `complete` - complete
+     * * `branch` - branch
      */
     export type OnErrorEnum = typeof OnErrorEnum[keyof typeof OnErrorEnum];
 
@@ -19302,8 +19340,8 @@ export namespace Schemas {
 
     /**
      * * `events` - events
-    * `person-updates` - person-updates
-    * `data-warehouse-table` - data-warehouse-table
+     * * `person-updates` - person-updates
+     * * `data-warehouse-table` - data-warehouse-table
      */
     export type HogFunctionFiltersSourceEnum = typeof HogFunctionFiltersSourceEnum[keyof typeof HogFunctionFiltersSourceEnum];
 
@@ -19345,11 +19383,11 @@ export namespace Schemas {
       /** Optional description. */
       description?: string;
       /** On failure: continue (skip), abort (stop), complete (mark done), branch (follow error edge).
-
-      * `continue` - continue
-      * `abort` - abort
-      * `complete` - complete
-      * `branch` - branch */
+       *
+       * * `continue` - continue
+       * * `abort` - abort
+       * * `complete` - complete
+       * * `branch` - branch */
       on_error?: OnErrorEnum | null;
       /** Created at (epoch ms). Frontend-managed. */
       created_at?: number;
@@ -19370,8 +19408,8 @@ export namespace Schemas {
 
     /**
      * * `active` - Active
-    * `paused` - Paused
-    * `completed` - Completed
+     * * `paused` - Paused
+     * * `completed` - Completed
      */
     export type HogFlowScheduleStatusEnum = typeof HogFlowScheduleStatusEnum[keyof typeof HogFlowScheduleStatusEnum];
 
@@ -19396,10 +19434,10 @@ export namespace Schemas {
       /** Variable value overrides merged with the workflow defaults on each run. */
       variables?: unknown;
       /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-
-      * `active` - Active
-      * `paused` - Paused
-      * `completed` - Completed */
+       *
+       * * `active` - Active
+       * * `paused` - Paused
+       * * `completed` - Completed */
       readonly status: HogFlowScheduleStatusEnum;
       /**
          * Next scheduled fire time, computed by the scheduler.
@@ -19422,10 +19460,10 @@ export namespace Schemas {
       description?: string;
       readonly version: number;
       /** draft (no execution), active (live), archived (disabled).
-
-      * `draft` - Draft
-      * `active` - Active
-      * `archived` - Archived */
+       *
+       * * `draft` - Draft
+       * * `active` - Active
+       * * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at: string;
       readonly created_by: UserBasic;
@@ -19436,11 +19474,11 @@ export namespace Schemas {
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
       /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-
-      * `exit_on_conversion` - Conversion
-      * `exit_on_trigger_not_matched` - Trigger Not Matched
-      * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-      * `exit_only_at_end` - Only At End */
+       *
+       * * `exit_on_conversion` - Conversion
+       * * `exit_on_trigger_not_matched` - Trigger Not Matched
+       * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+       * * `exit_only_at_end` - Only At End */
       exit_condition?: ExitConditionEnum;
       /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
       edges?: HogFlowEdge[];
@@ -19457,11 +19495,11 @@ export namespace Schemas {
 
     /**
      * * `waiting` - Waiting
-    * `queued` - Queued
-    * `active` - Active
-    * `completed` - Completed
-    * `cancelled` - Cancelled
-    * `failed` - Failed
+     * * `queued` - Queued
+     * * `active` - Active
+     * * `completed` - Completed
+     * * `cancelled` - Cancelled
+     * * `failed` - Failed
      */
     export type HogFlowBatchJobStatusEnum = typeof HogFlowBatchJobStatusEnum[keyof typeof HogFlowBatchJobStatusEnum];
 
@@ -19478,13 +19516,13 @@ export namespace Schemas {
     export interface HogFlowBatchJob {
       readonly id: string;
       /** Not currently tracked — stays at its initial value. Use the workflow logs/metrics endpoints for run outcome.
-
-      * `waiting` - Waiting
-      * `queued` - Queued
-      * `active` - Active
-      * `completed` - Completed
-      * `cancelled` - Cancelled
-      * `failed` - Failed */
+       *
+       * * `waiting` - Waiting
+       * * `queued` - Queued
+       * * `active` - Active
+       * * `completed` - Completed
+       * * `cancelled` - Cancelled
+       * * `failed` - Failed */
       status?: HogFlowBatchJobStatusEnum;
       /** ID of the workflow this batch run belongs to. */
       hog_flow: string;
@@ -19547,8 +19585,8 @@ export namespace Schemas {
 
     /**
      * * `team` - Only team
-    * `organization` - Organization
-    * `global` - Global
+     * * `organization` - Organization
+     * * `global` - Global
      */
     export type HogFlowTemplateScopeEnum = typeof HogFlowTemplateScopeEnum[keyof typeof HogFlowTemplateScopeEnum];
 
@@ -19561,7 +19599,7 @@ export namespace Schemas {
 
     /**
      * Custom action serializer for templates that skips input validation
-    (since templates should have default/empty values).
+     * (since templates should have default/empty values).
      */
     export interface HogFlowTemplateAction {
       id: string;
@@ -19580,7 +19618,7 @@ export namespace Schemas {
 
     /**
      * Serializer for creating hog flow templates.
-    Validates and sanitizes the workflow before creating it as a template.
+     * Validates and sanitizes the workflow before creating it as a template.
      */
     export interface HogFlowTemplate {
       readonly id: string;
@@ -19614,7 +19652,7 @@ export namespace Schemas {
 
     /**
      * * `hog` - hog
-    * `liquid` - liquid
+     * * `liquid` - liquid
      */
     export type HogFunctionTemplatingEnum = typeof HogFunctionTemplatingEnum[keyof typeof HogFunctionTemplatingEnum];
 
@@ -19639,12 +19677,12 @@ export namespace Schemas {
 
     /**
      * * `destination` - Destination
-    * `site_destination` - Site Destination
-    * `internal_destination` - Internal Destination
-    * `source_webhook` - Source Webhook
-    * `warehouse_source_webhook` - Warehouse Source Webhook
-    * `site_app` - Site App
-    * `transformation` - Transformation
+     * * `site_destination` - Site Destination
+     * * `internal_destination` - Internal Destination
+     * * `source_webhook` - Source Webhook
+     * * `warehouse_source_webhook` - Warehouse Source Webhook
+     * * `site_app` - Site App
+     * * `transformation` - Transformation
      */
     export type HogFunctionTypeEnum = typeof HogFunctionTypeEnum[keyof typeof HogFunctionTypeEnum];
 
@@ -19661,19 +19699,19 @@ export namespace Schemas {
 
     /**
      * * `string` - string
-    * `number` - number
-    * `boolean` - boolean
-    * `dictionary` - dictionary
-    * `choice` - choice
-    * `json` - json
-    * `integration` - integration
-    * `integration_field` - integration_field
-    * `email` - email
-    * `native_email` - native_email
-    * `posthog_assignee` - posthog_assignee
-    * `posthog_ticket_tags` - posthog_ticket_tags
-    * `posthog_business_hours` - posthog_business_hours
-    * `non_failure_status_codes` - non_failure_status_codes
+     * * `number` - number
+     * * `boolean` - boolean
+     * * `dictionary` - dictionary
+     * * `choice` - choice
+     * * `json` - json
+     * * `integration` - integration
+     * * `integration_field` - integration_field
+     * * `email` - email
+     * * `native_email` - native_email
+     * * `posthog_assignee` - posthog_assignee
+     * * `posthog_ticket_tags` - posthog_ticket_tags
+     * * `posthog_business_hours` - posthog_business_hours
+     * * `non_failure_status_codes` - non_failure_status_codes
      */
     export type InputsSchemaItemTypeEnum = typeof InputsSchemaItemTypeEnum[keyof typeof InputsSchemaItemTypeEnum];
 
@@ -19818,11 +19856,11 @@ export namespace Schemas {
 
     /**
      * * `0` - 0
-    * `1` - 1
-    * `2` - 2
-    * `3` - 3
-    * `11` - 11
-    * `12` - 12
+     * * `1` - 1
+     * * `2` - 2
+     * * `3` - 3
+     * * `11` - 11
+     * * `12` - 12
      */
     export type HogFunctionStatusStateEnum = typeof HogFunctionStatusStateEnum[keyof typeof HogFunctionStatusStateEnum];
 
@@ -19844,14 +19882,14 @@ export namespace Schemas {
     export interface HogFunction {
       readonly id: string;
       /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-
-      * `destination` - Destination
-      * `site_destination` - Site Destination
-      * `internal_destination` - Internal Destination
-      * `source_webhook` - Source Webhook
-      * `warehouse_source_webhook` - Warehouse Source Webhook
-      * `site_app` - Site App
-      * `transformation` - Transformation */
+       *
+       * * `destination` - Destination
+       * * `site_destination` - Site Destination
+       * * `internal_destination` - Internal Destination
+       * * `source_webhook` - Source Webhook
+       * * `warehouse_source_webhook` - Warehouse Source Webhook
+       * * `site_app` - Site App
+       * * `transformation` - Transformation */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -20680,7 +20718,7 @@ export namespace Schemas {
       /** count of all mouse activity in the recording, not just clicks */
       mouse_activity_count?: number | null;
       /** whether we have received data for this recording in the last 5 minutes (assumes the recording was loaded from ClickHouse)
-      * */
+       * * */
       ongoing?: boolean | null;
       person?: PersonType | null;
       /** Length of recording in seconds. */
@@ -20991,9 +21029,9 @@ export namespace Schemas {
 
     /**
      * * `trends` - trends
-    * `funnel` - funnel
-    * `retention` - retention
-    * `sql` - sql
+     * * `funnel` - funnel
+     * * `retention` - retention
+     * * `sql` - sql
      */
     export type InsightTypeEnum = typeof InsightTypeEnum[keyof typeof InsightTypeEnum];
 
@@ -21007,10 +21045,10 @@ export namespace Schemas {
 
     /**
      * * `String` - String
-    * `Number` - Number
-    * `Boolean` - Boolean
-    * `List` - List
-    * `Date` - Date
+     * * `Number` - Number
+     * * `Boolean` - Boolean
+     * * `List` - List
+     * * `Date` - Date
      */
     export type InsightVariableTypeEnum = typeof InsightVariableTypeEnum[keyof typeof InsightVariableTypeEnum];
 
@@ -21032,12 +21070,12 @@ export namespace Schemas {
          */
       name: string;
       /** Variable type. Controls how the value is rendered and substituted in HogQL.
-
-      * `String` - String
-      * `Number` - Number
-      * `Boolean` - Boolean
-      * `List` - List
-      * `Date` - Date */
+       *
+       * * `String` - String
+       * * `Number` - Number
+       * * `Boolean` - Boolean
+       * * `List` - List
+       * * `Date` - Date */
       type: InsightVariableTypeEnum;
       /** Default value used when a query references this variable. */
       default_value?: unknown;
@@ -21073,7 +21111,7 @@ export namespace Schemas {
 
     /**
      * * `api_key` - api_key
-    * `oauth` - oauth
+     * * `oauth` - oauth
      */
     export type InstallCustomAuthTypeEnum = typeof InstallCustomAuthTypeEnum[keyof typeof InstallCustomAuthTypeEnum];
 
@@ -21085,7 +21123,7 @@ export namespace Schemas {
 
     /**
      * * `posthog` - posthog
-    * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      */
     export type InstallSourceEnum = typeof InstallSourceEnum[keyof typeof InstallSourceEnum];
 
@@ -21118,41 +21156,41 @@ export namespace Schemas {
 
     /**
      * * `anthropic` - Anthropic
-    * `apns` - Apple Push
-    * `azure-blob` - Azure Blob
-    * `bing-ads` - Bing Ads
-    * `clickup` - Clickup
-    * `customerio-app` - Customerio App
-    * `customerio-track` - Customerio Track
-    * `customerio-webhook` - Customerio Webhook
-    * `databricks` - Databricks
-    * `email` - Email
-    * `firebase` - Firebase
-    * `github` - Github
-    * `gitlab` - Gitlab
-    * `google-ads` - Google Ads
-    * `google-cloud-service-account` - Google Cloud Service Account
-    * `google-cloud-storage` - Google Cloud Storage
-    * `google-pubsub` - Google Pubsub
-    * `google-search-console` - Google Search Console
-    * `google-sheets` - Google Sheets
-    * `hubspot` - Hubspot
-    * `intercom` - Intercom
-    * `jira` - Jira
-    * `linear` - Linear
-    * `linkedin-ads` - Linkedin Ads
-    * `meta-ads` - Meta Ads
-    * `pinterest-ads` - Pinterest Ads
-    * `postgresql` - Postgresql
-    * `reddit-ads` - Reddit Ads
-    * `salesforce` - Salesforce
-    * `slack` - Slack
-    * `slack-posthog-code` - Slack Posthog Code
-    * `snapchat` - Snapchat
-    * `stripe` - Stripe
-    * `tiktok-ads` - Tiktok Ads
-    * `twilio` - Twilio
-    * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     export type IntegrationKindEnum = typeof IntegrationKindEnum[keyof typeof IntegrationKindEnum];
 
@@ -21326,8 +21364,8 @@ export namespace Schemas {
 
     /**
      * * `text` - Text
-    * `url` - URL
-    * `file` - File
+     * * `url` - URL
+     * * `file` - File
      */
     export type KnowledgeSourceSourceTypeEnum = typeof KnowledgeSourceSourceTypeEnum[keyof typeof KnowledgeSourceSourceTypeEnum];
 
@@ -21340,9 +21378,9 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `processing` - Processing
-    * `ready` - Ready
-    * `error` - Error
+     * * `processing` - Processing
+     * * `ready` - Ready
+     * * `error` - Error
      */
     export type KnowledgeSourceStatusEnum = typeof KnowledgeSourceStatusEnum[keyof typeof KnowledgeSourceStatusEnum];
 
@@ -21356,8 +21394,8 @@ export namespace Schemas {
 
     /**
      * * `success` - Success
-    * `not_modified` - Not modified
-    * `error` - Error
+     * * `not_modified` - Not modified
+     * * `error` - Error
      */
     export type LastRefreshStatusEnum = typeof LastRefreshStatusEnum[keyof typeof LastRefreshStatusEnum];
 
@@ -21370,10 +21408,10 @@ export namespace Schemas {
 
     /**
      * * `manual` - Manual only
-    * `1h` - Every hour
-    * `6h` - Every 6 hours
-    * `24h` - Every day
-    * `7d` - Every week
+     * * `1h` - Every hour
+     * * `6h` - Every 6 hours
+     * * `24h` - Every day
+     * * `7d` - Every week
      */
     export type RefreshIntervalEnum = typeof RefreshIntervalEnum[keyof typeof RefreshIntervalEnum];
 
@@ -21820,9 +21858,9 @@ export namespace Schemas {
 
     /**
      * * `today` - today
-    * `this_week` - this_week
-    * `inactive` - inactive
-    * `never` - never
+     * * `this_week` - this_week
+     * * `inactive` - inactive
+     * * `never` - never
      */
     export type LastActiveEnum = typeof LastActiveEnum[keyof typeof LastActiveEnum];
 
@@ -21845,8 +21883,8 @@ export namespace Schemas {
 
     /**
      * * `preserve` - preserve
-    * `two_column` - two_column
-    * `full_width` - full_width
+     * * `two_column` - two_column
+     * * `full_width` - full_width
      */
     export type LayoutEnum = typeof LayoutEnum[keyof typeof LayoutEnum];
 
@@ -21884,7 +21922,7 @@ export namespace Schemas {
 
     /**
      * * `burst` - burst
-    * `sustained` - sustained
+     * * `sustained` - sustained
      */
     export type LimitTypeEnum = typeof LimitTypeEnum[keyof typeof LimitTypeEnum];
 
@@ -21901,17 +21939,17 @@ export namespace Schemas {
       /** ID of the file download batch export run. */
       id: string;
       /** Current status of the file download batch export run.
-
-      * `Cancelled` - Cancelled
-      * `Completed` - Completed
-      * `ContinuedAsNew` - Continued As New
-      * `Failed` - Failed
-      * `FailedRetryable` - Failed Retryable
-      * `FailedBilling` - Failed Billing
-      * `Terminated` - Terminated
-      * `TimedOut` - Timedout
-      * `Running` - Running
-      * `Starting` - Starting */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Completed` - Completed
+       * * `ContinuedAsNew` - Continued As New
+       * * `Failed` - Failed
+       * * `FailedRetryable` - Failed Retryable
+       * * `FailedBilling` - Failed Billing
+       * * `Terminated` - Terminated
+       * * `TimedOut` - Timedout
+       * * `Running` - Running
+       * * `Starting` - Starting */
       status: BatchExportRunStatusEnum;
     }
 
@@ -21940,7 +21978,7 @@ export namespace Schemas {
 
     /**
      * * `above` - Above
-    * `below` - Below
+     * * `below` - Below
      */
     export type ThresholdOperatorEnum = typeof ThresholdOperatorEnum[keyof typeof ThresholdOperatorEnum];
 
@@ -21952,11 +21990,11 @@ export namespace Schemas {
 
     /**
      * * `not_firing` - Not firing
-    * `firing` - Firing
-    * `pending_resolve` - Pending resolve
-    * `errored` - Errored
-    * `snoozed` - Snoozed
-    * `broken` - Broken
+     * * `firing` - Firing
+     * * `pending_resolve` - Pending resolve
+     * * `errored` - Errored
+     * * `snoozed` - Snoozed
+     * * `broken` - Broken
      */
     export type LogsAlertConfigurationStateEnum = typeof LogsAlertConfigurationStateEnum[keyof typeof LogsAlertConfigurationStateEnum];
 
@@ -21976,13 +22014,13 @@ export namespace Schemas {
       /** Interval end (UTC, exclusive). */
       end: string;
       /** Alert state during this interval.
-
-      * `not_firing` - Not firing
-      * `firing` - Firing
-      * `pending_resolve` - Pending resolve
-      * `errored` - Errored
-      * `snoozed` - Snoozed
-      * `broken` - Broken */
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
       state: LogsAlertConfigurationStateEnum;
       /** Whether the alert was enabled during this interval. Disabled alerts keep their state but are inactive. */
       enabled: boolean;
@@ -21990,7 +22028,7 @@ export namespace Schemas {
 
     /**
      * * `slack` - slack
-    * `webhook` - webhook
+     * * `webhook` - webhook
      */
     export type NotificationDestinationTypeEnum = typeof NotificationDestinationTypeEnum[keyof typeof NotificationDestinationTypeEnum];
 
@@ -22018,22 +22056,22 @@ export namespace Schemas {
          */
       threshold_count?: number;
       /** Whether the alert fires when the count is above or below the threshold.
-
-      * `above` - Above
-      * `below` - Below */
+       *
+       * * `above` - Above
+       * * `below` - Below */
       threshold_operator?: ThresholdOperatorEnum;
       /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes: number;
       /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-
-      * `not_firing` - Not firing
-      * `firing` - Firing
-      * `pending_resolve` - Pending resolve
-      * `errored` - Errored
-      * `snoozed` - Snoozed
-      * `broken` - Broken */
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
       readonly state: LogsAlertConfigurationStateEnum;
       /**
          * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -22100,9 +22138,9 @@ export namespace Schemas {
 
     export interface LogsAlertCreateDestination {
       /** Destination type — slack or webhook.
-
-      * `slack` - slack
-      * `webhook` - webhook */
+       *
+       * * `slack` - slack
+       * * `webhook` - webhook */
       type: NotificationDestinationTypeEnum;
       /** Integration ID for the Slack workspace. Required when type=slack. */
       slack_workspace_id?: number;
@@ -22128,13 +22166,13 @@ export namespace Schemas {
 
     /**
      * * `check` - Check
-    * `reset` - Reset
-    * `enable` - Enable
-    * `disable` - Disable
-    * `snooze` - Snooze
-    * `unsnooze` - Unsnooze
-    * `threshold_change` - Threshold change
-    * `broken_config` - Broken config
+     * * `reset` - Reset
+     * * `enable` - Enable
+     * * `disable` - Disable
+     * * `snooze` - Snooze
+     * * `unsnooze` - Unsnooze
+     * * `threshold_change` - Threshold change
+     * * `broken_config` - Broken config
      */
     export type LogsAlertEventKindEnum = typeof LogsAlertEventKindEnum[keyof typeof LogsAlertEventKindEnum];
 
@@ -22189,9 +22227,9 @@ export namespace Schemas {
          */
       threshold_count: number;
       /** Whether the alert fires when the count is above or below the threshold.
-
-      * `above` - Above
-      * `below` - Below */
+       *
+       * * `above` - Above
+       * * `below` - Below */
       threshold_operator: ThresholdOperatorEnum;
       /** Window size in minutes — determines bucket interval. */
       window_minutes: number;
@@ -22241,8 +22279,8 @@ export namespace Schemas {
 
     /**
      * * `severity_sampling` - Severity-based reduction
-    * `path_drop` - Path exclusion
-    * `rate_limit` - Rate limit
+     * * `path_drop` - Path exclusion
+     * * `rate_limit` - Rate limit
      */
     export type RuleTypeEnum = typeof RuleTypeEnum[keyof typeof RuleTypeEnum];
 
@@ -22270,10 +22308,10 @@ export namespace Schemas {
          */
       priority?: number | null;
       /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-
-      * `severity_sampling` - Severity-based reduction
-      * `path_drop` - Path exclusion
-      * `rate_limit` - Rate limit */
+       *
+       * * `severity_sampling` - Severity-based reduction
+       * * `path_drop` - Path exclusion
+       * * `rate_limit` - Rate limit */
       rule_type: RuleTypeEnum;
       /**
          * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -22332,7 +22370,7 @@ export namespace Schemas {
 
     /**
      * * `feedback` - Feedback
-    * `missing_capability` - Missing capability
+     * * `missing_capability` - Missing capability
      */
     export type MCPAnalyticsSubmissionKindEnum = typeof MCPAnalyticsSubmissionKindEnum[keyof typeof MCPAnalyticsSubmissionKindEnum];
 
@@ -22346,9 +22384,9 @@ export namespace Schemas {
       /** Unique identifier for this submission. */
       readonly id: string;
       /** Whether this submission is general feedback or a missing capability report.
-
-      * `feedback` - Feedback
-      * `missing_capability` - Missing capability */
+       *
+       * * `feedback` - Feedback
+       * * `missing_capability` - Missing capability */
       readonly kind: MCPAnalyticsSubmissionKindEnum;
       /** The user's goal in plain language. */
       goal: string;
@@ -22383,7 +22421,7 @@ export namespace Schemas {
 
     /**
      * * `api_key` - API Key
-    * `oauth` - OAuth
+     * * `oauth` - OAuth
      */
     export type MCPAuthTypeEnum = typeof MCPAuthTypeEnum[keyof typeof MCPAuthTypeEnum];
 
@@ -22395,10 +22433,10 @@ export namespace Schemas {
 
     /**
      * * `results` - Results
-    * `usability` - Usability
-    * `bug` - Bug
-    * `docs` - Docs
-    * `other` - Other
+     * * `usability` - Usability
+     * * `bug` - Bug
+     * * `docs` - Docs
+     * * `other` - Other
      */
     export type MCPFeedbackCreateCategoryEnum = typeof MCPFeedbackCreateCategoryEnum[keyof typeof MCPFeedbackCreateCategoryEnum];
 
@@ -22458,12 +22496,12 @@ export namespace Schemas {
          */
       feedback: string;
       /** High-level category for the feedback.
-
-      * `results` - Results
-      * `usability` - Usability
-      * `bug` - Bug
-      * `docs` - Docs
-      * `other` - Other */
+       *
+       * * `results` - Results
+       * * `usability` - Usability
+       * * `bug` - Bug
+       * * `docs` - Docs
+       * * `other` - Other */
       category?: MCPFeedbackCreateCategoryEnum;
     }
 
@@ -22482,7 +22520,7 @@ export namespace Schemas {
 
     /**
      * * `completed` - Completed
-    * `error` - Error
+     * * `error` - Error
      */
     export type OutcomeEnum = typeof OutcomeEnum[keyof typeof OutcomeEnum];
 
@@ -22496,9 +22534,9 @@ export namespace Schemas {
       /** Ordered tool names called during the path. Length is fixed; null entries indicate the session ended before this step. */
       readonly steps: readonly (string | null)[];
       /** Terminal outcome of the sessions following this path.
-
-      * `completed` - Completed
-      * `error` - Error */
+       *
+       * * `completed` - Completed
+       * * `error` - Error */
       readonly outcome: OutcomeEnum;
       /** Number of sessions in this cluster that followed this exact path. */
       readonly count: number;
@@ -22540,8 +22578,8 @@ export namespace Schemas {
 
     /**
      * * `idle` - Idle
-    * `computing` - Computing
-    * `error` - Error
+     * * `computing` - Computing
+     * * `error` - Error
      */
     export type MCPIntentClusterSnapshotStatusEnum = typeof MCPIntentClusterSnapshotStatusEnum[keyof typeof MCPIntentClusterSnapshotStatusEnum];
 
@@ -22565,10 +22603,10 @@ export namespace Schemas {
 
     export interface MCPIntentClusterSnapshot {
       /** Whether a snapshot is current (idle), being recomputed (computing), or failed (error).
-
-      * `idle` - Idle
-      * `computing` - Computing
-      * `error` - Error */
+       *
+       * * `idle` - Idle
+       * * `computing` - Computing
+       * * `error` - Error */
       readonly status: MCPIntentClusterSnapshotStatusEnum;
       /** Error message from the most recent failed run, otherwise empty. */
       readonly error_message: string;
@@ -22661,8 +22699,8 @@ export namespace Schemas {
 
     /**
      * * `approved` - Approved
-    * `needs_approval` - Needs approval
-    * `do_not_use` - Do not use
+     * * `needs_approval` - Needs approval
+     * * `do_not_use` - Do not use
      */
     export type MCPServerInstallationToolApprovalStateEnum = typeof MCPServerInstallationToolApprovalStateEnum[keyof typeof MCPServerInstallationToolApprovalStateEnum];
 
@@ -22690,11 +22728,11 @@ export namespace Schemas {
 
     /**
      * * `business` - Business Operations
-    * `data` - Data & Analytics
-    * `design` - Design & Content
-    * `dev` - Developer Tools & APIs
-    * `infra` - Infrastructure
-    * `productivity` - Productivity & Collaboration
+     * * `data` - Data & Analytics
+     * * `design` - Design & Content
+     * * `dev` - Developer Tools & APIs
+     * * `infra` - Infrastructure
+     * * `productivity` - Productivity & Collaboration
      */
     export type MCPServerTemplateCategoryEnum = typeof MCPServerTemplateCategoryEnum[keyof typeof MCPServerTemplateCategoryEnum];
 
@@ -22795,7 +22833,7 @@ export namespace Schemas {
 
     /**
      * * `key` - key
-    * `value` - value
+     * * `value` - value
      */
     export type MatchedOnEnum = typeof MatchedOnEnum[keyof typeof MatchedOnEnum];
 
@@ -22829,9 +22867,9 @@ export namespace Schemas {
 
     /**
      * * `PENDING` - Pending
-    * `BACKFILL` - Backfill
-    * `READY` - Ready
-    * `ERROR` - Error
+     * * `BACKFILL` - Backfill
+     * * `READY` - Ready
+     * * `ERROR` - Error
      */
     export type MaterializedColumnSlotStateEnum = typeof MaterializedColumnSlotStateEnum[keyof typeof MaterializedColumnSlotStateEnum];
 
@@ -22868,8 +22906,8 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `completed` - Completed
-    * `skipped` - Skipped
+     * * `completed` - Completed
+     * * `skipped` - Skipped
      */
     export type ScrapingStatusEnum = typeof ScrapingStatusEnum[keyof typeof ScrapingStatusEnum];
 
@@ -22989,10 +23027,10 @@ export namespace Schemas {
 
     /**
      * * `user_message` - user_message
-    * `cancel` - cancel
-    * `close` - close
-    * `permission_response` - permission_response
-    * `set_config_option` - set_config_option
+     * * `cancel` - cancel
+     * * `close` - close
+     * * `permission_response` - permission_response
+     * * `set_config_option` - set_config_option
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -23007,8 +23045,8 @@ export namespace Schemas {
 
     /**
      * * `precise` - PRECISE
-    * `coarse` - COARSE
-    * `partial` - PARTIAL
+     * * `coarse` - COARSE
+     * * `partial` - PARTIAL
      */
     export type MetricQualityEnum = typeof MetricQualityEnum[keyof typeof MetricQualityEnum];
 
@@ -23076,8 +23114,8 @@ export namespace Schemas {
 
     /**
      * * `trusted` - Trusted
-    * `full` - Full
-    * `custom` - Custom
+     * * `full` - Full
+     * * `custom` - Custom
      */
     export type NetworkAccessLevelEnum = typeof NetworkAccessLevelEnum[keyof typeof NetworkAccessLevelEnum];
 
@@ -23090,9 +23128,9 @@ export namespace Schemas {
 
     /**
      * * `table` - Table
-    * `view` - View
-    * `matview` - Mat View
-    * `endpoint` - Endpoint
+     * * `view` - View
+     * * `matview` - Mat View
+     * * `endpoint` - Endpoint
      */
     export type NodeTypeEnum = typeof NodeTypeEnum[keyof typeof NodeTypeEnum];
 
@@ -23228,13 +23266,13 @@ export namespace Schemas {
 
     /**
      * * `replay` - REPLAY
-    * `notebook` - NOTEBOOK
-    * `insight` - INSIGHT
-    * `feature_flag` - FEATURE_FLAG
-    * `dashboard` - DASHBOARD
-    * `survey` - SURVEY
-    * `experiment` - EXPERIMENT
-    * `error_tracking` - ERROR_TRACKING
+     * * `notebook` - NOTEBOOK
+     * * `insight` - INSIGHT
+     * * `feature_flag` - FEATURE_FLAG
+     * * `dashboard` - DASHBOARD
+     * * `survey` - SURVEY
+     * * `experiment` - EXPERIMENT
+     * * `error_tracking` - ERROR_TRACKING
      */
     export type NotificationEventSourceTypeEnum = typeof NotificationEventSourceTypeEnum[keyof typeof NotificationEventSourceTypeEnum];
 
@@ -23390,10 +23428,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
-    * `running` - Running
-    * `succeeded` - Succeeded
-    * `failed` - Failed
-    * `ineligible` - Ineligible
+     * * `running` - Running
+     * * `succeeded` - Succeeded
+     * * `failed` - Failed
+     * * `ineligible` - Ineligible
      */
     export type ObservationStatusEnum = typeof ObservationStatusEnum[keyof typeof ObservationStatusEnum];
 
@@ -23408,7 +23446,7 @@ export namespace Schemas {
 
     /**
      * * `schedule` - Schedule
-    * `on_demand` - On demand
+     * * `on_demand` - On demand
      */
     export type ObservationTriggerEnum = typeof ObservationTriggerEnum[keyof typeof ObservationTriggerEnum];
 
@@ -23459,7 +23497,7 @@ export namespace Schemas {
 
     /**
      * * `later` - Later
-    * `other` - Other
+     * * `other` - Other
      */
     export type OnboardingSkipRequestReasonEnum = typeof OnboardingSkipRequestReasonEnum[keyof typeof OnboardingSkipRequestReasonEnum];
 
@@ -23471,16 +23509,16 @@ export namespace Schemas {
 
     /**
      * Request body for POST /api/users/{id}/onboarding/skip/.
-
-    Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
-    runtime so the contract clients believe is enforced (length cap, choice validation,
-    no extra fields) is actually enforced server-side.
+     *
+     * Source of truth for OpenAPI / generated TS / zod / MCP — bind this serializer at
+     * runtime so the contract clients believe is enforced (length cap, choice validation,
+     * no extra fields) is actually enforced server-side.
      */
     export interface OnboardingSkipRequest {
       /** Why the user is leaving onboarding. 'later' keeps them able to return; 'other' is a catch-all. 'delegated' is rejected here — use the delegate endpoint so the delegation invite is created atomically.
-
-      * `later` - Later
-      * `other` - Other */
+       *
+       * * `later` - Later
+       * * `other` - Other */
       reason: OnboardingSkipRequestReasonEnum;
       /**
          * Onboarding step key the user was on when skipping, for analytics only.
@@ -23491,8 +23529,8 @@ export namespace Schemas {
 
     /**
      * * `delegated` - Delegated to teammate
-    * `later` - Skipped for later
-    * `other` - Other
+     * * `later` - Skipped for later
+     * * `other` - Other
      */
     export type OnboardingSkippedReasonEnum = typeof OnboardingSkippedReasonEnum[keyof typeof OnboardingSkippedReasonEnum];
 
@@ -23505,7 +23543,7 @@ export namespace Schemas {
 
     /**
      * * `latest` - latest
-    * `earliest` - earliest
+     * * `earliest` - earliest
      */
     export type OrderByEnum = typeof OrderByEnum[keyof typeof OrderByEnum];
 
@@ -23523,9 +23561,9 @@ export namespace Schemas {
 
     /**
      * * `0` - none
-    * `3` - config
-    * `6` - install
-    * `9` - root
+     * * `3` - config
+     * * `6` - install
+     * * `9` - root
      */
     export type PluginsAccessLevelEnum = typeof PluginsAccessLevelEnum[keyof typeof PluginsAccessLevelEnum];
 
@@ -23590,9 +23628,9 @@ export namespace Schemas {
       /** @nullable */
       readonly is_hipaa: boolean | null;
       /** Default statistical method for new experiments in this organization.
-
-      * `bayesian` - Bayesian
-      * `frequentist` - Frequentist */
+       *
+       * * `bayesian` - Bayesian
+       * * `frequentist` - Frequentist */
       default_experiment_stats_method?: DefaultExperimentStatsMethodEnum | BlankEnum | null;
       /** Default setting for 'Discard client IP data' for new projects in this organization. */
       default_anonymize_ips?: boolean;
@@ -23620,7 +23658,7 @@ export namespace Schemas {
 
     /**
      * Serializer for `Organization` model with minimal attributes to speeed up loading and transfer times.
-    Also used for nested serializers.
+     * Also used for nested serializers.
      */
     export interface OrganizationBasic {
       readonly id: string;
@@ -23700,7 +23738,10 @@ export namespace Schemas {
          * @nullable
          */
       id_jag_jwks_url?: string | null;
-      /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
+      /**
+         * Allowed ID-JAG client IDs. Empty list allows any client_id.
+         * @items.maxLength 256
+         */
       id_jag_allowed_clients?: string[];
     }
 
@@ -23730,8 +23771,8 @@ export namespace Schemas {
 
     /**
      * * `1` - member
-    * `8` - administrator
-    * `15` - owner
+     * * `8` - administrator
+     * * `15` - owner
      */
     export type OrganizationMembershipLevelEnum = typeof OrganizationMembershipLevelEnum[keyof typeof OrganizationMembershipLevelEnum];
 
@@ -23848,14 +23889,14 @@ export namespace Schemas {
 
     /**
      * * `error_tracking` - Error Tracking
-    * `eval_clusters` - Eval Clusters
-    * `user_created` - User Created
-    * `automation` - Automation
-    * `slack` - Slack
-    * `support_queue` - Support Queue
-    * `session_summaries` - Session Summaries
-    * `signal_report` - Signal Report
-    * `signals_scout` - Signals Scout
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `automation` - Automation
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout
      */
     export type OriginProductEnum = typeof OriginProductEnum[keyof typeof OriginProductEnum];
 
@@ -23895,7 +23936,7 @@ export namespace Schemas {
 
     /**
      * * `healthy` - healthy
-    * `needs_attention` - needs_attention
+     * * `needs_attention` - needs_attention
      */
     export type OverallHealthEnum = typeof OverallHealthEnum[keyof typeof OverallHealthEnum];
 
@@ -23926,10 +23967,10 @@ export namespace Schemas {
       /** Pull request title. */
       title: string;
       /** Derived state: 'open', 'closed', or 'merged'.
-
-      * `open` - OPEN
-      * `closed` - CLOSED
-      * `merged` - MERGED */
+       *
+       * * `open` - OPEN
+       * * `closed` - CLOSED
+       * * `merged` - MERGED */
       state: EngineeringAnalyticsPRStateEnum;
       /** True if the pull request is a draft. */
       is_draft: boolean;
@@ -23949,10 +23990,10 @@ export namespace Schemas {
 
     /**
      * * `opened` - OPENED
-    * `ci_started` - CI_STARTED
-    * `ci_finished` - CI_FINISHED
-    * `merged` - MERGED
-    * `closed` - CLOSED
+     * * `ci_started` - CI_STARTED
+     * * `ci_finished` - CI_FINISHED
+     * * `merged` - MERGED
+     * * `closed` - CLOSED
      */
     export type PRLifecycleEventKindEnum = typeof PRLifecycleEventKindEnum[keyof typeof PRLifecycleEventKindEnum];
 
@@ -23967,12 +24008,12 @@ export namespace Schemas {
 
     export interface PRLifecycleEvent {
       /** Event kind: opened, ci_started, ci_finished, merged, or closed.
-
-      * `opened` - OPENED
-      * `ci_started` - CI_STARTED
-      * `ci_finished` - CI_FINISHED
-      * `merged` - MERGED
-      * `closed` - CLOSED */
+       *
+       * * `opened` - OPENED
+       * * `ci_started` - CI_STARTED
+       * * `ci_finished` - CI_FINISHED
+       * * `merged` - MERGED
+       * * `closed` - CLOSED */
       kind: PRLifecycleEventKindEnum;
       /** When the event occurred. */
       at: string;
@@ -23989,10 +24030,10 @@ export namespace Schemas {
       /** Lifecycle events ordered by time. */
       events: PRLifecycleEvent[];
       /** Always 'partial' — CI events only; reviews and comments are not yet available.
-
-      * `precise` - PRECISE
-      * `coarse` - COARSE
-      * `partial` - PARTIAL */
+       *
+       * * `precise` - PRECISE
+       * * `coarse` - COARSE
+       * * `partial` - PARTIAL */
       metric_quality?: MetricQualityEnum;
     }
 
@@ -25017,8 +25058,8 @@ export namespace Schemas {
 
     /**
      * * `home` - Home
-    * `pinned` - Pinned
-    * `custom_products` - Custom Products
+     * * `pinned` - Pinned
+     * * `custom_products` - Custom Products
      */
     export type PersistedFolderTypeEnum = typeof PersistedFolderTypeEnum[keyof typeof PersistedFolderTypeEnum];
 
@@ -25032,10 +25073,10 @@ export namespace Schemas {
     export interface PersistedFolder {
       readonly id: string;
       /** Which persisted folder this is for the user (home, pinned, custom_products).
-
-      * `home` - Home
-      * `pinned` - Pinned
-      * `custom_products` - Custom Products */
+       *
+       * * `home` - Home
+       * * `pinned` - Pinned
+       * * `custom_products` - Custom Products */
       type: PersistedFolderTypeEnum;
       /**
          * Protocol prefix of the folder location, e.g. 'products://'.
@@ -25087,8 +25128,8 @@ export namespace Schemas {
 
     /**
      * * `SYSTEM` - SYSTEM
-    * `PLUGIN` - PLUGIN
-    * `CONSOLE` - CONSOLE
+     * * `PLUGIN` - PLUGIN
+     * * `CONSOLE` - CONSOLE
      */
     export type PluginLogEntrySourceEnum = typeof PluginLogEntrySourceEnum[keyof typeof PluginLogEntrySourceEnum];
 
@@ -25101,10 +25142,10 @@ export namespace Schemas {
 
     /**
      * * `DEBUG` - DEBUG
-    * `LOG` - LOG
-    * `INFO` - INFO
-    * `WARN` - WARN
-    * `ERROR` - ERROR
+     * * `LOG` - LOG
+     * * `INFO` - INFO
+     * * `WARN` - WARN
+     * * `ERROR` - ERROR
      */
     export type PluginLogEntryTypeEnum = typeof PluginLogEntryTypeEnum[keyof typeof PluginLogEntryTypeEnum];
 
@@ -25184,9 +25225,9 @@ export namespace Schemas {
 
     /**
      * Like `ProjectBasicSerializer`, but also works as a drop-in replacement for `TeamBasicSerializer` by way of
-    passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
-    backward compatibility of the REST API.
-    Do not use this in greenfield endpoints!
+     * passthrough fields. This allows the meaning of `Team` to change from "project" to "environment" without breaking
+     * backward compatibility of the REST API.
+     * Do not use this in greenfield endpoints!
      */
     export interface ProjectBackwardCompatBasic {
       readonly id: number;
@@ -25262,11 +25303,11 @@ export namespace Schemas {
     export interface QueryTabState {
       readonly id: string;
       /**
-                  Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-                  and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-                  ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-                  for a user.
-                   */
+       *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+       *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+       *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+       *             for a user.
+       *              */
       state?: unknown;
     }
 
@@ -25281,7 +25322,7 @@ export namespace Schemas {
 
     /**
      * * `manual-options` - manual-options
-    * `auto-discovery` - auto-discovery
+     * * `auto-discovery` - auto-discovery
      */
     export type QuickFilterTypeEnum = typeof QuickFilterTypeEnum[keyof typeof QuickFilterTypeEnum];
 
@@ -25315,9 +25356,9 @@ export namespace Schemas {
 
     /**
      * * `monitor` - Monitor
-    * `classifier` - Classifier
-    * `scorer` - Scorer
-    * `summarizer` - Summarizer
+     * * `classifier` - Classifier
+     * * `scorer` - Scorer
+     * * `summarizer` - Summarizer
      */
     export type ScannerTypeEnum = typeof ScannerTypeEnum[keyof typeof ScannerTypeEnum];
 
@@ -25331,7 +25372,7 @@ export namespace Schemas {
 
     /**
      * * `gemini-3-flash-preview` - Gemini 3 Flash
-    * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
+     * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite
      */
     export type ScannerModelEnum = typeof ScannerModelEnum[keyof typeof ScannerModelEnum];
 
@@ -25358,22 +25399,22 @@ export namespace Schemas {
       /** Scanner name at run time. */
       name: string;
       /** Scanner type (monitor, classifier, scorer, summarizer) at run time.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer */
+       *
+       * * `monitor` - Monitor
+       * * `classifier` - Classifier
+       * * `scorer` - Scorer
+       * * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
       /** The `ReplayScanner.scanner_version` value at the moment the workflow ran. */
       scanner_version: number;
       /** Concrete model that ran the observation.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+       *
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model: ScannerModelEnum;
       /** Concrete provider that ran the observation.
-
-      * `google` - Google */
+       *
+       * * `google` - Google */
       provider: ScannerProviderEnum;
       /** Whether the observation was run with Signal emission enabled. */
       emits_signals: boolean;
@@ -25401,12 +25442,12 @@ export namespace Schemas {
       /** Session recording id this scanner was applied to. */
       readonly session_id: string;
       /** Observation status (pending, running, succeeded, failed, ineligible).
-
-      * `pending` - Pending
-      * `running` - Running
-      * `succeeded` - Succeeded
-      * `failed` - Failed
-      * `ineligible` - Ineligible */
+       *
+       * * `pending` - Pending
+       * * `running` - Running
+       * * `succeeded` - Succeeded
+       * * `failed` - Failed
+       * * `ineligible` - Ineligible */
       readonly status: ObservationStatusEnum;
       /** Populated on terminal non-success statuses; formatted as `kind:human-readable message`. For `ineligible`, kind is one of no_recording / too_short / too_inactive / too_long / no_events. For `failed`, kind is one of provider_transient / provider_rejected / rasterization_failed / validation_failed / internal_error. */
       readonly error_reason: string;
@@ -25417,9 +25458,9 @@ export namespace Schemas {
       /** Result data persisted on success; null until the observation succeeds. */
       readonly scanner_result: ScannerResult | null;
       /** Whether this observation came from the schedule or an on-demand request.
-
-      * `schedule` - Schedule
-      * `on_demand` - On demand */
+       *
+       * * `schedule` - Schedule
+       * * `on_demand` - On demand */
       readonly triggered_by: ObservationTriggerEnum;
       /** User who triggered an on-demand observation; null for scheduled observations. */
       readonly triggered_by_user: UserBasic | null;
@@ -25449,11 +25490,11 @@ export namespace Schemas {
       /** Free-form description shown in the scanner management UI. */
       description?: string;
       /** What the scanner does: monitor, classifier, scorer, or summarizer.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer */
+       *
+       * * `monitor` - Monitor
+       * * `classifier` - Classifier
+       * * `scorer` - Scorer
+       * * `summarizer` - Summarizer */
       scanner_type: ScannerTypeEnum;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config: unknown;
@@ -25466,13 +25507,13 @@ export namespace Schemas {
          */
       sampling_rate?: number;
       /** LLM provider. v1 is Google-only.
-
-      * `google` - Google */
+       *
+       * * `google` - Google */
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+       *
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model: ScannerModelEnum;
       /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
@@ -25664,9 +25705,15 @@ export namespace Schemas {
       /** @maxLength 255 */
       name: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /** List of allowed domains for custom network access */
+      /**
+         * List of allowed domains for custom network access
+         * @items.maxLength 255
+         */
       allowed_domains?: string[];
-      /** List of repositories this environment applies to (format: org/repo) */
+      /**
+         * List of repositories this environment applies to (format: org/repo)
+         * @items.maxLength 255
+         */
       repositories?: string[];
       /** If true, only the creator can see this environment. Otherwise visible to whole team. */
       private?: boolean;
@@ -25688,9 +25735,9 @@ export namespace Schemas {
 
     /**
      * * `daily` - daily
-    * `weekly` - weekly
-    * `monthly` - monthly
-    * `yearly` - yearly
+     * * `weekly` - weekly
+     * * `monthly` - monthly
+     * * `yearly` - yearly
      */
     export type RecurrenceIntervalEnum = typeof RecurrenceIntervalEnum[keyof typeof RecurrenceIntervalEnum];
 
@@ -25711,8 +25758,8 @@ export namespace Schemas {
          */
       record_id: string;
       /** The type of record to modify. Currently only "FeatureFlag" is supported.
-
-      * `FeatureFlag` - feature flag */
+       *
+       * * `FeatureFlag` - feature flag */
       model_name: ModelNameEnum;
       /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
       payload: unknown;
@@ -25731,11 +25778,11 @@ export namespace Schemas {
       /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
       is_recurring?: boolean;
       /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly
-      * `yearly` - yearly */
+       *
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly
+       * * `yearly` - yearly */
       recurrence_interval?: RecurrenceIntervalEnum | null;
       /**
          * @maxLength 100
@@ -25839,7 +25886,7 @@ export namespace Schemas {
 
     /**
      * Serializer for linking session recordings to external issue trackers.
-    Reuses error tracking's integration infrastructure
+     * Reuses error tracking's integration infrastructure
      */
     export interface SessionRecordingExternalRef {
       readonly id: string;
@@ -25926,7 +25973,7 @@ export namespace Schemas {
 
     /**
      * * `collection` - Collection
-    * `filters` - Filters
+     * * `filters` - Filters
      */
     export type SessionRecordingPlaylistTypeEnum = typeof SessionRecordingPlaylistTypeEnum[keyof typeof SessionRecordingPlaylistTypeEnum];
 
@@ -25966,9 +26013,9 @@ export namespace Schemas {
       readonly last_modified_by: UserBasic;
       readonly recordings_counts: SessionRecordingPlaylistRecordingsCounts;
       /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-
-      * `collection` - Collection
-      * `filters` - Filters */
+       *
+       * * `collection` - Collection
+       * * `filters` - Filters */
       type?: SessionRecordingPlaylistTypeEnum | null;
       /** Return whether this is a synthetic playlist */
       readonly is_synthetic: boolean;
@@ -25986,14 +26033,14 @@ export namespace Schemas {
 
     /**
      * * `potential` - Potential
-    * `candidate` - Candidate
-    * `in_progress` - In Progress
-    * `pending_input` - Pending Input
-    * `ready` - Ready
-    * `resolved` - Resolved
-    * `failed` - Failed
-    * `deleted` - Deleted
-    * `suppressed` - Suppressed
+     * * `candidate` - Candidate
+     * * `in_progress` - In Progress
+     * * `pending_input` - Pending Input
+     * * `ready` - Ready
+     * * `resolved` - Resolved
+     * * `failed` - Failed
+     * * `deleted` - Deleted
+     * * `suppressed` - Suppressed
      */
     export type SignalReportStatusEnum = typeof SignalReportStatusEnum[keyof typeof SignalReportStatusEnum];
 
@@ -26059,15 +26106,15 @@ export namespace Schemas {
 
     /**
      * * `session_replay` - Session replay
-    * `llm_analytics` - LLM analytics
-    * `github` - GitHub
-    * `linear` - Linear
-    * `zendesk` - Zendesk
-    * `conversations` - Conversations
-    * `error_tracking` - Error tracking
-    * `pganalyze` - pganalyze
-    * `signals_scout` - Signals scout
-    * `logs` - Logs
+     * * `llm_analytics` - LLM analytics
+     * * `github` - GitHub
+     * * `linear` - Linear
+     * * `zendesk` - Zendesk
+     * * `conversations` - Conversations
+     * * `error_tracking` - Error tracking
+     * * `pganalyze` - pganalyze
+     * * `signals_scout` - Signals scout
+     * * `logs` - Logs
      */
     export type SourceProductEnum = typeof SourceProductEnum[keyof typeof SourceProductEnum];
 
@@ -26087,14 +26134,14 @@ export namespace Schemas {
 
     /**
      * * `session_analysis_cluster` - Session analysis cluster
-    * `evaluation` - Evaluation
-    * `issue` - Issue
-    * `ticket` - Ticket
-    * `issue_created` - Issue created
-    * `issue_reopened` - Issue reopened
-    * `issue_spiking` - Issue spiking
-    * `cross_source_issue` - Cross source issue
-    * `alert_state_change` - Alert state change
+     * * `evaluation` - Evaluation
+     * * `issue` - Issue
+     * * `ticket` - Ticket
+     * * `issue_created` - Issue created
+     * * `issue_reopened` - Issue reopened
+     * * `issue_spiking` - Issue spiking
+     * * `cross_source_issue` - Cross source issue
+     * * `alert_state_change` - Alert state change
      */
     export type SignalSourceConfigSourceTypeEnum = typeof SignalSourceConfigSourceTypeEnum[keyof typeof SignalSourceConfigSourceTypeEnum];
 
@@ -26277,9 +26324,9 @@ export namespace Schemas {
 
     /**
      * * `starting` - Starting
-    * `completed` - Completed
-    * `failed` - Failed
-    * `skipped` - Skipped
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `skipped` - Skipped
      */
     export type SubscriptionDeliveryStatusEnum = typeof SubscriptionDeliveryStatusEnum[keyof typeof SubscriptionDeliveryStatusEnum];
 
@@ -26311,18 +26358,22 @@ export namespace Schemas {
       readonly target_type: string;
       /** Destination snapshot at send time (emails, channel id, URL). */
       readonly target_value: string;
-      /** ExportedAsset ids generated for this send. */
+      /**
+         * ExportedAsset ids generated for this send.
+         * @items.minimum -2147483648
+         * @items.maximum 2147483647
+         */
       readonly exported_asset_ids: readonly number[];
       /** Snapshot at send time: dashboard metadata, total_insight_count, and per-exported-insight entries (id, short_id, name, query_hash, cache_key, query_results, optional query_error). */
       readonly content_snapshot: unknown;
       /** Per-destination outcomes; items use status success, failed, or partial. */
       readonly recipient_results: unknown;
       /** Overall run status: starting, completed, failed, or skipped.
-
-      * `starting` - Starting
-      * `completed` - Completed
-      * `failed` - Failed
-      * `skipped` - Skipped */
+       *
+       * * `starting` - Starting
+       * * `completed` - Completed
+       * * `failed` - Failed
+       * * `skipped` - Skipped */
       readonly status: SubscriptionDeliveryStatusEnum;
       /** Top-level failure payload when status is failed, if any. */
       readonly error: unknown;
@@ -26352,8 +26403,8 @@ export namespace Schemas {
 
     /**
      * * `insight` - Insight
-    * `dashboard` - Dashboard
-    * `ai_prompt` - AI prompt
+     * * `dashboard` - Dashboard
+     * * `ai_prompt` - AI prompt
      */
     export type ResourceTypeEnum = typeof ResourceTypeEnum[keyof typeof ResourceTypeEnum];
 
@@ -26366,7 +26417,7 @@ export namespace Schemas {
 
     /**
      * * `email` - Email
-    * `slack` - Slack
+     * * `slack` - Slack
      */
     export type TargetTypeEnum = typeof TargetTypeEnum[keyof typeof TargetTypeEnum];
 
@@ -26378,9 +26429,9 @@ export namespace Schemas {
 
     /**
      * * `daily` - Daily
-    * `weekly` - Weekly
-    * `monthly` - Monthly
-    * `yearly` - Yearly
+     * * `weekly` - Weekly
+     * * `monthly` - Monthly
+     * * `yearly` - Yearly
      */
     export type SubscriptionFrequencyEnum = typeof SubscriptionFrequencyEnum[keyof typeof SubscriptionFrequencyEnum];
 
@@ -26394,12 +26445,12 @@ export namespace Schemas {
 
     /**
      * * `monday` - Monday
-    * `tuesday` - Tuesday
-    * `wednesday` - Wednesday
-    * `thursday` - Thursday
-    * `friday` - Friday
-    * `saturday` - Saturday
-    * `sunday` - Sunday
+     * * `tuesday` - Tuesday
+     * * `wednesday` - Wednesday
+     * * `thursday` - Thursday
+     * * `friday` - Friday
+     * * `saturday` - Saturday
+     * * `sunday` - Sunday
      */
     export type SubscriptionByweekdayItem = typeof SubscriptionByweekdayItem[keyof typeof SubscriptionByweekdayItem];
 
@@ -26420,10 +26471,10 @@ export namespace Schemas {
     export interface Subscription {
       readonly id: number;
       /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-
-      * `insight` - Insight
-      * `dashboard` - Dashboard
-      * `ai_prompt` - AI prompt */
+       *
+       * * `insight` - Insight
+       * * `dashboard` - Dashboard
+       * * `ai_prompt` - AI prompt */
       readonly resource_type: ResourceTypeEnum;
       /**
          * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -26447,18 +26498,18 @@ export namespace Schemas {
          */
       prompt?: string | null;
       /** Delivery channel: email or slack.
-
-      * `email` - Email
-      * `slack` - Slack */
+       *
+       * * `email` - Email
+       * * `slack` - Slack */
       target_type: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
       target_value: string;
       /** How often to deliver: daily, weekly, monthly, or yearly.
-
-      * `daily` - Daily
-      * `weekly` - Weekly
-      * `monthly` - Monthly
-      * `yearly` - Yearly */
+       *
+       * * `daily` - Daily
+       * * `weekly` - Weekly
+       * * `monthly` - Monthly
+       * * `yearly` - Yearly */
       frequency: SubscriptionFrequencyEnum;
       /**
          * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -26538,9 +26589,9 @@ export namespace Schemas {
 
     /**
      * * `popover` - popover
-    * `widget` - widget
-    * `external_survey` - external survey
-    * `api` - api
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api
      */
     export type SurveyType = typeof SurveyType[keyof typeof SurveyType];
 
@@ -26554,8 +26605,8 @@ export namespace Schemas {
 
     /**
      * * `day` - day
-    * `week` - week
-    * `month` - month
+     * * `week` - week
+     * * `month` - month
      */
     export type ResponseSamplingIntervalTypeEnum = typeof ResponseSamplingIntervalTypeEnum[keyof typeof ResponseSamplingIntervalTypeEnum];
 
@@ -26592,117 +26643,117 @@ export namespace Schemas {
       readonly targeting_flag: MinimalFeatureFlag;
       readonly internal_targeting_flag: MinimalFeatureFlag;
       /**
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-               */
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *          */
       questions?: unknown;
       /** @nullable */
       readonly conditions: SurveyConditions;
@@ -26788,11 +26839,11 @@ export namespace Schemas {
 
     /**
      * * `CSV` - CSV
-    * `CSVWithNames` - CSVWithNames
-    * `Parquet` - Parquet
-    * `JSONEachRow` - JSON
-    * `Delta` - Delta
-    * `DeltaS3Wrapper` - DeltaS3Wrapper
+     * * `CSVWithNames` - CSVWithNames
+     * * `Parquet` - Parquet
+     * * `JSONEachRow` - JSON
+     * * `Delta` - Delta
+     * * `DeltaS3Wrapper` - DeltaS3Wrapper
      */
     export type TableFormatEnum = typeof TableFormatEnum[keyof typeof TableFormatEnum];
 
@@ -26875,7 +26926,7 @@ export namespace Schemas {
 
     /**
      * * `llm` - LLM
-    * `hog` - Hog
+     * * `hog` - Hog
      */
     export type TaggerTypeEnum = typeof TaggerTypeEnum[keyof typeof TaggerTypeEnum];
 
@@ -26910,14 +26961,14 @@ export namespace Schemas {
      */
     export interface TaggerModelConfiguration {
       /** LLM provider to use for this tagger.
-
-      * `openai` - Openai
-      * `anthropic` - Anthropic
-      * `gemini` - Gemini
-      * `openrouter` - Openrouter
-      * `fireworks` - Fireworks
-      * `azure_openai` - Azure OpenAI
-      * `together_ai` - Together AI */
+       *
+       * * `openai` - Openai
+       * * `anthropic` - Anthropic
+       * * `gemini` - Gemini
+       * * `openrouter` - Openrouter
+       * * `fireworks` - Fireworks
+       * * `azure_openai` - Azure OpenAI
+       * * `together_ai` - Together AI */
       provider: LLMProviderEnum;
       /**
          * Provider model identifier to use for this tagger.
@@ -27032,16 +27083,16 @@ export namespace Schemas {
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
       /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-
-      * `error_tracking` - Error Tracking
-      * `eval_clusters` - Eval Clusters
-      * `user_created` - User Created
-      * `automation` - Automation
-      * `slack` - Slack
-      * `support_queue` - Support Queue
-      * `session_summaries` - Session Summaries
-      * `signal_report` - Signal Report
-      * `signals_scout` - Signals Scout */
+       *
+       * * `error_tracking` - Error Tracking
+       * * `eval_clusters` - Eval Clusters
+       * * `user_created` - User Created
+       * * `automation` - Automation
+       * * `slack` - Slack
+       * * `support_queue` - Support Queue
+       * * `session_summaries` - Session Summaries
+       * * `signal_report` - Signal Report
+       * * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -27096,11 +27147,11 @@ export namespace Schemas {
 
     /**
      * * `not_started` - Not Started
-    * `queued` - Queued
-    * `in_progress` - In Progress
-    * `completed` - Completed
-    * `failed` - Failed
-    * `cancelled` - Cancelled
+     * * `queued` - Queued
+     * * `in_progress` - In Progress
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `cancelled` - Cancelled
      */
     export type TaskRunStatusEnum = typeof TaskRunStatusEnum[keyof typeof TaskRunStatusEnum];
 
@@ -27116,7 +27167,7 @@ export namespace Schemas {
 
     /**
      * * `local` - Local
-    * `cloud` - Cloud
+     * * `cloud` - Cloud
      */
     export type TaskRunEnvironmentEnum = typeof TaskRunEnvironmentEnum[keyof typeof TaskRunEnvironmentEnum];
 
@@ -27128,7 +27179,7 @@ export namespace Schemas {
 
     /**
      * * `claude` - claude
-    * `codex` - codex
+     * * `codex` - codex
      */
     export type RuntimeAdapterEnum = typeof RuntimeAdapterEnum[keyof typeof RuntimeAdapterEnum];
 
@@ -27182,9 +27233,9 @@ export namespace Schemas {
       branch?: string | null;
       status?: TaskRunStatusEnum;
       /** Execution environment
-
-      * `local` - Local
-      * `cloud` - Cloud */
+       *
+       * * `local` - Local
+       * * `cloud` - Cloud */
       environment?: TaskRunEnvironmentEnum;
       /** Configured runtime adapter for this run, such as 'claude' or 'codex'. */
       readonly runtime_adapter: RuntimeAdapterEnum | null;
@@ -27253,7 +27304,7 @@ export namespace Schemas {
 
     /**
      * Serializer for `Team` model with minimal attributes to speeed up loading and transfer times.
-    Also used for nested serializers.
+     * Also used for nested serializers.
      */
     export interface TeamBasic {
       readonly id: number;
@@ -27304,8 +27355,8 @@ export namespace Schemas {
 
     /**
      * * `low` - Low
-    * `medium` - Medium
-    * `high` - High
+     * * `medium` - Medium
+     * * `high` - High
      */
     export type PriorityEnum = typeof PriorityEnum[keyof typeof PriorityEnum];
 
@@ -27363,18 +27414,18 @@ export namespace Schemas {
       readonly channel_detail: ChannelDetailEnum | null;
       readonly distinct_id: string;
       /** Ticket status: new, open, pending, on_hold, or resolved
-
-      * `new` - New
-      * `open` - Open
-      * `pending` - Pending
-      * `on_hold` - On hold
-      * `resolved` - Resolved */
+       *
+       * * `new` - New
+       * * `open` - Open
+       * * `pending` - Pending
+       * * `on_hold` - On hold
+       * * `resolved` - Resolved */
       status?: TicketStatusEnum;
       /** Ticket priority: low, medium, or high. Null if unset.
-
-      * `low` - Low
-      * `medium` - Medium
-      * `high` - High */
+       *
+       * * `low` - Low
+       * * `medium` - Medium
+       * * `high` - High */
       priority?: PriorityEnum | BlankEnum | null;
       readonly assignee: TicketAssignment;
       /** Customer-provided traits such as name and email */
@@ -27652,6 +27703,7 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
+      /** @items.maxLength 254 */
       interviewee_emails?: string[];
       readonly interviewee_identifier: string;
       /** @nullable */
@@ -27676,9 +27728,15 @@ export namespace Schemas {
       readonly id: string;
       readonly created_by: UserBasic;
       readonly created_at: string;
-      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
+      /**
+         * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
+         * @items.maxLength 254
+         */
       interviewee_emails?: string[];
-      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
+      /**
+         * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
+         * @items.maxLength 400
+         */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic: string;
@@ -27709,7 +27767,7 @@ export namespace Schemas {
 
     /**
      * * `disabled` - disabled
-    * `toolbar` - toolbar
+     * * `toolbar` - toolbar
      */
     export type ToolbarModeEnum = typeof ToolbarModeEnum[keyof typeof ToolbarModeEnum];
 
@@ -27728,8 +27786,8 @@ export namespace Schemas {
 
     /**
      * * `light` - Light
-    * `dark` - Dark
-    * `system` - System
+     * * `dark` - Dark
+     * * `system` - System
      */
     export type ThemeModeEnum = typeof ThemeModeEnum[keyof typeof ThemeModeEnum];
 
@@ -27742,8 +27800,8 @@ export namespace Schemas {
 
     /**
      * * `above` - Above
-    * `below` - Below
-    * `hidden` - Hidden
+     * * `below` - Below
+     * * `hidden` - Hidden
      */
     export type ShortcutPositionEnum = typeof ShortcutPositionEnum[keyof typeof ShortcutPositionEnum];
 
@@ -27869,13 +27927,13 @@ export namespace Schemas {
 
     /**
      * * `onboarding` - Onboarding
-    * `product_intent` - Product Intent
-    * `used_by_colleagues` - Used by Colleagues
-    * `used_similar_products` - Used Similar Products
-    * `used_on_separate_team` - Used on Separate Team
-    * `new_product` - New Product
-    * `sales_led` - Sales Led
-    * `onboarding_delegated` - Onboarding Delegated
+     * * `product_intent` - Product Intent
+     * * `used_by_colleagues` - Used by Colleagues
+     * * `used_similar_products` - Used Similar Products
+     * * `used_on_separate_team` - Used on Separate Team
+     * * `new_product` - New Product
+     * * `sales_led` - Sales Led
+     * * `onboarding_delegated` - Onboarding Delegated
      */
     export type UserProductListReasonEnum = typeof UserProductListReasonEnum[keyof typeof UserProductListReasonEnum];
 
@@ -27974,20 +28032,20 @@ export namespace Schemas {
       created_at?: string;
       readonly feature_flag_key: string;
       /** Variants for the web experiment. Example:
-
-              {
-                  "control": {
-                      "transforms": [
-                          {
-                              "text": "Here comes Superman!",
-                              "html": "",
-                              "selector": "#page > #body > .header h1"
-                          }
-                      ],
-                      "conditions": "None",
-                      "rollout_percentage": 50
-                  },
-              } */
+       *
+       *         {
+       *             "control": {
+       *                 "transforms": [
+       *                     {
+       *                         "text": "Here comes Superman!",
+       *                         "html": "",
+       *                         "selector": "#page > #body > .header h1"
+       *                     }
+       *                 ],
+       *                 "conditions": "None",
+       *                 "rollout_percentage": 50
+       *             },
+       *         } */
       variants: unknown;
     }
 
@@ -28002,9 +28060,9 @@ export namespace Schemas {
 
     /**
      * * `idle` - IDLE
-    * `running` - RUNNING
-    * `completed` - COMPLETED
-    * `error` - ERROR
+     * * `running` - RUNNING
+     * * `completed` - COMPLETED
+     * * `error` - ERROR
      */
     export type RunPhaseEnum = typeof RunPhaseEnum[keyof typeof RunPhaseEnum];
 
@@ -28018,10 +28076,10 @@ export namespace Schemas {
 
     /**
      * * `pending` - PENDING
-    * `in_progress` - IN_PROGRESS
-    * `completed` - COMPLETED
-    * `failed` - FAILED
-    * `canceled` - CANCELED
+     * * `in_progress` - IN_PROGRESS
+     * * `completed` - COMPLETED
+     * * `failed` - FAILED
+     * * `canceled` - CANCELED
      */
     export type WizardTaskDTOStatusEnum = typeof WizardTaskDTOStatusEnum[keyof typeof WizardTaskDTOStatusEnum];
 
@@ -28234,12 +28292,12 @@ export namespace Schemas {
       config?: TrendsAlertConfig | null;
       detector_config?: DetectorConfig | null;
       /** How often the alert is checked: every 15 minutes (Boost+), hourly, daily, weekly, or monthly.
-
-      * `every_15_minutes` - every_15_minutes
-      * `hourly` - hourly
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly */
+       *
+       * * `every_15_minutes` - every_15_minutes
+       * * `hourly` - hourly
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly */
       calculation_interval?: CalculationIntervalEnum;
       /**
          * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
@@ -28263,9 +28321,9 @@ export namespace Schemas {
       /** When enabled (and investigation_agent_enabled is on), notification dispatch is held until the investigation agent produces a verdict. Notifications are suppressed when the verdict is false_positive (and optionally when inconclusive). A safety-net task force-fires after a few minutes if the investigation stalls. */
       investigation_gates_notifications?: boolean;
       /** How to handle an 'inconclusive' verdict when notifications are gated. 'notify' is the safe default — an agent that can't be sure is itself useful signal.
-
-      * `notify` - Notify
-      * `suppress` - Suppress */
+       *
+       * * `notify` - Notify
+       * * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
     }
 
@@ -28283,9 +28341,9 @@ export namespace Schemas {
          */
       date_marker?: string | null;
       /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
-
-      * `USR` - user
-      * `GIT` - GitHub */
+       *
+       * * `USR` - user
+       * * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -28306,12 +28364,12 @@ export namespace Schemas {
       /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
       /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
-
-      * `dashboard_item` - insight
-      * `dashboard` - dashboard
-      * `project` - project
-      * `organization` - organization
-      * `recording` - recording */
+       *
+       * * `dashboard_item` - insight
+       * * `dashboard` - dashboard
+       * * `project` - project
+       * * `organization` - organization
+       * * `recording` - recording */
       scope?: AnnotationScopeEnum;
       /**
          * Optional emoji shown in place of the default badge when this annotation is surfaced on a chart.
@@ -28341,29 +28399,29 @@ export namespace Schemas {
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
-
-    Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
-    `destination` schema so integration_id is marked required on the types that need
-    it. Responses continue to use `BatchExportSerializer`.
+     *
+     * Mirrors the writeable fields of `BatchExportSerializer` but uses a polymorphic
+     * `destination` schema so integration_id is marked required on the types that need
+     * it. Responses continue to use `BatchExportSerializer`.
      */
     export interface PatchedBatchExportRequest {
       /** Human-readable name for the batch export. */
       name?: string;
       /** Which data model to export (events, persons, sessions).
-
-      * `events` - Events
-      * `persons` - Persons
-      * `sessions` - Sessions */
+       *
+       * * `events` - Events
+       * * `persons` - Persons
+       * * `sessions` - Sessions */
       model?: ModelEnum;
       /** Destination configuration. Required integration_id is enforced per destination type. */
       destination?: BatchExportDestinationRequest;
       /** How often the batch export should run.
-
-      * `hour` - hour
-      * `day` - day
-      * `week` - week
-      * `every 5 minutes` - every 5 minutes
-      * `every 15 minutes` - every 15 minutes */
+       *
+       * * `hour` - hour
+       * * `day` - day
+       * * `week` - week
+       * * `every 5 minutes` - every 5 minutes
+       * * `every 15 minutes` - every 15 minutes */
       interval?: IntervalEnum;
       /** Whether the batch export is paused. */
       paused?: boolean;
@@ -28456,12 +28514,12 @@ export namespace Schemas {
       readonly count?: number | null;
       is_static?: boolean;
       /** Type of cohort based on filter complexity
-
-      * `static` - static
-      * `person_property` - person_property
-      * `behavioral` - behavioral
-      * `realtime` - realtime
-      * `analytical` - analytical */
+       *
+       * * `static` - static
+       * * `person_property` - person_property
+       * * `behavioral` - behavioral
+       * * `realtime` - realtime
+       * * `analytical` - analytical */
       cohort_type?: CohortTypeEnum | BlankEnum | null;
       readonly experiment_set?: readonly number[];
       _create_in_folder?: string;
@@ -28560,9 +28618,9 @@ export namespace Schemas {
       readonly agent_mode?: string | null;
       readonly is_sandbox?: boolean;
       /** Return pending approval cards as structured data.
-
-      Combines metadata from conversation.approval_decisions with payload from checkpoint
-      interrupts (single source of truth for payload data). */
+       *
+       * Combines metadata from conversation.approval_decisions with payload from checkpoint
+       * interrupts (single source of truth for payload data). */
       readonly pending_approvals?: readonly PatchedConversationPendingApprovalsItem[];
     }
 
@@ -28576,15 +28634,15 @@ export namespace Schemas {
       /** Optional description */
       description?: string;
       /** Lifecycle category for this core event
-
-      * `acquisition` - Acquisition
-      * `activation` - Activation
-      * `monetization` - Monetization
-      * `expansion` - Expansion
-      * `referral` - Referral
-      * `retention` - Retention
-      * `churn` - Churn
-      * `reactivation` - Reactivation */
+       *
+       * * `acquisition` - Acquisition
+       * * `activation` - Activation
+       * * `monetization` - Monetization
+       * * `expansion` - Expansion
+       * * `referral` - Referral
+       * * `retention` - Retention
+       * * `churn` - Churn
+       * * `reactivation` - Reactivation */
       category?: CoreEventCategoryEnum;
       /** Filter configuration - event, action, or data warehouse node */
       filter?: unknown;
@@ -28735,7 +28793,10 @@ export namespace Schemas {
          */
       dashboard_description?: string | null;
       dashboard_filters?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       tags?: string[] | null;
       tiles?: unknown;
       variables?: unknown;
@@ -28752,7 +28813,10 @@ export namespace Schemas {
       /** @nullable */
       readonly team_id?: number | null;
       scope?: DashboardTemplateScopeEnum | BlankEnum | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 255
+         */
       availability_contexts?: string[] | null;
       /** Manually curated; used to highlight templates in the UI. */
       is_featured?: boolean;
@@ -28788,8 +28852,8 @@ export namespace Schemas {
 
     /**
      * Shared methods for DataWarehouseSavedQuery serializers.
-
-    This mixin is intended to be used with serializers.ModelSerializer subclasses.
+     *
+     * This mixin is intended to be used with serializers.ModelSerializer subclasses.
      */
     export interface PatchedDataWarehouseSavedQuery {
       readonly id?: string;
@@ -28808,12 +28872,12 @@ export namespace Schemas {
       readonly sync_frequency?: string | null;
       readonly columns?: readonly PatchedDataWarehouseSavedQueryColumnsItem[];
       /** The status of when this SavedQuery last ran.
-
-      * `Cancelled` - Cancelled
-      * `Modified` - Modified
-      * `Completed` - Completed
-      * `Failed` - Failed
-      * `Running` - Running */
+       *
+       * * `Cancelled` - Cancelled
+       * * `Modified` - Modified
+       * * `Completed` - Completed
+       * * `Failed` - Failed
+       * * `Running` - Running */
       readonly status?: SavedQueryStatusEnum | null;
       /** @nullable */
       readonly last_run_at?: string | null;
@@ -28851,10 +28915,10 @@ export namespace Schemas {
       /** @nullable */
       readonly is_materialized?: boolean | null;
       /** Where this SavedQuery is created.
-
-      * `data_warehouse` - Data Warehouse
-      * `endpoint` - Endpoint
-      * `managed_viewset` - Managed Viewset */
+       *
+       * * `data_warehouse` - Data Warehouse
+       * * `endpoint` - Endpoint
+       * * `managed_viewset` - Managed Viewset */
       readonly origin?: OriginEnum | null;
       /** Whether this view is for testing only and will auto-expire. */
       is_test?: boolean;
@@ -29029,13 +29093,13 @@ export namespace Schemas {
       /** A longer description of what this early access feature does, shown to users in the opt-in UI. */
       description?: string;
       /** Lifecycle stage. Valid values: draft, concept, alpha, beta, general-availability, archived. Moving to an active stage (alpha/beta/general-availability) enables the feature flag for opted-in users.
-
-      * `draft` - draft
-      * `concept` - concept
-      * `alpha` - alpha
-      * `beta` - beta
-      * `general-availability` - general availability
-      * `archived` - archived */
+       *
+       * * `draft` - draft
+       * * `concept` - concept
+       * * `alpha` - alpha
+       * * `beta` - beta
+       * * `general-availability` - general availability
+       * * `archived` - archived */
       stage?: StageEnum;
       /**
          * URL to external documentation for this feature. Shown to users in the opt-in UI.
@@ -29070,7 +29134,10 @@ export namespace Schemas {
          * @nullable
          */
       tag_name?: string | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       attr_class?: string[] | null;
       /**
          * @maxLength 10000
@@ -29444,15 +29511,15 @@ export namespace Schemas {
       readonly status?: EvaluationStatusEnum;
       readonly status_reason?: StatusReasonEnum | null;
       /** 'llm_judge' uses an LLM to score outputs against a prompt; 'hog' runs deterministic Hog code.
-
-      * `llm_judge` - LLM as a judge
-      * `hog` - Hog */
+       *
+       * * `llm_judge` - LLM as a judge
+       * * `hog` - Hog */
       evaluation_type?: EvaluationTypeEnum;
       /** Configuration dict. For 'llm_judge': {prompt}. For 'hog': {source}. */
       evaluation_config?: PatchedEvaluationEvaluationConfig;
       /** Output format. Currently only 'boolean' is supported.
-
-      * `boolean` - Boolean (Pass/Fail) */
+       *
+       * * `boolean` - Boolean (Pass/Fail) */
       output_type?: OutputTypeEnum;
       /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
       output_config?: PatchedEvaluationOutputConfig;
@@ -29471,9 +29538,9 @@ export namespace Schemas {
       /** UUID of the evaluation this report config belongs to. */
       evaluation?: string;
       /** How report generation is triggered. 'every_n' fires once N new evaluation results have accumulated (subject to cooldown_minutes and daily_run_cap). 'scheduled' fires on the cadence defined by rrule + starts_at + timezone_name.
-
-      * `scheduled` - Scheduled
-      * `every_n` - Every N */
+       *
+       * * `scheduled` - Scheduled
+       * * `every_n` - Every N */
       frequency?: EvaluationReportFrequencyEnum;
       /** RFC 5545 recurrence rule string (e.g. 'FREQ=WEEKLY;BYDAY=MO'). Must not contain DTSTART — the anchor is set via starts_at. Required when frequency is 'scheduled'; ignored otherwise. */
       rrule?: string;
@@ -29587,9 +29654,9 @@ export namespace Schemas {
       readonly created_at?: string;
       readonly updated_at?: string;
       /** Experiment type: web for frontend UI changes, product for backend/API changes.
-
-      * `web` - web
-      * `product` - product */
+       *
+       * * `web` - web
+       * * `product` - product */
       type?: ExperimentTypeEnum | null;
       /** Exposure configuration including filter test accounts and custom exposure events. */
       exposure_criteria?: ExperimentApiExposureCriteria | null;
@@ -29603,12 +29670,12 @@ export namespace Schemas {
       allow_unknown_events?: boolean;
       _create_in_folder?: string;
       /** Experiment conclusion: won, lost, inconclusive, stopped_early, or invalid.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Comment about the experiment conclusion.
@@ -29715,12 +29782,12 @@ export namespace Schemas {
       /** @nullable */
       readonly status?: string | null;
       /** Sync strategy: incremental, full_refresh, append, or cdc.
-
-      * `full_refresh` - full_refresh
-      * `incremental` - incremental
-      * `append` - append
-      * `webhook` - webhook
-      * `cdc` - cdc */
+       *
+       * * `full_refresh` - full_refresh
+       * * `incremental` - incremental
+       * * `append` - append
+       * * `webhook` - webhook
+       * * `cdc` - cdc */
       sync_type?: SyncTypeEnum | null;
       /**
          * Column name used to track sync progress.
@@ -29728,27 +29795,27 @@ export namespace Schemas {
          */
       incremental_field?: string | null;
       /** Data type of the incremental field.
-
-      * `integer` - integer
-      * `numeric` - numeric
-      * `datetime` - datetime
-      * `date` - date
-      * `timestamp` - timestamp
-      * `objectid` - objectid */
+       *
+       * * `integer` - integer
+       * * `numeric` - numeric
+       * * `datetime` - datetime
+       * * `date` - date
+       * * `timestamp` - timestamp
+       * * `objectid` - objectid */
       incremental_field_type?: IncrementalFieldTypeEnum | null;
       /** How often to sync.
-
-      * `never` - never
-      * `1min` - 1min
-      * `5min` - 5min
-      * `15min` - 15min
-      * `30min` - 30min
-      * `1hour` - 1hour
-      * `6hour` - 6hour
-      * `12hour` - 12hour
-      * `24hour` - 24hour
-      * `7day` - 7day
-      * `30day` - 30day */
+       *
+       * * `never` - never
+       * * `1min` - 1min
+       * * `5min` - 5min
+       * * `15min` - 15min
+       * * `30min` - 30min
+       * * `1hour` - 1hour
+       * * `6hour` - 6hour
+       * * `12hour` - 12hour
+       * * `24hour` - 24hour
+       * * `7day` - 7day
+       * * `30day` - 30day */
       sync_frequency?: SyncFrequencyEnum | null;
       /**
          * UTC time of day to run the sync (HH:MM:SS).
@@ -29763,10 +29830,10 @@ export namespace Schemas {
          */
       primary_key_columns?: string[] | null;
       /** For CDC syncs: consolidated, cdc_only, or both.
-
-      * `consolidated` - consolidated
-      * `cdc_only` - cdc_only
-      * `both` - both */
+       *
+       * * `consolidated` - consolidated
+       * * `cdc_only` - cdc_only
+       * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
@@ -29798,10 +29865,10 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by?: string | null;
       /** How this source was created. Defaults to `api` on create when omitted. `web` for the in-app UI, `api` for direct API callers, `mcp` for agent/MCP tool calls. Ignored on update.
-
-      * `web` - web
-      * `api` - api
-      * `mcp` - mcp */
+       *
+       * * `web` - web
+       * * `api` - api
+       * * `mcp` - mcp */
       created_via?: CreatedViaEnum | null;
       readonly status?: string;
       client_secret?: string;
@@ -29821,9 +29888,9 @@ export namespace Schemas {
       description?: string | null;
       readonly access_method?: AccessMethodEnum;
       /** Backend engine detected for the direct connection.
-
-      * `duckdb` - duckdb
-      * `postgres` - postgres */
+       *
+       * * `duckdb` - duckdb
+       * * `postgres` - postgres */
       readonly engine?: EngineEnum | null;
       /** @nullable */
       readonly last_run_at?: string | null;
@@ -29939,10 +30006,10 @@ export namespace Schemas {
 
     /**
      * Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-    **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-    **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
+     *
+     * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+     *
+     * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported.
      */
     export type PatchedGroupUsageMetricFilters = { [key: string]: unknown };
 
@@ -29954,27 +30021,27 @@ export namespace Schemas {
          */
       name?: string;
       /** How the metric value is formatted in the UI. One of `numeric` or `currency`.
-
-      * `numeric` - numeric
-      * `currency` - currency */
+       *
+       * * `numeric` - numeric
+       * * `currency` - currency */
       format?: GroupUsageMetricFormatEnum;
       /** Rolling time window in days used to compute the metric. Defaults to 7. */
       interval?: number;
       /** Visual representation in the UI. One of `number` or `sparkline`.
-
-      * `number` - number
-      * `sparkline` - sparkline */
+       *
+       * * `number` - number
+       * * `sparkline` - sparkline */
       display?: GroupUsageMetricDisplayEnum;
       /** Filter definition for the metric. Two shapes are accepted, discriminated by an optional `source` key.
-
-      **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
-
-      **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
+       *
+       * **Events** (default, when `source` is missing or `"events"`): HogFunction filter shape — `events: [...]`, optional `actions: [...]`, `properties: [...]`, `filter_test_accounts: bool`.
+       *
+       * **Data warehouse** (`source: "data_warehouse"`): `table_name` (synced DW table), `timestamp_field` (timestamp column or HogQL expression), `key_field` (column whose value matches the entity key). Currently DW metrics only render on group profiles — person profiles are not yet supported. */
       filters?: PatchedGroupUsageMetricFilters;
       /** Aggregation function. `count` counts matching events; `sum` sums the value of `math_property` on matching events.
-
-      * `count` - count
-      * `sum` - sum */
+       *
+       * * `count` - count
+       * * `sum` - sum */
       math?: MathEnum;
       /**
          * Required when `math` is `sum`; must be empty when `math` is `count`. For events metrics this is an event property name. For data warehouse metrics this is the column name (or HogQL expression) to sum on the DW table.
@@ -29995,15 +30062,15 @@ export namespace Schemas {
       /** Which health check produced this issue (e.g. 'sdk_outdated', 'external_data_failure', 'no_live_events', 'ingestion_warnings'). Stable string key — use it to filter issues by category. */
       readonly kind?: string;
       /** How serious the issue is: 'critical', 'warning', or 'info'.
-
-      * `critical` - Critical
-      * `warning` - Warning
-      * `info` - Info */
+       *
+       * * `critical` - Critical
+       * * `warning` - Warning
+       * * `info` - Info */
       readonly severity?: HealthIssueSeverityEnum;
       /** 'active' while the underlying problem is still detected; 'resolved' once a later check run no longer finds it.
-
-      * `active` - Active
-      * `resolved` - Resolved */
+       *
+       * * `active` - Active
+       * * `resolved` - Resolved */
       readonly status?: HealthIssueStatusEnum;
       /** Whether a user has dismissed this issue from the Health UI. Dismissed issues stay in the list but are hidden by default. */
       dismissed?: boolean;
@@ -30037,10 +30104,10 @@ export namespace Schemas {
       description?: string;
       readonly version?: number;
       /** draft (no execution), active (live), archived (disabled).
-
-      * `draft` - Draft
-      * `active` - Active
-      * `archived` - Archived */
+       *
+       * * `draft` - Draft
+       * * `active` - Active
+       * * `archived` - Archived */
       status?: HogFlowStatusEnum;
       readonly created_at?: string;
       readonly created_by?: UserBasic;
@@ -30051,11 +30118,11 @@ export namespace Schemas {
       /** Conversion goal: {filters: [<cond>, ...], window_minutes}. <cond>: {key, value, operator, type: event|person|group}. Empty filters = any event in window. Required for exit_on_conversion / exit_on_trigger_not_matched_or_conversion. bytecode compiled server-side. */
       conversion?: unknown;
       /** exit_only_at_end: only at exit node (default). exit_on_conversion: also on conversion (needs 'conversion'; silent no-op otherwise). exit_on_trigger_not_matched: also when trigger filter stops matching. exit_on_trigger_not_matched_or_conversion: both (needs 'conversion').
-
-      * `exit_on_conversion` - Conversion
-      * `exit_on_trigger_not_matched` - Trigger Not Matched
-      * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
-      * `exit_only_at_end` - Only At End */
+       *
+       * * `exit_on_conversion` - Conversion
+       * * `exit_on_trigger_not_matched` - Trigger Not Matched
+       * * `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion
+       * * `exit_only_at_end` - Only At End */
       exit_condition?: ExitConditionEnum;
       /** Graph edges: [{from, to, type: 'continue'|'branch', index?}]. 'continue' = fall-through (sequential, or no-match path of conditional_branch). 'branch' requires 'index': matches config.conditions[index] on conditional_branch / wait_until_condition. Every non-exit action needs a reachable next action ('No next action found' otherwise). */
       edges?: HogFlowEdge[];
@@ -30084,10 +30151,10 @@ export namespace Schemas {
       /** Variable value overrides merged with the workflow defaults on each run. */
       variables?: unknown;
       /** active, paused, or completed (set once the RRULE's COUNT/UNTIL is exhausted).
-
-      * `active` - Active
-      * `paused` - Paused
-      * `completed` - Completed */
+       *
+       * * `active` - Active
+       * * `paused` - Paused
+       * * `completed` - Completed */
       readonly status?: HogFlowScheduleStatusEnum;
       /**
          * Next scheduled fire time, computed by the scheduler.
@@ -30110,7 +30177,7 @@ export namespace Schemas {
 
     /**
      * Serializer for creating hog flow templates.
-    Validates and sanitizes the workflow before creating it as a template.
+     * Validates and sanitizes the workflow before creating it as a template.
      */
     export interface PatchedHogFlowTemplate {
       readonly id?: string;
@@ -30150,14 +30217,14 @@ export namespace Schemas {
     export interface PatchedHogFunction {
       readonly id?: string;
       /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
-
-      * `destination` - Destination
-      * `site_destination` - Site Destination
-      * `internal_destination` - Internal Destination
-      * `source_webhook` - Source Webhook
-      * `warehouse_source_webhook` - Warehouse Source Webhook
-      * `site_app` - Site App
-      * `transformation` - Transformation */
+       *
+       * * `destination` - Destination
+       * * `site_destination` - Site Destination
+       * * `internal_destination` - Internal Destination
+       * * `source_webhook` - Source Webhook
+       * * `warehouse_source_webhook` - Warehouse Source Webhook
+       * * `site_app` - Site App
+       * * `transformation` - Transformation */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -30260,21 +30327,21 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
-              DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
-              A dashboard ID for each of the dashboards that this insight is displayed on.
-               */
+       *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
+       *         A dashboard ID for each of the dashboards that this insight is displayed on.
+       *          */
       dashboards?: number[];
       /**
-          A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
-           */
+       *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
+       *      */
       readonly dashboard_tiles?: readonly DashboardTileBasic[];
       /**
          *
-          The datetime this insight's results were generated.
-          If added to one or more dashboards the insight can be refreshed separately on each.
-          Returns the appropriate last_refresh datetime for the context the insight is viewed in
-          (see from_dashboard query parameter).
-
+       *     The datetime this insight's results were generated.
+       *     If added to one or more dashboards the insight can be refreshed separately on each.
+       *     Returns the appropriate last_refresh datetime for the context the insight is viewed in
+       *     (see from_dashboard query parameter).
+       *
          * @nullable
          */
       readonly last_refresh?: string | null;
@@ -30285,9 +30352,9 @@ export namespace Schemas {
       readonly cache_target_age?: string | null;
       /**
          *
-          The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
-          by querying the database.
-
+       *     The earliest possible datetime at which we'll allow the cached results for this insight to be refreshed
+       *     by querying the database.
+       *
          * @nullable
          */
       readonly next_allowed_client_refresh?: string | null;
@@ -30347,12 +30414,12 @@ export namespace Schemas {
          */
       name?: string;
       /** Variable type. Controls how the value is rendered and substituted in HogQL.
-
-      * `String` - String
-      * `Number` - Number
-      * `Boolean` - Boolean
-      * `List` - List
-      * `Date` - Date */
+       *
+       * * `String` - String
+       * * `Number` - Number
+       * * `Boolean` - Boolean
+       * * `List` - List
+       * * `Date` - Date */
       type?: InsightVariableTypeEnum;
       /** Default value used when a query references this variable. */
       default_value?: unknown;
@@ -30531,22 +30598,22 @@ export namespace Schemas {
          */
       threshold_count?: number;
       /** Whether the alert fires when the count is above or below the threshold.
-
-      * `above` - Above
-      * `below` - Below */
+       *
+       * * `above` - Above
+       * * `below` - Below */
       threshold_operator?: ThresholdOperatorEnum;
       /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes?: number;
       /** Current alert state: not_firing, firing, pending_resolve, errored, or snoozed. Server-managed.
-
-      * `not_firing` - Not firing
-      * `firing` - Firing
-      * `pending_resolve` - Pending resolve
-      * `errored` - Errored
-      * `snoozed` - Snoozed
-      * `broken` - Broken */
+       *
+       * * `not_firing` - Not firing
+       * * `firing` - Firing
+       * * `pending_resolve` - Pending resolve
+       * * `errored` - Errored
+       * * `snoozed` - Snoozed
+       * * `broken` - Broken */
       readonly state?: LogsAlertConfigurationStateEnum;
       /**
          * Total number of check periods in the sliding evaluation window for firing (M in N-of-M).
@@ -30630,10 +30697,10 @@ export namespace Schemas {
          */
       priority?: number | null;
       /** Rule kind: severity_sampling, path_drop, or rate_limit (caps matching log volume at ingestion).
-
-      * `severity_sampling` - Severity-based reduction
-      * `path_drop` - Path exclusion
-      * `rate_limit` - Rate limit */
+       *
+       * * `severity_sampling` - Severity-based reduction
+       * * `path_drop` - Path exclusion
+       * * `rate_limit` - Rate limit */
       rule_type?: RuleTypeEnum;
       /**
          * Optional legacy service-name scope; new rules use `config.filter_group` for matching instead.
@@ -30907,9 +30974,9 @@ export namespace Schemas {
       /** @nullable */
       readonly is_hipaa?: boolean | null;
       /** Default statistical method for new experiments in this organization.
-
-      * `bayesian` - Bayesian
-      * `frequentist` - Frequentist */
+       *
+       * * `bayesian` - Bayesian
+       * * `frequentist` - Frequentist */
       default_experiment_stats_method?: DefaultExperimentStatsMethodEnum | BlankEnum | null;
       /** Default setting for 'Discard client IP data' for new projects in this organization. */
       default_anonymize_ips?: boolean;
@@ -30982,7 +31049,10 @@ export namespace Schemas {
          * @nullable
          */
       id_jag_jwks_url?: string | null;
-      /** Allowed ID-JAG client IDs. Empty list allows any client_id. */
+      /**
+         * Allowed ID-JAG client IDs. Empty list allows any client_id.
+         * @items.maxLength 256
+         */
       id_jag_allowed_clients?: string[];
     }
 
@@ -31030,10 +31100,10 @@ export namespace Schemas {
     export interface PatchedPersistedFolder {
       readonly id?: string;
       /** Which persisted folder this is for the user (home, pinned, custom_products).
-
-      * `home` - Home
-      * `pinned` - Pinned
-      * `custom_products` - Custom Products */
+       *
+       * * `home` - Home
+       * * `pinned` - Pinned
+       * * `custom_products` - Custom Products */
       type?: PersistedFolderTypeEnum;
       /**
          * Protocol prefix of the folder location, e.g. 'products://'.
@@ -31108,7 +31178,7 @@ export namespace Schemas {
 
     /**
      * * `app` - app
-    * `toolbar` - toolbar
+     * * `toolbar` - toolbar
      */
     export type ProductTourSerializerCreateUpdateOnlyCreationContextEnum = typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnum[keyof typeof ProductTourSerializerCreateUpdateOnlyCreationContextEnum];
 
@@ -31142,9 +31212,9 @@ export namespace Schemas {
       readonly updated_at?: string;
       archived?: boolean;
       /** Where the tour was created/updated from
-
-      * `app` - app
-      * `toolbar` - toolbar */
+       *
+       * * `app` - app
+       * * `toolbar` - toolbar */
       creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnum;
     }
 
@@ -31162,9 +31232,9 @@ export namespace Schemas {
 
     /**
      * * `30d` - 30 Days
-    * `90d` - 90 Days
-    * `1y` - 1 Year
-    * `5y` - 5 Years
+     * * `90d` - 90 Days
+     * * `1y` - 1 Year
+     * * `5y` - 5 Years
      */
     export type SessionRecordingRetentionPeriodEnum = typeof SessionRecordingRetentionPeriodEnum[keyof typeof SessionRecordingRetentionPeriodEnum];
 
@@ -31178,7 +31248,7 @@ export namespace Schemas {
 
     /**
      * * `0` - Sunday
-    * `1` - Monday
+     * * `1` - Monday
      */
     export type WeekStartDayEnum = typeof WeekStartDayEnum[keyof typeof WeekStartDayEnum];
 
@@ -31216,6 +31286,7 @@ export namespace Schemas {
       readonly updated_at?: string | null;
       readonly uuid?: string;
       readonly api_token?: string;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       /** When true, PostHog drops the IP address from every ingested event. */
       anonymize_ips?: boolean;
@@ -31232,609 +31303,610 @@ export namespace Schemas {
       path_cleaning_filters?: unknown;
       is_demo?: boolean;
       /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-
-      * `Africa/Abidjan` - Africa/Abidjan
-      * `Africa/Accra` - Africa/Accra
-      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-      * `Africa/Algiers` - Africa/Algiers
-      * `Africa/Asmara` - Africa/Asmara
-      * `Africa/Asmera` - Africa/Asmera
-      * `Africa/Bamako` - Africa/Bamako
-      * `Africa/Bangui` - Africa/Bangui
-      * `Africa/Banjul` - Africa/Banjul
-      * `Africa/Bissau` - Africa/Bissau
-      * `Africa/Blantyre` - Africa/Blantyre
-      * `Africa/Brazzaville` - Africa/Brazzaville
-      * `Africa/Bujumbura` - Africa/Bujumbura
-      * `Africa/Cairo` - Africa/Cairo
-      * `Africa/Casablanca` - Africa/Casablanca
-      * `Africa/Ceuta` - Africa/Ceuta
-      * `Africa/Conakry` - Africa/Conakry
-      * `Africa/Dakar` - Africa/Dakar
-      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-      * `Africa/Djibouti` - Africa/Djibouti
-      * `Africa/Douala` - Africa/Douala
-      * `Africa/El_Aaiun` - Africa/El_Aaiun
-      * `Africa/Freetown` - Africa/Freetown
-      * `Africa/Gaborone` - Africa/Gaborone
-      * `Africa/Harare` - Africa/Harare
-      * `Africa/Johannesburg` - Africa/Johannesburg
-      * `Africa/Juba` - Africa/Juba
-      * `Africa/Kampala` - Africa/Kampala
-      * `Africa/Khartoum` - Africa/Khartoum
-      * `Africa/Kigali` - Africa/Kigali
-      * `Africa/Kinshasa` - Africa/Kinshasa
-      * `Africa/Lagos` - Africa/Lagos
-      * `Africa/Libreville` - Africa/Libreville
-      * `Africa/Lome` - Africa/Lome
-      * `Africa/Luanda` - Africa/Luanda
-      * `Africa/Lubumbashi` - Africa/Lubumbashi
-      * `Africa/Lusaka` - Africa/Lusaka
-      * `Africa/Malabo` - Africa/Malabo
-      * `Africa/Maputo` - Africa/Maputo
-      * `Africa/Maseru` - Africa/Maseru
-      * `Africa/Mbabane` - Africa/Mbabane
-      * `Africa/Mogadishu` - Africa/Mogadishu
-      * `Africa/Monrovia` - Africa/Monrovia
-      * `Africa/Nairobi` - Africa/Nairobi
-      * `Africa/Ndjamena` - Africa/Ndjamena
-      * `Africa/Niamey` - Africa/Niamey
-      * `Africa/Nouakchott` - Africa/Nouakchott
-      * `Africa/Ouagadougou` - Africa/Ouagadougou
-      * `Africa/Porto-Novo` - Africa/Porto-Novo
-      * `Africa/Sao_Tome` - Africa/Sao_Tome
-      * `Africa/Timbuktu` - Africa/Timbuktu
-      * `Africa/Tripoli` - Africa/Tripoli
-      * `Africa/Tunis` - Africa/Tunis
-      * `Africa/Windhoek` - Africa/Windhoek
-      * `America/Adak` - America/Adak
-      * `America/Anchorage` - America/Anchorage
-      * `America/Anguilla` - America/Anguilla
-      * `America/Antigua` - America/Antigua
-      * `America/Araguaina` - America/Araguaina
-      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-      * `America/Argentina/Salta` - America/Argentina/Salta
-      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-      * `America/Aruba` - America/Aruba
-      * `America/Asuncion` - America/Asuncion
-      * `America/Atikokan` - America/Atikokan
-      * `America/Atka` - America/Atka
-      * `America/Bahia` - America/Bahia
-      * `America/Bahia_Banderas` - America/Bahia_Banderas
-      * `America/Barbados` - America/Barbados
-      * `America/Belem` - America/Belem
-      * `America/Belize` - America/Belize
-      * `America/Blanc-Sablon` - America/Blanc-Sablon
-      * `America/Boa_Vista` - America/Boa_Vista
-      * `America/Bogota` - America/Bogota
-      * `America/Boise` - America/Boise
-      * `America/Buenos_Aires` - America/Buenos_Aires
-      * `America/Cambridge_Bay` - America/Cambridge_Bay
-      * `America/Campo_Grande` - America/Campo_Grande
-      * `America/Cancun` - America/Cancun
-      * `America/Caracas` - America/Caracas
-      * `America/Catamarca` - America/Catamarca
-      * `America/Cayenne` - America/Cayenne
-      * `America/Cayman` - America/Cayman
-      * `America/Chicago` - America/Chicago
-      * `America/Chihuahua` - America/Chihuahua
-      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-      * `America/Coral_Harbour` - America/Coral_Harbour
-      * `America/Cordoba` - America/Cordoba
-      * `America/Costa_Rica` - America/Costa_Rica
-      * `America/Creston` - America/Creston
-      * `America/Cuiaba` - America/Cuiaba
-      * `America/Curacao` - America/Curacao
-      * `America/Danmarkshavn` - America/Danmarkshavn
-      * `America/Dawson` - America/Dawson
-      * `America/Dawson_Creek` - America/Dawson_Creek
-      * `America/Denver` - America/Denver
-      * `America/Detroit` - America/Detroit
-      * `America/Dominica` - America/Dominica
-      * `America/Edmonton` - America/Edmonton
-      * `America/Eirunepe` - America/Eirunepe
-      * `America/El_Salvador` - America/El_Salvador
-      * `America/Ensenada` - America/Ensenada
-      * `America/Fort_Nelson` - America/Fort_Nelson
-      * `America/Fort_Wayne` - America/Fort_Wayne
-      * `America/Fortaleza` - America/Fortaleza
-      * `America/Glace_Bay` - America/Glace_Bay
-      * `America/Godthab` - America/Godthab
-      * `America/Goose_Bay` - America/Goose_Bay
-      * `America/Grand_Turk` - America/Grand_Turk
-      * `America/Grenada` - America/Grenada
-      * `America/Guadeloupe` - America/Guadeloupe
-      * `America/Guatemala` - America/Guatemala
-      * `America/Guayaquil` - America/Guayaquil
-      * `America/Guyana` - America/Guyana
-      * `America/Halifax` - America/Halifax
-      * `America/Havana` - America/Havana
-      * `America/Hermosillo` - America/Hermosillo
-      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-      * `America/Indiana/Knox` - America/Indiana/Knox
-      * `America/Indiana/Marengo` - America/Indiana/Marengo
-      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-      * `America/Indiana/Vevay` - America/Indiana/Vevay
-      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-      * `America/Indiana/Winamac` - America/Indiana/Winamac
-      * `America/Indianapolis` - America/Indianapolis
-      * `America/Inuvik` - America/Inuvik
-      * `America/Iqaluit` - America/Iqaluit
-      * `America/Jamaica` - America/Jamaica
-      * `America/Jujuy` - America/Jujuy
-      * `America/Juneau` - America/Juneau
-      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-      * `America/Knox_IN` - America/Knox_IN
-      * `America/Kralendijk` - America/Kralendijk
-      * `America/La_Paz` - America/La_Paz
-      * `America/Lima` - America/Lima
-      * `America/Los_Angeles` - America/Los_Angeles
-      * `America/Louisville` - America/Louisville
-      * `America/Lower_Princes` - America/Lower_Princes
-      * `America/Maceio` - America/Maceio
-      * `America/Managua` - America/Managua
-      * `America/Manaus` - America/Manaus
-      * `America/Marigot` - America/Marigot
-      * `America/Martinique` - America/Martinique
-      * `America/Matamoros` - America/Matamoros
-      * `America/Mazatlan` - America/Mazatlan
-      * `America/Mendoza` - America/Mendoza
-      * `America/Menominee` - America/Menominee
-      * `America/Merida` - America/Merida
-      * `America/Metlakatla` - America/Metlakatla
-      * `America/Mexico_City` - America/Mexico_City
-      * `America/Miquelon` - America/Miquelon
-      * `America/Moncton` - America/Moncton
-      * `America/Monterrey` - America/Monterrey
-      * `America/Montevideo` - America/Montevideo
-      * `America/Montreal` - America/Montreal
-      * `America/Montserrat` - America/Montserrat
-      * `America/Nassau` - America/Nassau
-      * `America/New_York` - America/New_York
-      * `America/Nipigon` - America/Nipigon
-      * `America/Nome` - America/Nome
-      * `America/Noronha` - America/Noronha
-      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-      * `America/North_Dakota/Center` - America/North_Dakota/Center
-      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-      * `America/Nuuk` - America/Nuuk
-      * `America/Ojinaga` - America/Ojinaga
-      * `America/Panama` - America/Panama
-      * `America/Pangnirtung` - America/Pangnirtung
-      * `America/Paramaribo` - America/Paramaribo
-      * `America/Phoenix` - America/Phoenix
-      * `America/Port-au-Prince` - America/Port-au-Prince
-      * `America/Port_of_Spain` - America/Port_of_Spain
-      * `America/Porto_Acre` - America/Porto_Acre
-      * `America/Porto_Velho` - America/Porto_Velho
-      * `America/Puerto_Rico` - America/Puerto_Rico
-      * `America/Punta_Arenas` - America/Punta_Arenas
-      * `America/Rainy_River` - America/Rainy_River
-      * `America/Rankin_Inlet` - America/Rankin_Inlet
-      * `America/Recife` - America/Recife
-      * `America/Regina` - America/Regina
-      * `America/Resolute` - America/Resolute
-      * `America/Rio_Branco` - America/Rio_Branco
-      * `America/Rosario` - America/Rosario
-      * `America/Santa_Isabel` - America/Santa_Isabel
-      * `America/Santarem` - America/Santarem
-      * `America/Santiago` - America/Santiago
-      * `America/Santo_Domingo` - America/Santo_Domingo
-      * `America/Sao_Paulo` - America/Sao_Paulo
-      * `America/Scoresbysund` - America/Scoresbysund
-      * `America/Shiprock` - America/Shiprock
-      * `America/Sitka` - America/Sitka
-      * `America/St_Barthelemy` - America/St_Barthelemy
-      * `America/St_Johns` - America/St_Johns
-      * `America/St_Kitts` - America/St_Kitts
-      * `America/St_Lucia` - America/St_Lucia
-      * `America/St_Thomas` - America/St_Thomas
-      * `America/St_Vincent` - America/St_Vincent
-      * `America/Swift_Current` - America/Swift_Current
-      * `America/Tegucigalpa` - America/Tegucigalpa
-      * `America/Thule` - America/Thule
-      * `America/Thunder_Bay` - America/Thunder_Bay
-      * `America/Tijuana` - America/Tijuana
-      * `America/Toronto` - America/Toronto
-      * `America/Tortola` - America/Tortola
-      * `America/Vancouver` - America/Vancouver
-      * `America/Virgin` - America/Virgin
-      * `America/Whitehorse` - America/Whitehorse
-      * `America/Winnipeg` - America/Winnipeg
-      * `America/Yakutat` - America/Yakutat
-      * `America/Yellowknife` - America/Yellowknife
-      * `Antarctica/Casey` - Antarctica/Casey
-      * `Antarctica/Davis` - Antarctica/Davis
-      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-      * `Antarctica/Macquarie` - Antarctica/Macquarie
-      * `Antarctica/Mawson` - Antarctica/Mawson
-      * `Antarctica/McMurdo` - Antarctica/McMurdo
-      * `Antarctica/Palmer` - Antarctica/Palmer
-      * `Antarctica/Rothera` - Antarctica/Rothera
-      * `Antarctica/South_Pole` - Antarctica/South_Pole
-      * `Antarctica/Syowa` - Antarctica/Syowa
-      * `Antarctica/Troll` - Antarctica/Troll
-      * `Antarctica/Vostok` - Antarctica/Vostok
-      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-      * `Asia/Aden` - Asia/Aden
-      * `Asia/Almaty` - Asia/Almaty
-      * `Asia/Amman` - Asia/Amman
-      * `Asia/Anadyr` - Asia/Anadyr
-      * `Asia/Aqtau` - Asia/Aqtau
-      * `Asia/Aqtobe` - Asia/Aqtobe
-      * `Asia/Ashgabat` - Asia/Ashgabat
-      * `Asia/Ashkhabad` - Asia/Ashkhabad
-      * `Asia/Atyrau` - Asia/Atyrau
-      * `Asia/Baghdad` - Asia/Baghdad
-      * `Asia/Bahrain` - Asia/Bahrain
-      * `Asia/Baku` - Asia/Baku
-      * `Asia/Bangkok` - Asia/Bangkok
-      * `Asia/Barnaul` - Asia/Barnaul
-      * `Asia/Beirut` - Asia/Beirut
-      * `Asia/Bishkek` - Asia/Bishkek
-      * `Asia/Brunei` - Asia/Brunei
-      * `Asia/Calcutta` - Asia/Calcutta
-      * `Asia/Chita` - Asia/Chita
-      * `Asia/Choibalsan` - Asia/Choibalsan
-      * `Asia/Chongqing` - Asia/Chongqing
-      * `Asia/Chungking` - Asia/Chungking
-      * `Asia/Colombo` - Asia/Colombo
-      * `Asia/Dacca` - Asia/Dacca
-      * `Asia/Damascus` - Asia/Damascus
-      * `Asia/Dhaka` - Asia/Dhaka
-      * `Asia/Dili` - Asia/Dili
-      * `Asia/Dubai` - Asia/Dubai
-      * `Asia/Dushanbe` - Asia/Dushanbe
-      * `Asia/Famagusta` - Asia/Famagusta
-      * `Asia/Gaza` - Asia/Gaza
-      * `Asia/Harbin` - Asia/Harbin
-      * `Asia/Hebron` - Asia/Hebron
-      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-      * `Asia/Hong_Kong` - Asia/Hong_Kong
-      * `Asia/Hovd` - Asia/Hovd
-      * `Asia/Irkutsk` - Asia/Irkutsk
-      * `Asia/Istanbul` - Asia/Istanbul
-      * `Asia/Jakarta` - Asia/Jakarta
-      * `Asia/Jayapura` - Asia/Jayapura
-      * `Asia/Jerusalem` - Asia/Jerusalem
-      * `Asia/Kabul` - Asia/Kabul
-      * `Asia/Kamchatka` - Asia/Kamchatka
-      * `Asia/Karachi` - Asia/Karachi
-      * `Asia/Kashgar` - Asia/Kashgar
-      * `Asia/Kathmandu` - Asia/Kathmandu
-      * `Asia/Katmandu` - Asia/Katmandu
-      * `Asia/Khandyga` - Asia/Khandyga
-      * `Asia/Kolkata` - Asia/Kolkata
-      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-      * `Asia/Kuching` - Asia/Kuching
-      * `Asia/Kuwait` - Asia/Kuwait
-      * `Asia/Macao` - Asia/Macao
-      * `Asia/Macau` - Asia/Macau
-      * `Asia/Magadan` - Asia/Magadan
-      * `Asia/Makassar` - Asia/Makassar
-      * `Asia/Manila` - Asia/Manila
-      * `Asia/Muscat` - Asia/Muscat
-      * `Asia/Nicosia` - Asia/Nicosia
-      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-      * `Asia/Novosibirsk` - Asia/Novosibirsk
-      * `Asia/Omsk` - Asia/Omsk
-      * `Asia/Oral` - Asia/Oral
-      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-      * `Asia/Pontianak` - Asia/Pontianak
-      * `Asia/Pyongyang` - Asia/Pyongyang
-      * `Asia/Qatar` - Asia/Qatar
-      * `Asia/Qostanay` - Asia/Qostanay
-      * `Asia/Qyzylorda` - Asia/Qyzylorda
-      * `Asia/Rangoon` - Asia/Rangoon
-      * `Asia/Riyadh` - Asia/Riyadh
-      * `Asia/Saigon` - Asia/Saigon
-      * `Asia/Sakhalin` - Asia/Sakhalin
-      * `Asia/Samarkand` - Asia/Samarkand
-      * `Asia/Seoul` - Asia/Seoul
-      * `Asia/Shanghai` - Asia/Shanghai
-      * `Asia/Singapore` - Asia/Singapore
-      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-      * `Asia/Taipei` - Asia/Taipei
-      * `Asia/Tashkent` - Asia/Tashkent
-      * `Asia/Tbilisi` - Asia/Tbilisi
-      * `Asia/Tehran` - Asia/Tehran
-      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-      * `Asia/Thimbu` - Asia/Thimbu
-      * `Asia/Thimphu` - Asia/Thimphu
-      * `Asia/Tokyo` - Asia/Tokyo
-      * `Asia/Tomsk` - Asia/Tomsk
-      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-      * `Asia/Urumqi` - Asia/Urumqi
-      * `Asia/Ust-Nera` - Asia/Ust-Nera
-      * `Asia/Vientiane` - Asia/Vientiane
-      * `Asia/Vladivostok` - Asia/Vladivostok
-      * `Asia/Yakutsk` - Asia/Yakutsk
-      * `Asia/Yangon` - Asia/Yangon
-      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-      * `Asia/Yerevan` - Asia/Yerevan
-      * `Atlantic/Azores` - Atlantic/Azores
-      * `Atlantic/Bermuda` - Atlantic/Bermuda
-      * `Atlantic/Canary` - Atlantic/Canary
-      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-      * `Atlantic/Faeroe` - Atlantic/Faeroe
-      * `Atlantic/Faroe` - Atlantic/Faroe
-      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-      * `Atlantic/Madeira` - Atlantic/Madeira
-      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-      * `Atlantic/St_Helena` - Atlantic/St_Helena
-      * `Atlantic/Stanley` - Atlantic/Stanley
-      * `Australia/ACT` - Australia/ACT
-      * `Australia/Adelaide` - Australia/Adelaide
-      * `Australia/Brisbane` - Australia/Brisbane
-      * `Australia/Broken_Hill` - Australia/Broken_Hill
-      * `Australia/Canberra` - Australia/Canberra
-      * `Australia/Currie` - Australia/Currie
-      * `Australia/Darwin` - Australia/Darwin
-      * `Australia/Eucla` - Australia/Eucla
-      * `Australia/Hobart` - Australia/Hobart
-      * `Australia/LHI` - Australia/LHI
-      * `Australia/Lindeman` - Australia/Lindeman
-      * `Australia/Lord_Howe` - Australia/Lord_Howe
-      * `Australia/Melbourne` - Australia/Melbourne
-      * `Australia/NSW` - Australia/NSW
-      * `Australia/North` - Australia/North
-      * `Australia/Perth` - Australia/Perth
-      * `Australia/Queensland` - Australia/Queensland
-      * `Australia/South` - Australia/South
-      * `Australia/Sydney` - Australia/Sydney
-      * `Australia/Tasmania` - Australia/Tasmania
-      * `Australia/Victoria` - Australia/Victoria
-      * `Australia/West` - Australia/West
-      * `Australia/Yancowinna` - Australia/Yancowinna
-      * `Brazil/Acre` - Brazil/Acre
-      * `Brazil/DeNoronha` - Brazil/DeNoronha
-      * `Brazil/East` - Brazil/East
-      * `Brazil/West` - Brazil/West
-      * `CET` - CET
-      * `CST6CDT` - CST6CDT
-      * `Canada/Atlantic` - Canada/Atlantic
-      * `Canada/Central` - Canada/Central
-      * `Canada/Eastern` - Canada/Eastern
-      * `Canada/Mountain` - Canada/Mountain
-      * `Canada/Newfoundland` - Canada/Newfoundland
-      * `Canada/Pacific` - Canada/Pacific
-      * `Canada/Saskatchewan` - Canada/Saskatchewan
-      * `Canada/Yukon` - Canada/Yukon
-      * `Chile/Continental` - Chile/Continental
-      * `Chile/EasterIsland` - Chile/EasterIsland
-      * `Cuba` - Cuba
-      * `EET` - EET
-      * `EST` - EST
-      * `EST5EDT` - EST5EDT
-      * `Egypt` - Egypt
-      * `Eire` - Eire
-      * `Etc/GMT` - Etc/GMT
-      * `Etc/GMT+0` - Etc/GMT+0
-      * `Etc/GMT+1` - Etc/GMT+1
-      * `Etc/GMT+10` - Etc/GMT+10
-      * `Etc/GMT+11` - Etc/GMT+11
-      * `Etc/GMT+12` - Etc/GMT+12
-      * `Etc/GMT+2` - Etc/GMT+2
-      * `Etc/GMT+3` - Etc/GMT+3
-      * `Etc/GMT+4` - Etc/GMT+4
-      * `Etc/GMT+5` - Etc/GMT+5
-      * `Etc/GMT+6` - Etc/GMT+6
-      * `Etc/GMT+7` - Etc/GMT+7
-      * `Etc/GMT+8` - Etc/GMT+8
-      * `Etc/GMT+9` - Etc/GMT+9
-      * `Etc/GMT-0` - Etc/GMT-0
-      * `Etc/GMT-1` - Etc/GMT-1
-      * `Etc/GMT-10` - Etc/GMT-10
-      * `Etc/GMT-11` - Etc/GMT-11
-      * `Etc/GMT-12` - Etc/GMT-12
-      * `Etc/GMT-13` - Etc/GMT-13
-      * `Etc/GMT-14` - Etc/GMT-14
-      * `Etc/GMT-2` - Etc/GMT-2
-      * `Etc/GMT-3` - Etc/GMT-3
-      * `Etc/GMT-4` - Etc/GMT-4
-      * `Etc/GMT-5` - Etc/GMT-5
-      * `Etc/GMT-6` - Etc/GMT-6
-      * `Etc/GMT-7` - Etc/GMT-7
-      * `Etc/GMT-8` - Etc/GMT-8
-      * `Etc/GMT-9` - Etc/GMT-9
-      * `Etc/GMT0` - Etc/GMT0
-      * `Etc/Greenwich` - Etc/Greenwich
-      * `Etc/UCT` - Etc/UCT
-      * `Etc/UTC` - Etc/UTC
-      * `Etc/Universal` - Etc/Universal
-      * `Etc/Zulu` - Etc/Zulu
-      * `Europe/Amsterdam` - Europe/Amsterdam
-      * `Europe/Andorra` - Europe/Andorra
-      * `Europe/Astrakhan` - Europe/Astrakhan
-      * `Europe/Athens` - Europe/Athens
-      * `Europe/Belfast` - Europe/Belfast
-      * `Europe/Belgrade` - Europe/Belgrade
-      * `Europe/Berlin` - Europe/Berlin
-      * `Europe/Bratislava` - Europe/Bratislava
-      * `Europe/Brussels` - Europe/Brussels
-      * `Europe/Bucharest` - Europe/Bucharest
-      * `Europe/Budapest` - Europe/Budapest
-      * `Europe/Busingen` - Europe/Busingen
-      * `Europe/Chisinau` - Europe/Chisinau
-      * `Europe/Copenhagen` - Europe/Copenhagen
-      * `Europe/Dublin` - Europe/Dublin
-      * `Europe/Gibraltar` - Europe/Gibraltar
-      * `Europe/Guernsey` - Europe/Guernsey
-      * `Europe/Helsinki` - Europe/Helsinki
-      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-      * `Europe/Istanbul` - Europe/Istanbul
-      * `Europe/Jersey` - Europe/Jersey
-      * `Europe/Kaliningrad` - Europe/Kaliningrad
-      * `Europe/Kiev` - Europe/Kiev
-      * `Europe/Kirov` - Europe/Kirov
-      * `Europe/Kyiv` - Europe/Kyiv
-      * `Europe/Lisbon` - Europe/Lisbon
-      * `Europe/Ljubljana` - Europe/Ljubljana
-      * `Europe/London` - Europe/London
-      * `Europe/Luxembourg` - Europe/Luxembourg
-      * `Europe/Madrid` - Europe/Madrid
-      * `Europe/Malta` - Europe/Malta
-      * `Europe/Mariehamn` - Europe/Mariehamn
-      * `Europe/Minsk` - Europe/Minsk
-      * `Europe/Monaco` - Europe/Monaco
-      * `Europe/Moscow` - Europe/Moscow
-      * `Europe/Nicosia` - Europe/Nicosia
-      * `Europe/Oslo` - Europe/Oslo
-      * `Europe/Paris` - Europe/Paris
-      * `Europe/Podgorica` - Europe/Podgorica
-      * `Europe/Prague` - Europe/Prague
-      * `Europe/Riga` - Europe/Riga
-      * `Europe/Rome` - Europe/Rome
-      * `Europe/Samara` - Europe/Samara
-      * `Europe/San_Marino` - Europe/San_Marino
-      * `Europe/Sarajevo` - Europe/Sarajevo
-      * `Europe/Saratov` - Europe/Saratov
-      * `Europe/Simferopol` - Europe/Simferopol
-      * `Europe/Skopje` - Europe/Skopje
-      * `Europe/Sofia` - Europe/Sofia
-      * `Europe/Stockholm` - Europe/Stockholm
-      * `Europe/Tallinn` - Europe/Tallinn
-      * `Europe/Tirane` - Europe/Tirane
-      * `Europe/Tiraspol` - Europe/Tiraspol
-      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-      * `Europe/Uzhgorod` - Europe/Uzhgorod
-      * `Europe/Vaduz` - Europe/Vaduz
-      * `Europe/Vatican` - Europe/Vatican
-      * `Europe/Vienna` - Europe/Vienna
-      * `Europe/Vilnius` - Europe/Vilnius
-      * `Europe/Volgograd` - Europe/Volgograd
-      * `Europe/Warsaw` - Europe/Warsaw
-      * `Europe/Zagreb` - Europe/Zagreb
-      * `Europe/Zaporozhye` - Europe/Zaporozhye
-      * `Europe/Zurich` - Europe/Zurich
-      * `GB` - GB
-      * `GB-Eire` - GB-Eire
-      * `GMT` - GMT
-      * `GMT+0` - GMT+0
-      * `GMT-0` - GMT-0
-      * `GMT0` - GMT0
-      * `Greenwich` - Greenwich
-      * `HST` - HST
-      * `Hongkong` - Hongkong
-      * `Iceland` - Iceland
-      * `Indian/Antananarivo` - Indian/Antananarivo
-      * `Indian/Chagos` - Indian/Chagos
-      * `Indian/Christmas` - Indian/Christmas
-      * `Indian/Cocos` - Indian/Cocos
-      * `Indian/Comoro` - Indian/Comoro
-      * `Indian/Kerguelen` - Indian/Kerguelen
-      * `Indian/Mahe` - Indian/Mahe
-      * `Indian/Maldives` - Indian/Maldives
-      * `Indian/Mauritius` - Indian/Mauritius
-      * `Indian/Mayotte` - Indian/Mayotte
-      * `Indian/Reunion` - Indian/Reunion
-      * `Iran` - Iran
-      * `Israel` - Israel
-      * `Jamaica` - Jamaica
-      * `Japan` - Japan
-      * `Kwajalein` - Kwajalein
-      * `Libya` - Libya
-      * `MET` - MET
-      * `MST` - MST
-      * `MST7MDT` - MST7MDT
-      * `Mexico/BajaNorte` - Mexico/BajaNorte
-      * `Mexico/BajaSur` - Mexico/BajaSur
-      * `Mexico/General` - Mexico/General
-      * `NZ` - NZ
-      * `NZ-CHAT` - NZ-CHAT
-      * `Navajo` - Navajo
-      * `PRC` - PRC
-      * `PST8PDT` - PST8PDT
-      * `Pacific/Apia` - Pacific/Apia
-      * `Pacific/Auckland` - Pacific/Auckland
-      * `Pacific/Bougainville` - Pacific/Bougainville
-      * `Pacific/Chatham` - Pacific/Chatham
-      * `Pacific/Chuuk` - Pacific/Chuuk
-      * `Pacific/Easter` - Pacific/Easter
-      * `Pacific/Efate` - Pacific/Efate
-      * `Pacific/Enderbury` - Pacific/Enderbury
-      * `Pacific/Fakaofo` - Pacific/Fakaofo
-      * `Pacific/Fiji` - Pacific/Fiji
-      * `Pacific/Funafuti` - Pacific/Funafuti
-      * `Pacific/Galapagos` - Pacific/Galapagos
-      * `Pacific/Gambier` - Pacific/Gambier
-      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-      * `Pacific/Guam` - Pacific/Guam
-      * `Pacific/Honolulu` - Pacific/Honolulu
-      * `Pacific/Johnston` - Pacific/Johnston
-      * `Pacific/Kanton` - Pacific/Kanton
-      * `Pacific/Kiritimati` - Pacific/Kiritimati
-      * `Pacific/Kosrae` - Pacific/Kosrae
-      * `Pacific/Kwajalein` - Pacific/Kwajalein
-      * `Pacific/Majuro` - Pacific/Majuro
-      * `Pacific/Marquesas` - Pacific/Marquesas
-      * `Pacific/Midway` - Pacific/Midway
-      * `Pacific/Nauru` - Pacific/Nauru
-      * `Pacific/Niue` - Pacific/Niue
-      * `Pacific/Norfolk` - Pacific/Norfolk
-      * `Pacific/Noumea` - Pacific/Noumea
-      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-      * `Pacific/Palau` - Pacific/Palau
-      * `Pacific/Pitcairn` - Pacific/Pitcairn
-      * `Pacific/Pohnpei` - Pacific/Pohnpei
-      * `Pacific/Ponape` - Pacific/Ponape
-      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-      * `Pacific/Rarotonga` - Pacific/Rarotonga
-      * `Pacific/Saipan` - Pacific/Saipan
-      * `Pacific/Samoa` - Pacific/Samoa
-      * `Pacific/Tahiti` - Pacific/Tahiti
-      * `Pacific/Tarawa` - Pacific/Tarawa
-      * `Pacific/Tongatapu` - Pacific/Tongatapu
-      * `Pacific/Truk` - Pacific/Truk
-      * `Pacific/Wake` - Pacific/Wake
-      * `Pacific/Wallis` - Pacific/Wallis
-      * `Pacific/Yap` - Pacific/Yap
-      * `Poland` - Poland
-      * `Portugal` - Portugal
-      * `ROC` - ROC
-      * `ROK` - ROK
-      * `Singapore` - Singapore
-      * `Turkey` - Turkey
-      * `UCT` - UCT
-      * `US/Alaska` - US/Alaska
-      * `US/Aleutian` - US/Aleutian
-      * `US/Arizona` - US/Arizona
-      * `US/Central` - US/Central
-      * `US/East-Indiana` - US/East-Indiana
-      * `US/Eastern` - US/Eastern
-      * `US/Hawaii` - US/Hawaii
-      * `US/Indiana-Starke` - US/Indiana-Starke
-      * `US/Michigan` - US/Michigan
-      * `US/Mountain` - US/Mountain
-      * `US/Pacific` - US/Pacific
-      * `US/Samoa` - US/Samoa
-      * `UTC` - UTC
-      * `Universal` - Universal
-      * `W-SU` - W-SU
-      * `WET` - WET
-      * `Zulu` - Zulu */
+       *
+       * * `Africa/Abidjan` - Africa/Abidjan
+       * * `Africa/Accra` - Africa/Accra
+       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+       * * `Africa/Algiers` - Africa/Algiers
+       * * `Africa/Asmara` - Africa/Asmara
+       * * `Africa/Asmera` - Africa/Asmera
+       * * `Africa/Bamako` - Africa/Bamako
+       * * `Africa/Bangui` - Africa/Bangui
+       * * `Africa/Banjul` - Africa/Banjul
+       * * `Africa/Bissau` - Africa/Bissau
+       * * `Africa/Blantyre` - Africa/Blantyre
+       * * `Africa/Brazzaville` - Africa/Brazzaville
+       * * `Africa/Bujumbura` - Africa/Bujumbura
+       * * `Africa/Cairo` - Africa/Cairo
+       * * `Africa/Casablanca` - Africa/Casablanca
+       * * `Africa/Ceuta` - Africa/Ceuta
+       * * `Africa/Conakry` - Africa/Conakry
+       * * `Africa/Dakar` - Africa/Dakar
+       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+       * * `Africa/Djibouti` - Africa/Djibouti
+       * * `Africa/Douala` - Africa/Douala
+       * * `Africa/El_Aaiun` - Africa/El_Aaiun
+       * * `Africa/Freetown` - Africa/Freetown
+       * * `Africa/Gaborone` - Africa/Gaborone
+       * * `Africa/Harare` - Africa/Harare
+       * * `Africa/Johannesburg` - Africa/Johannesburg
+       * * `Africa/Juba` - Africa/Juba
+       * * `Africa/Kampala` - Africa/Kampala
+       * * `Africa/Khartoum` - Africa/Khartoum
+       * * `Africa/Kigali` - Africa/Kigali
+       * * `Africa/Kinshasa` - Africa/Kinshasa
+       * * `Africa/Lagos` - Africa/Lagos
+       * * `Africa/Libreville` - Africa/Libreville
+       * * `Africa/Lome` - Africa/Lome
+       * * `Africa/Luanda` - Africa/Luanda
+       * * `Africa/Lubumbashi` - Africa/Lubumbashi
+       * * `Africa/Lusaka` - Africa/Lusaka
+       * * `Africa/Malabo` - Africa/Malabo
+       * * `Africa/Maputo` - Africa/Maputo
+       * * `Africa/Maseru` - Africa/Maseru
+       * * `Africa/Mbabane` - Africa/Mbabane
+       * * `Africa/Mogadishu` - Africa/Mogadishu
+       * * `Africa/Monrovia` - Africa/Monrovia
+       * * `Africa/Nairobi` - Africa/Nairobi
+       * * `Africa/Ndjamena` - Africa/Ndjamena
+       * * `Africa/Niamey` - Africa/Niamey
+       * * `Africa/Nouakchott` - Africa/Nouakchott
+       * * `Africa/Ouagadougou` - Africa/Ouagadougou
+       * * `Africa/Porto-Novo` - Africa/Porto-Novo
+       * * `Africa/Sao_Tome` - Africa/Sao_Tome
+       * * `Africa/Timbuktu` - Africa/Timbuktu
+       * * `Africa/Tripoli` - Africa/Tripoli
+       * * `Africa/Tunis` - Africa/Tunis
+       * * `Africa/Windhoek` - Africa/Windhoek
+       * * `America/Adak` - America/Adak
+       * * `America/Anchorage` - America/Anchorage
+       * * `America/Anguilla` - America/Anguilla
+       * * `America/Antigua` - America/Antigua
+       * * `America/Araguaina` - America/Araguaina
+       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+       * * `America/Argentina/Salta` - America/Argentina/Salta
+       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+       * * `America/Aruba` - America/Aruba
+       * * `America/Asuncion` - America/Asuncion
+       * * `America/Atikokan` - America/Atikokan
+       * * `America/Atka` - America/Atka
+       * * `America/Bahia` - America/Bahia
+       * * `America/Bahia_Banderas` - America/Bahia_Banderas
+       * * `America/Barbados` - America/Barbados
+       * * `America/Belem` - America/Belem
+       * * `America/Belize` - America/Belize
+       * * `America/Blanc-Sablon` - America/Blanc-Sablon
+       * * `America/Boa_Vista` - America/Boa_Vista
+       * * `America/Bogota` - America/Bogota
+       * * `America/Boise` - America/Boise
+       * * `America/Buenos_Aires` - America/Buenos_Aires
+       * * `America/Cambridge_Bay` - America/Cambridge_Bay
+       * * `America/Campo_Grande` - America/Campo_Grande
+       * * `America/Cancun` - America/Cancun
+       * * `America/Caracas` - America/Caracas
+       * * `America/Catamarca` - America/Catamarca
+       * * `America/Cayenne` - America/Cayenne
+       * * `America/Cayman` - America/Cayman
+       * * `America/Chicago` - America/Chicago
+       * * `America/Chihuahua` - America/Chihuahua
+       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+       * * `America/Coral_Harbour` - America/Coral_Harbour
+       * * `America/Cordoba` - America/Cordoba
+       * * `America/Costa_Rica` - America/Costa_Rica
+       * * `America/Creston` - America/Creston
+       * * `America/Cuiaba` - America/Cuiaba
+       * * `America/Curacao` - America/Curacao
+       * * `America/Danmarkshavn` - America/Danmarkshavn
+       * * `America/Dawson` - America/Dawson
+       * * `America/Dawson_Creek` - America/Dawson_Creek
+       * * `America/Denver` - America/Denver
+       * * `America/Detroit` - America/Detroit
+       * * `America/Dominica` - America/Dominica
+       * * `America/Edmonton` - America/Edmonton
+       * * `America/Eirunepe` - America/Eirunepe
+       * * `America/El_Salvador` - America/El_Salvador
+       * * `America/Ensenada` - America/Ensenada
+       * * `America/Fort_Nelson` - America/Fort_Nelson
+       * * `America/Fort_Wayne` - America/Fort_Wayne
+       * * `America/Fortaleza` - America/Fortaleza
+       * * `America/Glace_Bay` - America/Glace_Bay
+       * * `America/Godthab` - America/Godthab
+       * * `America/Goose_Bay` - America/Goose_Bay
+       * * `America/Grand_Turk` - America/Grand_Turk
+       * * `America/Grenada` - America/Grenada
+       * * `America/Guadeloupe` - America/Guadeloupe
+       * * `America/Guatemala` - America/Guatemala
+       * * `America/Guayaquil` - America/Guayaquil
+       * * `America/Guyana` - America/Guyana
+       * * `America/Halifax` - America/Halifax
+       * * `America/Havana` - America/Havana
+       * * `America/Hermosillo` - America/Hermosillo
+       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+       * * `America/Indiana/Knox` - America/Indiana/Knox
+       * * `America/Indiana/Marengo` - America/Indiana/Marengo
+       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+       * * `America/Indiana/Vevay` - America/Indiana/Vevay
+       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+       * * `America/Indiana/Winamac` - America/Indiana/Winamac
+       * * `America/Indianapolis` - America/Indianapolis
+       * * `America/Inuvik` - America/Inuvik
+       * * `America/Iqaluit` - America/Iqaluit
+       * * `America/Jamaica` - America/Jamaica
+       * * `America/Jujuy` - America/Jujuy
+       * * `America/Juneau` - America/Juneau
+       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+       * * `America/Knox_IN` - America/Knox_IN
+       * * `America/Kralendijk` - America/Kralendijk
+       * * `America/La_Paz` - America/La_Paz
+       * * `America/Lima` - America/Lima
+       * * `America/Los_Angeles` - America/Los_Angeles
+       * * `America/Louisville` - America/Louisville
+       * * `America/Lower_Princes` - America/Lower_Princes
+       * * `America/Maceio` - America/Maceio
+       * * `America/Managua` - America/Managua
+       * * `America/Manaus` - America/Manaus
+       * * `America/Marigot` - America/Marigot
+       * * `America/Martinique` - America/Martinique
+       * * `America/Matamoros` - America/Matamoros
+       * * `America/Mazatlan` - America/Mazatlan
+       * * `America/Mendoza` - America/Mendoza
+       * * `America/Menominee` - America/Menominee
+       * * `America/Merida` - America/Merida
+       * * `America/Metlakatla` - America/Metlakatla
+       * * `America/Mexico_City` - America/Mexico_City
+       * * `America/Miquelon` - America/Miquelon
+       * * `America/Moncton` - America/Moncton
+       * * `America/Monterrey` - America/Monterrey
+       * * `America/Montevideo` - America/Montevideo
+       * * `America/Montreal` - America/Montreal
+       * * `America/Montserrat` - America/Montserrat
+       * * `America/Nassau` - America/Nassau
+       * * `America/New_York` - America/New_York
+       * * `America/Nipigon` - America/Nipigon
+       * * `America/Nome` - America/Nome
+       * * `America/Noronha` - America/Noronha
+       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+       * * `America/North_Dakota/Center` - America/North_Dakota/Center
+       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+       * * `America/Nuuk` - America/Nuuk
+       * * `America/Ojinaga` - America/Ojinaga
+       * * `America/Panama` - America/Panama
+       * * `America/Pangnirtung` - America/Pangnirtung
+       * * `America/Paramaribo` - America/Paramaribo
+       * * `America/Phoenix` - America/Phoenix
+       * * `America/Port-au-Prince` - America/Port-au-Prince
+       * * `America/Port_of_Spain` - America/Port_of_Spain
+       * * `America/Porto_Acre` - America/Porto_Acre
+       * * `America/Porto_Velho` - America/Porto_Velho
+       * * `America/Puerto_Rico` - America/Puerto_Rico
+       * * `America/Punta_Arenas` - America/Punta_Arenas
+       * * `America/Rainy_River` - America/Rainy_River
+       * * `America/Rankin_Inlet` - America/Rankin_Inlet
+       * * `America/Recife` - America/Recife
+       * * `America/Regina` - America/Regina
+       * * `America/Resolute` - America/Resolute
+       * * `America/Rio_Branco` - America/Rio_Branco
+       * * `America/Rosario` - America/Rosario
+       * * `America/Santa_Isabel` - America/Santa_Isabel
+       * * `America/Santarem` - America/Santarem
+       * * `America/Santiago` - America/Santiago
+       * * `America/Santo_Domingo` - America/Santo_Domingo
+       * * `America/Sao_Paulo` - America/Sao_Paulo
+       * * `America/Scoresbysund` - America/Scoresbysund
+       * * `America/Shiprock` - America/Shiprock
+       * * `America/Sitka` - America/Sitka
+       * * `America/St_Barthelemy` - America/St_Barthelemy
+       * * `America/St_Johns` - America/St_Johns
+       * * `America/St_Kitts` - America/St_Kitts
+       * * `America/St_Lucia` - America/St_Lucia
+       * * `America/St_Thomas` - America/St_Thomas
+       * * `America/St_Vincent` - America/St_Vincent
+       * * `America/Swift_Current` - America/Swift_Current
+       * * `America/Tegucigalpa` - America/Tegucigalpa
+       * * `America/Thule` - America/Thule
+       * * `America/Thunder_Bay` - America/Thunder_Bay
+       * * `America/Tijuana` - America/Tijuana
+       * * `America/Toronto` - America/Toronto
+       * * `America/Tortola` - America/Tortola
+       * * `America/Vancouver` - America/Vancouver
+       * * `America/Virgin` - America/Virgin
+       * * `America/Whitehorse` - America/Whitehorse
+       * * `America/Winnipeg` - America/Winnipeg
+       * * `America/Yakutat` - America/Yakutat
+       * * `America/Yellowknife` - America/Yellowknife
+       * * `Antarctica/Casey` - Antarctica/Casey
+       * * `Antarctica/Davis` - Antarctica/Davis
+       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+       * * `Antarctica/Macquarie` - Antarctica/Macquarie
+       * * `Antarctica/Mawson` - Antarctica/Mawson
+       * * `Antarctica/McMurdo` - Antarctica/McMurdo
+       * * `Antarctica/Palmer` - Antarctica/Palmer
+       * * `Antarctica/Rothera` - Antarctica/Rothera
+       * * `Antarctica/South_Pole` - Antarctica/South_Pole
+       * * `Antarctica/Syowa` - Antarctica/Syowa
+       * * `Antarctica/Troll` - Antarctica/Troll
+       * * `Antarctica/Vostok` - Antarctica/Vostok
+       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+       * * `Asia/Aden` - Asia/Aden
+       * * `Asia/Almaty` - Asia/Almaty
+       * * `Asia/Amman` - Asia/Amman
+       * * `Asia/Anadyr` - Asia/Anadyr
+       * * `Asia/Aqtau` - Asia/Aqtau
+       * * `Asia/Aqtobe` - Asia/Aqtobe
+       * * `Asia/Ashgabat` - Asia/Ashgabat
+       * * `Asia/Ashkhabad` - Asia/Ashkhabad
+       * * `Asia/Atyrau` - Asia/Atyrau
+       * * `Asia/Baghdad` - Asia/Baghdad
+       * * `Asia/Bahrain` - Asia/Bahrain
+       * * `Asia/Baku` - Asia/Baku
+       * * `Asia/Bangkok` - Asia/Bangkok
+       * * `Asia/Barnaul` - Asia/Barnaul
+       * * `Asia/Beirut` - Asia/Beirut
+       * * `Asia/Bishkek` - Asia/Bishkek
+       * * `Asia/Brunei` - Asia/Brunei
+       * * `Asia/Calcutta` - Asia/Calcutta
+       * * `Asia/Chita` - Asia/Chita
+       * * `Asia/Choibalsan` - Asia/Choibalsan
+       * * `Asia/Chongqing` - Asia/Chongqing
+       * * `Asia/Chungking` - Asia/Chungking
+       * * `Asia/Colombo` - Asia/Colombo
+       * * `Asia/Dacca` - Asia/Dacca
+       * * `Asia/Damascus` - Asia/Damascus
+       * * `Asia/Dhaka` - Asia/Dhaka
+       * * `Asia/Dili` - Asia/Dili
+       * * `Asia/Dubai` - Asia/Dubai
+       * * `Asia/Dushanbe` - Asia/Dushanbe
+       * * `Asia/Famagusta` - Asia/Famagusta
+       * * `Asia/Gaza` - Asia/Gaza
+       * * `Asia/Harbin` - Asia/Harbin
+       * * `Asia/Hebron` - Asia/Hebron
+       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+       * * `Asia/Hong_Kong` - Asia/Hong_Kong
+       * * `Asia/Hovd` - Asia/Hovd
+       * * `Asia/Irkutsk` - Asia/Irkutsk
+       * * `Asia/Istanbul` - Asia/Istanbul
+       * * `Asia/Jakarta` - Asia/Jakarta
+       * * `Asia/Jayapura` - Asia/Jayapura
+       * * `Asia/Jerusalem` - Asia/Jerusalem
+       * * `Asia/Kabul` - Asia/Kabul
+       * * `Asia/Kamchatka` - Asia/Kamchatka
+       * * `Asia/Karachi` - Asia/Karachi
+       * * `Asia/Kashgar` - Asia/Kashgar
+       * * `Asia/Kathmandu` - Asia/Kathmandu
+       * * `Asia/Katmandu` - Asia/Katmandu
+       * * `Asia/Khandyga` - Asia/Khandyga
+       * * `Asia/Kolkata` - Asia/Kolkata
+       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+       * * `Asia/Kuching` - Asia/Kuching
+       * * `Asia/Kuwait` - Asia/Kuwait
+       * * `Asia/Macao` - Asia/Macao
+       * * `Asia/Macau` - Asia/Macau
+       * * `Asia/Magadan` - Asia/Magadan
+       * * `Asia/Makassar` - Asia/Makassar
+       * * `Asia/Manila` - Asia/Manila
+       * * `Asia/Muscat` - Asia/Muscat
+       * * `Asia/Nicosia` - Asia/Nicosia
+       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+       * * `Asia/Novosibirsk` - Asia/Novosibirsk
+       * * `Asia/Omsk` - Asia/Omsk
+       * * `Asia/Oral` - Asia/Oral
+       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+       * * `Asia/Pontianak` - Asia/Pontianak
+       * * `Asia/Pyongyang` - Asia/Pyongyang
+       * * `Asia/Qatar` - Asia/Qatar
+       * * `Asia/Qostanay` - Asia/Qostanay
+       * * `Asia/Qyzylorda` - Asia/Qyzylorda
+       * * `Asia/Rangoon` - Asia/Rangoon
+       * * `Asia/Riyadh` - Asia/Riyadh
+       * * `Asia/Saigon` - Asia/Saigon
+       * * `Asia/Sakhalin` - Asia/Sakhalin
+       * * `Asia/Samarkand` - Asia/Samarkand
+       * * `Asia/Seoul` - Asia/Seoul
+       * * `Asia/Shanghai` - Asia/Shanghai
+       * * `Asia/Singapore` - Asia/Singapore
+       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+       * * `Asia/Taipei` - Asia/Taipei
+       * * `Asia/Tashkent` - Asia/Tashkent
+       * * `Asia/Tbilisi` - Asia/Tbilisi
+       * * `Asia/Tehran` - Asia/Tehran
+       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+       * * `Asia/Thimbu` - Asia/Thimbu
+       * * `Asia/Thimphu` - Asia/Thimphu
+       * * `Asia/Tokyo` - Asia/Tokyo
+       * * `Asia/Tomsk` - Asia/Tomsk
+       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+       * * `Asia/Urumqi` - Asia/Urumqi
+       * * `Asia/Ust-Nera` - Asia/Ust-Nera
+       * * `Asia/Vientiane` - Asia/Vientiane
+       * * `Asia/Vladivostok` - Asia/Vladivostok
+       * * `Asia/Yakutsk` - Asia/Yakutsk
+       * * `Asia/Yangon` - Asia/Yangon
+       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+       * * `Asia/Yerevan` - Asia/Yerevan
+       * * `Atlantic/Azores` - Atlantic/Azores
+       * * `Atlantic/Bermuda` - Atlantic/Bermuda
+       * * `Atlantic/Canary` - Atlantic/Canary
+       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+       * * `Atlantic/Faeroe` - Atlantic/Faeroe
+       * * `Atlantic/Faroe` - Atlantic/Faroe
+       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+       * * `Atlantic/Madeira` - Atlantic/Madeira
+       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+       * * `Atlantic/St_Helena` - Atlantic/St_Helena
+       * * `Atlantic/Stanley` - Atlantic/Stanley
+       * * `Australia/ACT` - Australia/ACT
+       * * `Australia/Adelaide` - Australia/Adelaide
+       * * `Australia/Brisbane` - Australia/Brisbane
+       * * `Australia/Broken_Hill` - Australia/Broken_Hill
+       * * `Australia/Canberra` - Australia/Canberra
+       * * `Australia/Currie` - Australia/Currie
+       * * `Australia/Darwin` - Australia/Darwin
+       * * `Australia/Eucla` - Australia/Eucla
+       * * `Australia/Hobart` - Australia/Hobart
+       * * `Australia/LHI` - Australia/LHI
+       * * `Australia/Lindeman` - Australia/Lindeman
+       * * `Australia/Lord_Howe` - Australia/Lord_Howe
+       * * `Australia/Melbourne` - Australia/Melbourne
+       * * `Australia/NSW` - Australia/NSW
+       * * `Australia/North` - Australia/North
+       * * `Australia/Perth` - Australia/Perth
+       * * `Australia/Queensland` - Australia/Queensland
+       * * `Australia/South` - Australia/South
+       * * `Australia/Sydney` - Australia/Sydney
+       * * `Australia/Tasmania` - Australia/Tasmania
+       * * `Australia/Victoria` - Australia/Victoria
+       * * `Australia/West` - Australia/West
+       * * `Australia/Yancowinna` - Australia/Yancowinna
+       * * `Brazil/Acre` - Brazil/Acre
+       * * `Brazil/DeNoronha` - Brazil/DeNoronha
+       * * `Brazil/East` - Brazil/East
+       * * `Brazil/West` - Brazil/West
+       * * `CET` - CET
+       * * `CST6CDT` - CST6CDT
+       * * `Canada/Atlantic` - Canada/Atlantic
+       * * `Canada/Central` - Canada/Central
+       * * `Canada/Eastern` - Canada/Eastern
+       * * `Canada/Mountain` - Canada/Mountain
+       * * `Canada/Newfoundland` - Canada/Newfoundland
+       * * `Canada/Pacific` - Canada/Pacific
+       * * `Canada/Saskatchewan` - Canada/Saskatchewan
+       * * `Canada/Yukon` - Canada/Yukon
+       * * `Chile/Continental` - Chile/Continental
+       * * `Chile/EasterIsland` - Chile/EasterIsland
+       * * `Cuba` - Cuba
+       * * `EET` - EET
+       * * `EST` - EST
+       * * `EST5EDT` - EST5EDT
+       * * `Egypt` - Egypt
+       * * `Eire` - Eire
+       * * `Etc/GMT` - Etc/GMT
+       * * `Etc/GMT+0` - Etc/GMT+0
+       * * `Etc/GMT+1` - Etc/GMT+1
+       * * `Etc/GMT+10` - Etc/GMT+10
+       * * `Etc/GMT+11` - Etc/GMT+11
+       * * `Etc/GMT+12` - Etc/GMT+12
+       * * `Etc/GMT+2` - Etc/GMT+2
+       * * `Etc/GMT+3` - Etc/GMT+3
+       * * `Etc/GMT+4` - Etc/GMT+4
+       * * `Etc/GMT+5` - Etc/GMT+5
+       * * `Etc/GMT+6` - Etc/GMT+6
+       * * `Etc/GMT+7` - Etc/GMT+7
+       * * `Etc/GMT+8` - Etc/GMT+8
+       * * `Etc/GMT+9` - Etc/GMT+9
+       * * `Etc/GMT-0` - Etc/GMT-0
+       * * `Etc/GMT-1` - Etc/GMT-1
+       * * `Etc/GMT-10` - Etc/GMT-10
+       * * `Etc/GMT-11` - Etc/GMT-11
+       * * `Etc/GMT-12` - Etc/GMT-12
+       * * `Etc/GMT-13` - Etc/GMT-13
+       * * `Etc/GMT-14` - Etc/GMT-14
+       * * `Etc/GMT-2` - Etc/GMT-2
+       * * `Etc/GMT-3` - Etc/GMT-3
+       * * `Etc/GMT-4` - Etc/GMT-4
+       * * `Etc/GMT-5` - Etc/GMT-5
+       * * `Etc/GMT-6` - Etc/GMT-6
+       * * `Etc/GMT-7` - Etc/GMT-7
+       * * `Etc/GMT-8` - Etc/GMT-8
+       * * `Etc/GMT-9` - Etc/GMT-9
+       * * `Etc/GMT0` - Etc/GMT0
+       * * `Etc/Greenwich` - Etc/Greenwich
+       * * `Etc/UCT` - Etc/UCT
+       * * `Etc/UTC` - Etc/UTC
+       * * `Etc/Universal` - Etc/Universal
+       * * `Etc/Zulu` - Etc/Zulu
+       * * `Europe/Amsterdam` - Europe/Amsterdam
+       * * `Europe/Andorra` - Europe/Andorra
+       * * `Europe/Astrakhan` - Europe/Astrakhan
+       * * `Europe/Athens` - Europe/Athens
+       * * `Europe/Belfast` - Europe/Belfast
+       * * `Europe/Belgrade` - Europe/Belgrade
+       * * `Europe/Berlin` - Europe/Berlin
+       * * `Europe/Bratislava` - Europe/Bratislava
+       * * `Europe/Brussels` - Europe/Brussels
+       * * `Europe/Bucharest` - Europe/Bucharest
+       * * `Europe/Budapest` - Europe/Budapest
+       * * `Europe/Busingen` - Europe/Busingen
+       * * `Europe/Chisinau` - Europe/Chisinau
+       * * `Europe/Copenhagen` - Europe/Copenhagen
+       * * `Europe/Dublin` - Europe/Dublin
+       * * `Europe/Gibraltar` - Europe/Gibraltar
+       * * `Europe/Guernsey` - Europe/Guernsey
+       * * `Europe/Helsinki` - Europe/Helsinki
+       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+       * * `Europe/Istanbul` - Europe/Istanbul
+       * * `Europe/Jersey` - Europe/Jersey
+       * * `Europe/Kaliningrad` - Europe/Kaliningrad
+       * * `Europe/Kiev` - Europe/Kiev
+       * * `Europe/Kirov` - Europe/Kirov
+       * * `Europe/Kyiv` - Europe/Kyiv
+       * * `Europe/Lisbon` - Europe/Lisbon
+       * * `Europe/Ljubljana` - Europe/Ljubljana
+       * * `Europe/London` - Europe/London
+       * * `Europe/Luxembourg` - Europe/Luxembourg
+       * * `Europe/Madrid` - Europe/Madrid
+       * * `Europe/Malta` - Europe/Malta
+       * * `Europe/Mariehamn` - Europe/Mariehamn
+       * * `Europe/Minsk` - Europe/Minsk
+       * * `Europe/Monaco` - Europe/Monaco
+       * * `Europe/Moscow` - Europe/Moscow
+       * * `Europe/Nicosia` - Europe/Nicosia
+       * * `Europe/Oslo` - Europe/Oslo
+       * * `Europe/Paris` - Europe/Paris
+       * * `Europe/Podgorica` - Europe/Podgorica
+       * * `Europe/Prague` - Europe/Prague
+       * * `Europe/Riga` - Europe/Riga
+       * * `Europe/Rome` - Europe/Rome
+       * * `Europe/Samara` - Europe/Samara
+       * * `Europe/San_Marino` - Europe/San_Marino
+       * * `Europe/Sarajevo` - Europe/Sarajevo
+       * * `Europe/Saratov` - Europe/Saratov
+       * * `Europe/Simferopol` - Europe/Simferopol
+       * * `Europe/Skopje` - Europe/Skopje
+       * * `Europe/Sofia` - Europe/Sofia
+       * * `Europe/Stockholm` - Europe/Stockholm
+       * * `Europe/Tallinn` - Europe/Tallinn
+       * * `Europe/Tirane` - Europe/Tirane
+       * * `Europe/Tiraspol` - Europe/Tiraspol
+       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+       * * `Europe/Uzhgorod` - Europe/Uzhgorod
+       * * `Europe/Vaduz` - Europe/Vaduz
+       * * `Europe/Vatican` - Europe/Vatican
+       * * `Europe/Vienna` - Europe/Vienna
+       * * `Europe/Vilnius` - Europe/Vilnius
+       * * `Europe/Volgograd` - Europe/Volgograd
+       * * `Europe/Warsaw` - Europe/Warsaw
+       * * `Europe/Zagreb` - Europe/Zagreb
+       * * `Europe/Zaporozhye` - Europe/Zaporozhye
+       * * `Europe/Zurich` - Europe/Zurich
+       * * `GB` - GB
+       * * `GB-Eire` - GB-Eire
+       * * `GMT` - GMT
+       * * `GMT+0` - GMT+0
+       * * `GMT-0` - GMT-0
+       * * `GMT0` - GMT0
+       * * `Greenwich` - Greenwich
+       * * `HST` - HST
+       * * `Hongkong` - Hongkong
+       * * `Iceland` - Iceland
+       * * `Indian/Antananarivo` - Indian/Antananarivo
+       * * `Indian/Chagos` - Indian/Chagos
+       * * `Indian/Christmas` - Indian/Christmas
+       * * `Indian/Cocos` - Indian/Cocos
+       * * `Indian/Comoro` - Indian/Comoro
+       * * `Indian/Kerguelen` - Indian/Kerguelen
+       * * `Indian/Mahe` - Indian/Mahe
+       * * `Indian/Maldives` - Indian/Maldives
+       * * `Indian/Mauritius` - Indian/Mauritius
+       * * `Indian/Mayotte` - Indian/Mayotte
+       * * `Indian/Reunion` - Indian/Reunion
+       * * `Iran` - Iran
+       * * `Israel` - Israel
+       * * `Jamaica` - Jamaica
+       * * `Japan` - Japan
+       * * `Kwajalein` - Kwajalein
+       * * `Libya` - Libya
+       * * `MET` - MET
+       * * `MST` - MST
+       * * `MST7MDT` - MST7MDT
+       * * `Mexico/BajaNorte` - Mexico/BajaNorte
+       * * `Mexico/BajaSur` - Mexico/BajaSur
+       * * `Mexico/General` - Mexico/General
+       * * `NZ` - NZ
+       * * `NZ-CHAT` - NZ-CHAT
+       * * `Navajo` - Navajo
+       * * `PRC` - PRC
+       * * `PST8PDT` - PST8PDT
+       * * `Pacific/Apia` - Pacific/Apia
+       * * `Pacific/Auckland` - Pacific/Auckland
+       * * `Pacific/Bougainville` - Pacific/Bougainville
+       * * `Pacific/Chatham` - Pacific/Chatham
+       * * `Pacific/Chuuk` - Pacific/Chuuk
+       * * `Pacific/Easter` - Pacific/Easter
+       * * `Pacific/Efate` - Pacific/Efate
+       * * `Pacific/Enderbury` - Pacific/Enderbury
+       * * `Pacific/Fakaofo` - Pacific/Fakaofo
+       * * `Pacific/Fiji` - Pacific/Fiji
+       * * `Pacific/Funafuti` - Pacific/Funafuti
+       * * `Pacific/Galapagos` - Pacific/Galapagos
+       * * `Pacific/Gambier` - Pacific/Gambier
+       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+       * * `Pacific/Guam` - Pacific/Guam
+       * * `Pacific/Honolulu` - Pacific/Honolulu
+       * * `Pacific/Johnston` - Pacific/Johnston
+       * * `Pacific/Kanton` - Pacific/Kanton
+       * * `Pacific/Kiritimati` - Pacific/Kiritimati
+       * * `Pacific/Kosrae` - Pacific/Kosrae
+       * * `Pacific/Kwajalein` - Pacific/Kwajalein
+       * * `Pacific/Majuro` - Pacific/Majuro
+       * * `Pacific/Marquesas` - Pacific/Marquesas
+       * * `Pacific/Midway` - Pacific/Midway
+       * * `Pacific/Nauru` - Pacific/Nauru
+       * * `Pacific/Niue` - Pacific/Niue
+       * * `Pacific/Norfolk` - Pacific/Norfolk
+       * * `Pacific/Noumea` - Pacific/Noumea
+       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+       * * `Pacific/Palau` - Pacific/Palau
+       * * `Pacific/Pitcairn` - Pacific/Pitcairn
+       * * `Pacific/Pohnpei` - Pacific/Pohnpei
+       * * `Pacific/Ponape` - Pacific/Ponape
+       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+       * * `Pacific/Rarotonga` - Pacific/Rarotonga
+       * * `Pacific/Saipan` - Pacific/Saipan
+       * * `Pacific/Samoa` - Pacific/Samoa
+       * * `Pacific/Tahiti` - Pacific/Tahiti
+       * * `Pacific/Tarawa` - Pacific/Tarawa
+       * * `Pacific/Tongatapu` - Pacific/Tongatapu
+       * * `Pacific/Truk` - Pacific/Truk
+       * * `Pacific/Wake` - Pacific/Wake
+       * * `Pacific/Wallis` - Pacific/Wallis
+       * * `Pacific/Yap` - Pacific/Yap
+       * * `Poland` - Poland
+       * * `Portugal` - Portugal
+       * * `ROC` - ROC
+       * * `ROK` - ROK
+       * * `Singapore` - Singapore
+       * * `Turkey` - Turkey
+       * * `UCT` - UCT
+       * * `US/Alaska` - US/Alaska
+       * * `US/Aleutian` - US/Aleutian
+       * * `US/Arizona` - US/Arizona
+       * * `US/Central` - US/Central
+       * * `US/East-Indiana` - US/East-Indiana
+       * * `US/Eastern` - US/Eastern
+       * * `US/Hawaii` - US/Hawaii
+       * * `US/Indiana-Starke` - US/Indiana-Starke
+       * * `US/Michigan` - US/Michigan
+       * * `US/Mountain` - US/Mountain
+       * * `US/Pacific` - US/Pacific
+       * * `US/Samoa` - US/Samoa
+       * * `UTC` - UTC
+       * * `Universal` - Universal
+       * * `W-SU` - W-SU
+       * * `WET` - WET
+       * * `Zulu` - Zulu */
       timezone?: string;
       /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
       data_attributes?: unknown;
       /**
          * Ordered list of person properties used to render a human-friendly display name in the UI.
          * @nullable
+         * @items.maxLength 400
          */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
@@ -31897,19 +31969,19 @@ export namespace Schemas {
       /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
       session_recording_trigger_groups?: unknown;
       /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-
-      * `30d` - 30 Days
-      * `90d` - 90 Days
-      * `1y` - 1 Year
-      * `5y` - 5 Years */
+       *
+       * * `30d` - 30 Days
+       * * `90d` - 90 Days
+       * * `1y` - 1 Year
+       * * `5y` - 5 Years */
       session_recording_retention_period?: SessionRecordingRetentionPeriodEnum;
       session_replay_config?: unknown;
       survey_config?: unknown;
       access_control?: boolean;
       /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-
-      * `0` - Sunday
-      * `1` - Monday */
+       *
+       * * `0` - Sunday
+       * * `1` - Monday */
       week_start_day?: WeekStartDayEnum | null;
       /**
          * ID of the dashboard shown as the project's default landing dashboard.
@@ -31921,6 +31993,7 @@ export namespace Schemas {
       /**
          * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
          * @nullable
+         * @items.maxLength 200
          */
       recording_domains?: (string | null)[] | null;
       readonly person_on_events_querying_enabled?: boolean;
@@ -31953,10 +32026,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /**
          * Enables the customer conversations / live chat product for this project.
@@ -31994,11 +32067,11 @@ export namespace Schemas {
     export interface PatchedQueryTabState {
       readonly id?: string;
       /**
-                  Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
-                  and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
-                  ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
-                  for a user.
-                   */
+       *             Dict of query tab state for a user. Keys are editorModelsStateKey, activeModelStateKey, activeModelVariablesStateKey
+       *             and values are the state for that key. EditorModelsStateKey is a list of all the editor models for a user.
+       *             ActiveModelStateKey is the active model for a user. ActiveModelVariablesStateKey is the active model variables
+       *             for a user.
+       *              */
       state?: unknown;
     }
 
@@ -32030,11 +32103,11 @@ export namespace Schemas {
       /** Free-form description shown in the scanner management UI. */
       description?: string;
       /** What the scanner does: monitor, classifier, scorer, or summarizer.
-
-      * `monitor` - Monitor
-      * `classifier` - Classifier
-      * `scorer` - Scorer
-      * `summarizer` - Summarizer */
+       *
+       * * `monitor` - Monitor
+       * * `classifier` - Classifier
+       * * `scorer` - Scorer
+       * * `summarizer` - Summarizer */
       scanner_type?: ScannerTypeEnum;
       /** Type-specific configuration. All scanner types require `prompt`; monitors add optional `allow_inconclusive`, classifiers add `tags`, scorers add `scale`, summarizers add optional `length`. */
       scanner_config?: unknown;
@@ -32047,13 +32120,13 @@ export namespace Schemas {
          */
       sampling_rate?: number;
       /** LLM provider. v1 is Google-only.
-
-      * `google` - Google */
+       *
+       * * `google` - Google */
       provider?: ScannerProviderEnum;
       /** Concrete model to use for this scanner.
-
-      * `gemini-3-flash-preview` - Gemini 3 Flash
-      * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
+       *
+       * * `gemini-3-flash-preview` - Gemini 3 Flash
+       * * `gemini-3.1-flash-lite-preview` - Gemini 3 Flash Lite */
       model?: ScannerModelEnum;
       /** When false, the reconciler removes the scanner's Temporal schedule. On-demand triggers still work. */
       enabled?: boolean;
@@ -32100,11 +32173,17 @@ export namespace Schemas {
       /** @maxLength 255 */
       name?: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /** List of allowed domains for custom network access */
+      /**
+         * List of allowed domains for custom network access
+         * @items.maxLength 255
+         */
       allowed_domains?: string[];
       /** Whether to include default trusted domains (GitHub, npm, PyPI) */
       include_default_domains?: boolean;
-      /** List of repositories this environment applies to (format: org/repo) */
+      /**
+         * List of repositories this environment applies to (format: org/repo)
+         * @items.maxLength 255
+         */
       repositories?: string[];
       /** Encrypted environment variables (write-only, never returned in responses) */
       environment_variables?: unknown;
@@ -32142,13 +32221,15 @@ export namespace Schemas {
       /**
          * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
          * @maxItems 16
+         * @items.minimum 100
+         * @items.maximum 3000
          */
       widths?: number[];
       /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-
-      * `screenshot` - Screenshot
-      * `iframe` - Iframe
-      * `recording` - Recording */
+       *
+       * * `screenshot` - Screenshot
+       * * `iframe` - Iframe
+       * * `recording` - Recording */
       type?: HeatmapType;
       /** Set true to soft-delete the saved heatmap. */
       deleted?: boolean;
@@ -32163,8 +32244,8 @@ export namespace Schemas {
          */
       record_id?: string;
       /** The type of record to modify. Currently only "FeatureFlag" is supported.
-
-      * `FeatureFlag` - feature flag */
+       *
+       * * `FeatureFlag` - feature flag */
       model_name?: ModelNameEnum;
       /** The change to apply. Must include an 'operation' key and a 'value' key. Supported operations: 'update_status' (value: true/false to enable/disable the flag), 'add_release_condition' (value: object with 'groups', 'payloads', and 'multivariate' keys), 'update_variants' (value: object with 'variants' and 'payloads' keys). */
       payload?: unknown;
@@ -32183,11 +32264,11 @@ export namespace Schemas {
       /** Whether this schedule repeats. Only the 'update_status' operation supports recurring schedules. */
       is_recurring?: boolean;
       /** How often the schedule repeats. Required when is_recurring is true. One of: daily, weekly, monthly, yearly.
-
-      * `daily` - daily
-      * `weekly` - weekly
-      * `monthly` - monthly
-      * `yearly` - yearly */
+       *
+       * * `daily` - daily
+       * * `weekly` - weekly
+       * * `monthly` - monthly
+       * * `yearly` - yearly */
       recurrence_interval?: RecurrenceIntervalEnum | null;
       /**
          * @maxLength 100
@@ -32236,7 +32317,10 @@ export namespace Schemas {
       readonly id?: string;
       /** Title of the group session summary */
       readonly title?: string;
-      /** List of session replay IDs included in this group summary */
+      /**
+         * List of session replay IDs included in this group summary
+         * @items.maxLength 200
+         */
       readonly session_ids?: readonly string[];
       /** Group summary in JSON format (EnrichedSessionGroupSummaryPatternsList schema) */
       readonly summary?: unknown;
@@ -32307,7 +32391,7 @@ export namespace Schemas {
 
     /**
      * Serializer for linking session recordings to external issue trackers.
-    Reuses error tracking's integration infrastructure
+     * Reuses error tracking's integration infrastructure
      */
     export interface PatchedSessionRecordingExternalRef {
       readonly id?: string;
@@ -32353,9 +32437,9 @@ export namespace Schemas {
       readonly last_modified_by?: UserBasic;
       readonly recordings_counts?: PatchedSessionRecordingPlaylistRecordingsCounts;
       /** Playlist type: 'collection' for manually curated recordings, 'filters' for saved filter views. Required on create, cannot be changed after.
-
-      * `collection` - Collection
-      * `filters` - Filters */
+       *
+       * * `collection` - Collection
+       * * `filters` - Filters */
       type?: SessionRecordingPlaylistTypeEnum | null;
       /** Return whether this is a synthetic playlist */
       readonly is_synthetic?: boolean;
@@ -32379,9 +32463,9 @@ export namespace Schemas {
 
     /**
      * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-
-    One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-    when it discovers a scout skill; this serializer lets agents tune the row.
+     *
+     * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+     * when it discovers a scout skill; this serializer lets agents tune the row.
      */
     export interface PatchedSignalScoutConfig {
       readonly id?: string;
@@ -32419,12 +32503,12 @@ export namespace Schemas {
 
     /**
      * * `monday` - Monday
-    * `tuesday` - Tuesday
-    * `wednesday` - Wednesday
-    * `thursday` - Thursday
-    * `friday` - Friday
-    * `saturday` - Saturday
-    * `sunday` - Sunday
+     * * `tuesday` - Tuesday
+     * * `wednesday` - Wednesday
+     * * `thursday` - Thursday
+     * * `friday` - Friday
+     * * `saturday` - Saturday
+     * * `sunday` - Sunday
      */
     export type PatchedSubscriptionByweekdayItem = typeof PatchedSubscriptionByweekdayItem[keyof typeof PatchedSubscriptionByweekdayItem];
 
@@ -32445,10 +32529,10 @@ export namespace Schemas {
     export interface PatchedSubscription {
       readonly id?: number;
       /** What the subscription delivers: 'insight' (snapshot of one insight), 'dashboard' (snapshot of one dashboard), or 'ai_prompt' (LLM-generated report). Read-only — derived from the populated target (insight → insight, dashboard → dashboard, prompt → ai_prompt).
-
-      * `insight` - Insight
-      * `dashboard` - Dashboard
-      * `ai_prompt` - AI prompt */
+       *
+       * * `insight` - Insight
+       * * `dashboard` - Dashboard
+       * * `ai_prompt` - AI prompt */
       readonly resource_type?: ResourceTypeEnum;
       /**
          * Dashboard ID to subscribe to (mutually exclusive with insight on create).
@@ -32472,18 +32556,18 @@ export namespace Schemas {
          */
       prompt?: string | null;
       /** Delivery channel: email or slack.
-
-      * `email` - Email
-      * `slack` - Slack */
+       *
+       * * `email` - Email
+       * * `slack` - Slack */
       target_type?: TargetTypeEnum;
       /** Recipient(s): comma-separated email addresses for email, or Slack channel name/ID for slack. */
       target_value?: string;
       /** How often to deliver: daily, weekly, monthly, or yearly.
-
-      * `daily` - Daily
-      * `weekly` - Weekly
-      * `monthly` - Monthly
-      * `yearly` - Yearly */
+       *
+       * * `daily` - Daily
+       * * `weekly` - Weekly
+       * * `monthly` - Monthly
+       * * `yearly` - Yearly */
       frequency?: SubscriptionFrequencyEnum;
       /**
          * Interval multiplier (e.g. 2 with weekly frequency means every 2 weeks). Required on create; must be 1 or greater.
@@ -32554,8 +32638,8 @@ export namespace Schemas {
 
     /**
      * * `once` - once
-    * `recurring` - recurring
-    * `always` - always
+     * * `recurring` - recurring
+     * * `always` - always
      */
     export type ScheduleEnum = typeof ScheduleEnum[keyof typeof ScheduleEnum];
 
@@ -32583,9 +32667,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32610,9 +32694,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32634,7 +32718,7 @@ export namespace Schemas {
 
     /**
      * * `number` - number
-    * `emoji` - emoji
+     * * `emoji` - emoji
      */
     export type SurveyRatingQuestionSchemaDisplayEnum = typeof SurveyRatingQuestionSchemaDisplayEnum[keyof typeof SurveyRatingQuestionSchemaDisplayEnum];
 
@@ -32656,8 +32740,8 @@ export namespace Schemas {
 
     export interface SurveyNextQuestionBranching {
       /** Continue to the next question in sequence.
-
-      * `next_question` - next_question */
+       *
+       * * `next_question` - next_question */
       type: SurveyNextQuestionBranchingTypeEnum;
     }
 
@@ -32673,8 +32757,8 @@ export namespace Schemas {
 
     export interface SurveyEndBranching {
       /** End the survey.
-
-      * `end` - end */
+       *
+       * * `end` - end */
       type: SurveyEndBranchingTypeEnum;
     }
 
@@ -32690,8 +32774,8 @@ export namespace Schemas {
 
     export interface SurveySpecificQuestionBranching {
       /** Jump to a specific question index.
-
-      * `specific_question` - specific_question */
+       *
+       * * `specific_question` - specific_question */
       type: SurveySpecificQuestionBranchingTypeEnum;
       /**
          * 0-based index of the next question.
@@ -32717,8 +32801,8 @@ export namespace Schemas {
 
     export interface SurveyResponseBasedBranching {
       /** Branch based on the selected or entered response.
-
-      * `response_based` - response_based */
+       *
+       * * `response_based` - response_based */
       type: SurveyResponseBasedBranchingTypeEnum;
       /** Response-based branching map. Values can be a question index or 'end'. */
       responseValues: SurveyResponseBasedBranchingResponseValues;
@@ -32733,18 +32817,18 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
       /** Custom button label. */
       buttonText?: string;
       /** Display format: 'number' shows numeric scale, 'emoji' shows emoji scale.
-
-      * `number` - number
-      * `emoji` - emoji */
+       *
+       * * `number` - number
+       * * `emoji` - emoji */
       display?: SurveyRatingQuestionSchemaDisplayEnum;
       /**
          * Rating scale can be one of 3, 5, or 7
@@ -32775,9 +32859,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32813,9 +32897,9 @@ export namespace Schemas {
       /** Optional helper text. */
       description?: string;
       /** Format for the description field.
-
-      * `text` - text
-      * `html` - html */
+       *
+       * * `text` - text
+       * * `html` - html */
       descriptionContentType?: DescriptionContentTypeEnum;
       /** Whether respondents may skip this question. */
       optional?: boolean;
@@ -32856,25 +32940,25 @@ export namespace Schemas {
          */
       seenSurveyWaitPeriodInDays?: number;
       /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains */
+       *
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains */
       urlMatchType?: StringMatchOperatorEnum;
       events?: SurveyEventsConditionSchema;
       /** Device types that should match for this survey to be shown. */
       deviceTypes?: DeviceTypesEnum[];
       /** URL/device matching types: 'regex' (matches regex pattern), 'not_regex' (does not match regex pattern), 'exact' (exact string match), 'is_not' (not exact match), 'icontains' (case-insensitive contains), 'not_icontains' (case-insensitive does not contain).
-
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains */
+       *
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains */
       deviceTypesMatchType?: StringMatchOperatorEnum;
       /** The variant of the feature flag linked to this survey. */
       linkedFlagVariant?: string;
@@ -32882,8 +32966,8 @@ export namespace Schemas {
 
     /**
      * * `button` - button
-    * `tab` - tab
-    * `selector` - selector
+     * * `tab` - tab
+     * * `selector` - selector
      */
     export type WidgetTypeEnum = typeof WidgetTypeEnum[keyof typeof WidgetTypeEnum];
 
@@ -32937,17 +33021,17 @@ export namespace Schemas {
       /** Survey description. */
       description?: string;
       /** Survey type.
-
-      * `popover` - popover
-      * `widget` - widget
-      * `external_survey` - external survey
-      * `api` - api */
+       *
+       * * `popover` - popover
+       * * `widget` - widget
+       * * `external_survey` - external survey
+       * * `api` - api */
       type?: SurveyType;
       /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-
-      * `once` - once
-      * `recurring` - recurring
-      * `always` - always */
+       *
+       * * `once` - once
+       * * `recurring` - recurring
+       * * `always` - always */
       schedule?: ScheduleEnum | null;
       readonly linked_flag?: MinimalFeatureFlag;
       /**
@@ -32970,117 +33054,117 @@ export namespace Schemas {
       remove_targeting_flag?: boolean | null;
       /**
          *
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *
          * @nullable
          */
       questions?: SurveyQuestionInputSchema[] | null;
@@ -33202,14 +33286,14 @@ export namespace Schemas {
 
     export interface TaggerModelConfigurationWrite {
       /** LLM provider to use for this tagger.
-
-      * `openai` - Openai
-      * `anthropic` - Anthropic
-      * `gemini` - Gemini
-      * `openrouter` - Openrouter
-      * `fireworks` - Fireworks
-      * `azure_openai` - Azure OpenAI
-      * `together_ai` - Together AI */
+       *
+       * * `openai` - Openai
+       * * `anthropic` - Anthropic
+       * * `gemini` - Gemini
+       * * `openrouter` - Openrouter
+       * * `fireworks` - Fireworks
+       * * `azure_openai` - Azure OpenAI
+       * * `together_ai` - Together AI */
       provider: LLMProviderEnum;
       /**
          * Provider model identifier to use for this tagger.
@@ -33257,16 +33341,16 @@ export namespace Schemas {
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
       /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-
-      * `error_tracking` - Error Tracking
-      * `eval_clusters` - Eval Clusters
-      * `user_created` - User Created
-      * `automation` - Automation
-      * `slack` - Slack
-      * `support_queue` - Support Queue
-      * `session_summaries` - Session Summaries
-      * `signal_report` - Signal Report
-      * `signals_scout` - Signals Scout */
+       *
+       * * `error_tracking` - Error Tracking
+       * * `eval_clusters` - Eval Clusters
+       * * `user_created` - User Created
+       * * `automation` - Automation
+       * * `slack` - Slack
+       * * `support_queue` - Support Queue
+       * * `session_summaries` - Session Summaries
+       * * `signal_report` - Signal Report
+       * * `signals_scout` - Signals Scout */
       origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
@@ -33350,11 +33434,11 @@ export namespace Schemas {
 
     /**
      * * `not_started` - not_started
-    * `queued` - queued
-    * `in_progress` - in_progress
-    * `completed` - completed
-    * `failed` - failed
-    * `cancelled` - cancelled
+     * * `queued` - queued
+     * * `in_progress` - in_progress
+     * * `completed` - completed
+     * * `failed` - failed
+     * * `cancelled` - cancelled
      */
     export type TaskRunUpdateStatusEnum = typeof TaskRunUpdateStatusEnum[keyof typeof TaskRunUpdateStatusEnum];
 
@@ -33380,13 +33464,13 @@ export namespace Schemas {
 
     export interface PatchedTaskRunUpdate {
       /** Current execution status
-
-      * `not_started` - not_started
-      * `queued` - queued
-      * `in_progress` - in_progress
-      * `completed` - completed
-      * `failed` - failed
-      * `cancelled` - cancelled */
+       *
+       * * `not_started` - not_started
+       * * `queued` - queued
+       * * `in_progress` - in_progress
+       * * `completed` - completed
+       * * `failed` - failed
+       * * `cancelled` - cancelled */
       status?: TaskRunUpdateStatusEnum;
       /**
          * Git branch name to associate with the task
@@ -33410,8 +33494,8 @@ export namespace Schemas {
          */
       error_message?: string | null;
       /** Transition a cloud run to local. Use the resume_in_cloud action to move a run into cloud.
-
-      * `local` - local */
+       *
+       * * `local` - local */
       environment?: TaskRunUpdateEnvironmentEnum;
     }
 
@@ -33497,28 +33581,29 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level?: string | null;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       /** Filters used to identify internal/test users. Each entry is a property filter.
-
-                  Supported entry types and the exact shape each accepts:
-
-                  # Person property — match (or exclude) by a person property
-                  {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
-
-                  # Event property — match by an event property
-                  {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
-
-                  # Cohort membership — match (or exclude) members of a cohort.
-                  # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
-                  # `negation` field here — `negation` is specific to cohort *definitions*
-                  # (the inner sub-filters that build a cohort) and is rejected by the
-                  # property-filter schema.
-                  {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
-
-                  Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
-                  "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
+       *
+       *             Supported entry types and the exact shape each accepts:
+       *
+       *             # Person property — match (or exclude) by a person property
+       *             {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
+       *
+       *             # Event property — match by an event property
+       *             {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
+       *
+       *             # Cohort membership — match (or exclude) members of a cohort.
+       *             # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
+       *             # `negation` field here — `negation` is specific to cohort *definitions*
+       *             # (the inner sub-filters that build a cohort) and is rejected by the
+       *             # property-filter schema.
+       *             {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
+       *
+       *             Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
+       *             "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
       test_account_filters?: unknown;
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
@@ -33526,7 +33611,10 @@ export namespace Schemas {
       is_demo?: boolean;
       timezone?: string;
       data_attributes?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 400
+         */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
       /** @nullable */
@@ -33578,7 +33666,10 @@ export namespace Schemas {
       primary_dashboard?: number | null;
       /** @nullable */
       live_events_columns?: string[] | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       recording_domains?: (string | null)[] | null;
       cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
       /** @nullable */
@@ -33626,10 +33717,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /** @nullable */
       conversations_enabled?: boolean | null;
@@ -33657,18 +33748,18 @@ export namespace Schemas {
       readonly channel_detail?: ChannelDetailEnum | null;
       readonly distinct_id?: string;
       /** Ticket status: new, open, pending, on_hold, or resolved
-
-      * `new` - New
-      * `open` - Open
-      * `pending` - Pending
-      * `on_hold` - On hold
-      * `resolved` - Resolved */
+       *
+       * * `new` - New
+       * * `open` - Open
+       * * `pending` - Pending
+       * * `on_hold` - On hold
+       * * `resolved` - Resolved */
       status?: TicketStatusEnum;
       /** Ticket priority: low, medium, or high. Null if unset.
-
-      * `low` - Low
-      * `medium` - Medium
-      * `high` - High */
+       *
+       * * `low` - Low
+       * * `medium` - Medium
+       * * `high` - High */
       priority?: PriorityEnum | BlankEnum | null;
       readonly assignee?: TicketAssignment;
       /** Customer-provided traits such as name and email */
@@ -33718,8 +33809,8 @@ export namespace Schemas {
 
     /**
      * * `approved` - approved
-    * `needs_approval` - needs_approval
-    * `do_not_use` - do_not_use
+     * * `needs_approval` - needs_approval
+     * * `do_not_use` - do_not_use
      */
     export type ToolApprovalUpdateApprovalStateEnum = typeof ToolApprovalUpdateApprovalStateEnum[keyof typeof ToolApprovalUpdateApprovalStateEnum];
 
@@ -33746,6 +33837,7 @@ export namespace Schemas {
          * Categorical option keys selected for this score.
          * @minItems 1
          * @nullable
+         * @items.maxLength 128
          */
       categorical_values?: string[] | null;
       /**
@@ -33795,7 +33887,7 @@ export namespace Schemas {
 
     /**
      * PATCH payload for text sources. Both fields optional, at least one
-    required. `text` triggers a re-chunk; `name` alone does not.
+     * required. `text` triggers a re-chunk; `name` alone does not.
      */
     export interface PatchedUpdateTextSource {
       /**
@@ -33904,6 +33996,7 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
+      /** @items.maxLength 254 */
       interviewee_emails?: string[];
       readonly interviewee_identifier?: string;
       /** @nullable */
@@ -33919,9 +34012,15 @@ export namespace Schemas {
       readonly id?: string;
       readonly created_by?: UserBasic;
       readonly created_at?: string;
-      /** Email addresses of people to interview. May be combined with interviewee_distinct_ids. */
+      /**
+         * Email addresses of people to interview. May be combined with interviewee_distinct_ids.
+         * @items.maxLength 254
+         */
       interviewee_emails?: string[];
-      /** PostHog distinct IDs of people to interview. May be combined with interviewee_emails. */
+      /**
+         * PostHog distinct IDs of people to interview. May be combined with interviewee_emails.
+         * @items.maxLength 400
+         */
       interviewee_distinct_ids?: string[];
       /** The product, feature, or idea you want to ask interviewees about. */
       topic?: string;
@@ -33997,20 +34096,20 @@ export namespace Schemas {
       created_at?: string;
       readonly feature_flag_key?: string;
       /** Variants for the web experiment. Example:
-
-              {
-                  "control": {
-                      "transforms": [
-                          {
-                              "text": "Here comes Superman!",
-                              "html": "",
-                              "selector": "#page > #body > .header h1"
-                          }
-                      ],
-                      "conditions": "None",
-                      "rollout_percentage": 50
-                  },
-              } */
+       *
+       *         {
+       *             "control": {
+       *                 "transforms": [
+       *                     {
+       *                         "text": "Here comes Superman!",
+       *                         "html": "",
+       *                         "selector": "#page > #body > .header h1"
+       *                     }
+       *                 ],
+       *                 "conditions": "None",
+       *                 "rollout_percentage": 50
+       *             },
+       *         } */
       variants?: unknown;
     }
 
@@ -34351,9 +34450,9 @@ export namespace Schemas {
       readonly updated_at: string;
       archived?: boolean;
       /** Where the tour was created/updated from
-
-      * `app` - app
-      * `toolbar` - toolbar */
+       *
+       * * `app` - app
+       * * `toolbar` - toolbar */
       creation_context?: ProductTourSerializerCreateUpdateOnlyCreationContextEnum;
     }
 
@@ -34397,6 +34496,7 @@ export namespace Schemas {
       readonly updated_at: string | null;
       readonly uuid: string;
       readonly api_token: string;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       /** When true, PostHog drops the IP address from every ingested event. */
       anonymize_ips?: boolean;
@@ -34413,609 +34513,610 @@ export namespace Schemas {
       path_cleaning_filters?: unknown;
       is_demo?: boolean;
       /** IANA timezone used for date-based filters and reporting (e.g. `America/Los_Angeles`).
-
-      * `Africa/Abidjan` - Africa/Abidjan
-      * `Africa/Accra` - Africa/Accra
-      * `Africa/Addis_Ababa` - Africa/Addis_Ababa
-      * `Africa/Algiers` - Africa/Algiers
-      * `Africa/Asmara` - Africa/Asmara
-      * `Africa/Asmera` - Africa/Asmera
-      * `Africa/Bamako` - Africa/Bamako
-      * `Africa/Bangui` - Africa/Bangui
-      * `Africa/Banjul` - Africa/Banjul
-      * `Africa/Bissau` - Africa/Bissau
-      * `Africa/Blantyre` - Africa/Blantyre
-      * `Africa/Brazzaville` - Africa/Brazzaville
-      * `Africa/Bujumbura` - Africa/Bujumbura
-      * `Africa/Cairo` - Africa/Cairo
-      * `Africa/Casablanca` - Africa/Casablanca
-      * `Africa/Ceuta` - Africa/Ceuta
-      * `Africa/Conakry` - Africa/Conakry
-      * `Africa/Dakar` - Africa/Dakar
-      * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
-      * `Africa/Djibouti` - Africa/Djibouti
-      * `Africa/Douala` - Africa/Douala
-      * `Africa/El_Aaiun` - Africa/El_Aaiun
-      * `Africa/Freetown` - Africa/Freetown
-      * `Africa/Gaborone` - Africa/Gaborone
-      * `Africa/Harare` - Africa/Harare
-      * `Africa/Johannesburg` - Africa/Johannesburg
-      * `Africa/Juba` - Africa/Juba
-      * `Africa/Kampala` - Africa/Kampala
-      * `Africa/Khartoum` - Africa/Khartoum
-      * `Africa/Kigali` - Africa/Kigali
-      * `Africa/Kinshasa` - Africa/Kinshasa
-      * `Africa/Lagos` - Africa/Lagos
-      * `Africa/Libreville` - Africa/Libreville
-      * `Africa/Lome` - Africa/Lome
-      * `Africa/Luanda` - Africa/Luanda
-      * `Africa/Lubumbashi` - Africa/Lubumbashi
-      * `Africa/Lusaka` - Africa/Lusaka
-      * `Africa/Malabo` - Africa/Malabo
-      * `Africa/Maputo` - Africa/Maputo
-      * `Africa/Maseru` - Africa/Maseru
-      * `Africa/Mbabane` - Africa/Mbabane
-      * `Africa/Mogadishu` - Africa/Mogadishu
-      * `Africa/Monrovia` - Africa/Monrovia
-      * `Africa/Nairobi` - Africa/Nairobi
-      * `Africa/Ndjamena` - Africa/Ndjamena
-      * `Africa/Niamey` - Africa/Niamey
-      * `Africa/Nouakchott` - Africa/Nouakchott
-      * `Africa/Ouagadougou` - Africa/Ouagadougou
-      * `Africa/Porto-Novo` - Africa/Porto-Novo
-      * `Africa/Sao_Tome` - Africa/Sao_Tome
-      * `Africa/Timbuktu` - Africa/Timbuktu
-      * `Africa/Tripoli` - Africa/Tripoli
-      * `Africa/Tunis` - Africa/Tunis
-      * `Africa/Windhoek` - Africa/Windhoek
-      * `America/Adak` - America/Adak
-      * `America/Anchorage` - America/Anchorage
-      * `America/Anguilla` - America/Anguilla
-      * `America/Antigua` - America/Antigua
-      * `America/Araguaina` - America/Araguaina
-      * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
-      * `America/Argentina/Catamarca` - America/Argentina/Catamarca
-      * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
-      * `America/Argentina/Cordoba` - America/Argentina/Cordoba
-      * `America/Argentina/Jujuy` - America/Argentina/Jujuy
-      * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
-      * `America/Argentina/Mendoza` - America/Argentina/Mendoza
-      * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
-      * `America/Argentina/Salta` - America/Argentina/Salta
-      * `America/Argentina/San_Juan` - America/Argentina/San_Juan
-      * `America/Argentina/San_Luis` - America/Argentina/San_Luis
-      * `America/Argentina/Tucuman` - America/Argentina/Tucuman
-      * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
-      * `America/Aruba` - America/Aruba
-      * `America/Asuncion` - America/Asuncion
-      * `America/Atikokan` - America/Atikokan
-      * `America/Atka` - America/Atka
-      * `America/Bahia` - America/Bahia
-      * `America/Bahia_Banderas` - America/Bahia_Banderas
-      * `America/Barbados` - America/Barbados
-      * `America/Belem` - America/Belem
-      * `America/Belize` - America/Belize
-      * `America/Blanc-Sablon` - America/Blanc-Sablon
-      * `America/Boa_Vista` - America/Boa_Vista
-      * `America/Bogota` - America/Bogota
-      * `America/Boise` - America/Boise
-      * `America/Buenos_Aires` - America/Buenos_Aires
-      * `America/Cambridge_Bay` - America/Cambridge_Bay
-      * `America/Campo_Grande` - America/Campo_Grande
-      * `America/Cancun` - America/Cancun
-      * `America/Caracas` - America/Caracas
-      * `America/Catamarca` - America/Catamarca
-      * `America/Cayenne` - America/Cayenne
-      * `America/Cayman` - America/Cayman
-      * `America/Chicago` - America/Chicago
-      * `America/Chihuahua` - America/Chihuahua
-      * `America/Ciudad_Juarez` - America/Ciudad_Juarez
-      * `America/Coral_Harbour` - America/Coral_Harbour
-      * `America/Cordoba` - America/Cordoba
-      * `America/Costa_Rica` - America/Costa_Rica
-      * `America/Creston` - America/Creston
-      * `America/Cuiaba` - America/Cuiaba
-      * `America/Curacao` - America/Curacao
-      * `America/Danmarkshavn` - America/Danmarkshavn
-      * `America/Dawson` - America/Dawson
-      * `America/Dawson_Creek` - America/Dawson_Creek
-      * `America/Denver` - America/Denver
-      * `America/Detroit` - America/Detroit
-      * `America/Dominica` - America/Dominica
-      * `America/Edmonton` - America/Edmonton
-      * `America/Eirunepe` - America/Eirunepe
-      * `America/El_Salvador` - America/El_Salvador
-      * `America/Ensenada` - America/Ensenada
-      * `America/Fort_Nelson` - America/Fort_Nelson
-      * `America/Fort_Wayne` - America/Fort_Wayne
-      * `America/Fortaleza` - America/Fortaleza
-      * `America/Glace_Bay` - America/Glace_Bay
-      * `America/Godthab` - America/Godthab
-      * `America/Goose_Bay` - America/Goose_Bay
-      * `America/Grand_Turk` - America/Grand_Turk
-      * `America/Grenada` - America/Grenada
-      * `America/Guadeloupe` - America/Guadeloupe
-      * `America/Guatemala` - America/Guatemala
-      * `America/Guayaquil` - America/Guayaquil
-      * `America/Guyana` - America/Guyana
-      * `America/Halifax` - America/Halifax
-      * `America/Havana` - America/Havana
-      * `America/Hermosillo` - America/Hermosillo
-      * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
-      * `America/Indiana/Knox` - America/Indiana/Knox
-      * `America/Indiana/Marengo` - America/Indiana/Marengo
-      * `America/Indiana/Petersburg` - America/Indiana/Petersburg
-      * `America/Indiana/Tell_City` - America/Indiana/Tell_City
-      * `America/Indiana/Vevay` - America/Indiana/Vevay
-      * `America/Indiana/Vincennes` - America/Indiana/Vincennes
-      * `America/Indiana/Winamac` - America/Indiana/Winamac
-      * `America/Indianapolis` - America/Indianapolis
-      * `America/Inuvik` - America/Inuvik
-      * `America/Iqaluit` - America/Iqaluit
-      * `America/Jamaica` - America/Jamaica
-      * `America/Jujuy` - America/Jujuy
-      * `America/Juneau` - America/Juneau
-      * `America/Kentucky/Louisville` - America/Kentucky/Louisville
-      * `America/Kentucky/Monticello` - America/Kentucky/Monticello
-      * `America/Knox_IN` - America/Knox_IN
-      * `America/Kralendijk` - America/Kralendijk
-      * `America/La_Paz` - America/La_Paz
-      * `America/Lima` - America/Lima
-      * `America/Los_Angeles` - America/Los_Angeles
-      * `America/Louisville` - America/Louisville
-      * `America/Lower_Princes` - America/Lower_Princes
-      * `America/Maceio` - America/Maceio
-      * `America/Managua` - America/Managua
-      * `America/Manaus` - America/Manaus
-      * `America/Marigot` - America/Marigot
-      * `America/Martinique` - America/Martinique
-      * `America/Matamoros` - America/Matamoros
-      * `America/Mazatlan` - America/Mazatlan
-      * `America/Mendoza` - America/Mendoza
-      * `America/Menominee` - America/Menominee
-      * `America/Merida` - America/Merida
-      * `America/Metlakatla` - America/Metlakatla
-      * `America/Mexico_City` - America/Mexico_City
-      * `America/Miquelon` - America/Miquelon
-      * `America/Moncton` - America/Moncton
-      * `America/Monterrey` - America/Monterrey
-      * `America/Montevideo` - America/Montevideo
-      * `America/Montreal` - America/Montreal
-      * `America/Montserrat` - America/Montserrat
-      * `America/Nassau` - America/Nassau
-      * `America/New_York` - America/New_York
-      * `America/Nipigon` - America/Nipigon
-      * `America/Nome` - America/Nome
-      * `America/Noronha` - America/Noronha
-      * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
-      * `America/North_Dakota/Center` - America/North_Dakota/Center
-      * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
-      * `America/Nuuk` - America/Nuuk
-      * `America/Ojinaga` - America/Ojinaga
-      * `America/Panama` - America/Panama
-      * `America/Pangnirtung` - America/Pangnirtung
-      * `America/Paramaribo` - America/Paramaribo
-      * `America/Phoenix` - America/Phoenix
-      * `America/Port-au-Prince` - America/Port-au-Prince
-      * `America/Port_of_Spain` - America/Port_of_Spain
-      * `America/Porto_Acre` - America/Porto_Acre
-      * `America/Porto_Velho` - America/Porto_Velho
-      * `America/Puerto_Rico` - America/Puerto_Rico
-      * `America/Punta_Arenas` - America/Punta_Arenas
-      * `America/Rainy_River` - America/Rainy_River
-      * `America/Rankin_Inlet` - America/Rankin_Inlet
-      * `America/Recife` - America/Recife
-      * `America/Regina` - America/Regina
-      * `America/Resolute` - America/Resolute
-      * `America/Rio_Branco` - America/Rio_Branco
-      * `America/Rosario` - America/Rosario
-      * `America/Santa_Isabel` - America/Santa_Isabel
-      * `America/Santarem` - America/Santarem
-      * `America/Santiago` - America/Santiago
-      * `America/Santo_Domingo` - America/Santo_Domingo
-      * `America/Sao_Paulo` - America/Sao_Paulo
-      * `America/Scoresbysund` - America/Scoresbysund
-      * `America/Shiprock` - America/Shiprock
-      * `America/Sitka` - America/Sitka
-      * `America/St_Barthelemy` - America/St_Barthelemy
-      * `America/St_Johns` - America/St_Johns
-      * `America/St_Kitts` - America/St_Kitts
-      * `America/St_Lucia` - America/St_Lucia
-      * `America/St_Thomas` - America/St_Thomas
-      * `America/St_Vincent` - America/St_Vincent
-      * `America/Swift_Current` - America/Swift_Current
-      * `America/Tegucigalpa` - America/Tegucigalpa
-      * `America/Thule` - America/Thule
-      * `America/Thunder_Bay` - America/Thunder_Bay
-      * `America/Tijuana` - America/Tijuana
-      * `America/Toronto` - America/Toronto
-      * `America/Tortola` - America/Tortola
-      * `America/Vancouver` - America/Vancouver
-      * `America/Virgin` - America/Virgin
-      * `America/Whitehorse` - America/Whitehorse
-      * `America/Winnipeg` - America/Winnipeg
-      * `America/Yakutat` - America/Yakutat
-      * `America/Yellowknife` - America/Yellowknife
-      * `Antarctica/Casey` - Antarctica/Casey
-      * `Antarctica/Davis` - Antarctica/Davis
-      * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
-      * `Antarctica/Macquarie` - Antarctica/Macquarie
-      * `Antarctica/Mawson` - Antarctica/Mawson
-      * `Antarctica/McMurdo` - Antarctica/McMurdo
-      * `Antarctica/Palmer` - Antarctica/Palmer
-      * `Antarctica/Rothera` - Antarctica/Rothera
-      * `Antarctica/South_Pole` - Antarctica/South_Pole
-      * `Antarctica/Syowa` - Antarctica/Syowa
-      * `Antarctica/Troll` - Antarctica/Troll
-      * `Antarctica/Vostok` - Antarctica/Vostok
-      * `Arctic/Longyearbyen` - Arctic/Longyearbyen
-      * `Asia/Aden` - Asia/Aden
-      * `Asia/Almaty` - Asia/Almaty
-      * `Asia/Amman` - Asia/Amman
-      * `Asia/Anadyr` - Asia/Anadyr
-      * `Asia/Aqtau` - Asia/Aqtau
-      * `Asia/Aqtobe` - Asia/Aqtobe
-      * `Asia/Ashgabat` - Asia/Ashgabat
-      * `Asia/Ashkhabad` - Asia/Ashkhabad
-      * `Asia/Atyrau` - Asia/Atyrau
-      * `Asia/Baghdad` - Asia/Baghdad
-      * `Asia/Bahrain` - Asia/Bahrain
-      * `Asia/Baku` - Asia/Baku
-      * `Asia/Bangkok` - Asia/Bangkok
-      * `Asia/Barnaul` - Asia/Barnaul
-      * `Asia/Beirut` - Asia/Beirut
-      * `Asia/Bishkek` - Asia/Bishkek
-      * `Asia/Brunei` - Asia/Brunei
-      * `Asia/Calcutta` - Asia/Calcutta
-      * `Asia/Chita` - Asia/Chita
-      * `Asia/Choibalsan` - Asia/Choibalsan
-      * `Asia/Chongqing` - Asia/Chongqing
-      * `Asia/Chungking` - Asia/Chungking
-      * `Asia/Colombo` - Asia/Colombo
-      * `Asia/Dacca` - Asia/Dacca
-      * `Asia/Damascus` - Asia/Damascus
-      * `Asia/Dhaka` - Asia/Dhaka
-      * `Asia/Dili` - Asia/Dili
-      * `Asia/Dubai` - Asia/Dubai
-      * `Asia/Dushanbe` - Asia/Dushanbe
-      * `Asia/Famagusta` - Asia/Famagusta
-      * `Asia/Gaza` - Asia/Gaza
-      * `Asia/Harbin` - Asia/Harbin
-      * `Asia/Hebron` - Asia/Hebron
-      * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
-      * `Asia/Hong_Kong` - Asia/Hong_Kong
-      * `Asia/Hovd` - Asia/Hovd
-      * `Asia/Irkutsk` - Asia/Irkutsk
-      * `Asia/Istanbul` - Asia/Istanbul
-      * `Asia/Jakarta` - Asia/Jakarta
-      * `Asia/Jayapura` - Asia/Jayapura
-      * `Asia/Jerusalem` - Asia/Jerusalem
-      * `Asia/Kabul` - Asia/Kabul
-      * `Asia/Kamchatka` - Asia/Kamchatka
-      * `Asia/Karachi` - Asia/Karachi
-      * `Asia/Kashgar` - Asia/Kashgar
-      * `Asia/Kathmandu` - Asia/Kathmandu
-      * `Asia/Katmandu` - Asia/Katmandu
-      * `Asia/Khandyga` - Asia/Khandyga
-      * `Asia/Kolkata` - Asia/Kolkata
-      * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
-      * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
-      * `Asia/Kuching` - Asia/Kuching
-      * `Asia/Kuwait` - Asia/Kuwait
-      * `Asia/Macao` - Asia/Macao
-      * `Asia/Macau` - Asia/Macau
-      * `Asia/Magadan` - Asia/Magadan
-      * `Asia/Makassar` - Asia/Makassar
-      * `Asia/Manila` - Asia/Manila
-      * `Asia/Muscat` - Asia/Muscat
-      * `Asia/Nicosia` - Asia/Nicosia
-      * `Asia/Novokuznetsk` - Asia/Novokuznetsk
-      * `Asia/Novosibirsk` - Asia/Novosibirsk
-      * `Asia/Omsk` - Asia/Omsk
-      * `Asia/Oral` - Asia/Oral
-      * `Asia/Phnom_Penh` - Asia/Phnom_Penh
-      * `Asia/Pontianak` - Asia/Pontianak
-      * `Asia/Pyongyang` - Asia/Pyongyang
-      * `Asia/Qatar` - Asia/Qatar
-      * `Asia/Qostanay` - Asia/Qostanay
-      * `Asia/Qyzylorda` - Asia/Qyzylorda
-      * `Asia/Rangoon` - Asia/Rangoon
-      * `Asia/Riyadh` - Asia/Riyadh
-      * `Asia/Saigon` - Asia/Saigon
-      * `Asia/Sakhalin` - Asia/Sakhalin
-      * `Asia/Samarkand` - Asia/Samarkand
-      * `Asia/Seoul` - Asia/Seoul
-      * `Asia/Shanghai` - Asia/Shanghai
-      * `Asia/Singapore` - Asia/Singapore
-      * `Asia/Srednekolymsk` - Asia/Srednekolymsk
-      * `Asia/Taipei` - Asia/Taipei
-      * `Asia/Tashkent` - Asia/Tashkent
-      * `Asia/Tbilisi` - Asia/Tbilisi
-      * `Asia/Tehran` - Asia/Tehran
-      * `Asia/Tel_Aviv` - Asia/Tel_Aviv
-      * `Asia/Thimbu` - Asia/Thimbu
-      * `Asia/Thimphu` - Asia/Thimphu
-      * `Asia/Tokyo` - Asia/Tokyo
-      * `Asia/Tomsk` - Asia/Tomsk
-      * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
-      * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
-      * `Asia/Ulan_Bator` - Asia/Ulan_Bator
-      * `Asia/Urumqi` - Asia/Urumqi
-      * `Asia/Ust-Nera` - Asia/Ust-Nera
-      * `Asia/Vientiane` - Asia/Vientiane
-      * `Asia/Vladivostok` - Asia/Vladivostok
-      * `Asia/Yakutsk` - Asia/Yakutsk
-      * `Asia/Yangon` - Asia/Yangon
-      * `Asia/Yekaterinburg` - Asia/Yekaterinburg
-      * `Asia/Yerevan` - Asia/Yerevan
-      * `Atlantic/Azores` - Atlantic/Azores
-      * `Atlantic/Bermuda` - Atlantic/Bermuda
-      * `Atlantic/Canary` - Atlantic/Canary
-      * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
-      * `Atlantic/Faeroe` - Atlantic/Faeroe
-      * `Atlantic/Faroe` - Atlantic/Faroe
-      * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
-      * `Atlantic/Madeira` - Atlantic/Madeira
-      * `Atlantic/Reykjavik` - Atlantic/Reykjavik
-      * `Atlantic/South_Georgia` - Atlantic/South_Georgia
-      * `Atlantic/St_Helena` - Atlantic/St_Helena
-      * `Atlantic/Stanley` - Atlantic/Stanley
-      * `Australia/ACT` - Australia/ACT
-      * `Australia/Adelaide` - Australia/Adelaide
-      * `Australia/Brisbane` - Australia/Brisbane
-      * `Australia/Broken_Hill` - Australia/Broken_Hill
-      * `Australia/Canberra` - Australia/Canberra
-      * `Australia/Currie` - Australia/Currie
-      * `Australia/Darwin` - Australia/Darwin
-      * `Australia/Eucla` - Australia/Eucla
-      * `Australia/Hobart` - Australia/Hobart
-      * `Australia/LHI` - Australia/LHI
-      * `Australia/Lindeman` - Australia/Lindeman
-      * `Australia/Lord_Howe` - Australia/Lord_Howe
-      * `Australia/Melbourne` - Australia/Melbourne
-      * `Australia/NSW` - Australia/NSW
-      * `Australia/North` - Australia/North
-      * `Australia/Perth` - Australia/Perth
-      * `Australia/Queensland` - Australia/Queensland
-      * `Australia/South` - Australia/South
-      * `Australia/Sydney` - Australia/Sydney
-      * `Australia/Tasmania` - Australia/Tasmania
-      * `Australia/Victoria` - Australia/Victoria
-      * `Australia/West` - Australia/West
-      * `Australia/Yancowinna` - Australia/Yancowinna
-      * `Brazil/Acre` - Brazil/Acre
-      * `Brazil/DeNoronha` - Brazil/DeNoronha
-      * `Brazil/East` - Brazil/East
-      * `Brazil/West` - Brazil/West
-      * `CET` - CET
-      * `CST6CDT` - CST6CDT
-      * `Canada/Atlantic` - Canada/Atlantic
-      * `Canada/Central` - Canada/Central
-      * `Canada/Eastern` - Canada/Eastern
-      * `Canada/Mountain` - Canada/Mountain
-      * `Canada/Newfoundland` - Canada/Newfoundland
-      * `Canada/Pacific` - Canada/Pacific
-      * `Canada/Saskatchewan` - Canada/Saskatchewan
-      * `Canada/Yukon` - Canada/Yukon
-      * `Chile/Continental` - Chile/Continental
-      * `Chile/EasterIsland` - Chile/EasterIsland
-      * `Cuba` - Cuba
-      * `EET` - EET
-      * `EST` - EST
-      * `EST5EDT` - EST5EDT
-      * `Egypt` - Egypt
-      * `Eire` - Eire
-      * `Etc/GMT` - Etc/GMT
-      * `Etc/GMT+0` - Etc/GMT+0
-      * `Etc/GMT+1` - Etc/GMT+1
-      * `Etc/GMT+10` - Etc/GMT+10
-      * `Etc/GMT+11` - Etc/GMT+11
-      * `Etc/GMT+12` - Etc/GMT+12
-      * `Etc/GMT+2` - Etc/GMT+2
-      * `Etc/GMT+3` - Etc/GMT+3
-      * `Etc/GMT+4` - Etc/GMT+4
-      * `Etc/GMT+5` - Etc/GMT+5
-      * `Etc/GMT+6` - Etc/GMT+6
-      * `Etc/GMT+7` - Etc/GMT+7
-      * `Etc/GMT+8` - Etc/GMT+8
-      * `Etc/GMT+9` - Etc/GMT+9
-      * `Etc/GMT-0` - Etc/GMT-0
-      * `Etc/GMT-1` - Etc/GMT-1
-      * `Etc/GMT-10` - Etc/GMT-10
-      * `Etc/GMT-11` - Etc/GMT-11
-      * `Etc/GMT-12` - Etc/GMT-12
-      * `Etc/GMT-13` - Etc/GMT-13
-      * `Etc/GMT-14` - Etc/GMT-14
-      * `Etc/GMT-2` - Etc/GMT-2
-      * `Etc/GMT-3` - Etc/GMT-3
-      * `Etc/GMT-4` - Etc/GMT-4
-      * `Etc/GMT-5` - Etc/GMT-5
-      * `Etc/GMT-6` - Etc/GMT-6
-      * `Etc/GMT-7` - Etc/GMT-7
-      * `Etc/GMT-8` - Etc/GMT-8
-      * `Etc/GMT-9` - Etc/GMT-9
-      * `Etc/GMT0` - Etc/GMT0
-      * `Etc/Greenwich` - Etc/Greenwich
-      * `Etc/UCT` - Etc/UCT
-      * `Etc/UTC` - Etc/UTC
-      * `Etc/Universal` - Etc/Universal
-      * `Etc/Zulu` - Etc/Zulu
-      * `Europe/Amsterdam` - Europe/Amsterdam
-      * `Europe/Andorra` - Europe/Andorra
-      * `Europe/Astrakhan` - Europe/Astrakhan
-      * `Europe/Athens` - Europe/Athens
-      * `Europe/Belfast` - Europe/Belfast
-      * `Europe/Belgrade` - Europe/Belgrade
-      * `Europe/Berlin` - Europe/Berlin
-      * `Europe/Bratislava` - Europe/Bratislava
-      * `Europe/Brussels` - Europe/Brussels
-      * `Europe/Bucharest` - Europe/Bucharest
-      * `Europe/Budapest` - Europe/Budapest
-      * `Europe/Busingen` - Europe/Busingen
-      * `Europe/Chisinau` - Europe/Chisinau
-      * `Europe/Copenhagen` - Europe/Copenhagen
-      * `Europe/Dublin` - Europe/Dublin
-      * `Europe/Gibraltar` - Europe/Gibraltar
-      * `Europe/Guernsey` - Europe/Guernsey
-      * `Europe/Helsinki` - Europe/Helsinki
-      * `Europe/Isle_of_Man` - Europe/Isle_of_Man
-      * `Europe/Istanbul` - Europe/Istanbul
-      * `Europe/Jersey` - Europe/Jersey
-      * `Europe/Kaliningrad` - Europe/Kaliningrad
-      * `Europe/Kiev` - Europe/Kiev
-      * `Europe/Kirov` - Europe/Kirov
-      * `Europe/Kyiv` - Europe/Kyiv
-      * `Europe/Lisbon` - Europe/Lisbon
-      * `Europe/Ljubljana` - Europe/Ljubljana
-      * `Europe/London` - Europe/London
-      * `Europe/Luxembourg` - Europe/Luxembourg
-      * `Europe/Madrid` - Europe/Madrid
-      * `Europe/Malta` - Europe/Malta
-      * `Europe/Mariehamn` - Europe/Mariehamn
-      * `Europe/Minsk` - Europe/Minsk
-      * `Europe/Monaco` - Europe/Monaco
-      * `Europe/Moscow` - Europe/Moscow
-      * `Europe/Nicosia` - Europe/Nicosia
-      * `Europe/Oslo` - Europe/Oslo
-      * `Europe/Paris` - Europe/Paris
-      * `Europe/Podgorica` - Europe/Podgorica
-      * `Europe/Prague` - Europe/Prague
-      * `Europe/Riga` - Europe/Riga
-      * `Europe/Rome` - Europe/Rome
-      * `Europe/Samara` - Europe/Samara
-      * `Europe/San_Marino` - Europe/San_Marino
-      * `Europe/Sarajevo` - Europe/Sarajevo
-      * `Europe/Saratov` - Europe/Saratov
-      * `Europe/Simferopol` - Europe/Simferopol
-      * `Europe/Skopje` - Europe/Skopje
-      * `Europe/Sofia` - Europe/Sofia
-      * `Europe/Stockholm` - Europe/Stockholm
-      * `Europe/Tallinn` - Europe/Tallinn
-      * `Europe/Tirane` - Europe/Tirane
-      * `Europe/Tiraspol` - Europe/Tiraspol
-      * `Europe/Ulyanovsk` - Europe/Ulyanovsk
-      * `Europe/Uzhgorod` - Europe/Uzhgorod
-      * `Europe/Vaduz` - Europe/Vaduz
-      * `Europe/Vatican` - Europe/Vatican
-      * `Europe/Vienna` - Europe/Vienna
-      * `Europe/Vilnius` - Europe/Vilnius
-      * `Europe/Volgograd` - Europe/Volgograd
-      * `Europe/Warsaw` - Europe/Warsaw
-      * `Europe/Zagreb` - Europe/Zagreb
-      * `Europe/Zaporozhye` - Europe/Zaporozhye
-      * `Europe/Zurich` - Europe/Zurich
-      * `GB` - GB
-      * `GB-Eire` - GB-Eire
-      * `GMT` - GMT
-      * `GMT+0` - GMT+0
-      * `GMT-0` - GMT-0
-      * `GMT0` - GMT0
-      * `Greenwich` - Greenwich
-      * `HST` - HST
-      * `Hongkong` - Hongkong
-      * `Iceland` - Iceland
-      * `Indian/Antananarivo` - Indian/Antananarivo
-      * `Indian/Chagos` - Indian/Chagos
-      * `Indian/Christmas` - Indian/Christmas
-      * `Indian/Cocos` - Indian/Cocos
-      * `Indian/Comoro` - Indian/Comoro
-      * `Indian/Kerguelen` - Indian/Kerguelen
-      * `Indian/Mahe` - Indian/Mahe
-      * `Indian/Maldives` - Indian/Maldives
-      * `Indian/Mauritius` - Indian/Mauritius
-      * `Indian/Mayotte` - Indian/Mayotte
-      * `Indian/Reunion` - Indian/Reunion
-      * `Iran` - Iran
-      * `Israel` - Israel
-      * `Jamaica` - Jamaica
-      * `Japan` - Japan
-      * `Kwajalein` - Kwajalein
-      * `Libya` - Libya
-      * `MET` - MET
-      * `MST` - MST
-      * `MST7MDT` - MST7MDT
-      * `Mexico/BajaNorte` - Mexico/BajaNorte
-      * `Mexico/BajaSur` - Mexico/BajaSur
-      * `Mexico/General` - Mexico/General
-      * `NZ` - NZ
-      * `NZ-CHAT` - NZ-CHAT
-      * `Navajo` - Navajo
-      * `PRC` - PRC
-      * `PST8PDT` - PST8PDT
-      * `Pacific/Apia` - Pacific/Apia
-      * `Pacific/Auckland` - Pacific/Auckland
-      * `Pacific/Bougainville` - Pacific/Bougainville
-      * `Pacific/Chatham` - Pacific/Chatham
-      * `Pacific/Chuuk` - Pacific/Chuuk
-      * `Pacific/Easter` - Pacific/Easter
-      * `Pacific/Efate` - Pacific/Efate
-      * `Pacific/Enderbury` - Pacific/Enderbury
-      * `Pacific/Fakaofo` - Pacific/Fakaofo
-      * `Pacific/Fiji` - Pacific/Fiji
-      * `Pacific/Funafuti` - Pacific/Funafuti
-      * `Pacific/Galapagos` - Pacific/Galapagos
-      * `Pacific/Gambier` - Pacific/Gambier
-      * `Pacific/Guadalcanal` - Pacific/Guadalcanal
-      * `Pacific/Guam` - Pacific/Guam
-      * `Pacific/Honolulu` - Pacific/Honolulu
-      * `Pacific/Johnston` - Pacific/Johnston
-      * `Pacific/Kanton` - Pacific/Kanton
-      * `Pacific/Kiritimati` - Pacific/Kiritimati
-      * `Pacific/Kosrae` - Pacific/Kosrae
-      * `Pacific/Kwajalein` - Pacific/Kwajalein
-      * `Pacific/Majuro` - Pacific/Majuro
-      * `Pacific/Marquesas` - Pacific/Marquesas
-      * `Pacific/Midway` - Pacific/Midway
-      * `Pacific/Nauru` - Pacific/Nauru
-      * `Pacific/Niue` - Pacific/Niue
-      * `Pacific/Norfolk` - Pacific/Norfolk
-      * `Pacific/Noumea` - Pacific/Noumea
-      * `Pacific/Pago_Pago` - Pacific/Pago_Pago
-      * `Pacific/Palau` - Pacific/Palau
-      * `Pacific/Pitcairn` - Pacific/Pitcairn
-      * `Pacific/Pohnpei` - Pacific/Pohnpei
-      * `Pacific/Ponape` - Pacific/Ponape
-      * `Pacific/Port_Moresby` - Pacific/Port_Moresby
-      * `Pacific/Rarotonga` - Pacific/Rarotonga
-      * `Pacific/Saipan` - Pacific/Saipan
-      * `Pacific/Samoa` - Pacific/Samoa
-      * `Pacific/Tahiti` - Pacific/Tahiti
-      * `Pacific/Tarawa` - Pacific/Tarawa
-      * `Pacific/Tongatapu` - Pacific/Tongatapu
-      * `Pacific/Truk` - Pacific/Truk
-      * `Pacific/Wake` - Pacific/Wake
-      * `Pacific/Wallis` - Pacific/Wallis
-      * `Pacific/Yap` - Pacific/Yap
-      * `Poland` - Poland
-      * `Portugal` - Portugal
-      * `ROC` - ROC
-      * `ROK` - ROK
-      * `Singapore` - Singapore
-      * `Turkey` - Turkey
-      * `UCT` - UCT
-      * `US/Alaska` - US/Alaska
-      * `US/Aleutian` - US/Aleutian
-      * `US/Arizona` - US/Arizona
-      * `US/Central` - US/Central
-      * `US/East-Indiana` - US/East-Indiana
-      * `US/Eastern` - US/Eastern
-      * `US/Hawaii` - US/Hawaii
-      * `US/Indiana-Starke` - US/Indiana-Starke
-      * `US/Michigan` - US/Michigan
-      * `US/Mountain` - US/Mountain
-      * `US/Pacific` - US/Pacific
-      * `US/Samoa` - US/Samoa
-      * `UTC` - UTC
-      * `Universal` - Universal
-      * `W-SU` - W-SU
-      * `WET` - WET
-      * `Zulu` - Zulu */
+       *
+       * * `Africa/Abidjan` - Africa/Abidjan
+       * * `Africa/Accra` - Africa/Accra
+       * * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+       * * `Africa/Algiers` - Africa/Algiers
+       * * `Africa/Asmara` - Africa/Asmara
+       * * `Africa/Asmera` - Africa/Asmera
+       * * `Africa/Bamako` - Africa/Bamako
+       * * `Africa/Bangui` - Africa/Bangui
+       * * `Africa/Banjul` - Africa/Banjul
+       * * `Africa/Bissau` - Africa/Bissau
+       * * `Africa/Blantyre` - Africa/Blantyre
+       * * `Africa/Brazzaville` - Africa/Brazzaville
+       * * `Africa/Bujumbura` - Africa/Bujumbura
+       * * `Africa/Cairo` - Africa/Cairo
+       * * `Africa/Casablanca` - Africa/Casablanca
+       * * `Africa/Ceuta` - Africa/Ceuta
+       * * `Africa/Conakry` - Africa/Conakry
+       * * `Africa/Dakar` - Africa/Dakar
+       * * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+       * * `Africa/Djibouti` - Africa/Djibouti
+       * * `Africa/Douala` - Africa/Douala
+       * * `Africa/El_Aaiun` - Africa/El_Aaiun
+       * * `Africa/Freetown` - Africa/Freetown
+       * * `Africa/Gaborone` - Africa/Gaborone
+       * * `Africa/Harare` - Africa/Harare
+       * * `Africa/Johannesburg` - Africa/Johannesburg
+       * * `Africa/Juba` - Africa/Juba
+       * * `Africa/Kampala` - Africa/Kampala
+       * * `Africa/Khartoum` - Africa/Khartoum
+       * * `Africa/Kigali` - Africa/Kigali
+       * * `Africa/Kinshasa` - Africa/Kinshasa
+       * * `Africa/Lagos` - Africa/Lagos
+       * * `Africa/Libreville` - Africa/Libreville
+       * * `Africa/Lome` - Africa/Lome
+       * * `Africa/Luanda` - Africa/Luanda
+       * * `Africa/Lubumbashi` - Africa/Lubumbashi
+       * * `Africa/Lusaka` - Africa/Lusaka
+       * * `Africa/Malabo` - Africa/Malabo
+       * * `Africa/Maputo` - Africa/Maputo
+       * * `Africa/Maseru` - Africa/Maseru
+       * * `Africa/Mbabane` - Africa/Mbabane
+       * * `Africa/Mogadishu` - Africa/Mogadishu
+       * * `Africa/Monrovia` - Africa/Monrovia
+       * * `Africa/Nairobi` - Africa/Nairobi
+       * * `Africa/Ndjamena` - Africa/Ndjamena
+       * * `Africa/Niamey` - Africa/Niamey
+       * * `Africa/Nouakchott` - Africa/Nouakchott
+       * * `Africa/Ouagadougou` - Africa/Ouagadougou
+       * * `Africa/Porto-Novo` - Africa/Porto-Novo
+       * * `Africa/Sao_Tome` - Africa/Sao_Tome
+       * * `Africa/Timbuktu` - Africa/Timbuktu
+       * * `Africa/Tripoli` - Africa/Tripoli
+       * * `Africa/Tunis` - Africa/Tunis
+       * * `Africa/Windhoek` - Africa/Windhoek
+       * * `America/Adak` - America/Adak
+       * * `America/Anchorage` - America/Anchorage
+       * * `America/Anguilla` - America/Anguilla
+       * * `America/Antigua` - America/Antigua
+       * * `America/Araguaina` - America/Araguaina
+       * * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+       * * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+       * * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia
+       * * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+       * * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+       * * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+       * * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+       * * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+       * * `America/Argentina/Salta` - America/Argentina/Salta
+       * * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+       * * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+       * * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+       * * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+       * * `America/Aruba` - America/Aruba
+       * * `America/Asuncion` - America/Asuncion
+       * * `America/Atikokan` - America/Atikokan
+       * * `America/Atka` - America/Atka
+       * * `America/Bahia` - America/Bahia
+       * * `America/Bahia_Banderas` - America/Bahia_Banderas
+       * * `America/Barbados` - America/Barbados
+       * * `America/Belem` - America/Belem
+       * * `America/Belize` - America/Belize
+       * * `America/Blanc-Sablon` - America/Blanc-Sablon
+       * * `America/Boa_Vista` - America/Boa_Vista
+       * * `America/Bogota` - America/Bogota
+       * * `America/Boise` - America/Boise
+       * * `America/Buenos_Aires` - America/Buenos_Aires
+       * * `America/Cambridge_Bay` - America/Cambridge_Bay
+       * * `America/Campo_Grande` - America/Campo_Grande
+       * * `America/Cancun` - America/Cancun
+       * * `America/Caracas` - America/Caracas
+       * * `America/Catamarca` - America/Catamarca
+       * * `America/Cayenne` - America/Cayenne
+       * * `America/Cayman` - America/Cayman
+       * * `America/Chicago` - America/Chicago
+       * * `America/Chihuahua` - America/Chihuahua
+       * * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+       * * `America/Coral_Harbour` - America/Coral_Harbour
+       * * `America/Cordoba` - America/Cordoba
+       * * `America/Costa_Rica` - America/Costa_Rica
+       * * `America/Creston` - America/Creston
+       * * `America/Cuiaba` - America/Cuiaba
+       * * `America/Curacao` - America/Curacao
+       * * `America/Danmarkshavn` - America/Danmarkshavn
+       * * `America/Dawson` - America/Dawson
+       * * `America/Dawson_Creek` - America/Dawson_Creek
+       * * `America/Denver` - America/Denver
+       * * `America/Detroit` - America/Detroit
+       * * `America/Dominica` - America/Dominica
+       * * `America/Edmonton` - America/Edmonton
+       * * `America/Eirunepe` - America/Eirunepe
+       * * `America/El_Salvador` - America/El_Salvador
+       * * `America/Ensenada` - America/Ensenada
+       * * `America/Fort_Nelson` - America/Fort_Nelson
+       * * `America/Fort_Wayne` - America/Fort_Wayne
+       * * `America/Fortaleza` - America/Fortaleza
+       * * `America/Glace_Bay` - America/Glace_Bay
+       * * `America/Godthab` - America/Godthab
+       * * `America/Goose_Bay` - America/Goose_Bay
+       * * `America/Grand_Turk` - America/Grand_Turk
+       * * `America/Grenada` - America/Grenada
+       * * `America/Guadeloupe` - America/Guadeloupe
+       * * `America/Guatemala` - America/Guatemala
+       * * `America/Guayaquil` - America/Guayaquil
+       * * `America/Guyana` - America/Guyana
+       * * `America/Halifax` - America/Halifax
+       * * `America/Havana` - America/Havana
+       * * `America/Hermosillo` - America/Hermosillo
+       * * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+       * * `America/Indiana/Knox` - America/Indiana/Knox
+       * * `America/Indiana/Marengo` - America/Indiana/Marengo
+       * * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+       * * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+       * * `America/Indiana/Vevay` - America/Indiana/Vevay
+       * * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+       * * `America/Indiana/Winamac` - America/Indiana/Winamac
+       * * `America/Indianapolis` - America/Indianapolis
+       * * `America/Inuvik` - America/Inuvik
+       * * `America/Iqaluit` - America/Iqaluit
+       * * `America/Jamaica` - America/Jamaica
+       * * `America/Jujuy` - America/Jujuy
+       * * `America/Juneau` - America/Juneau
+       * * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+       * * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+       * * `America/Knox_IN` - America/Knox_IN
+       * * `America/Kralendijk` - America/Kralendijk
+       * * `America/La_Paz` - America/La_Paz
+       * * `America/Lima` - America/Lima
+       * * `America/Los_Angeles` - America/Los_Angeles
+       * * `America/Louisville` - America/Louisville
+       * * `America/Lower_Princes` - America/Lower_Princes
+       * * `America/Maceio` - America/Maceio
+       * * `America/Managua` - America/Managua
+       * * `America/Manaus` - America/Manaus
+       * * `America/Marigot` - America/Marigot
+       * * `America/Martinique` - America/Martinique
+       * * `America/Matamoros` - America/Matamoros
+       * * `America/Mazatlan` - America/Mazatlan
+       * * `America/Mendoza` - America/Mendoza
+       * * `America/Menominee` - America/Menominee
+       * * `America/Merida` - America/Merida
+       * * `America/Metlakatla` - America/Metlakatla
+       * * `America/Mexico_City` - America/Mexico_City
+       * * `America/Miquelon` - America/Miquelon
+       * * `America/Moncton` - America/Moncton
+       * * `America/Monterrey` - America/Monterrey
+       * * `America/Montevideo` - America/Montevideo
+       * * `America/Montreal` - America/Montreal
+       * * `America/Montserrat` - America/Montserrat
+       * * `America/Nassau` - America/Nassau
+       * * `America/New_York` - America/New_York
+       * * `America/Nipigon` - America/Nipigon
+       * * `America/Nome` - America/Nome
+       * * `America/Noronha` - America/Noronha
+       * * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+       * * `America/North_Dakota/Center` - America/North_Dakota/Center
+       * * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+       * * `America/Nuuk` - America/Nuuk
+       * * `America/Ojinaga` - America/Ojinaga
+       * * `America/Panama` - America/Panama
+       * * `America/Pangnirtung` - America/Pangnirtung
+       * * `America/Paramaribo` - America/Paramaribo
+       * * `America/Phoenix` - America/Phoenix
+       * * `America/Port-au-Prince` - America/Port-au-Prince
+       * * `America/Port_of_Spain` - America/Port_of_Spain
+       * * `America/Porto_Acre` - America/Porto_Acre
+       * * `America/Porto_Velho` - America/Porto_Velho
+       * * `America/Puerto_Rico` - America/Puerto_Rico
+       * * `America/Punta_Arenas` - America/Punta_Arenas
+       * * `America/Rainy_River` - America/Rainy_River
+       * * `America/Rankin_Inlet` - America/Rankin_Inlet
+       * * `America/Recife` - America/Recife
+       * * `America/Regina` - America/Regina
+       * * `America/Resolute` - America/Resolute
+       * * `America/Rio_Branco` - America/Rio_Branco
+       * * `America/Rosario` - America/Rosario
+       * * `America/Santa_Isabel` - America/Santa_Isabel
+       * * `America/Santarem` - America/Santarem
+       * * `America/Santiago` - America/Santiago
+       * * `America/Santo_Domingo` - America/Santo_Domingo
+       * * `America/Sao_Paulo` - America/Sao_Paulo
+       * * `America/Scoresbysund` - America/Scoresbysund
+       * * `America/Shiprock` - America/Shiprock
+       * * `America/Sitka` - America/Sitka
+       * * `America/St_Barthelemy` - America/St_Barthelemy
+       * * `America/St_Johns` - America/St_Johns
+       * * `America/St_Kitts` - America/St_Kitts
+       * * `America/St_Lucia` - America/St_Lucia
+       * * `America/St_Thomas` - America/St_Thomas
+       * * `America/St_Vincent` - America/St_Vincent
+       * * `America/Swift_Current` - America/Swift_Current
+       * * `America/Tegucigalpa` - America/Tegucigalpa
+       * * `America/Thule` - America/Thule
+       * * `America/Thunder_Bay` - America/Thunder_Bay
+       * * `America/Tijuana` - America/Tijuana
+       * * `America/Toronto` - America/Toronto
+       * * `America/Tortola` - America/Tortola
+       * * `America/Vancouver` - America/Vancouver
+       * * `America/Virgin` - America/Virgin
+       * * `America/Whitehorse` - America/Whitehorse
+       * * `America/Winnipeg` - America/Winnipeg
+       * * `America/Yakutat` - America/Yakutat
+       * * `America/Yellowknife` - America/Yellowknife
+       * * `Antarctica/Casey` - Antarctica/Casey
+       * * `Antarctica/Davis` - Antarctica/Davis
+       * * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+       * * `Antarctica/Macquarie` - Antarctica/Macquarie
+       * * `Antarctica/Mawson` - Antarctica/Mawson
+       * * `Antarctica/McMurdo` - Antarctica/McMurdo
+       * * `Antarctica/Palmer` - Antarctica/Palmer
+       * * `Antarctica/Rothera` - Antarctica/Rothera
+       * * `Antarctica/South_Pole` - Antarctica/South_Pole
+       * * `Antarctica/Syowa` - Antarctica/Syowa
+       * * `Antarctica/Troll` - Antarctica/Troll
+       * * `Antarctica/Vostok` - Antarctica/Vostok
+       * * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+       * * `Asia/Aden` - Asia/Aden
+       * * `Asia/Almaty` - Asia/Almaty
+       * * `Asia/Amman` - Asia/Amman
+       * * `Asia/Anadyr` - Asia/Anadyr
+       * * `Asia/Aqtau` - Asia/Aqtau
+       * * `Asia/Aqtobe` - Asia/Aqtobe
+       * * `Asia/Ashgabat` - Asia/Ashgabat
+       * * `Asia/Ashkhabad` - Asia/Ashkhabad
+       * * `Asia/Atyrau` - Asia/Atyrau
+       * * `Asia/Baghdad` - Asia/Baghdad
+       * * `Asia/Bahrain` - Asia/Bahrain
+       * * `Asia/Baku` - Asia/Baku
+       * * `Asia/Bangkok` - Asia/Bangkok
+       * * `Asia/Barnaul` - Asia/Barnaul
+       * * `Asia/Beirut` - Asia/Beirut
+       * * `Asia/Bishkek` - Asia/Bishkek
+       * * `Asia/Brunei` - Asia/Brunei
+       * * `Asia/Calcutta` - Asia/Calcutta
+       * * `Asia/Chita` - Asia/Chita
+       * * `Asia/Choibalsan` - Asia/Choibalsan
+       * * `Asia/Chongqing` - Asia/Chongqing
+       * * `Asia/Chungking` - Asia/Chungking
+       * * `Asia/Colombo` - Asia/Colombo
+       * * `Asia/Dacca` - Asia/Dacca
+       * * `Asia/Damascus` - Asia/Damascus
+       * * `Asia/Dhaka` - Asia/Dhaka
+       * * `Asia/Dili` - Asia/Dili
+       * * `Asia/Dubai` - Asia/Dubai
+       * * `Asia/Dushanbe` - Asia/Dushanbe
+       * * `Asia/Famagusta` - Asia/Famagusta
+       * * `Asia/Gaza` - Asia/Gaza
+       * * `Asia/Harbin` - Asia/Harbin
+       * * `Asia/Hebron` - Asia/Hebron
+       * * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+       * * `Asia/Hong_Kong` - Asia/Hong_Kong
+       * * `Asia/Hovd` - Asia/Hovd
+       * * `Asia/Irkutsk` - Asia/Irkutsk
+       * * `Asia/Istanbul` - Asia/Istanbul
+       * * `Asia/Jakarta` - Asia/Jakarta
+       * * `Asia/Jayapura` - Asia/Jayapura
+       * * `Asia/Jerusalem` - Asia/Jerusalem
+       * * `Asia/Kabul` - Asia/Kabul
+       * * `Asia/Kamchatka` - Asia/Kamchatka
+       * * `Asia/Karachi` - Asia/Karachi
+       * * `Asia/Kashgar` - Asia/Kashgar
+       * * `Asia/Kathmandu` - Asia/Kathmandu
+       * * `Asia/Katmandu` - Asia/Katmandu
+       * * `Asia/Khandyga` - Asia/Khandyga
+       * * `Asia/Kolkata` - Asia/Kolkata
+       * * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+       * * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+       * * `Asia/Kuching` - Asia/Kuching
+       * * `Asia/Kuwait` - Asia/Kuwait
+       * * `Asia/Macao` - Asia/Macao
+       * * `Asia/Macau` - Asia/Macau
+       * * `Asia/Magadan` - Asia/Magadan
+       * * `Asia/Makassar` - Asia/Makassar
+       * * `Asia/Manila` - Asia/Manila
+       * * `Asia/Muscat` - Asia/Muscat
+       * * `Asia/Nicosia` - Asia/Nicosia
+       * * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+       * * `Asia/Novosibirsk` - Asia/Novosibirsk
+       * * `Asia/Omsk` - Asia/Omsk
+       * * `Asia/Oral` - Asia/Oral
+       * * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+       * * `Asia/Pontianak` - Asia/Pontianak
+       * * `Asia/Pyongyang` - Asia/Pyongyang
+       * * `Asia/Qatar` - Asia/Qatar
+       * * `Asia/Qostanay` - Asia/Qostanay
+       * * `Asia/Qyzylorda` - Asia/Qyzylorda
+       * * `Asia/Rangoon` - Asia/Rangoon
+       * * `Asia/Riyadh` - Asia/Riyadh
+       * * `Asia/Saigon` - Asia/Saigon
+       * * `Asia/Sakhalin` - Asia/Sakhalin
+       * * `Asia/Samarkand` - Asia/Samarkand
+       * * `Asia/Seoul` - Asia/Seoul
+       * * `Asia/Shanghai` - Asia/Shanghai
+       * * `Asia/Singapore` - Asia/Singapore
+       * * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+       * * `Asia/Taipei` - Asia/Taipei
+       * * `Asia/Tashkent` - Asia/Tashkent
+       * * `Asia/Tbilisi` - Asia/Tbilisi
+       * * `Asia/Tehran` - Asia/Tehran
+       * * `Asia/Tel_Aviv` - Asia/Tel_Aviv
+       * * `Asia/Thimbu` - Asia/Thimbu
+       * * `Asia/Thimphu` - Asia/Thimphu
+       * * `Asia/Tokyo` - Asia/Tokyo
+       * * `Asia/Tomsk` - Asia/Tomsk
+       * * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang
+       * * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+       * * `Asia/Ulan_Bator` - Asia/Ulan_Bator
+       * * `Asia/Urumqi` - Asia/Urumqi
+       * * `Asia/Ust-Nera` - Asia/Ust-Nera
+       * * `Asia/Vientiane` - Asia/Vientiane
+       * * `Asia/Vladivostok` - Asia/Vladivostok
+       * * `Asia/Yakutsk` - Asia/Yakutsk
+       * * `Asia/Yangon` - Asia/Yangon
+       * * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+       * * `Asia/Yerevan` - Asia/Yerevan
+       * * `Atlantic/Azores` - Atlantic/Azores
+       * * `Atlantic/Bermuda` - Atlantic/Bermuda
+       * * `Atlantic/Canary` - Atlantic/Canary
+       * * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+       * * `Atlantic/Faeroe` - Atlantic/Faeroe
+       * * `Atlantic/Faroe` - Atlantic/Faroe
+       * * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen
+       * * `Atlantic/Madeira` - Atlantic/Madeira
+       * * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+       * * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+       * * `Atlantic/St_Helena` - Atlantic/St_Helena
+       * * `Atlantic/Stanley` - Atlantic/Stanley
+       * * `Australia/ACT` - Australia/ACT
+       * * `Australia/Adelaide` - Australia/Adelaide
+       * * `Australia/Brisbane` - Australia/Brisbane
+       * * `Australia/Broken_Hill` - Australia/Broken_Hill
+       * * `Australia/Canberra` - Australia/Canberra
+       * * `Australia/Currie` - Australia/Currie
+       * * `Australia/Darwin` - Australia/Darwin
+       * * `Australia/Eucla` - Australia/Eucla
+       * * `Australia/Hobart` - Australia/Hobart
+       * * `Australia/LHI` - Australia/LHI
+       * * `Australia/Lindeman` - Australia/Lindeman
+       * * `Australia/Lord_Howe` - Australia/Lord_Howe
+       * * `Australia/Melbourne` - Australia/Melbourne
+       * * `Australia/NSW` - Australia/NSW
+       * * `Australia/North` - Australia/North
+       * * `Australia/Perth` - Australia/Perth
+       * * `Australia/Queensland` - Australia/Queensland
+       * * `Australia/South` - Australia/South
+       * * `Australia/Sydney` - Australia/Sydney
+       * * `Australia/Tasmania` - Australia/Tasmania
+       * * `Australia/Victoria` - Australia/Victoria
+       * * `Australia/West` - Australia/West
+       * * `Australia/Yancowinna` - Australia/Yancowinna
+       * * `Brazil/Acre` - Brazil/Acre
+       * * `Brazil/DeNoronha` - Brazil/DeNoronha
+       * * `Brazil/East` - Brazil/East
+       * * `Brazil/West` - Brazil/West
+       * * `CET` - CET
+       * * `CST6CDT` - CST6CDT
+       * * `Canada/Atlantic` - Canada/Atlantic
+       * * `Canada/Central` - Canada/Central
+       * * `Canada/Eastern` - Canada/Eastern
+       * * `Canada/Mountain` - Canada/Mountain
+       * * `Canada/Newfoundland` - Canada/Newfoundland
+       * * `Canada/Pacific` - Canada/Pacific
+       * * `Canada/Saskatchewan` - Canada/Saskatchewan
+       * * `Canada/Yukon` - Canada/Yukon
+       * * `Chile/Continental` - Chile/Continental
+       * * `Chile/EasterIsland` - Chile/EasterIsland
+       * * `Cuba` - Cuba
+       * * `EET` - EET
+       * * `EST` - EST
+       * * `EST5EDT` - EST5EDT
+       * * `Egypt` - Egypt
+       * * `Eire` - Eire
+       * * `Etc/GMT` - Etc/GMT
+       * * `Etc/GMT+0` - Etc/GMT+0
+       * * `Etc/GMT+1` - Etc/GMT+1
+       * * `Etc/GMT+10` - Etc/GMT+10
+       * * `Etc/GMT+11` - Etc/GMT+11
+       * * `Etc/GMT+12` - Etc/GMT+12
+       * * `Etc/GMT+2` - Etc/GMT+2
+       * * `Etc/GMT+3` - Etc/GMT+3
+       * * `Etc/GMT+4` - Etc/GMT+4
+       * * `Etc/GMT+5` - Etc/GMT+5
+       * * `Etc/GMT+6` - Etc/GMT+6
+       * * `Etc/GMT+7` - Etc/GMT+7
+       * * `Etc/GMT+8` - Etc/GMT+8
+       * * `Etc/GMT+9` - Etc/GMT+9
+       * * `Etc/GMT-0` - Etc/GMT-0
+       * * `Etc/GMT-1` - Etc/GMT-1
+       * * `Etc/GMT-10` - Etc/GMT-10
+       * * `Etc/GMT-11` - Etc/GMT-11
+       * * `Etc/GMT-12` - Etc/GMT-12
+       * * `Etc/GMT-13` - Etc/GMT-13
+       * * `Etc/GMT-14` - Etc/GMT-14
+       * * `Etc/GMT-2` - Etc/GMT-2
+       * * `Etc/GMT-3` - Etc/GMT-3
+       * * `Etc/GMT-4` - Etc/GMT-4
+       * * `Etc/GMT-5` - Etc/GMT-5
+       * * `Etc/GMT-6` - Etc/GMT-6
+       * * `Etc/GMT-7` - Etc/GMT-7
+       * * `Etc/GMT-8` - Etc/GMT-8
+       * * `Etc/GMT-9` - Etc/GMT-9
+       * * `Etc/GMT0` - Etc/GMT0
+       * * `Etc/Greenwich` - Etc/Greenwich
+       * * `Etc/UCT` - Etc/UCT
+       * * `Etc/UTC` - Etc/UTC
+       * * `Etc/Universal` - Etc/Universal
+       * * `Etc/Zulu` - Etc/Zulu
+       * * `Europe/Amsterdam` - Europe/Amsterdam
+       * * `Europe/Andorra` - Europe/Andorra
+       * * `Europe/Astrakhan` - Europe/Astrakhan
+       * * `Europe/Athens` - Europe/Athens
+       * * `Europe/Belfast` - Europe/Belfast
+       * * `Europe/Belgrade` - Europe/Belgrade
+       * * `Europe/Berlin` - Europe/Berlin
+       * * `Europe/Bratislava` - Europe/Bratislava
+       * * `Europe/Brussels` - Europe/Brussels
+       * * `Europe/Bucharest` - Europe/Bucharest
+       * * `Europe/Budapest` - Europe/Budapest
+       * * `Europe/Busingen` - Europe/Busingen
+       * * `Europe/Chisinau` - Europe/Chisinau
+       * * `Europe/Copenhagen` - Europe/Copenhagen
+       * * `Europe/Dublin` - Europe/Dublin
+       * * `Europe/Gibraltar` - Europe/Gibraltar
+       * * `Europe/Guernsey` - Europe/Guernsey
+       * * `Europe/Helsinki` - Europe/Helsinki
+       * * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+       * * `Europe/Istanbul` - Europe/Istanbul
+       * * `Europe/Jersey` - Europe/Jersey
+       * * `Europe/Kaliningrad` - Europe/Kaliningrad
+       * * `Europe/Kiev` - Europe/Kiev
+       * * `Europe/Kirov` - Europe/Kirov
+       * * `Europe/Kyiv` - Europe/Kyiv
+       * * `Europe/Lisbon` - Europe/Lisbon
+       * * `Europe/Ljubljana` - Europe/Ljubljana
+       * * `Europe/London` - Europe/London
+       * * `Europe/Luxembourg` - Europe/Luxembourg
+       * * `Europe/Madrid` - Europe/Madrid
+       * * `Europe/Malta` - Europe/Malta
+       * * `Europe/Mariehamn` - Europe/Mariehamn
+       * * `Europe/Minsk` - Europe/Minsk
+       * * `Europe/Monaco` - Europe/Monaco
+       * * `Europe/Moscow` - Europe/Moscow
+       * * `Europe/Nicosia` - Europe/Nicosia
+       * * `Europe/Oslo` - Europe/Oslo
+       * * `Europe/Paris` - Europe/Paris
+       * * `Europe/Podgorica` - Europe/Podgorica
+       * * `Europe/Prague` - Europe/Prague
+       * * `Europe/Riga` - Europe/Riga
+       * * `Europe/Rome` - Europe/Rome
+       * * `Europe/Samara` - Europe/Samara
+       * * `Europe/San_Marino` - Europe/San_Marino
+       * * `Europe/Sarajevo` - Europe/Sarajevo
+       * * `Europe/Saratov` - Europe/Saratov
+       * * `Europe/Simferopol` - Europe/Simferopol
+       * * `Europe/Skopje` - Europe/Skopje
+       * * `Europe/Sofia` - Europe/Sofia
+       * * `Europe/Stockholm` - Europe/Stockholm
+       * * `Europe/Tallinn` - Europe/Tallinn
+       * * `Europe/Tirane` - Europe/Tirane
+       * * `Europe/Tiraspol` - Europe/Tiraspol
+       * * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+       * * `Europe/Uzhgorod` - Europe/Uzhgorod
+       * * `Europe/Vaduz` - Europe/Vaduz
+       * * `Europe/Vatican` - Europe/Vatican
+       * * `Europe/Vienna` - Europe/Vienna
+       * * `Europe/Vilnius` - Europe/Vilnius
+       * * `Europe/Volgograd` - Europe/Volgograd
+       * * `Europe/Warsaw` - Europe/Warsaw
+       * * `Europe/Zagreb` - Europe/Zagreb
+       * * `Europe/Zaporozhye` - Europe/Zaporozhye
+       * * `Europe/Zurich` - Europe/Zurich
+       * * `GB` - GB
+       * * `GB-Eire` - GB-Eire
+       * * `GMT` - GMT
+       * * `GMT+0` - GMT+0
+       * * `GMT-0` - GMT-0
+       * * `GMT0` - GMT0
+       * * `Greenwich` - Greenwich
+       * * `HST` - HST
+       * * `Hongkong` - Hongkong
+       * * `Iceland` - Iceland
+       * * `Indian/Antananarivo` - Indian/Antananarivo
+       * * `Indian/Chagos` - Indian/Chagos
+       * * `Indian/Christmas` - Indian/Christmas
+       * * `Indian/Cocos` - Indian/Cocos
+       * * `Indian/Comoro` - Indian/Comoro
+       * * `Indian/Kerguelen` - Indian/Kerguelen
+       * * `Indian/Mahe` - Indian/Mahe
+       * * `Indian/Maldives` - Indian/Maldives
+       * * `Indian/Mauritius` - Indian/Mauritius
+       * * `Indian/Mayotte` - Indian/Mayotte
+       * * `Indian/Reunion` - Indian/Reunion
+       * * `Iran` - Iran
+       * * `Israel` - Israel
+       * * `Jamaica` - Jamaica
+       * * `Japan` - Japan
+       * * `Kwajalein` - Kwajalein
+       * * `Libya` - Libya
+       * * `MET` - MET
+       * * `MST` - MST
+       * * `MST7MDT` - MST7MDT
+       * * `Mexico/BajaNorte` - Mexico/BajaNorte
+       * * `Mexico/BajaSur` - Mexico/BajaSur
+       * * `Mexico/General` - Mexico/General
+       * * `NZ` - NZ
+       * * `NZ-CHAT` - NZ-CHAT
+       * * `Navajo` - Navajo
+       * * `PRC` - PRC
+       * * `PST8PDT` - PST8PDT
+       * * `Pacific/Apia` - Pacific/Apia
+       * * `Pacific/Auckland` - Pacific/Auckland
+       * * `Pacific/Bougainville` - Pacific/Bougainville
+       * * `Pacific/Chatham` - Pacific/Chatham
+       * * `Pacific/Chuuk` - Pacific/Chuuk
+       * * `Pacific/Easter` - Pacific/Easter
+       * * `Pacific/Efate` - Pacific/Efate
+       * * `Pacific/Enderbury` - Pacific/Enderbury
+       * * `Pacific/Fakaofo` - Pacific/Fakaofo
+       * * `Pacific/Fiji` - Pacific/Fiji
+       * * `Pacific/Funafuti` - Pacific/Funafuti
+       * * `Pacific/Galapagos` - Pacific/Galapagos
+       * * `Pacific/Gambier` - Pacific/Gambier
+       * * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+       * * `Pacific/Guam` - Pacific/Guam
+       * * `Pacific/Honolulu` - Pacific/Honolulu
+       * * `Pacific/Johnston` - Pacific/Johnston
+       * * `Pacific/Kanton` - Pacific/Kanton
+       * * `Pacific/Kiritimati` - Pacific/Kiritimati
+       * * `Pacific/Kosrae` - Pacific/Kosrae
+       * * `Pacific/Kwajalein` - Pacific/Kwajalein
+       * * `Pacific/Majuro` - Pacific/Majuro
+       * * `Pacific/Marquesas` - Pacific/Marquesas
+       * * `Pacific/Midway` - Pacific/Midway
+       * * `Pacific/Nauru` - Pacific/Nauru
+       * * `Pacific/Niue` - Pacific/Niue
+       * * `Pacific/Norfolk` - Pacific/Norfolk
+       * * `Pacific/Noumea` - Pacific/Noumea
+       * * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+       * * `Pacific/Palau` - Pacific/Palau
+       * * `Pacific/Pitcairn` - Pacific/Pitcairn
+       * * `Pacific/Pohnpei` - Pacific/Pohnpei
+       * * `Pacific/Ponape` - Pacific/Ponape
+       * * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+       * * `Pacific/Rarotonga` - Pacific/Rarotonga
+       * * `Pacific/Saipan` - Pacific/Saipan
+       * * `Pacific/Samoa` - Pacific/Samoa
+       * * `Pacific/Tahiti` - Pacific/Tahiti
+       * * `Pacific/Tarawa` - Pacific/Tarawa
+       * * `Pacific/Tongatapu` - Pacific/Tongatapu
+       * * `Pacific/Truk` - Pacific/Truk
+       * * `Pacific/Wake` - Pacific/Wake
+       * * `Pacific/Wallis` - Pacific/Wallis
+       * * `Pacific/Yap` - Pacific/Yap
+       * * `Poland` - Poland
+       * * `Portugal` - Portugal
+       * * `ROC` - ROC
+       * * `ROK` - ROK
+       * * `Singapore` - Singapore
+       * * `Turkey` - Turkey
+       * * `UCT` - UCT
+       * * `US/Alaska` - US/Alaska
+       * * `US/Aleutian` - US/Aleutian
+       * * `US/Arizona` - US/Arizona
+       * * `US/Central` - US/Central
+       * * `US/East-Indiana` - US/East-Indiana
+       * * `US/Eastern` - US/Eastern
+       * * `US/Hawaii` - US/Hawaii
+       * * `US/Indiana-Starke` - US/Indiana-Starke
+       * * `US/Michigan` - US/Michigan
+       * * `US/Mountain` - US/Mountain
+       * * `US/Pacific` - US/Pacific
+       * * `US/Samoa` - US/Samoa
+       * * `UTC` - UTC
+       * * `Universal` - Universal
+       * * `W-SU` - W-SU
+       * * `WET` - WET
+       * * `Zulu` - Zulu */
       timezone?: string;
       /** Element attributes that posthog-js should capture as action identifiers (e.g. `['data-attr']`). */
       data_attributes?: unknown;
       /**
          * Ordered list of person properties used to render a human-friendly display name in the UI.
          * @nullable
+         * @items.maxLength 400
          */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
@@ -35078,19 +35179,19 @@ export namespace Schemas {
       /** V2 trigger groups configuration for session recording. If present, takes precedence over legacy trigger fields. */
       session_recording_trigger_groups?: unknown;
       /** How long to retain new session recordings. One of `30d`, `90d`, `1y`, or `5y` (availability depends on plan).
-
-      * `30d` - 30 Days
-      * `90d` - 90 Days
-      * `1y` - 1 Year
-      * `5y` - 5 Years */
+       *
+       * * `30d` - 30 Days
+       * * `90d` - 90 Days
+       * * `1y` - 1 Year
+       * * `5y` - 5 Years */
       session_recording_retention_period?: SessionRecordingRetentionPeriodEnum;
       session_replay_config?: unknown;
       survey_config?: unknown;
       access_control?: boolean;
       /** First day of the week for date range filters. 0 = Sunday, 1 = Monday.
-
-      * `0` - Sunday
-      * `1` - Monday */
+       *
+       * * `0` - Sunday
+       * * `1` - Monday */
       week_start_day?: WeekStartDayEnum | null;
       /**
          * ID of the dashboard shown as the project's default landing dashboard.
@@ -35102,6 +35203,7 @@ export namespace Schemas {
       /**
          * Origins permitted to record session replays and heatmaps. Empty list allows all origins.
          * @nullable
+         * @items.maxLength 200
          */
       recording_domains?: (string | null)[] | null;
       readonly person_on_events_querying_enabled: boolean;
@@ -35134,10 +35236,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /**
          * Enables the customer conversations / live chat product for this project.
@@ -35556,10 +35658,10 @@ export namespace Schemas {
 
     /**
      * The deterministic inventory layer of a project profile.
-
-    Read this to orient on the team's product mix, integrations, warehouse sources, signal
-    coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
-    profile is ground truth from authoritative tables; memory is agent inference.
+     *
+     * Read this to orient on the team's product mix, integrations, warehouse sources, signal
+     * coverage, and existing inbox surface in one tool call. Distinct from `SignalScratchpad`:
+     * profile is ground truth from authoritative tables; memory is agent inference.
      */
     export interface ProjectProfileInventory {
       /** Free-form orientation: human-set product description + registered app URLs. */
@@ -35607,9 +35709,9 @@ export namespace Schemas {
 
     /**
      * Top-level `payload` shape on a `SignalProjectProfile` row.
-
-    v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
-    `narrative` slots — they're absent (not null) in v1 responses.
+     *
+     * v1 carries `inventory` only. Phase 7 will add `deltas`, `activity_notes`, and
+     * `narrative` slots — they're absent (not null) in v1 responses.
      */
     export interface ProjectProfilePayload {
       /** Deterministic snapshot of what's true about the project. */
@@ -35618,11 +35720,11 @@ export namespace Schemas {
 
     /**
      * Wire shape for the project profile returned by `signals-scout-harness-project-profile-list`.
-
-    Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
-    is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
-    latest cached profile or a freshly-built one if the cache was stale or the caller passed
-    `force_refresh=true`.
+     *
+     * Read this once at the start of a run (after `skill-get`) to orient on the team. Cache
+     * is per-team with a soft TTL (`PROFILE_TTL`); the response always reflects either the
+     * latest cached profile or a freshly-built one if the cache was stale or the caller passed
+     * `force_refresh=true`.
      */
     export interface ProjectProfile {
       /** UUID of the `SignalProjectProfile` row. */
@@ -35647,48 +35749,48 @@ export namespace Schemas {
 
     export interface Property {
       /**
-       You can use a simplified version:
-      ```json
-      {
-          "properties": [
-              {
-                  "key": "email",
-                  "value": "x@y.com",
-                  "operator": "exact",
-                  "type": "event"
-              }
-          ]
-      }
-      ```
-
-      Or you can create more complicated queries with AND and OR:
-      ```json
-      {
-          "properties": {
-              "type": "AND",
-              "values": [
-                  {
-                      "type": "OR",
-                      "values": [
-                          {"key": "email", ...},
-                          {"key": "email", ...}
-                      ]
-                  },
-                  {
-                      "type": "AND",
-                      "values": [
-                          {"key": "email", ...},
-                          {"key": "email", ...}
-                      ]
-                  }
-              ]
-          ]
-      }
-      ```
-
-
-      * `AND` - AND
-      * `OR` - OR */
+       *  You can use a simplified version:
+       * ```json
+       * {
+       *     "properties": [
+       *         {
+       *             "key": "email",
+       *             "value": "x@y.com",
+       *             "operator": "exact",
+       *             "type": "event"
+       *         }
+       *     ]
+       * }
+       * ```
+       *
+       * Or you can create more complicated queries with AND and OR:
+       * ```json
+       * {
+       *     "properties": {
+       *         "type": "AND",
+       *         "values": [
+       *             {
+       *                 "type": "OR",
+       *                 "values": [
+       *                     {"key": "email", ...},
+       *                     {"key": "email", ...}
+       *                 ]
+       *             },
+       *             {
+       *                 "type": "AND",
+       *                 "values": [
+       *                     {"key": "email", ...},
+       *                     {"key": "email", ...}
+       *                 ]
+       *             }
+       *         ]
+       *     ]
+       * }
+       * ```
+       *
+       *
+       * * `AND` - AND
+       * * `OR` - OR */
       type?: PropertyGroupOperator;
       values: PropertyItem[];
     }
@@ -35699,10 +35801,10 @@ export namespace Schemas {
     export interface PropertyAccessControlRule {
       readonly id: string;
       /** The access level for this rule.
-
-      * `read_write` - read_write
-      * `read` - read
-      * `none` - none */
+       *
+       * * `read_write` - read_write
+       * * `read` - read
+       * * `none` - none */
       access_level: AccessLevelEnum;
       /**
          * The organization member UUID this rule applies to, if any.
@@ -35722,9 +35824,9 @@ export namespace Schemas {
 
     /**
      * Serializes the aggregate state for a property definition.
-
-    Preserves the existing API shape: ``access_controls`` is the list
-    of rules, plus the available levels and the computed default.
+     *
+     * Preserves the existing API shape: ``access_controls`` is the list
+     * of rules, plus the available levels and the computed default.
      */
     export interface PropertyAccessControlState {
       /** List of all access control rules for this property definition. */
@@ -35742,10 +35844,10 @@ export namespace Schemas {
       /** The property definition ID this rule applies to. */
       property_definition_id: string;
       /** The access level to set for this rule.
-
-      * `read_write` - read_write
-      * `read` - read
-      * `none` - none */
+       *
+       * * `read_write` - read_write
+       * * `read` - read
+       * * `none` - none */
       access_level: AccessLevelEnum;
       /**
          * The organization member UUID to set an override for.
@@ -35819,12 +35921,12 @@ export namespace Schemas {
 
     /**
      * * `waiting` - Waiting
-    * `issuing` - Issuing
-    * `valid` - Valid
-    * `warning` - Warning
-    * `erroring` - Erroring
-    * `deleting` - Deleting
-    * `timed_out` - Timed Out
+     * * `issuing` - Issuing
+     * * `valid` - Valid
+     * * `warning` - Warning
+     * * `erroring` - Erroring
+     * * `deleting` - Deleting
+     * * `timed_out` - Timed Out
      */
     export type ProxyRecordStatusEnum = typeof ProxyRecordStatusEnum[keyof typeof ProxyRecordStatusEnum];
 
@@ -35847,14 +35949,14 @@ export namespace Schemas {
       /** The CNAME target to add as a DNS record for your domain. Point your domain's CNAME to this value. */
       readonly target_cname: string;
       /** Current provisioning status. Values: waiting (DNS verification pending), issuing (SSL certificate being issued), valid (proxy is live and working), warning (proxy has issues but is operational), erroring (proxy setup failed), deleting (removal in progress), timed_out (DNS verification timed out).
-
-      * `waiting` - Waiting
-      * `issuing` - Issuing
-      * `valid` - Valid
-      * `warning` - Warning
-      * `erroring` - Erroring
-      * `deleting` - Deleting
-      * `timed_out` - Timed Out */
+       *
+       * * `waiting` - Waiting
+       * * `issuing` - Issuing
+       * * `valid` - Valid
+       * * `warning` - Warning
+       * * `erroring` - Erroring
+       * * `deleting` - Deleting
+       * * `timed_out` - Timed Out */
       readonly status: ProxyRecordStatusEnum;
       /**
          * Human-readable status message with details about errors or warnings, if any.
@@ -35887,10 +35989,10 @@ export namespace Schemas {
       /** Pull request title. */
       title: string;
       /** Derived state: 'open', 'closed', or 'merged'.
-
-      * `open` - OPEN
-      * `closed` - CLOSED
-      * `merged` - MERGED */
+       *
+       * * `open` - OPEN
+       * * `closed` - CLOSED
+       * * `merged` - MERGED */
       state: EngineeringAnalyticsPRStateEnum;
       /** True if the pull request is a draft. */
       is_draft: boolean;
@@ -35921,8 +36023,8 @@ export namespace Schemas {
 
     /**
      * * `ios` - iOS
-    * `android` - Android
-    * `web` - Web
+     * * `android` - Android
+     * * `web` - Web
      */
     export type PushTokenPlatformEnum = typeof PushTokenPlatformEnum[keyof typeof PushTokenPlatformEnum];
 
@@ -36116,24 +36218,24 @@ export namespace Schemas {
       /** Name given to a query. It's used to identify the query in the UI. Up to 128 characters for a name. */
       name?: string | null;
       /** Submit a JSON string representing a query for PostHog data analysis, for example a HogQL query.
-
-      Example payload:
-
-      ```
-
-      {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
-
-      ```
-
-      For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
+       *
+       * Example payload:
+       *
+       * ```
+       *
+       * {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
+       *
+       * ```
+       *
+       * For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
       query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
       /** Whether results should be calculated sync or async, and how much to rely on the cache:
-      - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-      - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-      - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-      - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-      - `'force_async'` - kick off background calculation, even if fresh results are already cached
-      - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates Background calculation can be tracked using the `query_status` response field. */
+       * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+       * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+       * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+       * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+       * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+       * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates Background calculation can be tracked using the `query_status` response field. */
       refresh?: RefreshType | null;
       variables_override?: QueryRequestVariablesOverride;
     }
@@ -38215,10 +38317,10 @@ export namespace Schemas {
          */
       tile_order: number[];
       /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
-
-      * `preserve` - preserve
-      * `two_column` - two_column
-      * `full_width` - full_width */
+       *
+       * * `preserve` - preserve
+       * * `two_column` - two_column
+       * * `full_width` - full_width */
       layout?: LayoutEnum;
     }
 
@@ -38287,8 +38389,8 @@ export namespace Schemas {
 
     /**
      * * `Starting` - Starting
-    * `Running` - Running
-    * `Cancelled` - Cancelled
+     * * `Running` - Running
+     * * `Cancelled` - Cancelled
      */
     export type RetrieveBasicOutputStatusEnum = typeof RetrieveBasicOutputStatusEnum[keyof typeof RetrieveBasicOutputStatusEnum];
 
@@ -38345,10 +38447,10 @@ export namespace Schemas {
 
     /**
      * * `Failed` - Failed
-    * `FailedRetryable` - FailedRetryable
-    * `FailedBilling` - FailedBilling
-    * `Terminated` - Terminated
-    * `TimedOut` - TimedOut
+     * * `FailedRetryable` - FailedRetryable
+     * * `FailedBilling` - FailedBilling
+     * * `Terminated` - Terminated
+     * * `TimedOut` - TimedOut
      */
     export type RetrieveFailedOutputStatusEnum = typeof RetrieveFailedOutputStatusEnum[keyof typeof RetrieveFailedOutputStatusEnum];
 
@@ -38420,11 +38522,17 @@ export namespace Schemas {
       /** @maxLength 255 */
       name: string;
       network_access_level?: NetworkAccessLevelEnum;
-      /** List of allowed domains for custom network access */
+      /**
+         * List of allowed domains for custom network access
+         * @items.maxLength 255
+         */
       allowed_domains?: string[];
       /** Whether to include default trusted domains (GitHub, npm, PyPI) */
       include_default_domains?: boolean;
-      /** List of repositories this environment applies to (format: org/repo) */
+      /**
+         * List of repositories this environment applies to (format: org/repo)
+         * @items.maxLength 255
+         */
       repositories?: string[];
       /** Encrypted environment variables (write-only, never returned in responses) */
       environment_variables?: unknown;
@@ -38468,13 +38576,15 @@ export namespace Schemas {
       /**
          * Viewport widths (px, 100-3000) to render the heatmap screenshot at — one render per width. Defaults to [320, 375, 425, 768, 1024, 1440, 1920] when omitted. At most 16 widths.
          * @maxItems 16
+         * @items.minimum 100
+         * @items.maximum 3000
          */
       widths?: number[];
       /** Render mode: 'screenshot' (renders the page headlessly, default), 'iframe', or 'recording'. Only 'screenshot' generates image bytes.
-
-      * `screenshot` - Screenshot
-      * `iframe` - Iframe
-      * `recording` - Recording */
+       *
+       * * `screenshot` - Screenshot
+       * * `iframe` - Iframe
+       * * `recording` - Recording */
       type?: HeatmapType;
       /** Set true to soft-delete the saved heatmap. */
       deleted?: boolean;
@@ -38532,10 +38642,10 @@ export namespace Schemas {
          */
       description?: string | null;
       /** Scorer kind. This cannot be changed after creation.
-
-      * `categorical` - categorical
-      * `numeric` - numeric
-      * `boolean` - boolean */
+       *
+       * * `categorical` - categorical
+       * * `numeric` - numeric
+       * * `boolean` - boolean */
       kind: ExperimentMetricKindEnum;
       /** New scorers are always created as active. */
       archived?: boolean;
@@ -38580,8 +38690,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `warning` - warning
-    * `danger` - danger
+     * * `warning` - warning
+     * * `danger` - danger
      */
     export type SdkAssessmentSeverityEnum = typeof SdkAssessmentSeverityEnum[keyof typeof SdkAssessmentSeverityEnum];
 
@@ -38644,10 +38754,10 @@ export namespace Schemas {
       /** True if the primary in-use version is flagged as old by age alone. */
       is_old: boolean;
       /** UI severity badge — 'none' when healthy, 'warning' when outdated, 'danger' when the majority of team SDKs are outdated.
-
-      * `none` - none
-      * `warning` - warning
-      * `danger` - danger */
+       *
+       * * `none` - none
+       * * `warning` - warning
+       * * `danger` - danger */
       severity: SdkAssessmentSeverityEnum;
       /** Per-SDK programmatic summary (used for ranking/filtering). For user-facing copy, prefer releases[].status_reason (badge tooltip) and banners (top-level alert text) — those match the UI exactly. */
       reason: string;
@@ -38661,15 +38771,15 @@ export namespace Schemas {
 
     export interface SdkHealthReport {
       /** 'healthy' when no SDKs need updating, 'needs_attention' otherwise.
-
-      * `healthy` - healthy
-      * `needs_attention` - needs_attention */
+       *
+       * * `healthy` - healthy
+       * * `needs_attention` - needs_attention */
       overall_health: OverallHealthEnum;
       /** UI-level status — 'success' when healthy, 'warning' when some SDKs are outdated, 'danger' when the majority are outdated.
-
-      * `success` - success
-      * `warning` - warning
-      * `danger` - danger */
+       *
+       * * `success` - success
+       * * `warning` - warning
+       * * `danger` - danger */
       health: HealthEnum;
       /** Number of SDKs that need updating. */
       needs_updating_count: number;
@@ -38711,10 +38821,10 @@ export namespace Schemas {
 
     /**
      * Filter shape mirrors the previous frontend `api.query({filters: ...})` payload.
-
-    `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
-    path used (dateRange, filterTestAccounts, properties), so the migration is
-    behaviour-preserving for callers that pass a request unchanged.
+     *
+     * `filters` accepts the same `HogQLFilters` schema that the legacy frontend HogQL
+     * path used (dateRange, filterTestAccounts, properties), so the migration is
+     * behaviour-preserving for callers that pass a request unchanged.
      */
     export interface SentimentGenerationsRequest {
       filters?: unknown;
@@ -38726,7 +38836,7 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `generation` - generation
+     * * `generation` - generation
      */
     export type SentimentRequestAnalysisLevelEnum = typeof SentimentRequestAnalysisLevelEnum[keyof typeof SentimentRequestAnalysisLevelEnum];
 
@@ -38744,9 +38854,9 @@ export namespace Schemas {
          */
       ids: string[];
       /** Whether the IDs are 'trace' IDs or 'generation' IDs.
-
-      * `trace` - trace
-      * `generation` - generation */
+       *
+       * * `trace` - trace
+       * * `generation` - generation */
       analysis_level?: SentimentRequestAnalysisLevelEnum;
       /** If true, bypass cache and reclassify. */
       force_refresh?: boolean;
@@ -38766,7 +38876,10 @@ export namespace Schemas {
       readonly id: string;
       /** Title of the group session summary */
       readonly title: string;
-      /** List of session replay IDs included in this group summary */
+      /**
+         * List of session replay IDs included in this group summary
+         * @items.maxLength 200
+         */
       readonly session_ids: readonly string[];
       /** Group summary in JSON format (EnrichedSessionGroupSummaryPatternsList schema) */
       readonly summary: unknown;
@@ -38820,11 +38933,11 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `debug` - debug
-    * `info` - info
-    * `warn` - warn
-    * `error` - error
-    * `fatal` - fatal
+     * * `debug` - debug
+     * * `info` - info
+     * * `warn` - warn
+     * * `error` - error
+     * * `fatal` - fatal
      */
     export type SeverityLevelsEnum = typeof SeverityLevelsEnum[keyof typeof SeverityLevelsEnum];
 
@@ -38862,12 +38975,12 @@ export namespace Schemas {
 
     export interface ShipVariant {
       /** The conclusion of the experiment.
-
-      * `won` - won
-      * `lost` - lost
-      * `inconclusive` - inconclusive
-      * `stopped_early` - stopped_early
-      * `invalid` - invalid */
+       *
+       * * `won` - won
+       * * `lost` - lost
+       * * `inconclusive` - inconclusive
+       * * `stopped_early` - stopped_early
+       * * `invalid` - invalid */
       conclusion?: ConclusionEnum | null;
       /**
          * Optional comment about the experiment conclusion.
@@ -38882,7 +38995,7 @@ export namespace Schemas {
 
     /**
      * * `suppressed` - suppressed
-    * `potential` - potential
+     * * `potential` - potential
      */
     export type SignalReportStateRequestStateEnum = typeof SignalReportStateRequestStateEnum[keyof typeof SignalReportStateRequestStateEnum];
 
@@ -38894,9 +39007,9 @@ export namespace Schemas {
 
     export interface SignalReportStateRequest {
       /** Target state for the report. Use 'suppressed' to dismiss the report from the inbox, or 'potential' to snooze/reopen it for later review.
-
-      * `suppressed` - suppressed
-      * `potential` - potential */
+       *
+       * * `suppressed` - suppressed
+       * * `potential` - potential */
       state: SignalReportStateRequestStateEnum;
       /** Optional short reason code for the dismissal (e.g. 'not_a_bug', 'wont_fix', 'duplicate'). The set of reason codes is owned by the caller and is not validated server-side. */
       dismissal_reason?: string;
@@ -38915,9 +39028,9 @@ export namespace Schemas {
 
     /**
      * Per-(team, skill) scout config: schedule, enablement, and emit posture.
-
-    One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
-    when it discovers a scout skill; this serializer lets agents tune the row.
+     *
+     * One row per `signals-scout-*` skill on the team. The coordinator auto-creates a row
+     * when it discovers a scout skill; this serializer lets agents tune the row.
      */
     export interface SignalScoutConfig {
       readonly id: string;
@@ -38943,9 +39056,9 @@ export namespace Schemas {
 
     /**
      * One finding a scout run emitted to the inbox — the persisted, queryable record of
-    *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
-    lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
-    back into the underlying signal store.
+     * *what* the run surfaced, returned by `signals-scout-runs-emissions-list`. The emitted text
+     * lives in `description`; `source_id` is the join key (`run:<run_id>:finding:<finding_id>`)
+     * back into the underlying signal store.
      */
     export interface SignalScoutEmission {
       readonly id: string;
@@ -38968,12 +39081,12 @@ export namespace Schemas {
          */
       confidence: number;
       /** Optional severity tag — one of P0, P1, P2, P3, P4 — or null if the run didn't set one.
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
+       *
+       * * `P0` - P0
+       * * `P1` - P1
+       * * `P2` - P2
+       * * `P3` - P3
+       * * `P4` - P4 */
       severity: AutonomyPriorityEnum | null;
       /** Deterministic `run:<run_id>:finding:<finding_id>` — the join key into the underlying signal store. */
       source_id: string;
@@ -38983,8 +39096,8 @@ export namespace Schemas {
 
     /**
      * Full `SignalScoutRun` projection used by `get-run`. Same shape as the summary
-    today; kept distinct so future detail-only extensions (linked Signal rows,
-    LLMA token-cost join) can land here without bloating the list response.
+     * today; kept distinct so future detail-only extensions (linked Signal rows,
+     * LLMA token-cost join) can land here without bloating the list response.
      */
     export interface SignalScoutRunDetail {
       /** UUID of the bridge row. */
@@ -39027,8 +39140,8 @@ export namespace Schemas {
 
     /**
      * Lightweight projection of a `SignalScoutRun` row used by `search-recent-runs`.
-
-    Status and timestamps flow from the linked `tasks.TaskRun`.
+     *
+     * Status and timestamps flow from the linked `tasks.TaskRun`.
      */
     export interface SignalScoutRunSummary {
       /** UUID of the bridge row. */
@@ -39093,12 +39206,12 @@ export namespace Schemas {
          */
       slack_notification_channel?: string | null;
       /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
-
-      * `P0` - P0
-      * `P1` - P1
-      * `P2` - P2
-      * `P3` - P3
-      * `P4` - P4 */
+       *
+       * * `P0` - P0
+       * * `P1` - P1
+       * * `P2` - P2
+       * * `P3` - P3
+       * * `P4` - P4 */
       slack_notification_min_priority?: AutonomyPriorityEnum | BlankEnum | null;
       readonly created_at: string;
       readonly updated_at: string;
@@ -39192,10 +39305,10 @@ export namespace Schemas {
 
     /**
      * The internal sandbox run the discovery agent used to pick this run's repo.
-
-    Only present when the originating mention was ambiguous (multiple candidate
-    repos, no explicit mention) — that's the only path that spins up a research
-    sandbox. Null otherwise.
+     *
+     * Only present when the originating mention was ambiguous (multiple candidate
+     * repos, no explicit mention) — that's the only path that spins up a research
+     * sandbox. Null otherwise.
      */
     export interface SlackThreadContextRepoResearch {
       /** UUID of the internal repo-research Task. */
@@ -39356,8 +39469,8 @@ export namespace Schemas {
 
     /**
      * * `none` - none
-    * `auto` - auto
-    * `mapped` - mapped
+     * * `auto` - auto
+     * * `mapped` - mapped
      */
     export type SourceMatchEnum = typeof SourceMatchEnum[keyof typeof SourceMatchEnum];
 
@@ -39370,7 +39483,7 @@ export namespace Schemas {
 
     /**
      * * `severity` - severity
-    * `service` - service
+     * * `service` - service
      */
     export type SparklineBreakdownByEnum = typeof SparklineBreakdownByEnum[keyof typeof SparklineBreakdownByEnum];
 
@@ -39407,7 +39520,7 @@ export namespace Schemas {
 
     /**
      * * `trace` - trace
-    * `event` - event
+     * * `event` - event
      */
     export type SummarizeTypeEnum = typeof SummarizeTypeEnum[keyof typeof SummarizeTypeEnum];
 
@@ -39419,14 +39532,14 @@ export namespace Schemas {
 
     export interface SummarizeRequest {
       /** Type of entity to summarize. Inferred automatically when using trace_id or generation_id.
-
-      * `trace` - trace
-      * `event` - event */
+       *
+       * * `trace` - trace
+       * * `event` - event */
       summarize_type?: SummarizeTypeEnum;
       /** Summary detail level: 'minimal' for 3-5 points, 'detailed' for 5-10 points
-
-      * `minimal` - minimal
-      * `detailed` - detailed */
+       *
+       * * `minimal` - minimal
+       * * `detailed` - detailed */
       mode?: DetailModeValueEnum;
       /** Data to summarize. For traces: {trace, hierarchy}. For events: {event}. Not required when using trace_id or generation_id. */
       data?: unknown;
@@ -39602,117 +39715,117 @@ export namespace Schemas {
       /** @nullable */
       remove_targeting_flag?: boolean | null;
       /**
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-               */
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *          */
       questions?: unknown;
       conditions?: unknown;
       appearance?: unknown;
@@ -39792,17 +39905,17 @@ export namespace Schemas {
       /** Survey description. */
       description?: string;
       /** Survey type.
-
-      * `popover` - popover
-      * `widget` - widget
-      * `external_survey` - external survey
-      * `api` - api */
+       *
+       * * `popover` - popover
+       * * `widget` - widget
+       * * `external_survey` - external survey
+       * * `api` - api */
       type: SurveyType;
       /** Survey scheduling behavior: 'once' = show once per user (default), 'recurring' = repeat based on iteration_count and iteration_frequency_days settings, 'always' = show every time conditions are met (mainly for widget surveys)
-
-      * `once` - once
-      * `recurring` - recurring
-      * `always` - always */
+       *
+       * * `once` - once
+       * * `recurring` - recurring
+       * * `always` - always */
       schedule?: ScheduleEnum | null;
       readonly linked_flag: MinimalFeatureFlag;
       /**
@@ -39825,117 +39938,117 @@ export namespace Schemas {
       remove_targeting_flag?: boolean | null;
       /**
          *
-              The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
-
-              Basic (open-ended question)
-              - `id`: The question ID
-              - `type`: `open`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Link (a question with a link)
-              - `id`: The question ID
-              - `type`: `link`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `link`: The URL associated with the question.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Rating (a question with a rating scale)
-              - `id`: The question ID
-              - `type`: `rating`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `display`: Display style of the rating (`number` or `emoji`).
-              - `scale`: The scale of the rating (`number`).
-              - `lowerBoundLabel`: Label for the lower bound of the scale.
-              - `upperBoundLabel`: Label for the upper bound of the scale.
-              - `isNpsQuestion`: Whether the question is an NPS rating.
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Multiple choice
-              - `id`: The question ID
-              - `type`: `single_choice` or `multiple_choice`
-              - `question`: The text of the question.
-              - `description`: Optional description of the question.
-              - `descriptionContentType`: Content type of the description (`html` or `text`).
-              - `optional`: Whether the question is optional (`boolean`).
-              - `buttonText`: Text displayed on the submit button.
-              - `choices`: An array of choices for the question.
-              - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
-              - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
-              - `branching`: Branching logic for the question. See branching types below for details.
-
-              Branching logic can be one of the following types:
-
-              Next question: Proceeds to the next question
-              ```json
-              {
-                  "type": "next_question"
-              }
-              ```
-
-              End: Ends the survey, optionally displaying a confirmation message.
-              ```json
-              {
-                  "type": "end"
-              }
-              ```
-
-              Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
-              ```json
-              {
-                  "type": "response_based",
-                  "responseValues": {
-                      "responseKey": "value"
-                  }
-              }
-              ```
-
-              Specific question: Proceeds to a specific question by index.
-              ```json
-              {
-                  "type": "specific_question",
-                  "index": 2
-              }
-              ```
-
-              Translations: Each question can include inline translations.
-              - `translations`: Object mapping language codes to translated fields.
-              - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
-              - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
-
-              Example with translations:
-              ```json
-              {
-                  "id": "uuid",
-                  "type": "rating",
-                  "question": "How satisfied are you?",
-                  "lowerBoundLabel": "Not satisfied",
-                  "upperBoundLabel": "Very satisfied",
-                  "translations": {
-                      "es": {
-                          "question": "¿Qué tan satisfecho estás?",
-                          "lowerBoundLabel": "No satisfecho",
-                          "upperBoundLabel": "Muy satisfecho"
-                      },
-                      "fr": {
-                          "question": "Dans quelle mesure êtes-vous satisfait?"
-                      }
-                  }
-              }
-              ```
-
+       *         The `array` of questions included in the survey. Each question must conform to one of the defined question types: Basic, Link, Rating, or Multiple Choice.
+       *
+       *         Basic (open-ended question)
+       *         - `id`: The question ID
+       *         - `type`: `open`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Link (a question with a link)
+       *         - `id`: The question ID
+       *         - `type`: `link`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `link`: The URL associated with the question.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Rating (a question with a rating scale)
+       *         - `id`: The question ID
+       *         - `type`: `rating`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `display`: Display style of the rating (`number` or `emoji`).
+       *         - `scale`: The scale of the rating (`number`).
+       *         - `lowerBoundLabel`: Label for the lower bound of the scale.
+       *         - `upperBoundLabel`: Label for the upper bound of the scale.
+       *         - `isNpsQuestion`: Whether the question is an NPS rating.
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Multiple choice
+       *         - `id`: The question ID
+       *         - `type`: `single_choice` or `multiple_choice`
+       *         - `question`: The text of the question.
+       *         - `description`: Optional description of the question.
+       *         - `descriptionContentType`: Content type of the description (`html` or `text`).
+       *         - `optional`: Whether the question is optional (`boolean`).
+       *         - `buttonText`: Text displayed on the submit button.
+       *         - `choices`: An array of choices for the question.
+       *         - `shuffleOptions`: Whether to shuffle the order of the choices (`boolean`).
+       *         - `hasOpenChoice`: Whether the question allows an open-ended response (`boolean`).
+       *         - `branching`: Branching logic for the question. See branching types below for details.
+       *
+       *         Branching logic can be one of the following types:
+       *
+       *         Next question: Proceeds to the next question
+       *         ```json
+       *         {
+       *             "type": "next_question"
+       *         }
+       *         ```
+       *
+       *         End: Ends the survey, optionally displaying a confirmation message.
+       *         ```json
+       *         {
+       *             "type": "end"
+       *         }
+       *         ```
+       *
+       *         Response-based: Branches based on the response values. Available for the `rating` and `single_choice` question types.
+       *         ```json
+       *         {
+       *             "type": "response_based",
+       *             "responseValues": {
+       *                 "responseKey": "value"
+       *             }
+       *         }
+       *         ```
+       *
+       *         Specific question: Proceeds to a specific question by index.
+       *         ```json
+       *         {
+       *             "type": "specific_question",
+       *             "index": 2
+       *         }
+       *         ```
+       *
+       *         Translations: Each question can include inline translations.
+       *         - `translations`: Object mapping language codes to translated fields.
+       *         - Language codes: Canonical BCP-47-ish strings (e.g., "es", "es-MX", "zh-CN"). Aliases like "english" or "default" are rejected. The survey's `base_language` (default "en") declares the language of the untranslated text and cannot also appear as a translation key.
+       *         - Translatable fields: `question`, `description`, `buttonText`, `choices`, `lowerBoundLabel`, `upperBoundLabel`, `link`
+       *
+       *         Example with translations:
+       *         ```json
+       *         {
+       *             "id": "uuid",
+       *             "type": "rating",
+       *             "question": "How satisfied are you?",
+       *             "lowerBoundLabel": "Not satisfied",
+       *             "upperBoundLabel": "Very satisfied",
+       *             "translations": {
+       *                 "es": {
+       *                     "question": "¿Qué tan satisfecho estás?",
+       *                     "lowerBoundLabel": "No satisfecho",
+       *                     "upperBoundLabel": "Muy satisfecho"
+       *                 },
+       *                 "fr": {
+       *                     "question": "Dans quelle mesure êtes-vous satisfait?"
+       *                 }
+       *             }
+       *         }
+       *         ```
+       *
          * @nullable
          */
       questions?: SurveyQuestionInputSchema[] | null;
@@ -40110,13 +40223,13 @@ export namespace Schemas {
 
     /**
      * Request body for the presence beacon and beacon-leave endpoints.
-
-    `device_id` is the UUID of the caller's `UserPushToken` row, which the
-    client received when it registered for push via `/api/users/@me/push_tokens/`.
-    The client is expected to use the same identifier on the beacon and leave
-    calls; if the user has unregistered the underlying push token, the value
-    won't resolve and the call returns 404 — at which point pushes were
-    already not going there anyway.
+     *
+     * `device_id` is the UUID of the caller's `UserPushToken` row, which the
+     * client received when it registered for push via `/api/users/@me/push_tokens/`.
+     * The client is expected to use the same identifier on the beacon and leave
+     * calls; if the user has unregistered the underlying push token, the value
+     * won't resolve and the call returns 404 — at which point pushes were
+     * already not going there anyway.
      */
     export interface TaskPresenceBeaconRequest {
       /** UUID of the caller's UserPushToken (returned by `/api/users/@me/push_tokens/` on register). */
@@ -40137,12 +40250,12 @@ export namespace Schemas {
 
     /**
      * * `plan` - plan
-    * `context` - context
-    * `reference` - reference
-    * `output` - output
-    * `artifact` - artifact
-    * `tree_snapshot` - tree_snapshot
-    * `user_attachment` - user_attachment
+     * * `context` - context
+     * * `reference` - reference
+     * * `output` - output
+     * * `artifact` - artifact
+     * * `tree_snapshot` - tree_snapshot
+     * * `user_attachment` - user_attachment
      */
     export type TaskRunArtifactTypeEnum = typeof TaskRunArtifactTypeEnum[keyof typeof TaskRunArtifactTypeEnum];
 
@@ -40166,14 +40279,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40199,14 +40312,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40269,14 +40382,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40286,9 +40399,9 @@ export namespace Schemas {
       /** Artifact contents encoded according to content_encoding */
       content: string;
       /** Encoding used for content. Use base64 for binary files and utf-8 for text payloads.
-
-      * `utf-8` - utf-8
-      * `base64` - base64 */
+       *
+       * * `utf-8` - utf-8
+       * * `base64` - base64 */
       content_encoding?: ContentEncodingEnum;
       /**
          * Optional MIME type for the artifact
@@ -40329,7 +40442,7 @@ export namespace Schemas {
 
     /**
      * * `local` - local
-    * `cloud` - cloud
+     * * `cloud` - cloud
      */
     export type TaskRunBootstrapCreateRequestEnvironmentEnum = typeof TaskRunBootstrapCreateRequestEnvironmentEnum[keyof typeof TaskRunBootstrapCreateRequestEnvironmentEnum];
 
@@ -40341,12 +40454,12 @@ export namespace Schemas {
 
     /**
      * * `default` - default
-    * `acceptEdits` - acceptEdits
-    * `plan` - plan
-    * `bypassPermissions` - bypassPermissions
-    * `auto` - auto
-    * `read-only` - read-only
-    * `full-access` - full-access
+     * * `acceptEdits` - acceptEdits
+     * * `plan` - plan
+     * * `bypassPermissions` - bypassPermissions
+     * * `auto` - auto
+     * * `read-only` - read-only
+     * * `full-access` - full-access
      */
     export type TaskRunBootstrapCreateRequestInitialPermissionModeEnum = typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum[keyof typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum];
 
@@ -40366,14 +40479,14 @@ export namespace Schemas {
      */
     export interface TaskRunBootstrapCreateRequest {
       /** Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.
-
-      * `local` - local
-      * `cloud` - cloud */
+       *
+       * * `local` - local
+       * * `cloud` - cloud */
       environment?: TaskRunBootstrapCreateRequestEnvironmentEnum;
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -40384,43 +40497,43 @@ export namespace Schemas {
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
       /** Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.
-
-      * `claude` - claude
-      * `codex` - codex */
+       *
+       * * `claude` - claude
+       * * `codex` - codex */
       runtime_adapter?: RuntimeAdapterEnum;
       /** LLM model identifier to run in the selected runtime. */
       model?: string;
       /** Reasoning effort to request for models that expose an effort control.
-
-      * `low` - low
-      * `medium` - medium
-      * `high` - high
-      * `xhigh` - xhigh
-      * `max` - max */
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high
+       * * `xhigh` - xhigh
+       * * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
       github_user_token?: string;
       /** Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.
-
-      * `default` - default
-      * `acceptEdits` - acceptEdits
-      * `plan` - plan
-      * `bypassPermissions` - bypassPermissions
-      * `auto` - auto
-      * `read-only` - read-only
-      * `full-access` - full-access */
+       *
+       * * `default` - default
+       * * `acceptEdits` - acceptEdits
+       * * `plan` - plan
+       * * `bypassPermissions` - bypassPermissions
+       * * `auto` - auto
+       * * `read-only` - read-only
+       * * `full-access` - full-access */
       initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnum;
     }
 
@@ -40434,16 +40547,16 @@ export namespace Schemas {
      */
     export interface TaskRunCommandRequest {
       /** JSON-RPC version, must be '2.0'
-
-      * `2.0` - 2.0 */
+       *
+       * * `2.0` - 2.0 */
       jsonrpc: JsonrpcEnum;
       /** Command method to execute on the agent server
-
-      * `user_message` - user_message
-      * `cancel` - cancel
-      * `close` - close
-      * `permission_response` - permission_response
-      * `set_config_option` - set_config_option */
+       *
+       * * `user_message` - user_message
+       * * `cancel` - cancel
+       * * `close` - close
+       * * `permission_response` - permission_response
+       * * `set_config_option` - set_config_option */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;
@@ -40477,9 +40590,9 @@ export namespace Schemas {
 
     export interface TaskRunResumeRequestSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
-
-      * `interactive` - interactive
-      * `background` - background */
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
       mode?: TaskExecutionModeEnum;
       /**
          * Git branch to checkout in the sandbox
@@ -40494,14 +40607,14 @@ export namespace Schemas {
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
       /** Whether pull requests for this run should be authored by the user or the bot.
-
-      * `user` - user
-      * `bot` - bot */
+       *
+       * * `user` - user
+       * * `bot` - bot */
       pr_authorship_mode?: PrAuthorshipModeEnum;
       /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
-
-      * `manual` - manual
-      * `signal_report` - signal_report */
+       *
+       * * `manual` - manual
+       * * `signal_report` - signal_report */
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
@@ -40525,9 +40638,9 @@ export namespace Schemas {
       /** Artifact ids that could not be resolved for the run */
       missing_artifact_ids?: string[];
       /** Which usage limit was hit on a rate_limited error: 'burst' (daily) or 'sustained' (monthly)
-
-      * `burst` - burst
-      * `sustained` - sustained */
+       *
+       * * `burst` - burst
+       * * `sustained` - sustained */
       limit_type?: LimitTypeEnum;
       /** ISO 8601 timestamp when the hit usage limit resets, when known */
       reset_at?: string;
@@ -40550,7 +40663,10 @@ export namespace Schemas {
     export interface TaskRunStartRequest {
       /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
-      /** Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox. */
+      /**
+         * Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.
+         * @items.maxLength 128
+         */
       pending_user_artifact_ids?: string[];
     }
 
@@ -40563,14 +40679,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40596,14 +40712,14 @@ export namespace Schemas {
          */
       name: string;
       /** Classification for the artifact
-
-      * `plan` - plan
-      * `context` - context
-      * `reference` - reference
-      * `output` - output
-      * `artifact` - artifact
-      * `tree_snapshot` - tree_snapshot
-      * `user_attachment` - user_attachment */
+       *
+       * * `plan` - plan
+       * * `context` - context
+       * * `reference` - reference
+       * * `output` - output
+       * * `artifact` - artifact
+       * * `tree_snapshot` - tree_snapshot
+       * * `user_attachment` - user_attachment */
       type: TaskRunArtifactTypeEnum;
       /**
          * Optional source label for the artifact, such as agent_output or user_attachment
@@ -40710,28 +40826,29 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level: string | null;
+      /** @items.maxLength 200 */
       app_urls?: (string | null)[];
       anonymize_ips?: boolean;
       completed_snippet_onboarding?: boolean;
       /** Filters used to identify internal/test users. Each entry is a property filter.
-
-                  Supported entry types and the exact shape each accepts:
-
-                  # Person property — match (or exclude) by a person property
-                  {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
-
-                  # Event property — match by an event property
-                  {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
-
-                  # Cohort membership — match (or exclude) members of a cohort.
-                  # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
-                  # `negation` field here — `negation` is specific to cohort *definitions*
-                  # (the inner sub-filters that build a cohort) and is rejected by the
-                  # property-filter schema.
-                  {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
-
-                  Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
-                  "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
+       *
+       *             Supported entry types and the exact shape each accepts:
+       *
+       *             # Person property — match (or exclude) by a person property
+       *             {"key": "email", "type": "person", "value": "@example.com", "operator": "icontains"}
+       *
+       *             # Event property — match by an event property
+       *             {"key": "$host", "type": "event", "value": "localhost", "operator": "icontains"}
+       *
+       *             # Cohort membership — match (or exclude) members of a cohort.
+       *             # Use operator "in" for inclusion and "not_in" for exclusion. Do NOT use a
+       *             # `negation` field here — `negation` is specific to cohort *definitions*
+       *             # (the inner sub-filters that build a cohort) and is rejected by the
+       *             # property-filter schema.
+       *             {"key": "id", "type": "cohort", "value": 8814, "operator": "not_in"}
+       *
+       *             Common operators: "exact", "is_not", "icontains", "not_icontains", "regex",
+       *             "not_regex", "gt", "lt", "gte", "lte", "is_set", "is_not_set", "in", "not_in". */
       test_account_filters?: unknown;
       /** @nullable */
       test_account_filters_default_checked?: boolean | null;
@@ -40739,7 +40856,10 @@ export namespace Schemas {
       is_demo?: boolean;
       timezone?: string;
       data_attributes?: unknown;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 400
+         */
       person_display_name_properties?: string[] | null;
       correlation_config?: unknown;
       /** @nullable */
@@ -40791,7 +40911,10 @@ export namespace Schemas {
       primary_dashboard?: number | null;
       /** @nullable */
       live_events_columns?: string[] | null;
-      /** @nullable */
+      /**
+         * @nullable
+         * @items.maxLength 200
+         */
       recording_domains?: (string | null)[] | null;
       cookieless_server_hash_mode?: CookielessServerHashModeEnum | null;
       /** @nullable */
@@ -40839,10 +40962,10 @@ export namespace Schemas {
       /** @nullable */
       receive_org_level_activity_logs?: boolean | null;
       /** Whether this project serves B2B or B2C customers, used to optimize the UI layout.
-
-      * `b2b` - B2B
-      * `b2c` - B2C
-      * `other` - Other */
+       *
+       * * `b2b` - B2B
+       * * `b2c` - B2C
+       * * `other` - Other */
       business_model?: BusinessModelEnum | BlankEnum | null;
       /** @nullable */
       conversations_enabled?: boolean | null;
@@ -41016,11 +41139,11 @@ export namespace Schemas {
 
     export interface TextReprRequest {
       /** Type of LLM event to stringify
-
-      * `$ai_generation` - $ai_generation
-      * `$ai_span` - $ai_span
-      * `$ai_embedding` - $ai_embedding
-      * `$ai_trace` - $ai_trace */
+       *
+       * * `$ai_generation` - $ai_generation
+       * * `$ai_span` - $ai_span
+       * * `$ai_embedding` - $ai_embedding
+       * * `$ai_trace` - $ai_trace */
       event_type: EventTypeEnum;
       /** Event data to stringify. For traces, should include 'trace' and 'hierarchy' fields. */
       data: unknown;
@@ -41141,11 +41264,11 @@ export namespace Schemas {
       /** UTC timestamp when the wizard started this run. Matches the timestamp encoded in session_id. */
       started_at: string;
       /** Lifecycle stage of the wizard run.
-
-      * `idle` - IDLE
-      * `running` - RUNNING
-      * `completed` - COMPLETED
-      * `error` - ERROR */
+       *
+       * * `idle` - IDLE
+       * * `running` - RUNNING
+       * * `completed` - COMPLETED
+       * * `error` - ERROR */
       run_phase: RunPhaseEnum;
       tasks: WizardTaskDTO[];
       /**
@@ -41201,7 +41324,7 @@ export namespace Schemas {
 
     /**
      * * `transcript` - transcript
-    * `summary` - summary
+     * * `summary` - summary
      */
     export type UserInterviewSearchDocumentTypeEnum = typeof UserInterviewSearchDocumentTypeEnum[keyof typeof UserInterviewSearchDocumentTypeEnum];
 
@@ -41244,9 +41367,9 @@ export namespace Schemas {
       /** ID of the matched UserInterview. */
       interview_id: string;
       /** Which document type matched — `transcript` is the raw conversation, `summary` is the AI-generated abstract.
-
-      * `transcript` - transcript
-      * `summary` - summary */
+       *
+       * * `transcript` - transcript
+       * * `summary` - summary */
       document_type: UserInterviewSearchDocumentTypeEnum;
       /** Cosine similarity in [0, 1]; higher is closer to the query. Computed as `1 - cosineDistance`. */
       similarity: number;
@@ -41267,10 +41390,10 @@ export namespace Schemas {
       /** PostHog UserPushToken row id. */
       id: string;
       /** Device platform the token was issued for.
-
-      * `ios` - iOS
-      * `android` - Android
-      * `web` - Web */
+       *
+       * * `ios` - iOS
+       * * `android` - Android
+       * * `web` - Web */
       platform: PushTokenPlatformEnum;
       /** When this token was first registered. */
       created_at: string;
@@ -41285,10 +41408,10 @@ export namespace Schemas {
          */
       token: string;
       /** Device platform the token was issued for. One of `ios`, `android`, or `web`.
-
-      * `ios` - iOS
-      * `android` - Android
-      * `web` - Web */
+       *
+       * * `ios` - iOS
+       * * `android` - Android
+       * * `web` - Web */
       platform: PushTokenPlatformEnum;
     }
 
@@ -41308,16 +41431,16 @@ export namespace Schemas {
       /** Number of pageview events with this UTM combination */
       event_count: number;
       /** How utm_campaign matched: none, auto (direct name/id), or mapped (manual mapping)
-
-      * `none` - none
-      * `auto` - auto
-      * `mapped` - mapped */
+       *
+       * * `none` - none
+       * * `auto` - auto
+       * * `mapped` - mapped */
       campaign_match: SourceMatchEnum;
       /** How utm_source matched: none, auto (default source), or mapped (custom mapping)
-
-      * `none` - none
-      * `auto` - auto
-      * `mapped` - mapped */
+       *
+       * * `none` - none
+       * * `auto` - auto
+       * * `mapped` - mapped */
       source_match: SourceMatchEnum;
       /**
          * Name of the matched campaign, if any
@@ -41390,11 +41513,11 @@ export namespace Schemas {
 
     /**
      * * `pending` - pending
-    * `provisioning` - provisioning
-    * `ready` - ready
-    * `failed` - failed
-    * `deleting` - deleting
-    * `deleted` - deleted
+     * * `provisioning` - provisioning
+     * * `ready` - ready
+     * * `failed` - failed
+     * * `deleting` - deleting
+     * * `deleted` - deleted
      */
     export type WarehouseStatusResponseStateEnum = typeof WarehouseStatusResponseStateEnum[keyof typeof WarehouseStatusResponseStateEnum];
 
@@ -41592,9 +41715,9 @@ export namespace Schemas {
       /** Property filter type: "log_attribute" or "log_resource_attribute". Use this as the `type` field when filtering. */
       propertyFilterType: string;
       /** How the search query matched this row: "key" if the attribute key matched, "value" if a value matched.
-
-      * `key` - key
-      * `value` - value */
+       *
+       * * `key` - key
+       * * `value` - value */
       matchedOn: MatchedOnEnum;
       /**
          * Sample matching value — only set when matchedOn is "value".
@@ -41649,8 +41772,8 @@ export namespace Schemas {
 
     /**
      * * `log` - log
-    * `log_attribute` - log_attribute
-    * `log_resource_attribute` - log_resource_attribute
+     * * `log_attribute` - log_attribute
+     * * `log_resource_attribute` - log_resource_attribute
      */
     export type _LogPropertyFilterTypeEnum = typeof _LogPropertyFilterTypeEnum[keyof typeof _LogPropertyFilterTypeEnum];
 
@@ -41663,18 +41786,18 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `is_date_exact` - is_date_exact
-    * `is_date_before` - is_date_before
-    * `is_date_after` - is_date_after
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `is_date_exact` - is_date_exact
+     * * `is_date_before` - is_date_before
+     * * `is_date_after` - is_date_after
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set
      */
     export type _LogPropertyFilterOperatorEnum = typeof _LogPropertyFilterOperatorEnum[keyof typeof _LogPropertyFilterOperatorEnum];
 
@@ -41699,26 +41822,26 @@ export namespace Schemas {
       /** Attribute key. For type "log", use "message". For "log_attribute"/"log_resource_attribute", use the attribute key (e.g. "k8s.container.name"). */
       key: string;
       /** "log" filters the log body/message. "log_attribute" filters log-level attributes. "log_resource_attribute" filters resource-level attributes.
-
-      * `log` - log
-      * `log_attribute` - log_attribute
-      * `log_resource_attribute` - log_resource_attribute */
+       *
+       * * `log` - log
+       * * `log_attribute` - log_attribute
+       * * `log_resource_attribute` - log_resource_attribute */
       type: _LogPropertyFilterTypeEnum;
       /** Comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `gt` - gt
-      * `lt` - lt
-      * `is_date_exact` - is_date_exact
-      * `is_date_before` - is_date_before
-      * `is_date_after` - is_date_after
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `gt` - gt
+       * * `lt` - lt
+       * * `is_date_exact` - is_date_exact
+       * * `is_date_before` - is_date_before
+       * * `is_date_after` - is_date_after
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: _LogPropertyFilterOperatorEnum;
       /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
       value?: unknown;
@@ -41802,9 +41925,9 @@ export namespace Schemas {
       /** Filter by service names. */
       serviceNames?: string[];
       /** Order results by timestamp.
-
-      * `latest` - latest
-      * `earliest` - earliest */
+       *
+       * * `latest` - latest
+       * * `earliest` - earliest */
       orderBy?: OrderByEnum;
       /** Full-text search term to filter log bodies. */
       searchTerm?: string;
@@ -41927,9 +42050,9 @@ export namespace Schemas {
       /** Property filters for the query. */
       filterGroup?: _LogPropertyFilter[];
       /** Break down sparkline by "severity" (default) or "service".
-
-      * `severity` - severity
-      * `service` - service */
+       *
+       * * `severity` - severity
+       * * `service` - service */
       sparklineBreakdownBy?: SparklineBreakdownByEnum;
     }
 
@@ -41981,11 +42104,11 @@ export namespace Schemas {
          */
       metricName: string;
       /** Aggregation applied per time bucket.
-
-      * `sum` - sum
-      * `avg` - avg
-      * `count` - count
-      * `p95` - p95 */
+       *
+       * * `sum` - sum
+       * * `avg` - avg
+       * * `count` - count
+       * * `p95` - p95 */
       aggregation?: AggregationEnum;
       /** Lower bound (inclusive) for the query range. ISO 8601. */
       dateFrom: string;
@@ -42012,8 +42135,8 @@ export namespace Schemas {
 
     /**
      * * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      */
     export type _SpanPropertyFilterTypeEnum = typeof _SpanPropertyFilterTypeEnum[keyof typeof _SpanPropertyFilterTypeEnum];
 
@@ -42026,15 +42149,15 @@ export namespace Schemas {
 
     /**
      * * `exact` - exact
-    * `is_not` - is_not
-    * `icontains` - icontains
-    * `not_icontains` - not_icontains
-    * `regex` - regex
-    * `not_regex` - not_regex
-    * `gt` - gt
-    * `lt` - lt
-    * `is_set` - is_set
-    * `is_not_set` - is_not_set
+     * * `is_not` - is_not
+     * * `icontains` - icontains
+     * * `not_icontains` - not_icontains
+     * * `regex` - regex
+     * * `not_regex` - not_regex
+     * * `gt` - gt
+     * * `lt` - lt
+     * * `is_set` - is_set
+     * * `is_not_set` - is_not_set
      */
     export type _SpanPropertyFilterOperatorEnum = typeof _SpanPropertyFilterOperatorEnum[keyof typeof _SpanPropertyFilterOperatorEnum];
 
@@ -42056,23 +42179,23 @@ export namespace Schemas {
       /** Attribute key. For type "span", use built-in fields (trace_id, span_id, duration, name, kind, status_code). For "span_attribute"/"span_resource_attribute", use the attribute key (e.g. "http.method"). */
       key: string;
       /** "span" filters built-in span fields. "span_attribute" filters span-level attributes. "span_resource_attribute" filters resource-level attributes.
-
-      * `span` - span
-      * `span_attribute` - span_attribute
-      * `span_resource_attribute` - span_resource_attribute */
+       *
+       * * `span` - span
+       * * `span_attribute` - span_attribute
+       * * `span_resource_attribute` - span_resource_attribute */
       type: _SpanPropertyFilterTypeEnum;
       /** Comparison operator.
-
-      * `exact` - exact
-      * `is_not` - is_not
-      * `icontains` - icontains
-      * `not_icontains` - not_icontains
-      * `regex` - regex
-      * `not_regex` - not_regex
-      * `gt` - gt
-      * `lt` - lt
-      * `is_set` - is_set
-      * `is_not_set` - is_not_set */
+       *
+       * * `exact` - exact
+       * * `is_not` - is_not
+       * * `icontains` - icontains
+       * * `not_icontains` - not_icontains
+       * * `regex` - regex
+       * * `not_regex` - not_regex
+       * * `gt` - gt
+       * * `lt` - lt
+       * * `is_set` - is_set
+       * * `is_not_set` - is_not_set */
       operator: _SpanPropertyFilterOperatorEnum;
       /** Value to compare against. String, number, or array of strings. Omit for is_set/is_not_set operators. */
       value?: unknown;
@@ -42141,9 +42264,9 @@ export namespace Schemas {
       /** Filter by HTTP status codes. */
       statusCodes?: number[];
       /** Order results by timestamp. Defaults to latest.
-
-      * `latest` - latest
-      * `earliest` - earliest */
+       *
+       * * `latest` - latest
+       * * `earliest` - earliest */
       orderBy?: OrderByEnum;
       /** Property filters for the query. */
       filterGroup?: _SpanPropertyFilter[];
@@ -42890,11 +43013,11 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
      */
     order_by?: string[];
     /**
@@ -43114,13 +43237,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort order for symbol sets. Prefix with `-` for descending order.
-
-    * `created_at` - created_at
-    * `-created_at` - -created_at
-    * `ref` - ref
-    * `-ref` - -ref
-    * `last_used` - last_used
-    * `-last_used` - -last_used
+     *
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `ref` - ref
+     * * `-ref` - -ref
+     * * `last_used` - last_used
+     * * `-last_used` - -last_used
      * @minLength 1
      */
     order_by?: string;
@@ -43136,10 +43259,10 @@ export namespace Schemas {
     search?: string;
     /**
      * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-
-    * `all` - all
-    * `valid` - valid
-    * `invalid` - invalid
+     *
+     * * `all` - all
+     * * `valid` - valid
+     * * `invalid` - invalid
      * @minLength 1
      */
     status?: EnvironmentsErrorTrackingSymbolSetsListStatus;
@@ -43175,13 +43298,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -43545,9 +43668,9 @@ export namespace Schemas {
     export type EnvironmentsHeatmapsListParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: EnvironmentsHeatmapsListAggregation;
@@ -43611,9 +43734,9 @@ export namespace Schemas {
     export type EnvironmentsHeatmapsEventsRetrieveParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: EnvironmentsHeatmapsEventsRetrieveAggregation;
@@ -43747,8 +43870,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * * `draft` - Draft
-    * `active` - Active
-    * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     status?: EnvironmentsHogFlowsListStatus;
     updated_at?: string;
@@ -43837,9 +43960,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFlowsMetricsRetrieveBreakdownBy;
@@ -43850,10 +43973,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFlowsMetricsRetrieveInterval;
@@ -43899,9 +44022,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFlowsMetricsTotalsRetrieveBreakdownBy;
@@ -43912,10 +44035,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFlowsMetricsTotalsRetrieveInterval;
@@ -44026,9 +44149,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFunctionsMetricsRetrieveBreakdownBy;
@@ -44039,10 +44162,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFunctionsMetricsRetrieveInterval;
@@ -44088,9 +44211,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: EnvironmentsHogFunctionsMetricsTotalsRetrieveBreakdownBy;
@@ -44101,10 +44224,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: EnvironmentsHogFunctionsMetricsTotalsRetrieveInterval;
@@ -44200,14 +44323,14 @@ export namespace Schemas {
     offset?: number;
     /**
      *
-    Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsListRefresh;
     /**
@@ -44295,20 +44418,20 @@ export namespace Schemas {
     format?: EnvironmentsInsightsRetrieveFormat;
     /**
      *
-    Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-    When set, the specified dashboard's filters and date range override will be applied.
+     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+     * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
     /**
      *
-    Whether to refresh the insight, how aggresively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the insight, how aggresively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: EnvironmentsInsightsRetrieveRefresh;
     /**
@@ -44537,41 +44660,41 @@ export namespace Schemas {
     export type EnvironmentsIntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-    * `apns` - Apple Push
-    * `azure-blob` - Azure Blob
-    * `bing-ads` - Bing Ads
-    * `clickup` - Clickup
-    * `customerio-app` - Customerio App
-    * `customerio-track` - Customerio Track
-    * `customerio-webhook` - Customerio Webhook
-    * `databricks` - Databricks
-    * `email` - Email
-    * `firebase` - Firebase
-    * `github` - Github
-    * `gitlab` - Gitlab
-    * `google-ads` - Google Ads
-    * `google-cloud-service-account` - Google Cloud Service Account
-    * `google-cloud-storage` - Google Cloud Storage
-    * `google-pubsub` - Google Pubsub
-    * `google-search-console` - Google Search Console
-    * `google-sheets` - Google Sheets
-    * `hubspot` - Hubspot
-    * `intercom` - Intercom
-    * `jira` - Jira
-    * `linear` - Linear
-    * `linkedin-ads` - Linkedin Ads
-    * `meta-ads` - Meta Ads
-    * `pinterest-ads` - Pinterest Ads
-    * `postgresql` - Postgresql
-    * `reddit-ads` - Reddit Ads
-    * `salesforce` - Salesforce
-    * `slack` - Slack
-    * `slack-posthog-code` - Slack Posthog Code
-    * `snapchat` - Snapchat
-    * `stripe` - Stripe
-    * `tiktok-ads` - Tiktok Ads
-    * `twilio` - Twilio
-    * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     kind?: EnvironmentsIntegrationsListKind;
     /**
@@ -44931,10 +45054,10 @@ export namespace Schemas {
     export type EnvironmentsLlmPromptsListParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: EnvironmentsLlmPromptsListContent;
@@ -44968,10 +45091,10 @@ export namespace Schemas {
     export type EnvironmentsLlmPromptsNameRetrieveParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: EnvironmentsLlmPromptsNameRetrieveContent;
@@ -45115,9 +45238,9 @@ export namespace Schemas {
     export type EnvironmentsLogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: EnvironmentsLogsAttributesRetrieveAttributeType;
@@ -45192,9 +45315,9 @@ export namespace Schemas {
     export type EnvironmentsLogsValuesRetrieveParams = {
     /**
      * Type of attribute: "log" or "resource". Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: EnvironmentsLogsValuesRetrieveAttributeType;
@@ -45347,7 +45470,7 @@ export namespace Schemas {
     export type EnvironmentsMcpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-    * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: EnvironmentsMcpServerInstallationsAuthorizeRetrieveInstallSource;
@@ -45994,13 +46117,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -46012,9 +46135,9 @@ export namespace Schemas {
     export type EnvironmentsTracingSpansAttributesRetrieveParams = {
     /**
      * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: EnvironmentsTracingSpansAttributesRetrieveAttributeType;
@@ -46060,10 +46183,10 @@ export namespace Schemas {
     export type EnvironmentsTracingSpansValuesRetrieveParams = {
     /**
      * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: EnvironmentsTracingSpansValuesRetrieveAttributeType;
@@ -46986,69 +47109,69 @@ export namespace Schemas {
     page_size?: number;
     /**
      * Filter by a single activity scope, e.g. "FeatureFlag", "Insight", "Dashboard", "Experiment".
-
-    * `Cohort` - Cohort
-    * `FeatureFlag` - FeatureFlag
-    * `Person` - Person
-    * `Group` - Group
-    * `Insight` - Insight
-    * `Plugin` - Plugin
-    * `PluginConfig` - PluginConfig
-    * `HogFunction` - HogFunction
-    * `HogFlow` - HogFlow
-    * `DataManagement` - DataManagement
-    * `EventDefinition` - EventDefinition
-    * `PropertyDefinition` - PropertyDefinition
-    * `Notebook` - Notebook
-    * `Endpoint` - Endpoint
-    * `EndpointVersion` - EndpointVersion
-    * `Dashboard` - Dashboard
-    * `Replay` - Replay
-    * `Experiment` - Experiment
-    * `ExperimentHoldout` - ExperimentHoldout
-    * `ExperimentSavedMetric` - ExperimentSavedMetric
-    * `Survey` - Survey
-    * `EarlyAccessFeature` - EarlyAccessFeature
-    * `SessionRecordingPlaylist` - SessionRecordingPlaylist
-    * `Comment` - Comment
-    * `Team` - Team
-    * `Project` - Project
-    * `ErrorTrackingIssue` - ErrorTrackingIssue
-    * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-    * `LegalDocument` - LegalDocument
-    * `Organization` - Organization
-    * `OrganizationDomain` - OrganizationDomain
-    * `OrganizationMembership` - OrganizationMembership
-    * `Role` - Role
-    * `UserGroup` - UserGroup
-    * `BatchExport` - BatchExport
-    * `BatchImport` - BatchImport
-    * `Integration` - Integration
-    * `Annotation` - Annotation
-    * `Tag` - Tag
-    * `TaggedItem` - TaggedItem
-    * `Subscription` - Subscription
-    * `PersonalAPIKey` - PersonalAPIKey
-    * `ProjectSecretAPIKey` - ProjectSecretAPIKey
-    * `User` - User
-    * `Action` - Action
-    * `AlertConfiguration` - AlertConfiguration
-    * `Threshold` - Threshold
-    * `AlertSubscription` - AlertSubscription
-    * `ExternalDataSource` - ExternalDataSource
-    * `ExternalDataSchema` - ExternalDataSchema
-    * `Evaluation` - Evaluation
-    * `LLMTrace` - LLMTrace
-    * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-    * `CustomerProfileConfig` - CustomerProfileConfig
-    * `Log` - Log
-    * `LogsAlertConfiguration` - LogsAlertConfiguration
-    * `LogsExclusionRule` - LogsExclusionRule
-    * `DashboardWidget` - DashboardWidget
-    * `ProductTour` - ProductTour
-    * `Ticket` - Ticket
-    * `InstanceSetting` - InstanceSetting
-    * `SignalScoutConfig` - SignalScoutConfig
+     *
+     * * `Cohort` - Cohort
+     * * `FeatureFlag` - FeatureFlag
+     * * `Person` - Person
+     * * `Group` - Group
+     * * `Insight` - Insight
+     * * `Plugin` - Plugin
+     * * `PluginConfig` - PluginConfig
+     * * `HogFunction` - HogFunction
+     * * `HogFlow` - HogFlow
+     * * `DataManagement` - DataManagement
+     * * `EventDefinition` - EventDefinition
+     * * `PropertyDefinition` - PropertyDefinition
+     * * `Notebook` - Notebook
+     * * `Endpoint` - Endpoint
+     * * `EndpointVersion` - EndpointVersion
+     * * `Dashboard` - Dashboard
+     * * `Replay` - Replay
+     * * `Experiment` - Experiment
+     * * `ExperimentHoldout` - ExperimentHoldout
+     * * `ExperimentSavedMetric` - ExperimentSavedMetric
+     * * `Survey` - Survey
+     * * `EarlyAccessFeature` - EarlyAccessFeature
+     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+     * * `Comment` - Comment
+     * * `Team` - Team
+     * * `Project` - Project
+     * * `ErrorTrackingIssue` - ErrorTrackingIssue
+     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+     * * `LegalDocument` - LegalDocument
+     * * `Organization` - Organization
+     * * `OrganizationDomain` - OrganizationDomain
+     * * `OrganizationMembership` - OrganizationMembership
+     * * `Role` - Role
+     * * `UserGroup` - UserGroup
+     * * `BatchExport` - BatchExport
+     * * `BatchImport` - BatchImport
+     * * `Integration` - Integration
+     * * `Annotation` - Annotation
+     * * `Tag` - Tag
+     * * `TaggedItem` - TaggedItem
+     * * `Subscription` - Subscription
+     * * `PersonalAPIKey` - PersonalAPIKey
+     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `User` - User
+     * * `Action` - Action
+     * * `AlertConfiguration` - AlertConfiguration
+     * * `Threshold` - Threshold
+     * * `AlertSubscription` - AlertSubscription
+     * * `ExternalDataSource` - ExternalDataSource
+     * * `ExternalDataSchema` - ExternalDataSchema
+     * * `Evaluation` - Evaluation
+     * * `LLMTrace` - LLMTrace
+     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+     * * `CustomerProfileConfig` - CustomerProfileConfig
+     * * `Log` - Log
+     * * `LogsAlertConfiguration` - LogsAlertConfiguration
+     * * `LogsExclusionRule` - LogsExclusionRule
+     * * `DashboardWidget` - DashboardWidget
+     * * `ProductTour` - ProductTour
+     * * `Ticket` - Ticket
+     * * `InstanceSetting` - InstanceSetting
+     * * `SignalScoutConfig` - SignalScoutConfig
      * @minLength 1
      */
     scope?: ActivityLogListScope;
@@ -47132,67 +47255,67 @@ export namespace Schemas {
 
     /**
      * * `Cohort` - Cohort
-    * `FeatureFlag` - FeatureFlag
-    * `Person` - Person
-    * `Group` - Group
-    * `Insight` - Insight
-    * `Plugin` - Plugin
-    * `PluginConfig` - PluginConfig
-    * `HogFunction` - HogFunction
-    * `HogFlow` - HogFlow
-    * `DataManagement` - DataManagement
-    * `EventDefinition` - EventDefinition
-    * `PropertyDefinition` - PropertyDefinition
-    * `Notebook` - Notebook
-    * `Endpoint` - Endpoint
-    * `EndpointVersion` - EndpointVersion
-    * `Dashboard` - Dashboard
-    * `Replay` - Replay
-    * `Experiment` - Experiment
-    * `ExperimentHoldout` - ExperimentHoldout
-    * `ExperimentSavedMetric` - ExperimentSavedMetric
-    * `Survey` - Survey
-    * `EarlyAccessFeature` - EarlyAccessFeature
-    * `SessionRecordingPlaylist` - SessionRecordingPlaylist
-    * `Comment` - Comment
-    * `Team` - Team
-    * `Project` - Project
-    * `ErrorTrackingIssue` - ErrorTrackingIssue
-    * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
-    * `LegalDocument` - LegalDocument
-    * `Organization` - Organization
-    * `OrganizationDomain` - OrganizationDomain
-    * `OrganizationMembership` - OrganizationMembership
-    * `Role` - Role
-    * `UserGroup` - UserGroup
-    * `BatchExport` - BatchExport
-    * `BatchImport` - BatchImport
-    * `Integration` - Integration
-    * `Annotation` - Annotation
-    * `Tag` - Tag
-    * `TaggedItem` - TaggedItem
-    * `Subscription` - Subscription
-    * `PersonalAPIKey` - PersonalAPIKey
-    * `ProjectSecretAPIKey` - ProjectSecretAPIKey
-    * `User` - User
-    * `Action` - Action
-    * `AlertConfiguration` - AlertConfiguration
-    * `Threshold` - Threshold
-    * `AlertSubscription` - AlertSubscription
-    * `ExternalDataSource` - ExternalDataSource
-    * `ExternalDataSchema` - ExternalDataSchema
-    * `Evaluation` - Evaluation
-    * `LLMTrace` - LLMTrace
-    * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
-    * `CustomerProfileConfig` - CustomerProfileConfig
-    * `Log` - Log
-    * `LogsAlertConfiguration` - LogsAlertConfiguration
-    * `LogsExclusionRule` - LogsExclusionRule
-    * `DashboardWidget` - DashboardWidget
-    * `ProductTour` - ProductTour
-    * `Ticket` - Ticket
-    * `InstanceSetting` - InstanceSetting
-    * `SignalScoutConfig` - SignalScoutConfig
+     * * `FeatureFlag` - FeatureFlag
+     * * `Person` - Person
+     * * `Group` - Group
+     * * `Insight` - Insight
+     * * `Plugin` - Plugin
+     * * `PluginConfig` - PluginConfig
+     * * `HogFunction` - HogFunction
+     * * `HogFlow` - HogFlow
+     * * `DataManagement` - DataManagement
+     * * `EventDefinition` - EventDefinition
+     * * `PropertyDefinition` - PropertyDefinition
+     * * `Notebook` - Notebook
+     * * `Endpoint` - Endpoint
+     * * `EndpointVersion` - EndpointVersion
+     * * `Dashboard` - Dashboard
+     * * `Replay` - Replay
+     * * `Experiment` - Experiment
+     * * `ExperimentHoldout` - ExperimentHoldout
+     * * `ExperimentSavedMetric` - ExperimentSavedMetric
+     * * `Survey` - Survey
+     * * `EarlyAccessFeature` - EarlyAccessFeature
+     * * `SessionRecordingPlaylist` - SessionRecordingPlaylist
+     * * `Comment` - Comment
+     * * `Team` - Team
+     * * `Project` - Project
+     * * `ErrorTrackingIssue` - ErrorTrackingIssue
+     * * `DataWarehouseSavedQuery` - DataWarehouseSavedQuery
+     * * `LegalDocument` - LegalDocument
+     * * `Organization` - Organization
+     * * `OrganizationDomain` - OrganizationDomain
+     * * `OrganizationMembership` - OrganizationMembership
+     * * `Role` - Role
+     * * `UserGroup` - UserGroup
+     * * `BatchExport` - BatchExport
+     * * `BatchImport` - BatchImport
+     * * `Integration` - Integration
+     * * `Annotation` - Annotation
+     * * `Tag` - Tag
+     * * `TaggedItem` - TaggedItem
+     * * `Subscription` - Subscription
+     * * `PersonalAPIKey` - PersonalAPIKey
+     * * `ProjectSecretAPIKey` - ProjectSecretAPIKey
+     * * `User` - User
+     * * `Action` - Action
+     * * `AlertConfiguration` - AlertConfiguration
+     * * `Threshold` - Threshold
+     * * `AlertSubscription` - AlertSubscription
+     * * `ExternalDataSource` - ExternalDataSource
+     * * `ExternalDataSchema` - ExternalDataSchema
+     * * `Evaluation` - Evaluation
+     * * `LLMTrace` - LLMTrace
+     * * `WebAnalyticsFilterPreset` - WebAnalyticsFilterPreset
+     * * `CustomerProfileConfig` - CustomerProfileConfig
+     * * `Log` - Log
+     * * `LogsAlertConfiguration` - LogsAlertConfiguration
+     * * `LogsExclusionRule` - LogsExclusionRule
+     * * `DashboardWidget` - DashboardWidget
+     * * `ProductTour` - ProductTour
+     * * `Ticket` - Ticket
+     * * `InstanceSetting` - InstanceSetting
+     * * `SignalScoutConfig` - SignalScoutConfig
      */
     export type ActivityLogListScopesItem = typeof ActivityLogListScopesItem[keyof typeof ActivityLogListScopesItem];
 
@@ -47586,10 +47709,10 @@ export namespace Schemas {
     export type CommentsListParams = {
     /**
      * When kind=task, restrict to open (incomplete) or completed tasks. Ignored when kind is not 'task'. Defaults to 'any' (no filter).
-
-    * `any` - any
-    * `open` - open
-    * `completed` - completed
+     *
+     * * `any` - any
+     * * `open` - open
+     * * `completed` - completed
      * @minLength 1
      */
     completed?: CommentsListCompleted;
@@ -47604,10 +47727,10 @@ export namespace Schemas {
     item_id?: string;
     /**
      * Filter by comment kind. 'task' returns only items intentionally created as actionable. 'comment' excludes tasks. Defaults to 'any' (no filter).
-
-    * `any` - any
-    * `comment` - comment
-    * `task` - task
+     *
+     * * `any` - any
+     * * `comment` - comment
+     * * `task` - task
      * @minLength 1
      */
     kind?: CommentsListKind;
@@ -48238,11 +48361,11 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
      */
     order_by?: string[];
     /**
@@ -48565,13 +48688,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Sort order for symbol sets. Prefix with `-` for descending order.
-
-    * `created_at` - created_at
-    * `-created_at` - -created_at
-    * `ref` - ref
-    * `-ref` - -ref
-    * `last_used` - last_used
-    * `-last_used` - -last_used
+     *
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `ref` - ref
+     * * `-ref` - -ref
+     * * `last_used` - last_used
+     * * `-last_used` - -last_used
      * @minLength 1
      */
     order_by?: string;
@@ -48587,10 +48710,10 @@ export namespace Schemas {
     search?: string;
     /**
      * Upload status filter: `valid` has an uploaded file, `invalid` is missing a file, `all` returns both.
-
-    * `all` - all
-    * `valid` - valid
-    * `invalid` - invalid
+     *
+     * * `all` - all
+     * * `valid` - valid
+     * * `invalid` - invalid
      * @minLength 1
      */
     status?: ErrorTrackingSymbolSetsListStatus;
@@ -48626,13 +48749,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -49274,9 +49397,9 @@ export namespace Schemas {
     export type HeatmapsListParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: HeatmapsListAggregation;
@@ -49340,9 +49463,9 @@ export namespace Schemas {
     export type HeatmapsEventsRetrieveParams = {
     /**
      * How to aggregate counts: 'total_count' (every interaction, default) or 'unique_visitors' (distinct people).
-
-    * `unique_visitors` - unique_visitors
-    * `total_count` - total_count
+     *
+     * * `unique_visitors` - unique_visitors
+     * * `total_count` - total_count
      * @minLength 1
      */
     aggregation?: HeatmapsEventsRetrieveAggregation;
@@ -49476,8 +49599,8 @@ export namespace Schemas {
     offset?: number;
     /**
      * * `draft` - Draft
-    * `active` - Active
-    * `archived` - Archived
+     * * `active` - Active
+     * * `archived` - Archived
      */
     status?: HogFlowsListStatus;
     updated_at?: string;
@@ -49566,9 +49689,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFlowsMetricsRetrieveBreakdownBy;
@@ -49579,10 +49702,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFlowsMetricsRetrieveInterval;
@@ -49628,9 +49751,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFlowsMetricsTotalsRetrieveBreakdownBy;
@@ -49641,10 +49764,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFlowsMetricsTotalsRetrieveInterval;
@@ -49778,9 +49901,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFunctionsMetricsRetrieveBreakdownBy;
@@ -49791,10 +49914,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFunctionsMetricsRetrieveInterval;
@@ -49840,9 +49963,9 @@ export namespace Schemas {
     before?: string;
     /**
      * Group the series by metric 'name' or 'kind'. Defaults to 'kind'.
-
-    * `name` - name
-    * `kind` - kind
+     *
+     * * `name` - name
+     * * `kind` - kind
      * @minLength 1
      */
     breakdown_by?: HogFunctionsMetricsTotalsRetrieveBreakdownBy;
@@ -49853,10 +49976,10 @@ export namespace Schemas {
     instance_id?: string;
     /**
      * Time bucket size for the series. One of: hour, day, week. Defaults to 'day'.
-
-    * `hour` - hour
-    * `day` - day
-    * `week` - week
+     *
+     * * `hour` - hour
+     * * `day` - day
+     * * `week` - week
      * @minLength 1
      */
     interval?: HogFunctionsMetricsTotalsRetrieveInterval;
@@ -49952,14 +50075,14 @@ export namespace Schemas {
     offset?: number;
     /**
      *
-    Whether to refresh the retrieved insights, how aggressively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the retrieved insights, how aggressively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsListRefresh;
     /**
@@ -50047,20 +50170,20 @@ export namespace Schemas {
     format?: InsightsRetrieveFormat;
     /**
      *
-    Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
-    When set, the specified dashboard's filters and date range override will be applied.
+     * Only if loading an insight in the context of a dashboard: The relevant dashboard's ID.
+     * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
     /**
      *
-    Whether to refresh the insight, how aggresively, and if sync or async:
-    - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
-    - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
-    - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
-    - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
-    - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
-    - `'force_async'` - kick off background calculation, even if fresh results are already cached
-    Background calculation can be tracked using the `query_status` response field.
+     * Whether to refresh the insight, how aggresively, and if sync or async:
+     * - `'force_cache'` - return cached data or a cache miss; always completes immediately as it never calculates
+     * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
+     * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
+     * - `'lazy_async'` - kick off background calculation, UNLESS there are somewhat fresh results in the cache
+     * - `'force_blocking'` - calculate synchronously, even if fresh results are already cached
+     * - `'force_async'` - kick off background calculation, even if fresh results are already cached
+     * Background calculation can be tracked using the `query_status` response field.
      */
     refresh?: InsightsRetrieveRefresh;
     /**
@@ -50289,41 +50412,41 @@ export namespace Schemas {
     export type IntegrationsListParams = {
     /**
      * * `anthropic` - Anthropic
-    * `apns` - Apple Push
-    * `azure-blob` - Azure Blob
-    * `bing-ads` - Bing Ads
-    * `clickup` - Clickup
-    * `customerio-app` - Customerio App
-    * `customerio-track` - Customerio Track
-    * `customerio-webhook` - Customerio Webhook
-    * `databricks` - Databricks
-    * `email` - Email
-    * `firebase` - Firebase
-    * `github` - Github
-    * `gitlab` - Gitlab
-    * `google-ads` - Google Ads
-    * `google-cloud-service-account` - Google Cloud Service Account
-    * `google-cloud-storage` - Google Cloud Storage
-    * `google-pubsub` - Google Pubsub
-    * `google-search-console` - Google Search Console
-    * `google-sheets` - Google Sheets
-    * `hubspot` - Hubspot
-    * `intercom` - Intercom
-    * `jira` - Jira
-    * `linear` - Linear
-    * `linkedin-ads` - Linkedin Ads
-    * `meta-ads` - Meta Ads
-    * `pinterest-ads` - Pinterest Ads
-    * `postgresql` - Postgresql
-    * `reddit-ads` - Reddit Ads
-    * `salesforce` - Salesforce
-    * `slack` - Slack
-    * `slack-posthog-code` - Slack Posthog Code
-    * `snapchat` - Snapchat
-    * `stripe` - Stripe
-    * `tiktok-ads` - Tiktok Ads
-    * `twilio` - Twilio
-    * `vercel` - Vercel
+     * * `apns` - Apple Push
+     * * `azure-blob` - Azure Blob
+     * * `bing-ads` - Bing Ads
+     * * `clickup` - Clickup
+     * * `customerio-app` - Customerio App
+     * * `customerio-track` - Customerio Track
+     * * `customerio-webhook` - Customerio Webhook
+     * * `databricks` - Databricks
+     * * `email` - Email
+     * * `firebase` - Firebase
+     * * `github` - Github
+     * * `gitlab` - Gitlab
+     * * `google-ads` - Google Ads
+     * * `google-cloud-service-account` - Google Cloud Service Account
+     * * `google-cloud-storage` - Google Cloud Storage
+     * * `google-pubsub` - Google Pubsub
+     * * `google-search-console` - Google Search Console
+     * * `google-sheets` - Google Sheets
+     * * `hubspot` - Hubspot
+     * * `intercom` - Intercom
+     * * `jira` - Jira
+     * * `linear` - Linear
+     * * `linkedin-ads` - Linkedin Ads
+     * * `meta-ads` - Meta Ads
+     * * `pinterest-ads` - Pinterest Ads
+     * * `postgresql` - Postgresql
+     * * `reddit-ads` - Reddit Ads
+     * * `salesforce` - Salesforce
+     * * `slack` - Slack
+     * * `slack-posthog-code` - Slack Posthog Code
+     * * `snapchat` - Snapchat
+     * * `stripe` - Stripe
+     * * `tiktok-ads` - Tiktok Ads
+     * * `twilio` - Twilio
+     * * `vercel` - Vercel
      */
     kind?: IntegrationsListKind;
     /**
@@ -50743,10 +50866,10 @@ export namespace Schemas {
     export type LlmPromptsListParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: LlmPromptsListContent;
@@ -50780,10 +50903,10 @@ export namespace Schemas {
     export type LlmPromptsNameRetrieveParams = {
     /**
      * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
-
-    * `full` - full
-    * `preview` - preview
-    * `none` - none
+     *
+     * * `full` - full
+     * * `preview` - preview
+     * * `none` - none
      * @minLength 1
      */
     content?: LlmPromptsNameRetrieveContent;
@@ -50927,9 +51050,9 @@ export namespace Schemas {
     export type LogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: LogsAttributesRetrieveAttributeType;
@@ -51004,9 +51127,9 @@ export namespace Schemas {
     export type LogsValuesRetrieveParams = {
     /**
      * Type of attribute: "log" or "resource". Defaults to "log".
-
-    * `log` - log
-    * `resource` - resource
+     *
+     * * `log` - log
+     * * `resource` - resource
      * @minLength 1
      */
     attribute_type?: LogsValuesRetrieveAttributeType;
@@ -51072,9 +51195,9 @@ export namespace Schemas {
     search?: string;
     /**
      * * `completed` - Completed
-    * `failed` - Failed
-    * `paused` - Paused
-    * `running` - Running
+     * * `failed` - Failed
+     * * `paused` - Paused
+     * * `running` - Running
      */
     status?: ManagedMigrationsListStatus;
     };
@@ -51195,7 +51318,7 @@ export namespace Schemas {
     export type McpServerInstallationsAuthorizeRetrieveParams = {
     /**
      * * `posthog` - posthog
-    * `posthog-code` - posthog-code
+     * * `posthog-code` - posthog-code
      * @minLength 1
      */
     install_source?: McpServerInstallationsAuthorizeRetrieveInstallSource;
@@ -51263,8 +51386,8 @@ export namespace Schemas {
     export type NotebooksListParams = {
     /**
      * Filter for notebooks that match a provided filter.
-                    Each match pair is separated by a colon,
-                    multiple match pairs can be sent separated by a space or a comma
+     *                 Each match pair is separated by a colon,
+     *                 multiple match pairs can be sent separated by a space or a comma
      */
     contains?: string;
     /**
@@ -51793,11 +51916,11 @@ export namespace Schemas {
     search?: string;
     /**
      * What property definitions to return
-
-    * `event` - event
-    * `person` - person
-    * `group` - group
-    * `session` - session
+     *
+     * * `event` - event
+     * * `person` - person
+     * * `group` - group
+     * * `session` - session
      * @minLength 1
      */
     type?: PropertyDefinitionsListType;
@@ -52214,9 +52337,9 @@ export namespace Schemas {
     search?: string;
     /**
      * * `popover` - popover
-    * `widget` - widget
-    * `external_survey` - external survey
-    * `api` - api
+     * * `widget` - widget
+     * * `external_survey` - external survey
+     * * `api` - api
      */
     type?: SurveysListType;
     };
@@ -52326,13 +52449,13 @@ export namespace Schemas {
     offset?: number;
     /**
      * Ordering
-
-    * `created_at` - Created At
-    * `-created_at` - Created At (descending)
-    * `updated_at` - Updated At
-    * `-updated_at` - Updated At (descending)
-    * `name` - Name
-    * `-name` - Name (descending)
+     *
+     * * `created_at` - Created At
+     * * `-created_at` - Created At (descending)
+     * * `updated_at` - Updated At
+     * * `-updated_at` - Updated At (descending)
+     * * `name` - Name
+     * * `-name` - Name (descending)
      */
     order_by?: string[];
     /**
@@ -52366,10 +52489,10 @@ export namespace Schemas {
     export type TasksListParams = {
     /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
-
-    * `true` - true
-    * `false` - false
-    * `all` - all
+     *
+     * * `true` - true
+     * * `false` - false
+     * * `all` - all
      * @minLength 1
      */
     archived?: TasksListArchived;
@@ -52418,13 +52541,13 @@ export namespace Schemas {
     stage?: string;
     /**
      * Filter tasks by the status of their most recent run.
-
-    * `not_started` - not_started
-    * `queued` - queued
-    * `in_progress` - in_progress
-    * `completed` - completed
-    * `failed` - failed
-    * `cancelled` - cancelled
+     *
+     * * `not_started` - not_started
+     * * `queued` - queued
+     * * `in_progress` - in_progress
+     * * `completed` - completed
+     * * `failed` - failed
+     * * `cancelled` - cancelled
      * @minLength 1
      */
     status?: TasksListStatus;
@@ -52529,9 +52652,9 @@ export namespace Schemas {
     export type TracingSpansAttributesRetrieveParams = {
     /**
      * Type of attributes: "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansAttributesRetrieveAttributeType;
@@ -52577,10 +52700,10 @@ export namespace Schemas {
     export type TracingSpansValuesRetrieveParams = {
     /**
      * Type of attribute: "span" for built-in span fields (e.g. name), "span_attribute" for span-level attributes, "span_resource_attribute" for resource-level attributes.
-
-    * `span` - span
-    * `span_attribute` - span_attribute
-    * `span_resource_attribute` - span_resource_attribute
+     *
+     * * `span` - span
+     * * `span_attribute` - span_attribute
+     * * `span_resource_attribute` - span_resource_attribute
      * @minLength 1
      */
     attribute_type?: TracingSpansValuesRetrieveAttributeType;

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -60,9 +60,9 @@ export const LlmAnalyticsPersonalSpendListQueryParams = /* @__PURE__ */ zod.obje
 
 /**
  * Create a new evaluation run.
-
-This endpoint validates the request and enqueues a Temporal workflow
-to asynchronously execute the evaluation.
+ *
+ * This endpoint validates the request and enqueues a Temporal workflow
+ * to asynchronously execute the evaluation.
  */
 export const EvaluationRunsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -734,19 +734,19 @@ export const LlmAnalyticsEvaluationReportsRunsListQueryParams = /* @__PURE__ */ 
 
 /**
  *
-Generate an AI-powered summary of evaluation results.
-
-This endpoint analyzes evaluation runs and identifies patterns in passing
-and failing evaluations, providing actionable recommendations.
-
-Data is fetched server-side by evaluation ID to ensure data integrity.
-
-**Use Cases:**
-- Understand why evaluations are passing or failing
-- Identify systematic issues in LLM responses
-- Get recommendations for improving response quality
-- Review patterns across many evaluation runs at once
-
+ * Generate an AI-powered summary of evaluation results.
+ *
+ * This endpoint analyzes evaluation runs and identifies patterns in passing
+ * and failing evaluations, providing actionable recommendations.
+ *
+ * Data is fetched server-side by evaluation ID to ensure data integrity.
+ *
+ * **Use Cases:**
+ * - Understand why evaluations are passing or failing
+ * - Identify systematic issues in LLM responses
+ * - Get recommendations for improving response quality
+ * - Review patterns across many evaluation runs at once
+ *
  */
 export const LlmAnalyticsEvaluationSummaryCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -1189,27 +1189,27 @@ export const LlmAnalyticsSentimentCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  *
-Generate an AI-powered summary of an LLM trace or event.
-
-This endpoint analyzes the provided trace/event, generates a line-numbered text
-representation, and uses an LLM to create a concise summary with line references.
-
-**Two ways to use this endpoint:**
-
-1. **By ID (recommended):** Pass `trace_id` or `generation_id` with an optional `date_from`/`date_to`.
-   The backend fetches the data automatically. `summarize_type` is inferred.
-2. **By data:** Pass the full trace/event data blob in `data` with `summarize_type`.
-   This is how the frontend uses it.
-
-**Summary Format:**
-- Title (concise, max 10 words)
-- Mermaid flow diagram showing the main flow
-- 3-10 summary bullets with line references
-- "Interesting Notes" section for failures, successes, or unusual patterns
-- Line references in [L45] or [L45-52] format pointing to relevant sections
-
-The response includes the structured summary, the text representation, and metadata.
-
+ * Generate an AI-powered summary of an LLM trace or event.
+ *
+ * This endpoint analyzes the provided trace/event, generates a line-numbered text
+ * representation, and uses an LLM to create a concise summary with line references.
+ *
+ * **Two ways to use this endpoint:**
+ *
+ * 1. **By ID (recommended):** Pass `trace_id` or `generation_id` with an optional `date_from`/`date_to`.
+ *    The backend fetches the data automatically. `summarize_type` is inferred.
+ * 2. **By data:** Pass the full trace/event data blob in `data` with `summarize_type`.
+ *    This is how the frontend uses it.
+ *
+ * **Summary Format:**
+ * - Title (concise, max 10 words)
+ * - Mermaid flow diagram showing the main flow
+ * - 3-10 summary bullets with line references
+ * - "Interesting Notes" section for failures, successes, or unusual patterns
+ * - Line references in [L45] or [L45-52] format pointing to relevant sections
+ *
+ * The response includes the structured summary, the text representation, and metadata.
+ *
  */
 export const LlmAnalyticsSummarizationCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -515,10 +515,10 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
 
 /**
  * Get a batch export on demand run.
-
-If the underlying batch export run has completed, we return keys to the
-generated file downloads so that users may download them by making a request
-to /download.
+ *
+ * If the underlying batch export run has completed, we return keys to the
+ * generated file downloads so that users may download them by making a request
+ * to /download.
  */
 export const FileDownloadBatchExportsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this batch export run.'),

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -234,9 +234,9 @@ export const OrganizationsProjectsPartialUpdateBody = /* @__PURE__ */ zod
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const DesktopFileSystemListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -254,9 +254,9 @@ export const DesktopFileSystemListQueryParams = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const DesktopFileSystemCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -281,9 +281,9 @@ export const DesktopFileSystemCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * The file tree for the desktop product surface. Reuses all FileSystemViewSet behaviour but is
-scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
-
-Adds per-folder, versioned markdown instructions describing the contents of a folder.
+ * scoped to the "desktop" surface, so its tree is fully isolated from the default "web" tree.
+ *
+ * Adds per-folder, versioned markdown instructions describing the contents of a folder.
  */
 export const DesktopFileSystemRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this file system.'),

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -183,9 +183,9 @@ export const DashboardsCopyTileCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Add a markdown text tile to a dashboard.
-
-Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
-or annotations between insight tiles to give the dashboard structure.
+ *
+ * Text tiles render as markdown blocks on the dashboard — useful as section headings, dividers,
+ * or annotations between insight tiles to give the dashboard structure.
  */
 export const DashboardsCreateTextTileCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
@@ -246,10 +246,10 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Soft-delete a single tile from a dashboard.
-
-Works for text, insight, and button tiles. The underlying Insight, Text, or ButtonTile
-object is preserved — only the dashboard tile is hidden. To delete the entire dashboard,
-use the dashboard delete endpoint instead.
+ *
+ * Works for text, insight, and button tiles. The underlying Insight, Text, or ButtonTile
+ * object is preserved — only the dashboard tile is hidden. To delete the entire dashboard,
+ * use the dashboard delete endpoint instead.
  */
 export const DashboardsDeleteTileParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),

--- a/services/mcp/src/generated/data_warehouse/api.ts
+++ b/services/mcp/src/generated/data_warehouse/api.ts
@@ -10,7 +10,7 @@ import * as zod from 'zod'
 
 /**
  * Returns failed/disabled data pipeline items for the Pipeline status side panel.
-Includes: materializations, syncs, sources, destinations, and transformations.
+ * Includes: materializations, syncs, sources, destinations, and transformations.
  */
 export const DataWarehouseDataHealthIssuesRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -912,9 +912,9 @@ export const ExternalDataSourcesWebhookInfoRetrieveParams = /* @__PURE__ */ zod.
 
 /**
  * Validate CDC prerequisites against a live Postgres connection.
-
-Used by the source wizard to surface ✅/❌ checks before source creation,
-and by the self-managed setup popup to verify user-created publications.
+ *
+ * Used by the source wizard to surface ✅/❌ checks before source creation,
+ * and by the self-managed setup popup to verify user-created publications.
  */
 export const ExternalDataSourcesCheckCdcPrerequisitesCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -1196,7 +1196,7 @@ export const WarehouseSavedQueriesMaterializeCreateBody = /* @__PURE__ */ zod
 
 /**
  * Undo materialization, revert back to the original view.
-(i.e. delete the materialized table and the schedule)
+ * (i.e. delete the materialized table and the schedule)
  */
 export const WarehouseSavedQueriesRevertMaterializationCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this data warehouse saved query.'),

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -4758,10 +4758,10 @@ export const ExperimentsDestroyParams = /* @__PURE__ */ zod.object({
 
 /**
  * Archive an ended experiment.
-
-Hides the experiment from the default list view. The experiment can be
-restored at any time by updating archived=false. Returns 400 if the
-experiment is already archived or has not ended yet.
+ *
+ * Hides the experiment from the default list view. The experiment can be
+ * restored at any time by updating archived=false. Returns 400 if the
+ * experiment is already archived or has not ended yet.
  */
 export const ExperimentsArchiveCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -4774,10 +4774,10 @@ export const ExperimentsArchiveCreateParams = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsDuplicateCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7076,27 +7076,27 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
 
 /**
  * End a running experiment without shipping a variant.
-
-Sets end_date to now and marks the experiment as stopped. The feature
-flag is NOT modified — users continue to see their assigned variants
-and exposure events ($feature_flag_called) continue to be recorded.
-However, only data up to end_date is included in experiment results.
-
-Use this when:
-
-- You want to freeze the results window without changing which variant
-  users see.
-- A variant was already shipped manually via the feature flag UI and
-  the experiment just needs to be marked complete.
-
-The end_date can be adjusted after ending via PATCH if it needs to be
-backdated (e.g. to match when the flag was actually paused).
-
-Other options:
-- Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
-- Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
-
-Returns 400 if the experiment is not running.
+ *
+ * Sets end_date to now and marks the experiment as stopped. The feature
+ * flag is NOT modified — users continue to see their assigned variants
+ * and exposure events ($feature_flag_called) continue to be recorded.
+ * However, only data up to end_date is included in experiment results.
+ *
+ * Use this when:
+ *
+ * - You want to freeze the results window without changing which variant
+ *   users see.
+ * - A variant was already shipped manually via the feature flag UI and
+ *   the experiment just needs to be marked complete.
+ *
+ * The end_date can be adjusted after ending via PATCH if it needs to be
+ * backdated (e.g. to match when the flag was actually paused).
+ *
+ * Other options:
+ * - Use ship_variant to end the experiment AND roll out a single variant to 100%% of users.
+ * - Use pause to deactivate the flag without ending the experiment (stops variant assignment but does not freeze results).
+ *
+ * Returns 400 if the experiment is not running.
  */
 export const ExperimentsEndCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7126,11 +7126,11 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Launch a draft experiment.
-
-Validates the experiment is in draft state, activates its linked feature flag,
-sets start_date to the current server time, and transitions the experiment to running.
-Returns 400 if the experiment has already been launched or if the feature flag
-configuration is invalid (e.g. missing "control" variant or fewer than 2 variants).
+ *
+ * Validates the experiment is in draft state, activates its linked feature flag,
+ * sets start_date to the current server time, and transitions the experiment to running.
+ * Returns 400 if the experiment has already been launched or if the feature flag
+ * configuration is invalid (e.g. missing "control" variant or fewer than 2 variants).
  */
 export const ExperimentsLaunchCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7143,12 +7143,12 @@ export const ExperimentsLaunchCreateParams = /* @__PURE__ */ zod.object({
 
 /**
  * Pause a running experiment.
-
-Deactivates the linked feature flag so it is no longer returned by the
-/decide endpoint. Users fall back to the application default (typically
-the control experience), and no new exposure events are recorded (i.e.
-$feature_flag_called is not fired).
-Returns 400 if the experiment is not running or is already paused.
+ *
+ * Deactivates the linked feature flag so it is no longer returned by the
+ * /decide endpoint. Users fall back to the application default (typically
+ * the control experience), and no new exposure events are recorded (i.e.
+ * $feature_flag_called is not fired).
+ * Returns 400 if the experiment is not running or is already paused.
  */
 export const ExperimentsPauseCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7161,14 +7161,14 @@ export const ExperimentsPauseCreateParams = /* @__PURE__ */ zod.object({
 
 /**
  * Reset an experiment back to draft state.
-
-Clears start/end dates, conclusion, and archived flag. The feature
-flag is left unchanged — users continue to see their assigned variants.
-
-Previously collected events still exist but won't be included in
-results unless the start date is manually adjusted after re-launch.
-
-Returns 400 if the experiment is already in draft state.
+ *
+ * Clears start/end dates, conclusion, and archived flag. The feature
+ * flag is left unchanged — users continue to see their assigned variants.
+ *
+ * Previously collected events still exist but won't be included in
+ * results unless the start date is manually adjusted after re-launch.
+ *
+ * Returns 400 if the experiment is already in draft state.
  */
 export const ExperimentsResetCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7181,11 +7181,11 @@ export const ExperimentsResetCreateParams = /* @__PURE__ */ zod.object({
 
 /**
  * Resume a paused experiment.
-
-Reactivates the linked feature flag so it is returned by /decide again.
-Users are re-bucketed deterministically into the same variants they had
-before the pause, and exposure tracking resumes.
-Returns 400 if the experiment is not running or is not paused.
+ *
+ * Reactivates the linked feature flag so it is returned by /decide again.
+ * Users are re-bucketed deterministically into the same variants they had
+ * before the pause, and exposure tracking resumes.
+ * Returns 400 if the experiment is not running or is not paused.
  */
 export const ExperimentsResumeCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7198,25 +7198,25 @@ export const ExperimentsResumeCreateParams = /* @__PURE__ */ zod.object({
 
 /**
  * Ship a variant and (optionally) end the experiment.
-
-Updates the feature flag so the selected variant gets 100% of the variant
-distribution. By default, existing release conditions on the flag are preserved
-untouched — the variant is served only to users who already match them. Pass
-``release_to_everyone: true`` to also prepend a catch-all release condition
-that rolls the variant out to 100% of users (overrides any existing release
-conditions on the flag).
-
-Can be called on both running and stopped experiments. If the experiment is
-still running, it will also be ended (end_date set and status marked as stopped).
-If the experiment has already ended, only the flag is rewritten - this supports
-the "end first, ship later" workflow.
-
-If an approval policy requires review before changes on the flag take effect,
-the API returns 409 with a change_request_id. The experiment is NOT ended until
-the change request is approved and the user retries.
-
-Returns 400 if the experiment is in draft state, the variant_key is not found
-on the flag, or the experiment has no linked feature flag.
+ *
+ * Updates the feature flag so the selected variant gets 100% of the variant
+ * distribution. By default, existing release conditions on the flag are preserved
+ * untouched — the variant is served only to users who already match them. Pass
+ * ``release_to_everyone: true`` to also prepend a catch-all release condition
+ * that rolls the variant out to 100% of users (overrides any existing release
+ * conditions on the flag).
+ *
+ * Can be called on both running and stopped experiments. If the experiment is
+ * still running, it will also be ended (end_date set and status marked as stopped).
+ * If the experiment has already ended, only the flag is rewritten - this supports
+ * the "end first, ship later" workflow.
+ *
+ * If an approval policy requires review before changes on the flag take effect,
+ * the API returns 409 with a change_request_id. The experiment is NOT ended until
+ * the change request is approved and the user retries.
+ *
+ * Returns 400 if the experiment is in draft state, the variant_key is not found
+ * on the flag, or the experiment has no linked feature flag.
  */
 export const ExperimentsShipVariantCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7255,10 +7255,10 @@ export const ExperimentsShipVariantCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsTimeseriesResultsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7284,9 +7284,9 @@ export const ExperimentsTimeseriesResultsRetrieveQueryParams = /* @__PURE__ */ z
 
 /**
  * Unarchive an archived experiment.
-
-Restores the experiment to the default list view. Returns 400 if the
-experiment is not currently archived.
+ *
+ * Restores the experiment to the default list view. Returns 400 if the
+ * experiment is not currently archived.
  */
 export const ExperimentsUnarchiveCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this experiment.'),
@@ -7299,10 +7299,10 @@ export const ExperimentsUnarchiveCreateParams = /* @__PURE__ */ zod.object({
 
 /**
  * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
-
-This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
-on serializer methods and converts them into proper HTTP 409 Conflict responses with
-change request details.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
  */
 export const ExperimentsStatsRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -42,8 +42,8 @@ export const FeatureFlagsCopyFlagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -79,8 +79,8 @@ export const FeatureFlagsListQueryParams = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -388,8 +388,8 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
@@ -402,8 +402,8 @@ export const FeatureFlagsRetrieveParams = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
@@ -724,8 +724,8 @@ export const FeatureFlagsDestroyParams = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsActivityRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
@@ -763,8 +763,8 @@ export const FeatureFlagsDependentFlagsListParams = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsStatusRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
@@ -777,10 +777,10 @@ export const FeatureFlagsStatusRetrieveParams = /* @__PURE__ */ zod.object({
 
 /**
  * Test feature flag evaluation against a specific user at an optional point in time.
-
-This endpoint allows testing how a feature flag would evaluate for a specific user,
-optionally at a historical timestamp. When a timestamp is provided, both the flag
-conditions and person properties are evaluated as they existed at that time.
+ *
+ * This endpoint allows testing how a feature flag would evaluate for a specific user,
+ * optionally at a historical timestamp. When a timestamp is provided, both the flag
+ * conditions and person properties are evaluated as they existed at that time.
  */
 export const FeatureFlagsTestEvaluationCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
@@ -811,15 +811,15 @@ export const FeatureFlagsTestEvaluationCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Bulk delete feature flags by filter criteria or explicit IDs.
-
-Accepts either:
-- {"filters": {...}} - Same filter params as list endpoint (search, active, type, etc.)
-- {"ids": [...]} - Explicit list of flag IDs (no limit)
-
-Returns same format as bulk_delete for UI compatibility.
-
-Uses bulk operations for efficiency: database updates are batched and cache
-invalidation happens once at the end rather than per-flag.
+ *
+ * Accepts either:
+ * - {"filters": {...}} - Same filter params as list endpoint (search, active, type, etc.)
+ * - {"ids": [...]} - Explicit list of flag IDs (no limit)
+ *
+ * Returns same format as bulk_delete for UI compatibility.
+ *
+ * Uses bulk operations for efficiency: database updates are batched and cache
+ * invalidation happens once at the end rather than per-flag.
  */
 export const FeatureFlagsBulkDeleteCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -879,7 +879,7 @@ export const FeatureFlagsBulkDeleteCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Get feature flag keys by IDs.
-Accepts a list of feature flag IDs and returns a mapping of ID to key.
+ * Accepts a list of feature flag IDs and returns a mapping of ID to key.
  */
 export const FeatureFlagsBulkKeysRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -900,22 +900,22 @@ export const FeatureFlagsBulkKeysRetrieveBody = /* @__PURE__ */ zod.object({
 
 /**
  * Bulk update tags on multiple objects.
-
-PAT access: this action has no ``required_scopes=`` on the decorator —
-inheriting viewsets must add ``"bulk_update_tags"`` to their
-``scope_object_write_actions`` list to accept personal API keys.
-Without that opt-in, ``APIScopePermission`` rejects PAT requests with
-"This action does not support personal API key access". Done per-viewset
-so granting ``<scope>:write`` for one resource doesn't leak access to
-sibling resources that share this mixin.
-
-Accepts:
-- {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
-
-Actions:
-- "add": Add tags to existing tags on each object
-- "remove": Remove specific tags from each object
-- "set": Replace all tags on each object with the provided list
+ *
+ * PAT access: this action has no ``required_scopes=`` on the decorator —
+ * inheriting viewsets must add ``"bulk_update_tags"`` to their
+ * ``scope_object_write_actions`` list to accept personal API keys.
+ * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
+ * "This action does not support personal API key access". Done per-viewset
+ * so granting ``<scope>:write`` for one resource doesn't leak access to
+ * sibling resources that share this mixin.
+ *
+ * Accepts:
+ * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
+ *
+ * Actions:
+ * - "add": Add tags to existing tags on each object
+ * - "remove": Remove specific tags from each object
+ * - "set": Replace all tags on each object with the provided list
  */
 export const FeatureFlagsBulkUpdateTagsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -943,8 +943,8 @@ export const FeatureFlagsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsEvaluationReasonsRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -966,8 +966,8 @@ export const FeatureFlagsEvaluationReasonsRetrieveQueryParams = /* @__PURE__ */ 
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsMyFlagsRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -988,8 +988,8 @@ export const FeatureFlagsMyFlagsRetrieveQueryParams = /* @__PURE__ */ zod.object
 
 /**
  * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
-
-If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ *
+ * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
 export const FeatureFlagsUserBlastRadiusCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -10,11 +10,11 @@ import * as zod from 'zod'
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -118,11 +118,11 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -166,11 +166,11 @@ export const InsightsCreateBody = /* @__PURE__ */ zod
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod
@@ -223,11 +223,11 @@ export const InsightsRetrieveQueryParams = /* @__PURE__ */ zod.object({
 
 /**
  * DRF ViewSet mixin that gates coalesced responses behind permission checks.
-
-The QueryCoalescingMiddleware attaches cached response data to
-request.META["_coalesced_response"] for followers. This mixin runs DRF's
-initial() (auth + permissions + throttling) before returning the
-cached response, ensuring the request is authorized.
+ *
+ * The QueryCoalescingMiddleware attaches cached response data to
+ * request.META["_coalesced_response"] for followers. This mixin runs DRF's
+ * initial() (auth + permissions + throttling) before returning the
+ * cached response, ensuring the request is authorized.
  */
 export const InsightsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -63,20 +63,20 @@ export const SignalsReportsRetrieveParams = /* @__PURE__ */ zod.object({
 
 /**
  * Transition a report to a new state. The model validates allowed transitions.
-
-The request body is validated by SignalReportStateRequestSerializer — only the
-fields it declares (state, dismissal_reason, dismissal_note, snooze_for) are read,
-and only snooze_for is ever forwarded to transition_to. Any other key is ignored,
-so internal transition_to kwargs (reset_weight, error, ...) can't be injected.
-
-Body: {
-    "state": "suppressed" | "potential",
-    # Optional dismissal feedback (honored when state == "suppressed" or "potential"):
-    "dismissal_reason": "<any string code, owned by the caller>",
-    "dismissal_note": "free-form text",
-    # Optional, only honored for state == "potential":
-    "snooze_for": <number of additional signals before re-promotion>,
-}
+ *
+ * The request body is validated by SignalReportStateRequestSerializer — only the
+ * fields it declares (state, dismissal_reason, dismissal_note, snooze_for) are read,
+ * and only snooze_for is ever forwarded to transition_to. Any other key is ignored,
+ * so internal transition_to kwargs (reset_weight, error, ...) can't be injected.
+ *
+ * Body: {
+ *     "state": "suppressed" | "potential",
+ *     # Optional dismissal feedback (honored when state == "suppressed" or "potential"):
+ *     "dismissal_reason": "<any string code, owned by the caller>",
+ *     "dismissal_note": "free-form text",
+ *     # Optional, only honored for state == "potential":
+ *     "snooze_for": <number of additional signals before re-promotion>,
+ * }
  */
 export const SignalsReportsStateCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this signal report.'),

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -1702,15 +1702,15 @@ export const SurveysResponsesListQueryParams = /* @__PURE__ */ zod.object({
 
 /**
  * Get survey response statistics for a specific survey.
-
-Args:
-    date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
-    date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
-    exclude_archived: Optional boolean to exclude archived responses (default: false, includes archived)
-    include_per_question_stats: Optional boolean to include per-question response counts and distributions
-
-Returns:
-    Survey statistics including event counts, unique respondents, and conversion rates
+ *
+ * Args:
+ *     date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
+ *     date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
+ *     exclude_archived: Optional boolean to exclude archived responses (default: false, includes archived)
+ *     include_per_question_stats: Optional boolean to include per-question response counts and distributions
+ *
+ * Returns:
+ *     Survey statistics including event counts, unique respondents, and conversion rates
  */
 export const SurveysStatsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
@@ -1784,13 +1784,13 @@ export const SurveysSummarizeResponsesCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Get aggregated response statistics across all surveys.
-
-Args:
-    date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
-    date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
-
-Returns:
-    Aggregated statistics across all surveys including total counts and rates
+ *
+ * Args:
+ *     date_from: Optional ISO timestamp for start date (e.g. 2024-01-01T00:00:00Z)
+ *     date_to: Optional ISO timestamp for end date (e.g. 2024-01-31T23:59:59Z)
+ *
+ * Returns:
+ *     Aggregated statistics across all surveys including total counts and rates
  */
 export const SurveysGlobalStatsRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod

--- a/services/mcp/src/generated/visual_review/api.ts
+++ b/services/mcp/src/generated/visual_review/api.ts
@@ -70,9 +70,9 @@ export const VisualReviewRunsRetrieveParams = /* @__PURE__ */ zod.object({
 
 /**
  * Mark snapshots reviewed (DB only).
-
-Records the per-snapshot "Accept change" decision. Does not commit the baseline
-or change the GitHub gate — call finalize to ship the run.
+ *
+ * Records the per-snapshot "Accept change" decision. Does not commit the baseline
+ * or change the GitHub gate — call finalize to ship the run.
  */
 export const VisualReviewRunsApproveCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string(),
@@ -102,11 +102,11 @@ export const VisualReviewRunsApproveCreateBody = /* @__PURE__ */ zod.object({
 
 /**
  * Finalize a fully-reviewed run: commit the approved baseline and green the gate.
-
-Commits exactly the snapshots approved in the DB (tolerated ones keep their baseline)
-and only succeeds once every changed/new snapshot is resolved. With approve_all=true,
-any still-pending changed/new snapshot is approved first. With commit_to_github=false
-the server returns the signed baseline YAML instead of committing it.
+ *
+ * Commits exactly the snapshots approved in the DB (tolerated ones keep their baseline)
+ * and only succeeds once every changed/new snapshot is resolved. With approve_all=true,
+ * any still-pending changed/new snapshot is approved first. With commit_to_github=false
+ * the server returns the signed baseline YAML instead of committing it.
  */
 export const VisualReviewRunsFinalizeCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string(),

--- a/tools/openapi-codegen/package.json
+++ b/tools/openapi-codegen/package.json
@@ -11,7 +11,7 @@
         "test": "vitest run"
     },
     "dependencies": {
-        "orval": "8.9.1"
+        "orval": "8.14.0"
     },
     "devDependencies": {
         "vitest": "^3.0.0"


### PR DESCRIPTION
## Problem

PostHog pins Orval at 8.9.1. The dashboard widget config SSOT work ([dw-09](https://github.com/PostHog/posthog/pull/61945)) needs newer Orval behavior to emit **reusable per-component Zod schemas** from OpenAPI `$ref`s instead of inlining polymorphic response trees into unusable operation-prefixed exports.

Upstream context we're targeting:

- [orval-labs/orval#2535](https://github.com/orval-labs/orval/issues/2535) — Zod generator recursively inlines `#/components/schemas/*` into monolithic operation schemas (our exact pain on 8.9.1 catalog slice)
- [orval-labs/orval#3449](https://github.com/orval-labs/orval/pull/3449) — `generateReusableSchemas` opt-in flag (landed **8.13**): one export per component `$ref`, referenced everywhere instead of inlined
- [orval-labs/orval#3460](https://github.com/orval-labs/orval/issues/3460), [#3478](https://github.com/orval-labs/orval/issues/3478), [#3485](https://github.com/orval-labs/orval/pull/3485) — follow-on `generateReusableSchemas` fixes in **8.14** (missing schema files, response-wrapper name collisions)

Still-open edge case to be aware of (does not block this bump): [orval-labs/orval#1316](https://github.com/orval-labs/orval/issues/1316) — polymorphic `oneOf`/discriminator handling when nested deep in a response property. dw-09 works around this with `generateReusableSchemas` + a pydantic OpenAPI inject for `DashboardWidgetConfig.oneOf`.

This PR is **infra-only** — version bump + regen — split out of dw-09 so reviewers aren't wading through 140+ generated files mixed with widget product changes.

## Changes

- Bump `orval` in `tools/openapi-codegen` from 8.9.1 → 8.14.0
- Regenerate all OpenAPI fetch/Zod/MCP outputs (`hogli build:openapi`)

No changes to our Orval invocation in `frontend/bin/generate-openapi-types.mjs`:

- `client: 'fetch'` + `client: 'zod'` (not react-query)
- Zod: `body: true`, `response: false`
- `generateReusableSchemas` **not** enabled globally (opt-in on dw-09 widget catalog job only)

### Upgrade safety check (8.9.1 → 8.14)

| Area | Risk assessed | Finding |
| --- | --- | --- |
| Labeled breaking changes | [8.10 milestone](https://github.com/orval-labs/orval/issues?q=is%3Aclosed+milestone%3A8.10.0+label%3A%22breaking+change%22) | **react-query only** (non-GET query key namespacing, `useQuery` on POST). We don't use Orval's query client. |
| Existing Zod codegen | Side-by-side spike on dashboards op slice (`batch_create` + `list`) with identical config | **Zod output byte-identical** aside from `Generated by orval v8.x` header; same export count, same `*Default = null` pattern (`fixNullDefaults` postprocessor still applies). |
| Existing fetch codegen | Same slice | +12 lines: JSDoc bullet formatting + some inline enums extracted to named consts (e.g. `WidgetDateRangeApiDateFrom`). Additive typing, no removed exports. |
| `generateReusableSchemas` | Opt-in, 8.13+ | **Not turned on** in this PR — no behavior change until dw-09 enables it for widget config Zod. |
| Full regen | `hogli build:openapi` on branch | Completed successfully; large git diff expected (cosmetic + enum extraction fleet-wide). |

## How did you test this code?

- `hogli build:openapi` (full regen)
- `pnpm --filter @posthog/openapi-codegen test` (52 tests)
- Manual spike: Orval 8.9.1 vs 8.14 on filtered dashboards OpenAPI slice (fetch + zod, our exact override config)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — dependency bump only. dw-09 updates widget codegen docs when it lands `generateReusableSchemas` on the catalog slice.

## 🤖 Agent context

Agent-assisted. Split from [dw-09](https://github.com/PostHog/posthog/pull/61945) after spiking Orval on the widget catalog slice: 8.9.1 inlined polymorphic `config_schema` into `dashboardsWidgetCatalogRetrieveResponseResultsItemOneConfigSchemaOne…`; 8.14 + `generateReusableSchemas` emits proper `ErrorTrackingListWidgetConfig` reusable schemas. Widget-specific `DashboardWidgetConfig` `oneOf` inject stays on dw-09 (depends on pydantic stub serializers there).