### PR TITLE
feat(experiments): add retention metrics to the metric breakdown injector

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -472,7 +472,9 @@ class ExperimentQueryRunner(QueryRunner):
         breakdown_injector: MetricBreakdownInjector | None = None
         # Metric types migrated to the metric-event breakdown injector. Others fall back to the
         # old BreakdownInjector until they migrate (then BreakdownInjector is deleted).
-        migrated_metric = isinstance(self.metric, ExperimentFunnelMetric | ExperimentMeanMetric)
+        migrated_metric = isinstance(
+            self.metric, ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric
+        )
         if breakdowns and migrated_metric and self._metric_event_breakdowns_enabled():
             breakdown_injector = MetricBreakdownInjector(breakdowns, self.metric)
 

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -546,7 +546,9 @@ class ExperimentQueryRunner(QueryRunner):
         breakdown_injector: MetricBreakdownInjector | None = None
         # Metric types migrated to the metric-event breakdown injector. Others fall back to the
         # old BreakdownInjector until they migrate (then BreakdownInjector is deleted).
-        migrated_metric = isinstance(self.metric, ExperimentFunnelMetric | ExperimentMeanMetric)
+        migrated_metric = isinstance(
+            self.metric, ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric
+        )
         # Data warehouse sources aren't supported by the injector yet: funnels route through the
         # legacy builder that drops the injected columns, and DW mean metrics select from the
         # warehouse table where event/person/session breakdown chains don't resolve.

--- a/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
@@ -19,7 +19,6 @@ from products.experiments.backend.hogql_queries.base_query_utils import (
     data_warehouse_node_to_filter,
     event_or_action_to_filter,
 )
-from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 
 if TYPE_CHECKING:
     from products.experiments.backend.hogql_queries.experiment_query_builder import ExperimentQueryBuilder
@@ -230,9 +229,9 @@ class RetentionQueryBuilder:
                 else:
                     start_events_cte.expr.having = ast.And(exprs=[start_events_cte.expr.having, retention_maturity])
 
-        # Inject breakdown columns if breakdown filter is present. The metric-event injector is
-        # funnel-only, so retention metrics always use the property-from-exposure BreakdownInjector.
-        if isinstance(self._b.breakdown_injector, BreakdownInjector):
+        # Inject breakdown columns if breakdown filter is present. Both injectors expose
+        # inject_retention_breakdown_columns (old: exposure source; new: start-event source + limit).
+        if self._b.breakdown_injector:
             self._b.breakdown_injector.inject_retention_breakdown_columns(query)
 
         return query

--- a/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
@@ -21,7 +21,6 @@ from products.experiments.backend.hogql_queries.base_query_utils import (
     data_warehouse_node_to_filter,
     event_or_action_to_filter,
 )
-from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 
 if TYPE_CHECKING:
     from products.experiments.backend.hogql_queries.experiment_query_builder import ExperimentQueryBuilder
@@ -359,9 +358,9 @@ class RetentionQueryBuilder:
                 else:
                     start_events_cte.expr.having = ast.And(exprs=[start_events_cte.expr.having, retention_maturity])
 
-        # Inject breakdown columns if breakdown filter is present. The metric-event injector is
-        # funnel-only, so retention metrics always use the property-from-exposure BreakdownInjector.
-        if isinstance(self._b.breakdown_injector, BreakdownInjector):
+        # Inject breakdown columns if breakdown filter is present. Both injectors expose
+        # inject_retention_breakdown_columns (old: exposure source; new: start-event source + limit).
+        if self._b.breakdown_injector:
             self._b.breakdown_injector.inject_retention_breakdown_columns(query)
 
         return query

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -401,3 +401,49 @@ class MetricBreakdownInjector:
                         for condition in join_conditions[1:]:
                             condition_expr = ast.And(exprs=[condition_expr, condition])
                         join_expr.constraint = ast.JoinConstraint(expr=condition_expr, constraint_type="ON")
