### PR TITLE
feat(data-warehouse): support custom Salesforce objects as sources

### DIFF
--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -68,6 +68,7 @@ LLM_ANALYTICS_INTERNAL_TEAM_ID: int = 2
 DUCKGRES_API_URL: str | None = get_from_env("DUCKGRES_API_URL", optional=True)
 DUCKGRES_INTERNAL_SECRET: str | None = get_from_env("DUCKGRES_INTERNAL_SECRET", optional=True)
 DUCKGRES_PG_PORT: int = get_from_env("DUCKGRES_PG_PORT", 5432, type_cast=int)
+DUCKGRES_PG_URL: str | None = get_from_env("DUCKGRES_PG_URL", optional=True)
 
 # Bulk deletion operations can be disabled during database migrations
 DISABLE_BULK_DELETES: bool = get_from_env("DISABLE_BULK_DELETES", False, type_cast=str_to_bool)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
@@ -5,12 +5,14 @@ from typing import Any, Optional
 
 from requests import Request, Response
 
-from posthog.temporal.data_imports.sources.common.http import make_tracked_session
-from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resource
-from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
-from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
-from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from posthog.temporal.data_imports.sources.salesforce.auth import SalesforceAuth
+from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth import SalesforceAuth
+from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.settings import ENDPOINTS
 
 
 @dataclasses.dataclass
@@ -411,6 +413,36 @@ def get_resource(name: str, should_use_incremental_field: bool) -> EndpointResou
     return resources[name]
 
 
+def get_custom_object_resource(name: str, should_use_incremental_field: bool) -> EndpointResource:
+    return {
+        "name": name,
+        "table_name": NamingConvention.normalize_identifier(name),
+        "write_disposition": {
+            "disposition": "merge",
+            "strategy": "upsert",
+        }
+        if should_use_incremental_field
+        else "replace",
+        "endpoint": {
+            "data_selector": "records",
+            "path": "/services/data/v61.0/query",
+            "params": {
+                "q": {
+                    "type": "incremental",
+                    "cursor_path": "SystemModstamp",
+                    "initial_value": "2000-01-01T00:00:00.000+0000",
+                    "convert": lambda date_str: (
+                        f"SELECT FIELDS(ALL) FROM {name} WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200"
+                    ),
+                }
+                if should_use_incremental_field
+                else f"SELECT FIELDS(ALL) FROM {name} ORDER BY Id ASC LIMIT 200",
+            },
+        },
+        "table_format": "delta",
+    }
+
+
 _DATE_FILTER_RE = re.compile(r"SystemModstamp >= (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.+?)\s")
 
 
@@ -530,6 +562,29 @@ def salesforce_source(
     resumable_source_manager: ResumableSourceManager[SalesforceResumeConfig],
     should_use_incremental_field: bool = False,
 ):
