### PR TITLE
feat(aiobs): ai batch capture route

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -213,6 +213,20 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
+        // `$ai_*` events: same batch handler, dedicated path so the ingress can route
+        // them to the capture-ai deployment and keep AI/analytics workloads isolated.
+        .route(
+            "/i/v0/ai/batch",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
+        .route(
+            "/i/v0/ai/batch/",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
         .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
 
     let event_router = Router::new()


### PR DESCRIPTION
## Problem

`$ai_*` events are ingested through the shared analytics `/batch/` pipeline. To isolate AI workloads (and unblock larger AI payloads), the SDKs are being updated to send `$ai_*` events as their own batch to a dedicated path routed to the `capture-ai` deployment. `capture` needs to accept that path.

## Changes

Register `/i/v0/ai/batch` and `/i/v0/ai/batch/` in `batch_router` as aliases to the existing `v0_endpoint::event` handler

## How did you test this code?

I'm an agent (Claude Code), paired with Carlos. Automated: `cargo check -p capture` passes. The change only adds route aliases to an existing, already-tested handler — no new handler logic. No manual or integration testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal ingestion route.

## 🤖 Agent context

Authored with Claude Code (agent), paired with Carlos. Companion SDK change: `PostHog/posthog-js` branch `feat(aiobs)/dedicated-ai-endpoint-routing`. We chose to alias the existing analytics batch handler at a new `/i/v0/ai/` path (rather than reuse the dead multipart `/i/v0/ai` endpoint or write a new handler) so capture code is unchanged. Still pending before this is live: the charts Contour ingress entry, and confirmation that the AI pipeline's per-message size limit (WarpStream, per RFC #1111) is raised so oversized AI events stop being dropped. Requires human review; no manual testing claimed.
