### PR TITLE
fix(tasks): repair Slack mrkdwn link markers misplaced inside angle brackets

### DIFF
--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -18,6 +18,17 @@ _RE_FENCE = re.compile(r"^\s*(```|~~~)")
 _RE_INLINE_MARKDOWN_MARKERS = re.compile(r"\*\*|__|\*|_|~~|`")
 _RE_MD_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
+# Repair pattern: bold/italic markers placed *inside* the close of a Slack-style
+# angle-bracket link, e.g. ``**<https://example.com**>`` instead of
+# ``**<https://example.com>**``. The agent hand-rolls Slack mrkdwn occasionally
+# and types the closing marker before ``>``; the standard converter has no way
+# to recover, so the asterisks end up adjacent to ``>`` in the final output and
+# Slack renders neither the bold nor the link. The flanking lookbehind/lookahead
+# require the opening and closing marker runs to be balanced — they refuse to
+# half-match a longer asterisk run, so unbalanced edge cases like ``**<url*>``
+# are left alone rather than silently rewritten into a different broken shape.
+_RE_LINK_TRAILING_MARKER = re.compile(r"(?<![*_~])(\*+|_+|~+)<([^<>]+?)\1>(?![*_~])")
+
 
 class _RelayAlreadyRecorded(Exception):
     """Raised when a relay was already recorded while holding the row lock."""
@@ -29,10 +40,24 @@ def _markdown_to_slack_mrkdwn(text: str) -> str:
     Tables are pre-converted to fenced code blocks before the library runs because
     Slack ``mrkdwn`` is rendered in a proportional font — pipe-separated rows do
     not line up. A fenced code block forces monospace and the columns align.
+
+    Misplaced link markers (e.g. ``**<url**>``) are normalized first so the
+    converter sees well-formed input.
     """
     if not text:
         return text
-    return _CONVERTER.convert(_tables_to_fenced_code_blocks(text))
+    return _CONVERTER.convert(_tables_to_fenced_code_blocks(_repair_link_trailing_markers(text)))
+
+
+def _repair_link_trailing_markers(text: str) -> str:
+    """Move emphasis markers from inside a Slack-style link close to outside.
+
+    Handles ``**<url**>``/``*<url*>``/``_<url_>`` (and the ``<url|label>``
+    variants) by relocating the closing marker after ``>``. The negated
+    character class stops the match at the next ``<`` or ``>``, so adjacent
+    links don't cross-contaminate.
+    """
+    return _RE_LINK_TRAILING_MARKER.sub(r"\1<\2>\1", text)
 
 
 def _tables_to_fenced_code_blocks(text: str) -> str:

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -18,6 +18,7 @@ from products.tasks.backend.temporal.slack_relay.activities import (
     SLACK_MESSAGE_TEXT_LIMIT,
     RelaySlackMessageInput,
     _markdown_to_slack_mrkdwn,
+    _repair_link_trailing_markers,
     _split_markdown_for_slack,
     relay_slack_message,
 )
@@ -125,6 +126,25 @@ class TestMarkdownToSlackMrkdwn(unittest.TestCase):
             ("horizontal_rule", "---", "──────────"),
             ("blockquote_preserved", "> quote", "> quote"),
             ("nested_bold_in_dash_list", "- **MIT** is permissive", "• *MIT* is permissive"),
+            (
+                "bold_markdown_link",
+                "**[pr-shepherd](https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd)**",
+                "*<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd|pr-shepherd>*",
+            ),
+            # Agent emits double-asterisk closing markers inside the angle brackets
+            # (`**<url**>`). Without the repair pass the converter would halve those
+            # asterisks in place and produce `*<url*>`, which Slack renders as
+            # literal text with no link and no bold.
+            (
+                "agent_typo_double_asterisk_autolink",
+                "**<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd**>",
+                "*<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd>*",
+            ),
+            (
+                "agent_typo_double_asterisk_labeled_link",
+                "**<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd|pr-shepherd**>",
+                "*<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd|pr-shepherd>*",
+            ),
             ("plain_text_unchanged", "Hello world", "Hello world"),
             ("inline_code_preserved", "Use `git commit`", "Use `git commit`"),
         ]
@@ -156,6 +176,34 @@ class TestMarkdownToSlackMrkdwn(unittest.TestCase):
         md = "| a | b |\n| c | d |"
         result = _markdown_to_slack_mrkdwn(md)
         assert "```" not in result
+
+
+class TestRepairLinkTrailingMarkers(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("autolink_double_asterisk", "**<https://x.com**>", "**<https://x.com>**"),
+            ("autolink_single_asterisk", "*<https://x.com*>", "*<https://x.com>*"),
+            ("autolink_underscore", "_<https://x.com_>", "_<https://x.com>_"),
+            ("autolink_strikethrough", "~<https://x.com~>", "~<https://x.com>~"),
+            (
+                "labeled_link_double_asterisk",
+                "**<https://x.com|label**>",
+                "**<https://x.com|label>**",
+            ),
+            (
+                "two_broken_links_in_one_line",
+                "**<https://a.com**> and **<https://b.com**>",
+                "**<https://a.com>** and **<https://b.com>**",
+            ),
+            ("well_formed_autolink_unchanged", "**<https://x.com>**", "**<https://x.com>**"),
+            ("plain_text_unchanged", "Hello world", "Hello world"),
+            # Mismatched openers/closers shouldn't be rewritten — leave alone so we
+            # don't silently corrupt content that looks vaguely link-shaped.
+            ("mismatched_markers_unchanged", "**<https://x.com*>", "**<https://x.com*>"),
+        ]
+    )
+    def test_repair(self, _name, text, expected):
+        assert _repair_link_trailing_markers(text) == expected
 
 
 class TestSplitTextForSlack(TestCase):


### PR DESCRIPTION
## Problem

The `@PostHog` Slack bot occasionally renders bolded links as broken text with a stray `*` — e.g. `*<https://…/pull/123*>` instead of a clean bolded clickable link. It's a recurring complaint ([papercuts thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1780667562658769), [Charles](https://posthog.slack.com/archives/C09SK2PAGKF/p1780631381914569), [Ian](https://posthog.slack.com/archives/C09K2HHN1GH/p1780618225903999), [Joshua](https://posthog.slack.com/archives/C09SK2PAGKF/p1780630093052779)) and shows up most reliably on the PR-completion message that posts the new PR link.

The agent emits Slack mrkdwn by hand and sometimes types the closing bold/italic marker *inside* the angle brackets: `**<url**>` instead of `**<url>**`. The `markdown_to_mrkdwn` converter halves the run in place, leaving `*<url*>`, which Slack renders as plain text with a stray `*` jammed onto the URL.

## Changes

- `products/tasks/backend/temporal/slack_relay/activities.py`: add `_repair_link_trailing_markers`, invoked from `_markdown_to_slack_mrkdwn` before the converter runs. Detects balanced bold/italic/strike markers placed inside a Slack-style link close and moves them outside. Flanking lookbehind/lookahead keep it conservative — unbalanced edge cases are left alone.
- `products/tasks/backend/temporal/slack_relay/tests/test_activities.py`: parametrize block for the repair helper plus end-to-end converter cases pinning the agent-typo shapes.

## How did you test this code?

- `pytest products/tasks/backend/temporal/slack_relay/tests/test_activities.py::TestMarkdownToSlackMrkdwn ::TestRepairLinkTrailingMarkers` — 32 cases pass.
- Tested end-to-end on local: asked the bot to open a small PR and confirmed the completion message renders as a clean bolded clickable link with no stray `*`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with Claude Code (Opus 4.7).