### PR TITLE
test(provisioning): pin OIDC key in confirm-attribution test

### DIFF
--- a/ee/api/agentic_provisioning/test/test_authorize.py
+++ b/ee/api/agentic_provisioning/test/test_authorize.py
@@ -190,7 +190,7 @@ class TestAgenticAuthorizeConfirm(AgenticAuthorizeMultiOrgBase):
 
     # Creating an RS256 app requires OIDC_RSA_PRIVATE_KEY. The env-level key can be cleared by
     # other OAuth tests overriding OAUTH2_PROVIDER (django-oauth-toolkit caches its settings), so
-    # assert it here too.
+    # pin it here too.
     @override_settings(
         OIDC_RSA_PRIVATE_KEY=_RSA_KEY,
         OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": _RSA_KEY},

--- a/ee/api/agentic_provisioning/test/test_authorize.py
+++ b/ee/api/agentic_provisioning/test/test_authorize.py
@@ -188,6 +188,13 @@ class TestAgenticAuthorizeConfirm(AgenticAuthorizeMultiOrgBase):
         )
         assert cache.get(f"{PENDING_AUTH_CACHE_PREFIX}state_consume") is None
 
+    # Creating an RS256 app requires OIDC_RSA_PRIVATE_KEY. The env-level key can be cleared by
+    # other OAuth tests overriding OAUTH2_PROVIDER (django-oauth-toolkit caches its settings), so
+    # assert it here too.
+    @override_settings(
+        OIDC_RSA_PRIVATE_KEY=_RSA_KEY,
+        OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": _RSA_KEY},
+    )
     @patch("ee.api.agentic_provisioning.views._capture_provisioning_event")
     def test_confirm_success_attributes_partner(self, mock_capture_event):
         partner = OAuthApplication.objects.create(


### PR DESCRIPTION
## Problem

`test_confirm_success_attributes_partner` in the agentic provisioning suite is flaky. It creates an `OAuthApplication` whose model enforces the RS256 algorithm, which requires `OIDC_RSA_PRIVATE_KEY` to be set. django-oauth-toolkit caches its settings, so another OAuth test that overrides `OAUTH2_PROVIDER` can leave the key cleared by the time this test runs, and the app creation fails.

## Changes

Pin a known test RSA key on the test at both levels it can be read from: the top-level `OIDC_RSA_PRIVATE_KEY` setting and the nested `OAUTH2_PROVIDER["OIDC_RSA_PRIVATE_KEY"]` copy that django-oauth-toolkit reads. This makes the test deterministic regardless of test ordering or cross-test settings-cache pollution. It mirrors the same two-key override already applied to the sibling `test_full_a1_flow_with_token_exchange`.

Test-only change, no production code touched.

## How did you test this code?

The full `TestAgenticAuthorizeConfirm` class (8 tests) passes.