### PR TITLE
feat(flags): add remote config as a distinct flag template

### DIFF
--- a/frontend/src/scenes/feature-flags/NewFeatureFlagMenu.tsx
+++ b/frontend/src/scenes/feature-flags/NewFeatureFlagMenu.tsx
@@ -34,7 +34,10 @@ interface DropdownTemplateMetadata {
     icon: React.ComponentType
 }
 
-const TEMPLATE_METADATA: Record<TemplateKey, DropdownTemplateMetadata> = {
+// Remote config has its own dedicated menu item below, so the preset dropdown excludes it.
+type PresetTemplateKey = Exclude<TemplateKey, 'remote-config'>
+
+const TEMPLATE_METADATA: Record<PresetTemplateKey, DropdownTemplateMetadata> = {
     simple: {
         name: 'Simple flag',
         description: 'On/off for all users',
@@ -57,7 +60,7 @@ const TEMPLATE_METADATA: Record<TemplateKey, DropdownTemplateMetadata> = {
     },
 }
 
-const TEMPLATES: TemplateKey[] = ['simple', 'targeted', 'multivariate', 'targeted-multivariate']
+const TEMPLATES: PresetTemplateKey[] = ['simple', 'targeted', 'multivariate', 'targeted-multivariate']
 
 const AI_TOOL_DEFINITION = getToolDefinition('create_feature_flag')!
 const AI_SUGGESTIONS = [
@@ -67,7 +70,7 @@ const AI_SUGGESTIONS = [
     'Create a beta testing flag for…',
 ]
 
-function IntentSubmenu({ template, onBack }: { template: TemplateKey; onBack: () => void }): JSX.Element {
+function IntentSubmenu({ template, onBack }: { template: PresetTemplateKey; onBack: () => void }): JSX.Element {
     const metadata = TEMPLATE_METADATA[template]
 
     return (
@@ -114,7 +117,7 @@ export function OverlayForNewFeatureFlagMenu(): JSX.Element {
 
     const intentsEnabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAG_CREATION_INTENTS]
     // useState is intentional — this is an ephemeral popover overlay that unmounts on close
-    const [selectedTemplate, setSelectedTemplate] = useState<TemplateKey | null>(null)
+    const [selectedTemplate, setSelectedTemplate] = useState<PresetTemplateKey | null>(null)
 
     if (intentsEnabled && selectedTemplate) {
         return <IntentSubmenu template={selectedTemplate} onBack={() => setSelectedTemplate(null)} />

--- a/products/feature_flags/frontend/FeatureFlagTemplatesScene.tsx
+++ b/products/feature_flags/frontend/FeatureFlagTemplatesScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import { IconArrowLeft, IconFlask, IconPeople, IconPlus, IconTestTube, IconToggle } from '@posthog/icons'
+import { IconArrowLeft, IconCode, IconFlask, IconPeople, IconPlus, IconTestTube, IconToggle } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { FlagIntent } from 'scenes/feature-flags/featureFlagIntentWarningLogic'
@@ -43,6 +43,11 @@ const TEMPLATES: FeatureFlagTemplate[] = [
         key: 'targeted-multivariate',
         description: 'Test variants for specific user or group segments',
         icon: <IconFlask className="w-6 h-6 text-primary-3000" />,
+    },
+    {
+        key: 'remote-config',
+        description: 'Deliver configuration values to your app',
+        icon: <IconCode className="w-6 h-6 text-primary-3000" />,
     },
 ]
 

--- a/products/feature_flags/frontend/featureFlagTemplateConstants.ts
+++ b/products/feature_flags/frontend/featureFlagTemplateConstants.ts
@@ -4,13 +4,14 @@ import { IconRocket, IconServer } from '@posthog/icons'
 
 import type { FlagIntent } from 'scenes/feature-flags/featureFlagIntentWarningLogic'
 
-export type TemplateKey = 'simple' | 'targeted' | 'multivariate' | 'targeted-multivariate'
+export type TemplateKey = 'simple' | 'targeted' | 'multivariate' | 'targeted-multivariate' | 'remote-config'
 
 export const TEMPLATE_NAMES: Record<TemplateKey, string> = {
     simple: 'Percentage rollout',
     targeted: 'Targeted release',
     multivariate: 'Multivariate',
     'targeted-multivariate': 'Targeted multivariate',
+    'remote-config': 'Remote config',
 }
 
 export interface IntentMetadata {

--- a/products/feature_flags/frontend/featureFlagTemplatesSceneLogic.test.ts
+++ b/products/feature_flags/frontend/featureFlagTemplatesSceneLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -54,6 +55,42 @@ describe('featureFlagTemplatesSceneLogic', () => {
             await expectLogic(logic).toMatchValues({
                 intentsEnabled: expected,
             })
+        })
+    })
+
+    describe('selectTemplate listener', () => {
+        function mountWithIntents(enabled: boolean): void {
+            enabledFeaturesLogic.actions.setFeatureFlags(
+                [],
+                enabled ? { [FEATURE_FLAGS.FEATURE_FLAG_CREATION_INTENTS]: true } : {}
+            )
+            logic = featureFlagTemplatesSceneLogic()
+            logic.mount()
+        }
+
+        it.each([
+            { name: 'when intents are enabled', intentsEnabled: true },
+            { name: 'when intents are disabled', intentsEnabled: false },
+        ])(
+            'routes remote-config to the new flag via type, skipping the intent step $name',
+            async ({ intentsEnabled }) => {
+                mountWithIntents(intentsEnabled)
+
+                logic.actions.selectTemplate('remote-config')
+
+                await expectLogic(logic).toMatchValues({ selectedTemplate: null })
+                expect(router.values.location.pathname).toContain('/feature_flags/new')
+                expect(router.values.searchParams.type).toBe('remote_config')
+                expect(router.values.searchParams.template).toBeUndefined()
+            }
+        )
+
+        it('shows the intent step for a non-remote-config template when intents are enabled', async () => {
+            mountWithIntents(true)
+
+            logic.actions.selectTemplate('targeted')
+
+            await expectLogic(logic).toMatchValues({ selectedTemplate: 'targeted' })
         })
     })
 })

--- a/products/feature_flags/frontend/featureFlagTemplatesSceneLogic.ts
+++ b/products/feature_flags/frontend/featureFlagTemplatesSceneLogic.ts
@@ -18,7 +18,10 @@ export function navigateToNewFlag(
     intent?: FlagIntent
 ): void {
     const params: Record<string, any> = { ...searchParams }
-    if (template && template !== 'blank') {
+    if (template === 'remote-config') {
+        // Remote config is a distinct flag type, not a targeting preset — route via the type param.
+        params.type = 'remote_config'
+    } else if (template && template !== 'blank') {
         params.template = template
     }
     if (intent) {
@@ -54,7 +57,8 @@ export const featureFlagTemplatesSceneLogic = kea<featureFlagTemplatesSceneLogic
         selectTemplate: ({ template }) => {
             posthog.capture('feature flag template selected', { template_key: template })
 
-            if (values.intentsEnabled) {
+            // Remote config skips the intent step — its evaluation warnings only apply to client-side flags.
+            if (values.intentsEnabled && template !== 'remote-config') {
                 actions.setSelectedTemplate(template)
             } else {
                 navigateToNewFlag(router.values.searchParams, template)


### PR DESCRIPTION
## Problem

The templates scene (the "Create a feature flag" cards page) offered simple, targeted, multivariate, and targeted-multivariate, but not remote config. The new-flag dropdown already listed remote config as its own item, so the two surfaces were out of sync and remote config wasn't discoverable from the templates scene.

__BEFORE__

<img width="1124" height="670" alt="Screenshot 2026-06-08 at 5 58 44 PM" src="https://github.com/user-attachments/assets/b28fd4d9-ff86-405b-9ebc-0708a3f7db51" />

__AFTER__

<img width="1031" height="578" alt="Screenshot 2026-06-08 at 5 51 42 PM" src="https://github.com/user-attachments/assets/bf6c95aa-e2fd-4d1e-bf47-1a8fc3c793c4" />

This matches what we have in the New Flag button menu dropdown:

<img width="365" height="484" alt="Screenshot 2026-06-08 at 5 56 45 PM" src="https://github.com/user-attachments/assets/96cd363b-d9c9-472f-a416-1ccf697dc3ea" />

## Changes

Adds remote config as a card on the templates scene and wires it up as the distinct flag type it is.

- Adds `remote-config` to `TemplateKey` with the display name "Remote config".
- Gives remote config its own card on the templates scene, with the `IconCode` icon and a "Deliver configuration values to your app" description.
- Routes remote config through the `type=remote_config` URL param instead of the `template` param, since it's a flag type rather than a targeting preset.
- Skips the intent step for remote config, because the intent evaluation warnings only apply to client-side flags.
- Adds a `PresetTemplateKey` type in the new-flag menu. This is type-only: widening `TemplateKey` would otherwise force the preset metadata record to require a `remote-config` entry it doesn't use, since the dropdown's preset group stays simple/targeted/multivariate/targeted-multivariate and remote config keeps its existing dedicated item.

## How did you test this code?

Manually tested in the app. Confirmed remote config shows as its own card on the templates scene with the code icon and description, routes to the remote config flag type when selected, and skips the intent step. Confirmed the new-flag dropdown still shows its existing remote config item unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?