### PR TITLE
feat(replay-vision): add bulk "scan these recordings" action

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -1,15 +1,23 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
-import { IconEllipsis, IconPlus, IconSort, IconTrash } from '@posthog/icons'
+import { IconChevronRight, IconEllipsis, IconEye, IconPlus, IconSort, IconTrash } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal, Spinner } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { LemonMenu, LemonMenuItem } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { sessionRecordingCollectionsLogic } from 'scenes/session-recordings/collections/sessionRecordingCollectionsLogic'
 import { SettingsBar, SettingsMenu } from 'scenes/session-recordings/components/PanelSettings'
+import { urls } from 'scenes/urls'
 
 import { AccessControlLevel, AccessControlResourceType, RecordingUniversalFilters } from '~/types'
+
+import { bulkScanLogic } from 'products/replay_vision/frontend/logics/bulkScanLogic'
+import { visionQuotaLogic } from 'products/replay_vision/frontend/logics/visionQuotaLogic'
+import { quotaUx } from 'products/replay_vision/frontend/utils/quotaProjection'
 
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
 import {
@@ -334,6 +342,61 @@ export function AddToCollectionModal({ shortId }: { shortId?: string }): JSX.Ele
     )
 }
 
+/** Bulk "Scan these recordings" row whose scanner list opens on hover (a nested `items` menu is click-only). */
+function BulkScanMenuItem(): JSX.Element {
+    const { selectedRecordingsIds } = useValues(sessionRecordingsPlaylistLogic)
+    const { scanners, scannersLoading, scanning } = useValues(bulkScanLogic)
+    const { scanRecordings } = useActions(bulkScanLogic)
+    const { quota } = useValues(visionQuotaLogic)
+    const { disabledReason: quotaDisabledReason, tooltip: quotaTooltip } = quotaUx(quota)
+
+    const submenuItems: LemonMenuItem[] = scannersLoading
+        ? [{ label: 'Loading scanners…', disabledReason: 'Loading' }]
+        : scanners.length === 0
+          ? [
+                {
+                    label: 'No scanners yet — create one',
+                    onClick: () => router.actions.push(urls.replayVision()),
+                    'data-attr': 'vision-bulk-scan-create-scanner',
+                },
+            ]
+          : scanners.map((scanner) => ({
+                label: scanner.name,
+                onClick: () => scanRecordings(scanner.id, selectedRecordingsIds),
+                'data-attr': 'vision-bulk-scan-scanner-item',
+            }))
+
+    return (
+        <LemonMenu
+            items={submenuItems}
+            placement="right-start"
+            trigger="hover"
+            buttonSize="xsmall"
+            closeOnClickInside
+            closeParentPopoverOnClickInside
+        >
+            <LemonButton
+                fullWidth
+                role="menuitem"
+                size="xsmall"
+                icon={<IconEye />}
+                sideIcon={<IconChevronRight />}
+                disabledReason={
+                    scanning
+                        ? 'Starting scans…'
+                        : selectedRecordingsIds.length === 0
+                          ? 'Select recordings to scan'
+                          : quotaDisabledReason
+                }
+                tooltip={quotaTooltip}
+                data-attr="vision-bulk-scan-recordings"
+            >
+                Scan these recordings
+            </LemonButton>
+        </LemonMenu>
+    )
+}
+
 export function SessionRecordingsPlaylistTopSettings({
     filters,
     setFilters,
@@ -360,6 +423,7 @@ export function SessionRecordingsPlaylistTopSettings({
         handleBulkMarkAsViewed,
         handleBulkMarkAsNotViewed,
     } = useActions(sessionRecordingsPlaylistLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const recordings = type === 'filters' ? otherRecordings : pinnedRecordings
     const checked = recordings.length > 0 && selectedRecordingsIds.length === recordings.length
@@ -368,6 +432,8 @@ export function SessionRecordingsPlaylistTopSettings({
         AccessControlResourceType.SessionRecording,
         AccessControlLevel.Editor
     )
+
+    const visionEnabled = !!featureFlags[FEATURE_FLAGS.REPLAY_VISION]
 
     const getActionsMenuItems = (): LemonMenuItem[] => {
         const menuItems: LemonMenuItem[] = [
@@ -399,6 +465,15 @@ export function SessionRecordingsPlaylistTopSettings({
             onClick: () => handleBulkMarkAsNotViewed(shortId),
             'data-attr': 'mark-as-not-viewed',
         })
+
+        if (visionEnabled) {
+            // Custom item so the scanner list opens on hover (the nested `items` API is click-only).
+            menuItems.push({
+                key: 'bulk-scan-recordings',
+                label: () => <BulkScanMenuItem />,
+                custom: true,
+            })
+        }
 
         menuItems.push({
             label: 'Delete',

--- a/products/replay_vision/frontend/components/ObservationsDock.tsx
+++ b/products/replay_vision/frontend/components/ObservationsDock.tsx
@@ -6,38 +6,20 @@ import { LemonButton, LemonInput, Link, Spinner } from '@posthog/lemon-ui'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
-import { dayjs } from 'lib/dayjs'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown/LemonDropdown'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
 
-import type { ReplayScannerApi, VisionQuotaApi } from '../generated/api.schemas'
+import type { ReplayScannerApi } from '../generated/api.schemas'
 import { observationsDockLogic } from '../logics/observationsDockLogic'
 import { visionQuotaLogic } from '../logics/visionQuotaLogic'
-import { QUOTA_WARN_THRESHOLD } from '../utils/quotaProjection'
+import { quotaUx } from '../utils/quotaProjection'
 import { ObservationDockCard } from './ObservationCard'
 
 const COLLAPSED_HEIGHT = 44
 const DEFAULT_EXPANDED_HEIGHT = 480
 const MIN_EXPANDED_HEIGHT = 120
 const MAX_EXPANDED_HEIGHT = 800
-
-// Assumes block-only overage policy; revisit when `usage_based` lands so we don't disable buttons on metered orgs.
-function quotaUx(quota: VisionQuotaApi | null): { disabledReason?: string; tooltip?: string } {
-    if (!quota || quota.monthly_quota <= 0) {
-        return {}
-    }
-    const resetsOn = dayjs(quota.period_end).format('MMMM D')
-    if (quota.exhausted) {
-        return { disabledReason: `Monthly observation quota reached. Resets ${resetsOn}.` }
-    }
-    if (quota.usage_this_month / quota.monthly_quota >= QUOTA_WARN_THRESHOLD) {
-        return {
-            tooltip: `${quota.remaining.toLocaleString()} observations left this month (resets ${resetsOn})`,
-        }
-    }
-    return {}
-}
 
 export function ObservationsDock(): JSX.Element | null {
     const { sessionRecordingId } = useValues(sessionRecordingPlayerLogic)

--- a/products/replay_vision/frontend/logics/bulkScanLogic.ts
+++ b/products/replay_vision/frontend/logics/bulkScanLogic.ts
@@ -1,0 +1,91 @@
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { visionScannersList, visionScannersObserveCreate } from '../generated/api'
+import type { ReplayScannerApi } from '../generated/api.schemas'
+import type { bulkScanLogicType } from './bulkScanLogicType'
+
+export const bulkScanLogic = kea<bulkScanLogicType>([
+    path(['products', 'replay_vision', 'frontend', 'logics', 'bulkScanLogic']),
+
+    actions({
+        scanRecordings: (scannerId: string, sessionIds: string[]) => ({ scannerId, sessionIds }),
+        scanRecordingsSuccess: true,
+        scanRecordingsFailure: true,
+    }),
+
+    loaders({
+        scanners: [
+            [] as ReplayScannerApi[],
+            {
+                loadScanners: async () => {
+                    const teamId = teamLogic.values.currentTeamId
+                    if (!teamId) {
+                        return []
+                    }
+                    try {
+                        const response = await visionScannersList(String(teamId))
+                        return response.results ?? []
+                    } catch {
+                        return []
+                    }
+                },
+            },
+        ],
+    }),
+
+    reducers({
+        scanning: [
+            false,
+            {
+                scanRecordings: () => true,
+                scanRecordingsSuccess: () => false,
+                scanRecordingsFailure: () => false,
+            },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        scanRecordings: async ({ scannerId, sessionIds }) => {
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId || sessionIds.length === 0) {
+                actions.scanRecordingsFailure()
+                return
+            }
+            // The backend keys the workflow on (scanner, session) and silently no-ops duplicates,
+            // so re-running the same pair is safe and needs no client-side dedup.
+            const results = await Promise.allSettled(
+                sessionIds.map((session_id) => visionScannersObserveCreate(String(teamId), scannerId, { session_id }))
+            )
+            const failed = results.filter((r) => r.status === 'rejected').length
+            const started = results.length - failed
+            const scannerName = values.scanners.find((s) => s.id === scannerId)?.name ?? 'scanner'
+
+            if (started > 0) {
+                lemonToast.success(
+                    `Started scanning ${started} recording${started === 1 ? '' : 's'} with “${scannerName}”`,
+                    {
+                        button: {
+                            label: 'Go to scanner page',
+                            action: () => router.actions.push(urls.replayVision(scannerId)),
+                            dataAttr: 'vision-bulk-scan-go-to-scanner',
+                        },
+                    }
+                )
+            }
+            if (failed > 0) {
+                lemonToast.error(`Failed to start scanning ${failed} recording${failed === 1 ? '' : 's'}`)
+            }
+            actions.scanRecordingsSuccess()
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadScanners()
+    }),
+])

--- a/products/replay_vision/frontend/utils/quotaProjection.ts
+++ b/products/replay_vision/frontend/utils/quotaProjection.ts
@@ -74,3 +74,23 @@ export function projectQuota(
         combinedDailyRate,
     }
 }
+
+/**
+ * Disabled-reason / tooltip for scan triggers based on the monthly observation quota.
+ * Assumes block-only overage policy; revisit when `usage_based` lands so we don't disable on metered orgs.
+ */
+export function quotaUx(quota: VisionQuotaApi | null): { disabledReason?: string; tooltip?: string } {
+    if (!quota || quota.monthly_quota <= 0) {
+        return {}
+    }
+    const resetsOn = dayjs(quota.period_end).format('MMMM D')
+    if (quota.exhausted) {
+        return { disabledReason: `Monthly observation quota reached. Resets ${resetsOn}.` }
+    }
+    if (quota.usage_this_month / quota.monthly_quota >= QUOTA_WARN_THRESHOLD) {
+        return {
+            tooltip: `${quota.remaining.toLocaleString()} observations left this month (resets ${resetsOn})`,
+        }
+    }
+    return {}
+}


### PR DESCRIPTION
## Problem

Kicking off a Replay Vision scanner was a one-at-a-time action — you had to open each recording in the player and use the "Scan this recording" dropdown in the observations dock. There was no way to run a scanner across many recordings at once.

## Changes

Adds a **"Scan these recordings"** item to the bulk-actions dropdown in the session recordings list (the menu with "Add to collection…", "Mark as viewed", "Delete"). It opens a **hover** submenu listing the team's scanners; picking one kicks off that scanner against every selected recording.

- New propless `bulkScanLogic` loads scanners (`visionScannersList`) and fans out `visionScannersObserveCreate` calls with `Promise.allSettled`, then toasts a summary that includes the scanner name and a **"Go to scanner page"** link. No client-side dedup — the backend keys workflows on `(scanner, session)` and no-ops duplicates.
- The submenu opens on hover rather than click: the nested `items` menu API is click-only, so this uses a `custom` menu item rendering a hover-triggered `LemonMenu`.
- Gated entirely behind the `REPLAY_VISION` feature flag — the component (and therefore the scanner/quota API calls) never mounts when the flag is off, matching the player dock's gate.
- Quota-aware: the entrypoint is disabled with a reset-date reason when the monthly observation quota is exhausted. The `quotaUx` helper was lifted out of `ObservationsDock` into the shared `quotaProjection` util so the dock and the bulk menu stay consistent.
- All interactive elements carry `vision-`\-prefixed `data-attr`s.

## How did you test this code?

![Screenshot 2026-06-08 at 10.00.38 PM.png](https://app.graphite.com/user-attachments/assets/ebc1cdba-e834-4c93-979a-a54898b90a6f.png)![Screenshot 2026-06-08 at 10.01.08 PM.png](https://app.graphite.com/user-attachments/assets/0f402c5d-7f00-4347-b16e-24fcde67f118.png)![Screenshot 2026-06-08 at 10.00.59 PM.png](https://app.graphite.com/user-attachments/assets/a7c598fe-20fd-4899-b586-299ca53efcbf.png)



- `kea-typegen write` to generate the new logic type
- `tsc --noEmit` — no type errors in the changed files
- `oxfmt` formatting on the changed files



## 🤖 Agent context

Authored with PostHog Code (Claude). The reviewer-relevant decisions:

- **Hover vs click submenu:** the existing `LemonMenu` nested-`items` API only expands on click. To meet the hover requirement, the scanner list is rendered as a `custom` menu item wrapping a `trigger="hover"` `LemonMenu`, mirroring the searchable picker pattern from the per-session dock.
- **New logic instead of reusing** **`observationsDockLogic`:** that logic is keyed by `sessionId`, so a small propless `bulkScanLogic` was added for the multi-recording case.
- **Shared quota helper:** `quotaUx` was extracted to `quotaProjection.ts` rather than duplicated.

Agent-authored; requires human review.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)