### PR TITLE
test(project): add e2e for creating a project on an existing org

### DIFF
--- a/playwright/e2e/project-creation.spec.ts
+++ b/playwright/e2e/project-creation.spec.ts
@@ -1,0 +1,57 @@
+import { randomString } from '../utils'
+import { PlaywrightWorkspaceSetupResult, expect, test } from '../utils/workspace-test-base'
+
+// Creating a new project on an existing org is a fundamental flow that spans the modal, the
+// projects API (gated by the organizations_projects feature), and the post-create team switch.
+// Only a full-stack browser test proves all three agree, so it lives here rather than a unit test.
+test.describe('Project creation', () => {
+    let workspace: PlaywrightWorkspaceSetupResult | null = null
+
+    test.beforeAll(async ({ playwrightSetup }) => {
+        workspace = await playwrightSetup.createWorkspace({
+            organization_name: randomString('Project Creation Org'),
+            no_demo_data: true,
+            skip_onboarding: true,
+            // Required to create a second project — without it both the UI and API block it.
+            available_features: ['organizations_projects'],
+        })
+    })
+
+    test.beforeEach(async ({ page, playwrightSetup }) => {
+        await playwrightSetup.loginAndNavigateToTeam(page, workspace!)
+    })
+
+    test('creates a new project within the existing organization', async ({ page }) => {
+        const originalProjectName = workspace!.team_name
+        const newProjectName = randomString('New Project')
+
+        await test.step('open the create-project modal from the account menu', async () => {
+            await page.getByTestId('new-account-menu-button').click()
+            await page.getByTestId('new-account-menu-create-project-icon-button').click()
+
+            const modal = page.getByRole('dialog')
+            await expect(modal).toBeVisible()
+            await expect(modal).toContainText(`Create a project within ${workspace!.organization_name}`)
+        })
+
+        await test.step('name and create the project', async () => {
+            const modal = page.getByRole('dialog')
+            await modal.getByRole('textbox').fill(newProjectName)
+            await modal.getByRole('button', { name: 'Create project' }).click()
+        })
+
+        await test.step('app switches into the newly created project', async () => {
+            // On success the app navigates into the new project, so its name becomes the active one.
+            await expect(page.getByTestId('new-account-menu-button')).toContainText(newProjectName, { timeout: 30000 })
+        })
+
+        await test.step('both projects are listed under the same organization', async () => {
+            await page.getByTestId('new-account-menu-button').click()
+            await page.getByTestId('new-account-menu-all-projects-button').click()
+
+            await expect(page.getByLabel('Search projects')).toBeVisible()
+            await expect(page.getByRole('option', { name: originalProjectName })).toBeVisible()
+            await expect(page.getByRole('option', { name: newProjectName })).toBeVisible()
+        })
+    })
+})

--- a/playwright/e2e/project-creation.spec.ts
+++ b/playwright/e2e/project-creation.spec.ts
@@ -14,6 +14,8 @@ test.describe('Project creation', () => {
             skip_onboarding: true,
             // Required to create a second project — without it both the UI and API block it.
             available_features: ['organizations_projects'],
+            // Creating a project requires org admin rights (UserCanCreateProjectPermission).
+            membership_level: 'admin',
         })
     })
 

