### PR TITLE
feat(replay-vision): add in-app feedback survey buttons

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5703,9 +5703,9 @@ snapshots:
     scenes-app-promoted-product--intent-with-product--light:
         hash: v1.k794b7964.a520d81ca3c66ae61e8fa10602ed5f40da3d97bee4efd9daf03009c238a8b0dc.Ruf-wJ_f_UjycVlKd7vE_z2t-r_SY8cC5bO-NSR0Ao4
     scenes-app-replay-vision--scanners-list--dark:
-        hash: v1.k794b7964.bcb104797b0216e5b8e55c80afd258ae30dc4a786c39baef05e6ad9a3097b2a8.uXVyFXWo6v9isQ-fI_HjB29MyvNjeIdWhK0Od7GnHfA
+        hash: v1.k794b7964.799b429ca99dca7adb8cdd95f91e011bd63158763e8a16605da222f8523dc844.3Rnmy2I38dZUyEx1G59wDeho1bwV-oWF8EMtJIQmpeE
     scenes-app-replay-vision--scanners-list--light:
-        hash: v1.k794b7964.0b7623ca48d83996f9ce31902306ee592d919da1ba56ea19ca8e772b2af18036._WsfdWi3XlVh3J_dJXPFajxDOruRhYfBbDEsOBkQBh8
+        hash: v1.k794b7964.7d5fe1b0fee217479a9ac2b87cf5bf86f167d246c88a136694706ff951866637.bY8VMFOdL1WFJqfU6IrUkYl1Y7k4_LcEjwHYTjHSS1c
     scenes-app-revenue-analytics--revenue-analytics-dashboard--dark:
         hash: v1.k794b7964.7c2a90fe3c3a969c054186bb666664efa891d65d411a546539a968518938ea71.OoOKh-Mc_IiPWTgIV4QNPtACZXPPktfU7bjGk-q-uLE
     scenes-app-revenue-analytics--revenue-analytics-dashboard--light:

--- a/products/replay_vision/frontend/components/ReplayVisionFeedbackButton.tsx
+++ b/products/replay_vision/frontend/components/ReplayVisionFeedbackButton.tsx
@@ -1,0 +1,26 @@
+import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
+
+import posthog from 'lib/posthog-typed'
+
+/**
+ * Feedback button for the Replay vision product. Clicking it captures the `replay_vision_feedback_clicked`
+ * event, which triggers the Replay vision feedback survey (a popover) configured in PostHog.
+ */
+export function ReplayVisionFeedbackButton({
+    label = 'Feedback',
+    type,
+}: {
+    label?: string
+    type?: LemonButtonProps['type']
+} = {}): JSX.Element {
+    return (
+        <LemonButton
+            size="small"
+            type={type}
+            tooltip="Share feedback on Replay vision"
+            onClick={() => posthog.capture('replay_vision_feedback_clicked')}
+        >
+            {label}
+        </LemonButton>
+    )
+}

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -29,6 +29,7 @@ import {
     readResult,
 } from '../components/ObservationCard'
 import { ObservationProgressBar } from '../components/ObservationProgressBar'
