### PR TITLE
fix(subscriptions): distinguish failed AI report queries from empty data

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
@@ -239,7 +239,10 @@ Format guidelines:
   data" can only be determined if the data explicitly establishes it — if it cannot (the events
   table only contains events that fired), say plainly that it can't be determined from the available
   data rather than guessing. Do NOT fabricate a list of inactive events.
-- If a query returned an error or no data, say so in one line and move on.
+- Distinguish query *errors* from *empty* data. A result block whose body reads "Query failed to
+  run …" means that query errored — report that the metric could not be computed this run, and do
+  NOT call it zero, empty, or "no data". Only say a metric has "no data" when a query actually ran and
+  returned no rows. Either way, keep it to one line and move on.
 - Keep it under ~400 words. Clarity over comprehensiveness.
 - Do not include raw SQL or implementation details.
 - This is a one-way scheduled email, not a conversation. Never address the reader with questions,

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -282,7 +282,12 @@ async def _run_steps(
             capture_exception(last_exc, {"trace_correlation_id": trace_correlation_id, "stage": "query"})
         # type only — ClickHouse errors can echo team-scoped identifiers
         type_name = type(last_exc).__name__ if last_exc is not None else "UnknownError"
-        return (f"### {safe_description}\n\n_Query failed: {type_name}_", False)
+        # Explicit failure marker, distinct from a genuinely-empty result, so synthesis reports the
+        # metric as "could not be computed" instead of paraphrasing the failure into "no data".
+        return (
+            f"### {safe_description}\n\n_Query failed to run ({type_name}) — metric not computed, not empty data._",
+            False,
+        )
 
     step_results: list[tuple[str, bool]] = await asyncio.gather(*(run_step(step) for step in spec.plan.steps))
     rendered = [text for text, _ in step_results]

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -59,7 +59,7 @@ _MAX_QUERY_FIX_RETRIES = 2
 _FIX_LLM_TIMEOUT_SECONDS = 30.0
 
 # Errors signalling "the query itself is wrong" — rewriting may help. Everything else (timeouts, infra
-# failures, generic exceptions) falls through to the "_Query failed_" placeholder without retrying,
+# failures, generic exceptions) falls through to the "_Query failed to run_" placeholder without retrying,
 # since a different SELECT won't fix a ClickHouse outage or a heartbeat timeout.
 _RETRYABLE_QUERY_ERRORS: tuple[type[BaseException], ...] = (
     MaxToolRetryableError,

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -90,7 +90,7 @@ async def test_degraded_report_still_synthesizes(
 ) -> None:
     # One step failed (failed_count=1) but the report still ships — graceful degradation.
     mock_bep.return_value = _spec(steps=1)
-    mock_run.return_value = (["### s0\n\n_Query failed: ExposedHogQLError_"], 1)
+    mock_run.return_value = (["### s0\n\n_Query failed to run (ExposedHogQLError) — metric not computed, not empty data._"], 1)
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Weekly report")
 
     result = await generate_ai_report(team=MagicMock(), user=MagicMock(), prompt="x", window_days=7)
@@ -168,7 +168,7 @@ async def test_run_steps_non_retryable_error_degrades_to_placeholder(mock_execut
     mock_executor_cls.return_value.arun_and_format_query = AsyncMock(side_effect=RuntimeError("boom"))
     rendered, failed = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), None)
     assert failed == 1
-    assert "_Query failed:" in rendered[0]
+    assert "Query failed to run" in rendered[0]
 
 
 @patch(f"{_RP}._arequest_hogql_fix", new_callable=AsyncMock)
@@ -196,7 +196,7 @@ async def test_run_steps_breaks_early_when_fix_returns_same_query(
     mock_fix.return_value = "SELECT 1"  # identical to QueryPlanStep.hogql in _spec()
     rendered, failed = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), None)
     assert failed == 1
-    assert "_Query failed:" in rendered[0]
+    assert "Query failed to run" in rendered[0]
     # Executor ran exactly once (no rerun of the identical fixed query); the fix was requested once.
     assert mock_executor_cls.return_value.arun_and_format_query.await_count == 1
     mock_fix.assert_awaited_once()

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -90,7 +90,10 @@ async def test_degraded_report_still_synthesizes(
 ) -> None:
     # One step failed (failed_count=1) but the report still ships — graceful degradation.
     mock_bep.return_value = _spec(steps=1)
-    mock_run.return_value = (["### s0\n\n_Query failed to run (ExposedHogQLError) — metric not computed, not empty data._"], 1)
+    mock_run.return_value = (
+        ["### s0\n\n_Query failed to run (ExposedHogQLError) — metric not computed, not empty data._"],
+        1,
+    )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Weekly report")
 
     result = await generate_ai_report(team=MagicMock(), user=MagicMock(), prompt="x", window_days=7)

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline_integration.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline_integration.py
@@ -78,4 +78,4 @@ class TestAIReportPipelineIntegration(ClickhouseTestMixin, NonAtomicBaseTest):
         report = await generate_ai_report(team=self.team, user=self.user, prompt="x", window_days=7)
 
         assert report == "# Degraded report"
-        assert "_Query failed" in captured["human"]
+        assert "Query failed to run" in captured["human"]


### PR DESCRIPTION
## Problem

When a planned query fails, the report degrades gracefully — the step renders a placeholder and the report still ships. But the placeholder was `_Query failed: <type>_`, and the synthesis LLM paraphrased it into a vague **"no data available"**. That conflated two very different things: a query **error** (a bug to fix) and a genuinely **empty** metric (a real finding). A reader couldn't tell which they were looking at — a failed query looked like the underlying data was simply zero.

```mermaid
flowchart TD
    STEP["query step"]
    STEP -->|"ran, returned rows"| DATA["real results"]
    STEP -->|"ran, 0 rows"| EMPTY["genuinely empty"]
    STEP -->|"errored"| FAIL["marker: 'Query failed to run (type)'"]
    DATA --> SYN["synthesis LLM"]
    EMPTY --> SYN
    FAIL --> SYN
    SYN --> OUT["report distinguishes:<br/>• errored → 'could not be computed'<br/>• empty → 'no data'"]
    classDef bad fill:#2d1417,stroke:#cf222e,color:#e8e8e8;
    class FAIL bad;
```

Before this PR the **errored** and **empty** branches both collapsed to "no data" at synthesis — so a real bug was indistinguishable from a real finding. This makes the failure marker explicit and teaches the synthesis prompt to keep the two apart.

## Changes

- Per-step failure now renders `Query failed to run (<type>) — metric not computed, not empty data`.
- The synthesis prompt distinguishes an **errored** query ("could not be computed this run") from a query that ran and returned **no rows** ("no data").
- Fixed a stale comment that still referenced the old `_Query failed_` placeholder.

Rendering/copy only — the degrade-but-ship resilience is unchanged.

## How did you test this code?

I'm an agent (Claude Code); I did not manually test. Automated only: `test_report_pipeline.py` (unit) + `test_report_pipeline_integration.py` (real HogQL — the degrade path produces the new marker) pass; `ruff` clean. (A later PR in the stack adds a guard test pinning that the placeholder phrase and the synthesis prompt stay in lockstep.)

## 🤖 Agent context

Authored with Claude Code. Found by dogfooding: digests reported "no data available" for metrics that were trivially queryable — synthesis was hiding query errors as if the data were empty. Scoped deliberately to the marker + synthesis copy so the existing graceful-degradation behavior is untouched.

Third of a 4-PR stack (← #62301).
