### PR TITLE
feat(experiments): add ratio metrics to the metric breakdown injector

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -473,7 +473,8 @@ class ExperimentQueryRunner(QueryRunner):
         # Metric types migrated to the metric-event breakdown injector. Others fall back to the
         # old BreakdownInjector until they migrate (then BreakdownInjector is deleted).
         migrated_metric = isinstance(
-            self.metric, ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric
+            self.metric,
+            ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric | ExperimentRatioMetric,
         )
         if breakdowns and migrated_metric and self._metric_event_breakdowns_enabled():
             breakdown_injector = MetricBreakdownInjector(breakdowns, self.metric)

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -544,21 +544,11 @@ class ExperimentQueryRunner(QueryRunner):
 
         breakdowns = self._get_breakdowns_for_builder()
         breakdown_injector: MetricBreakdownInjector | None = None
-        # Metric types migrated to the metric-event breakdown injector. Others fall back to the
-        # old BreakdownInjector until they migrate (then BreakdownInjector is deleted).
-        migrated_metric = isinstance(
-            self.metric,
-            ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric | ExperimentRatioMetric,
-        )
-        # Data warehouse sources aren't supported by the injector yet: funnels route through the
-        # legacy builder that drops the injected columns, and DW mean metrics select from the
-        # warehouse table where event/person/session breakdown chains don't resolve.
-        if (
-            breakdowns
-            and migrated_metric
-            and not self.is_data_warehouse_query
-            and self._metric_event_breakdowns_enabled()
-        ):
+        # Every experiment metric type now uses the metric-event breakdown injector, except data
+        # warehouse sources: DW funnels route through the legacy builder that drops the injected
+        # columns, and DW mean/ratio select from the warehouse table where event/person/session
+        # breakdown chains don't resolve. Gate DW out until the injector supports it.
+        if breakdowns and not self.is_data_warehouse_query and self._metric_event_breakdowns_enabled():
             breakdown_injector = MetricBreakdownInjector(breakdowns, self.metric)
 
         builder = ExperimentQueryBuilder(

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -547,7 +547,8 @@ class ExperimentQueryRunner(QueryRunner):
         # Metric types migrated to the metric-event breakdown injector. Others fall back to the
         # old BreakdownInjector until they migrate (then BreakdownInjector is deleted).
         migrated_metric = isinstance(
-            self.metric, ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric
+            self.metric,
+            ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRetentionMetric | ExperimentRatioMetric,
         )
         # Data warehouse sources aren't supported by the injector yet: funnels route through the
         # legacy builder that drops the injected columns, and DW mean metrics select from the

--- a/products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py
@@ -5,7 +5,6 @@ from posthog.schema import ExperimentDataWarehouseNode, ExperimentMetricOutlierH
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
 
-from products.experiments.backend.hogql_queries.breakdown_injector import BreakdownInjector
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 if TYPE_CHECKING:
@@ -62,9 +61,9 @@ class RatioQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
-        # so ratio metrics always use the property-from-exposure BreakdownInjector.
-        if isinstance(self._b.breakdown_injector, BreakdownInjector):
+        # Inject breakdown columns into the query AST. Both injectors expose
+        # inject_ratio_breakdown_columns (old: exposure source; new: numerator-event source + limit).
+        if self._b.breakdown_injector:
             self._b.breakdown_injector.inject_ratio_breakdown_columns(query)
 
         return query
@@ -199,9 +198,9 @@ class RatioQueryBuilder:
 
         assert isinstance(query, ast.SelectQuery)
 
-        # Inject breakdown columns into the query AST. The metric-event injector is funnel-only,
-        # so ratio metrics always use the property-from-exposure BreakdownInjector.
-        if isinstance(self._b.breakdown_injector, BreakdownInjector):
+        # Inject breakdown columns into the query AST. Both injectors expose
+        # inject_ratio_breakdown_columns (old: exposure source; new: numerator-event source + limit).
+        if self._b.breakdown_injector:
             self._b.breakdown_injector.inject_ratio_breakdown_columns(query, winsorized=True)
 
         return query

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -447,3 +447,63 @@ class MetricBreakdownInjector:
                     entity_metrics_cte.expr.group_by.append(ast.Field(chain=["start_events", alias]))
 
         self._inject_final_breakdown_columns(query, aliases)
+
+    def inject_ratio_breakdown_columns(self, query: ast.SelectQuery, winsorized: bool = False) -> None:
+        """Inject breakdown columns into a ratio query.
+
+        Ratio is ``Σnumerator / Σdenominator`` over two separate event streams, pre-aggregated
+        per entity before joining exposures. To keep one experiment unit = one breakdown bucket
+        (so per-breakdown rows sum to the overall), the whole user is attributed by their
+        **numerator event** — read off ``numerator_events``, first-touch via ``argMin`` over the
+        numerator timestamp in ``numerator_agg``, then carried through ``entity_metrics``.
+
+        When ``winsorized`` the query has ``percentiles`` and ``winsorized_entity_metrics`` CTEs;
+        per-breakdown-group thresholds are preserved (not changed).
+        """
+        if not self._has_breakdown():
+            return
+
+        aliases = self._get_breakdown_aliases()
+        final_cte_name = "winsorized_entity_metrics" if winsorized else "entity_metrics"
+        breakdown_exprs = self.build_breakdown_exprs(table_alias="")
+
+        # Read the breakdown off the numerator event.
+        if query.ctes and "numerator_events" in query.ctes:
+            numerator_events_cte = query.ctes["numerator_events"]
+            if isinstance(numerator_events_cte, ast.CTE) and isinstance(numerator_events_cte.expr, ast.SelectQuery):
+                for alias, expr in breakdown_exprs:
+                    numerator_events_cte.expr.select.append(ast.Alias(alias=alias, expr=expr))
+
+        # First-touch attribute per entity in numerator_agg (it groups by entity).
+        if query.ctes and "numerator_agg" in query.ctes:
+            numerator_agg_cte = query.ctes["numerator_agg"]
+            if isinstance(numerator_agg_cte, ast.CTE) and isinstance(numerator_agg_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    numerator_agg_cte.expr.select.append(
+                        ast.Alias(
+                            alias=alias,
+                            expr=ast.Call(
+                                name="argMin",
+                                args=[
+                                    ast.Field(chain=["numerator_events", alias]),
+                                    ast.Field(chain=["numerator_events", "timestamp"]),
+                                ],
+                            ),
+                        )
+                    )
+
+        # Carry the attributed breakdown into entity_metrics (which aggregates with any()).
+        if query.ctes and "entity_metrics" in query.ctes:
+            entity_metrics_cte = query.ctes["entity_metrics"]
+            if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    entity_metrics_cte.expr.select.append(
+                        ast.Alias(
+                            alias=alias, expr=ast.Call(name="any", args=[ast.Field(chain=["numerator_agg", alias])])
+                        )
+                    )
+
+        # Winsorization carry-through (percentiles + winsorized_entity_metrics) reuses the mean helper.
+        self._inject_winsorization_breakdown_columns(query, aliases, final_cte_name)
+
+        self._inject_final_breakdown_columns(query, aliases, final_cte_name=final_cte_name)

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -529,15 +529,22 @@ class MetricBreakdownInjector:
                     )
 
         # Carry the attributed breakdown into entity_metrics (which aggregates with any()).
+        # Denominator-only users have no numerator_agg row, so the LEFT JOIN yields NULL and any()
+        # returns "". build_breakdown_exprs already maps real null property values to the null
+        # label, so an empty string here means "no numerator event" and gets the null label too,
+        # rather than an invisible "" bucket that steals a top-N slot and collides with real values.
         if query.ctes and "entity_metrics" in query.ctes:
             entity_metrics_cte = query.ctes["entity_metrics"]
             if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
                 for alias in aliases:
-                    entity_metrics_cte.expr.select.append(
-                        ast.Alias(
-                            alias=alias, expr=ast.Call(name="any", args=[ast.Field(chain=["numerator_agg", alias])])
-                        )
+                    attributed = parse_expr(
+                        "if(empty({value}), {null_label}, {value})",
+                        placeholders={
+                            "value": ast.Call(name="any", args=[ast.Field(chain=["numerator_agg", alias])]),
+                            "null_label": ast.Constant(value=BREAKDOWN_NULL_STRING_LABEL),
+                        },
                     )
+                    entity_metrics_cte.expr.select.append(ast.Alias(alias=alias, expr=attributed))
 
         # Winsorization carry-through (percentiles + winsorized_entity_metrics) reuses the mean helper.
         self._inject_winsorization_breakdown_columns(query, aliases, final_cte_name)

--- a/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/metric_breakdown_injector.py
@@ -483,3 +483,63 @@ class MetricBreakdownInjector:
                     entity_metrics_cte.expr.group_by.append(ast.Field(chain=["start_events", alias]))
 
         self._inject_final_breakdown_columns(query, aliases)
+
+    def inject_ratio_breakdown_columns(self, query: ast.SelectQuery, winsorized: bool = False) -> None:
+        """Inject breakdown columns into a ratio query.
+
+        Ratio is ``Σnumerator / Σdenominator`` over two separate event streams, pre-aggregated
+        per entity before joining exposures. To keep one experiment unit = one breakdown bucket
+        (so per-breakdown rows sum to the overall), the whole user is attributed by their
+        **numerator event** — read off ``numerator_events``, first-touch via ``argMin`` over the
+        numerator timestamp in ``numerator_agg``, then carried through ``entity_metrics``.
+
+        When ``winsorized`` the query has ``percentiles`` and ``winsorized_entity_metrics`` CTEs;
+        per-breakdown-group thresholds are preserved (not changed).
+        """
+        if not self._has_breakdown():
+            return
+
+        aliases = self._get_breakdown_aliases()
+        final_cte_name = "winsorized_entity_metrics" if winsorized else "entity_metrics"
+        breakdown_exprs = self.build_breakdown_exprs(table_alias="")
+
+        # Read the breakdown off the numerator event.
+        if query.ctes and "numerator_events" in query.ctes:
+            numerator_events_cte = query.ctes["numerator_events"]
+            if isinstance(numerator_events_cte, ast.CTE) and isinstance(numerator_events_cte.expr, ast.SelectQuery):
+                for alias, expr in breakdown_exprs:
+                    numerator_events_cte.expr.select.append(ast.Alias(alias=alias, expr=expr))
+
+        # First-touch attribute per entity in numerator_agg (it groups by entity).
+        if query.ctes and "numerator_agg" in query.ctes:
+            numerator_agg_cte = query.ctes["numerator_agg"]
+            if isinstance(numerator_agg_cte, ast.CTE) and isinstance(numerator_agg_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    numerator_agg_cte.expr.select.append(
+                        ast.Alias(
+                            alias=alias,
+                            expr=ast.Call(
+                                name="argMin",
+                                args=[
+                                    ast.Field(chain=["numerator_events", alias]),
+                                    ast.Field(chain=["numerator_events", "timestamp"]),
+                                ],
+                            ),
+                        )
+                    )
+
+        # Carry the attributed breakdown into entity_metrics (which aggregates with any()).
+        if query.ctes and "entity_metrics" in query.ctes:
+            entity_metrics_cte = query.ctes["entity_metrics"]
+            if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
+                for alias in aliases:
+                    entity_metrics_cte.expr.select.append(
+                        ast.Alias(
+                            alias=alias, expr=ast.Call(name="any", args=[ast.Field(chain=["numerator_agg", alias])])
+                        )
+                    )
+
+        # Winsorization carry-through (percentiles + winsorized_entity_metrics) reuses the mean helper.
+        self._inject_winsorization_breakdown_columns(query, aliases, final_cte_name)
+
+        self._inject_final_breakdown_columns(query, aliases, final_cte_name=final_cte_name)

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py
@@ -16,8 +16,10 @@ from posthog.schema import (
     ExperimentFunnelMetric,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
+    ExperimentMetricOutlierHandling,
     ExperimentQuery,
     ExperimentQueryResponse,
+    ExperimentRatioMetric,
     ExperimentRetentionMetric,
     FunnelConversionWindowTimeUnit,
     StartHandling,
@@ -1132,3 +1134,476 @@ class TestMetricBreakdown(ExperimentQueryRunnerBaseTest):
             br.baseline.number_of_samples for br in result.breakdown_results if br.baseline is not None
         )
         self.assertEqual(per_breakdown_baseline, result.baseline.number_of_samples)
+
+    def _create_ratio_metric(self, breakdown_limit=None):
+        return ExperimentRatioMetric(
+            numerator=EventsNode(event="purchase", math=ExperimentMetricMathType.SUM, math_property="amount"),
+            denominator=EventsNode(event="view_item", math=ExperimentMetricMathType.TOTAL),
+            breakdownFilter=BreakdownFilter(
+                breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit
+            ),
+        )
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_from_numerator_event(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_ratio_metric()
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Exposure carries "ExposureBrowser"; the numerator (purchase) event carries "NumeratorBrowser".
+        for variant in ["control", "test"]:
+            distinct_id = f"user_{variant}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                    "$browser": "ExposureBrowser",
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="view_item",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant, "$browser": "DenominatorBrowser"},
+            )
+            _create_event(
+                team=self.team,
+                event="purchase",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:02:00Z",
+                properties={feature_flag_property: variant, "$browser": "NumeratorBrowser", "amount": 10},
+            )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        # The breakdown is attributed from the numerator event, not the exposure or denominator.
+        self.assertEqual(buckets, {"NumeratorBrowser"})
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_limit_collapses_to_other(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_ratio_metric(breakdown_limit=2)
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Four browsers with descending numerator-event user counts; limit=2 keeps the top two.
+        browser_counts = {"Chrome": 4, "Safari": 3, "Firefox": 2, "Edge": 1}
+        user_index = 0
+        for browser, count in browser_counts.items():
+            for _ in range(count):
+                variant = "control" if user_index % 2 == 0 else "test"
+                distinct_id = f"user_ratio_{user_index}"
+                user_index += 1
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="view_item",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant, "$browser": browser},
+                )
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:02:00Z",
+                    properties={feature_flag_property: variant, "$browser": browser, "amount": 10},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        self.assertEqual(buckets, {"Chrome", "Safari", BREAKDOWN_OTHER_STRING_LABEL})
+
+        ordered_values = [value for br in result.breakdown_results for value in br.breakdown_value]
+        self.assertEqual(ordered_values[-1], BREAKDOWN_OTHER_STRING_LABEL)
+
+    @parameterized.expand(
+        [
+            ("two_breakdowns", ["$browser", "$os"], 2),
+            ("three_breakdowns", ["$browser", "$os", "$device_type"], 3),
+        ]
+    )
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_with_multiple_breakdowns(self, _name, breakdown_properties, expected_tuple_len):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentRatioMetric(
+            numerator=EventsNode(event="purchase", math=ExperimentMetricMathType.SUM, math_property="amount"),
+            denominator=EventsNode(event="view_item", math=ExperimentMetricMathType.TOTAL),
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property=p) for p in breakdown_properties]),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        combos = [
+            {"$browser": "Chrome", "$os": "Windows", "$device_type": "Desktop"},
+            {"$browser": "Safari", "$os": "Mac", "$device_type": "Mobile"},
+        ]
+        for variant in ["control", "test"]:
+            for idx, combo in enumerate(combos):
+                distinct_id = f"user_ratio_multi_{variant}_{idx}"
+                purchase_props = {k: v for k, v in combo.items() if k in breakdown_properties}
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="view_item",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:02:00Z",
+                    properties={feature_flag_property: variant, "amount": 10, **purchase_props},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        for breakdown_result in result.breakdown_results:
+            self.assertEqual(len(breakdown_result.breakdown_value), expected_tuple_len)
+
+        breakdown_values = [tuple(br.breakdown_value) for br in result.breakdown_results]
+        expected_chrome = tuple(combos[0][p] for p in breakdown_properties)
+        expected_safari = tuple(combos[1][p] for p in breakdown_properties)
+        self.assertIn(expected_chrome, breakdown_values)
+        self.assertIn(expected_safari, breakdown_values)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_null_values(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_ratio_metric()
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Two users per variant: one with $browser on the purchase (numerator) event, one without.
+        for variant in ["control", "test"]:
+            for idx, has_browser in enumerate([True, False]):
+                distinct_id = f"user_ratio_null_{variant}_{idx}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="view_item",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+                purchase_props: dict = {feature_flag_property: variant, "amount": 10}
+                if has_browser:
+                    purchase_props["$browser"] = "Chrome"
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:02:00Z",
+                    properties=purchase_props,
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        breakdown_values = [br.breakdown_value for br in result.breakdown_results]
+        self.assertIn(["Chrome"], breakdown_values)
+        self.assertIn([BREAKDOWN_NULL_STRING_LABEL], breakdown_values)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_person_property(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentRatioMetric(
+            numerator=EventsNode(event="purchase", math=ExperimentMetricMathType.SUM, math_property="amount"),
+            denominator=EventsNode(event="view_item", math=ExperimentMetricMathType.TOTAL),
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="country", type="person")]),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        country_by_variant = {"control": "US", "test": "UK"}
+        for variant, country in country_by_variant.items():
+            for i in range(2):
+                distinct_id = f"user_ratio_person_{variant}_{i}"
+                _create_person(distinct_ids=[distinct_id], team_id=self.team.pk, properties={"country": country})
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                _create_event(
+                    team=self.team,
+                    event="view_item",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:01:00Z",
+                    properties={feature_flag_property: variant},
+                )
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=distinct_id,
+                    timestamp="2020-01-02T12:02:00Z",
+                    properties={feature_flag_property: variant, "amount": 10},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        assert result.breakdown_results is not None
+        breakdown_values = [br.breakdown_value for br in result.breakdown_results]
+        self.assertIn(["US"], breakdown_values)
+        self.assertIn(["UK"], breakdown_values)
+
+        us_breakdown = next((br for br in result.breakdown_results if br.breakdown_value == ["US"]), None)
+        self.assertIsNotNone(us_breakdown)
+        assert us_breakdown is not None
+        self.assertEqual(us_breakdown.baseline.number_of_samples, 2)
+
+        uk_breakdown = next((br for br in result.breakdown_results if br.breakdown_value == ["UK"]), None)
+        self.assertIsNotNone(uk_breakdown)
+        assert uk_breakdown is not None
+        self.assertEqual(len(uk_breakdown.variants), 1)
+        self.assertEqual(uk_breakdown.variants[0].number_of_samples, 2)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_with_winsorization(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = ExperimentRatioMetric(
+            numerator=EventsNode(event="purchase", math=ExperimentMetricMathType.SUM, math_property="amount"),
+            denominator=EventsNode(event="view_item", math=ExperimentMetricMathType.TOTAL),
+            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
+            numerator_outlier_handling=ExperimentMetricOutlierHandling(upper_bound_percentile=0.95),
+        )
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Two browsers on the numerator (purchase) event side — breakdown bucket comes from there.
+        for i in range(4):
+            browser = "Chrome" if i < 2 else "Safari"
+            variant = "control" if i % 2 == 0 else "test"
+            distinct_id = f"user_ratio_winsor_{i}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="view_item",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant},
+            )
+            _create_event(
+                team=self.team,
+                event="purchase",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:02:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$browser": browser,
+                    "amount": 10 + i * 5,
+                },
+            )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        # Winsorized ratio path must run without error and buckets must come from the numerator event.
+        assert result.breakdown_results is not None
+        buckets = {value for br in result.breakdown_results for value in br.breakdown_value}
+        self.assertEqual(buckets, {"Chrome", "Safari"})
+        for breakdown_result in result.breakdown_results:
+            self.assertIsNotNone(breakdown_result.baseline)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_ratio_breakdown_denominator_only_user(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        metric = self._create_ratio_metric()
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Normal user: has both denominator (view_item) and numerator (purchase) events.
+        for variant in ["control", "test"]:
+            distinct_id = f"user_ratio_normal_{variant}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="view_item",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant},
+            )
+            _create_event(
+                team=self.team,
+                event="purchase",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:02:00Z",
+                properties={feature_flag_property: variant, "$browser": "Chrome", "amount": 10},
+            )
+
+        # Denominator-only user: has a view_item but NO purchase — no numerator event to attribute from.
+        # Their breakdown is null/absent; they contribute to denominator sum but not a named browser bucket.
+        for variant in ["control", "test"]:
+            distinct_id = f"user_ratio_denom_only_{variant}"
+            _create_person(distinct_ids=[distinct_id], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: variant,
+                    "$feature_flag_response": variant,
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            _create_event(
+                team=self.team,
+                event="view_item",
+                distinct_id=distinct_id,
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: variant},
+            )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        # Query must run without error.
+        assert result.breakdown_results is not None
+        breakdown_values = [br.breakdown_value for br in result.breakdown_results]
+        # The normal user's Chrome bucket must be present.
+        self.assertIn(["Chrome"], breakdown_values)

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py
@@ -1607,3 +1607,7 @@ class TestMetricBreakdown(ExperimentQueryRunnerBaseTest):
         breakdown_values = [br.breakdown_value for br in result.breakdown_results]
         # The normal user's Chrome bucket must be present.
         self.assertIn(["Chrome"], breakdown_values)
