### PR TITLE
feat(replay-vision): remove duplicate button from scanner rows

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5703,9 +5703,9 @@ snapshots:
     scenes-app-promoted-product--intent-with-product--light:
         hash: v1.k794b7964.a520d81ca3c66ae61e8fa10602ed5f40da3d97bee4efd9daf03009c238a8b0dc.Ruf-wJ_f_UjycVlKd7vE_z2t-r_SY8cC5bO-NSR0Ao4
     scenes-app-replay-vision--scanners-list--dark:
-        hash: v1.k794b7964.a071938f5b745d1b6096c3d45126316a93a656d009b1e9d60bd589c6fbbf2eea.JNJof48nrSqm-xKWn19bCnlnCNMTiQfSQKYxPqUPx1I
+        hash: v1.k794b7964.bcb104797b0216e5b8e55c80afd258ae30dc4a786c39baef05e6ad9a3097b2a8.uXVyFXWo6v9isQ-fI_HjB29MyvNjeIdWhK0Od7GnHfA
     scenes-app-replay-vision--scanners-list--light:
-        hash: v1.k794b7964.0f1eb55f1322005e852dd4ce6396f45fff1d4f1c92b07bec5f26b07be6c58792.b5H9qgJdi4NyB4dsSNg9SDGSm9AVJDzkoqhoZht41Hc
+        hash: v1.k794b7964.0b7623ca48d83996f9ce31902306ee592d919da1ba56ea19ca8e772b2af18036._WsfdWi3XlVh3J_dJXPFajxDOruRhYfBbDEsOBkQBh8
     scenes-app-revenue-analytics--revenue-analytics-dashboard--dark:
         hash: v1.k794b7964.7c2a90fe3c3a969c054186bb666664efa891d65d411a546539a968518938ea71.OoOKh-Mc_IiPWTgIV4QNPtACZXPPktfU7bjGk-q-uLE
     scenes-app-revenue-analytics--revenue-analytics-dashboard--light:

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCopy, IconPencil, IconPlus, IconSearch, IconTrash } from '@posthog/icons'
+import { IconPencil, IconPlus, IconSearch, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSwitch, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -59,7 +59,7 @@ export function ReplayScannersScene(): JSX.Element {
         hasActiveFilters,
         scannerStats,
     } = useValues(replayScannersLogic)
-    const { loadScanners, deleteScanner, duplicateScanner, toggleScannerEnabled, setScannersFilters, clearFilters } =
+    const { loadScanners, deleteScanner, toggleScannerEnabled, setScannersFilters, clearFilters } =
         useActions(replayScannersLogic)
     const { push } = useActions(router)
 
@@ -155,18 +155,6 @@ export function ReplayScannersScene(): JSX.Element {
                             icon={<IconPencil />}
                             onClick={() => push(urls.replayVision(scanner.id))}
                             tooltip="Edit"
-                        />
-                    </AccessControlAction>
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.SessionRecording}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
-                        <LemonButton
-                            size="small"
-                            type="secondary"
-                            icon={<IconCopy />}
-                            onClick={() => duplicateScanner(scanner.id)}
-                            tooltip="Duplicate"
                         />
                     </AccessControlAction>
                     <AccessControlAction

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -274,17 +274,9 @@ describe('replayScannersLogic', () => {
         })
     })
 
