### PR TITLE
feat(web-analytics): allow raising memory ceiling for dimensional precompute inserts

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -1000,6 +1000,7 @@ def ensure_precomputed(
     placeholders: dict[str, ast.Expr] | None = None,
     sentinel_placeholders: set[str] | None = None,
     query_type: str | None = None,
+    insert_settings: dict | None = None,
 ) -> LazyComputationResult:
     """
     Ensure lazy-computed data exists for the given query and time range.
@@ -1038,6 +1039,9 @@ def ensure_precomputed(
                       for hashing. Use this for placeholders whose values change between
                       requests (e.g. datetime.now()) but shouldn't invalidate the cache.
                       The real values are still used at INSERT time.
+        insert_settings: Optional ClickHouse settings merged over the shared INSERT
+                      defaults for this path only (e.g. a higher max_memory_usage for
+                      heavy per-team backfills). Does not affect other callers.
 
     Returns:
         ComputationResult with job_ids that can be used to query the data
@@ -1114,7 +1118,9 @@ def ensure_precomputed(
             sync_execute(
                 insert_sql,
                 values,
-                settings=_get_insert_settings(t.id),
+                # Per-call overrides (e.g. a higher memory ceiling for heavy
+                # per-team-per-day backfills) layer on top of the shared defaults.
+                settings={**_get_insert_settings(t.id), **(insert_settings or {})},
             )
 
     ttl_schedule = parse_ttl_schedule(ttl_seconds, team.timezone)

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -919,6 +919,26 @@ class TestEnsurePrecomputed(ClickhouseTestMixin, BaseTest):
         assert job.status == PreaggregationJob.Status.READY
         assert job.team == self.team
 
+    def test_insert_settings_are_merged_over_defaults(self):
+        with patch(
+            "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.sync_execute"
+        ) as mock_exec:
+            ensure_precomputed(
+                team=self.team,
+                insert_query=self.MANUAL_INSERT_QUERY,
+                time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+                time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
+                insert_settings={"max_memory_usage": 12345, "max_bytes_before_external_group_by": 678},
+            )
+
+        insert_calls = [c for c in mock_exec.call_args_list if "settings" in c.kwargs]
+        assert insert_calls, "expected the INSERT to pass ClickHouse settings"
+        settings = insert_calls[-1].kwargs["settings"]
+        assert settings["max_memory_usage"] == 12345
+        assert settings["max_bytes_before_external_group_by"] == 678
+        # the shared insert defaults are still applied alongside the override
+        assert "max_execution_time" in settings
+
     def test_reuses_existing_jobs(self):
         # First call
         first_result = ensure_precomputed(

--- a/products/web_analytics/backend/hogql_queries/web_dimensional_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_dimensional_precompute.py
@@ -25,6 +25,7 @@ Parity with v2 is intentional, with two deliberate deviations:
 from datetime import datetime
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_expr
 
 from posthog.models.team import Team
@@ -46,6 +47,18 @@ DIMENSIONAL_TTL_SECONDS: dict[str, int] = {
     "2d": 24 * 60 * 60,
     "default": 90 * 24 * 60 * 60,
 }
+
+# Extra memory headroom for the dimensional INSERTs, mirroring v2's preagg ETL
+# (`web_preaggregated_utils.py`: 140 GiB / 70 GiB external group-by) but ~half,
+# since the dimensional path runs one INSERT per team PER DAY rather than v2's
+# single per-team full-history REPLACE PARTITION. `max_bytes_before_external_group_by`
+# spills the GROUP BY to disk before the ceiling, which is what avoids OOM on the
+# highest-volume teams. Built from HogQLGlobalSettings so the override goes through
+# the same typed ClickHouse-settings model as the rest of the query path.
+DIMENSIONAL_INSERT_SETTINGS: dict = HogQLGlobalSettings(
+    max_memory_usage=70 * 1024**3,
+    max_bytes_before_external_group_by=35 * 1024**3,
+).model_dump(include={"max_memory_usage", "max_bytes_before_external_group_by"})
 
 
 # Per-session row, then aggregated into hourly buckets. `host`/`device_type`/
@@ -316,6 +329,7 @@ def ensure_web_stats_dimensional_precomputed(
         table=LazyComputationTable.WEB_STATS_DIMENSIONAL_PREAGGREGATED,
         placeholders=_base_placeholders(),
         query_type="web_stats_dimensional_insert",
+        insert_settings=DIMENSIONAL_INSERT_SETTINGS,
     )
 
 
@@ -333,4 +347,5 @@ def ensure_web_bounces_dimensional_precomputed(
         table=LazyComputationTable.WEB_BOUNCES_DIMENSIONAL_PREAGGREGATED,
         placeholders=_base_placeholders(),
         query_type="web_bounces_dimensional_insert",
+        insert_settings=DIMENSIONAL_INSERT_SETTINGS,
     )


### PR DESCRIPTION
## Problem

The scheduled dimensional precompute backfill OOMed on the highest-volume pilot team (one day-chunk hit the default ~42 GiB ClickHouse ceiling). v2's preagg ETL avoids this with a generous memory budget (140 GiB + 70 GiB external group-by), but the dimensional path runs one INSERT **per team per day**, so it needs far less headroom than v2's single per-team full-history `REPLACE PARTITION`.

## Changes

- Add an optional `insert_settings` override to `ensure_precomputed` — per-call ClickHouse settings merged over the shared insert defaults, affecting only the caller that passes them.
- The two dimensional ensure functions pass a `max_memory_usage=70 GiB` + `max_bytes_before_external_group_by=35 GiB` override (≈half of v2). The external-group-by setting spills the GROUP BY to disk before the ceiling, which is what actually prevents the OOM. Built via `HogQLGlobalSettings` so the values go through the same typed ClickHouse-settings model as the rest of the query path.

No other lazy-computation caller (experiments, web_overview/stats lazy, goals) is affected.

## How did you test this code?

Agent-authored (Claude Code). Added `test_insert_settings_are_merged_over_defaults` asserting the override reaches the INSERT's `sync_execute` settings while the shared defaults remain. Verified the typed-model construction resolves to `{max_memory_usage: 75161927680, max_bytes_before_external_group_by: 37580963840}`. ClickHouse-backed executor tests run in CI (not runnable locally here). Ruff + ty pass.

## 🤖 Agent context

Found while watching the dimensional cold backfill — a single team-55348 day-chunk OOMed at 42 GiB (the rest succeeded). Mirrors v2's memory approach but halved, since dimensional is per-team-per-day. Scoped via a new `insert_settings` param rather than bumping the shared `_get_insert_settings`, so experiments/lazy paths are untouched.
