### PR TITLE
fix(onboarding): use correct unit for plan card data retention

### DIFF
--- a/frontend/src/scenes/onboarding/billing/PlanCards.test.ts
+++ b/frontend/src/scenes/onboarding/billing/PlanCards.test.ts
@@ -1,0 +1,31 @@
+import { BillingFeatureType } from '~/types'
+
+import { formatDataRetentionFeature } from './PlanCards'
+
+describe('formatDataRetentionFeature', () => {
+    const makeFeature = (limit?: number | null, unit?: string | null): BillingFeatureType =>
+        ({ key: 'session_replay_data_retention', name: 'Data retention', limit, unit }) as BillingFeatureType
+
+    // pluralize() joins the count and unit with a non-breaking space (U+00A0); normalize it for readable assertions.
+    const normalize = (value: string | null): string | null =>
+        value ? value.split(String.fromCharCode(160)).join(' ') : null
+
+    it.each([
+        // Analytics retention is supplied in years; session replay in months. Both must read naturally.
+        [7, 'years', '7 years data retention'],
+        [1, 'year', '1 year data retention'],
+        [3, 'months', '3 months data retention'],
+        [1, 'month', '1 month data retention'],
+        [90, 'days', '90 days data retention'],
+    ])('formats limit %s with unit "%s" as "%s"', (limit, unit, expected) => {
+        expect(normalize(formatDataRetentionFeature(makeFeature(limit, unit)))).toBe(expected)
+    })
+
+    it.each([
+        ['feature is undefined', undefined],
+        ['limit is missing', makeFeature(undefined, 'years')],
+        ['unit is missing', makeFeature(7, undefined)],
+    ])('returns null when %s', (_, feature) => {
+        expect(formatDataRetentionFeature(feature as BillingFeatureType | undefined)).toBe(null)
+    })
+})

--- a/frontend/src/scenes/onboarding/billing/PlanCards.tsx
+++ b/frontend/src/scenes/onboarding/billing/PlanCards.tsx
@@ -15,7 +15,7 @@ import { billingLogic } from 'scenes/billing/billingLogic'
 import { billingProductLogic } from 'scenes/billing/billingProductLogic'
 import { paymentEntryLogic } from 'scenes/billing/paymentEntryLogic'
 
-import { type BillingProductV2Type, OnboardingStepKey } from '~/types'
+import { type BillingFeatureType, type BillingProductV2Type, OnboardingStepKey } from '~/types'
 
 import { onboardingLogic } from '../onboardingLogic'
 import { FreeTierLimits } from './FreeTierLimits'
@@ -51,6 +51,16 @@ type PlanCardProps = {
     hogPosition?: 'top-right' | 'top-left'
 }
 
+// Retention differs per product: analytics is measured in years, session replay in months. Billing
+// supplies the unit ('year(s)' | 'month(s)' | 'day(s)'), so format from it rather than assuming years.
+export function formatDataRetentionFeature(feature?: BillingFeatureType): string | null {
+    if (!feature?.limit || !feature.unit) {
+        return null
+    }
+    const singularUnit = feature.unit.replace(/s$/, '')
+    return `${pluralize(feature.limit, singularUnit)} data retention`
+}
+
 export const PlanCard: React.FC<PlanCardProps> = ({ planData, product, highlight, hogPosition = 'top-right' }) => {
     const { billing } = useValues(billingLogic)
     const { billingProductLoading } = useValues(billingProductLogic({ product }))
@@ -69,6 +79,7 @@ export const PlanCard: React.FC<PlanCardProps> = ({ planData, product, highlight
         (feature) => feature.key === `${product.type}_data_retention`
     )
     const projectLimitFeature = platformPlan?.features.find((feature) => feature.key === 'organizations_projects')
+    const dataRetentionLabel = formatDataRetentionFeature(dataRetentionFeature)
 
     const features = [
         ...(projectLimitFeature?.limit
@@ -79,9 +90,7 @@ export const PlanCard: React.FC<PlanCardProps> = ({ planData, product, highlight
                   },
               ]
             : []),
-        ...(dataRetentionFeature?.limit
-            ? [{ name: `${dataRetentionFeature.limit}-year data retention`, available: true }]
-            : []),
+        ...(dataRetentionLabel ? [{ name: dataRetentionLabel, available: true }] : []),
         ...planData.features,
     ]
 


### PR DESCRIPTION
## Problem

The onboarding "Select a plan" cards always rendered a product's data-retention entitlement with a hardcoded `-year` suffix, ignoring the unit the billing service actually returns for that feature. Most products express retention in years, but **session replay** expresses it in **months** — so the session replay onboarding step showed e.g. "1-year data retention" / "3-year data retention" when the real entitlement is 1 month / 3 months. The number was right; the unit was wrong, which materially overstates how long session recordings are kept.

## Changes

`PlanCards.tsx` now formats the retention bullet from the feature's own `unit` (`year(s)` / `month(s)` / `day(s)`) via the existing `pluralize()` helper, instead of assuming years.

| Onboarding step | Plan | Before | After |
|---|---|---|---|
| Session replay | Free | 1-year data retention | 1 month data retention |
| Session replay | Pay-as-you-go | 3-year data retention | 3 months data retention |
| Product analytics | Pay-as-you-go | 7-year data retention | 7 years data retention (unchanged) |

Products whose unit is already years (e.g. product analytics) are unaffected — they were only correct by coincidence before, and stay correct now.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran:

- Added `PlanCards.test.ts` — 8 parameterized cases over the new `formatDataRetentionFeature` helper (years/months/days, singular vs plural, and null guards). All pass via `hogli test`.
- `oxlint` + `oxfmt`: 0 warnings/errors on the changed files.
- `tsc --noEmit`: no errors in the changed files.

I did not manually exercise the onboarding UI in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Authored by **PostHog Code** (agent), with Abhischek as the human author.

The investigation began from a session replay where a session-replay onboarding plan card showed "3-year data retention". Using the session-replay and SQL MCP tools I confirmed the user was on the `step=plans:session_replay` onboarding step at the relevant moment, then traced the rendered string to `PlanCards.tsx`.

The retention units were then confirmed against the billing service's plan definitions (the source of truth), not just the repo's billing mock fixtures: `session_replay_data_retention` is months-based (free = 1 month, paid = 3 months), whereas `product_analytics_data_retention` is years-based (free = 1 year, paid = 7 years). That contrast is exactly why only the session replay step rendered wrong, while the analytics step's "7 years" was correct only by coincidence. It also matches the live entitlement (paid session replay = 3 months → a 90-day recording retention).

Decision: format from the feature's actual unit (accurate per product) rather than hardcoding a single platform-wide figure, so each onboarding step states that product's true retention. This mirrors the existing unit-aware handling in `SessionRecordingSettings.tsx` and the backend `posthog/session_recordings/data_retention.py`.

Follow-up (out of scope): `ee/vercel/integration.py` has a separate hardcoded "7 years" retention string worth a look.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