--- a/playwright/utils/playwright-setup.ts
+++ b/playwright/utils/playwright-setup.ts
@@ -66,6 +66,11 @@ export interface PlaywrightWorkspaceSetupData {
     use_current_time?: boolean
     skip_onboarding?: boolean
     no_demo_data?: boolean
+    /**
+     * Extra available product feature keys to grant the org (e.g. 'organizations_projects' to
+     * allow creating more than one project). Merged with the always-on access_control feature.
+     */
+    available_features?: string[]
     insight_variables?: PlaywrightSetupVariable[]
     insights?: PlaywrightSetupInsight[]
     dashboards?: PlaywrightSetupDashboard[]

--- a/playwright/utils/playwright-setup.ts
+++ b/playwright/utils/playwright-setup.ts
@@ -71,6 +71,11 @@ export interface PlaywrightWorkspaceSetupData {
      * allow creating more than one project). Merged with the always-on access_control feature.
      */
     available_features?: string[]
+    /**
+     * Organization membership level for the test user. Defaults to 'member'; use 'admin' for flows
+     * that require admin rights (e.g. creating a project).
+     */
+    membership_level?: 'member' | 'admin' | 'owner'
     insight_variables?: PlaywrightSetupVariable[]
     insights?: PlaywrightSetupInsight[]
     dashboards?: PlaywrightSetupDashboard[]

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -75,6 +75,9 @@ class PlaywrightWorkspaceSetupData(BaseModel):
     use_current_time: bool | None = None
     skip_onboarding: bool | None = None
     no_demo_data: bool | None = None
+    # Extra available product feature keys to grant the org (e.g. "organizations_projects"
+    # to allow creating more than one project). Merged with the always-on access_control feature.
+    available_features: list[str] | None = None
     insight_variables: list[PlaywrightSetupVariable] | None = None
     insights: list[PlaywrightSetupInsight] | None = None
     dashboards: list[PlaywrightSetupDashboard] | None = None
@@ -187,13 +190,9 @@ def create_organization_with_team(
 
     # Bypass billing quota limits so insights always compute on CI
     organization.never_drop_data = True
-    # Add access control feature for password-protected sharing
-    organization.available_product_features = [
-        {
-            "key": AvailableFeature.ACCESS_CONTROL,
-            "name": AvailableFeature.ACCESS_CONTROL,
-        }
-    ]
+    # Add access control feature for password-protected sharing, plus any extra features the test requested
+    feature_keys = [AvailableFeature.ACCESS_CONTROL, *(data.available_features or [])]
+    organization.available_product_features = [{"key": key, "name": key} for key in feature_keys]
     organization.save()
 
     # Create personal API key for the user

--- a/posthog/test/playwright_setup_functions.py
+++ b/posthog/test/playwright_setup_functions.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.constants import AvailableFeature
 from posthog.management.commands.generate_demo_data import Command as GenerateDemoDataCommand
-from posthog.models import PersonalAPIKey, Team, User
+from posthog.models import OrganizationMembership, PersonalAPIKey, Team, User
 from posthog.models.utils import hash_key_value, mask_key_value
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -78,6 +78,9 @@ class PlaywrightWorkspaceSetupData(BaseModel):
     # Extra available product feature keys to grant the org (e.g. "organizations_projects"
     # to allow creating more than one project). Merged with the always-on access_control feature.
     available_features: list[str] | None = None
+    # Organization membership level for the test user. Defaults to "member"; use "admin" for flows
+    # that require admin rights (e.g. creating a project, which needs UserCanCreateProjectPermission).
+    membership_level: str | None = None
     insight_variables: list[PlaywrightSetupVariable] | None = None
     insights: list[PlaywrightSetupInsight] | None = None
     dashboards: list[PlaywrightSetupDashboard] | None = None
@@ -191,9 +194,17 @@ def create_organization_with_team(
     # Bypass billing quota limits so insights always compute on CI
     organization.never_drop_data = True
     # Add access control feature for password-protected sharing, plus any extra features the test requested
-    feature_keys = [AvailableFeature.ACCESS_CONTROL, *(data.available_features or [])]
+    feature_keys = list(dict.fromkeys([AvailableFeature.ACCESS_CONTROL, *(data.available_features or [])]))
     organization.available_product_features = [{"key": key, "name": key} for key in feature_keys]
     organization.save()
+
+    if data.membership_level:
+        level = {
+            "member": OrganizationMembership.Level.MEMBER,
+            "admin": OrganizationMembership.Level.ADMIN,
+            "owner": OrganizationMembership.Level.OWNER,
+        }[data.membership_level]
+        OrganizationMembership.objects.filter(user=user, organization=organization).update(level=level)
 
     # Create personal API key for the user
     api_key_value = f"phx_test_api_key_for_playwright_tests_{unique_suffix}"

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,5 +1,7 @@
+import os
 import json
 import base64
+import tempfile
 from datetime import datetime, timedelta
 from typing import Any, cast
 from zoneinfo import ZoneInfo
@@ -12,7 +14,7 @@ from unittest.mock import call, patch
 from django.core.cache import cache
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.client import RequestFactory
 
 from parameterized import parameterized
@@ -22,6 +24,7 @@ from posthog.exceptions import RequestParsingError, UnspecifiedCompressionFallba
 from posthog.models import EventDefinition, GroupTypeMapping
 from posthog.settings.utils import get_from_env
 from posthog.utils import (
+    GenericEmails,
     PotentialSecurityProblemException,
     absolute_uri,
     base64_decode,
@@ -1059,3 +1062,44 @@ class TestTemplateContextHistogram(TestCase):
             get_context_for_template("index.html", request)
 
         assert self._count_for_labels("index.html", expected_label) == before + 1
+
+
+class TestGenericEmailsEncoding(SimpleTestCase):
+    # Regression guard for the Python 3.13 / nginx-unit incident that broke project creation.
+    # Every POST /api/projects/ reaches GenericEmails via get_or_create_internal_test_users_cohort,
+    # which read posthog/helpers/generic_emails.txt with open() and no explicit encoding. Under
+    # nginx unit's embedded libpython the default text encoding is ASCII (PEP 538/540 locale
+    # coercion only runs for the python CLI, not an embedded interpreter), so a non-ASCII byte in
+    # the file raised UnicodeDecodeError and the request 500'd. CI and the e2e harness never caught
+    # it because they launch Python via the CLI, where the C locale is coerced to UTF-8. We model
+    # that ASCII-default runtime in-process here so the read is exercised the way production hit it.
+
+    def _ascii_default_open(self, real_open):
+        def opener(file, mode="r", *args, encoding=None, **kwargs):
+            if encoding is None and "b" not in mode:
+                encoding = "ascii"
+            return real_open(file, mode, *args, encoding=encoding, **kwargs)
+
+        return opener
+
+    def test_reads_non_ascii_domains_when_default_encoding_is_ascii(self) -> None:
+        with tempfile.NamedTemporaryFile("wb", suffix=".txt", delete=False) as f:
+            # "münchen-test.de" — ü is 0xc3 0xbc in UTF-8, undecodable as ASCII, just like the
+            # non-breaking space that shipped in generic_emails.txt during the incident.
+            f.write("gmail.com\nmünchen-test.de\n".encode())
+            emails_path = f.name
+        self.addCleanup(os.unlink, emails_path)
+
+        with (
+            patch("posthog.utils.get_absolute_path", return_value=emails_path),
+            patch("builtins.open", side_effect=self._ascii_default_open(open)),
+        ):
+            generic_emails = GenericEmails()
+
+        self.assertTrue(generic_emails.is_generic("someone@münchen-test.de"))
+
+    def test_shipped_generic_emails_file_loads_under_ascii_default(self) -> None:
+        with patch("builtins.open", side_effect=self._ascii_default_open(open)):
+            generic_emails = GenericEmails()
+
+        self.assertTrue(generic_emails.is_generic("someone@gmail.com"))


### PR DESCRIPTION
## Problem

Creating a new project within an existing organization is a fundamental user action, and a recent incident broke it. This PR adds regression coverage at two layers and answers a key question from the follow-up: *would a test have caught the incident before the image was promoted?*

**Why:** follow-up to a discussion about whether project creation should be part of pre-promotion smoke tests, and how a break this fundamental slipped through.

## Root cause of the incident (confirmed)

Every `POST /api/projects/` reaches `GenericEmails` via `get_or_create_internal_test_users_cohort` (called on every team creation), which read `posthog/helpers/generic_emails.txt` with `open()` and **no explicit encoding**. The file contained a UTF-8 non-breaking space (`atlanticbb.net\xc2\xa0`). Under nginx unit's embedded libpython on Python 3.13, the default text encoding is ASCII, so reading that byte raised `UnicodeDecodeError` → 500. Fixed in #62269 (`encoding="utf-8"` + cleaning the byte).

## Would the e2e test have caught it? — No (important finding)

The failure is **runtime-specific**, not a logic bug. The `python` CLI auto-enables UTF-8 mode under a `C` locale (PEP 540) and/or coerces the locale (PEP 538), so `open()` defaults to UTF-8 there. Only nginx unit's *embedded* interpreter — which doesn't apply that — defaulted to ASCII. CI and the e2e harness launch Python via the CLI, so they would have read the file as UTF-8 and **passed on the buggy code**. I verified this empirically on CPython 3.13.13: the byte only fails to decode with `PYTHONUTF8=0` under a `C` locale.

So the truly faithful catch is an **image-level smoke test** hitting the built container (which matches the original "should this be in pre-promotion smoke tests?" question). The Django test below is the fast in-process proxy for that.

## Changes

- **`posthog/test/test_utils.py` — fast regression guard (recommended).** Models the ASCII-default runtime in-process and exercises the real `GenericEmails` read. It **fails on the pre-fix `open()`** (`UnicodeDecodeError`) and passes with `encoding="utf-8"`, in ~1s with no DB. This is the "targeted Django-level test that would have failed" — verified by reverting the fix locally.
- **`playwright/e2e/project-creation.spec.ts` — functional e2e.** Guards the project-creation *flow* (modal → API → team switch) against logic/permission/UI regressions. It would not have caught *this* encoding incident (see above), but it covers the broader flow that the unit test cannot.
- **Workspace setup `available_features` option.** Creating a second project is gated by `organizations_projects` on both frontend (`guardAvailableFeature`) and backend (`PremiumMultiProjectPermission`); a fresh test org only has `access_control`, so the e2e test grants the feature.

## How did you test this code?

I'm an agent (PostHog Slack app).

- **Django regression test:** ran it on CPython 3.13.13 — passes (1.2s, no DB). Reverted `encoding="utf-8"` in `posthog/utils.py` and confirmed it fails with the exact incident error (`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3`), then restored the fix. `ruff check`/`format` pass.
- **Playwright spec:** could not run the full e2e stack in my environment, so it has **not** been executed or flake-checked — that runs in CI. Verified statically: `--list` discovery, scoped `tsc` (clean), `oxlint`/`oxfmt` pass, and selectors/flow/feature-gates/`Combobox.Item` role checked against source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) from a Slack thread: https://posthog.slack.com/archives/C0B8QBGF0UF/p1780980396492109?thread_ts=1780980396.492109&cid=C0B8QBGF0UF

Investigation: traced the incident to PR #62269, fetched the pre-fix file bytes to confirm the non-breaking space, and empirically reproduced the ASCII-default `UnicodeDecodeError` on 3.13.13. Key conclusion: the e2e test would *not* have caught this incident under normal CI (PEP 538/540 locale coercion applies to the python CLI but not nginx unit's embedded interpreter), so the durable, fast guard is the in-process Django test; an image smoke test would be the faithful end-to-end catch. The in-process test models the ASCII default by wrapping `open()` and injecting non-ASCII content, keeping it meaningful even though the shipped file is now clean ASCII.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
