### PR TITLE
fix(subscriptions): forward resolution errors to HogQL repair LLM

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -9,7 +9,7 @@ import structlog
 
 from posthog.schema import AssistantHogQLQuery
 
-from posthog.hogql.errors import ExposedHogQLError, InternalHogQLError
+from posthog.hogql.errors import ExposedHogQLError, InternalHogQLError, ResolutionError
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
@@ -255,8 +255,13 @@ async def _run_steps(
                 )
                 fixed = await _arequest_hogql_fix(
                     original_hogql=current_hogql,
-                    # don't forward internal error text to the LLM — it can echo cluster URLs/table names
-                    error_message=str(exc) if isinstance(exc, ExposedHogQLError) else type(exc).__name__,
+                    # Forward the message for exposed errors and ResolutionError — the latter only names the
+                    # field/property the planner itself referenced (e.g. "Unable to resolve field 'operaton'"),
+                    # which is exactly what the fixer needs and carries no cluster internals. Other internal
+                    # errors (parsing/impossible-AST) stay type-only — they can echo cluster URLs/table names.
+                    error_message=(
+                        str(exc) if isinstance(exc, (ExposedHogQLError, ResolutionError)) else type(exc).__name__
+                    ),
                     step_description=safe_description,
                     team=team,
                     user=user,

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -255,10 +255,11 @@ async def _run_steps(
                 )
                 fixed = await _arequest_hogql_fix(
                     original_hogql=current_hogql,
-                    # Forward the message for exposed errors and ResolutionError — the latter only names the
-                    # field/property the planner itself referenced (e.g. "Unable to resolve field 'operaton'"),
-                    # which is exactly what the fixer needs and carries no cluster internals. Other internal
-                    # errors (parsing/impossible-AST) stay type-only — they can echo cluster URLs/table names.
+                    # Forward the message for exposed errors and ResolutionError. ResolutionError messages
+                    # describe query structure — usually the field/property the planner itself referenced
+                    # (e.g. "Unable to resolve field 'operaton'"), which is what the fixer needs. A few raise
+                    # sites wrap a nested exception, but those describe query shape, not cluster topology, so
+                    # the leak risk stays low. Other internal errors (parsing/impossible-AST) stay type-only.
                     error_message=(
                         str(exc) if isinstance(exc, (ExposedHogQLError, ResolutionError)) else type(exc).__name__
                     ),

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 import asyncio
 from datetime import UTC, datetime
@@ -23,6 +22,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.prompts imp
     HOGQL_FIX_PROMPT,
     HOGQL_FIX_PROMPT_NAME,
     SYNTHESIS_PROMPT_NAME,
+    render_prompt,
     resolve_prompt,
 )
 from products.exports.backend.temporal.subscriptions.ai_subscription.schemas import (
@@ -312,18 +312,12 @@ async def _arequest_hogql_fix(
         posthog_properties=posthog_properties,
     ).with_structured_output(HogQLFix, method="json_schema", include_raw=False)
 
-    substitutions = {
-        "description": step_description,
-        "error": error_message,
-        "original_hogql": original_hogql,
-    }
     fix_prompt = await database_sync_to_async(resolve_prompt, thread_sensitive=False)(
         team, HOGQL_FIX_PROMPT_NAME, HOGQL_FIX_PROMPT
     )
-    rendered = re.sub(
-        r"\{\{\{(\w+)\}\}\}",
-        lambda m: substitutions.get(m.group(1), m.group(0)),
+    rendered = render_prompt(
         fix_prompt,
+        {"description": step_description, "error": error_message, "original_hogql": original_hogql},
     )
 
     try:


### PR DESCRIPTION
## Problem

When the planner emits HogQL referencing a field/property that doesn't exist — its single most common mistake — HogQL raises `ResolutionError`. The repair loop feeds the error back to a fix-LLM so it can rewrite the query, but it only forwarded the error **message** for `ExposedHogQLError`; for internal errors it forwarded just the **type name**.

The catch: `ResolutionError` is a subclass of `InternalHogQLError`, not `ExposedHogQLError`. So the fixer was handed the bare string `"ResolutionError"` — no field name, nothing to act on — and couldn't repair the very errors it exists to fix.

```mermaid
flowchart TD
    ERR{"query step raises a retryable error"}
    ERR -->|ExposedHogQLError| MSG["forward full message"]
    ERR -->|"ResolutionError — subclass of InternalHogQLError,<br/>names the field the planner itself wrote<br/>(e.g. 'Unable to resolve field operaton')"| MSG
    ERR -->|"other InternalHogQLError<br/>(parsing / impossible-AST — may echo cluster internals)"| T["forward type name only"]
    MSG --> FIX["HogQL fix-LLM rewrites the query"]
    T --> FIX
    FIX --> RETRY["re-run the step"]
    classDef fix fill:#0f2417,stroke:#2ea043,color:#e8e8e8;
    class MSG fix;
```

Before this PR, `ResolutionError` sat in the **"type name only"** bucket (because it's an `InternalHogQLError`), starving the fixer. This routes it to **"forward message"** — its message only names the field the planner itself referenced, so it carries no cluster internals. Parsing/impossible-AST errors stay type-only (they can echo table paths / cluster identifiers). A follow-up commit on this PR also points the repair loop's prompt rendering at the shared `render_prompt()` helper.

## Changes

- Verified the HogQL error hierarchy (`posthog/hogql/errors.py`): `ResolutionError` extends `InternalHogQLError`.
- Forward the message for `ExposedHogQLError` **and** `ResolutionError`; keep other internal errors type-only.
- Soften the leak-safety comment (a few `ResolutionError` sites wrap a nested exception — described as low-risk, not an absolute guarantee).
- Use the shared `render_prompt()` helper instead of an inline `re.sub` in the fix loop.

## How did you test this code?

I'm an agent (Claude Code); I did not manually test. Automated only: `test_report_pipeline.py` (12) pass, including the existing fix-loop tests; `ruff` clean.

## 🤖 Agent context

Authored with Claude Code. Surfaced while investigating why degraded reports showed "no data" — the repair loop was effectively a no-op for the planner's most common error class because the message never reached it. Narrowed the fix to `ResolutionError` specifically rather than all internal errors, preserving the original leak-prevention intent.

Second of a 4-PR stack (← #62300 grounding).
