### PR TITLE
feat(error-tracking): show pending recommendations count on tab

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -131,8 +131,6 @@ export function ErrorTrackingScene(): JSX.Element {
     )
 }
 
-// Mounting this label keeps recommendationsTabLogic active on every error tracking tab,
-// so the pending count is fetched even when the Recommendations tab isn't open.
 const RecommendationsTabLabel = (): JSX.Element => {
     const { activeRecommendations, recommendationsLoading } = useValues(recommendationsTabLogic)
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { LemonBanner, LemonButton, LemonTab, LemonTabs, Link } from '@posthog/lemon-ui'
+import { LemonBadge, LemonBanner, LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -34,6 +34,7 @@ import { IssuesFilters } from './tabs/issues/IssuesFilters'
 import { IssuesList } from './tabs/issues/IssuesList'
 import { SourceMapsBanner } from './tabs/issues/SourceMapsBanner'
 import { RecommendationsTab } from './tabs/recommendations/RecommendationsTab'
+import { recommendationsTabLogic } from './tabs/recommendations/recommendationsTabLogic'
 
 const ERROR_TRACKING_ALERT_FILTER_GROUPS: CyclotronJobFiltersType[] = [
     { events: [{ id: '$error_tracking_issue_created', type: 'events' }] },
@@ -94,7 +95,7 @@ export function ErrorTrackingScene(): JSX.Element {
             ? [
                   {
                       key: 'recommendations' as const,
-                      label: 'Recommendations',
+                      label: <RecommendationsTabLabel />,
                       content: <RecommendationsTab />,
                   },
               ]
@@ -127,6 +128,23 @@ export function ErrorTrackingScene(): JSX.Element {
                 </BindLogic>
             </BindLogic>
         </StyleVariables>
+    )
+}
+
+// Mounting this label keeps recommendationsTabLogic active on every error tracking tab,
+// so the pending count is fetched even when the Recommendations tab isn't open.
+const RecommendationsTabLabel = (): JSX.Element => {
+    const { activeRecommendations, recommendationsLoading } = useValues(recommendationsTabLogic)
+
+    return (
+        <span className="flex items-center gap-1.5">
+            Recommendations
+            {recommendationsLoading ? (
+                <LemonBadge size="small" content={<Spinner textColored />} />
+            ) : (
+                <LemonBadge.Number count={activeRecommendations.length} size="small" />
+            )}
+        </span>
     )
 }
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -140,7 +140,7 @@ const RecommendationsTabLabel = (): JSX.Element => {
             {recommendationsLoading ? (
                 <LemonBadge size="small" content={<Spinner textColored />} />
             ) : (
-                <LemonBadge.Number count={activeRecommendations.length} size="small" />
+                <LemonBadge.Number count={activeRecommendations.length} size="small" showZero />
             )}
         </span>
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
@@ -75,8 +75,6 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
             },
         ],
         recommendationsLoading: [
-            // Starts true because the logic always loads on mount; keeps the tab's count
-            // badge a constant-width spinner from first paint instead of expanding in late.
             true,
             {
                 setRecommendationsLoading: (_, { loading }) => loading,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
@@ -75,7 +75,9 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
             },
         ],
         recommendationsLoading: [
-            false,
+            // Starts true because the logic always loads on mount; keeps the tab's count
+            // badge a constant-width spinner from first paint instead of expanding in late.
+            true,
             {
                 setRecommendationsLoading: (_, { loading }) => loading,
             },


### PR DESCRIPTION
Adds count of active recommendations to the recs tab


https://github.com/user-attachments/assets/3e6bc833-7777-4377-b706-dfaf4c1a6ac5

