### PR TITLE
fix(ai): tell Slack chat agent to write standard Markdown

### DIFF
--- a/posthog/temporal/ai/slack_conversation.py
+++ b/posthog/temporal/ai/slack_conversation.py
@@ -221,9 +221,19 @@ async def process_slack_conversation_activity(inputs: SlackConversationRunnerWor
 
     is_new_conversation = created
 
-    # Join all Slack messages into a single HumanMessage
+    # Join all Slack messages into a single HumanMessage. The preamble on a new
+    # conversation steers the LLM toward standard Markdown — the reply is fed
+    # through `markdown_to_mrkdwn` before reaching Slack, so emitting Slack
+    # mrkdwn directly (e.g. `*<url|label>*`) tends to produce mangled output
+    # like `*<url*>` when the LLM gets the syntax slightly wrong.
     message_texts = (
-        ["_This conversation is in a Slack thread, using Slack's native Markdown._"] if is_new_conversation else []
+        [
+            "_This conversation is delivered via Slack. Write your responses in standard Markdown — "
+            "links as `[label](url)`, bold as `**text**`. Do not write Slack mrkdwn syntax such as "
+            "`<url|label>` or `*bold*`; the output is converted to Slack formatting automatically._"
+        ]
+        if is_new_conversation
+        else []
     )
     for msg in inputs.messages:
         username = msg.get("user", "Unknown")

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -125,6 +125,11 @@ class TestMarkdownToSlackMrkdwn(unittest.TestCase):
             ("horizontal_rule", "---", "──────────"),
             ("blockquote_preserved", "> quote", "> quote"),
             ("nested_bold_in_dash_list", "- **MIT** is permissive", "• *MIT* is permissive"),
+            (
+                "bold_link",
+                "**[pr-shepherd](https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd)**",
+                "*<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd|pr-shepherd>*",
+            ),
             ("plain_text_unchanged", "Hello world", "Hello world"),
             ("inline_code_preserved", "Use `git commit`", "Use `git commit`"),
         ]


### PR DESCRIPTION
## Problem

The `@PostHog` Slack bot occasionally produces broken Slack mrkdwn — most visibly, bolded links rendered as plain text with stray asterisks, e.g.

```
*<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd*>
```

Slack neither bolds nor links it because the closing `*` ended up _inside_ the angle brackets. The same agent in the same thread had emitted well-formed `*<url|label>*` moments earlier, so the syntax was being hand-rolled inconsistently.

The cause was the new-conversation human-message preamble in `posthog/temporal/ai/slack_conversation.py`, which told the LLM:

> _This conversation is in a Slack thread, using Slack's native Markdown._

That sentence opts the model out of standard Markdown and asks it to emit Slack mrkdwn directly. The output is then fed through `markdown_to_mrkdwn.SlackMarkdownConverter` anyway, so even when the LLM gets the syntax right, conversion can downgrade it (bold `*…*` is treated as Markdown italics and becomes `_…_`).

The library handles `**[label](url)**` → `*<url|label>*` correctly, so the right contract is standard Markdown in, Slack mrkdwn out — the agent should just write Markdown.

## Changes

- `posthog/temporal/ai/slack_conversation.py`: flip the new-conversation preamble to ask for standard Markdown and explicitly call out that Slack-shaped syntax (`<url|label>`, `*bold*`) is input-only — the output is converted automatically. Added a code comment explaining why the boundary matters.
- `products/tasks/backend/temporal/slack_relay/tests/test_activities.py`: add a `bold_link` case to the converter's parametrize table pinning `**[label](url)**` → `*<url|label>*`. The existing table had bold, plain links, and bold-in-lists, but not the combination that triggered this bug.

## How did you test this code?

Automated:

- Added the `bold_link` test case in `test_activities.py` and ran `pytest products/tasks/backend/temporal/slack_relay/tests/test_activities.py::TestMarkdownToSlackMrkdwn` — all 21 cases pass.
- Reproduced the converter's behaviour against several candidate LLM outputs in a REPL to confirm the library produces correct Slack mrkdwn from standard Markdown and that the previously observed mangling can only come from the LLM emitting broken Slack syntax directly.

Manual: not performed. Recommend a smoke test in the dev Slack workspace — `@PostHog link to the pr-shepherd skill in the skill store` (the exact prompt from the original thread) — should now render as a clickable, bolded link. Also worth a follow-up reply in the same thread to confirm the agent carries the instruction past the new-conversation preamble; if it forgets on follow-ups, we'd promote the instruction to a Slack-only system-prompt addition.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Investigation traced the bug from the broken Slack output through the relay converter (`_markdown_to_slack_mrkdwn`) and the chat-agent invocation site to the preamble line. The converter and the shared chat-agent system prompt (`ee/hogai/chat_agent/prompts/base.py`) were both ruled out — the converter handles the canonical Markdown shapes correctly, and the system prompt already asks for "light Markdown formatting", so the Slack-only override was the actual signal the LLM was following.

Two alternatives were considered and deferred: (1) sanitising inbound thread text from Slack mrkdwn back to Markdown before the LLM sees it (cleaner long-term but a larger behaviour change), and (2) hardening the converter against malformed Slack mrkdwn input (papers over the prompt rather than fixing it). If the agent forgets the instruction across follow-up turns in a thread, the natural next step is to move the guidance into a Slack-gated system prompt addition rather than the human-message preamble.