### PR TITLE
feat(llma): move skills to top-level /skills url

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -189,8 +189,8 @@ export const productRoutes: Record<string, [string, string]> = {
     '/ai-evals/evaluations/:id': ['AIObservabilityEvaluation', 'aiObservabilityEvaluation'],
     '/prompt-management/prompts': ['AIObservabilityPrompts', 'aiObservabilityPrompts'],
     '/prompt-management/prompts/:name': ['AIObservabilityPrompt', 'aiObservabilityPrompt'],
-    '/prompt-management/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
-    '/prompt-management/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
+    '/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
+    '/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
     '/business-knowledge': ['BusinessKnowledge', 'businessKnowledge'],
     '/transformations': ['Transformations', 'transformations'],
     '/event-filtering': ['EventFiltering', 'eventFiltering'],
@@ -385,6 +385,10 @@ export const productRedirects: Record<
         combineUrl(urls.aiObservabilityPrompts(), searchParams, hashParams).url,
     '/llm-analytics/prompts/:name': (params, searchParams, hashParams) =>
         combineUrl(urls.aiObservabilityPrompt(params.name), searchParams, hashParams).url,
+    '/prompt-management/skills': (_params, searchParams, hashParams) =>
+        combineUrl(urls.aiObservabilitySkills(), searchParams, hashParams).url,
+    '/prompt-management/skills/:name': (params, searchParams, hashParams) =>
+        combineUrl(urls.aiObservabilitySkill(params.name), searchParams, hashParams).url,
     '/llm-analytics/skills': (_params, searchParams, hashParams) =>
         combineUrl(urls.aiObservabilitySkills(), searchParams, hashParams).url,
     '/llm-analytics/skills/:name': (params, searchParams, hashParams) =>
@@ -845,14 +849,14 @@ export const productUrls = {
     aiObservabilityEvaluation: (id: string): string => `/ai-evals/evaluations/${id}`,
     aiObservabilityPrompts: (): string => '/prompt-management/prompts',
     aiObservabilityPrompt: (name: string): string => `/prompt-management/prompts/${name}`,
-    aiObservabilitySkills: (): string => '/prompt-management/skills',
+    aiObservabilitySkills: (): string => '/skills',
     aiObservabilitySkill: (
         name: string,
         params?: {
             file?: string
             version?: number
         }
-    ): string => combineUrl(`/prompt-management/skills/${name}`, params).url,
+    ): string => combineUrl(`/skills/${name}`, params).url,
     aiObservabilityClusters: (runId?: string): string =>
         runId ? `/ai-observability/clusters/${encodeURIComponent(runId)}` : '/ai-observability/clusters',
     aiObservabilityCluster: (runId: string, clusterId: number | string): string =>

--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -38,7 +38,7 @@ describe('LLM analytics URL split', () => {
         expect(urls.aiObservabilityTags()).toBe('/ai-evals/taggers')
         expect(urls.aiObservabilityEvaluations()).toBe('/ai-evals/evaluations')
         expect(urls.aiObservabilityPrompts()).toBe('/prompt-management/prompts')
-        expect(urls.aiObservabilitySkills()).toBe('/prompt-management/skills')
+        expect(urls.aiObservabilitySkills()).toBe('/skills')
     })
 
     it('redirects legacy LLM analytics URLs to their new product areas', () => {
@@ -63,9 +63,8 @@ describe('LLM analytics URL split', () => {
         expect(redirectUrl('/llm-analytics/prompts/:name', { name: 'prompt-1' })).toBe(
             '/prompt-management/prompts/prompt-1'
         )
-        expect(redirectUrl('/llm-analytics/skills/:name', { name: 'skill-1' })).toBe(
-            '/prompt-management/skills/skill-1'
-        )
+        expect(redirectUrl('/llm-analytics/skills/:name', { name: 'skill-1' })).toBe('/skills/skill-1')
+        expect(redirectUrl('/prompt-management/skills/:name', { name: 'skill-1' })).toBe('/skills/skill-1')
     })
 
     it('redirects AI observability settings to the project-level BYOK setting', () => {

--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -63,7 +63,9 @@ describe('LLM analytics URL split', () => {
         expect(redirectUrl('/llm-analytics/prompts/:name', { name: 'prompt-1' })).toBe(
             '/prompt-management/prompts/prompt-1'
         )
+        expect(redirectUrl('/llm-analytics/skills', {})).toBe('/skills')
         expect(redirectUrl('/llm-analytics/skills/:name', { name: 'skill-1' })).toBe('/skills/skill-1')
+        expect(redirectUrl('/prompt-management/skills', {})).toBe('/skills')
         expect(redirectUrl('/prompt-management/skills/:name', { name: 'skill-1' })).toBe('/skills/skill-1')
     })
 

--- a/products/ai_observability/frontend/skills/llmSkillLogic.ts
+++ b/products/ai_observability/frontend/skills/llmSkillLogic.ts
@@ -557,7 +557,7 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
     }),
 
     urlToAction(({ actions, values }) => ({
-        '/prompt-management/skills/:name': (_, __, ___, { method }) => {
+        '/skills/:name': (_, __, ___, { method }) => {
             if (method === 'PUSH' && values.isNewSkill) {
                 actions.setSkill(DEFAULT_SKILL_FORM_VALUES)
                 actions.resetSkillForm(DEFAULT_SKILL_FORM_VALUES)

--- a/products/ai_observability/manifest.tsx
+++ b/products/ai_observability/manifest.tsx
@@ -181,8 +181,8 @@ export const manifest: ProductManifest = {
         '/ai-evals/evaluations/:id': ['AIObservabilityEvaluation', 'aiObservabilityEvaluation'],
         '/prompt-management/prompts': ['AIObservabilityPrompts', 'aiObservabilityPrompts'],
         '/prompt-management/prompts/:name': ['AIObservabilityPrompt', 'aiObservabilityPrompt'],
-        '/prompt-management/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
-        '/prompt-management/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
+        '/skills': ['AIObservabilitySkills', 'aiObservabilitySkills'],
+        '/skills/:name': ['AIObservabilitySkill', 'aiObservabilitySkill'],
     },
     redirects: {
         '/ai-observability': (_params, searchParams, hashParams) =>
@@ -286,6 +286,10 @@ export const manifest: ProductManifest = {
             combineUrl(urls.aiObservabilityPrompts(), searchParams, hashParams).url,
         '/llm-analytics/prompts/:name': (params, searchParams, hashParams) =>
             combineUrl(urls.aiObservabilityPrompt(params.name), searchParams, hashParams).url,
+        '/prompt-management/skills': (_params, searchParams, hashParams) =>
+            combineUrl(urls.aiObservabilitySkills(), searchParams, hashParams).url,
+        '/prompt-management/skills/:name': (params, searchParams, hashParams) =>
+            combineUrl(urls.aiObservabilitySkill(params.name), searchParams, hashParams).url,
         '/llm-analytics/skills': (_params, searchParams, hashParams) =>
             combineUrl(urls.aiObservabilitySkills(), searchParams, hashParams).url,
         '/llm-analytics/skills/:name': (params, searchParams, hashParams) =>
@@ -356,9 +360,9 @@ export const manifest: ProductManifest = {
         aiObservabilityEvaluation: (id: string): string => `/ai-evals/evaluations/${id}`,
         aiObservabilityPrompts: (): string => '/prompt-management/prompts',
         aiObservabilityPrompt: (name: string): string => `/prompt-management/prompts/${name}`,
-        aiObservabilitySkills: (): string => '/prompt-management/skills',
+        aiObservabilitySkills: (): string => '/skills',
         aiObservabilitySkill: (name: string, params?: { file?: string; version?: number }): string =>
-            combineUrl(`/prompt-management/skills/${name}`, params).url,
+            combineUrl(`/skills/${name}`, params).url,
         aiObservabilityClusters: (runId?: string): string =>
             runId ? `/ai-observability/clusters/${encodeURIComponent(runId)}` : '/ai-observability/clusters',
         aiObservabilityCluster: (runId: string, clusterId: number | string): string =>


### PR DESCRIPTION
## Problem

Skills currently live under the AI observability "prompt management" area, so they're served at `/prompt-management/skills`. We want to break skills out into its own standalone product. Rather than do the full extraction in one large PR (frontend scenes, backend models, DB tables, RBAC scopes), we're starting with the user-facing URL and moving the rest incrementally.

## Changes

First step: serve the skills scenes at a top-level `/skills` URL instead of nesting them under `/prompt-management/skills`.

- `manifest.tsx`: routes and URL builders (`aiObservabilitySkills`, `aiObservabilitySkill`) now point at `/skills` and `/skills/:name`.
- Added redirects so existing links keep working — both `/prompt-management/skills(/:name)` and the older `/llm-analytics/skills(/:name)` now redirect to `/skills(/:name)`.
- `llmSkillLogic.ts`: `urlToAction` pattern updated to `/skills/:name`.
- Regenerated `frontend/src/products.tsx` from the manifest.
- Updated URL/redirect assertions in `aiObservabilityLogic.test.ts`.

Code still lives in the `ai_observability` product and the backend API (`/llm_skills`) is unchanged — those move in follow-up PRs as we extract skills into its own product directory.

No screenshots: this is a routing change only, the scenes render identically.

## How did you test this code?

I'm an agent (Claude Code). I ran the affected frontend test suite locally — `products/ai_observability/frontend/aiObservabilityLogic.test.ts` (28 passing), which covers the `urls.aiObservabilitySkills()` value and the legacy-URL redirects. I did not perform manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus 4.8) at Andy's direction. We scoped this deliberately as "URLs first, then the full move bit by bit" — keeping this PR to a pure routing change rather than physically relocating frontend/backend code or touching DB tables and RBAC scopes (which would need a `SeparateDatabaseAndState` migration and is riskier). Backward-compat redirects were added for both the current `/prompt-management/skills` path and the older `/llm-analytics/skills` path so no existing links break. Requires human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
