### PR TITLE
chore(capture): add tests for capture_v1_internal routing dispatch

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -304,7 +304,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(message["event"], "Group notebook creation failed")
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_create_group_missing_group_properties(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,
@@ -336,7 +336,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         mock_capture.assert_called_once()
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     @pytest.mark.flaky(reruns=2)
     def test_create_group(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
@@ -424,7 +424,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
             prop_name = result["detail"]["name"]
             self.assertEqual(result["detail"]["changes"][0]["after"], group_properties[prop_name])
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_create_group_duplicated_group_key(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,
@@ -461,7 +461,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         mock_capture.assert_not_called()
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_create_group_missing_group_key(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,
@@ -491,7 +491,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         mock_capture.assert_not_called()
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_create_group_missing_group_type_index(self, mock_capture):
         response = self.client.post(
             f"/api/projects/{self.team.id}/groups",
@@ -515,7 +515,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         mock_capture.assert_not_called()
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     @pytest.mark.flaky(reruns=2)
     def test_group_property_crud_add_success(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
@@ -600,7 +600,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["after"], "technology")
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     @pytest.mark.flaky(reruns=2)
     def test_group_property_crud_update_success(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
@@ -724,7 +724,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 404)
 
     @freeze_time("2021-05-02")
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     @pytest.mark.flaky(reruns=2)
     def test_group_property_crud_delete_success(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
@@ -859,7 +859,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 400)
 
     @freeze_time("2021-05-02")
-    @patch("ee.clickhouse.views.groups.capture_internal")
+    @patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_delete_property_nonexistent_property(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         create_group_type_mapping_without_created_at(
@@ -904,7 +904,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, 400)
 
     @freeze_time("2021-05-02")
-    @patch("ee.clickhouse.views.groups.capture_internal")
+    @patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_get_group_activities_success(self, mock_capture):
         # Mock the response to return a 200 OK
         mock_capture.return_value = mock.MagicMock(status_code=200)
@@ -944,7 +944,7 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.json()["results"][0]["detail"]["changes"][0]["action"], "changed")
 
     @freeze_time("2021-05-02")
-    @patch("ee.clickhouse.views.groups.capture_internal")
+    @patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_get_group_activities_invalid_group(self, mock_capture):
         # Mock the response to return a 200 OK
         mock_capture.return_value = mock.MagicMock(status_code=200)
@@ -2098,7 +2098,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
         self.group_key = "test_company"
         self.base_url = f"/api/projects/{self.team.id}/groups/"
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_create_group_creates_property_definitions(self, mock_capture):
         data = {
             "group_type_index": self.group_type_index,
@@ -2132,7 +2132,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(revenue_prop.property_type, "Numeric")
         self.assertTrue(revenue_prop.is_numerical)
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_update_property_creates_property_definition(self, mock_capture):
         create_group(
             team_id=self.team.pk,
@@ -2162,7 +2162,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(prop_def.property_type, "String")
         self.assertFalse(prop_def.is_numerical)
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_update_property_with_different_types(self, mock_capture):
         create_group(
             team_id=self.team.pk, group_type_index=self.group_type_index, group_key=self.group_key, properties={}
@@ -2199,7 +2199,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
                 self.assertEqual(prop_def.property_type, expected_type)
                 self.assertEqual(prop_def.is_numerical, expected_numerical)
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_update_existing_property_definition(self, mock_capture):
         create_group(
             team_id=self.team.pk, group_type_index=self.group_type_index, group_key=self.group_key, properties={}
@@ -2227,7 +2227,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(prop_def.property_type, "Numeric")
         self.assertTrue(prop_def.is_numerical)
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_update_property_missing_key(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         create_group(
@@ -2241,7 +2241,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(response.status_code, 400)
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_update_property_empty_key(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         create_group(
@@ -2255,7 +2255,7 @@ class GroupPropertyDefinitionsTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(response.status_code, 400)
 
-    @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @mock.patch("ee.clickhouse.views.groups.capture_internal_routed")
     def test_property_definitions_have_correct_group_type_index(self, mock_capture):
         self.group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,

--- a/posthog/api/test/test_capture_dispatch.py
+++ b/posthog/api/test/test_capture_dispatch.py
@@ -1,0 +1,284 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.api.capture_dispatch import (
+    CAPTURE_INTERNAL_ROUTED,
+    CAPTURE_ROUTED_ERROR,
+    CaptureRoutedError,
+    RoutedCaptureResult,
+    _capture_v1_enabled,
+    capture_batch_internal_routed,
+    capture_internal_routed,
+)
+
+
+def _make_team(pk: int = 1, organization_id: str = "org-1", api_token: str = "phc_test") -> MagicMock:
+    team = MagicMock()
+    team.pk = pk
+    team.id = pk
+    team.organization_id = organization_id
+    team.api_token = api_token
+    return team
+
+
+def _make_ok_result(status_code: int = 200) -> MagicMock:
+    result = MagicMock()
+    result.status_code = status_code
+    result.raise_for_status.return_value = None
+    return result
+
+
+COMMON_KWARGS: dict[str, Any] = {
+    "token": "phc_test",
+    "event_name": "test_event",
+    "distinct_id": "user-1",
+    "timestamp": datetime.now(UTC),
+    "properties": {"key": "value"},
+    "event_source": "person_viewset",
+}
+
+
+class TestRoutedCaptureResult(SimpleTestCase):
+    def test_success_no_raise(self) -> None:
+        r = RoutedCaptureResult(status_code=200, impl="legacy")
+        r.raise_for_status()
+
+    def test_error_raises_with_status(self) -> None:
+        r = RoutedCaptureResult(status_code=503, impl="legacy", error_message="server error")
+        with self.assertRaises(CaptureRoutedError) as ctx:
+            r.raise_for_status()
+        assert ctx.exception.status_code == 503
+        assert "server error" in str(ctx.exception)
+
+
+class TestCaptureRoutedError(SimpleTestCase):
+    def test_is_subclass_of_capture_internal_error(self) -> None:
+        from posthog.api.capture import CaptureInternalError
+
+        err = CaptureRoutedError("test", status_code=404)
+        assert isinstance(err, CaptureInternalError)
+        assert err.status_code == 404
+
+
+class TestCaptureV1Enabled(SimpleTestCase):
+    def test_unknown_event_source_returns_false(self) -> None:
+        team = _make_team()
+        assert _capture_v1_enabled("nonexistent_source", team=team) is False
+
+    def test_no_team_and_no_token_returns_false(self) -> None:
+        assert _capture_v1_enabled("person_viewset") is False
+
+    @patch("posthog.api.capture_dispatch.posthoganalytics.feature_enabled", return_value=True)
+    def test_flag_enabled_returns_true(self, mock_flag: MagicMock) -> None:
+        team = _make_team()
+        assert _capture_v1_enabled("person_viewset", team=team) is True
+        mock_flag.assert_called_once()
+        call_kwargs = mock_flag.call_args.kwargs
+        assert call_kwargs["only_evaluate_locally"] is True
+        assert call_kwargs["send_feature_flag_events"] is False
+
+    @patch("posthog.api.capture_dispatch.posthoganalytics.feature_enabled", return_value=False)
+    def test_flag_disabled_returns_false(self, mock_flag: MagicMock) -> None:
+        team = _make_team()
+        assert _capture_v1_enabled("person_viewset", team=team) is False
+
+    @patch("posthog.api.capture_dispatch.posthoganalytics.feature_enabled", side_effect=Exception("boom"))
+    def test_exception_returns_false(self, mock_flag: MagicMock) -> None:
+        team = _make_team()
+        assert _capture_v1_enabled("person_viewset", team=team) is False
+
+    @patch("posthog.api.capture_dispatch.posthoganalytics.feature_enabled", return_value=None)
+    def test_none_returns_false(self, mock_flag: MagicMock) -> None:
+        team = _make_team()
+        assert _capture_v1_enabled("person_viewset", team=team) is False
+
+    @patch("posthog.api.capture_dispatch.posthoganalytics.feature_enabled", return_value=True)
+    def test_token_resolves_team(self, mock_flag: MagicMock) -> None:
+        team = _make_team()
+        with patch(
+            "posthog.models.team.team.TeamManager.get_team_from_cache_or_token", return_value=team
+        ) as mock_resolve:
+            result = _capture_v1_enabled("person_viewset", token="phc_test")
+            assert result is True
+            mock_resolve.assert_called_once_with("phc_test")
+
+
+class TestCaptureInternalRouted(SimpleTestCase):
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False)
+    @patch("posthog.api.capture_dispatch.capture_internal")
+    def test_flag_off_routes_to_legacy(self, mock_capture: MagicMock, mock_flag: MagicMock) -> None:
+        mock_capture.return_value = _make_ok_result()
+        team = _make_team()
+
+        result = capture_internal_routed(**COMMON_KWARGS, team=team)
+        assert result.impl == "legacy"
+        assert result.status_code == 200
+        result.raise_for_status()
+        mock_capture.assert_called_once()
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=True)
+    @patch("posthog.api.capture_dispatch.capture_v1_internal")
+    def test_flag_on_routes_to_v1(self, mock_v1: MagicMock, mock_flag: MagicMock) -> None:
+        mock_v1.return_value = _make_ok_result()
+        team = _make_team()
+
+        result = capture_internal_routed(**COMMON_KWARGS, team=team)
+        assert result.impl == "v1"
+        assert result.status_code == 200
+        result.raise_for_status()
+        mock_v1.assert_called_once()
+
+    @parameterized.expand([("$snapshot",), ("$performance_event",), ("$snapshot_items",)])
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=True)
+    @patch("posthog.api.capture_dispatch.capture_internal")
+    def test_all_replay_event_names_force_legacy(
+        self, event_name: str, mock_capture: MagicMock, mock_flag: MagicMock
+    ) -> None:
+        mock_capture.return_value = _make_ok_result()
+        kwargs = {**COMMON_KWARGS, "event_name": event_name}
+        result = capture_internal_routed(**kwargs, team=_make_team())
+        assert result.impl == "legacy"
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False)
+    @patch("posthog.api.capture_dispatch.capture_internal")
+    def test_legacy_http_error_normalized(self, mock_capture: MagicMock, mock_flag: MagicMock) -> None:
+        from requests import HTTPError
+
+        resp_mock = MagicMock()
+        resp_mock.status_code = 503
+        resp_mock.raise_for_status.side_effect = HTTPError(response=resp_mock)
+        mock_capture.return_value = resp_mock
+
+        result = capture_internal_routed(**COMMON_KWARGS, team=_make_team())
+        assert result.impl == "legacy"
+        assert result.status_code == 503
+        with self.assertRaises(CaptureRoutedError) as ctx:
+            result.raise_for_status()
+        assert ctx.exception.status_code == 503
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=True)
+    @patch("posthog.api.capture_dispatch.capture_v1_internal")
+    def test_v1_error_normalized(self, mock_v1: MagicMock, mock_flag: MagicMock) -> None:
+        from posthog.api.capture_v1 import CaptureV1InternalError
+
+        v1_result = MagicMock()
+        v1_result.status_code = 200
+        v1_result.raise_for_status.side_effect = CaptureV1InternalError("partial failure")
+        mock_v1.return_value = v1_result
+
+        result = capture_internal_routed(**COMMON_KWARGS, team=_make_team())
+        assert result.impl == "v1"
+        with self.assertRaises(CaptureRoutedError):
+            result.raise_for_status()
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False)
+    @patch("posthog.api.capture_dispatch.capture_internal", side_effect=ConnectionError("refused"))
+    def test_legacy_transport_error_normalized(self, mock_capture: MagicMock, mock_flag: MagicMock) -> None:
+        result = capture_internal_routed(**COMMON_KWARGS, team=_make_team())
+        assert result.impl == "legacy"
+        assert result.status_code == 0
+        with self.assertRaises(CaptureRoutedError):
+            result.raise_for_status()
+
+    def test_routing_metric_incremented(self) -> None:
+        before_legacy = CAPTURE_INTERNAL_ROUTED.labels(event_source="person_viewset", impl="legacy")._value.get()
+        with (
+            patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False),
+            patch("posthog.api.capture_dispatch.capture_internal", return_value=_make_ok_result()),
+        ):
+            capture_internal_routed(**COMMON_KWARGS, team=_make_team())
+        after_legacy = CAPTURE_INTERNAL_ROUTED.labels(event_source="person_viewset", impl="legacy")._value.get()
+        assert after_legacy == before_legacy + 1
+
+    def test_error_metric_incremented_on_failure(self) -> None:
+        from requests import HTTPError
+
+        before = CAPTURE_ROUTED_ERROR.labels(
+            event_source="person_viewset", impl="legacy", error_type="http"
+        )._value.get()
+        resp_mock = MagicMock()
+        resp_mock.status_code = 500
+        resp_mock.raise_for_status.side_effect = HTTPError(response=resp_mock)
+        with (
+            patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False),
+            patch("posthog.api.capture_dispatch.capture_internal", return_value=resp_mock),
+        ):
+            capture_internal_routed(**COMMON_KWARGS, team=_make_team())
+        after = CAPTURE_ROUTED_ERROR.labels(
+            event_source="person_viewset", impl="legacy", error_type="http"
+        )._value.get()
+        assert after == before + 1
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False)
+    @patch("posthog.api.capture_dispatch.capture_internal")
+    def test_capture_internal_error_propagates_directly(self, mock_capture: MagicMock, mock_flag: MagicMock) -> None:
+        from posthog.api.capture import CaptureInternalError
+
+        mock_capture.side_effect = CaptureInternalError("bad token")
+        with self.assertRaises(CaptureInternalError):
+            capture_internal_routed(**COMMON_KWARGS, team=_make_team())
+
+
+class TestCaptureBatchInternalRouted(SimpleTestCase):
+    BATCH_KWARGS: dict[str, Any] = {
+        "events": [{"event": "e1", "distinct_id": "u1", "properties": {}}],
+        "event_source": "get_csp_report",
+        "token": "phc_test",
+    }
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False)
+    @patch("posthog.api.capture_dispatch.capture_batch_internal")
+    def test_flag_off_routes_to_legacy_batch(self, mock_batch: MagicMock, mock_flag: MagicMock) -> None:
+        future = MagicMock()
+        future.result.return_value = _make_ok_result()
+        mock_batch.return_value = [future]
+
+        result = capture_batch_internal_routed(**self.BATCH_KWARGS)
+        assert result.impl == "legacy"
+        result.raise_for_status()
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=True)
+    @patch("posthog.api.capture_dispatch.capture_v1_batch_internal")
+    def test_flag_on_routes_to_v1_batch(self, mock_v1: MagicMock, mock_flag: MagicMock) -> None:
+        mock_v1.return_value = _make_ok_result()
+
+        result = capture_batch_internal_routed(**self.BATCH_KWARGS)
+        assert result.impl == "v1"
+        result.raise_for_status()
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=False)
+    @patch("posthog.api.capture_dispatch.capture_batch_internal")
+    def test_legacy_batch_http_error(self, mock_batch: MagicMock, mock_flag: MagicMock) -> None:
+        from requests import HTTPError
+
+        resp_mock = MagicMock()
+        resp_mock.status_code = 500
+        resp_mock.raise_for_status.side_effect = HTTPError(response=resp_mock)
+        future = MagicMock()
+        future.result.return_value = resp_mock
+        mock_batch.return_value = [future]
+
+        result = capture_batch_internal_routed(**self.BATCH_KWARGS)
+        assert result.status_code == 500
+        with self.assertRaises(CaptureRoutedError):
+            result.raise_for_status()
+
+    @patch("posthog.api.capture_dispatch._capture_v1_enabled", return_value=True)
+    @patch("posthog.api.capture_dispatch.capture_v1_batch_internal")
+    def test_v1_batch_error(self, mock_v1: MagicMock, mock_flag: MagicMock) -> None:
+        from posthog.api.capture_v1 import CaptureV1InternalError
+
+        v1_result = MagicMock()
+        v1_result.raise_for_status.side_effect = CaptureV1InternalError("dropped")
+        mock_v1.return_value = v1_result
+
+        result = capture_batch_internal_routed(**self.BATCH_KWARGS)
+        assert result.impl == "v1"
+        with self.assertRaises(CaptureRoutedError):
+            result.raise_for_status()

--- a/posthog/api/test/test_capture_internal.py
+++ b/posthog/api/test/test_capture_internal.py
@@ -5,7 +5,12 @@ from uuid import uuid4
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
-from posthog.api.capture import CaptureInternalError, capture_batch_internal, capture_internal
+from posthog.api.capture import (
+    CAPTURE_INTERNAL_REQUEST_FAILED,
+    CaptureInternalError,
+    capture_batch_internal,
+    capture_internal,
+)
 from posthog.settings.ingestion import (
     CAPTURE_INTERNAL_URL,
     CAPTURE_REPLAY_INTERNAL_URL,
@@ -198,6 +203,10 @@ class TestCaptureInternal(BaseTest):
             "some_custom_property": True,
         }
 
+        before = CAPTURE_INTERNAL_REQUEST_FAILED.labels(
+            event_source="test_capture_internal_with_capture_post_server_error", status_code="503"
+        )._value.get()
+
         InstallCapturePostSpy(mock_session_class, status_code=503)
         response = capture_internal(
             token=token,
@@ -208,7 +217,11 @@ class TestCaptureInternal(BaseTest):
             properties=test_props,
         )
         assert response.status_code == 503
-        # note: retry mechanism is disabled since we mocked requests.Session
+
+        after = CAPTURE_INTERNAL_REQUEST_FAILED.labels(
+            event_source="test_capture_internal_with_capture_post_server_error", status_code="503"
+        )._value.get()
+        assert after == before + 1
 
     @patch("posthog.api.capture.internal_requests_session")
     def test_capture_internal_replay(self, mock_session_class):

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -783,7 +783,7 @@ class TestLLMPromptAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
 
     @override_settings(TEST=False)
-    @patch("posthog.api.llm_prompt.capture_internal")
+    @patch("posthog.api.llm_prompt.capture_internal_routed")
     def test_fetch_prompt_by_name_emits_version_metadata(self, mock_capture_internal, mock_feature_enabled):
         self.create_prompt_version(name="test-prompt", version=1, is_latest=False, prompt="v1")
         latest = self.create_prompt_version(name="test-prompt", version=2, is_latest=True, prompt="v2")

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -999,7 +999,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             self.validation_error_response("required", "This field is required.", "properties"),
         )
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_new_update_single_person_property(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,
@@ -1022,7 +1022,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             process_person_profile=True,
         )
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_new_delete_person_properties(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,
@@ -1045,7 +1045,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             process_person_profile=True,
         )
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_update_person_property_by_numeric_id(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,
@@ -1068,7 +1068,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             process_person_profile=True,
         )
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_delete_person_property_by_numeric_id(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,
@@ -1091,7 +1091,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             process_person_profile=True,
         )
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_update_person_property_with_null_value(self, mock_capture) -> None:
         person = _create_person(
             team=self.team,

--- a/posthog/api/test/test_person_personhog.py
+++ b/posthog/api/test/test_person_personhog.py
@@ -76,7 +76,7 @@ class TestRetrievePerson(PersonhogTestMixin, APIBaseTest):
 
 @parameterized_class(("personhog",), [(False,), (True,)])
 class TestUpdatePerson(PersonhogTestMixin, APIBaseTest):
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_update_properties_by_uuid(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         person = self._seed_person(
@@ -98,7 +98,7 @@ class TestUpdatePerson(PersonhogTestMixin, APIBaseTest):
         assert call_kwargs["properties"] == {"$set": {"new_key": "new_value"}}
         self._assert_personhog_called("get_person_by_uuid")
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_update_properties_by_pk(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         person = self._seed_person(
@@ -182,7 +182,7 @@ class TestCohortsByPerson(PersonhogTestMixin, APIBaseTest):
 
 @parameterized_class(("personhog",), [(False,), (True,)])
 class TestDeleteProperty(PersonhogTestMixin, APIBaseTest):
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_uuid_lookup(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         person = self._seed_person(
@@ -209,7 +209,7 @@ class TestDeleteProperty(PersonhogTestMixin, APIBaseTest):
         self._assert_personhog_called("get_person_by_uuid")
         self._assert_personhog_called("get_distinct_ids_for_person")
 
-    @mock.patch("posthog.api.person.capture_internal")
+    @mock.patch("posthog.api.person.capture_internal_routed")
     def test_integer_pk_lookup(self, mock_capture):
         mock_capture.return_value = mock.MagicMock(status_code=200)
         person = self._seed_person(

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -20,7 +20,7 @@ class TestCspReport(BaseTest):
         # it is really important to know that /capture is CSRF exempt. Enforce checking in the client
         self.client = Client(enforce_csrf_checks=True)
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     def test_submit_csp_report_to_new_internal_capture(self, mock_capture) -> None:
         payload = {
             "csp-report": {
@@ -43,9 +43,9 @@ class TestCspReport(BaseTest):
         assert resp.status_code == status.HTTP_204_NO_CONTENT
         assert mock_capture.call_count == 1
 
-    @patch("posthog.api.capture.capture_internal")
-    def test_submit_csp_report_list_to_new_internal_capture(self, mock_capture) -> None:
-        mock_capture.return_value = MagicMock(status_code=204)
+    @patch("posthog.api.report.capture_batch_internal_routed")
+    def test_submit_csp_report_list_to_new_internal_capture(self, mock_batch_capture) -> None:
+        mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
 
         multiple_violations = [
             {
@@ -100,9 +100,10 @@ class TestCspReport(BaseTest):
             content_type="application/reports+json",
         )
         assert resp.status_code == status.HTTP_204_NO_CONTENT
-        assert mock_capture.call_count == 3
+        mock_batch_capture.assert_called_once()
+        assert len(mock_batch_capture.call_args.kwargs["events"]) == 3
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     def test_capture_csp_violation(self, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
 
@@ -131,7 +132,7 @@ class TestCspReport(BaseTest):
         assert status.HTTP_204_NO_CONTENT == response.status_code
         assert mock_capture.call_count == 1
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     def test_capture_csp_no_trailing_slash(self, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
 
@@ -230,9 +231,9 @@ class TestCspReport(BaseTest):
         assert response.json()["code"] == "invalid_payload"
         assert "Failed to submit CSP report" in response.json()["detail"]
 
-    @patch("posthog.api.capture.capture_internal")
+    @patch("posthog.api.report.capture_batch_internal_routed")
     def test_integration_csp_report_with_report_to_format_returns_204(self, mock_capture):
-        mock_capture.return_value = MagicMock(status_code=204, content=b"")
+        mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
 
         report_to_format = [
             {
@@ -261,9 +262,9 @@ class TestCspReport(BaseTest):
         assert response.content == b""
         mock_capture.assert_called_once()
 
-    @patch("posthog.api.capture.capture_internal")
+    @patch("posthog.api.report.capture_batch_internal_routed")
     def test_capture_csp_report_to_violation(self, mock_capture):
-        mock_capture.return_value = MagicMock(status_code=204)
+        mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
 
         report_to_format = [
             {
@@ -315,7 +316,7 @@ class TestCspReport(BaseTest):
         # Verify we processed both events
         assert mock_capture.call_count == 2
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     @patch("posthog.api.report.logger")
     def test_csp_debug_logging_enabled(self, mock_logger, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
@@ -345,7 +346,7 @@ class TestCspReport(BaseTest):
         assert call_args[1]["content_type"] == "application/csp-report"
         assert "body" in call_args[1]
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     @patch("posthog.api.report.logger")
     def test_csp_debug_logging_disabled(self, mock_logger, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
@@ -367,7 +368,7 @@ class TestCspReport(BaseTest):
         mock_capture.assert_called_once()
         mock_logger.exception.assert_not_called()
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     @patch("posthog.api.report.logger")
     def test_csp_debug_logging_case_insensitive(self, mock_logger, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
@@ -439,7 +440,7 @@ class TestCspReport(BaseTest):
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    @patch("posthog.api.report.capture_internal")
+    @patch("posthog.api.report.capture_internal_routed")
     def test_safari_single_csp_violation_with_csp_report_content_type(self, mock_capture):
         mock_capture.return_value = MagicMock(status_code=204)
 

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -173,7 +173,7 @@ class TestRunEvaluationWorkflow:
         }
 
         with patch("posthog.temporal.ai_observability.run_evaluation.Team.objects.get") as mock_team_get:
-            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal") as mock_capture:
+            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal_routed") as mock_capture:
                 mock_team_get.return_value = team
                 mock_capture.return_value = MagicMock(status_code=200, raise_for_status=MagicMock())
 
@@ -230,7 +230,7 @@ class TestRunEvaluationWorkflow:
         }
 
         with patch("posthog.temporal.ai_observability.run_evaluation.Team.objects.get") as mock_team_get:
-            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal") as mock_capture:
+            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal_routed") as mock_capture:
                 mock_team_get.return_value = team
                 mock_capture.return_value = MagicMock(status_code=200, raise_for_status=MagicMock())
 
@@ -531,7 +531,7 @@ class TestRunEvaluationWorkflow:
         }
 
         with patch("posthog.temporal.ai_observability.run_evaluation.Team.objects.get") as mock_team_get:
-            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal") as mock_capture:
+            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal_routed") as mock_capture:
                 mock_team_get.return_value = team
                 mock_capture.return_value = MagicMock(status_code=200, raise_for_status=MagicMock())
 
@@ -572,7 +572,7 @@ class TestRunEvaluationWorkflow:
         }
 
         with patch("posthog.temporal.ai_observability.run_evaluation.Team.objects.get") as mock_team_get:
-            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal") as mock_capture:
+            with patch("posthog.temporal.ai_observability.run_evaluation.capture_internal_routed") as mock_capture:
                 mock_team_get.return_value = team
                 mock_capture.return_value = MagicMock(status_code=200, raise_for_status=MagicMock())
 

--- a/posthog/temporal/ai_observability/test_run_tagger.py
+++ b/posthog/temporal/ai_observability/test_run_tagger.py
@@ -380,7 +380,7 @@ class TestRunTaggerWorkflow:
         event_data = create_mock_event_data(team.id, properties={})
 
         with patch("posthog.temporal.ai_observability.run_tagger.Team.objects.get") as mock_team_get:
-            with patch("posthog.temporal.ai_observability.run_tagger.capture_internal") as mock_capture:
+            with patch("posthog.temporal.ai_observability.run_tagger.capture_internal_routed") as mock_capture:
                 mock_team_get.return_value = team
                 mock_capture.return_value = MagicMock(status_code=200, raise_for_status=MagicMock())
 

--- a/posthog/temporal/tests/session_replay/session_summary/test_event_capture.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_event_capture.py
@@ -2,8 +2,8 @@ import pytest
 from unittest.mock import MagicMock
 
 from pytest_mock import MockerFixture
-from requests import HTTPError, Response
 
+from posthog.api.capture_dispatch import CaptureRoutedError
 from posthog.sync import database_sync_to_async
 from posthog.temporal.session_replay.session_summary.activities.video_based.a7c_store_video_session_summary import (
     store_video_session_summary_activity,
@@ -40,17 +40,17 @@ def test_capture_session_summary_ready_emits_internal_project_event(
         created_by=user,
     )
     settings.SITE_URL = "http://localhost:8000"
-    response = mocker.MagicMock()
-    capture_internal = mocker.patch(
-        "posthog.temporal.session_replay.session_summary.event_capture.capture_internal", return_value=response
+    result = mocker.MagicMock()
+    capture_internal_routed = mocker.patch(
+        "posthog.temporal.session_replay.session_summary.event_capture.capture_internal_routed", return_value=result
     )
 
     from posthog.temporal.session_replay.session_summary.event_capture import capture_session_summary_ready
 
     capture_session_summary_ready(summary, team_api_token="token-override")
 
-    capture_internal.assert_called_once()
-    _, kwargs = capture_internal.call_args
+    capture_internal_routed.assert_called_once()
+    _, kwargs = capture_internal_routed.call_args
     assert kwargs["token"] == "token-override"
     assert kwargs["event_name"] == "$session_summary_ready"
     assert kwargs["event_source"] == "session_summary_events"
@@ -66,7 +66,7 @@ def test_capture_session_summary_ready_emits_internal_project_event(
     assert kwargs["properties"]["model_used"] == "gpt-test"
     assert kwargs["properties"]["session_start_time"] is None
     assert kwargs["properties"]["session_duration"] is None
-    response.raise_for_status.assert_called_once()
+    result.raise_for_status.assert_called_once()
 
 
 def test_capture_session_summary_ready_swallow_capture_errors(
@@ -83,10 +83,10 @@ def test_capture_session_summary_ready_swallow_capture_errors(
         distinct_id="customer-456",
         created_by=user,
     )
-    response = mocker.MagicMock()
-    response.raise_for_status.side_effect = HTTPError("boom", response=Response())
+    result = mocker.MagicMock()
+    result.raise_for_status.side_effect = CaptureRoutedError("boom", status_code=500)
     mocker.patch(
-        "posthog.temporal.session_replay.session_summary.event_capture.capture_internal", return_value=response
+        "posthog.temporal.session_replay.session_summary.event_capture.capture_internal_routed", return_value=result
     )
     logger = mocker.patch("posthog.temporal.session_replay.session_summary.event_capture.logger")
 

--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -34,7 +34,7 @@ class TestConversationEvents(BaseTest):
             anonymous_traits={"name": "Test Customer", "email": "test@example.com"},
         )
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_capture_ticket_created_uses_team_token(self, mock_capture):
         capture_ticket_created(self.ticket)
 
@@ -48,7 +48,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["customer_name"] == "Test Customer"
         assert call_kwargs["properties"]["customer_email"] == "test@example.com"
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_capture_ticket_status_changed_uses_team_token(self, mock_capture):
         capture_ticket_status_changed(self.ticket, "new", "pending")
 
@@ -61,7 +61,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["old_status"] == "new"
         assert call_kwargs["properties"]["new_status"] == "pending"
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_capture_ticket_priority_changed_uses_team_token(self, mock_capture):
         capture_ticket_priority_changed(self.ticket, None, "high")
 
@@ -74,7 +74,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["old_priority"] is None
         assert call_kwargs["properties"]["new_priority"] == "high"
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_capture_ticket_assigned_uses_team_token(self, mock_capture):
         capture_ticket_assigned(self.ticket, "user", "123")
 
@@ -87,7 +87,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["assignee_type"] == "user"
         assert call_kwargs["properties"]["assignee_id"] == "123"
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_capture_message_sent_uses_team_token(self, mock_capture):
         capture_message_sent(self.ticket, "msg-123", "Hello customer", 42)
 
@@ -102,7 +102,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["author_type"] == "team"
         assert call_kwargs["properties"]["author_id"] == 42
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_capture_message_received_uses_team_token(self, mock_capture):
         capture_message_received(self.ticket, "msg-456", "Hello support")
 
@@ -143,7 +143,7 @@ class TestConversationEvents(BaseTest):
             ),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_all_events_include_base_properties(self, _name, capture_fn, expected_event, extra_args, mock_capture):
         capture_fn(self.ticket, *extra_args)
 
@@ -157,7 +157,7 @@ class TestConversationEvents(BaseTest):
         assert props["status"] == self.ticket.status
         assert props["priority"] == self.ticket.priority
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_message_content_truncated_to_1000_chars(self, mock_capture):
         long_content = "x" * 1500
         capture_message_sent(self.ticket, "msg-id", long_content, 1)
@@ -165,7 +165,7 @@ class TestConversationEvents(BaseTest):
         call_kwargs = mock_capture.call_args.kwargs
         assert len(call_kwargs["properties"]["message_content"]) == 1000
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_event_uses_ticket_team_token_not_other_team(self, mock_capture):
         """Verify events route to the ticket's team, not any other team."""
         from posthog.models import Organization, Team
@@ -181,7 +181,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["token"] == self.team.api_token
         assert call_kwargs["token"] != other_team.api_token
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     def test_two_teams_events_routed_to_respective_projects(self, mock_capture):
         """Events from Team 1 ticket use Team 1 token, Team 2 ticket uses Team 2 token."""
         from posthog.models import Organization, Team
@@ -223,7 +223,7 @@ class TestConversationEvents(BaseTest):
             ("empty_distinct_id", False, False, False),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_person_processing(
         self, _name, has_person, is_identified, expect_groups, mock_get_persons, mock_capture
@@ -256,7 +256,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["process_person_profile"] is expect_groups
         assert "$groups" not in call_kwargs["properties"]
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_groups_from_person_org(self, mock_get_persons, mock_capture):
         from posthog.models.person.person import Person
@@ -276,7 +276,7 @@ class TestConversationEvents(BaseTest):
         assert groups["project"] == str(self.team.uuid)
         assert "instance" in groups
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_message_received_groups_from_person_org(self, mock_get_persons, mock_capture):
         from posthog.models.person.person import Person
@@ -303,7 +303,7 @@ class TestConversationEvents(BaseTest):
             ("empty_distinct_id", False, False),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_message_received_person_processing(
         self, _name, has_person, is_identified, mock_get_persons, mock_capture
@@ -336,7 +336,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["process_person_profile"] is False
         assert "$groups" not in call_kwargs["properties"]
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids", side_effect=Exception("db timeout"))
     def test_capture_message_received_still_fires_on_person_lookup_failure(self, mock_get_persons, mock_capture):
         capture_message_received(self.ticket, "msg-456", "Hello support")
@@ -352,7 +352,7 @@ class TestConversationEvents(BaseTest):
             ("user_has_no_membership", True, False),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_no_groups_when(
         self, _name, create_user, create_membership, mock_get_persons, mock_capture
@@ -370,7 +370,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["process_person_profile"] is False
         assert "$groups" not in call_kwargs["properties"]
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids", side_effect=Exception("db timeout"))
     def test_capture_ticket_created_still_fires_on_person_lookup_failure(self, mock_get_persons, mock_capture):
         capture_ticket_created(self.ticket)
@@ -389,7 +389,7 @@ class TestConversationEvents(BaseTest):
             ("email_from_only", "email", None, "biz@acme.com"),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events._get_persons_by_email")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_email_fallback_groups(
@@ -438,7 +438,7 @@ class TestConversationEvents(BaseTest):
             ("person_without_membership", True),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events._get_persons_by_email")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_email_fallback_no_groups(
@@ -472,7 +472,7 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["process_person_profile"] is False
         assert "$groups" not in call_kwargs["properties"]
 
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events._get_persons_by_email")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_identified_person_without_membership_skips_email_fallback(
@@ -498,7 +498,7 @@ class TestConversationEvents(BaseTest):
             ("github_no_email", "github"),
         ]
     )
-    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.capture_internal_routed")
     @patch("products.conversations.backend.events._get_persons_by_email")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
     def test_capture_ticket_created_non_verified_channels_skip_email_fallback(


### PR DESCRIPTION
## Problem

Stacked on #62252. Separates test changes for cleaner review.

## Changes

- New test suite `posthog/api/test/test_capture_dispatch.py` (26 tests) covering:
  - `RoutedCaptureResult` and `CaptureRoutedError` contracts
  - `_capture_v1_enabled` flag evaluation (unknown source, missing team, flag on/off, exceptions, token resolution)
  - `capture_internal_routed` routing (legacy/v1), replay event forcing, error normalization (HTTP, v1, transport)
  - `capture_batch_internal_routed` routing and error normalization
  - Prometheus counter assertions
- All existing call-site tests updated to mock through `capture_internal_routed` / `capture_batch_internal_routed`

## How did you test this code?

These are the tests. Unit suite passes locally (26/26). Integration tests require the full dev stack (CI).

## 🤖 Agent context

Split from #62252 to reduce review surface. Production code is in the base PR; this PR is test-only.