+    auth = SalesforceAuth(
+        refresh_token=refresh_token,
+        access_token=access_token,
+        instance_url=instance_url,
+    )
+
+    definitions = list_custom_object_definitions(
+        instance_url=instance_url,
+        access_token=auth.token,
+        endpoint="/services/data/v61.0/sobjects",
+    )
+
+    if endpoint not in ENDPOINTS:
+        match = next((d for d in definitions if d.get("name") == endpoint), None)
+        if match is None:
+            raise ValueError(
+                f"Salesforce custom object '{endpoint}' could not be resolved. "
+                "It may have been deleted or renamed in Salesforce; refresh source schemas to pick up the new name."
+            )
+        resource = get_custom_object_resource(endpoint, should_use_incremental_field)
+    else:
+        resource = get_resource(endpoint, should_use_incremental_field)
+
     config: RESTAPIConfig = {
         "client": {
             "base_url": instance_url,
@@ -537,7 +592,7 @@ def salesforce_source(
             "paginator": SalesforceEndpointPaginator(should_use_incremental_field=should_use_incremental_field),
         },
         "resource_defaults": {},
-        "resources": [get_resource(endpoint, should_use_incremental_field)],
+        "resources": [resource],
     }
 
     initial_paginator_state: Optional[dict[str, Any]] = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
@@ -563,15 +563,9 @@ def salesforce_source(
     should_use_incremental_field: bool = False,
 ):
     if endpoint not in ENDPOINTS:
-        auth = SalesforceAuth(
-            refresh_token=refresh_token,
-            access_token=access_token,
-            instance_url=instance_url,
-        )
-
         definitions = list_custom_object_definitions(
             instance_url=instance_url,
-            access_token=auth.token,
+            access_token=access_token,
             endpoint="/services/data/v61.0/sobjects",
         )
         match = next((d for d in definitions if d.get("name") == endpoint), None)
@@ -624,7 +618,7 @@ def list_custom_object_definitions(
     request = Request(
         "get",
         url=f"{instance_url}{endpoint}",
-        params={"limit": 100},
+        params={},
         headers={"Authorization": bearer_token},
     )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
@@ -564,11 +564,6 @@ def list_custom_object_definitions(
     instance_url: str,
     access_token: str,
     endpoint: str,
-    # team_id: int,
-    # job_id: str,
-    # db_incremental_field_last_value: Optional[Any],
-    # resumable_source_manager: ResumableSourceManager[SalesforceResumeConfig],
-    # should_use_incremental_field: bool = False,
 ) -> list[dict[str, Any]]:
     bearer_token = f"Bearer {access_token}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
@@ -562,19 +562,18 @@ def salesforce_source(
     resumable_source_manager: ResumableSourceManager[SalesforceResumeConfig],
     should_use_incremental_field: bool = False,
 ):
-    auth = SalesforceAuth(
-        refresh_token=refresh_token,
-        access_token=access_token,
-        instance_url=instance_url,
-    )
-
-    definitions = list_custom_object_definitions(
-        instance_url=instance_url,
-        access_token=auth.token,
-        endpoint="/services/data/v61.0/sobjects",
-    )
-
     if endpoint not in ENDPOINTS:
+        auth = SalesforceAuth(
+            refresh_token=refresh_token,
+            access_token=access_token,
+            instance_url=instance_url,
+        )
+
+        definitions = list_custom_object_definitions(
+            instance_url=instance_url,
+            access_token=auth.token,
+            endpoint="/services/data/v61.0/sobjects",
+        )
         match = next((d for d in definitions if d.get("name") == endpoint), None)
         if match is None:
             raise ValueError(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/salesforce.py
@@ -5,14 +5,12 @@ from typing import Any, Optional
 
 from requests import Request, Response
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
-    RESTAPIConfig,
-    rest_api_resource,
-)
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth import SalesforceAuth
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resource
+from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.salesforce.auth import SalesforceAuth
 
 
 @dataclasses.dataclass
@@ -560,3 +558,29 @@ def salesforce_source(
         resume_hook=save_checkpoint,
         initial_paginator_state=initial_paginator_state,
     )
+
+
+def list_custom_object_definitions(
+    instance_url: str,
+    access_token: str,
+    endpoint: str,
+    # team_id: int,
+    # job_id: str,
+    # db_incremental_field_last_value: Optional[Any],
+    # resumable_source_manager: ResumableSourceManager[SalesforceResumeConfig],
+    # should_use_incremental_field: bool = False,
+) -> list[dict[str, Any]]:
+    bearer_token = f"Bearer {access_token}"
+
+    request = Request(
+        "get",
+        url=f"{instance_url}{endpoint}",
+        params={"limit": 100},
+        headers={"Authorization": bearer_token},
+    )
+
+    with make_tracked_session() as session:
+        prepared = session.prepare_request(request)
+        response = session.send(prepared)
+        response.raise_for_status()
+        return [o for o in response.json().get("sobjects", []) if o.get("custom") and o.get("queryable")]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/settings.py
@@ -135,3 +135,10 @@ INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
         }
     ],
 }