+
+    def inject_retention_breakdown_columns(self, query: ast.SelectQuery) -> None:
+        """Inject breakdown columns into a retention query.
+
+        Reads the breakdown off the **start event** (in ``start_events``) and attributes each
+        user first-touch via ``argMin`` over the start event timestamp. Retention is a ratio
+        ``retained / cohort``; the cohort (denominator) is defined by the start event and every
+        retained user has one, so the start event is the only attribution source that keeps the
+        per-bucket denominator well-defined. The completion event is NOT used for the breakdown —
+        non-retained users have no completion event, which would break the per-bucket denominator.
+
+        ``start_events`` groups by entity, so the breakdown is deduped per user inside it; the
+        attributed value is then carried into ``entity_metrics``.
+        """
+        if not self._has_breakdown():
+            return
+
+        aliases = self._get_breakdown_aliases()
+        breakdown_exprs = self.build_breakdown_exprs(table_alias="")
+
+        # Read + first-touch attribute the breakdown off the start event, deduped per entity.
+        if query.ctes and "start_events" in query.ctes:
+            start_events_cte = query.ctes["start_events"]
+            if isinstance(start_events_cte, ast.CTE) and isinstance(start_events_cte.expr, ast.SelectQuery):
+                for alias, expr in breakdown_exprs:
+                    start_events_cte.expr.select.append(
+                        ast.Alias(
+                            alias=alias,
+                            expr=ast.Call(name="argMin", args=[expr, ast.Field(chain=["timestamp"])]),
+                        )
+                    )
+
+        # Carry the attributed breakdown into entity_metrics and group by it.
+        if query.ctes and "entity_metrics" in query.ctes:
+            entity_metrics_cte = query.ctes["entity_metrics"]
+            if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    entity_metrics_cte.expr.select.append(
+                        ast.Alias(alias=alias, expr=ast.Field(chain=["start_events", alias]))
+                    )
+                if entity_metrics_cte.expr.group_by is None:
+                    entity_metrics_cte.expr.group_by = []
+                for alias in aliases:
+                    entity_metrics_cte.expr.group_by.append(ast.Field(chain=["start_events", alias]))
+
+        self._inject_final_breakdown_columns(query, aliases)

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -429,3 +429,49 @@ class MetricBreakdownInjector:
                         for condition in join_conditions[1:]:
                             condition_expr = ast.And(exprs=[condition_expr, condition])
                         join_expr.constraint = ast.JoinConstraint(expr=condition_expr, constraint_type="ON")
+
+    def inject_retention_breakdown_columns(self, query: ast.SelectQuery) -> None:
+        """Inject breakdown columns into a retention query.
+
+        Reads the breakdown off the **start event** (in ``start_events``) and attributes each
+        user first-touch via ``argMin`` over the start event timestamp. Retention is a ratio
+        ``retained / cohort``; the cohort (denominator) is defined by the start event and every
+        retained user has one, so the start event is the only attribution source that keeps the
+        per-bucket denominator well-defined. The completion event is NOT used for the breakdown —
+        non-retained users have no completion event, which would break the per-bucket denominator.
+
+        ``start_events`` groups by entity, so the breakdown is deduped per user inside it; the
+        attributed value is then carried into ``entity_metrics``.
+        """
+        if not self._has_breakdown():
+            return
+
+        aliases = self._get_breakdown_aliases()
+        breakdown_exprs = self.build_breakdown_exprs(table_alias="")
+
+        # Read + first-touch attribute the breakdown off the start event, deduped per entity.
+        if query.ctes and "start_events" in query.ctes:
+            start_events_cte = query.ctes["start_events"]
+            if isinstance(start_events_cte, ast.CTE) and isinstance(start_events_cte.expr, ast.SelectQuery):
+                for alias, expr in breakdown_exprs:
+                    start_events_cte.expr.select.append(
+                        ast.Alias(
+                            alias=alias,
+                            expr=ast.Call(name="argMin", args=[expr, ast.Field(chain=["timestamp"])]),
+                        )
+                    )
+
+        # Carry the attributed breakdown into entity_metrics and group by it.
+        if query.ctes and "entity_metrics" in query.ctes:
+            entity_metrics_cte = query.ctes["entity_metrics"]
+            if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    entity_metrics_cte.expr.select.append(
+                        ast.Alias(alias=alias, expr=ast.Field(chain=["start_events", alias]))
+                    )
+                if entity_metrics_cte.expr.group_by is None:
+                    entity_metrics_cte.expr.group_by = []
+                for alias in aliases:
+                    entity_metrics_cte.expr.group_by.append(ast.Field(chain=["start_events", alias]))
+
+        self._inject_final_breakdown_columns(query, aliases)

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -22,6 +22,7 @@ from posthog.schema import (
     ExperimentRatioMetric,
     ExperimentRetentionMetric,
     MultipleBreakdownType,
+    StartHandling,
     StepOrderValue,
 )
 
