### PR TITLE
fix(docker): force PYTHONUTF8 in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,8 @@ RUN apt-get update && \
 FROM unit:1.34.2-python3.13
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONUTF8=1
 ARG UNIT_GIT_TAG=1.35.0
 ARG UNIT_GIT_REF=28404105810f53c570523c3e70006ad0ca210e58
 


### PR DESCRIPTION
## Problem

Project creation on master started failing with:

```
'ascii' codec can't decode byte 0xc2 in position 2209: ordinal not in range(128)
```

#59440 bumped Python 3.12 → 3.13.13, which swapped the runtime base image from `unit:1.34.2-python3.12` to `unit:1.34.2-python3.13`. The 3.12 variant of nginx/unit's image happened to ship with `LANG=C.UTF-8` in its ENV; the 3.13 variant doesn't. Our `Dockerfile` runtime stage doesn't set `LANG`/`LC_ALL` either.

Inside the container, `locale.getencoding()` then returns `ANSI_X3.4-1968` (ASCII). Anything in the project-creation path that calls `open(path)` in text mode without `encoding="utf-8"` (or `subprocess.run(..., text=True)`) decodes UTF-8 bytes through the ASCII codec and dies at the first byte > 127 — `0xc2` being the lead byte of most Latin-1-supplement characters.

## Changes

Set `PYTHONUTF8=1` in the runtime stage of `Dockerfile`. PEP 540's UTF-8 Mode forces `open()` and `subprocess` text mode to use UTF-8 regardless of `locale.getencoding()`, so the fix is independent of whether a UTF-8 locale is available in the base image. Chose this over `ENV LANG=C.UTF-8` because it skips the dependency on the locale being installed.

This is a fix-forward for #59440 rather than a revert — the Python upgrade itself is fine, only the runtime container locale assumption was wrong.

## How did you test this code?

I'm an agent (Claude Opus 4.7). I didn't run the container locally — verifying this requires rebuilding the prod image. No automated tests added; the change is one env var in the runtime Dockerfile stage and doesn't have a unit-testable surface. Validation should be: build the image, hit the create-project endpoint, confirm no decode error.

## 🤖 Agent context

Authored by Claude Opus 4.7 driven by @dmarticus.

Investigation path: started from the error message, ruled out the Python source changes in #59440 (all mypy-hint-only diffs unrelated to project creation), narrowed to the runtime container swap. Initially reached for `ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONUTF8=1` but trimmed to just `PYTHONUTF8=1` — it's the one that doesn't depend on the locale existing in the image, and the others would be redundant once UTF-8 mode is forced.

Not proven: the specific `open()` site that produces position 2209. The two most likely callers in `Team.objects.create_with_data` (`posthog/models/team/team.py:88`) are dashboard-template loading via `create_dashboard_from_template("DEFAULT_APP", ...)` and the Celery-dispatched `sync_user_product_lists_for_new_team`. PEP 540 neutralizes the class of bug regardless of which one, so chasing the precise call site felt like over-investigation for a one-line env-var fix; happy to dig further if a reviewer wants it pinned down.