+
+SYSTEM_MODSTAMP_INCREMENTAL_FIELD: IncrementalField = {
+    "label": "SystemModstamp",
+    "type": IncrementalFieldType.DateTime,
+    "field": "SystemModstamp",
+    "field_type": IncrementalFieldType.DateTime,
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
@@ -7,31 +7,30 @@ from posthog.schema import (
     SourceFieldOauthConfig,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
-    SourceInputs,
-    SourceResponse,
+from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
+from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.generated_configs import SalesforceSourceConfig
+from posthog.temporal.data_imports.sources.salesforce.auth import SalesforceAuth, salesforce_refresh_access_token
+from posthog.temporal.data_imports.sources.salesforce.salesforce import (
+    SalesforceResumeConfig,
+    list_custom_object_definitions,
+    salesforce_source,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import OAuthMixin
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
-from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SalesforceSourceConfig
-from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth import (
-    salesforce_refresh_access_token,
-)
-from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce import (
-    SalesforceResumeConfig,
-    salesforce_source,
-)
-from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.settings import (
+from posthog.temporal.data_imports.sources.salesforce.settings import (
     ENDPOINTS,
     INCREMENTAL_FIELDS,
+    SYSTEM_MODSTAMP_INCREMENTAL_FIELD,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
@@ -87,6 +86,41 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
             )
             for endpoint in ENDPOINTS
         ]
+
+        if names is None or any(name.endswith("__c") for name in names):
+            try:
+                integration = self.get_oauth_integration(config.salesforce_integration_id, team_id)
+                auth = SalesforceAuth(
+                    refresh_token=integration.refresh_token,
+                    access_token=integration.access_token,
+                    instance_url=integration.config.get("instance_url"),
+                )
+
+                definitions = list_custom_object_definitions(
+                    instance_url=integration.config.get("instance_url"),
+                    access_token=auth.token,
+                    endpoint="/services/data/v61.0/sobjects",
+                )
+            except Exception as e:
+                capture_exception(e)
+                definitions = []
+
+            for definition in definitions:
+                machine_name = definition.get("name")
+                if not machine_name:
+                    continue
+                if machine_name in schemas:
+                    continue
+                schemas.append(
+                    SourceSchema(
+                        name=machine_name,
+                        label=definition.get("label") or machine_name,
+                        supports_incremental=True,
+                        supports_append=True,
+                        incremental_fields=[SYSTEM_MODSTAMP_INCREMENTAL_FIELD],
+                    )
+                )
+
         if names:
             names_set = set(names)
             schemas = [s for s in schemas if s.name in names_set]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
@@ -8,15 +8,15 @@ from posthog.schema import (
 )
 
 from posthog.exceptions_capture import capture_exception
-from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
-from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
-from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
-from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
-from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
-from posthog.temporal.data_imports.sources.common.schema import SourceSchema
-from posthog.temporal.data_imports.sources.generated_configs import SalesforceSourceConfig
-from posthog.temporal.data_imports.sources.salesforce.auth import SalesforceAuth, salesforce_refresh_access_token
-from posthog.temporal.data_imports.sources.salesforce.salesforce import (
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import OAuthMixin
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SalesforceSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth import SalesforceAuth, salesforce_refresh_access_token
+from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce import (
     SalesforceResumeConfig,
     list_custom_object_definitions,
     salesforce_source,
@@ -24,13 +24,13 @@ from posthog.temporal.data_imports.sources.salesforce.salesforce import (
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
-from posthog.temporal.data_imports.sources.salesforce.settings import (
+from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.settings import (
     ENDPOINTS,
     INCREMENTAL_FIELDS,
     SYSTEM_MODSTAMP_INCREMENTAL_FIELD,
 )
 
-from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
@@ -90,15 +90,13 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
         if names is None or any(name.endswith("__c") for name in names):
             try:
                 integration = self.get_oauth_integration(config.salesforce_integration_id, team_id)
-                auth = SalesforceAuth(
-                    refresh_token=integration.refresh_token,
-                    access_token=integration.access_token,
-                    instance_url=integration.config.get("instance_url"),
-                )
+
+                salesforce_instance_url = integration.config.get("instance_url")
+                salesforce_access_token = self.get_salesforce_access_token(config.salesforce_integration_id, team_id)
 
                 definitions = list_custom_object_definitions(
-                    instance_url=integration.config.get("instance_url"),
-                    access_token=auth.token,
+                    instance_url=salesforce_instance_url,
+                    access_token=salesforce_access_token[0],
                     endpoint="/services/data/v61.0/sobjects",
                 )
             except Exception as e:
@@ -156,16 +154,10 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
     ) -> SourceResponse:
         integration = self.get_oauth_integration(config.salesforce_integration_id, inputs.team_id)
 
-        salesforce_refresh_token = integration.refresh_token
-
-        if not salesforce_refresh_token:
-            raise ValueError(f"Salesforce refresh token not found for job {inputs.job_id}")
-
-        salesforce_access_token = integration.access_token
         salesforce_instance_url = integration.config.get("instance_url")
-
-        if not salesforce_access_token:
-            salesforce_access_token = salesforce_refresh_access_token(salesforce_refresh_token, salesforce_instance_url)
+        salesforce_access_token, salesforce_refresh_token = self.get_salesforce_access_token(
+            config.salesforce_integration_id, inputs.team_id
+        )
 
         resource = salesforce_source(
             instance_url=salesforce_instance_url,
@@ -186,3 +178,19 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
             primary_keys=["id"] if inputs.should_use_incremental_field else None,
             column_hints=resource.column_hints,
         )
+
+    def get_salesforce_access_token(self, integration_id: int, team_id: int) -> tuple[str, str]:
+        integration = self.get_oauth_integration(integration_id, team_id)
+
+        salesforce_refresh_token = integration.refresh_token
+
+        if not salesforce_refresh_token:
+            raise ValueError(f"Salesforce refresh token not found for integration {integration_id}")
+
+        salesforce_access_token = integration.access_token
+        salesforce_instance_url = integration.config.get("instance_url")
+
+        if not salesforce_access_token:
+            salesforce_access_token = salesforce_refresh_access_token(salesforce_refresh_token, salesforce_instance_url)
+
+        return salesforce_access_token, salesforce_refresh_token

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce.py
@@ -261,7 +261,7 @@ class TestSalesforceCustomObjectDefinitions:
             ),
         ],
     )
-    @mock.patch("posthog.temporal.data_imports.sources.salesforce.salesforce.rest_api_resources")
+    @mock.patch("posthog.temporal.data_imports.sources.salesforce.salesforce.make_tracked_session")
     def test_returns_definitions(
         self, mock_rest: mock.MagicMock, expected_defs: list[dict[str, Any]], expected_call_count: int
     ) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import pytest
 from unittest import mock
@@ -9,6 +9,7 @@ from requests import Request, Session
 from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce import (
     SalesforceEndpointPaginator,
     SalesforceResumeConfig,
+    get_custom_object_resource,
     list_custom_object_definitions,
     salesforce_source,
 )
@@ -242,7 +243,7 @@ class TestSalesforceEndpointPaginator:
             assert request.params == {"q": "initial"}
 
 
-class TestSalesforceCustomObjectDefinitions:
+class TestSalesforceCustomObject:
     @pytest.mark.parametrize(
         "expected_defs,expected_call_count",
         [
@@ -261,8 +262,8 @@ class TestSalesforceCustomObjectDefinitions:
             ),
         ],
     )
-    @mock.patch("posthog.temporal.data_imports.sources.salesforce.salesforce.make_tracked_session")
-    def test_returns_definitions(
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.make_tracked_session")
+    def test_returns_custom_object_definitions(
         self, mock_rest: mock.MagicMock, expected_defs: list[dict[str, Any]], expected_call_count: int
     ) -> None:
         session = _make_session([_mock_sobjects_response(expected_defs)])
@@ -272,6 +273,24 @@ class TestSalesforceCustomObjectDefinitions:
 
         assert defs == expected_defs
         assert session.send.call_count == expected_call_count
+
+    @pytest.mark.parametrize("should_use_incremental_field", [False, True])
+    def test_builds_resource_for_custom_object(self, should_use_incremental_field: bool) -> None:
+        resource = get_custom_object_resource("Employee__c", should_use_incremental_field)
+        endpoint = cast(dict[str, Any], resource["endpoint"])
+
+        assert endpoint["path"] == "/services/data/v61.0/query"
+        assert resource["name"] == "Employee__c"
+        assert resource["table_name"] == "employee_c"
+
+        params = cast(dict[str, Any], endpoint["params"])
+        if should_use_incremental_field:
+            assert resource["write_disposition"] == {"disposition": "merge", "strategy": "upsert"}
+            assert params["q"]["type"] == "incremental"
+            assert params["q"]["cursor_path"] == "SystemModstamp"
+        else:
+            assert resource["write_disposition"] == "replace"
+            assert params["q"] == "SELECT FIELDS(ALL) FROM Employee__c ORDER BY Id ASC LIMIT 200"
 
 
 class TestSalesforceSourceResumeWiring:
@@ -283,6 +302,9 @@ class TestSalesforceSourceResumeWiring:
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.rest_api_resource"
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.list_custom_object_definitions"
     )
     def test_fresh_run_does_not_seed_paginator(self, mock_rest: mock.MagicMock) -> None:
         manager = self._build_manager(can_resume=False, loaded=None)
@@ -305,6 +327,9 @@ class TestSalesforceSourceResumeWiring:
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.rest_api_resource"
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.list_custom_object_definitions"
     )
     def test_resume_run_seeds_paginator_from_saved_state(self, mock_rest: mock.MagicMock) -> None:
         loaded = SalesforceResumeConfig(
@@ -335,6 +360,9 @@ class TestSalesforceSourceResumeWiring:
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.rest_api_resource"
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.list_custom_object_definitions"
     )
     def test_resume_hook_persists_checkpoint(self, mock_rest: mock.MagicMock) -> None:
         manager = self._build_manager(can_resume=False, loaded=None)
@@ -375,3 +403,34 @@ class TestSalesforceSourceResumeWiring:
 
         resume_hook({"model_name": "Account"})
         manager.save_state.assert_not_called()
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.rest_api_resource")
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce.list_custom_object_definitions")
+    def test_resume_run_seeds_paginator_for_custom_object(
+        self, mock_list: mock.MagicMock, mock_rest: mock.MagicMock
+    ) -> None:
+        mock_list.return_value = [
+            {"name": "Employee__c", "label": "Employee", "labelPlural": "Employees", "queryable": True, "custom": True}
+        ]
+        loaded = SalesforceResumeConfig(
+            model_name="Employee__c",
+            last_record_id="a00ZZZ",
+            date_filter="2024-01-01T00:00:00.000+0000",
+        )
+        manager = self._build_manager(can_resume=True, loaded=loaded)
+        salesforce_source(
+            instance_url=INSTANCE_URL,
+            access_token="token",
+            refresh_token="refresh",
+            endpoint="Employee__c",
+            team_id=1,
+            job_id="job-1",
+            db_incremental_field_last_value=None,
+            resumable_source_manager=manager,
+            should_use_incremental_field=True,
+        )
+        assert mock_rest.call_args.kwargs["initial_paginator_state"] == {
+            "model_name": "Employee__c",
+            "last_record_id": "a00ZZZ",
+            "date_filter": "2024-01-01T00:00:00.000+0000",
+        }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce.py
@@ -9,6 +9,7 @@ from requests import Request, Session
 from products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.salesforce import (
     SalesforceEndpointPaginator,
     SalesforceResumeConfig,
+    list_custom_object_definitions,
     salesforce_source,
 )
 
@@ -20,6 +21,23 @@ def _mock_response(records: list[dict[str, Any]]) -> mock.MagicMock:
     response = mock.MagicMock()
     response.json.return_value = {"records": records}
     return response
+
+
+def _mock_sobjects_response(sobjects: list[dict[str, Any]]) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.json.return_value = {"sobjects": sobjects}
+    return response
+
+
+def _make_session(responses: list[mock.MagicMock]) -> mock.MagicMock:
+    session = mock.MagicMock()
+    session.__enter__.return_value = session
+    session.__exit__.return_value = False
+    session.send.side_effect = responses
+    # prepare_request returns its argument unchanged so the paginator's url updates
+    # propagate to the next send() call.
+    session.prepare_request.side_effect = lambda r: r
+    return session
 
 
 def _mock_empty_response() -> mock.MagicMock:
@@ -222,6 +240,38 @@ class TestSalesforceEndpointPaginator:
             }
         else:
             assert request.params == {"q": "initial"}
