### PR TITLE
feat(signals): score anomaly scout via alert-simulate detectors

### DIFF
--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -16,6 +16,7 @@ compatibility: >
   (project-profile-get, runs-list, runs-retrieve, scratchpad-search/-remember/-forget,
   emit-signal) plus dashboard/insight tools (insights-trending-retrieve, insight-get,
   insight-query, dashboards-get-all, dashboard-get, dashboard-insights-run, insights-list),
+  alert-simulate (the anomaly-detection simulator — primary scorer for saved insights),
   execute-sql, read-data-schema, inbox-reports-list.
 metadata:
   owner_team: signals
@@ -29,16 +30,20 @@ actually cares about and surface **recent** anomalies in them — a metric that 
 spiked, cratered, flat-lined, or broke its trend in the last few hours or days — so a human
 gets told before they'd notice on their own.
 
-**The discriminator.** An anomaly is the **latest _complete_ bucket's robust deviation from
-that insight's own trailing, seasonality-matched baseline** — measured as a MAD-based
-z-score (`|value − median| / (1.4826 × MAD)`) over comparable buckets (same hour-of-week for
-hourly series, same day-of-week for daily series), gated by a minimum relative change so
-tiny absolute wiggles on low-count series don't trip. Internalize that shape: weekly
-seasonality and noisy low-count series are the two things that masquerade as anomalies, and
-this discriminator controls for both. The full method (cadence choice, baseline windows,
-minimum-data guards, per-insight-type recipes for trends / funnels / retention / paths) is
-in [`references/anomaly-methods.md`](references/anomaly-methods.md) — read it before scoring
-your first candidate.
+**The discriminator.** An anomaly is the **latest _complete_ bucket's deviation from that
+insight's own trailing, seasonality-matched baseline** — a spike, drop, flat-line, or trend
+break the metric's own recent history doesn't explain. **Don't reinvent the scoring.** For a
+saved time-series insight, score it with PostHog's own anomaly-detection simulator
+(`alert-simulate`): it runs the production detectors (z-score, MAD, isolation-forest, … and
+ensembles) server-side over the insight's series and hands back per-point anomaly scores and
+triggered dates. Only fall back to a hand-computed MAD-based z-score
+(`|value − median| / (1.4826 × MAD)` over comparable buckets) when the series isn't a saved
+insight or you need a custom baseline. Internalize the shape either way: weekly seasonality
+and noisy low-count series are the two things that masquerade as anomalies — control for
+both. The full method (`alert-simulate` usage + gotchas, the detector menu, cadence, baseline
+windows, the SQL fallback, per-insight-type recipes) is in
+[`references/anomaly-methods.md`](references/anomaly-methods.md) — read it before scoring your
+first candidate.
 
 You cannot scan a whole project in one run. Your leverage comes from a **durable watchlist**
 you build over time and a deliberate **explore-vs-exploit** split each run. The watchlist
@@ -80,17 +85,25 @@ Three cheap reads cold-start every run:
 
 From the watchlist entries you just read, pick the items whose check cadence is **due**
 (daily items not checked in ~24h, hourly items not checked in ~1–3h), most-overdue first.
-For each, pull the latest complete bucket and score it against its stored baseline (refresh
-the baseline as you go). Fetch fresh data with:
+For each, score the latest complete bucket against its baseline (refresh the baseline as you
+go). Tools, primary first:
 
-- `insight-query` (`insightId`, `output_format=json`) — runs one saved insight. **It returns the insight's own date range (often just `-7d`) — too short to baseline, so always widen it with `filters_override` (e.g. `{"date_from": "-63d"}`) or fall back to `execute-sql`.**
+- `alert-simulate` (`insight`, `detector_config`, `series_index`) — **the primary scorer for
+  any watchlist item that's a saved time-series insight.** Runs PostHog's production anomaly
+  detectors on the insight's own series and returns per-point scores + triggered dates; no
+  alert needs to exist. Pick the detector(s) that fit the series — `anomaly-methods.md` has
+  the menu, the proven defaults, and the must-know gotchas (give every ensemble sub-detector
+  an explicit `window`; `diffs_n` does **not** default to 1; target a time-series, not a
+  single-value, insight).
+- `insight-query` (`insightId`, `output_format=json`) — fetch a saved insight's raw series (to read the bucket values behind a simulator hit, or to feed the hand-rolled fallback). **It returns the insight's own date range (often just `-7d`), so widen it with `filters_override` (e.g. `{"date_from": "-63d"}`).**
 - `dashboard-insights-run` (`id`, `output_format=json`, `refresh=blocking`, `filters_override`)
   — runs every tile on a dashboard at once; efficient for sweeping a whole high-value
   dashboard. Pass `output_format=json` — the default `optimized` returns prose summaries, not