-    describe('delete / duplicate refresh', () => {
+    describe('delete refresh', () => {
         it('deleteScannerSuccess refetches the page and the creators list', async () => {
             await expectLogic(logic, () => logic.actions.deleteScannerSuccess('a')).toDispatchActions([
-                'loadScanners',
-                'loadCreators',
-            ])
-        })
-
-        it('duplicateScannerSuccess refetches the page and the creators list', async () => {
-            const dup = makeScanner({ id: 'd', name: 'Copied' })
-            await expectLogic(logic, () => logic.actions.duplicateScannerSuccess(dup)).toDispatchActions([
                 'loadScanners',
                 'loadCreators',
             ])

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -8,7 +8,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import {
-    visionScannersCreate,
     visionScannersCreatorsRetrieve,
     visionScannersDestroy,
     visionScannersList,
@@ -24,8 +23,6 @@ import {
     ScannerType,
     ReplayScanner,
     createdByLabel,
-    scannerFromApi,
-    scannerToApiBody,
     scannersFromApi,
 } from './types'
 
@@ -155,8 +152,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
         loadScannerStatsFailure: true,
         deleteScanner: (id: string) => ({ id }),
         deleteScannerSuccess: (id: string) => ({ id }),
-        duplicateScanner: (id: string) => ({ id }),
-        duplicateScannerSuccess: (scanner: ReplayScanner) => ({ scanner }),
         toggleScannerEnabled: (id: string) => ({ id }),
         toggleScannerEnabledDone: (id: string) => ({ id }),
         revertScannerEnabled: (id: string) => ({ id }),
@@ -171,7 +166,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             {
                 loadScannersSuccess: (_, { scanners }) => scanners,
                 deleteScannerSuccess: (state, { id }) => state.filter((l) => l.id !== id),
-                duplicateScannerSuccess: (state, { scanner }) => [...state, scanner],
                 toggleScannerEnabled: (state, { id }) =>
                     state.map((l) => (l.id === id ? { ...l, enabled: !l.enabled } : l)),
                 revertScannerEnabled: (state, { id }) =>
@@ -300,37 +294,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             }
         },
 
-        duplicateScanner: async ({ id }) => {
-            const original = values.scanners.find((l) => l.id === id)
-            if (!original) {
-                return
-            }
-            const teamId = teamLogic.values.currentTeamId
-            if (!teamId) {
-                return
-            }
-            const duplicate: Record<string, unknown> = {
-                name: `${original.name} (Copy)`,
-                description: original.description,
-                enabled: false,
-                scanner_type: original.scanner_type,
-                scanner_config: original.scanner_config,
-                sampling_rate: original.sampling_rate,
-                provider: original.provider,
-                model: original.model,
-                emits_signals: original.emits_signals,
-            }
-            if (original.query != null) {
-                duplicate.query = original.query
-            }
-            try {
-                const response = await visionScannersCreate(String(teamId), scannerToApiBody(duplicate))
-                actions.duplicateScannerSuccess(scannerFromApi(response))
-            } catch (error: any) {
-                lemonToast.error(`Failed to duplicate scanner${error.detail ? `: ${error.detail}` : ''}`)
-            }
-        },
-
         loadCreators: async () => {
             const teamId = teamLogic.values.currentTeamId
             if (!teamId) {
@@ -361,11 +324,6 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
 
         // Refetch after any mutation so the page + creator dropdown + team-wide stats stay accurate.
         deleteScannerSuccess: () => {
-            actions.loadScanners()
-            actions.loadCreators()
-            actions.loadScannerStats()
-        },
-        duplicateScannerSuccess: () => {
             actions.loadScanners()
             actions.loadCreators()
             actions.loadScannerStats()


### PR DESCRIPTION
## Problem

The Replay Vision scanners list rendered a "Duplicate" action (a copy icon) on every scanner row. We want to remove it from the row actions.

## Changes

- Remove the Duplicate button from the scanner row Actions column, leaving only Edit and Delete.
- Remove the now-dead `duplicateScanner` / `duplicateScannerSuccess` actions, reducer case, and listeners from `replayScannersLogic`, plus the imports that were only used by the duplicate flow (`visionScannersCreate`, `scannerToApiBody`, `scannerFromApi`).
- Remove the corresponding logic test.

## How did you test this code?

I'm an agent. I ran the automated logic test suite (`replayScannersLogic.test.ts`, 29 passing) and a TypeScript check confirming no errors in the edited files. I did not perform manual UI testing.

## 🤖 Agent context

Authored with PostHog Code (Claude). The "copy" button referenced in the request was the copy-icon "Duplicate" action — the only copy-style control in the scanner rows. Scope was confirmed with the author to remove both the button UI and all supporting logic/tests rather than leaving orphaned code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*