### PR TITLE
fix(property-vals): distinct read from the property values table

### DIFF
--- a/posthog/hogql_queries/test/test_property_values_query_runner.py
+++ b/posthog/hogql_queries/test/test_property_values_query_runner.py
@@ -275,7 +275,7 @@ class TestPropertyValuesQueryRunnerAggregatedTable(ClickhouseTestMixin, APIBaseT
             rows,
         )
 
-    def test_values_ordered_by_summed_count(self):
+    def test_returns_distinct_values(self):
         now = datetime.now()
         self._insert_rows(
             [
@@ -287,7 +287,7 @@ class TestPropertyValuesQueryRunnerAggregatedTable(ClickhouseTestMixin, APIBaseT
 
         with self._flag_on():
             results = self._run(PropertyValuesQuery(property_type=PropertyType.EVENT, property_key="browser"))
-        assert [r.name for r in results] == ["Chrome", "Firefox"]
+        assert {r.name for r in results} == {"Chrome", "Firefox"}
         assert results[0].count is None
 
     @parameterized.expand(

--- a/posthog/queries/property_values.py
+++ b/posthog/queries/property_values.py
@@ -80,16 +80,18 @@ def get_property_values_for_key(
 
 
 # property_values_distributed routes to the aggregated table on the aux cluster.
+# DISTINCT, not GROUP BY + sum(property_count): lets LIMIT early-terminate on
+# high-cardinality keys instead of reading every value to rank by count. Mirrors the
+# events-scan semantics (unordered distinct values, shortest-first when searching).
 SELECT_EVENT_PROPERTY_VALUES_FROM_AGGREGATED_TABLE_SQL = """
-SELECT property_value, sum(property_count) AS prop_count
+SELECT DISTINCT property_value
 FROM property_values_distributed
 WHERE team_id = %(team_id)s
     AND property_type = 'event'
     AND property_key = %(key)s
     AND last_seen >= now() - INTERVAL 7 DAY
     {value_filter}
-GROUP BY property_value
-ORDER BY prop_count DESC
+{order_by_clause}
 LIMIT 10
 """
 
@@ -102,13 +104,17 @@ def get_event_property_values_from_aggregated_table(key: str, team: Team, value:
 
         params: dict = {"team_id": team.pk, "key": key}
         value_filter = ""
+        order_by_clause = ""
         if value:
             escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
             value_filter = "AND lower(property_value) LIKE %(value)s"
             params["value"] = f"%{escaped.lower()}%"
+            order_by_clause = "ORDER BY length(property_value)"
 
         result = insight_sync_execute(
-            SELECT_EVENT_PROPERTY_VALUES_FROM_AGGREGATED_TABLE_SQL.format(value_filter=value_filter),
+            SELECT_EVENT_PROPERTY_VALUES_FROM_AGGREGATED_TABLE_SQL.format(
+                value_filter=value_filter, order_by_clause=order_by_clause
+            ),
             params,
             query_type="get_event_property_values_from_aggregated_table",
             team_id=team.pk,


### PR DESCRIPTION
## Problem

The property-value autocomplete read path queries the aggregated `property_values` table with `GROUP BY property_value, sum(property_count) ... ORDER BY prop_count DESC LIMIT 10`. Ranking by count means the engine must read every value for a key before `LIMIT` applies, with no early termination. 

On high-cardinality keys this is pathological: `$current_url` for team 2 has ~11M distinct values, so each autocomplete request reads ~11M rows (~1.5 GiB).

A controlled prod benchmark on `$current_url` (5 runs each, p50, no-search dropdown case):

| query | p50 | bytes | rows |
|---|---|---|---|
| events `DISTINCT` (old path) | 575 ms | 169 MiB | 2.7M |
| table `DISTINCT` (this PR) | 164 ms | 231 MiB | 1.3M |
| table count-ranked (before this pr) | 896 ms | 1.94 GiB | 11.4M |

The count-ranked table read was slower than both the equivalent distinct read (5.5x) and the events scan it replaced. The count is never returned to the client (`_format_table_results` reads only the value); it existed solely to order results.

## Changes

Switch the table query to `SELECT DISTINCT property_value ... LIMIT 10`, dropping `GROUP BY` / `sum(property_count)` / `ORDER BY count`. This matches the semantics of the events-scan path it replaces:

- `DISTINCT` still deduplicates values that span unmerged `AggregatingMergeTree` parts.
- With no search term there is no `ORDER BY`, so `LIMIT 10` early-terminates.
- When searching, `ORDER BY length(property_value)` is added, exactly as the events query did (shortest match first).

Result quality matches the prior events behavior (unordered distinct values). We lose frequency ordering, which was never surfaced to the client.

## How did you test this code?

I am an agent (Claude Code). Ran the aggregated-table runner test class locally:

```
pytest posthog/hogql_queries/test/test_property_values_query_runner.py::TestPropertyValuesQueryRunnerAggregatedTable
# 15 passed
```

It covers dedup across rows, the search and wildcard-escaping cases, last-seen and team/type scoping, JSON-array flattening, and the events-scan fallbacks. The count-ordering test was retargeted to assert the distinct value set. Ruff and ty ran clean via lint-staged. The benchmark table above came from prod-us query_log; no manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

Authored with Claude Code at the PR owner's request, after diagnosing why the table read path was not delivering the speedup an earlier dev benchmark had suggested.

- The original dev benchmark compared a non-ranking table query against a JSON-parsing events baseline on a single-granule table, which is why it showed orders of magnitude. Production runs a count-ranking query at real cardinality, which is a different and much heavier query.
- EXPLAIN confirmed the primary key and ngram skip index are healthy; the cost is the `ORDER BY count` forcing a full per-key read.
- Considered bounding values per key with the aggregator top-K cap, but chose the query change: it takes effect immediately (no waiting for existing rows to age out via the 30-day TTL), needs no aggregator change, and keeps every value searchable.