+import { ReplayVisionFeedbackButton } from '../components/ReplayVisionFeedbackButton'
 import {
     failureKindDescription,
     ineligibleKindDescription,
@@ -181,6 +182,7 @@ export function ReplayObservationSceneComponent(): JSX.Element {
                 name={scannerName}
                 description={`Observation of session ${observation.session_id}`}
                 resourceType={{ type: 'replay_vision' }}
+                actions={<ReplayVisionFeedbackButton />}
             />
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -16,6 +16,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { ReplayVisionFeedbackButton } from '../components/ReplayVisionFeedbackButton'
 import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { QUOTA_WARN_THRESHOLD } from '../utils/quotaProjection'
 import { ScannerConfigReadonly } from './components/ScannerConfigReadonly'
@@ -55,29 +56,32 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                 description={scanner.description}
                 resourceType={{ type: 'replay_vision' }}
                 actions={
-                    <More
-                        size="small"
-                        overlay={
-                            <LemonButton
-                                status="danger"
-                                fullWidth
-                                onClick={() =>
-                                    LemonDialog.open({
-                                        title: `Delete "${scanner.name || 'Untitled scanner'}"?`,
-                                        description: 'This cannot be undone.',
-                                        primaryButton: {
-                                            children: 'Delete',
-                                            status: 'danger',
-                                            onClick: () => deleteScanner(),
-                                        },
-                                        secondaryButton: { children: 'Cancel' },
-                                    })
-                                }
-                            >
-                                Delete
-                            </LemonButton>
-                        }
-                    />
+                    <>
+                        <ReplayVisionFeedbackButton />
+                        <More
+                            size="small"
+                            overlay={
+                                <LemonButton
+                                    status="danger"
+                                    fullWidth
+                                    onClick={() =>
+                                        LemonDialog.open({
+                                            title: `Delete "${scanner.name || 'Untitled scanner'}"?`,
+                                            description: 'This cannot be undone.',
+                                            primaryButton: {
+                                                children: 'Delete',
+                                                status: 'danger',
+                                                onClick: () => deleteScanner(),
+                                            },
+                                            secondaryButton: { children: 'Cancel' },
+                                        })
+                                    }
+                                >
+                                    Delete
+                                </LemonButton>
+                            }
+                        />
+                    </>
                 }
             />
 

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconPencil, IconPlus, IconSearch, IconTrash } from '@posthog/icons'
+import { IconPencil, IconPlus, IconRefresh, IconSearch, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSwitch, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -20,6 +20,7 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { FilterPill } from '../components/FilterPill'
+import { ReplayVisionFeedbackButton } from '../components/ReplayVisionFeedbackButton'
 import { VisionMetrics } from './components/VisionMetrics'
 import { type ScannersSorting, SCANNERS_PAGE_SIZE, replayScannersLogic } from './replayScannersLogic'
 import {
@@ -192,6 +193,7 @@ export function ReplayScannersScene(): JSX.Element {
                 name="Replay vision"
                 description="Set up AI scanners that automatically analyze new session recordings as they come in. Each result emits a queryable event."
                 resourceType={{ type: 'replay_vision' }}
+                actions={<ReplayVisionFeedbackButton />}
             />
 
             <ProductIntroduction
@@ -234,6 +236,7 @@ export function ReplayScannersScene(): JSX.Element {
                         className="max-w-sm"
                     />
                     <div className="ml-auto flex flex-wrap items-center gap-2">
+                        <ReplayVisionFeedbackButton label="Feedback?" type="tertiary" />
                         <FilterPill<EnabledFilter>
                             label="Status"
                             options={ENABLED_OPTIONS}
@@ -257,9 +260,14 @@ export function ReplayScannersScene(): JSX.Element {
                                 Clear filters
                             </LemonButton>
                         )}
-                        <LemonButton type="secondary" onClick={() => loadScanners()} size="small">
-                            Refresh
-                        </LemonButton>
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconRefresh />}
+                            tooltip="Refresh"
+                            onClick={() => loadScanners()}
+                            loading={scannersLoading}
+                        />
                     </div>
                 </div>
 

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -24,6 +24,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { ReplayVisionFeedbackButton } from '../components/ReplayVisionFeedbackButton'
 import { ScannerTriggers } from './components/ScannerTriggers'
 import { ScannerTypeConfigEditor } from './components/ScannerTypeConfigEditor'
 import { replayScannerLogic } from './replayScannerLogic'
@@ -84,7 +85,11 @@ export function ScannerEditorSceneComponent(): JSX.Element {
         <SceneContent>
             <div className="flex flex-col items-center pt-16 pb-8">
                 <div className="w-full max-w-4xl px-4 flex flex-col gap-6">
-                    <SceneTitleSection name={title} resourceType={{ type: 'replay_vision' }} />
+                    <SceneTitleSection
+                        name={title}
+                        resourceType={{ type: 'replay_vision' }}
+                        actions={<ReplayVisionFeedbackButton />}
+                    />
                     <ScannerEditorStepper currentStep={step} onStepClick={goToStep} stepErrors={stepErrors} />
                     <Form logic={replayScannerLogic} props={{ id: scannerId }} formKey="scanner" enableFormOnSubmit>
                         <div className="bg-bg-light border rounded-lg shadow-sm p-6 flex flex-col gap-6 [&_.Field--error_.input-like]:!border-danger">


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

- need to add some survey entrypoints before launch

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- add entrypoints on all major pages for ad hoc feedback
- Replay Vision homepage
- Scanner create page
- Scanner page
- Observation Page

current triggers on click only

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- kind of funky to test locally 1:1 with prod, will test and iterate as soon a launched  
![Screenshot 2026-06-08 at 4.01.50 PM.png](https://app.graphite.com/user-attachments/assets/2d9cda57-7d88-43e4-826f-c8a98113a01e.png)

    

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->