### PR TITLE
chore(signals): refine health-checks scout from review + dogfooding

### DIFF
--- a/products/signals/skills/signals-scout-health-checks/SKILL.md
+++ b/products/signals/skills/signals-scout-health-checks/SKILL.md
@@ -41,6 +41,15 @@ been active across several runs (not auto-resolved) is real; one that flickers a
 is transient noise. Internalize that shape — re-emitting one signal per issue is exactly the
 noise this scout exists to avoid.
 
+**Calibration (dogfooded on a real high-volume project).** A live project with ~180 active
+issues collapsed to ~4 findings under this logic. Most of a ~95-issue `external_data_failure`
+set reduced to a few shared causes — one invalidated replication slot behind many syncs, a
+date-partitioned source regenerating the same "table not found" failure daily — and much of an
+~80-issue `materialized_view_failure` set was abandoned personal dev models nobody will fix.
+Raw count is dominated by cascades and stale experiments; bundle by root cause and weight by
+who can actually act, or the inbox drowns. This is the discriminator working as intended, not
+an edge case.
+
 ## Quick close-out: is anything actually wrong?
 
 Call `health-issues-summary` first — it returns total active non-dismissed issues plus
@@ -77,7 +86,11 @@ Cycle between these moves; skip what's not useful.
 
 ### Severity-to-kind cheat sheet
 
-The checks set severity; use it as a starting prior, then adjust by real impact.
+The checks set severity; use it as a starting prior, then adjust by real impact. This table is
+**illustrative, not exhaustive** — the live `health-issues-summary` is the source of truth for
+which kinds are actually firing, and new check kinds appear over time without this list being
+updated. Treat an unfamiliar kind on its own terms (read the payload + `remediation`) rather
+than assuming it's absent because it isn't here.
 
 | Kind                        | Typical severity | What it means / how to weight                                           |
 | --------------------------- | ---------------- | ----------------------------------------------------------------------- |
@@ -190,16 +203,17 @@ Write scratchpad entries continuously, encoding the category in the key prefix:
   - `finding_id` — a stable trace id (`<topic>-<entity>-<date>`), **not** a dedupe key:
     re-emitting the same id creates a second signal, so never retry an emit that may already
     have succeeded.
-  - `dedupe_keys`: `health_issue:<issue_id>` for a single issue and/or
-    `health_check_kind:<kind>` for a whole-kind cluster. For a sub-type or cascade bundle,
-    key on the **root cause** so future runs group on the cause, not the symptoms — e.g.
-    `ingestion_warning_type:client_ingestion_warning` or
-    `external_data_slot:posthog_019e51352190`. Add per-entity keys for the few ids you name
-    in the description.
+  - `dedupe_keys`: health issues already carry stable, deduplicated ids, so don't add a
+    per-issue key just to restate `issue_id` — cite it in evidence and move on. Reserve
+    `dedupe_keys` for the grouping the checks _don't_ do: a whole-kind cluster
+    (`health_check_kind:<kind>`), or a shared root cause behind many issues keyed on the
+    **cause** so future runs group on it, not the symptoms — e.g.
+    `ingestion_warning_type:<warning_type>` or `external_data_slot:<slot_id>`. A single issue
+    needs no dedupe key at all.
   - `severity`: map check severity to the emit scale — `critical` → P1 (P0 only for confirmed
     active data loss like `no_live_events` with zero recent capture), `warning` → P2–P3.
   - `evidence`: cite issue ids from the health-issues payloads and any corroborating
-    `query_runs` / `error_tracking` / `web_analytics` reads.
+    `query_runs` / `web_analytics` reads.
 - **Remember** below the bar but worth carrying forward (write the matching `dedupe:` /
   `noise:` entry).
 - **Skip** if a `dedupe:` / `noise:` / `addressed:` entry already covers it.


### PR DESCRIPTION
## Problem

Follow-up to #62289 (the `signals-scout-health-checks` scout). Review on that PR raised a few
concrete refinements, and before acting on them we dogfooded the scout's playbook read-only
against a real high-volume project to ground the decisions in actual data rather than taste.

## Changes

Small, content-only edits to `signals-scout-health-checks/SKILL.md`:

- **Trust the issue id for dedupe.** Health issues already carry stable, deduplicated ids, so
  the per-issue `dedupe_key` was redundant. Reserve `dedupe_keys` for the grouping the checks
  _don't_ do — whole-kind clusters and shared root causes (cascades) — and skip a key entirely
  for a lone issue. Also drops a real internal slot id that had leaked into the example in favour
  of a `<slot_id>` placeholder.
- **Drop `error_tracking` from the evidence example.** It isn't a meaningful corroborating source
  for setup-health findings.
- **Flag the severity-to-kind cheat sheet as illustrative, not exhaustive.** The live
  `health-issues-summary` is the source of truth for which kinds fire; new kinds appear without
  this table being updated, so an unfamiliar kind should be judged on its payload + remediation
  rather than assumed absent.
- **Add a calibration note from the dogfooding** so the selectivity rationale is grounded in a
  real example rather than asserted.

## How did you test this code?

I'm an agent (Claude Code). No manual UI testing. What I actually ran:

- `hogli lint:skills` — passes (69 skills).
- A read-only dogfood of the scout's playbook against a real high-volume project via the MCP
  health-issues tools (`health-issues-summary` / `-list` / `-get`), emitting nothing. The
  project had ~180 active issues across three kinds; following the bundle-by-root-cause logic
  collapsed them to ~4 actionable findings. The run confirmed the design's core assumption —
  raw issue count is dominated by cascades (one upstream cause behind many failing syncs) and
  stale/abandoned dev models — and surfaced the three refinements above. That observation is
  captured generically in the new calibration note.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Starting point was unaddressed review feedback on #62289
(from a human reviewer plus the automated reviewers). Rather than act on the comments blind, we
ran the scout's playbook read-only against a real project to see the behaviour in practice, then
made only the edits the data supported. The reviewer's broader "why be selective at all?"
question is intentionally **not** resolved here — the dogfooding supports keeping bundling and
agent-fixability triage (most failures in the sample were credential-gated or abandoned
experiments an agent can't fix), so that thread is left for human discussion rather than folded
into a content change. Internal project specifics (pipeline names, employee-owned models, infra
ids) are deliberately kept out of both the skill and this description.