-  the raw bucket series the z-score needs.
-- `execute-sql` — when you need a clean hourly/daily series with a long trailing baseline in
-  one query (the most reliable path for the z-score; recipes in `anomaly-methods.md`). Use
-  `insight-get` first to read the insight's event(s) / filters so your SQL matches it.
+  the raw bucket series.
+- `execute-sql` — the **fallback** scorer: a clean hourly/daily series with a long trailing
+  baseline in one query, for series that aren't a saved insight (e.g. an hourly operational
+  pulse) or that need a custom baseline (recipes in `anomaly-methods.md`). Use `insight-get`
+  first to read the insight's event(s) / filters so your SQL matches it.
 
 Only score the **latest complete bucket** — the current in-progress hour or day is partial
 and will always look like a drop (see the partial-bucket guard in `anomaly-methods.md`).
@@ -175,13 +188,16 @@ When in doubt, refresh the baseline memory instead of emitting.
 
 Direct (read-only):
 
+- `alert-simulate` — primary scorer: run PostHog's anomaly detectors on a saved insight's
+  series (no alert required); returns per-point scores + triggered dates.
 - `insights-trending-retrieve` — most-viewed insights (discovery / explore).
 - `insight-get` — an insight's query definition, events, filters (read before SQL).
 - `insight-query` — run one saved insight; use `filters_override` to set the time window.
 - `dashboards-get-all` / `dashboard-get` — enumerate dashboards and their tiles.
 - `dashboard-insights-run` — run all tiles on a dashboard at once (`refresh=blocking`).
 - `insights-list` / `execute-sql` over `system.*` — search insights/dashboards by name.
-- `execute-sql` over `events` — compute hourly/daily series + trailing baseline for scoring.
+- `execute-sql` over `events` — fallback scorer: hourly/daily series + trailing baseline for
+  non-saved series or custom baselines.
 - `read-data-schema` — confirm events/properties before any SQL.
 - `inbox-reports-list` — check whether the move is already reported before emitting.
 

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -1,13 +1,57 @@
 # Anomaly detection methods
 
-How to turn an insight into a clean time series, choose the right cadence, build a
-seasonality-matched baseline, and score the latest bucket. The goal is a method robust
-enough that you can trust a high z-score, and conservative enough that weekly seasonality and
-low-count noise don't generate false positives.
+How to score the latest bucket of an insight, choose the right cadence, and avoid the two
+false-positive traps (weekly seasonality and low-count noise). Two scorers: PostHog's own
+anomaly-detection **simulator** for saved time-series insights (primary), and a hand-rolled
+robust z-score for everything else (fallback).
 
-## The core score: robust z on the latest complete bucket
+## Primary scorer: the alert anomaly-detection simulator
 
