### PR TITLE
feat(experiments): add experiment actors query to the exposure event on funnel metrics.

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/FunnelBarVertical.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelBarVertical.tsx
@@ -14,7 +14,7 @@ import { StepBars } from './StepBars'
 import { StepLegend } from './StepLegend'
 
 interface TooltipContext {
-    showTooltip: (rect: [number, number, number], stepIndex: number, series: any, hasSessionData?: boolean) => void
+    showTooltip: (rect: [number, number, number], stepIndex: number, series: any) => void
     hideTooltip: () => void
 }
 

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelTooltip.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelTooltip.tsx
@@ -25,15 +25,9 @@ interface FunnelTooltipProps {
     stepIndex: number
     series: FunnelStepWithConversionMetrics
     embedded?: boolean
-    hasSessionData?: boolean
 }
 
-function FunnelTooltipContent({
-    stepIndex,
-    series,
-    embedded = false,
-    hasSessionData = false,
-}: FunnelTooltipProps): JSX.Element {
+function FunnelTooltipContent({ stepIndex, series, embedded = false }: FunnelTooltipProps): JSX.Element {
     return (
         <div
             className={clsx('FunnelTooltip InsightTooltip', {
@@ -93,24 +87,16 @@ function FunnelTooltipContent({
                     )}
                 </tbody>
             </table>
-            {hasSessionData && (
-                <>
-                    <LemonDivider className="my-2" />
-                    <ClickToInspectActors groupTypeLabel="persons" />
-                </>
-            )}
+
+            <LemonDivider className="my-2" />
+            <ClickToInspectActors groupTypeLabel="persons" />
         </div>
     )
 }
 
 export function useFunnelTooltip(): {
     vizRef: React.RefObject<HTMLDivElement>
-    showTooltip: (
-        rect: [number, number, number],
-        stepIndex: number,
-        series: FunnelStepWithConversionMetrics,
-        hasSessionData?: boolean
-    ) => void
+    showTooltip: (rect: [number, number, number], stepIndex: number, series: FunnelStepWithConversionMetrics) => void
     hideTooltip: () => void
 } {
     const vizRef = useRef<HTMLDivElement>(null)
@@ -119,18 +105,15 @@ export function useFunnelTooltip(): {
     const [isTooltipShown, setIsTooltipShown] = useState(false)
     const [currentTooltip, setCurrentTooltip] = useState<FunnelTooltipData | null>(null)
     const [tooltipOrigin, setTooltipOrigin] = useState<[number, number, number] | null>(null)
-    const [hasSessionData, setHasSessionData] = useState(false)
 
     const showTooltip = (
         rect: [number, number, number],
         stepIndex: number,
-        series: FunnelStepWithConversionMetrics,
-        hasSessionData: boolean = false
+        series: FunnelStepWithConversionMetrics
     ): void => {
         setIsTooltipShown(true)
         setCurrentTooltip({ stepIndex, series })
         setTooltipOrigin(rect)
-        setHasSessionData(hasSessionData)
     }
 
     const hideTooltip = (): void => {
@@ -147,11 +130,7 @@ export function useFunnelTooltip(): {
 
         if (tooltipOrigin && currentTooltip) {
             tooltipRoot.render(
-                <FunnelTooltipContent
-                    stepIndex={currentTooltip.stepIndex}
-                    series={currentTooltip.series}
-                    hasSessionData={hasSessionData}
-                />
+                <FunnelTooltipContent stepIndex={currentTooltip.stepIndex} series={currentTooltip.series} />
             )
 
             // Put the tooltip to the bottom right of the cursor, but flip to left if tooltip doesn't fit

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -67,15 +67,16 @@ function openExperimentPersonsModalForSeries({
         order_type: experimentQuery.metric.funnel_order_type,
     })
 
-    // IMPORTANT: For experiment funnels, the frontend adds an "Experiment exposure" step at index 0
-    // But the backend actors query funnel doesn't include this - it only has the actual metric events
+    // IMPORTANT: For experiment funnels, the frontend adds an "Experiment exposure" step at index 0.
+    // The backend actors query treats exposure as step 0 (returning all exposed actors) and the
+    // actual metric events as steps 1..N, so frontend step indices map directly to backend steps.
     // Frontend: Step 0=Exposure, Step 1=$pageview, Step 2=click
-    // Backend:                  Step 1=$pageview, Step 2=click
-    // So we map frontend step indices to backend step numbers directly (stepIndex = backendStepNo)
+    // Backend:  Step 0=Exposure, Step 1=$pageview, Step 2=click
     const backendStepNo = stepIndex
 
-    // Skip if trying to query the "Experiment exposure" step (stepIndex 0, doesn't exist in backend)
-    if (backendStepNo < 1) {
+    // The exposure step (step 0) only supports conversions ("all exposed actors").
+    // A drop-off "before exposure" is not a meaningful query.
+    if (backendStepNo === 0 && !converted) {
         return
     }
 
@@ -210,11 +211,11 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
                     if (ref.current) {
                         const rect = ref.current.getBoundingClientRect()
                         // Only show "Click to inspect actors" hint when clicking will actually work:
-                        // - Step 0 (exposure) with new feature enabled: can't use actors query (returns early), so don't show hint
+                        // - Step 0 (exposure) with new feature enabled: conversion click returns all exposed actors
                         // - Step 1 (first metric) drop-offs with new feature: can't query (no exposure in backend funnel), conversions work
                         // - Step 2+ with new feature: both conversions and drop-offs work
                         // - Legacy mode: show hint if sessionData exists
-                        const hasClickableData = hasActorsQueryFeature ? stepIndex > 0 : !!sessionData
+                        const hasClickableData = hasActorsQueryFeature ? stepIndex >= 0 : !!sessionData
                         showTooltip([rect.x, rect.y, rect.width], stepIndex, step, hasClickableData)
                     }
                 }}
@@ -238,7 +239,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
                     onClick={handleConversionClick}
                     style={{
                         cursor: hasActorsQueryFeature
-                            ? stepIndex > 0
+                            ? stepIndex >= 0
                                 ? 'pointer'
                                 : 'default'
                             : sessionData

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -174,12 +174,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
                 onMouseEnter={() => {
                     if (ref.current) {
                         const rect = ref.current.getBoundingClientRect()
-                        // Only show "Click to inspect actors" hint when clicking will actually work:
-                        // - Step 0 (exposure): can't use actors query (returns early), so don't show hint
-                        // - Step 1 (first metric) drop-offs: can't query (no exposure in backend funnel), conversions work
-                        // - Step 2+: both conversions and drop-offs work
-                        const hasClickableData = stepIndex > 0
-                        showTooltip([rect.x, rect.y, rect.width], stepIndex, step, hasClickableData)
+                        showTooltip([rect.x, rect.y, rect.width], stepIndex, step)
                     }
                 }}
                 onMouseLeave={() => hideTooltip()}
@@ -195,7 +190,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
                     className="StepBar__fill"
                     onClick={handleConversionClick}
                     style={{
-                        cursor: stepIndex > 0 ? 'pointer' : 'default',
+                        cursor: 'pointer',
                     }}
                 />
             </div>

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -64,15 +64,16 @@ function openExperimentPersonsModalForSeries({
         order_type: experimentQuery.metric.funnel_order_type,
     })
 
-    // IMPORTANT: For experiment funnels, the frontend adds an "Experiment exposure" step at index 0
-    // But the backend actors query funnel doesn't include this - it only has the actual metric events
+    // IMPORTANT: For experiment funnels, the frontend adds an "Experiment exposure" step at index 0.
+    // The backend actors query treats exposure as step 0 (returning all exposed actors) and the
+    // actual metric events as steps 1..N, so frontend step indices map directly to backend steps.
     // Frontend: Step 0=Exposure, Step 1=$pageview, Step 2=click
-    // Backend:                  Step 1=$pageview, Step 2=click
-    // So we map frontend step indices to backend step numbers directly (stepIndex = backendStepNo)
+    // Backend:  Step 0=Exposure, Step 1=$pageview, Step 2=click
     const backendStepNo = stepIndex
 
-    // Skip if trying to query the "Experiment exposure" step (stepIndex 0, doesn't exist in backend)
-    if (backendStepNo < 1) {
+    // The exposure step (step 0) only supports conversions ("all exposed actors").
+    // A drop-off "before exposure" is not a meaningful query.
+    if (backendStepNo === 0 && !converted) {
         return
     }
 

--- a/products/experiments/backend/hogql_queries/experiment_funnel_actors_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_funnel_actors_query_builder.py
@@ -88,6 +88,46 @@ class ExperimentFunnelActorsQueryBuilder:
 
         return query
 
+    def build_exposure_actors_query(self) -> ast.SelectQuery:
+        """
+        Build actors query for the exposure step (funnel step 0).
+
+        Unlike the metric-step actors query, this needs no funnel evaluation: the
+        exposure bar counts everyone who was exposed to a variant, so we select
+        straight from the exposures CTE. Recordings, when requested, point at the
+        first exposure event.
+        """
+        exposure_select_query = self._query_builder._exposure_query_builder().select_query()
+
+        query = cast(
+            ast.SelectQuery,
+            parse_select(
+                "WITH exposures AS ({exposure_query}) SELECT * FROM exposures",
+                placeholders={"exposure_query": exposure_select_query},
+            ),
+        )
+
+        select_exprs: list[ast.Expr] = [
+            ast.Alias(alias="actor_id", expr=ast.Field(chain=["entity_id"])),
+            ast.Alias(alias="variant", expr=ast.Field(chain=["variant"])),
+        ]
+
+        if self.include_recordings:
+            # Mirror the (timestamp, uuid, $session_id, $window_id) tuple shape the
+            # actors runner expects, sourced from the first exposure event.
+            select_exprs.append(
+                ast.Alias(
+                    alias="matching_events",
+                    expr=parse_expr("array(tuple(first_exposure_time, exposure_event_uuid, exposure_session_id, ''))"),
+                )
+            )
+
+        query.select = select_exprs
+        query.where = self._build_variant_filter()
+        query.order_by = [ast.OrderExpr(expr=ast.Field(chain=["actor_id"]))]
+
+        return query
+
     def _build_base_query_with_ctes(self) -> ast.SelectQuery:
         """
         Build query with exposures, metric_events, and entity_metrics CTEs.
@@ -369,18 +409,24 @@ class ExperimentFunnelActorsQueryBuilder:
             )
 
         # Filter by variant (skip if empty string or None)
-        if self.funnel_step_breakdown:
-            if isinstance(self.funnel_step_breakdown, int | float):
-                variant_value = str(int(self.funnel_step_breakdown))
-            else:
-                variant_value = self.funnel_step_breakdown
-
-            conditions.append(
-                parse_expr(
-                    "variant = {variant}",
-                    {"variant": ast.Constant(value=variant_value)},
-                )
-            )
+        variant_filter = self._build_variant_filter()
+        if variant_filter is not None:
+            conditions.append(variant_filter)
 
         query.where = ast.And(exprs=conditions) if conditions else None
         return query
+
+    def _build_variant_filter(self) -> ast.Expr | None:
+        """Build a `variant = ...` filter, or None when no variant is requested."""
+        if not self.funnel_step_breakdown:
+            return None
+
+        if isinstance(self.funnel_step_breakdown, int | float):
+            variant_value = str(int(self.funnel_step_breakdown))
+        else:
+            variant_value = self.funnel_step_breakdown
+
+        return parse_expr(
+            "variant = {variant}",
+            {"variant": ast.Constant(value=variant_value)},
+        )

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -671,12 +671,6 @@ class ExperimentQueryRunner(QueryRunner):
                 f"Valid drop-off steps: -2 (dropped after first metric step) to -{num_metric_steps + 1}."
             )
 
-        if funnel_step == 0:
-            raise ValidationError(
-                "Funnel steps are 1-indexed. Step 0 does not exist. "
-                f"Valid conversion steps: 1 (first metric step) to {num_metric_steps}."
-            )
-
         if funnel_step < -1:
             max_drop_off = -(num_metric_steps + 1)
             if funnel_step < max_drop_off:
@@ -771,6 +765,11 @@ class ExperimentQueryRunner(QueryRunner):
             funnel_step_breakdown=funnel_step_breakdown,
             include_recordings=self.actors_query.includeRecordings or False,
         )
+
+        # Step 0 is the exposure step: return everyone exposed to the variant,
+        # without funnel evaluation.
+        if funnel_step == 0:
+            return builder.build_exposure_actors_query()
 
         return builder.build_actors_query()
 

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -889,12 +889,6 @@ class ExperimentQueryRunner(QueryRunner):
                 f"Valid drop-off steps: -2 (dropped after first metric step) to -{num_metric_steps + 1}."
             )
 
-        if funnel_step == 0:
-            raise ValidationError(
-                "Funnel steps are 1-indexed. Step 0 does not exist. "
-                f"Valid conversion steps: 1 (first metric step) to {num_metric_steps}."
-            )
-
         if funnel_step < -1:
             max_drop_off = -(num_metric_steps + 1)
             if funnel_step < max_drop_off:
@@ -987,6 +981,11 @@ class ExperimentQueryRunner(QueryRunner):
             funnel_step_breakdown=funnel_step_breakdown,
             include_recordings=self.actors_query.includeRecordings or False,
         )
+
+        # Step 0 is the exposure step: return everyone exposed to the variant,
+        # without funnel evaluation.
+        if funnel_step == 0:
+            return builder.build_exposure_actors_query()
 
         return builder.build_actors_query()
 

--- a/products/experiments/backend/hogql_queries/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/products/experiments/backend/hogql_queries/test/__snapshots__/test_experiment_actors_query.ambr
@@ -1,5 +1,166 @@
 # serializer version: 1
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_0_conversions_step1_control
+# name: TestExperimentActorsQuery.test_experiment_exposure_actors_with_recordings
+  '''
+  SELECT source.id,
+         source.id AS id,
+         source.matching_events AS matching_events
+  FROM
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id) SELECT exposures.entity_id AS actor_id,
+                                   exposures.variant AS variant,
+                                   array(tuple(exposures.first_exposure_time, exposures.exposure_event_uuid, exposures.exposure_session_id, '')) AS matching_events,
+                                   actor_id AS id
+     FROM exposures
+     WHERE ifNull(equals(variant, 'control'), 0)
+     ORDER BY actor_id ASC) AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_exposure_actors_with_recordings.1
+  '''
+  SELECT session_replay_events.session_id AS session_id,
+         min(toTimeZone(session_replay_events.min_first_timestamp, 'UTC')) AS start_time,
+         max(session_replay_events.retention_period_days) AS retention_period_days,
+         plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 99999), in(session_replay_events.session_id, ['']))
+  GROUP BY session_replay_events.session_id
+  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(session_replay_events.is_deleted), 0), 0))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_0_exposure_control
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id) SELECT exposures.entity_id AS actor_id,
+                                   exposures.variant AS variant,
+                                   actor_id AS id
+     FROM exposures
+     WHERE ifNull(equals(variant, 'control'), 0)
+     ORDER BY actor_id ASC) AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_1_exposure_test
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id) SELECT exposures.entity_id AS actor_id,
+                                   exposures.variant AS variant,
+                                   actor_id AS id
+     FROM exposures
+     WHERE ifNull(equals(variant, 'test'), 0)
+     ORDER BY actor_id ASC) AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_2_conversions_step1_control
   '''
   SELECT source.id,
          source.id AS id
@@ -71,7 +232,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_1_conversions_step2_control
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_3_conversions_step2_control
   '''
   SELECT source.id,
          source.id AS id
@@ -143,7 +304,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_2_dropoffs_control
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_4_dropoffs_control
   '''
   SELECT source.id,
          source.id AS id
@@ -215,7 +376,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_3_conversions_step1_test
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_5_conversions_step1_test
   '''
   SELECT source.id,
          source.id AS id
@@ -287,7 +448,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_4_conversions_step2_test
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_6_conversions_step2_test
   '''
   SELECT source.id,
          source.id AS id
@@ -359,7 +520,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_5_dropoffs_test
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_7_dropoffs_test
   '''
   SELECT source.id,
          source.id AS id

--- a/products/experiments/backend/hogql_queries/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/products/experiments/backend/hogql_queries/test/__snapshots__/test_experiment_actors_query.ambr
@@ -7,23 +7,23 @@
   FROM
     (WITH exposures AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
-               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
                min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
                max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
                argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
                argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
         FROM events
         LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                   person_distinct_id_overrides.distinct_id AS distinct_id
            FROM person_distinct_id_overrides
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id) SELECT exposures.entity_id AS actor_id,
                                    exposures.variant AS variant,
-                                   array(tuple(exposures.first_exposure_time, exposures.exposure_event_uuid, exposures.exposure_session_id, '')) AS matching_events,
+                                   array(tuple(toTimeZone(exposures.first_exposure_time, 'UTC'), exposures.exposure_event_uuid, exposures.exposure_session_id, '')) AS matching_events,
                                    actor_id AS id
      FROM exposures
      WHERE ifNull(equals(variant, 'control'), 0)
@@ -55,7 +55,7 @@
   FROM session_replay_events
   WHERE and(equals(session_replay_events.team_id, 99999), in(session_replay_events.session_id, ['']))
   GROUP BY session_replay_events.session_id
-  HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(session_replay_events.is_deleted), 0), 0))
+  HAVING and(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), equals(max(session_replay_events.is_deleted), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -77,19 +77,19 @@
   FROM
     (WITH exposures AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
-               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
                min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
                max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
                argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
                argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
         FROM events
         LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                   person_distinct_id_overrides.distinct_id AS distinct_id
            FROM person_distinct_id_overrides
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id) SELECT exposures.entity_id AS actor_id,
                                    exposures.variant AS variant,
@@ -122,19 +122,19 @@
   FROM
     (WITH exposures AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
-               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               if(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
                min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
                max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
                argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
                argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
         FROM events
         LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                   person_distinct_id_overrides.distinct_id AS distinct_id
            FROM person_distinct_id_overrides
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id) SELECT exposures.entity_id AS actor_id,
                                    exposures.variant AS variant,

--- a/products/experiments/backend/hogql_queries/test/test_experiment_actors_query.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_actors_query.py
@@ -136,6 +136,8 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
 
     @parameterized.expand(
         [
+            ("exposure_control", 0, "control", 10),  # Step 0 = all exposed actors (control)
+            ("exposure_test", 0, "test", 10),  # Step 0 = all exposed actors (test)
             ("conversions_step1_control", 1, "control", 6),  # Step 1 conversions (signup)
             ("conversions_step2_control", 2, "control", 4),  # Step 2 conversions (purchase)
             ("dropoffs_control", -2, "control", 2),  # Step 2 drop-offs (signup but no purchase)
@@ -265,6 +267,38 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         assert isinstance(response.results[0][2], list)
 
     @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_experiment_exposure_actors_with_recordings(self):
+        """
+        Step 0 (exposure) actors query should still expose matched_recordings,
+        sourced from the first exposure event rather than a metric step.
+        """
+        feature_flag, _experiment, experiment_query = self._create_experiment_with_funnel()
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        self._create_funnel_data_both_variants(feature_flag_property)
+        flush_persons_and_events()
+
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=0,
+            funnelStepBreakdown="control",
+            includeRecordings=True,
+        )
+
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["id", "person", "matched_recordings"],
+        )
+
+        response = ActorsQueryRunner(query=actors_query, team=self.team).calculate()
+
+        assert len(response.results) == 10
+        assert len(response.results[0]) == 3
+        assert isinstance(response.results[0][2], list)
+
+    @freeze_time("2020-01-01T12:00:00Z")
     def test_experiment_funnel_actors_invalid_steps(self):
         """
         Test that invalid funnelStep values are properly rejected with helpful error messages.
@@ -276,9 +310,8 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         4. Use clear, actionable language
 
         Experiment funnels have unique constraints:
-        - Exposure is step 0 in main query but excluded from actors query
+        - Exposure is step 0 in main query and queryable via the actors query (returns all exposed actors)
         - funnelStep=-1 is invalid (would mean "exposed but never entered funnel")
-        - funnelStep=0 is invalid (steps are 1-indexed)
         - Out-of-range steps should be rejected
         """
         feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
@@ -310,30 +343,6 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         self.assertIn("exposed but never entered the funnel", error_message)  # Explains WHY invalid
         self.assertIn("Valid drop-off steps: -2", error_message)  # Shows valid range
         self.assertIn("-3", error_message)  # Shows upper bound of valid range
-
-        # Test 0: Invalid step (steps are 1-indexed)
-        # Error message should explain that step 0 doesn't exist and show valid range
-        experiment_actors_query_zero = ExperimentActorsQuery(
-            kind="ExperimentActorsQuery",
-            source=experiment_query,
-            funnelStep=0,
-            funnelStepBreakdown="control",
-            includeRecordings=False,
-        )
-
-        actors_query_zero = ActorsQuery(
-            source=experiment_actors_query_zero,
-            select=["id", "person"],
-        )
-
-        with self.assertRaises(Exception) as context:
-            ActorsQueryRunner(query=actors_query_zero, team=self.team).calculate()
-
-        error_message = str(context.exception)
-        self.assertIn("Funnel steps are 1-indexed", error_message)
-        self.assertIn("Step 0 does not exist", error_message)
-        self.assertIn("Valid conversion steps: 1", error_message)  # Shows start of valid range
-        self.assertIn("2", error_message)  # Shows end of valid range (2 metric steps)
 
         # Test out-of-range drop-off (2-step funnel, so -3 is last valid, -4 is invalid)
         # Error message should show the invalid step, number of metric steps, and valid range

--- a/products/experiments/backend/hogql_queries/test/test_experiment_actors_query.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_actors_query.py
@@ -147,6 +147,8 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
 
     @parameterized.expand(
         [
+            ("exposure_control", 0, "control", 10),  # Step 0 = all exposed actors (control)
+            ("exposure_test", 0, "test", 10),  # Step 0 = all exposed actors (test)
             ("conversions_step1_control", 1, "control", 6),  # Step 1 conversions (signup)
             ("conversions_step2_control", 2, "control", 4),  # Step 2 conversions (purchase)
             ("dropoffs_control", -2, "control", 2),  # Step 2 drop-offs (signup but no purchase)
@@ -316,6 +318,38 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         assert isinstance(response.results[0][2], list)
 
     @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_experiment_exposure_actors_with_recordings(self):
+        """
+        Step 0 (exposure) actors query should still expose matched_recordings,
+        sourced from the first exposure event rather than a metric step.
+        """
+        feature_flag, _experiment, experiment_query = self._create_experiment_with_funnel()
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        self._create_funnel_data_both_variants(feature_flag_property)
+        flush_persons_and_events()
+
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=0,
+            funnelStepBreakdown="control",
+            includeRecordings=True,
+        )
+
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["id", "person", "matched_recordings"],
+        )
+
+        response = ActorsQueryRunner(query=actors_query, team=self.team).calculate()
+
+        assert len(response.results) == 10
+        assert len(response.results[0]) == 3
+        assert isinstance(response.results[0][2], list)
+
+    @freeze_time("2020-01-01T12:00:00Z")
     def test_experiment_funnel_actors_invalid_steps(self):
         """
         Test that invalid funnelStep values are properly rejected with helpful error messages.
@@ -327,9 +361,8 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         4. Use clear, actionable language
 
         Experiment funnels have unique constraints:
-        - Exposure is step 0 in main query but excluded from actors query
+        - Exposure is step 0 in main query and queryable via the actors query (returns all exposed actors)
         - funnelStep=-1 is invalid (would mean "exposed but never entered funnel")
-        - funnelStep=0 is invalid (steps are 1-indexed)
         - Out-of-range steps should be rejected
         """
         feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
@@ -361,30 +394,6 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         self.assertIn("exposed but never entered the funnel", error_message)  # Explains WHY invalid
         self.assertIn("Valid drop-off steps: -2", error_message)  # Shows valid range
         self.assertIn("-3", error_message)  # Shows upper bound of valid range
-
-        # Test 0: Invalid step (steps are 1-indexed)
-        # Error message should explain that step 0 doesn't exist and show valid range
-        experiment_actors_query_zero = ExperimentActorsQuery(
-            kind="ExperimentActorsQuery",
-            source=experiment_query,
-            funnelStep=0,
-            funnelStepBreakdown="control",
-            includeRecordings=False,
-        )
-
-        actors_query_zero = ActorsQuery(
-            source=experiment_actors_query_zero,
-            select=["id", "person"],
-        )
-
-        with self.assertRaises(Exception) as context:
-            ActorsQueryRunner(query=actors_query_zero, team=self.team).calculate()
-
-        error_message = str(context.exception)
-        self.assertIn("Funnel steps are 1-indexed", error_message)
-        self.assertIn("Step 0 does not exist", error_message)
-        self.assertIn("Valid conversion steps: 1", error_message)  # Shows start of valid range
-        self.assertIn("2", error_message)  # Shows end of valid range (2 metric steps)
 
         # Test out-of-range drop-off (2-step funnel, so -3 is last valid, -4 is invalid)
         # Error message should show the invalid step, number of metric steps, and valid range


### PR DESCRIPTION
## Problem

Clicking the "Experiment exposure" bar (step 0) in an experiment funnel chart did nothing: the backend rejected any actors query for step 0 with a "Funnel steps are 1-indexed" error, so users could not inspect who was actually exposed to a variant.

## Changes

This PR makes the exposure step queryable, so clicking it returns every actor exposed to a variant, with session recordings.

### Exposure actors query

Step 0 needs no funnel evaluation: the exposure bar counts everyone exposed to a variant, so a new `build_exposure_actors_query` selects straight from the existing `exposures` CTE and filters by variant. When recordings are requested, it emits the `matching_events` tuple sourced from the first exposure event (`first_exposure_time`, `exposure_event_uuid`, `exposure_session_id`) rather than a metric step. The variant filter was extracted into a shared `_build_variant_filter` so both the metric-step and exposure-step paths use identical logic.

- `products/experiments/backend/hogql_queries/experiment_funnel_actors_query_builder.py`
- `products/experiments/backend/hogql_queries/experiment_query_runner.py`

### Runner routing

The `to_actors_query` method drops the `funnel_step == 0` validation error and instead routes step 0 to `build_exposure_actors_query`. Drop-off validation for step 0 is unchanged, since "dropped off before exposure" is not meaningful.

- `products/experiments/backend/hogql_queries/experiment_query_runner.py`

### Funnel chart interaction

The exposure bar is now clickable. The old guard blocking all of step 0 becomes a narrower guard that blocks only step-0 drop-offs, so a conversion click returns all exposed actors. Frontend step indices now map directly onto backend steps, since both treat exposure as step 0.

- `frontend/src/scenes/experiments/charts/funnel/StepBar.tsx`

### Tests

Added parameterized cases for step-0 exposure actors on both variants and a recordings case asserting `matched_recordings` come from the first exposure event. Removed the test asserting step 0 raised an error, since that behavior is intentionally gone.

- `products/experiments/backend/hogql_queries/test/test_experiment_actors_query.py`
- `products/experiments/backend/hogql_queries/test/__snapshots__/test_experiment_actors_query.ambr`

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/ff5038cc-6b78-47fb-a13b-a359eb0f5f50)

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **no**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Step 0 skips funnel evaluation entirely and reads from the `exposures` CTE, since the exposure count is just "everyone exposed to the variant" and running it through the funnel machinery would be wasted work.
- Recordings for the exposure step point at the first exposure event, not a metric step, keeping the `matching_events` tuple shape the actors runner already expects.
- Snapshots were regenerated during rebase: master's HogQL codegen simplified the shared exposures CTE (`argMax` instead of `tupleElement(argMax(tuple(...)))`), so the committed `.ambr` reflects current codegen, not a behavior change.