### PR TITLE
fix(project): force utf-8 so project creation survives c locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,11 @@ FROM unit:1.34.2-python3.13
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED 1
+# Unit embeds libpython instead of launching the python3 CLI, so PEP 538 C-locale
+# coercion never runs and open() defaults to ASCII under the container's bare locale.
+# Force UTF-8 so file reads with non-ASCII bytes don't raise UnicodeDecodeError.
+ENV PYTHONUTF8 1
+ENV LANG C.UTF-8
 ARG UNIT_GIT_TAG=1.35.0
 ARG UNIT_GIT_REF=28404105810f53c570523c3e70006ad0ca210e58
 

--- a/posthog/helpers/generic_emails.txt
+++ b/posthog/helpers/generic_emails.txt
@@ -173,7 +173,7 @@ asurfer.com
 athenachu.net
 atina.cl
 atl.lv
-atlanticbb.net 
+atlanticbb.net
 atlaswebmail.com
 atlink.com
 ato.check.com

--- a/posthog/migrations/0132_team_test_account_filters.py
+++ b/posthog/migrations/0132_team_test_account_filters.py
@@ -22,7 +22,7 @@ class GenericEmails:
     """
 
     def __init__(self):
-        with open(get_absolute_path("../helpers/generic_emails.txt")) as f:
+        with open(get_absolute_path("../helpers/generic_emails.txt"), encoding="utf-8") as f:
             self.emails = {x.rstrip(): True for x in f}
 
     def is_generic(self, email: str) -> bool:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1416,7 +1416,7 @@ class GenericEmails:
     """
 
     def __init__(self):
-        with open(get_absolute_path("helpers/generic_emails.txt")) as f:
+        with open(get_absolute_path("helpers/generic_emails.txt"), encoding="utf-8") as f:
             self.emails = {x.rstrip(): True for x in f}
 
     def is_generic(self, email: str) -> bool:


### PR DESCRIPTION
## Problem

New project/team creation is failing in master with:

```
'ascii' codec can't decode byte 0xc2 in position 2209: ordinal not in range(128)
```

The python bump (#59440) moved the production runtime to the `unit:1.34.2-python3.13` base image. NGINX Unit embeds libpython rather than launching the `python3` CLI, so PEP 538 C-locale coercion to UTF-8 never runs and `open()` defaults to the **ASCII** codec under the container's bare locale. This had been latent — the previous `python3.12` Unit image happened to start with a UTF-8 default.

The crash is in `GenericEmails`, which is read synchronously during team creation (via `get_or_create_internal_test_users_cohort`). It reads `posthog/helpers/generic_emails.txt` without an explicit encoding, and that file carries a stray non-breaking space (`\xc2\xa0`) at byte offset 2209 — an exact match for the error.

## Changes

Fix forward rather than reverting the Python upgrade:

| File | Change | Why |
|------|--------|-----|
| `Dockerfile` (Unit final stage) | `ENV PYTHONUTF8 1` + `ENV LANG C.UTF-8` | Pins UTF-8 at the container level so **every** unencoded `open()` is safe, not just this one — closes the whole bug class |
| `posthog/utils.py` | `encoding="utf-8"` on the crashing read | Direct fix; also protects local dev where the env var may not be set |
| `posthog/migrations/0132_team_test_account_filters.py` | `encoding="utf-8"` | Migration holds a verbatim copy of `GenericEmails` — same latent bug on fresh installs |
| `posthog/helpers/generic_emails.txt` | stripped the stray `\xc2\xa0` | Removes the malformed data artifact |

Rolling back #59440 was the alternative, but it reverts an intentional Python 3.13 upgrade to patch a one-line latent bug, and the same crash could resurface on any other unencoded `open()` in the codebase. The container-level env change neutralizes them all.

## How did you test this code?

I'm an agent; I did not perform manual testing in a running container. Automated checks I ran locally:

- Reproduced the failure mode by forcing the interpreter's default `open()` encoding to ASCII, then confirmed the fixed call (`encoding="utf-8"`) loads all 3,779 entries without error.
- Verified byte `0xc2` was at offset 2209 in the data file and that the file now has zero non-ASCII bytes after the strip.
- `ruff check` passes on both changed Python files; commit passed the repo's lint/format/typecheck pre-commit hooks.

A reviewer should still confirm the `Dockerfile` env vars take effect in an actual Unit container build.

## Docs update

No docs change needed.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus 4.8). Starting from a report that project creation was failing with an ASCII `UnicodeDecodeError`, I traced the creation path to `GenericEmails`, confirmed the offending byte offset matched the data file exactly, and bisected the trigger to the Unit base-image bump in #59440.

Key decision: fix forward instead of rolling back the Python bump. Considered three layers — (1) the targeted `encoding="utf-8"` on the crashing read, (2) the verbatim copy in migration 0132, (3) a container-level `PYTHONUTF8`/`LANG` env to cover the whole class of unencoded `open()` calls (several others exist, e.g. `js_snippet_versioning.py`, `products.py`). Shipped all three plus a cleanup of the stray non-breaking space, since the env var is the durable fix while the explicit encodings protect non-container contexts like local dev.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