+        # The denominator-only user has no numerator event to attribute from, so they land in the
+        # null bucket, not an invisible empty-string bucket.
+        self.assertIn([BREAKDOWN_NULL_STRING_LABEL], breakdown_values)
+        self.assertNotIn([""], breakdown_values)

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -10,6 +10,7 @@ from posthog.schema import (
     ExperimentFunnelMetric,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
+    ExperimentRatioMetric,
     ExperimentRetentionMetric,
     FunnelConversionWindowTimeUnit,
     StartHandling,
@@ -141,6 +142,55 @@ def _retention_query() -> ast.SelectQuery:
     query.ctes = {
         "start_events": ast.CTE(name="start_events", expr=se, cte_type="subquery"),
         "completion_events": ast.CTE(name="completion_events", expr=ce, cte_type="subquery"),
+        "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
+    }
+    return query
+
+
+def _ratio_metric(breakdown_limit=None):
+    return ExperimentRatioMetric(
+        numerator=EventsNode(event="purchase"),
+        denominator=EventsNode(event="pageview"),
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit),
+    )
+
+
+def _dw_ratio_metric():
+    return ExperimentRatioMetric(
+        numerator=ExperimentDataWarehouseNode(
+            table_name="orders",
+            events_join_key="properties.$user_id",
+            data_warehouse_join_key="userid",
+            timestamp_field="ds",
+            math=ExperimentMetricMathType.SUM,
+            math_property="amount",
+        ),
+        denominator=EventsNode(event="pageview"),
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="plan", type=BreakdownType.DATA_WAREHOUSE)]),
+    )
+
+
+def _ratio_query() -> ast.SelectQuery:
+    # Stand-in for the ratio shape: numerator_events -> numerator_agg -> entity_metrics
+    # (denominator side omitted; the breakdown attaches to the numerator side).
+    query = parse_select("SELECT variant FROM entity_metrics")
+    assert isinstance(query, ast.SelectQuery)
+    ne = parse_select("SELECT entity_id, timestamp, value FROM events")
+    na = parse_select(
+        "SELECT exposures.entity_id AS entity_id, sum(value) AS value "
+        "FROM numerator_events JOIN exposures ON exposures.entity_id = numerator_events.entity_id "
+        "GROUP BY exposures.entity_id"
+    )
+    em = parse_select(
+        "SELECT exposures.variant AS variant, exposures.entity_id AS entity_id, "
+        "any(numerator_agg.value) AS numerator_value "
+        "FROM exposures LEFT JOIN numerator_agg ON exposures.entity_id = numerator_agg.entity_id "
+        "GROUP BY exposures.variant, exposures.entity_id"
+    )
+    assert isinstance(ne, ast.SelectQuery) and isinstance(na, ast.SelectQuery) and isinstance(em, ast.SelectQuery)
+    query.ctes = {
+        "numerator_events": ast.CTE(name="numerator_events", expr=ne, cte_type="subquery"),
+        "numerator_agg": ast.CTE(name="numerator_agg", expr=na, cte_type="subquery"),
         "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
     }
     return query