+
+
+class TestSalesforceCustomObjectDefinitions:
+    @pytest.mark.parametrize(
+        "expected_defs,expected_call_count",
+        [
+            pytest.param(
+                [
+                    {
+                        "name": "Employee__c",
+                        "label": "Employee",
+                        "labelPlural": "Employees",
+                        "queryable": True,
+                        "custom": True,
+                    }
+                ],
+                1,
+                id="one_sobject",
+            ),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.salesforce.salesforce.rest_api_resources")
+    def test_returns_definitions(
+        self, mock_rest: mock.MagicMock, expected_defs: list[dict[str, Any]], expected_call_count: int
+    ) -> None:
+        session = _make_session([_mock_sobjects_response(expected_defs)])
+        mock_rest.return_value = session
+
+        defs = list_custom_object_definitions(INSTANCE_URL, "token", endpoint="/services/data/v61.0/sobjects")
+
+        assert defs == expected_defs
+        assert session.send.call_count == expected_call_count
 
 
 class TestSalesforceSourceResumeWiring:


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Currently, the Salesforce integration supports only 14 standard objects that can be synced. But there is a demand for syncing custom objects as well.

Closes #41224 

## Changes

- Added `list_custom_object_definitions` to retrieve custom object definitions similar to Vitally. 
- Added `get_custom_object_resource` to form the resource metadata of custom objects used for the sync.


## How did you test this code?

- Wrote relevant unit tests for `list_custom_object_definitions` thats used to get the schema from source. And another unit test that covers the resource handling of custom objects.
- Used a developer edition org to test the functionality end to end.


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - All PRs must be attributable to a human author, even if agent-assisted.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
