### PR TITLE
feat(tasks): gate dedicated redis streams on a feature flag

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -74,7 +74,7 @@ from .models import (
     TaskPresence,
     TaskRun,
 )
-from .redis import get_tasks_cache
+from .redis import get_tasks_cache, run_uses_dedicated_stream
 from .repository_readiness import compute_repository_readiness
 from .serializers import (
     CodeInviteRedeemRequestSerializer,
@@ -2787,14 +2787,14 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def stream(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
         stream_key = get_task_run_stream_key(str(task_run.id))
-        stream_created_at = task_run.created_at
+        use_dedicated_stream = run_uses_dedicated_stream(task_run.state)
         last_event_id = request.headers.get("Last-Event-ID")
         start_latest = request.GET.get("start") == "latest"
         format_sse_event = self._format_sse_event
         origin_product = origin_product_label(task_run)
 
         async def async_stream() -> AsyncGenerator[bytes, None]:
-            redis_stream = TaskRunRedisStream(stream_key, stream_created_at)
+            redis_stream = TaskRunRedisStream(stream_key, use_dedicated_stream)
             connection_started_at = asyncio.get_running_loop().time()
             # Default to client_disconnect: any exit that isn't an explicit
             # completion/error/unavailable is the client (or proxy) going away.

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -41,6 +41,7 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.constants import DEFAULT_TRUSTED_DOMAINS
 from products.tasks.backend.metrics import observe_task_run_created
+from products.tasks.backend.redis import evaluate_dedicated_stream_flag, run_uses_dedicated_stream
 from products.tasks.backend.stream.redis_stream import publish_task_run_stream_event
 
 logger = structlog.get_logger(__name__)
@@ -258,6 +259,13 @@ class Task(DeletedMetaFields, models.Model):
         state: dict = {"mode": mode}
         if extra_state:
             state.update({k: v for k, v in extra_state.items() if k != "mode"})
+        # Pin the stream-routing decision once so every reader/writer agrees for this run's life.
+        if "use_dedicated_stream" not in state:
+            distinct_id = (self.created_by.distinct_id if self.created_by else None) or f"team_{self.team_id}"
+            state["use_dedicated_stream"] = evaluate_dedicated_stream_flag(
+                organization_id=str(self.team.organization_id),
+                distinct_id=distinct_id,
+            )
         is_resume = bool((extra_state or {}).get("resume_from_run_id"))
         has_pending = bool(
             (extra_state or {}).get("pending_user_message") or (extra_state or {}).get("pending_user_artifact_ids")
@@ -978,7 +986,7 @@ class TaskRun(models.Model):
         }
 
     def publish_stream_event(self, event: dict[str, Any]) -> None:
-        publish_task_run_stream_event(str(self.id), event, self.created_at)
+        publish_task_run_stream_event(str(self.id), event, run_uses_dedicated_stream(self.state))
 
     def publish_stream_state_event(self) -> None:
         self.publish_stream_event(self.build_stream_state_event())

--- a/products/tasks/backend/redis.py
+++ b/products/tasks/backend/redis.py
@@ -1,41 +1,55 @@
-from datetime import UTC, datetime
-
 from django.conf import settings
 from django.core.cache import BaseCache, caches
+
+import posthoganalytics
 
 from posthog.caching.tasks_redis_cache import TASKS_DEDICATED_CACHE_ALIAS
 from posthog.redis import get_async_client, get_client
 
-# One-time stream cutover: runs created on/after this instant use the dedicated tasks Redis;
-# older runs stay on the shared Redis until their streams drain (~6h TTL), so a live run is
-# never split across instances. Transitional — remove this and the stream routing below once
-# prod-us has fully drained past the cutover.
-TASKS_REDIS_STREAM_CUTOVER_AT = datetime(2026, 6, 9, 0, 0, tzinfo=UTC)
+# Evaluated once at run creation and pinned onto TaskRun.state["use_dedicated_stream"] so the
+# SSE reader and the temporal worker always agree for a run's life (no split-brain on flag
+# propagation or pod restarts).
+TASKS_DEDICATED_REDIS_STREAMS_FLAG = "tasks-dedicated-redis-streams"
 
 
-def _use_dedicated_stream(created_at: datetime | None) -> bool:
+def evaluate_dedicated_stream_flag(*, organization_id: str, distinct_id: str) -> bool:
+    # Gated on TASKS_REDIS_URL so the deciding process only opts a run into the dedicated
+    # instance if it can itself reach it — a misconfigured pod fails safe to shared.
     if not settings.TASKS_REDIS_URL:
         return False
-    if created_at is None:
-        # Unknown creation time: stay on the shared Redis so we never split an
-        # already-running pre-cutover stream across instances.
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                TASKS_DEDICATED_REDIS_STREAMS_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
         return False
-    return created_at >= TASKS_REDIS_STREAM_CUTOVER_AT
 
 
-def _tasks_stream_redis_url(created_at: datetime | None) -> str:
+def run_uses_dedicated_stream(state: dict | None) -> bool:
+    # Defaults to shared so runs created before this rollout stay on the shared instance.
+    return bool((state or {}).get("use_dedicated_stream", False))
+
+
+def _tasks_stream_redis_url(use_dedicated: bool) -> str:
     dedicated = settings.TASKS_REDIS_URL
-    if dedicated is not None and _use_dedicated_stream(created_at):
+    if dedicated and use_dedicated:
         return dedicated
     return settings.REDIS_URL
 
 
-def get_tasks_stream_redis_async(created_at: datetime | None = None):
-    return get_async_client(_tasks_stream_redis_url(created_at))
+def get_tasks_stream_redis_async(use_dedicated: bool = False):
+    return get_async_client(_tasks_stream_redis_url(use_dedicated))
 
 
-def get_tasks_stream_redis_sync(created_at: datetime | None = None):
-    return get_client(_tasks_stream_redis_url(created_at))
+def get_tasks_stream_redis_sync(use_dedicated: bool = False):
+    return get_client(_tasks_stream_redis_url(use_dedicated))
 
 
 def get_tasks_cache() -> BaseCache:

--- a/products/tasks/backend/stream/redis_stream.py
+++ b/products/tasks/backend/stream/redis_stream.py
@@ -1,7 +1,6 @@
 import json
 import asyncio
 from collections.abc import AsyncGenerator
-from datetime import datetime
 from typing import Optional
 
 from django.conf import settings
@@ -112,12 +111,12 @@ class TaskRunRedisStream:
     def __init__(
         self,
         stream_key: str,
-        created_at: datetime | None = None,
+        use_dedicated: bool = False,
         timeout: int = TASK_RUN_STREAM_TIMEOUT,
         max_length: int = TASK_RUN_STREAM_MAX_LENGTH,
     ):
         self._stream_key = stream_key
-        self._redis_client = get_tasks_stream_redis_async(created_at)
+        self._redis_client = get_tasks_stream_redis_async(use_dedicated)
         self._timeout = timeout
         self._sequence_timeout = max(timeout, TASK_RUN_STREAM_SEQUENCE_TIMEOUT)
         self._max_length = max_length
@@ -508,7 +507,7 @@ class TaskRunRedisStream:
             return False
 
 
-def publish_task_run_stream_event(run_id: str, event: dict, created_at: datetime | None = None) -> str | None:
+def publish_task_run_stream_event(run_id: str, event: dict, use_dedicated: bool = False) -> str | None:
     """Synchronously publish a task-run event to Redis.
 
     This is intended for sync Django model/view code that needs to mirror
@@ -516,7 +515,7 @@ def publish_task_run_stream_event(run_id: str, event: dict, created_at: datetime
     """
 
     async def _publish() -> str:
-        redis_stream = TaskRunRedisStream(get_task_run_stream_key(run_id), created_at)
+        redis_stream = TaskRunRedisStream(get_task_run_stream_key(run_id), use_dedicated)
         return await redis_stream.write_event(event)
 
     try:
@@ -526,11 +525,11 @@ def publish_task_run_stream_event(run_id: str, event: dict, created_at: datetime
         return None
 
 
-def publish_task_run_stream_complete(run_id: str, created_at: datetime | None = None) -> None:
+def publish_task_run_stream_complete(run_id: str, use_dedicated: bool = False) -> None:
     """Synchronously publish a completion sentinel for a task-run stream."""
 
     async def _publish() -> None:
-        redis_stream = TaskRunRedisStream(get_task_run_stream_key(run_id), created_at)
+        redis_stream = TaskRunRedisStream(get_task_run_stream_key(run_id), use_dedicated)
         await redis_stream.mark_complete()
 
     try:

--- a/products/tasks/backend/temporal/process_task/activities/cleanup_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/cleanup_sandbox.py
@@ -6,6 +6,7 @@ from temporalio import activity
 from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.models import TaskRun
+from products.tasks.backend.redis import run_uses_dedicated_stream
 from products.tasks.backend.services.sandbox import Sandbox
 from products.tasks.backend.stream.redis_stream import publish_task_run_stream_complete
 from products.tasks.backend.temporal.exceptions import SandboxNotFoundError
@@ -47,14 +48,15 @@ def cleanup_sandbox(input: CleanupSandboxInput) -> None:
                 logger.warning("cleanup_sandbox_destroy_failed", extra={"sandbox_id": input.sandbox_id}, exc_info=True)
 
         if input.complete_stream_on_cleanup and input.run_id and stream_completion_safe:
-            created_at = None
+            use_dedicated = False
             try:
-                created_at = TaskRun.objects.filter(id=input.run_id).values_list("created_at", flat=True).first()
+                state = TaskRun.objects.filter(id=input.run_id).values_list("state", flat=True).first()
+                use_dedicated = run_uses_dedicated_stream(state)
             except Exception:
                 logger.warning(
-                    "cleanup_sandbox_created_at_lookup_failed", extra={"run_id": input.run_id}, exc_info=True
+                    "cleanup_sandbox_stream_routing_lookup_failed", extra={"run_id": input.run_id}, exc_info=True
                 )
-            publish_task_run_stream_complete(input.run_id, created_at)
+            publish_task_run_stream_complete(input.run_id, use_dedicated)
             logger.info(
                 "cleanup_sandbox_stream_completion_published",
                 extra={"sandbox_id": input.sandbox_id, "run_id": input.run_id},

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -14,6 +14,7 @@ from temporalio import activity
 from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.models import TaskRun as TaskRunModel
+from products.tasks.backend.redis import run_uses_dedicated_stream
 from products.tasks.backend.services.agent_command import validate_sandbox_url
 from products.tasks.backend.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.stream.redis_stream import TaskRunRedisStream, get_task_run_stream_key
@@ -62,7 +63,7 @@ async def relay_sandbox_events(input: RelaySandboxEventsInput) -> None:
     task_run = await TaskRunModel.objects.select_related("task__created_by").aget(id=input.run_id)
 
     stream_key = get_task_run_stream_key(input.run_id)
-    redis_stream = TaskRunRedisStream(stream_key, task_run.created_at)
+    redis_stream = TaskRunRedisStream(stream_key, run_uses_dedicated_stream(task_run.state))
     await redis_stream.initialize()
 
     created_by = task_run.task.created_by

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -1,7 +1,6 @@
 import json
 import time
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any
 
 import structlog
@@ -11,7 +10,7 @@ from posthog.temporal.common.utils import close_db_connections
 from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.models import TaskRun
-from products.tasks.backend.redis import get_tasks_stream_redis_sync
+from products.tasks.backend.redis import get_tasks_stream_redis_sync, run_uses_dedicated_stream
 from products.tasks.backend.services.agent_command import (
     FOLLOWUP_TIMEOUT_SECONDS,
     REFRESH_TIMEOUT_SECONDS,
@@ -80,7 +79,7 @@ def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
         artifacts, missing_artifact_ids = get_task_run_artifacts_by_id(task_run, artifact_ids)
         if missing_artifact_ids:
             error_msg = f"Artifacts not found on this run: {', '.join(missing_artifact_ids)}"
-            _write_error_and_complete(input.run_id, error_msg, task_run.created_at)
+            _write_error_and_complete(input.run_id, error_msg, run_uses_dedicated_stream(task_run.state))
             raise RuntimeError(f"send_followup failed: {error_msg}")
 
     result = send_user_message(
@@ -98,7 +97,7 @@ def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
     )
 
     if result.success:
-        _write_turn_complete(input.run_id, _get_stop_reason(result.data), task_run.created_at)
+        _write_turn_complete(input.run_id, _get_stop_reason(result.data), run_uses_dedicated_stream(task_run.state))
         logger.info("send_followup_delivered", run_id=input.run_id)
     else:
         logger.warning(
@@ -108,7 +107,7 @@ def send_followup_to_sandbox(input: SendFollowupToSandboxInput) -> None:
             status_code=result.status_code,
         )
         error_msg = result.error or "Failed to send message to sandbox"
-        _write_error_and_complete(input.run_id, error_msg, task_run.created_at)
+        _write_error_and_complete(input.run_id, error_msg, run_uses_dedicated_stream(task_run.state))
         # Propagate failure to the workflow.
         raise RuntimeError(f"send_followup failed: {error_msg}")
 
@@ -209,9 +208,7 @@ def _get_stop_reason(result_data: dict[str, Any] | None) -> str:
     return stop_reason if isinstance(stop_reason, str) and stop_reason else STOP_REASON_END_TURN
 
 
-def _write_turn_complete(
-    run_id: str, stop_reason: str = STOP_REASON_END_TURN, created_at: datetime | None = None
-) -> None:
+def _write_turn_complete(run_id: str, stop_reason: str = STOP_REASON_END_TURN, use_dedicated: bool = False) -> None:
     """Write a synthetic turn_complete event to the Redis stream."""
     stream_key = get_task_run_stream_key(run_id)
     event = {
@@ -221,14 +218,14 @@ def _write_turn_complete(
             "params": {"source": "posthog", "stopReason": stop_reason},
         },
     }
-    conn = get_tasks_stream_redis_sync(created_at)
+    conn = get_tasks_stream_redis_sync(use_dedicated)
     conn.xadd(stream_key, {"data": json.dumps(event)}, maxlen=2000)
 
 
-def _write_error_and_complete(run_id: str, error_message: str, created_at: datetime | None = None) -> None:
+def _write_error_and_complete(run_id: str, error_message: str, use_dedicated: bool = False) -> None:
     """Write an error event followed by turn_complete to the Redis stream."""
     stream_key = get_task_run_stream_key(run_id)
-    conn = get_tasks_stream_redis_sync(created_at)
+    conn = get_tasks_stream_redis_sync(use_dedicated)
 
     error_event = {
         "type": "notification",
@@ -238,4 +235,4 @@ def _write_error_and_complete(run_id: str, error_message: str, created_at: datet
         },
     }
     conn.xadd(stream_key, {"data": json.dumps(error_event)}, maxlen=2000)
-    _write_turn_complete(run_id, created_at=created_at)
+    _write_turn_complete(run_id, use_dedicated=use_dedicated)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_cleanup_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_cleanup_sandbox.py
@@ -82,7 +82,7 @@ def test_cleanup_sandbox_completes_stream_when_requested(activity_environment, m
 
     sandbox.execute.assert_not_called()
     sandbox.destroy.assert_called_once_with()
-    publish_complete.assert_called_once_with("run-123", None)
+    publish_complete.assert_called_once_with("run-123", False)
 
 
 @pytest.mark.django_db
@@ -134,7 +134,7 @@ def test_cleanup_sandbox_completes_stream_when_sandbox_is_already_gone(activity_
         ),
     )
 
-    publish_complete.assert_called_once_with("run-123", None)
+    publish_complete.assert_called_once_with("run-123", False)
 
 
 @pytest.mark.skipif(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -1,7 +1,6 @@
 import json
 import asyncio
 import importlib
-from datetime import datetime
 from types import SimpleNamespace
 from typing import cast
 
@@ -197,7 +196,7 @@ class TestRelaySandboxEventsCancellation:
         )
 
         class StubTaskRunRedisStream:
-            def __init__(self, stream_key: str, created_at: datetime | None = None) -> None:
+            def __init__(self, stream_key: str, use_dedicated: bool = False) -> None:
                 self.stream_key = stream_key
 
             async def initialize(self) -> None:
@@ -214,9 +213,7 @@ class TestRelaySandboxEventsCancellation:
                 return self
 
             async def aget(self, id: str) -> SimpleNamespace:
-                return SimpleNamespace(
-                    task=SimpleNamespace(created_by=SimpleNamespace(id=123)), created_at=datetime(2026, 1, 1)
-                )
+                return SimpleNamespace(task=SimpleNamespace(created_by=SimpleNamespace(id=123)), state={})
 
         async def fake_relay_loop(**_kwargs: object) -> None:
             raise asyncio.CancelledError
@@ -513,7 +510,7 @@ class TestRelaySandboxEventsErrorHandling:
         )
 
         class StubTaskRunRedisStream:
-            def __init__(self, stream_key: str, created_at: datetime | None = None) -> None:
+            def __init__(self, stream_key: str, use_dedicated: bool = False) -> None:
                 self.stream_key = stream_key
 
             async def initialize(self) -> None:
@@ -530,9 +527,7 @@ class TestRelaySandboxEventsErrorHandling:
                 return self
 
             async def aget(self, id: str) -> SimpleNamespace:
-                return SimpleNamespace(
-                    task=SimpleNamespace(created_by=SimpleNamespace(id=123)), created_at=datetime(2026, 1, 1)
-                )
+                return SimpleNamespace(task=SimpleNamespace(created_by=SimpleNamespace(id=123)), state={})
 
         async def fake_relay_loop(**_kwargs: object) -> None:
             raise RuntimeError("relay error")

--- a/products/tasks/backend/tests/test_redis_stream_routing.py
+++ b/products/tasks/backend/tests/test_redis_stream_routing.py
@@ -1,34 +1,53 @@
-from datetime import UTC, datetime, timedelta
-
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
 
+from parameterized import parameterized
+
 from products.tasks.backend import redis as tasks_redis
 
-CUTOVER = datetime(2026, 6, 9, tzinfo=UTC)
-AFTER = CUTOVER + timedelta(seconds=1)
-BEFORE = CUTOVER - timedelta(seconds=1)
 
-
-@patch.object(tasks_redis, "TASKS_REDIS_STREAM_CUTOVER_AT", CUTOVER)
 class TestStreamRouting(SimpleTestCase):
-    @override_settings(TASKS_REDIS_URL=None, REDIS_URL="redis://shared")
-    def test_no_dedicated_url_always_uses_shared(self):
-        self.assertFalse(tasks_redis._use_dedicated_stream(AFTER))
-        self.assertEqual(tasks_redis._tasks_stream_redis_url(AFTER), "redis://shared")
+    @parameterized.expand(
+        [
+            ("dedicated_set_pinned", "redis://dedicated", True, "redis://dedicated"),
+            ("dedicated_set_unpinned", "redis://dedicated", False, "redis://shared"),
+            ("no_dedicated_pinned", None, True, "redis://shared"),
+            ("no_dedicated_unpinned", None, False, "redis://shared"),
+        ]
+    )
+    def test_tasks_stream_redis_url(self, _name, dedicated_url, use_dedicated, expected):
+        with override_settings(TASKS_REDIS_URL=dedicated_url, REDIS_URL="redis://shared"):
+            self.assertEqual(tasks_redis._tasks_stream_redis_url(use_dedicated), expected)
 
-    @override_settings(TASKS_REDIS_URL="redis://dedicated", REDIS_URL="redis://shared")
-    def test_routes_by_cutover(self):
-        self.assertTrue(tasks_redis._use_dedicated_stream(CUTOVER))
-        self.assertTrue(tasks_redis._use_dedicated_stream(AFTER))
-        self.assertFalse(tasks_redis._use_dedicated_stream(BEFORE))
+    @parameterized.expand(
+        [
+            ("pinned_true", {"use_dedicated_stream": True}, True),
+            ("pinned_false", {"use_dedicated_stream": False}, False),
+            ("missing_key", {}, False),
+            ("none_state", None, False),
+        ]
+    )
+    def test_run_uses_dedicated_stream(self, _name, state, expected):
+        self.assertEqual(tasks_redis.run_uses_dedicated_stream(state), expected)
 
-        self.assertEqual(tasks_redis._tasks_stream_redis_url(AFTER), "redis://dedicated")
-        self.assertEqual(tasks_redis._tasks_stream_redis_url(BEFORE), "redis://shared")
 
-    @override_settings(TASKS_REDIS_URL="redis://dedicated", REDIS_URL="redis://shared")
-    def test_missing_created_at_uses_shared(self):
-        # Unknown created_at must not move a stream onto the dedicated instance.
-        self.assertFalse(tasks_redis._use_dedicated_stream(None))
-        self.assertEqual(tasks_redis._tasks_stream_redis_url(None), "redis://shared")
+class TestEvaluateDedicatedStreamFlag(SimpleTestCase):
+    @override_settings(TASKS_REDIS_URL=None)
+    def test_returns_false_without_dedicated_url(self):
+        with patch.object(tasks_redis.posthoganalytics, "feature_enabled") as mock_flag:
+            self.assertFalse(tasks_redis.evaluate_dedicated_stream_flag(organization_id="org", distinct_id="u"))
+            mock_flag.assert_not_called()
+
+    @parameterized.expand([("flag_on", True, True), ("flag_off", False, False)])
+    def test_returns_flag_value_when_url_present(self, _name, flag_value, expected):
+        with override_settings(TASKS_REDIS_URL="redis://dedicated"):
+            with patch.object(tasks_redis.posthoganalytics, "feature_enabled", return_value=flag_value):
+                self.assertEqual(
+                    tasks_redis.evaluate_dedicated_stream_flag(organization_id="org", distinct_id="u"), expected
+                )
+
+    @override_settings(TASKS_REDIS_URL="redis://dedicated")
+    def test_fails_safe_to_shared_on_flag_error(self):
+        with patch.object(tasks_redis.posthoganalytics, "feature_enabled", side_effect=RuntimeError("boom")):
+            self.assertFalse(tasks_redis.evaluate_dedicated_stream_flag(organization_id="org", distinct_id="u"))


### PR DESCRIPTION
## Problem

let's gate redis redirect over [flag](https://us.posthog.com/project/2/feature_flags/708263) so we can control each step cleanly