@@ -340,6 +390,85 @@ class TestMetricBreakdownInjectorMean:
         bd = next(c for c in me_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
         # A DW breakdown is a direct warehouse column (the metric_events CTE reads FROM the warehouse
         # table), so it must read bare `plan`, NOT be wrapped in an event `properties` chain.
+        coalesce_call = bd.expr
+        assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
+        to_string = coalesce_call.args[0]
+        assert isinstance(to_string, ast.Call) and to_string.name == "toString"
+        field = to_string.args[0]
+        assert isinstance(field, ast.Field)
+        assert field.chain == ["plan"]
+
+
+class TestMetricBreakdownInjectorRatio:
+    def test_breakdown_read_from_numerator_event(self):
+        metric = _ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        assert query.ctes is not None
+        ne_cte = query.ctes["numerator_events"]
+        assert isinstance(ne_cte, ast.CTE) and isinstance(ne_cte.expr, ast.SelectQuery)
+        ne_aliases = [c.alias for c in ne_cte.expr.select if isinstance(c, ast.Alias)]
+        assert "breakdown_value_1" in ne_aliases
+
+    def test_numerator_agg_first_touch_argmin(self):
+        metric = _ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        assert query.ctes is not None
+        na_cte = query.ctes["numerator_agg"]
+        assert isinstance(na_cte, ast.CTE) and isinstance(na_cte.expr, ast.SelectQuery)
+        bd = next(c for c in na_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # numerator_agg groups by entity, so first-touch via argMin over the numerator event timestamp.
+        assert isinstance(bd.expr, ast.Call)
+        assert bd.expr.name == "argMin"
+        assert bd.expr.args[1] == ast.Field(chain=["numerator_events", "timestamp"])
+
+    def test_entity_metrics_carries_breakdown_from_numerator_agg(self):
+        metric = _ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
+        assert isinstance(expr, ast.Call)
+        # any(numerator_agg.breakdown_value_1) — carried through the entity_metrics aggregation.
+        assert expr.name == "any"
+        assert expr.args[0] == ast.Field(chain=["numerator_agg", "breakdown_value_1"])
+
+    def test_final_select_applies_top_n_other_limit(self):
+        metric = _ratio_metric(breakdown_limit=3)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        final_alias = next(c for c in query.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        assert isinstance(final_alias.expr, ast.Call)
+        assert final_alias.expr.name == "if"
+        other = final_alias.expr.args[2]
+        assert isinstance(other, ast.Constant)
+        assert other.value == "$$_posthog_breakdown_other_$$"
+
+    def test_data_warehouse_breakdown_reads_warehouse_column(self):
+        metric = _dw_ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        assert query.ctes is not None
+        ne_cte = query.ctes["numerator_events"]
+        assert isinstance(ne_cte, ast.CTE) and isinstance(ne_cte.expr, ast.SelectQuery)
+        bd = next(c for c in ne_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # A DW breakdown is a direct warehouse column (numerator_events reads FROM the warehouse
+        # table), so it must read bare `plan`, NOT be wrapped in a properties chain.
         coalesce_call = bd.expr
         assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
         to_string = coalesce_call.args[0]

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -484,10 +484,16 @@ class TestMetricBreakdownInjectorRatio:
         injector.inject_ratio_breakdown_columns(query)
 
         expr = _entity_metrics_aliases(query)["breakdown_value_1"]
-        assert isinstance(expr, ast.Call)
-        # any(numerator_agg.breakdown_value_1) — carried through the entity_metrics aggregation.
-        assert expr.name == "any"
-        assert expr.args[0] == ast.Field(chain=["numerator_agg", "breakdown_value_1"])
+        # Denominator-only users have no numerator_agg row, so any() returns "". That empty value
+        # is mapped to the null label instead of forming an invisible "" bucket.
+        assert isinstance(expr, ast.Call) and expr.name == "if"
+        empty_check = expr.args[0]
+        assert isinstance(empty_check, ast.Call) and empty_check.name == "empty"
+        inner_any = empty_check.args[0]
+        assert isinstance(inner_any, ast.Call) and inner_any.name == "any"
+        assert inner_any.args[0] == ast.Field(chain=["numerator_agg", "breakdown_value_1"])
+        null_label = expr.args[1]
+        assert isinstance(null_label, ast.Constant) and null_label.value == BREAKDOWN_NULL_STRING_LABEL
 
     def test_final_select_applies_top_n_other_limit(self):
         metric = _ratio_metric(breakdown_limit=3)

--- a/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py
@@ -10,6 +10,7 @@ from posthog.schema import (
     ExperimentFunnelMetric,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
+    ExperimentRatioMetric,
     ExperimentRetentionMetric,
     FunnelConversionWindowTimeUnit,
     StartHandling,
@@ -154,6 +155,55 @@ def _retention_query() -> ast.SelectQuery:
     query.ctes = {
         "start_events": ast.CTE(name="start_events", expr=se, cte_type="subquery"),
         "completion_events": ast.CTE(name="completion_events", expr=ce, cte_type="subquery"),
+        "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
+    }
+    return query
+
+
+def _ratio_metric(breakdown_limit=None):
+    return ExperimentRatioMetric(
+        numerator=EventsNode(event="purchase"),
+        denominator=EventsNode(event="pageview"),
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")], breakdown_limit=breakdown_limit),
+    )
+
+
+def _dw_ratio_metric():
+    return ExperimentRatioMetric(
+        numerator=ExperimentDataWarehouseNode(
+            table_name="orders",
+            events_join_key="properties.$user_id",
+            data_warehouse_join_key="userid",
+            timestamp_field="ds",
+            math=ExperimentMetricMathType.SUM,
+            math_property="amount",
+        ),
+        denominator=EventsNode(event="pageview"),
+        breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="plan", type=BreakdownType.DATA_WAREHOUSE)]),
+    )
+
+
+def _ratio_query() -> ast.SelectQuery:
+    # Stand-in for the ratio shape: numerator_events -> numerator_agg -> entity_metrics
+    # (denominator side omitted; the breakdown attaches to the numerator side).
+    query = parse_select("SELECT variant FROM entity_metrics")
+    assert isinstance(query, ast.SelectQuery)
+    ne = parse_select("SELECT entity_id, timestamp, value FROM events")
+    na = parse_select(
+        "SELECT exposures.entity_id AS entity_id, sum(value) AS value "
+        "FROM numerator_events JOIN exposures ON exposures.entity_id = numerator_events.entity_id "
+        "GROUP BY exposures.entity_id"
+    )
+    em = parse_select(
+        "SELECT exposures.variant AS variant, exposures.entity_id AS entity_id, "
+        "any(numerator_agg.value) AS numerator_value "
+        "FROM exposures LEFT JOIN numerator_agg ON exposures.entity_id = numerator_agg.entity_id "
+        "GROUP BY exposures.variant, exposures.entity_id"
+    )
+    assert isinstance(ne, ast.SelectQuery) and isinstance(na, ast.SelectQuery) and isinstance(em, ast.SelectQuery)
+    query.ctes = {
+        "numerator_events": ast.CTE(name="numerator_events", expr=ne, cte_type="subquery"),
+        "numerator_agg": ast.CTE(name="numerator_agg", expr=na, cte_type="subquery"),
         "entity_metrics": ast.CTE(name="entity_metrics", expr=em, cte_type="subquery"),
     }
     return query
@@ -387,6 +437,85 @@ class TestMetricBreakdownInjectorMean:
         bd = next(c for c in me_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
         # A DW breakdown is a direct warehouse column (the metric_events CTE reads FROM the warehouse
         # table), so it must read bare `plan`, NOT be wrapped in an event `properties` chain.
+        coalesce_call = bd.expr
+        assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
+        to_string = coalesce_call.args[0]
+        assert isinstance(to_string, ast.Call) and to_string.name == "toString"
+        field = to_string.args[0]
+        assert isinstance(field, ast.Field)
+        assert field.chain == ["plan"]
+
+
+class TestMetricBreakdownInjectorRatio:
+    def test_breakdown_read_from_numerator_event(self):
+        metric = _ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        assert query.ctes is not None
+        ne_cte = query.ctes["numerator_events"]
+        assert isinstance(ne_cte, ast.CTE) and isinstance(ne_cte.expr, ast.SelectQuery)
+        ne_aliases = [c.alias for c in ne_cte.expr.select if isinstance(c, ast.Alias)]
+        assert "breakdown_value_1" in ne_aliases
+
+    def test_numerator_agg_first_touch_argmin(self):
+        metric = _ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        assert query.ctes is not None
+        na_cte = query.ctes["numerator_agg"]
+        assert isinstance(na_cte, ast.CTE) and isinstance(na_cte.expr, ast.SelectQuery)
+        bd = next(c for c in na_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # numerator_agg groups by entity, so first-touch via argMin over the numerator event timestamp.
+        assert isinstance(bd.expr, ast.Call)
+        assert bd.expr.name == "argMin"
+        assert bd.expr.args[1] == ast.Field(chain=["numerator_events", "timestamp"])
+
+    def test_entity_metrics_carries_breakdown_from_numerator_agg(self):
+        metric = _ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        expr = _entity_metrics_aliases(query)["breakdown_value_1"]
+        assert isinstance(expr, ast.Call)
+        # any(numerator_agg.breakdown_value_1) — carried through the entity_metrics aggregation.
+        assert expr.name == "any"
+        assert expr.args[0] == ast.Field(chain=["numerator_agg", "breakdown_value_1"])
+
+    def test_final_select_applies_top_n_other_limit(self):
+        metric = _ratio_metric(breakdown_limit=3)
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        final_alias = next(c for c in query.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        assert isinstance(final_alias.expr, ast.Call)
+        assert final_alias.expr.name == "if"
+        other = final_alias.expr.args[2]
+        assert isinstance(other, ast.Constant)
+        assert other.value == "$$_posthog_breakdown_other_$$"
+
+    def test_data_warehouse_breakdown_reads_warehouse_column(self):
+        metric = _dw_ratio_metric()
+        injector = MetricBreakdownInjector(metric.breakdownFilter.breakdowns, metric)
+        query = _ratio_query()
+
+        injector.inject_ratio_breakdown_columns(query)
+
+        assert query.ctes is not None
+        ne_cte = query.ctes["numerator_events"]
+        assert isinstance(ne_cte, ast.CTE) and isinstance(ne_cte.expr, ast.SelectQuery)
+        bd = next(c for c in ne_cte.expr.select if isinstance(c, ast.Alias) and c.alias == "breakdown_value_1")
+        # A DW breakdown is a direct warehouse column (numerator_events reads FROM the warehouse
+        # table), so it must read bare `plan`, NOT be wrapped in a properties chain.
         coalesce_call = bd.expr
         assert isinstance(coalesce_call, ast.Call) and coalesce_call.name == "coalesce"
         to_string = coalesce_call.args[0]


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Ratio metrics are the last type still attributing breakdowns from the exposure event; funnels, mean, and retention migrated in #61796, #62291, #62292.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR migrates ratio metrics to `MetricBreakdownInjector`, completing the per-type migration behind the `experiment-metric-event-breakdowns` flag.

### Ratio support in the injector

Ratio is `Σnumerator / Σdenominator` over two event streams, pre-aggregated per entity before joining exposures. To keep one experiment unit in exactly one bucket (so per-breakdown rows sum to the overall result), the whole user is attributed by their numerator event: read off `numerator_events`, first touch via `argMin` in `numerator_agg`, carried through `entity_metrics` with `any()`. Winsorized ratio queries reuse the mean winsorization carry-through helper.

- `products/experiments/backend/hogql_queries/metric_breakdown_injector.py`
- `products/experiments/backend/hogql_queries/experiment_query_runner.py`
- `products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py`

### Migration complete

All four metric types now use the metric-event injector when the flag is on. Deleting the old `BreakdownInjector` is a follow-up once the flag rolls out.

### Tests

Flag-on ratio cases in `test_metric_breakdown.py` (numerator attribution, winsorization, limit, Other bucket) plus injector unit tests.

- `products/experiments/backend/hogql_queries/test/experiment_query_runner/test_metric_breakdown.py`
- `products/experiments/backend/hogql_queries/test/test_metric_breakdown_injector.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/13bd026d-4774-424e-a409-9b53b7afd767)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session. -->

Model: Opus 4.7 (implementation), Fable 5 (restack and PR description)
Manually refactored: **yes**

Skills used:

- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Numerator-event attribution keeps each experiment unit in a single breakdown bucket, which is what makes per-breakdown results sum to the overall ratio.
- The denominator is never a breakdown source; a user can have denominator events in several buckets, which would double-count units.