### PR TITLE
fix(logs): store drop-rule rate limit as bytes, not records

### DIFF
--- a/nodejs/src/logs-ingestion/sampling/logs-sampling.rate-limit-impact.integration.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/logs-sampling.rate-limit-impact.integration.test.ts
@@ -1,0 +1,214 @@
+import avro from 'avsc'
+
+import { deleteKeysWithPrefix } from '~/cdp/_tests/redis'
+import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
+import { Hub } from '~/types'
+import { closeHub, createHub } from '~/utils/db/hub'
+
+import { type LogRecord, decodeLogRecords, encodeLogRecords } from '../log-record-avro'
+import { compileRuleSet } from './compile-rules'
+import { LogsSamplingService } from './logs-sampling.service'
+
+// Real-Redis integration test: drives the genuine token-bucket Lua with a mocked clock so we can
+// simulate a sustained log stream at different volumes deterministically (no sleeps). This is the
+// "save → impact" half of the rate-limit contract: it feeds the limiter the EXACT config shape the
+// drop-rule form writes (`kb_per_second` / `burst_kb`) and asserts the drop impact. The producer
+// side (form → that shape) is locked in by
+// products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts.
+
+const LOG_RECORD_AVRO = avro.Type.forSchema({
+    type: 'record',
+    name: 'LogRecord',
+    fields: [
+        { name: 'uuid', type: ['null', 'string'] },
+        { name: 'trace_id', type: ['null', 'bytes'] },
+        { name: 'span_id', type: ['null', 'bytes'] },
+        { name: 'trace_flags', type: ['null', 'int'] },
+        { name: 'timestamp', type: ['null', 'long'] },
+        { name: 'observed_timestamp', type: ['null', 'long'] },
+        { name: 'body', type: ['null', 'string'] },
+        { name: 'severity_text', type: ['null', 'string'] },
+        { name: 'severity_number', type: ['null', 'int'] },
+        { name: 'service_name', type: ['null', 'string'] },
+        { name: 'resource_attributes', type: ['null', { type: 'map', values: 'string' }] },
+        { name: 'instrumentation_scope', type: ['null', 'string'] },
+        { name: 'event_name', type: ['null', 'string'] },
+        { name: 'attributes', type: ['null', { type: 'map', values: 'string' }] },
+        { name: 'bytes_uncompressed', type: ['null', 'long'] },
+    ],
+})
+
+const logsSettings = { json_parse_logs: false, pii_scrub_logs: false }
+const SERVICE = 'smokescreen'
+const TEAM_ID = 4242
+// LogsSamplingService names its limiter 'logs-sampling-rate'; key prefix uses the test root.
+const SAMPLING_RATE_KEY_PREFIX = '@posthog-test/logs-sampling-rate'
+
+const mockNow: jest.SpyInstance = jest.spyOn(Date, 'now')
+
+/**
+ * Mirror of `buildSamplingConfigPayload` (rate-limit branch) in the drop-rule form logic:
+ * a byte rate in KB/s · MB/s · GB/s becomes `kb_per_second` + `burst_kb` (10× sustained).
+ */
+const UNIT_TO_KB = { 'KB/s': 1, 'MB/s': 1000, 'GB/s': 1_000_000 } as const
+function rateLimitConfigLikeUI(amount: number, unit: keyof typeof UNIT_TO_KB): Record<string, unknown> {
+    const kbPerSecond = Math.round(amount * UNIT_TO_KB[unit])
+    return { kb_per_second: kbPerSecond, burst_kb: kbPerSecond * 10 }
+}
+
+function ruleSetForLimit(ruleId: string, amount: number, unit: keyof typeof UNIT_TO_KB) {
+    return compileRuleSet([
+        {
+            id: ruleId,
+            rule_type: 'rate_limit',
+            scope_service: SERVICE,
+            scope_path_pattern: null,
+            scope_attribute_filters: [],
+            config: rateLimitConfigLikeUI(amount, unit),
+        },
+    ])
+}
+
+function logRow(uuid: string, bytesUncompressed: number): LogRecord {
+    return {
+        uuid,
+        trace_id: null,
+        span_id: null,
+        trace_flags: null,
+        timestamp: 1_700_000_000_000_000,
+        observed_timestamp: 1_700_000_000_000_000,
+        body: 'x',
+        severity_text: 'info',
+        severity_number: 9,
+        service_name: SERVICE,
+        resource_attributes: null,
+        instrumentation_scope: null,
+        event_name: null,
+        attributes: null,
+        bytes_uncompressed: bytesUncompressed,
+    }
+}
+
+describe('logs drop-rule rate limit — save-to-impact', () => {
+    jest.retryTimes(3)
+
+    let hub: Hub
+    let redis: RedisV2
+    let service: LogsSamplingService
+    let now: number
+
+    beforeEach(async () => {
+        hub = await createHub()
+        now = 1_720_000_000_000
+        mockNow.mockReturnValue(now)
+
+        redis = createRedisV2PoolFromConfig({
+            connection: hub.LOGS_REDIS_HOST
+                ? {
+                      url: hub.LOGS_REDIS_HOST,
+                      options: { port: hub.LOGS_REDIS_PORT, tls: hub.LOGS_REDIS_TLS ? {} : undefined },
+                  }
+                : { url: hub.REDIS_URL },
+            poolMinSize: hub.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
+        })
+        await deleteKeysWithPrefix(redis, SAMPLING_RATE_KEY_PREFIX)
+
+        service = new LogsSamplingService(redis, 60 * 60 * 24)
+    })
+
+    afterEach(async () => {
+        await closeHub(hub)
+        jest.clearAllMocks()
+    })
+
+    const advanceOneSecond = (): void => {
+        now += 1000
+        mockNow.mockReturnValue(now)
+    }
+
+    /** Push `recordsPerSecond` rows of `bytesEach` through one processBuffer call per simulated second. */
+    async function streamForSeconds(
+        ruleSet: ReturnType<typeof compileRuleSet>,
+        seconds: number,
+        recordsPerSecond: number,
+        bytesEach: number
+    ): Promise<{ dropped: number; kept: number }> {
+        let dropped = 0
+        let kept = 0
+        for (let s = 0; s < seconds; s++) {
+            const batch = Array.from({ length: recordsPerSecond }, (_, i) => logRow(`s${s}-r${i}`, bytesEach))
+            const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', batch)
+            const result = await service.processBuffer(buffer, logsSettings, ruleSet, TEAM_ID)
+            dropped += result.recordsDropped
+            kept += recordsPerSecond - result.recordsDropped
+            advanceOneSecond()
+        }
+        return { dropped, kept }
+    }
+
+    // ~530 KB/s of real traffic — the order of magnitude smokescreen actually emits once the
+    // 772× preview inflation is stripped out (530 rows/s × 1000 bytes).
+    const RECORDS_PER_SECOND = 530
+    const BYTES_EACH = 1000
+    const SECONDS = 6
+
+    it('a limit well above real volume (1 MB/s on ~530 KB/s) drops nothing', async () => {
+        const ruleSet = ruleSetForLimit('rl-high', 1, 'MB/s') // kb_per_second: 1000 → ~1.02 MB/s
+        const { dropped } = await streamForSeconds(ruleSet, SECONDS, RECORDS_PER_SECOND, BYTES_EACH)
+        expect(dropped).toBe(0)
+    })
+
+    it('a limit well below real volume (50 KB/s on ~530 KB/s) sheds a large share', async () => {
+        const ruleSet = ruleSetForLimit('rl-low', 50, 'KB/s') // kb_per_second: 50 → ~51 KB/s
+        const { dropped } = await streamForSeconds(ruleSet, SECONDS, RECORDS_PER_SECOND, BYTES_EACH)
+        // ~10× over the limit → a large share is dropped. We assert a robust floor rather than an
+        // exact count: the per-batch token bucket admits somewhat above the nominal rate, but the
+        // limit unambiguously bites (contrast the 1 MB/s case above, which drops nothing).
+        expect(dropped).toBeGreaterThan(RECORDS_PER_SECOND * SECONDS * 0.3)
+    })
+
+    it('lowering the limit from 1 MB/s to 50 KB/s changes the impact (the reported regression)', async () => {
+        // Before the form fix both values were written to `logs_per_second`, so the chosen byte rate
+        // was ignored and lowering it did nothing. With the fix the threshold is enforced in bytes,
+        // so the same stream is throttled far harder at 50 KB/s than at 1 MB/s.
+        const high = await streamForSeconds(
+            ruleSetForLimit('rl-cmp-high', 1, 'MB/s'),
+            SECONDS,
+            RECORDS_PER_SECOND,
+            BYTES_EACH
+        )
+        await deleteKeysWithPrefix(redis, SAMPLING_RATE_KEY_PREFIX)
+        const low = await streamForSeconds(
+            ruleSetForLimit('rl-cmp-low', 50, 'KB/s'),
+            SECONDS,
+            RECORDS_PER_SECOND,
+            BYTES_EACH
+        )
+
+        expect(high.dropped).toBe(0)
+        expect(low.dropped).toBeGreaterThan(high.dropped)
+    })
+
+    it('only drops once the stream exceeds the configured byte rate', async () => {
+        const ruleSet = ruleSetForLimit('rl-ramp', 100, 'KB/s') // ~102 KB/s sustained
+        // 50 KB/s — comfortably under the limit → nothing dropped even over several seconds.
+        const under = await streamForSeconds(ruleSet, SECONDS, 50, BYTES_EACH)
+        expect(under.dropped).toBe(0)
+
+        await deleteKeysWithPrefix(redis, SAMPLING_RATE_KEY_PREFIX)
+
+        // 400 KB/s — ~4× over the limit → sustained drops.
+        const over = await streamForSeconds(ruleSet, SECONDS, 400, BYTES_EACH)
+        expect(over.dropped).toBeGreaterThan(0)
+
+        // Decoding a sampled batch still yields valid avro (the kept rows re-encode cleanly).
+        const batch = Array.from({ length: 400 }, (_, i) => logRow(`final-${i}`, BYTES_EACH))
+        const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', batch)
+        const result = await service.processBuffer(buffer, logsSettings, ruleSet, TEAM_ID)
+        if (!result.allDropped) {
+            const [, , kept] = await decodeLogRecords(result.value)
+            expect(kept.length).toBe(400 - result.recordsDropped)
+        }
+    })
+})

