### PR TITLE
feat(signals): let scouts create notebooks (notebook:write)

### DIFF
--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -31,6 +31,19 @@ SCOUT_INTERNAL_SCOPES: list[str] = [
 ]
 
 
+# A deliberately narrow set of user-facing WRITE scopes granted to the Signals scout
+# sandbox so scouts can produce durable artifacts as part of a finding — e.g. a notebook
+# that documents and illustrates an emitted anomaly. Unlike `SCOUT_INTERNAL_SCOPES` these
+# are ordinary public scopes (also present in the `full` preset), but they are added to the
+# scout posture ONLY on the `signals_scout` branch below, never via the global
+# `INTERNAL_SCOPES`, so `read_only` task tokens stay strictly read-only. Keep this list
+# small: every entry is real write access an autonomous scout can exercise unattended, so
+# add a scope here only when a scout genuinely needs to create that kind of artifact.
+SCOUT_USER_WRITE_SCOPES: list[str] = [
+    "notebook:write",
+]
+
+
 # Derived from posthog.scopes so the token issued to a sandboxed agent cannot
 # drift out of subset of what the MCP server advertises in
 # `services/mcp/src/lib/oauth-scopes.generated.ts` (itself generated from
@@ -63,14 +76,16 @@ def resolve_scopes(scopes: PosthogMcpScopes = "read_only", *, include_internal_s
         if scopes == "full":
             resolved = [*MCP_READ_SCOPES, *MCP_WRITE_SCOPES, *internal]
         elif scopes == "signals_scout":
-            # The scout sandbox: reads + the scout's own internal write scope. The internal
-            # scout-write scope is added ONLY here (not via the global `INTERNAL_SCOPES`), so
-            # unrelated `full`/`read_only` task tokens never carry scout write access.
-            # `has_write_scopes("signals_scout")` also reports True so the MCP server doesn't
-            # enable read-only mode, which would otherwise strip the agent's own internal-write
-            # tools (`signal_scout_internal:write` is annotated as not-read-only).
+            # The scout sandbox: reads, the scout's own internal write scope, and a narrow
+            # allowlist of user-facing writes (`SCOUT_USER_WRITE_SCOPES`) for the durable
+            # artifacts a finding can produce (e.g. a notebook). Both extra sets are added
+            # ONLY here (not via the global `INTERNAL_SCOPES`), so unrelated `full`/`read_only`
+            # task tokens never carry them. `has_write_scopes("signals_scout")` also reports
+            # True so the MCP server doesn't enable read-only mode, which would otherwise strip
+            # the agent's own internal-write tools (`signal_scout_internal:write` is annotated
+            # as not-read-only).
             scout_internal = list(SCOUT_INTERNAL_SCOPES) if include_internal_scopes else []
-            resolved = [*MCP_READ_SCOPES, *internal, *scout_internal]
+            resolved = [*MCP_READ_SCOPES, *internal, *scout_internal, *SCOUT_USER_WRITE_SCOPES]
         else:
             # "read_only": reads + shared internal scopes only — no scout write scope.
             resolved = [*MCP_READ_SCOPES, *internal]

--- a/posthog/temporal/oauth.py
+++ b/posthog/temporal/oauth.py
@@ -39,6 +39,12 @@ SCOUT_INTERNAL_SCOPES: list[str] = [
 # `INTERNAL_SCOPES`, so `read_only` task tokens stay strictly read-only. Keep this list
 # small: every entry is real write access an autonomous scout can exercise unattended, so
 # add a scope here only when a scout genuinely needs to create that kind of artifact.
+# NOTE: scopes here are object-level, not tool-level. `notebook:write` also exposes the
+# `notebooks-destroy` / `notebooks-partial-update` MCP tools, not just `notebooks-create`,
+# so in principle a scout (or a prompt-injected run) could modify or soft-delete existing
+# notebooks in its own project. Accepted as low-risk for now — the token is scoped to a
+# single team, destroy is a recoverable soft-delete, and emits are rare — and monitored in
+# practice; tool-level (create-only) restriction isn't cheap in the current sandbox wiring.
 SCOUT_USER_WRITE_SCOPES: list[str] = [
     "notebook:write",
 ]
@@ -98,9 +104,10 @@ def has_write_scopes(scopes: PosthogMcpScopes) -> bool:
     if isinstance(scopes, str):
         # `signals_scout` reports True so the MCP server doesn't enable read-only mode for
         # the harness sandbox — the agent IS allowed to call its own internal-write tools
-        # (remember, forget, emit_finding) even though it has no user-facing write scopes.
-        # Read-only mode is a tool-annotation filter, not a scope filter, and would strip
-        # those tools categorically without this opt-out.
+        # (remember, forget, emit_finding) as well as the narrow user-facing writes in
+        # `SCOUT_USER_WRITE_SCOPES` (e.g. `notebook:write`). Read-only mode is a
+        # tool-annotation filter, not a scope filter, and would strip those tools
+        # categorically without this opt-out.
         return scopes in ("full", "signals_scout")
     return any(s in MCP_WRITE_SCOPES for s in scopes)
 

--- a/posthog/temporal/tests/test_oauth.py
+++ b/posthog/temporal/tests/test_oauth.py
@@ -45,15 +45,26 @@ class TestResolveScopes(SimpleTestCase):
         assert "signal_scout_internal:write" not in resolve_scopes(["feature_flag:read"])
         assert "signal_scout_internal:write" in resolve_scopes("signals_scout")
 
-    def test_scout_user_write_allowlist_isolated_from_read_only_tokens(self) -> None:
+    @parameterized.expand([(scope,) for scope in SCOUT_USER_WRITE_SCOPES])
+    def test_scout_user_write_allowlist_isolated_from_read_only_tokens(self, scope: str) -> None:
         # The scout's user-facing write allowlist (e.g. `notebook:write`) must reach the
         # `signals_scout` preset but NOT leak onto read-only task tokens. It legitimately
         # appears in `full` (which carries every MCP write scope) — that is expected and is
         # not what this invariant guards.
-        for scope in SCOUT_USER_WRITE_SCOPES:
-            assert scope in resolve_scopes("signals_scout")
-            assert scope not in resolve_scopes("read_only")
-            assert scope not in resolve_scopes(["feature_flag:read"])
+        assert scope in resolve_scopes("signals_scout")
+        assert scope not in resolve_scopes("read_only")
+        assert scope not in resolve_scopes(["feature_flag:read"])
+
+    def test_signals_scout_user_write_allowlist_ignores_internal_scopes_flag(self) -> None:
+        # `SCOUT_USER_WRITE_SCOPES` are ordinary public scopes, not internal ones, so they
+        # are granted to the scout posture independently of `include_internal_scopes`.
+        # Dropping internal scopes still strips the scout's own internal write scope.
+        result = resolve_scopes("signals_scout", include_internal_scopes=False)
+        assert set(result) == set(MCP_READ_SCOPES + SCOUT_USER_WRITE_SCOPES)
+        assert "notebook:write" in result
+        assert "signal_scout_internal:write" not in result
+        for scope in INTERNAL_SCOPES:
+            assert scope not in result
 
     def test_custom_scopes(self) -> None:
         custom = ["feature_flag:read", "feature_flag:write"]

--- a/posthog/temporal/tests/test_oauth.py
+++ b/posthog/temporal/tests/test_oauth.py
@@ -7,6 +7,7 @@ from posthog.temporal.oauth import (
     MCP_READ_SCOPES,
     MCP_WRITE_SCOPES,
     SCOUT_INTERNAL_SCOPES,
+    SCOUT_USER_WRITE_SCOPES,
     has_write_scopes,
     resolve_scopes,
 )
@@ -26,11 +27,13 @@ class TestResolveScopes(SimpleTestCase):
         assert set(result) == set(MCP_READ_SCOPES + MCP_WRITE_SCOPES + INTERNAL_SCOPES)
 
     def test_signals_scout_preset_adds_scout_internal_write(self) -> None:
-        # `signals_scout` = `read_only` content PLUS the scout's own internal write scope.
-        # No user-facing write scopes (`action:write`) leak in.
+        # `signals_scout` = `read_only` content PLUS the scout's own internal write scope
+        # PLUS the narrow user-facing write allowlist (`SCOUT_USER_WRITE_SCOPES`). No other
+        # user-facing write scopes (e.g. `action:write`) leak in.
         result = resolve_scopes("signals_scout")
-        assert set(result) == set(MCP_READ_SCOPES + INTERNAL_SCOPES + SCOUT_INTERNAL_SCOPES)
+        assert set(result) == set(MCP_READ_SCOPES + INTERNAL_SCOPES + SCOUT_INTERNAL_SCOPES + SCOUT_USER_WRITE_SCOPES)
         assert "signal_scout_internal:write" in result
+        assert "notebook:write" in result
         assert "action:write" not in result
 
     def test_scout_internal_write_only_on_signals_scout_preset(self) -> None:
@@ -41,6 +44,16 @@ class TestResolveScopes(SimpleTestCase):
         assert "signal_scout_internal:write" not in resolve_scopes("read_only")
         assert "signal_scout_internal:write" not in resolve_scopes(["feature_flag:read"])
         assert "signal_scout_internal:write" in resolve_scopes("signals_scout")
+
+    def test_scout_user_write_allowlist_isolated_from_read_only_tokens(self) -> None:
+        # The scout's user-facing write allowlist (e.g. `notebook:write`) must reach the
+        # `signals_scout` preset but NOT leak onto read-only task tokens. It legitimately
+        # appears in `full` (which carries every MCP write scope) — that is expected and is
+        # not what this invariant guards.
+        for scope in SCOUT_USER_WRITE_SCOPES:
+            assert scope in resolve_scopes("signals_scout")
+            assert scope not in resolve_scopes("read_only")
+            assert scope not in resolve_scopes(["feature_flag:read"])
 
     def test_custom_scopes(self) -> None:
         custom = ["feature_flag:read", "feature_flag:write"]

--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -238,13 +238,14 @@ async def _spawn_and_run(
         user_id=user_id,
         repository=repository,
         sandbox_environment_id=sandbox_env_id,
-        # `signals_scout` is the harness's own scope posture: same scope content as
-        # `read_only` (project reads + INTERNAL_SCOPES, including
-        # `signal_scout_internal:write`) but reports `has_write_scopes=True` so the
-        # MCP server doesn't enable read-only-mode tool filtering. Without that
-        # opt-out, the MCP layer would categorically strip every tool annotated
-        # `readOnlyHint: false` — including the agent's own `remember`, `forget`,
-        # and `emit_finding` tools — even though the OAuth token does carry the
+        # `signals_scout` is the harness's own scope posture: project reads +
+        # INTERNAL_SCOPES + the scout's `signal_scout_internal:write`, plus a narrow
+        # allowlist of user-facing writes (`SCOUT_USER_WRITE_SCOPES`, e.g.
+        # `notebook:write`) so a finding can produce a durable artifact. It reports
+        # `has_write_scopes=True` so the MCP server doesn't enable read-only-mode tool
+        # filtering. Without that opt-out, the MCP layer would categorically strip every
+        # tool annotated `readOnlyHint: false` — including the agent's own `remember`,
+        # `forget`, and `emit_finding` tools — even though the OAuth token does carry the
         # right scope to call them.
         posthog_mcp_scopes="signals_scout",
     )


### PR DESCRIPTION
## Problem

Signals scouts run in a sandbox whose OAuth token is minted from the `signals_scout` scope preset — project reads plus the scout's own `signal_scout_internal:write` (scratchpad + emit). That posture is read-only for every user-facing object, so a scout cannot produce any durable, human-readable artifact alongside a finding.

A recurring ask is for scouts to **document and illustrate a finding as a PostHog notebook** — e.g. the anomaly-detection scout writing up an emitted anomaly with a narrative and an embedded insight chart, so the human who picks up the inbox report lands on a self-contained explainer instead of reconstructing the analysis. This is broadly useful across the fleet, not just one scout.

The blocker was purely the scope: `notebooks-create` is already a globally-enabled MCP tool (`notebook:write`), the scout sandbox already exposes the full scope-gated MCP surface, and read-only-mode tool filtering is already disabled for the scout posture. The only thing missing was the write scope itself.

## Changes

- Add `SCOUT_USER_WRITE_SCOPES = ["notebook:write"]` in `posthog/temporal/oauth.py` and include it **only** on the `signals_scout` branch of `resolve_scopes()`. This is a deliberately narrow, named allowlist of user-facing writes that the autonomous scout may exercise — kept out of the global `INTERNAL_SCOPES`, so `read_only` and `full` task tokens are unchanged (`full` already carries `notebook:write` via the all-writes set; `read_only` still gets nothing).
- Update the scope-posture comment in `scout_harness/runner.py` to reflect the new allowlist.
- Tests: extend `test_signals_scout_preset_adds_scout_internal_write` to pin the new scope set, and add `test_scout_user_write_allowlist_isolated_from_read_only_tokens` to guard the isolation invariant (reaches `signals_scout`, never `read_only` / arbitrary custom tokens).

This is platform enablement only — it makes notebook creation *possible* for scouts. Teaching a specific scout to actually create the notebook on emit is per-skill SKILL.md work (the anomaly-detection scout is the first intended adopter) and will follow separately via the authoring-signals-scouts flow.

### Why this is low-risk
- `notebook:write` is an ordinary public scope (already in the `full` preset), not a privileged internal one.
- The scout token is `scoped_teams=[team_id]`, so notebooks land in the scout's own project.
- Emits are rare and high-bar (most runs close out empty), so notebook volume stays naturally low — no spam vector.
- It is the **first user-facing write scope** handed to the scout sandbox, so it's introduced as an explicit, named, isolated allowlist rather than a broad grant — adding future artifact scopes is a conscious one-line decision.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated unit tests for the changed module:

- `hogli test posthog/temporal/tests/test_oauth.py` → 19 passed (covers the new scope set and the isolation invariant).
- `ruff check` / `ruff format` clean; lint-staged (`uv run ty check`) passed on commit.

No manual end-to-end scout run was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored by Claude Code (Opus) at Andy's direction. We started by exploring how the anomaly-detection scout runs (config/runs/scratchpad/body via the PostHog MCP `signals-scout-*` tools), then investigated whether a scout could create a notebook given its scopes.

Key decision: an initial sub-investigation suggested two changes were needed (add the scope **and** register `notebooks-create` in `products/signals/mcp/tools.yaml`). On verifying against `oauth.py`, the scout's `runner.py` sandbox wiring, and the notebooks `tools.yaml`, the second turned out to be unnecessary — the scout consumes the full scope-gated MCP (it already calls `insight-query`, `execute-sql`, etc., none of which live in the signals tools.yaml), and `notebooks-create` is globally enabled. So the PR is a single, isolated scope grant. Modelled the new constant and its isolation test on the existing `SCOUT_INTERNAL_SCOPES` pattern.