@@ -434,11 +435,13 @@ class MetricBreakdownInjector:
         """Inject breakdown columns into a retention query.
 
         Reads the breakdown off the **start event** (in ``start_events``) and attributes each
-        user first-touch via ``argMin`` over the start event timestamp. Retention is a ratio
-        ``retained / cohort``; the cohort (denominator) is defined by the start event and every
-        retained user has one, so the start event is the only attribution source that keeps the
-        per-bucket denominator well-defined. The completion event is NOT used for the breakdown —
-        non-retained users have no completion event, which would break the per-bucket denominator.
+        user from the start event that anchors their retention window: ``argMin`` (earliest) for
+        FIRST_SEEN start handling, ``argMax`` (latest) for LAST_SEEN, so the bucket comes from the
+        same event the window anchors on. Retention is a ratio ``retained / cohort``; the cohort
+        (denominator) is defined by the start event and every retained user has one, so the start
+        event is the only attribution source that keeps the per-bucket denominator well-defined.
+        The completion event is NOT used for the breakdown — non-retained users have no completion
+        event, which would break the per-bucket denominator.
 
         ``start_events`` groups by entity, so the breakdown is deduped per user inside it; the
         attributed value is then carried into ``entity_metrics``.
@@ -449,7 +452,12 @@ class MetricBreakdownInjector:
         aliases = self._get_breakdown_aliases()
         breakdown_exprs = self.build_breakdown_exprs(table_alias="")
 
-        # Read + first-touch attribute the breakdown off the start event, deduped per entity.
+        # Attribute from the start event that anchors the window: latest for LAST_SEEN, earliest
+        # otherwise, so the breakdown bucket matches the anchoring start event.
+        assert isinstance(self.metric, ExperimentRetentionMetric)
+        attribution_agg = "argMax" if self.metric.start_handling == StartHandling.LAST_SEEN else "argMin"
+
+        # Read + attribute the breakdown off the start event, deduped per entity.
         if query.ctes and "start_events" in query.ctes:
             start_events_cte = query.ctes["start_events"]
             if isinstance(start_events_cte, ast.CTE) and isinstance(start_events_cte.expr, ast.SelectQuery):
@@ -457,7 +465,7 @@ class MetricBreakdownInjector:
                     start_events_cte.expr.select.append(
                         ast.Alias(
                             alias=alias,
-                            expr=ast.Call(name="argMin", args=[expr, ast.Field(chain=["timestamp"])]),
+                            expr=ast.Call(name=attribution_agg, args=[expr, ast.Field(chain=["timestamp"])]),
                         )
                     )
 

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py
@@ -18,6 +18,9 @@ from posthog.schema import (
     ExperimentMetricMathType,
     ExperimentQuery,
     ExperimentQueryResponse,
+    ExperimentRetentionMetric,
+    FunnelConversionWindowTimeUnit,
+    StartHandling,
 )
 
 from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRING_LABEL, BREAKDOWN_OTHER_STRING_LABEL
@@ -715,3 +718,417 @@ class TestMetricBreakdown(ExperimentQueryRunnerBaseTest):
         assert result.breakdown_results is not None
         breakdown_values = [br.breakdown_value for br in result.breakdown_results]
         self.assertIn(["Chrome"], breakdown_values)
+
+    def _create_retention_metric(self, breakdown_limit=None):
+        return ExperimentRetentionMetric(
+            start_event=EventsNode(event="signup", math=ExperimentMetricMathType.TOTAL),
+            completion_event=EventsNode(event="login", math=ExperimentMetricMathType.TOTAL),
+            retention_window_start=1,
+            retention_window_end=7,
+            retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+            start_handling=StartHandling.FIRST_SEEN,
+            breakdownFilter=BreakdownFilter(
+                breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit
+            ),
+        )
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_breakdown_from_start_event(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_retention_metric()
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Exposure carries "ExposureBrowser"; the start event carries "StartBrowser".
+        for variant in ["control", "test"]:
+            distinct_id = f"user_{variant}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                    "$browser": "ExposureBrowser",
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="signup",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant, "$browser": "StartBrowser"},
+            )
+            _create_event(
+                team=self.team,
+                event="login",
+                distinct_id=distinct_id,
+                timestamp="2020-01-03T12:01:00Z",
+                properties={feature_flag_property: variant, "$browser": "StartBrowser"},
+            )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        # The breakdown is attributed from the start event, not the exposure.
+        self.assertEqual(buckets, {"StartBrowser"})
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_breakdown_limit_collapses_to_other(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_retention_metric(breakdown_limit=2)
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Four browsers with descending start-event user counts; limit=2 keeps the top two.
+        browser_counts = {"Chrome": 4, "Safari": 3, "Firefox": 2, "Edge": 1}
+        user_index = 0
+        for browser, count in browser_counts.items():
+            for _ in range(count):
+                variant = "control" if user_index % 2 == 0 else "test"
+                distinct_id = f"user_ret_{user_index}"
+                user_index += 1
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="signup",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant, "$browser": browser},
+                )
+                _create_event(
+                    team=self.team,
+                    event="login",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-03T12:01:00Z",
+                    properties={feature_flag_property: variant, "$browser": browser},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        self.assertEqual(buckets, {"Chrome", "Safari", BREAKDOWN_OTHER_STRING_LABEL})
+
+        ordered_values = [value for br in result.breakdown_results for value in br.breakdown_value]
+        self.assertEqual(ordered_values[-1], BREAKDOWN_OTHER_STRING_LABEL)
+
+    @parameterized.expand(
+        [
+            ("two_breakdowns", ["$browser", "$os"], 2),
+            ("three_breakdowns", ["$browser", "$os", "$device_type"], 3),
+        ]
+    )
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_breakdown_with_multiple_breakdowns(self, _name, breakdown_properties, expected_tuple_len):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentRetentionMetric(
+            start_event=EventsNode(event="signup", math=ExperimentMetricMathType.TOTAL),
+            completion_event=EventsNode(event="login", math=ExperimentMetricMathType.TOTAL),
+            retention_window_start=1,
+            retention_window_end=7,
+            retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+            start_handling=StartHandling.FIRST_SEEN,
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property=p) for p in breakdown_properties]),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        combos = [
+            {"$browser": "Chrome", "$os": "Windows", "$device_type": "Desktop"},
+            {"$browser": "Safari", "$os": "Mac", "$device_type": "Mobile"},
+        ]
+        for variant in ["control", "test"]:
+            for idx, combo in enumerate(combos):
+                distinct_id = f"user_ret_multi_{variant}_{idx}"
+                start_props = {k: v for k, v in combo.items() if k in breakdown_properties}
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="signup",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant, **start_props},
+                )
+                _create_event(
+                    team=self.team,
+                    event="login",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-03T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        for breakdown_result in result.breakdown_results:
+            self.assertEqual(len(breakdown_result.breakdown_value), expected_tuple_len)
+
+        breakdown_values = [tuple(br.breakdown_value) for br in result.breakdown_results]
+        expected_chrome = tuple(combos[0][p] for p in breakdown_properties)
+        expected_safari = tuple(combos[1][p] for p in breakdown_properties)
+        self.assertIn(expected_chrome, breakdown_values)
+        self.assertIn(expected_safari, breakdown_values)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_breakdown_null_values(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_retention_metric()
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Two users per variant: one with $browser on the start event, one without.
+        for variant in ["control", "test"]:
+            for idx, has_browser in enumerate([True, False]):
+                distinct_id = f"user_ret_null_{variant}_{idx}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                start_props: dict = {feature_flag_property: variant}
+                if has_browser:
+                    start_props["$browser"] = "Chrome"
+                _create_event(
+                    team=self.team,
+                    event="signup",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties=start_props,
+                )
+                _create_event(
+                    team=self.team,
+                    event="login",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-03T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        breakdown_values = [br.breakdown_value for br in result.breakdown_results]
+        self.assertIn(["Chrome"], breakdown_values)
+        self.assertIn([BREAKDOWN_NULL_STRING_LABEL], breakdown_values)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_breakdown_person_property(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentRetentionMetric(
+            start_event=EventsNode(event="signup", math=ExperimentMetricMathType.TOTAL),
+            completion_event=EventsNode(event="login", math=ExperimentMetricMathType.TOTAL),
+            retention_window_start=1,
+            retention_window_end=7,
+            retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+            start_handling=StartHandling.FIRST_SEEN,
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="country", type="person")]),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Two users per variant; person property carries country (no event-level country).
+        country_by_variant = {"control": "US", "test": "UK"}
+        for variant, country in country_by_variant.items():
+            for i in range(2):
+                distinct_id = f"user_ret_person_{variant}_{i}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk, properties={"country": country})
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="signup",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+                _create_event(
+                    team=self.team,
+                    event="login",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-03T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        breakdown_values = [br.breakdown_value for br in result.breakdown_results]
+        self.assertIn(["US"], breakdown_values)
+        self.assertIn(["UK"], breakdown_values)
+
+        us_breakdown = next((br for br in result.breakdown_results if br.breakdown_value == ["US"]), None)
+        self.assertIsNotNone(us_breakdown)
+        assert us_breakdown is not None
+        self.assertEqual(us_breakdown.baseline.number_of_samples, 2)
+
+        uk_breakdown = next((br for br in result.breakdown_results if br.breakdown_value == ["UK"]), None)
+        self.assertIsNotNone(uk_breakdown)
+        assert uk_breakdown is not None
+        self.assertEqual(len(uk_breakdown.variants), 1)
+        self.assertEqual(uk_breakdown.variants[0].number_of_samples, 2)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_retention_breakdown_non_retained_users(self):
+        # Non-retained users (no login event) must still appear in their start-event browser bucket.
+        # This verifies the denominator is preserved: attributing from the start event ensures
+        # every cohort member has a breakdown value, so per-bucket samples sum to overall samples.
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_retention_metric()
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Seed per variant: 2 Chrome users (1 retained, 1 not) + 2 Safari users (both retained).
+        # Total cohort per variant = 4; Chrome bucket = 2, Safari bucket = 2.
+        for variant in ["control", "test"]:
+            for i in range(4):
+                browser = "Chrome" if i < 2 else "Safari"
+                distinct_id = f"user_ret_nonret_{variant}_{i}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="signup",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant, "$browser": browser},
+                )
+                # user index 1 (second Chrome user) has no login — non-retained.
+                if i != 1:
+                    _create_event(
+                        team=self.team,
+                        event="login",
+                        distinct_id=distinct_id,
+                        timestamp="2020-01-03T12:01:00Z",
+                        properties={feature_flag_property: variant},
+                    )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        # Query must succeed.
+        assert result.breakdown_results is not None
+
+        # Both browser buckets must be present — the non-retained Chrome user is still in
+        # the cohort and must appear in the Chrome bucket.
+        breakdown_values = [br.breakdown_value for br in result.breakdown_results]
+        self.assertIn(["Chrome"], breakdown_values)
+        self.assertIn(["Safari"], breakdown_values)
+
+        # Per-breakdown baseline samples must sum to the overall baseline — start-event
+        # attribution keeps the denominator intact across all buckets.
+        assert result.baseline is not None
+        per_breakdown_baseline = sum(
+            br.baseline.number_of_samples for br in result.breakdown_results if br.baseline is not None
+        )
+        self.assertEqual(per_breakdown_baseline, result.baseline.number_of_samples)

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -10,6 +10,9 @@ from posthog.schema import (
     ExperimentFunnelMetric,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
+    ExperimentRetentionMetric,
+    FunnelConversionWindowTimeUnit,
+    StartHandling,
 )
 
 from posthog.hogql import ast
@@ -83,6 +86,61 @@ def _session_mean_query() -> ast.SelectQuery:
     query.ctes = {
         "metric_events_by_session": ast.CTE(name="metric_events_by_session", expr=mebs, cte_type="subquery"),
         "metric_events": ast.CTE(name="metric_events", expr=me, cte_type="subquery"),
+        "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
+    }
+    return query
+
+
+def _dw_retention_metric():
+    return ExperimentRetentionMetric(
+        start_event=ExperimentDataWarehouseNode(
+            table_name="events_dw",
+            events_join_key="properties.$user_id",
+            data_warehouse_join_key="userid",
+            timestamp_field="ds",
+            math=ExperimentMetricMathType.TOTAL,
+        ),
+        completion_event=EventsNode(event="returned"),
+        retention_window_start=1,
+        retention_window_end=7,
+        retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+        start_handling=StartHandling.FIRST_SEEN,
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="plan", type=BreakdownType.DATA_WAREHOUSE)]),
+    )
+
+
+def _retention_metric(breakdown_limit=None):
+    return ExperimentRetentionMetric(
+        start_event=EventsNode(event="signed_up"),
+        completion_event=EventsNode(event="returned"),
+        retention_window_start=1,
+        retention_window_end=7,
+        retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+        start_handling=StartHandling.FIRST_SEEN,
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit),
+    )
+
+
+def _retention_query() -> ast.SelectQuery:
+    # Stand-in for the retention shape: start_events (GROUP BY entity) -> completion_events ->
+    # entity_metrics (joins exposures + start + completion).
+    query = parse_select("SELECT variant FROM entity_metrics")
+    assert isinstance(query, ast.SelectQuery)
+    se = parse_select(
+        "SELECT exposures.entity_id AS entity_id, min(timestamp) AS start_timestamp "
+        "FROM events INNER JOIN exposures ON entity_id = exposures.entity_id GROUP BY exposures.entity_id"
+    )
+    ce = parse_select("SELECT entity_id, timestamp AS completion_timestamp FROM events")
+    em = parse_select(
+        "SELECT exposures.entity_id AS entity_id, exposures.variant AS variant, max(value) AS value "
+        "FROM exposures INNER JOIN start_events ON exposures.entity_id = start_events.entity_id "
+        "LEFT JOIN completion_events ON exposures.entity_id = completion_events.entity_id "
+        "GROUP BY exposures.entity_id, exposures.variant"
+    )
+    assert isinstance(se, ast.SelectQuery) and isinstance(ce, ast.SelectQuery) and isinstance(em, ast.SelectQuery)
+    query.ctes = {
+        "start_events": ast.CTE(name="start_events", expr=se, cte_type="subquery"),
+        "completion_events": ast.CTE(name="completion_events", expr=ce, cte_type="subquery"),
         "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
     }
     return query
@@ -283,6 +341,85 @@ class TestMetricBreakdownInjectorMean:
         # A DW breakdown is a direct warehouse column (the metric_events CTE reads FROM the warehouse
         # table), so it must read bare `plan`, NOT be wrapped in an event `properties` chain.
         coalesce_call = bd.expr
+        assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
+        to_string = coalesce_call.args[0]
+        assert isinstance(to_string, ast.Call) and to_string.name == "toString"
+        field = to_string.args[0]
+        assert isinstance(field, ast.Field)
+        assert field.chain == ["plan"]
+
+
+class TestMetricBreakdownInjectorRetention:
+    def test_breakdown_read_from_start_event(self):
+        metric = _retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        assert query.ctes is not None
+        se_cte = query.ctes["start_events"]
+        assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
+        se_aliases = [c.alias for c in se_cte.expr.select if isinstance(c, ast.Alias)]
+        assert "breakdown_value_1" in se_aliases
+
+    def test_entity_metrics_first_touch_from_start_event(self):
+        metric = _retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
+        # Carried from the start_events CTE (first-touch attributed there over start_timestamp).
+        assert isinstance(expr, ast.Field)
+        assert expr.chain == ["start_events", "breakdown_value_1"]
+
+    def test_start_events_uses_argmin_over_start_timestamp(self):
+        metric = _retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        assert query.ctes is not None
+        se_cte = query.ctes["start_events"]
+        assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
+        bd = next(c for c in se_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # start_events groups by entity, so the breakdown is deduped first-touch via argMin.
+        assert isinstance(bd.expr, ast.Call)
+        assert bd.expr.name == "argMin"
+        assert bd.expr.args[1] == ast.Field(chain=["timestamp"])
+
+    def test_final_select_applies_top_n_other_limit(self):
+        metric = _retention_metric(breakdown_limit=3)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        final_alias = next(c for c in query.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        assert isinstance(final_alias.expr, ast.Call)
+        assert final_alias.expr.name == "if"
+        other = final_alias.expr.args[2]
+        assert isinstance(other, ast.Constant)
+        assert other.value == "$$_posthog_breakdown_other_$$"
+
+    def test_data_warehouse_breakdown_reads_warehouse_column(self):
+        metric = _dw_retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        assert query.ctes is not None
+        se_cte = query.ctes["start_events"]
+        assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
+        bd = next(c for c in se_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # A DW breakdown reads bare `plan` from the warehouse table (no `properties` wrapper).
+        argmin_call = bd.expr
+        assert isinstance(argmin_call, ast.Call) and argmin_call.name == "argMin"
+        coalesce_call = argmin_call.args[0]
         assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
         to_string = coalesce_call.args[0]
         assert isinstance(to_string, ast.Call) and to_string.name == "toString"

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -10,6 +10,9 @@ from posthog.schema import (
     ExperimentFunnelMetric,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
+    ExperimentRetentionMetric,
+    FunnelConversionWindowTimeUnit,
+    StartHandling,
     StepOrderValue,
 )
 
@@ -96,6 +99,61 @@ def _session_mean_query() -> ast.SelectQuery:
     query.ctes = {
         "metric_events_by_session": ast.CTE(name="metric_events_by_session", expr=mebs, cte_type="subquery"),
         "metric_events": ast.CTE(name="metric_events", expr=me, cte_type="subquery"),
+        "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
+    }
+    return query
+
+
+def _dw_retention_metric():
+    return ExperimentRetentionMetric(
+        start_event=ExperimentDataWarehouseNode(
+            table_name="events_dw",
+            events_join_key="properties.$user_id",
+            data_warehouse_join_key="userid",
+            timestamp_field="ds",
+            math=ExperimentMetricMathType.TOTAL,
+        ),
+        completion_event=EventsNode(event="returned"),
+        retention_window_start=1,
+        retention_window_end=7,
+        retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+        start_handling=StartHandling.FIRST_SEEN,
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="plan", type=BreakdownType.DATA_WAREHOUSE)]),
+    )
+
+
+def _retention_metric(breakdown_limit=None):
+    return ExperimentRetentionMetric(
+        start_event=EventsNode(event="signed_up"),
+        completion_event=EventsNode(event="returned"),
+        retention_window_start=1,
+        retention_window_end=7,
+        retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+        start_handling=StartHandling.FIRST_SEEN,
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit),
+    )
+
+
+def _retention_query() -> ast.SelectQuery:
+    # Stand-in for the retention shape: start_events (GROUP BY entity) -> completion_events ->
+    # entity_metrics (joins exposures + start + completion).
+    query = parse_select("SELECT variant FROM entity_metrics")
+    assert isinstance(query, ast.SelectQuery)
+    se = parse_select(
+        "SELECT exposures.entity_id AS entity_id, min(timestamp) AS start_timestamp "
+        "FROM events INNER JOIN exposures ON entity_id = exposures.entity_id GROUP BY exposures.entity_id"
+    )
+    ce = parse_select("SELECT entity_id, timestamp AS completion_timestamp FROM events")
+    em = parse_select(
+        "SELECT exposures.entity_id AS entity_id, exposures.variant AS variant, max(value) AS value "
+        "FROM exposures INNER JOIN start_events ON exposures.entity_id = start_events.entity_id "
+        "LEFT JOIN completion_events ON exposures.entity_id = completion_events.entity_id "
+        "GROUP BY exposures.entity_id, exposures.variant"
+    )
+    assert isinstance(se, ast.SelectQuery) and isinstance(ce, ast.SelectQuery) and isinstance(em, ast.SelectQuery)
+    query.ctes = {
+        "start_events": ast.CTE(name="start_events", expr=se, cte_type="subquery"),
+        "completion_events": ast.CTE(name="completion_events", expr=ce, cte_type="subquery"),
         "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
     }
     return query
@@ -330,6 +388,85 @@ class TestMetricBreakdownInjectorMean:
         # A DW breakdown is a direct warehouse column (the metric_events CTE reads FROM the warehouse
         # table), so it must read bare `plan`, NOT be wrapped in an event `properties` chain.
         coalesce_call = bd.expr
+        assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
+        to_string = coalesce_call.args[0]
+        assert isinstance(to_string, ast.Call) and to_string.name == "toString"
+        field = to_string.args[0]
+        assert isinstance(field, ast.Field)
+        assert field.chain == ["plan"]
+
+
+class TestMetricBreakdownInjectorRetention:
+    def test_breakdown_read_from_start_event(self):
+        metric = _retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        assert query.ctes is not None
+        se_cte = query.ctes["start_events"]
+        assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
+        se_aliases = [c.alias for c in se_cte.expr.select if isinstance(c, ast.Alias)]
+        assert "breakdown_value_1" in se_aliases
+
+    def test_entity_metrics_first_touch_from_start_event(self):
+        metric = _retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
+        # Carried from the start_events CTE (first-touch attributed there over start_timestamp).
+        assert isinstance(expr, ast.Field)
+        assert expr.chain == ["start_events", "breakdown_value_1"]
+
+    def test_start_events_uses_argmin_over_start_timestamp(self):
+        metric = _retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        assert query.ctes is not None
+        se_cte = query.ctes["start_events"]
+        assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
+        bd = next(c for c in se_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # start_events groups by entity, so the breakdown is deduped first-touch via argMin.
+        assert isinstance(bd.expr, ast.Call)
+        assert bd.expr.name == "argMin"
+        assert bd.expr.args[1] == ast.Field(chain=["timestamp"])
+
+    def test_final_select_applies_top_n_other_limit(self):
+        metric = _retention_metric(breakdown_limit=3)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        final_alias = next(c for c in query.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        assert isinstance(final_alias.expr, ast.Call)
+        assert final_alias.expr.name == "if"
+        other = final_alias.expr.args[2]
+        assert isinstance(other, ast.Constant)
+        assert other.value == "$$_posthog_breakdown_other_$$"
+
+    def test_data_warehouse_breakdown_reads_warehouse_column(self):
+        metric = _dw_retention_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _retention_query()
+
+        injector.inject_retention_breakdown_columns(query)
+
+        assert query.ctes is not None
+        se_cte = query.ctes["start_events"]
+        assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
+        bd = next(c for c in se_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # A DW breakdown reads bare `plan` from the warehouse table (no `properties` wrapper).
+        argmin_call = bd.expr
+        assert isinstance(argmin_call, ast.Call) and argmin_call.name == "argMin"
+        coalesce_call = argmin_call.args[0]
         assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
         to_string = coalesce_call.args[0]
         assert isinstance(to_string, ast.Call) and to_string.name == "toString"

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -122,14 +122,14 @@ def _dw_retention_metric():
     )
 
 
-def _retention_metric(breakdown_limit=None):
+def _retention_metric(breakdown_limit=None, start_handling=StartHandling.FIRST_SEEN):
     return ExperimentRetentionMetric(
         start_event=EventsNode(event="signed_up"),
         completion_event=EventsNode(event="returned"),
         retention_window_start=1,
         retention_window_end=7,
         retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
-        start_handling=StartHandling.FIRST_SEEN,
+        start_handling=start_handling,
         breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit),
     )
 
@@ -422,8 +422,17 @@ class TestMetricBreakdownInjectorRetention:
         assert isinstance(expr, ast.Field)
         assert expr.chain == ["start_events", "breakdown_value_1"]
 
-    def test_start_events_uses_argmin_over_start_timestamp(self):
-        metric = _retention_metric()
+    @parameterized.expand(
+        [
+            ("first_seen", StartHandling.FIRST_SEEN, "argMin"),
+            ("last_seen", StartHandling.LAST_SEEN, "argMax"),
+        ]
+    )
+    def test_start_events_attribution_matches_start_handling(self, _name, start_handling, expected_agg):
+        # The breakdown must come from the same start event the retention window anchors on:
+        # earliest for FIRST_SEEN, latest for LAST_SEEN. Using argMin for LAST_SEEN would bucket a
+        # user by a different event than the one that defines their window.
+        metric = _retention_metric(start_handling=start_handling)
         injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
         query = _retention_query()
 
@@ -433,9 +442,8 @@ class TestMetricBreakdownInjectorRetention:
         se_cte = query.ctes["start_events"]
         assert isinstance(se_cte, ast.CTE) and isinstance(se_cte.expr, ast.SelectQuery)
         bd = next(c for c in se_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
-        # start_events groups by entity, so the breakdown is deduped first-touch via argMin.
         assert isinstance(bd.expr, ast.Call)
-        assert bd.expr.name == "argMin"
+        assert bd.expr.name == expected_agg
         assert bd.expr.args[1] == ast.Field(chain=["timestamp"])
 
     def test_final_select_applies_top_n_other_limit(self):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Funnel (#61796) and mean (#62291) metrics attribute breakdowns from the metric event. Retention metrics still use the exposure-event injector.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR migrates retention metrics to `MetricBreakdownInjector`, behind the same flag.

### Retention support in the injector

The breakdown is read off the start event and attributed first touch (`argMin` over the start event timestamp). Attribution is fixed with no user choice, and that's deliberate: retention is `retained / cohort`, the cohort (denominator) is defined by the start event, and every retained user has one. Reading the breakdown off the completion event would break the per-bucket denominator, since non-retained users have no completion event to bucket by. `start_events` already groups by entity, so the value is deduped per user there and carried into `entity_metrics`.

- `products/experiments/backend/hogql_queries/metric_breakdown_injector.py`
- `products/experiments/backend/hogql_queries/experiment_query_runner.py`
- `products/experiments/backend/hogql_queries/experiment_retention_query_builder.py`

### Tests

Flag-on retention cases in `test_metric_breakdown.py` (start-event attribution, limit, Other bucket) plus injector unit tests.

- `products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py`
- `products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/9dc6c889-42f5-47e6-ab61-7b678ff89ccf)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session. -->

Model: Opus 4.7 (implementation), Fable 5 (restack and PR description)
Manually refactored: **yes**

Skills used:

- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Start-event attribution is the only source that keeps the per-bucket denominator well-defined, so no attribution dropdown is offered for retention.