--- a/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts
@@ -20,11 +20,13 @@ const rateLimitForm = (overrides: Partial<LogsSamplingFormType> = {}): LogsSampl
 })
 
 describe('logsSamplingFormLogic rate-limit serialization', () => {
-    it('converts amount + unit into KB/s', () => {
-        expect(rateLimitAmountToKbPerSecond('1', 'MB/s')).toEqual(1000)
-        expect(rateLimitAmountToKbPerSecond('50', 'KB/s')).toEqual(50)
-        expect(rateLimitAmountToKbPerSecond('1.5', 'MB/s')).toEqual(1500)
-        expect(rateLimitAmountToKbPerSecond('2', 'GB/s')).toEqual(2_000_000)
+    it.each([
+        ['1', 'MB/s', 1000],
+        ['50', 'KB/s', 50],
+        ['1.5', 'MB/s', 1500],
+        ['2', 'GB/s', 2_000_000],
+    ] as const)('converts %s %s into %s KB/s', (amount, unit, expected) => {
+        expect(rateLimitAmountToKbPerSecond(amount, unit)).toEqual(expected)
     })
 
     it('serializes a rate-limit rule into byte-mode config the ingestion worker enforces on', () => {

--- a/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.test.ts
@@ -1,0 +1,80 @@
+import { FilterLogicalOperator } from '~/types'
+
+import { LogsSamplingRuleApi, RuleTypeEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+import {
+    buildSamplingConfigPayload,
+    buildSamplingFormDefaults,
+    LogsSamplingFormType,
+    rateLimitAmountToKbPerSecond,
+} from './logsSamplingFormLogic'
+
+const rateLimitForm = (overrides: Partial<LogsSamplingFormType> = {}): LogsSamplingFormType => ({
+    name: 'cap smokescreen',
+    enabled: true,
+    rule_type: RuleTypeEnumApi.RateLimit,
+    filter_group: { type: FilterLogicalOperator.And, values: [] },
+    rate_limit_amount: '1',
+    rate_limit_unit: 'MB/s',
+    ...overrides,
+})
+
+describe('logsSamplingFormLogic rate-limit serialization', () => {
+    it('converts amount + unit into KB/s', () => {
+        expect(rateLimitAmountToKbPerSecond('1', 'MB/s')).toEqual(1000)
+        expect(rateLimitAmountToKbPerSecond('50', 'KB/s')).toEqual(50)
+        expect(rateLimitAmountToKbPerSecond('1.5', 'MB/s')).toEqual(1500)
+        expect(rateLimitAmountToKbPerSecond('2', 'GB/s')).toEqual(2_000_000)
+    })
+
+    it('serializes a rate-limit rule into byte-mode config the ingestion worker enforces on', () => {
+        const config = buildSamplingConfigPayload(rateLimitForm({ rate_limit_amount: '1', rate_limit_unit: 'MB/s' }))
+
+        // Byte mode: `kb_per_second` is what compile-rules.ts parses with costUnit 'bytes'.
+        expect(config.kb_per_second).toEqual(1000)
+        expect(config.burst_kb).toEqual(10000)
+        // The records-per-second fields must NOT be written — that was the bug.
+        expect(config).not.toHaveProperty('logs_per_second')
+        expect(config).not.toHaveProperty('burst_logs')
+    })
+
+    it('lowering the limit changes the stored byte threshold (50 KB/s != 1 MB/s)', () => {
+        const oneMb = buildSamplingConfigPayload(rateLimitForm({ rate_limit_amount: '1', rate_limit_unit: 'MB/s' }))
+        const fiftyKb = buildSamplingConfigPayload(rateLimitForm({ rate_limit_amount: '50', rate_limit_unit: 'KB/s' }))
+
+        expect(oneMb.kb_per_second).toEqual(1000)
+        expect(fiftyKb.kb_per_second).toEqual(50)
+        expect(oneMb.kb_per_second).not.toEqual(fiftyKb.kb_per_second)
+    })
+
+    it('round-trips a byte-mode rule back into the form', () => {
+        const rule = {
+            name: 'cap smokescreen',
+            enabled: true,
+            rule_type: RuleTypeEnumApi.RateLimit,
+            config: { kb_per_second: 1000, burst_kb: 10000, filter_group: { type: 'AND', values: [] } },
+        } as unknown as LogsSamplingRuleApi
+
+        const form = buildSamplingFormDefaults(rule)
+        expect(form.rate_limit_amount).toEqual('1')
+        expect(form.rate_limit_unit).toEqual('MB/s')
+    })
+
+    it('still displays legacy rules saved with logs_per_second so they can be re-saved', () => {
+        const legacy = {
+            name: 'legacy cap',
+            enabled: true,
+            rule_type: RuleTypeEnumApi.RateLimit,
+            config: { logs_per_second: 50, burst_logs: 500 },
+        } as unknown as LogsSamplingRuleApi
+
+        const form = buildSamplingFormDefaults(legacy)
+        expect(form.rate_limit_amount).toEqual('50')
+        expect(form.rate_limit_unit).toEqual('KB/s')
+
+        // Re-saving rewrites it into byte mode.
+        const config = buildSamplingConfigPayload(form)
+        expect(config.kb_per_second).toEqual(50)
+        expect(config).not.toHaveProperty('logs_per_second')
+    })
+})

--- a/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.ts
+++ b/products/logs/frontend/components/LogsSampling/logsSamplingFormLogic.ts
@@ -129,7 +129,11 @@ export function buildSamplingFormDefaults(rule: LogsSamplingRuleApi | null): Log
     }
     form.filter_group = extractFilterGroup(cfg.filter_group)
     if (rule_type === RuleTypeEnumApi.RateLimit) {
-        const stored = cfg.logs_per_second
+        // Read the byte-rate field the ingestion worker enforces on (`kb_per_second`).
+        // Fall back to the legacy `logs_per_second` field for rules saved before this
+        // fix so they still populate the form — the stored number was always derived as
+        // KB/s, and re-saving rewrites it to `kb_per_second`.
+        const stored = typeof cfg.kb_per_second === 'number' ? cfg.kb_per_second : cfg.logs_per_second
         if (typeof stored === 'number' && Number.isFinite(stored) && stored > 0) {
             const { amount, unit } = chooseDisplayUnit(stored)
             form.rate_limit_amount = amount
@@ -141,10 +145,14 @@ export function buildSamplingFormDefaults(rule: LogsSamplingRuleApi | null): Log
 
 export function buildSamplingConfigPayload(form: LogsSamplingFormType): Record<string, unknown> {
     if (form.rule_type === RuleTypeEnumApi.RateLimit) {
-        const lps = rateLimitAmountToKbPerSecond(form.rate_limit_amount, form.rate_limit_unit)
+        // The form expresses a byte rate (KB/s · MB/s · GB/s) and the preview plots the
+        // threshold in bytes — so the rule must be stored in byte mode (`kb_per_second`),
+        // which charges each log its own uncompressed size. Writing `logs_per_second`
+        // here silently enforced a records-per-second cap instead, ignoring the chosen unit.
+        const kbPerSecond = rateLimitAmountToKbPerSecond(form.rate_limit_amount, form.rate_limit_unit)
         return {
-            logs_per_second: lps,
-            burst_logs: lps * BURST_MULTIPLIER,
+            kb_per_second: kbPerSecond,
+            burst_kb: kbPerSecond * BURST_MULTIPLIER,
             filter_group: wrapFilterGroup(form.filter_group),
         }
     }


### PR DESCRIPTION
## Problem

The logs drop-rule form presents the rate limit as a **byte rate** (KB/s · MB/s · GB/s) and previews the threshold in bytes. But on save it wrote the chosen value into `logs_per_second` — the *records-per-second* limiter. So "1 MB/s" was silently enforced as **1000 logs/second**, and the byte-mode limiter (`kb_per_second`, which charges each log its own uncompressed size) was unreachable from the UI.

The user-visible symptom: changing the limit (e.g. lowering 1 MB/s → 50 KB/s) had no meaningful effect, because the chosen byte unit never reached the limiter in the unit it claimed.

## Changes

- `logsSamplingFormLogic.ts`: serialize rate-limit rules to **`kb_per_second` / `burst_kb`** (byte mode) instead of `logs_per_second` / `burst_logs`. Read-back prefers `kb_per_second` and falls back to the legacy `logs_per_second` field so rules saved before this fix still populate the form — and are rewritten to byte mode on next save.

No schema migration: `config` is a JSONField. The ingestion worker already supports `kb_per_second` end to end (`compile-rules.ts` byte branch + `costUnit: 'bytes'`); this change just feeds it the right field.

## How did you test this code?

I'm an agent; I ran these automated tests (no manual UI testing claimed):

- **Frontend** `logsSamplingFormLogic.test.ts` (new, 5 tests): the form now writes `kb_per_second`, 1 MB/s ≠ 50 KB/s in the stored config, byte-mode rules round-trip, and legacy `logs_per_second` rules still display.
- **Ingestion** `logs-sampling.rate-limit-impact.integration.test.ts` (new, 4 tests): drives the real Redis token bucket with a mocked clock to simulate a sustained ~530 KB/s stream, feeding the limiter the exact config the form now writes. Asserts a limit above real volume drops nothing, a limit below it sheds a large share, **lowering the limit changes the impact** (the reported regression), and drops begin only once the stream exceeds the configured byte rate. Run with `--forceExit` (open Redis pool otherwise lingers).

Together they cover the full path: form → `kb_per_second` config → real byte-rate drop behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude) while investigating a report that the logs rate limit "did nothing" when lowered. Root-caused two independent issues; this PR is the rate-limit half (the byte-preview inflation is a separate branch/PR). The fix was located by tracing the byte value from the form serializer through `compile-rules.ts` to the token bucket and finding the form wrote `logs_per_second` while everything downstream and in the UI assumed bytes.

Decisions:
- Chose byte mode (`kb_per_second`) over records mode because the entire UI (unit selector, bytes preview, reference line) already assumes a byte rate — only serialization was wrong.
- Left the legacy-rule data migration out of this PR (kept the diff frontend-only); existing rules convert on re-save via the read-back fallback. A one-line data migration is a reasonable follow-up if existing rules should adopt byte semantics immediately — see PR discussion.

Agent-authored; requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
