### PR TITLE
chore(django): mv fallback no team id cohort q

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1692,7 +1692,7 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
         queryset = (
             Person.objects.db_manager(READ_DB_FOR_PERSONS)  # nosemgrep: no-direct-persons-db-orm
             .filter(team_id=team_id)
-            .filter(property_group_to_Q(team_id, flag_property_group, cohorts_cache=cohorts_cache))
+            .filter(property_group_to_Q(project_id, flag_property_group, cohorts_cache=cohorts_cache))
             .order_by("id")
         )
         # get batchsize number of people at a time
@@ -1757,6 +1757,7 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
                         },
                         group_property_value_overrides={},
                         cohorts_cache=cohorts_cache,
+                        person_id=person.id,
                     ).get_match(feature_flag)
                     if match.match:
                         uuids_to_add_to_cohort.append(str(person.uuid))

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -348,10 +348,11 @@ def property_to_Q(
         if cohort.is_static:
             resolved_team_id = team_id if team_id is not None else cohort.team_id
 
-            # When a concrete person is in scope, short-circuit the Exists subquery
-            # with a direct membership check — routes through personhog when enabled,
-            # falling back to the persons-DB ORM otherwise. Mirrors the override
-            # short-circuit below (returning Q(pk__isnull=False|True)).
+            # When a concrete person is in scope, check membership directly instead of
+            # materializing the full member list; routes through personhog when enabled,
+            # falling back to the persons-DB ORM otherwise. Returns a match-all/match-none
+            # Q like the override short-circuit below.
+            # Assumes the queryset is already scoped to this person_id.
             if person_id is not None:
                 from products.cohorts.backend.models.util import is_person_in_cohort
 
@@ -359,10 +360,9 @@ def property_to_Q(
                     return Q(pk__isnull=False)
                 return Q(pk__isnull=True)
 
-            # List all member IDs and filter with Q(id__in=…) — routes through
-            # personhog when the gate is on, falling back to the CohortPeople
-            # table otherwise. This avoids the Exists(CohortPeople) subquery so
-            # the persons DB is not required on the personhog path.
+            # List member IDs and filter with Q(id__in=…); routes through personhog when
+            # enabled, falling back to the CohortPeople table otherwise. Listing IDs keeps
+            # the persons DB off the critical path when personhog is on.
             from products.cohorts.backend.models.util import list_cohort_member_ids
 
             member_ids = list_cohort_member_ids(team_id=resolved_team_id, cohort_id=cohort_id)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any, Optional, TypeVar, Union, cast
 from zoneinfo import ZoneInfo
 
-from django.db.models import Exists, OuterRef, Q, Value
+from django.db.models import Q, Value
 
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
@@ -20,7 +20,7 @@ from posthog.models.team import Team
 from posthog.queries.util import convert_to_datetime_aware
 from posthog.utils import get_compare_period_dates, is_valid_regex
 
-from products.cohorts.backend.models.cohort import Cohort, CohortOrEmpty, CohortPeople
+from products.cohorts.backend.models.cohort import Cohort, CohortOrEmpty
 
 FilterType = TypeVar("FilterType", Filter, PathFilter)
 
@@ -346,41 +346,29 @@ def property_to_Q(
             return Q(pk__isnull=True)
 
         if cohort.is_static:
+            resolved_team_id = team_id if team_id is not None else cohort.team_id
+
             # When a concrete person is in scope, short-circuit the Exists subquery
             # with a direct membership check — routes through personhog when enabled,
             # falling back to the persons-DB ORM otherwise. Mirrors the override
             # short-circuit below (returning Q(pk__isnull=False|True)).
-            if person_id is not None and team_id is not None:
+            if person_id is not None:
                 from products.cohorts.backend.models.util import is_person_in_cohort
 
-                if is_person_in_cohort(team_id=team_id, person_id=person_id, cohort_id=cohort_id):
+                if is_person_in_cohort(team_id=resolved_team_id, person_id=person_id, cohort_id=cohort_id):
                     return Q(pk__isnull=False)
                 return Q(pk__isnull=True)
 
-            # When team_id is available, list all member IDs and filter with
-            # Q(id__in=…) — routes through personhog when the gate is on,
-            # falling back to the CohortPeople table otherwise. This avoids
-            # the Exists(CohortPeople) subquery so the persons DB is not
-            # required on the personhog path.
-            if team_id is not None:
-                from products.cohorts.backend.models.util import list_cohort_member_ids
+            # List all member IDs and filter with Q(id__in=…) — routes through
+            # personhog when the gate is on, falling back to the CohortPeople
+            # table otherwise. This avoids the Exists(CohortPeople) subquery so
+            # the persons DB is not required on the personhog path.
+            from products.cohorts.backend.models.util import list_cohort_member_ids
 
-                member_ids = list_cohort_member_ids(team_id=team_id, cohort_id=cohort_id)
-                if not member_ids:
-                    return Q(pk__isnull=True)
-                return Q(id__in=member_ids)
-
-            return Q(
-                Exists(
-                    CohortPeople.objects.db_manager(using_database)  # nosemgrep: no-direct-persons-db-orm
-                    .filter(
-                        cohort_id=cohort_id,
-                        person_id=OuterRef("id"),
-                        cohort__id=cohort_id,
-                    )
-                    .only("id")
-                )
-            )
+            member_ids = list_cohort_member_ids(team_id=resolved_team_id, cohort_id=cohort_id)
+            if not member_ids:
+                return Q(pk__isnull=True)
+            return Q(id__in=member_ids)
         else:
             # :TRICKY: This has potential to create an infinite loop if the cohort is recursive.
             # But, this shouldn't happen because we check for cyclic cohorts on creation.

--- a/products/cohorts/backend/models/test/test_cohort_personhog.py
+++ b/products/cohorts/backend/models/test/test_cohort_personhog.py
@@ -424,6 +424,7 @@ class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
         )
 
         assert q == Q(pk__isnull=True)
+        self._assert_personhog_called("check_cohort_membership")
 
     def test_isolates_cohort_by_team_id(self):
         """A cohort owned by a different team (even within the same project)

--- a/products/cohorts/backend/models/test/test_cohort_personhog.py
+++ b/products/cohorts/backend/models/test/test_cohort_personhog.py
@@ -339,8 +339,8 @@ class TestCheckCohortMembershipFallback(BaseTest):
 
 @parameterized_class(("personhog",), [(False,), (True,)])
 class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
-    """property_to_Q short-circuits the Exists(CohortPeople) subquery when
-    caller passes person_id + team_id for a static cohort."""
+    """property_to_Q routes static cohort membership through personhog,
+    resolving team_id from cohort.team_id when not explicitly passed."""
 
     def _make_cohort_property(self, cohort_id: int):
         from posthog.models.property import Property
@@ -380,21 +380,50 @@ class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
 
         assert q == Q(pk__isnull=True)
 
-    def test_falls_back_to_exists_without_person_id_or_team_id(self):
+    def test_resolves_team_id_from_cohort_without_explicit_team_id(self):
+        from posthog.queries.base import property_to_Q
+
+        p1 = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=p1)
+        self._seed_cohort_membership(person_id=p1.id, cohort_id=cohort.id, is_member=True)
+
+        q = property_to_Q(self.team.project_id, self._make_cohort_property(cohort.id))
+
+        matched = Person.objects.filter(team_id=self.team.id).filter(q)
+        assert list(matched.values_list("id", flat=True)) == [p1.id]
+        self._assert_personhog_called("list_cohort_member_ids")
+
+    def test_resolves_team_id_from_cohort_with_person_id_no_team_id(self):
         from posthog.queries.base import property_to_Q
 
         person = self._seed_person(team=self.team, distinct_ids=["d1"])
         cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
         CohortPeople.objects.create(cohort=cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=cohort.id, is_member=True)
 
-        q = property_to_Q(self.team.project_id, self._make_cohort_property(cohort.id))
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            person_id=person.id,
+        )
 
-        # Not a short-circuit Q — it's an Exists() wrapped in Q
-        assert q != Q(pk__isnull=False)
-        assert q != Q(pk__isnull=True)
-        # The Exists subquery path never calls either RPC
-        self._assert_personhog_not_called("check_cohort_membership")
-        self._assert_personhog_not_called("list_cohort_member_ids")
+        assert q == Q(pk__isnull=False)
+        self._assert_personhog_called("check_cohort_membership")
+
+    def test_no_match_when_no_team_id_and_person_not_member(self):
+        from posthog.queries.base import property_to_Q
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            person_id=person.id,
+        )
+
+        assert q == Q(pk__isnull=True)
 
     def test_isolates_cohort_by_team_id(self):
         """A cohort owned by a different team (even within the same project)
@@ -496,7 +525,7 @@ class TestListCohortMemberIdsFallback(BaseTest):
 @parameterized_class(("personhog",), [(False,), (True,)])
 class TestPropertyToQStaticCohortMemberList(PersonhogTestMixin, BaseTest):
     """property_to_Q uses list_cohort_member_ids to produce Q(id__in=…) when
-    team_id is provided but person_id is not (queryset-wide filtering)."""
+    person_id is not provided (queryset-wide filtering)."""
 
     def _make_cohort_property(self, cohort_id: int):
         from posthog.models.property import Property

--- a/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
+++ b/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
@@ -786,86 +786,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.2
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."last_calculation_duration_ms",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."last_backfill_person_properties_at",
-         "posthog_cohort"."last_realtime_cohort_calculation_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."kind",
-         "posthog_cohort"."cohort_type",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_team"."project_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.3
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."last_calculation_duration_ms",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."last_backfill_person_properties_at",
-         "posthog_cohort"."last_realtime_cohort_calculation_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."kind",
-         "posthog_cohort"."cohort_type",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 99999)
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.4
-  '''
-  SELECT 1 AS "a"
-  FROM "posthog_cohort"
-  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
-  WHERE (("posthog_cohort"."team_id" =
-            (SELECT U0."parent_team_id" AS "parent_team_id"
-             FROM "posthog_team" U0
-             WHERE U0."id" = 99999
-             LIMIT 1)
-          OR ("posthog_team"."parent_team_id" IS NULL
-              AND "posthog_cohort"."team_id" = 99999))
-         AND "posthog_cohort"."id" = 99999)
-  LIMIT 1
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.5
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.10
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -972,7 +893,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.6
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.11
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -997,7 +918,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.7
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.12
   '''
   SELECT "posthog_filesystemshortcut"."id",
          "posthog_filesystemshortcut"."team_id",
@@ -1018,6 +939,177 @@
          AND NOT ("posthog_filesystemshortcut"."path" = 'some cohort'
                   AND "posthog_filesystemshortcut"."href" = '__skipped__'
                   AND "posthog_filesystemshortcut"."href" IS NOT NULL))
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.2
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."last_calculation_duration_ms",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."last_backfill_person_properties_at",
+         "posthog_cohort"."last_realtime_cohort_calculation_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."kind",
+         "posthog_cohort"."cohort_type",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_cohort"."id" = 99999
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.3
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."last_calculation_duration_ms",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."last_backfill_person_properties_at",
+         "posthog_cohort"."last_realtime_cohort_calculation_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."kind",
+         "posthog_cohort"."cohort_type",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.4
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (("posthog_cohort"."team_id" =
+            (SELECT U0."parent_team_id" AS "parent_team_id"
+             FROM "posthog_team" U0
+             WHERE U0."id" = 99999
+             LIMIT 1)
+          OR ("posthog_team"."parent_team_id" IS NULL
+              AND "posthog_cohort"."team_id" = 99999))
+         AND "posthog_cohort"."id" = 99999)
+  LIMIT 1
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.5
+  '''
+  SELECT "posthog_cohort"."id" AS "id"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (("posthog_cohort"."team_id" =
+            (SELECT U0."parent_team_id" AS "parent_team_id"
+             FROM "posthog_team" U0
+             WHERE U0."id" = 99999
+             LIMIT 1)
+          OR ("posthog_team"."parent_team_id" IS NULL
+              AND "posthog_cohort"."team_id" = 99999))
+         AND "posthog_cohort"."id" IN (1,
+                                       2,
+                                       3,
+                                       4,
+                                       5 /* ... */))
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.6
+  '''
+  SELECT "posthog_cohort"."id" AS "id"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (("posthog_cohort"."team_id" =
+            (SELECT U0."parent_team_id" AS "parent_team_id"
+             FROM "posthog_team" U0
+             WHERE U0."id" = 99999
+             LIMIT 1)
+          OR ("posthog_team"."parent_team_id" IS NULL
+              AND "posthog_cohort"."team_id" = 99999))
+         AND "posthog_cohort"."id" IN (1,
+                                       2,
+                                       3,
+                                       4,
+                                       5 /* ... */))
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.7
+  '''
+  SELECT "posthog_cohort"."id" AS "id"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (("posthog_cohort"."team_id" =
+            (SELECT U0."parent_team_id" AS "parent_team_id"
+             FROM "posthog_team" U0
+             WHERE U0."id" = 99999
+             LIMIT 1)
+          OR ("posthog_team"."parent_team_id" IS NULL
+              AND "posthog_cohort"."team_id" = 99999))
+         AND "posthog_cohort"."id" IN (1,
+                                       2,
+                                       3,
+                                       4,
+                                       5 /* ... */))
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.8
+  '''
+  SELECT "posthog_cohort"."id" AS "id"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (("posthog_cohort"."team_id" =
+            (SELECT U0."parent_team_id" AS "parent_team_id"
+             FROM "posthog_team" U0
+             WHERE U0."id" = 99999
+             LIMIT 1)
+          OR ("posthog_team"."parent_team_id" IS NULL
+              AND "posthog_cohort"."team_id" = 99999))
+         AND "posthog_cohort"."id" IN (1,
+                                       2,
+                                       3,
+                                       4,
+                                       5 /* ... */))
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.9
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (("posthog_cohort"."team_id" =
+            (SELECT U0."parent_team_id" AS "parent_team_id"
+             FROM "posthog_team" U0
+             WHERE U0."id" = 99999
+             LIMIT 1)
+          OR ("posthog_team"."parent_team_id" IS NULL
+              AND "posthog_cohort"."team_id" = 99999))
+         AND "posthog_cohort"."id" = 99999)
+  LIMIT 1
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -7854,8 +7854,12 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with snapshot_postgres_queries_context(self), self.assertNumQueries(32):
+        with snapshot_postgres_queries_context(self), self.assertNumQueries(42):
             # forced to evaluate flags by going to db, because cohorts need db query to evaluate
+            # Static cohort membership routes through personhog-backed helpers instead of an
+            # embedded Exists(CohortPeople) subquery: the prefilter fetches the member list once
+            # (ownership check + member list), then each matched person gets a direct membership
+            # check (ownership scoping + single-row lookup).
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature-new", self.team.pk)
 
         cohort.refresh_from_db()

--- a/products/feature_flags/backend/flag_matching.py
+++ b/products/feature_flags/backend/flag_matching.py
@@ -133,6 +133,7 @@ class FeatureFlagMatcher:
         group_property_value_overrides: Optional[dict[str, dict[str, Union[str, int]]]] = None,
         skip_database_flags: bool = False,
         cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,
+        person_id: Optional[int] = None,
     ):
         if group_property_value_overrides is None:
             group_property_value_overrides = {}
@@ -152,6 +153,10 @@ class FeatureFlagMatcher:
         self.property_value_overrides = property_value_overrides
         self.group_property_value_overrides = group_property_value_overrides
         self.skip_database_flags = skip_database_flags
+        # When the caller already knows the person's primary key (e.g. batch cohort
+        # generation iterating Person rows), static-cohort conditions resolve via a
+        # direct membership check instead of fetching the full cohort member list.
+        self.person_id = person_id
 
         if cohorts_cache is None:
             self.cohorts_cache = {}
@@ -450,6 +455,9 @@ class FeatureFlagMatcher:
                             override_property_values=target_properties,
                             cohorts_cache=self.cohorts_cache,
                             using_database=READ_ONLY_DATABASE_FOR_PERSONS,
+                            # person_id only applies to person-aggregated flags; group
+                            # conditions are evaluated against the group query.
+                            person_id=self.person_id if feature_flag.aggregation_group_type_index is None else None,
                         )
 
                         # TRICKY: Due to property overrides for cohorts, we sometimes shortcircuit the condition check.


### PR DESCRIPTION
## Problem

`property_to_Q` only routed static cohort membership through the personhog-backed helpers when the caller passed `team_id`, falling back to an embedded `Exists(CohortPeople)` subquery otherwise, a direct persons-DB ORM dependency. The main production caller of this path, `get_cohort_actors_for_feature_flag` (the "create static cohort from feature flag" task, which is also the last production user of the Python `FeatureFlagMatcher`), passed neither `person_id` nor `team_id`, so it always hit the unrouted fallback.

Simply removing the fallback wasn't enough: without a `person_id`, every per-person flag evaluation in that task would resolve static cohort conditions by fetching the full cohort member list — O(persons × cohort_size) data volume for a task that evaluates one person at a time.

The task also passed `team_id` as the `project_id` positional argument of `property_group_to_Q`, a latent bug for projects where the two differ.


## Changes

**`posthog/queries/base.py`:**

- Removed the `Exists(CohortPeople)` fallback for static cohorts. All static cohort membership now goes through the personhog-routed helpers (`is_person_in_cohort` when a concrete person is in scope, `list_cohort_member_ids` for queryset-wide filtering), each with ORM fallback behind the existing gate.
- When the caller doesn't pass `team_id`, it is resolved from `cohort.team_id`. The cohort is already validated against the caller's project, and scoping membership to the cohort's owning team preserves the old `Exists` semantics — including cohorts referenced across environments within a project.

**`products/feature_flags/backend/flag_matching.py`:**

- `FeatureFlagMatcher` accepts an optional `person_id`. When set (and the flag aggregates by persons), static cohort conditions resolve via a single-row membership check instead of materializing the member list, and the existing match-all/match-none short-circuit skips the SQL annotation for that condition.

**`posthog/api/cohort.py`:**

- `get_cohort_actors_for_feature_flag` passes the correct `project_id` to `property_group_to_Q`, and passes `person_id=person.id` to each per-person matcher. The batch prefilter fetches the cohort member list once per run; per-person evaluation is a bounded single-row check.

## How did you test this?

- `products/feature_flags/backend/api/test/test_feature_flag.py::TestCohortGenerationForFeatureFlag` (9 tests) — covers the end-to-end task, including the query-count assertion (32 → 42 vs master: +2 for the prefilter's ownership check + member list, +2 per matched person for the bounded membership check, replacing the embedded `Exists` subquery) and regenerated Postgres query snapshots, which show the per-person ownership-scoping queries from `check_cohort_membership`.
- `posthog/models/cohort/test/test_cohort_personhog.py` (109 tests, parameterized over personhog on/off) — covers `property_to_Q` static cohort routing: `team_id` resolution from the cohort, the `person_id` short-circuit, member-list filtering, and team isolation when `team_id` is passed explicitly.


