### PR TITLE
fix(insights): clip long names in insight tooltip table

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -864,6 +864,18 @@ snapshots:
         hash: v1.k794b7964.a5da914f6486b76afc43a8e1a7f29e3560e11b087748b6008a6677ae23e24168.szD53pfqHAVvxPL4w5UZg37otd9XNTyYPMcs7loV19Y
     components-html-elements-display--without-central-highlight-display--light:
         hash: v1.k794b7964.59d5a2262840ed80fa8f3cbc52e4135d71d4ea9c2d1fcb67f65a59ed2a86de58.dEvHx0f5nsPkujMiMiesufA4GuGubJh2oO2YKA4rrB8
+    components-insighttooltip--columns--dark:
+        hash: v1.k794b7964.2215e84b73ee4c85063be5cacf6a491c38051bfa6932408f1ecf5d6eb44d635b.llKueCRASM-Mf2hFS1I-rH6osr1LVSByf_RdwkUjMw4
+    components-insighttooltip--columns--light:
+        hash: v1.k794b7964.acca413c07eadd423b88a452f1d76a4f5d3ee51ea3a3af77e8b0b3c3dd785107.nBEt7UaKeQBhQVogW76yT9tmUiJNJUdmzccDAIZsSRw
+    components-insighttooltip--default--dark:
+        hash: v1.k794b7964.9885c31ba3ab13abe50a40f01112da6ef02b81b4e95dc2e1788a4709371df47d.ID9KwWTWMc6uuMPuS6Hz0780AbiKtssta5eVHXAYE_M
+    components-insighttooltip--default--light:
+        hash: v1.k794b7964.0c4021b0a9799847dfb04ce548acd4ed90bf5b490fc332d98acb700eb575e8a4.h-VRBbK2nOime0jzvIpuLkeCWS9v49E8IXZr3F1WmJ4
+    components-insighttooltip--long-names--dark:
+        hash: v1.k794b7964.5d75a9153e54f6fc45c587bd03f519b0dbc5aa871db38a3c9e90c9f84943ca9a.M9DnH_RO9dcVSO5RLT_tKejP8FdTiKKoKmCHVq3eeV4
+    components-insighttooltip--long-names--light:
+        hash: v1.k794b7964.a3cbff5e9d93637e541ee21344030f75fc32adb6edd2a363f7553ffb8d8fc407.VzgJ4zJ-yb9ZtDGxqQQZGPlH8D7diG9ufmZiyFOKwP4
     components-integrations-slack--slack-integration--dark:
         hash: v1.k794b7964.b9ee8adc2251177b325e3775fe7fd391540c3dba77c06d9da9db33ec80eddf81.0Jsmo2XKYiKkfSVMN4GzeK-ePRjh4q_l60Ez2M90L58
     components-integrations-slack--slack-integration--light:

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -85,6 +85,34 @@
             overflow-wrap: anywhere;
         }
 