-For a series of bucket values, the anomaly score of the latest **complete** bucket `x` is:
+For any watchlist item that is a **saved time-series insight**, score it with `alert-simulate`
+instead of hand-rolling stats. It runs PostHog's production anomaly detectors server-side over
+the insight's series and returns, per point, the anomaly score and the triggered dates. It's a
+stateless preview: it needs only a saved `insight` id, a `detector_config`, and a
+`series_index` — **no alert has to exist**, and nothing is written. This is the same engine
+behind PostHog's shipped anomaly alerts, so lean on it rather than reinvent z-scores in SQL.
+
+**Pick the detector that fits the series — don't be dogmatic.** The menu: `zscore`, `mad`,
+`iqr`, `copod`, `ecod`, `hbos`, `isolation_forest`, `knn`, `lof`, `ocsvm`, `pca`, and
+`ensemble` (combine several with `and`/`or`). Each takes a `threshold`, a `window` (rolling
+history length), and a `preprocessing` block (`diffs_n`, `lags_n`, `smooth_n`). The config
+proven across PostHog's own working alert inventories is an `or`-ensemble of `zscore`
+(`diffs_n: 1`, `smooth_n: 3`) + `isolation_forest` (`smooth_n: 3`) at `window` 336 hourly /
+~90 daily — a good starting point, not a mandate. For battle-tested, metric-shape-specific
+configs and a detector-selection guide, read the `anomaly-alerts`, `signals-alerts`, and
+`llma-alerts` skills (via `/phs`).
+
+**Gotchas that will bite (all learned in production):**
+
+- **Every sub-detector inside an `ensemble` needs an explicit `window`.** A null window on a
+  standalone detector defaults fine, but a null window inside an ensemble 500s the evaluation.
+- **`diffs_n` defaults to `0` (raw values), not `1`.** For `zscore`/`mad` on count or level
+  metrics with a diurnal cycle, set `diffs_n: 1` explicitly — differencing is what cancels the
+  daily/weekly rhythm. (`mad` on raw sparse/bursty integer counts over-fires; difference it or
+  use the ensemble.)
+- **Target a time-series insight.** A single-value / BoldNumber insight returns one point and
+  scores nothing — point the simulator at a trend displayed over time.
+- **Breakdown insights return a per-series block per breakdown value plus a meaningless
+  rolled-up total.** `series_index` does not cleanly isolate one breakdown value — read the
+  per-series sub-blocks, or prefer a non-breakdown insight for a clean read.
+- **Only points with ≥ `window` history get scored.** On a short series, simulate with a
+  smaller `window` (e.g. ≤ 168) to get scored points; `date_from` controls how far back to go.
+
+**When to still hand-roll (the fallback below).** `alert-simulate` requires a saved insight,
+and its detectors use rolling windows rather than explicit same-day-of-week / same-hour-of-week
+matching. Keep the SQL path for: series that aren't a saved insight (e.g. an hourly
+operational-pulse built in `execute-sql`), custom long baselines, or strict seasonality
+matching the detector doesn't do. The MAD-based z-score below is both that fallback and the
+concept the simulator automates.
+
+## Fallback scorer: robust z on the latest complete bucket
+
+Use this when `alert-simulate` doesn't apply (a non-saved series) or you need a custom
+baseline. For a series of bucket values, the anomaly score of the latest **complete** bucket
+`x` is:
 
 ```text
 median  = median(baseline buckets)
@@ -85,10 +129,11 @@ weeks.
 Exclude the latest complete bucket itself from its own baseline, and exclude the current
 partial bucket entirely.
 
-## execute-sql cookbook
+## execute-sql cookbook (fallback path)
 
-`execute-sql` is the most reliable path: it gives you the full series and the baseline in one
-query, with exact control over the bucket and the comparison window. Always
+When `alert-simulate` doesn't apply, `execute-sql` is the most reliable hand-rolled path: it
+gives you the full series and the baseline in one query, with exact control over the bucket and
+the comparison window. Always
 `read-data-schema` to confirm the event/properties first, and `insight-get` to learn which
 event(s)/filters the insight actually uses so your SQL matches it.
 
@@ -176,8 +221,8 @@ different metric.
 
 ### Trends (counts / sums / uniques over time) — primary
 
-The core method above. This is the bulk of dashboards. Pull the series via `insight-query`
-(json) or rebuild with `execute-sql`; score the latest complete bucket.
+This is the bulk of dashboards. Score it with `alert-simulate` on the saved insight; drop to
+the `insight-query` / `execute-sql` fallback only when the simulator doesn't apply.
 
 ### Funnels — overall conversion rate as the metric
 


### PR DESCRIPTION
## Problem

The `signals-scout-anomaly-detection` scout was hand-rolling anomaly scoring — computing MAD-based robust z-scores in HogQL via `execute-sql` on every run. PostHog already ships a purpose-built anomaly-detection engine (`alert-simulate`) that runs the production detectors server-side on any saved insight, yet the scout reinvented a weaker slice of it in SQL. That hand-rolled path is the source of the scout's recurring footguns (timezone-extraction caveats, ingestion-lag traps, and ~30-minute over-investigation timeouts) and only covers a single `mad`-style z-score where the real engine offers a dozen detectors plus ensembles.

We shouldn't be reinventing the wheel in the skill: when exploring time-series insights, the scout should use the alert anomaly-detection simulation tooling.

## Changes

Reframes the scout's scoring guidance around `alert-simulate` as the **primary** scorer for saved time-series insights, keeping the hand-rolled MAD z-score as an explicit **fallback** for series that aren't a saved insight (e.g. the hourly operational-pulse) or that need a custom baseline.

- `SKILL.md`: the discriminator now leads with the simulator; the exploit-loop tool list puts `alert-simulate` first; MCP tools + `compatibility` frontmatter updated.
- `references/anomaly-methods.md`: new "Primary scorer: the alert anomaly-detection simulator" section (stateless preview — no alert required, just a saved insight + detector config), and the existing z-score / `execute-sql` sections are reframed as the fallback path.

Deliberately **not** prescriptive about which detector or params the scout picks — it presents the detector menu, names the config proven across PostHog's own working alert inventories as a starting point (not a mandate), and points to the `anomaly-alerts` / `signals-alerts` / `llma-alerts` skills for battle-tested configs. It does bake in the must-know gotchas that otherwise bite (every ensemble sub-detector needs an explicit `window` or the eval 500s; `diffs_n` defaults to 0 not 1; target a time-series not a single-value insight; breakdown insights return per-series blocks plus a meaningless rolled-up total).

This is a canonical scout-fleet skill, so `lazy_seed` propagates it to every enrolled team on the next coordinator tick (non-diverged rows).

## How did you test this code?

I'm an agent (Claude Code). No automated tests cover skill prose. I validated the `alert-simulate` behavior the guidance relies on by calling the tool live against project 2: confirmed it runs with **no alert ID** (just a saved insight + detector config), that a single `mad` detector returns a full per-point scored series, and that an `ensemble` succeeds **only when each sub-detector carries an explicit `window`** (a null sub-detector window 500s — which is exactly the gotcha now documented). The detector menu, defaults, and gotchas were cross-checked against the existing working alert inventories (`signals-alerts`, `llma-alerts`).

## 🤖 Agent context

Authored by Claude Code at Andy's direction. Path: while reviewing how the anomaly-detection scout scores anomalies on project 2, we found it hand-rolling z-scores in SQL and ignoring the shipped `alert-simulate` engine. I probed `alert-simulate` live to confirm it's stateless (no alert needed) and to nail down its failure modes, then cross-referenced PostHog's own working anomaly-alert skills for proven detector configs. Decision was to keep the change non-prescriptive about detector choice (let the scout choose) while encoding the few production-learned gotchas, and to land it in the canonical repo skill rather than diverge a per-team row so all enrolled teams benefit. Agent-authored — requires human review.