+        // Clip long breakdown values and series/event names so a few-column
+        // tooltip never grows wide enough to require horizontal scrolling.
+        // max-width lives on the inner content (not the cell) because cells in
+        // an auto-layout table grow to fit content and ignore their own max-width.
+        .datum-title {
+            max-width: 12rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .datum-column .insights-label {
+            max-width: 12rem;
+            overflow: hidden;
+        }
+
+        .datum-counts-column .insights-label {
+            max-width: 8rem;
+            overflow: hidden;
+        }
+
+        // Let the nested flex wrappers shrink so the labels' built-in
+        // text-ellipsis truncation can engage.
+        .insights-label,
+        .insights-label * {
+            min-width: 0;
+        }
+
         .LemonTable__content > table > thead {
             letter-spacing: 0;
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -90,7 +90,7 @@
         // max-width lives on the inner content (not the cell) because cells in
         // an auto-layout table grow to fit content and ignore their own max-width.
         .datum-title {
-            max-width: 12rem;
+            max-width: 9rem;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -98,19 +98,28 @@
 
         .datum-column .insights-label {
             max-width: 12rem;
-            overflow: hidden;
         }
 
         .datum-counts-column .insights-label {
-            max-width: 8rem;
-            overflow: hidden;
+            max-width: 6rem;
         }
 
-        // Let the nested flex wrappers shrink so the labels' built-in
-        // text-ellipsis truncation can engage.
         .insights-label,
         .insights-label * {
             min-width: 0;
+        }
+
+        // InsightLabel nests its text in fit-content flex wrappers that ignore
+        // the label's max-width, so long names overflow and hard-clip at the
+        // tooltip edge. Cap the wrappers at the label width so the label's
+        // built-in text-ellipsis truncation can engage.
+        .datum-column .insights-label,
+        .datum-counts-column .insights-label {
+            overflow: hidden;
+
+            div {
+                max-width: 100%;
+            }
         }
 
         .LemonTable__content > table > thead {

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
@@ -70,7 +70,6 @@ const meta: Meta<InsightTooltipProps> = {
         renderSeries: (value) => value,
         groupTypeLabel: 'people',
     },
-    tags: ['test-skip'], // FIXME: The InWrapper story fails at locator.screenshot() for some reason
     render: (props) => {
         useMountedLogic(cohortsModel)
 
@@ -353,3 +352,5 @@ export function InWrapper(): JSX.Element {
         </div>
     )
 }
+// FIXME: InWrapper fails at locator.screenshot(), so it's skipped from visual regression
+InWrapper.tags = ['test-skip']

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
@@ -219,6 +219,109 @@ export const Columns: Story = {
     },
 }
 
+const longBreakdownValue =
+    'https://www.example.com/some/really/long/breakdown/value/that/keeps/going/and/going?utm_source=newsletter'
+const anotherLongBreakdownValue =
+    'https://www.example.com/another/extremely/long/path/segment/that/should/be/clipped/with/an/ellipsis'
+
+// Demonstrates that long breakdown values (first column) and long series/event
+// names (column headers) clip with an ellipsis instead of forcing the tooltip
+// wide enough to need horizontal scrolling.
+export const LongNames: Story = {
+    args: {
+        seriesData: [
+            {
+                id: 0,
+                dataIndex: 3,
+                datasetIndex: 0,
+                order: 0,
+                dotted: false,
+                breakdown_value: longBreakdownValue,
+                action: {
+                    id: '$pageview',
+                    type: 'events',
+                    order: 0,
+                    name: '$pageview',
+                    custom_name: 'Pageview of people with extremely long custom names that go on and on and on',
+                    math: 'total',
+                    math_property: null,
+                    math_hogql: null,
+                    math_group_type_index: null,
+                },
+                label: '$pageview - long',
+                color: '#1d4aff',
+                count: 1234,
+            },
+            {
+                id: 1,
+                dataIndex: 3,
+                datasetIndex: 1,
+                order: 1,
+                dotted: false,
+                breakdown_value: longBreakdownValue,
+                action: {
+                    id: 'some_event_with_an_extremely_long_machine_readable_name_that_keeps_going',
+                    type: 'events',
+                    order: 1,
+                    name: 'some_event_with_an_extremely_long_machine_readable_name_that_keeps_going',
+                    custom_name: null,
+                    math: 'total',
+                    math_property: null,
+                    math_hogql: null,
+                    math_group_type_index: null,
+                },
+                label: 'some_event_with_an_extremely_long_machine_readable_name_that_keeps_going',
+                color: '#621da6',
+                count: 56,
+            },
+            {
+                id: 2,
+                dataIndex: 3,
+                datasetIndex: 0,
+                order: 0,
+                dotted: false,
+                breakdown_value: anotherLongBreakdownValue,
+                action: {
+                    id: '$pageview',
+                    type: 'events',
+                    order: 0,
+                    name: '$pageview',
+                    custom_name: 'Pageview of people with extremely long custom names that go on and on and on',
+                    math: 'total',
+                    math_property: null,
+                    math_hogql: null,
+                    math_group_type_index: null,
+                },
+                label: '$pageview - long',
+                color: '#1d4aff',
+                count: 789,
+            },
+            {
+                id: 3,
+                dataIndex: 3,
+                datasetIndex: 1,
+                order: 1,
+                dotted: false,
+                breakdown_value: anotherLongBreakdownValue,
+                action: {
+                    id: 'some_event_with_an_extremely_long_machine_readable_name_that_keeps_going',
+                    type: 'events',
+                    order: 1,
+                    name: 'some_event_with_an_extremely_long_machine_readable_name_that_keeps_going',
+                    custom_name: null,
+                    math: 'total',
+                    math_property: null,
+                    math_hogql: null,
+                    math_group_type_index: null,
+                },
+                label: 'some_event_with_an_extremely_long_machine_readable_name_that_keeps_going',
+                color: '#621da6',
+                count: 4,
+            },
+        ] as any,
+    },
+}
+
 export function InWrapper(): JSX.Element {
     useMountedLogic(cohortsModel)
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -157,7 +157,7 @@ export function InsightTooltip({
                 title,
                 sticky: true,
                 render: function renderDatum(_, datum) {
-                    return <div className="whitespace-nowrap">{datum.datumTitle}</div>
+                    return <div className="datum-title">{datum.datumTitle}</div>
                 },
             },
         ]
@@ -186,7 +186,6 @@ export function InsightTooltip({
                                     hideBreakdown
                                     hideCompare
                                     hideIcon
-                                    allowWrap
                                 />,
                                 seriesColumn,
                                 colIdx
@@ -283,7 +282,6 @@ export function InsightTooltip({
                     hideBreakdown
                     hideCompare
                     hideIcon
-                    allowWrap
                 />,
                 datum,
                 rowIdx

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -9,6 +9,7 @@ import { IconX } from '@posthog/icons'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { dayjs } from 'lib/dayjs'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { shortTimeZone } from 'lib/utils'
 import { formatAggregationValue } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
@@ -136,13 +137,32 @@ export function InsightTooltip({
         weekStartDay,
     })
 
+    const shortFormattedDate = getFormattedDate(date, {
+        interval,
+        dateRange,
+        timezone,
+        weekStartDay,
+        short: true,
+    })
+
     const concreteTooltipTitle = altTitle ? getTooltipTitle(seriesData, altTitle, formattedDate) : null
+
+    const fullDateTitle = date
+        ? `${interval === 'day' ? `${dayjs.tz(date, timezone).format('dddd')}, ` : ''}${formattedDate} (${timezone ? shortTimeZone(timezone) : 'UTC'})`
+        : null
 
     const title: ReactNode | null =
         concreteTooltipTitle ||
-        (date
-            ? `${interval === 'day' ? `${dayjs.tz(date, timezone).format('dddd')}, ` : ''}${formattedDate} (${timezone ? shortTimeZone(timezone) : 'UTC'})`
-            : null)
+        (date ? (
+            // Only the column-per-entity layout is width-constrained enough to need the date shortened.
+            itemizeEntitiesAsColumns ? (
+                <Tooltip title={fullDateTitle}>
+                    <span>{shortFormattedDate}</span>
+                </Tooltip>
+            ) : (
+                fullDateTitle
+            )
+        ) : null)
     const rightTitle: ReactNode | null = altRightTitle
         ? getTooltipTitle(seriesData, altRightTitle, formattedDate)
         : null

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -88,6 +88,7 @@ export interface FormattedDateOptions {
     dateRange?: DateRange | null
     timezone?: string
     weekStartDay?: number // 0 for Sunday, 1 for Monday, etc.
+    short?: boolean // Drop the year for a compact label (e.g. tooltip headers)
 }
 
 export function getTooltipTitle(
@@ -114,22 +115,33 @@ export const INTERVAL_UNIT_TO_DAYJS_FORMAT: Record<IntervalType, string> = {
     month: 'MMMM YYYY',
 }
 
+const INTERVAL_UNIT_TO_DAYJS_FORMAT_SHORT: Record<IntervalType, string> = {
+    second: 'D MMM HH:mm:ss',
+    minute: 'D MMM HH:mm',
+    hour: 'D MMM HH:00',
+    day: 'D MMM',
+    week: 'D MMM',
+    month: 'MMM',
+}
+
 /**
  * Format a date range
  */
-function formatDateRange(startDate: dayjs.Dayjs, endDate: dayjs.Dayjs): string {
+function formatDateRange(startDate: dayjs.Dayjs, endDate: dayjs.Dayjs, short = false): string {
+    const yearSuffix = short ? '' : ' YYYY'
+
     // Same year and month
     if (startDate.month() === endDate.month() && startDate.year() === endDate.year()) {
-        return `${startDate.format('D')}-${endDate.format('D MMM YYYY')}`
+        return `${startDate.format('D')}-${endDate.format(`D MMM${yearSuffix}`)}`
     }
 
     // Same year but different months
     if (startDate.year() === endDate.year()) {
-        return `${startDate.format('D MMM')} - ${endDate.format('D MMM YYYY')}`
+        return `${startDate.format('D MMM')} - ${endDate.format(`D MMM${yearSuffix}`)}`
     }
 
     // Different years
-    return `${startDate.format('D MMM YYYY')} - ${endDate.format('D MMM YYYY')}`
+    return `${startDate.format(`D MMM${yearSuffix}`)} - ${endDate.format(`D MMM${yearSuffix}`)}`
 }
 
 export function getFormattedDate(input?: string | number, options?: FormattedDateOptions): string {
@@ -138,7 +150,7 @@ export function getFormattedDate(input?: string | number, options?: FormattedDat
         timezone: 'UTC',
         weekStartDay: 0, // Default to Sunday
     }
-    const { interval, dateRange, timezone, weekStartDay } = { ...defaultOptions, ...options }
+    const { interval, dateRange, timezone, weekStartDay, short } = { ...defaultOptions, ...options }
 
     // Number of intervals (i.e. days, weeks)
     if (Number.isInteger(input)) {
@@ -172,11 +184,11 @@ export function getFormattedDate(input?: string | number, options?: FormattedDat
             { start: dateFrom, end: dateTo },
             weekStartDay
         )
-        return formatDateRange(weekStart, weekEnd)
+        return formatDateRange(weekStart, weekEnd, short)
     }
 
     // Handle all other intervals
-    return day.format(INTERVAL_UNIT_TO_DAYJS_FORMAT[interval ?? 'day'])
+    return day.format((short ? INTERVAL_UNIT_TO_DAYJS_FORMAT_SHORT : INTERVAL_UNIT_TO_DAYJS_FORMAT)[interval ?? 'day'])
 }
 
 function getPillValues(

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -116,11 +116,11 @@ export const INTERVAL_UNIT_TO_DAYJS_FORMAT: Record<IntervalType, string> = {
 }
 
 const INTERVAL_UNIT_TO_DAYJS_FORMAT_SHORT: Record<IntervalType, string> = {
-    second: 'D MMM HH:mm:ss',
-    minute: 'D MMM HH:mm',
-    hour: 'D MMM HH:00',
-    day: 'D MMM',
-    week: 'D MMM',
+    second: 'D MMM HH:mm:ss',
+    minute: 'D MMM HH:mm',
+    hour: 'D MMM HH:00',
+    day: 'D MMM',
+    week: 'D MMM',
     month: 'MMM',
 }
 
@@ -128,20 +128,20 @@ const INTERVAL_UNIT_TO_DAYJS_FORMAT_SHORT: Record<IntervalType, string> = {
  * Format a date range
  */
 function formatDateRange(startDate: dayjs.Dayjs, endDate: dayjs.Dayjs, short = false): string {
-    const yearSuffix = short ? '' : ' YYYY'
+    const yearSuffix = short ? '' : ' YYYY'
 
     // Same year and month
     if (startDate.month() === endDate.month() && startDate.year() === endDate.year()) {
-        return `${startDate.format('D')}-${endDate.format(`D MMM${yearSuffix}`)}`
+        return `${startDate.format('D')}-${endDate.format(`D MMM${yearSuffix}`)}`
     }
 
     // Same year but different months
     if (startDate.year() === endDate.year()) {
-        return `${startDate.format('D MMM')} - ${endDate.format(`D MMM${yearSuffix}`)}`
+        return `${startDate.format('D MMM')} - ${endDate.format(`D MMM${yearSuffix}`)}`
     }
 
     // Different years
-    return `${startDate.format(`D MMM${yearSuffix}`)} - ${endDate.format(`D MMM${yearSuffix}`)}`
+    return `${startDate.format(`D MMM${yearSuffix}`)} - ${endDate.format(`D MMM${yearSuffix}`)}`
 }
 
 export function getFormattedDate(input?: string | number, options?: FormattedDateOptions): string {


### PR DESCRIPTION
## Problem

The breakdown popover (the `LemonTable` shown inside an insight tooltip) could grow wide enough to require horizontal scrolling, which you can only trigger by clicking into the popover first. That makes browsing breakdown values painful — a simple few-column tooltip shouldn't scroll sideways at all.

Reported in a Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1780995020553929?thread_ts=1780995020.553929&cid=C0ACRAMJUAG

## Changes

Clip the things that make the table wide so no column can push it past the tooltip's max width:

- **Breakdown-value cells** (first column) truncate with an ellipsis instead of `white-space: nowrap` running the column out as wide as the value.
- **Series/event-name column headers** no longer wrap — dropping `allowWrap` lets the existing `EntityFilterInfo`/`PropertyKeyInfo` ellipsis logic engage, which also adds a `title` so the full name shows on hover.
- The `max-width` caps live on the inner content (`.datum-title` / `.insights-label`) rather than the `<td>`/`<th>`, because the tooltip's auto-layout table grows to fit content and ignores a cell's own `max-width`. `min-width: 0` on the nested flex wrappers lets the labels actually shrink and truncate.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not run anything locally — frontend dependencies weren't installed in the working environment, so I couldn't run `prettier`, `typescript:check`, or regenerate Storybook snapshots. This change will shift the `InsightTooltip` story visual snapshots (expected); please regenerate them in CI. A human should verify the tooltip visually on a breakdown insight before merge.

## 🤖 Agent context

Authored by the PostHog Slack app (Claude Code) from a Slack request. The width cap was deliberately placed on the inner content blocks rather than the table cells: a quick check confirmed the tooltip's `LemonTable` uses auto table layout, where `max-width` on a `<td>` is ignored when the content is wider, so capping the inner `.datum-title` / `.insights-label` (plus `min-width: 0` on the flex wrappers) is what actually constrains the column. Removing `allowWrap` was chosen over CSS-only clipping because the label components only emit an ellipsis (and a hover `title`) when not wrapping.
