### PR TITLE
chore: add actions to experiment exposures for MCP

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18398,14 +18398,18 @@
         },
         "ExperimentApiExposureConfig": {
             "additionalProperties": false,
-            "description": "Slim exposure config for experiment API payloads.",
+            "description": "Slim exposure config for experiment API payloads. Discriminated by `kind`: 'ExperimentEventExposureConfig' tracks exposure via a custom event, 'ActionsNode' tracks exposure via an action.",
             "properties": {
                 "event": {
-                    "description": "Custom exposure event name.",
+                    "description": "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'.",
                     "type": "string"
                 },
+                "id": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Action ID. Required when kind is 'ActionsNode'."
+                },
                 "kind": {
-                    "const": "ExperimentEventExposureConfig",
+                    "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
                     "type": "string"
                 },
                 "properties": {
@@ -18416,7 +18420,7 @@
                     "type": "array"
                 }
             },
-            "required": ["kind", "event", "properties"],
+            "required": ["kind", "properties"],
             "type": "object"
         },
         "ExperimentApiExposureCriteria": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18409,6 +18409,7 @@
                     "description": "Action ID. Required when kind is 'ActionsNode'."
                 },
                 "kind": {
+                    "description": "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure.",
                     "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
                     "type": "string"
                 },
@@ -18420,7 +18421,7 @@
                     "type": "array"
                 }
             },
-            "required": ["kind", "properties"],
+            "required": ["properties"],
             "type": "object"
         },
         "ExperimentApiExposureCriteria": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3711,7 +3711,8 @@ export interface ExperimentParameters {
  *  'ExperimentEventExposureConfig' tracks exposure via a custom event,
  *  'ActionsNode' tracks exposure via an action. */
 export interface ExperimentApiExposureConfig {
-    kind: 'ExperimentEventExposureConfig' | 'ActionsNode'
+    /** Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure. */
+    kind?: 'ExperimentEventExposureConfig' | 'ActionsNode'
     /** Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'. */
     event?: string
     /** Action ID. Required when kind is 'ActionsNode'. */

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3707,11 +3707,15 @@ export interface ExperimentParameters {
     excluded_variants?: string[]
 }
 
-/** Slim exposure config for experiment API payloads. */
+/** Slim exposure config for experiment API payloads. Discriminated by `kind`:
+ *  'ExperimentEventExposureConfig' tracks exposure via a custom event,
+ *  'ActionsNode' tracks exposure via an action. */
 export interface ExperimentApiExposureConfig {
-    kind: NodeKind.ExperimentEventExposureConfig
-    /** Custom exposure event name. */
-    event: string
+    kind: 'ExperimentEventExposureConfig' | 'ActionsNode'
+    /** Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'. */
+    event?: string
+    /** Action ID. Required when kind is 'ActionsNode'. */
+    id?: integer
     /** Event property filters. Pass an empty array if no filters needed. */
     properties: EventPropertyFilter[]
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7167,7 +7167,12 @@ class ExperimentApiExposureConfig(BaseModel):
         description=("Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."),
     )
     id: int | None = Field(default=None, description="Action ID. Required when kind is 'ActionsNode'.")
-    kind: Kind1
+    kind: Kind1 | None = Field(
+        default=None,
+        description=(
+            "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
+        ),
+    )
     properties: list[EventPropertyFilter] = Field(
         ...,
         description="Event property filters. Pass an empty array if no filters needed.",

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1934,6 +1934,11 @@ class Kind(StrEnum):
     ACTIONS_NODE = "ActionsNode"
 
 
+class Kind1(StrEnum):
+    EXPERIMENT_EVENT_EXPOSURE_CONFIG = "ExperimentEventExposureConfig"
+    ACTIONS_NODE = "ActionsNode"
+
+
 class StartHandling(StrEnum):
     FIRST_SEEN = "first_seen"
     LAST_SEEN = "last_seen"
@@ -7157,8 +7162,12 @@ class ExperimentApiExposureConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    event: str = Field(..., description="Custom exposure event name.")
-    kind: Literal["ExperimentEventExposureConfig"] = "ExperimentEventExposureConfig"
+    event: str | None = Field(
+        default=None,
+        description=("Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."),
+    )
+    id: int | None = Field(default=None, description="Action ID. Required when kind is 'ActionsNode'.")
+    kind: Kind1
     properties: list[EventPropertyFilter] = Field(
         ...,
         description="Event property filters. Pass an empty array if no filters needed.",

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -210,6 +210,13 @@ export const ExperimentTypeEnumApi = {
     Product: 'product',
 } as const
 
+export type Kind1Api = (typeof Kind1Api)[keyof typeof Kind1Api]
+
+export const Kind1Api = {
+    ExperimentEventExposureConfig: 'ExperimentEventExposureConfig',
+    ActionsNode: 'ActionsNode',
+} as const
+
 export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
 
 export const PropertyOperatorApi = {
@@ -259,9 +266,11 @@ export interface EventPropertyFilterApi {
 }
 
 export interface ExperimentApiExposureConfigApi {
-    /** Custom exposure event name. */
-    event: string
-    kind?: 'ExperimentEventExposureConfig'
+    /** Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'. */
+    event?: string | null
+    /** Action ID. Required when kind is 'ActionsNode'. */
+    id?: number | null
+    kind: Kind1Api
     /** Event property filters. Pass an empty array if no filters needed. */
     properties: EventPropertyFilterApi[]
 }

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -270,7 +270,8 @@ export interface ExperimentApiExposureConfigApi {
     event?: string | null
     /** Action ID. Required when kind is 'ActionsNode'. */
     id?: number | null
-    kind: Kind1Api
+    /** Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure. */
+    kind?: Kind1Api | null
     /** Event property filters. Pass an empty array if no filters needed. */
     properties: EventPropertyFilterApi[]
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16825,7 +16825,8 @@ export namespace Schemas {
       event?: string | null;
       /** Action ID. Required when kind is 'ActionsNode'. */
       id?: number | null;
-      kind: Kind1;
+      /** Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure. */
+      kind?: Kind1 | null;
       /** Event property filters. Pass an empty array if no filters needed. */
       properties: EventPropertyFilter[];
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16812,10 +16812,20 @@ export namespace Schemas {
       Product: 'product',
     } as const;
 
+    export type Kind1 = typeof Kind1[keyof typeof Kind1];
+
+
+    export const Kind1 = {
+      ExperimentEventExposureConfig: 'ExperimentEventExposureConfig',
+      ActionsNode: 'ActionsNode',
+    } as const;
+
     export interface ExperimentApiExposureConfig {
-      /** Custom exposure event name. */
-      event: string;
-      kind?: 'ExperimentEventExposureConfig';
+      /** Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'. */
+      event?: string | null;
+      /** Action ID. Required when kind is 'ActionsNode'. */
+      id?: number | null;
+      kind: Kind1;
       /** Event property filters. Pass an empty array if no filters needed. */
       properties: EventPropertyFilter[];
     }

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -161,7 +161,6 @@ export const experimentsCreateBodyNameMax = 400
 export const experimentsCreateBodyDescriptionMax = 3000
 
 export const experimentsCreateBodyArchivedDefault = false
-export const experimentsCreateBodyExposureCriteriaOneExposureConfigOneKindDefault = `ExperimentEventExposureConfig`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOperatorDefault = `exact`
 export const experimentsCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTypeDefault = `event`
 export const experimentsCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
@@ -326,10 +325,17 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                     exposure_config: zod
                         .union([
                             zod.object({
-                                event: zod.string().describe('Custom exposure event name.'),
-                                kind: zod
-                                    .literal('ExperimentEventExposureConfig')
-                                    .default(experimentsCreateBodyExposureCriteriaOneExposureConfigOneKindDefault),
+                                event: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."
+                                    ),
+                                id: zod
+                                    .union([zod.number(), zod.null()])
+                                    .optional()
+                                    .describe("Action ID. Required when kind is 'ActionsNode'."),
+                                kind: zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']),
                                 properties: zod
                                     .array(
                                         zod.object({
@@ -2451,7 +2457,6 @@ export const experimentsPartialUpdateBodyNameMax = 400
 
 export const experimentsPartialUpdateBodyDescriptionMax = 3000
 
-export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOneKindDefault = `ExperimentEventExposureConfig`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOperatorDefault = `exact`
 export const experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTypeDefault = `event`
 export const experimentsPartialUpdateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
@@ -2611,12 +2616,17 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                     exposure_config: zod
                         .union([
                             zod.object({
-                                event: zod.string().describe('Custom exposure event name.'),
-                                kind: zod
-                                    .literal('ExperimentEventExposureConfig')
-                                    .default(
-                                        experimentsPartialUpdateBodyExposureCriteriaOneExposureConfigOneKindDefault
+                                event: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."
                                     ),
+                                id: zod
+                                    .union([zod.number(), zod.null()])
+                                    .optional()
+                                    .describe("Action ID. Required when kind is 'ActionsNode'."),
+                                kind: zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']),
                                 properties: zod
                                     .array(
                                         zod.object({
@@ -4767,7 +4777,6 @@ export const experimentsDuplicateCreateBodyNameMax = 400
 export const experimentsDuplicateCreateBodyDescriptionMax = 3000
 
 export const experimentsDuplicateCreateBodyArchivedDefault = false
-export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOneKindDefault = `ExperimentEventExposureConfig`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemOperatorDefault = `exact`
 export const experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOnePropertiesItemTypeDefault = `event`
 export const experimentsDuplicateCreateBodyMetricsOneItemCompletionEventOnePropertiesOneItemOperatorDefault = `exact`
@@ -4932,12 +4941,17 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                     exposure_config: zod
                         .union([
                             zod.object({
-                                event: zod.string().describe('Custom exposure event name.'),
-                                kind: zod
-                                    .literal('ExperimentEventExposureConfig')
-                                    .default(
-                                        experimentsDuplicateCreateBodyExposureCriteriaOneExposureConfigOneKindDefault
+                                event: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."
                                     ),
+                                id: zod
+                                    .union([zod.number(), zod.null()])
+                                    .optional()
+                                    .describe("Action ID. Required when kind is 'ActionsNode'."),
+                                kind: zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']),
                                 properties: zod
                                     .array(
                                         zod.object({

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -335,7 +335,12 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                                     .union([zod.number(), zod.null()])
                                     .optional()
                                     .describe("Action ID. Required when kind is 'ActionsNode'."),
-                                kind: zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']),
+                                kind: zod
+                                    .union([zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
+                                    ),
                                 properties: zod
                                     .array(
                                         zod.object({
@@ -2626,7 +2631,12 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                                     .union([zod.number(), zod.null()])
                                     .optional()
                                     .describe("Action ID. Required when kind is 'ActionsNode'."),
-                                kind: zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']),
+                                kind: zod
+                                    .union([zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
+                                    ),
                                 properties: zod
                                     .array(
                                         zod.object({
@@ -4951,7 +4961,12 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                                     .union([zod.number(), zod.null()])
                                     .optional()
                                     .describe("Action ID. Required when kind is 'ActionsNode'."),
-                                kind: zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']),
+                                kind: zod
+                                    .union([zod.enum(['ExperimentEventExposureConfig', 'ActionsNode']), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
+                                    ),
                                 properties: zod
                                     .array(
                                         zod.object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
@@ -49,8 +49,16 @@
                                             "description": "Action ID. Required when kind is 'ActionsNode'."
                                         },
                                         "kind": {
-                                            "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
-                                            "type": "string"
+                                            "anyOf": [
+                                                {
+                                                    "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
                                         },
                                         "properties": {
                                             "description": "Event property filters. Pass an empty array if no filters needed.",
@@ -161,7 +169,7 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["kind", "properties"],
+                                    "required": ["properties"],
                                     "type": "object"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
@@ -27,12 +27,29 @@
                                 {
                                     "properties": {
                                         "event": {
-                                            "description": "Custom exposure event name.",
-                                            "type": "string"
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."
+                                        },
+                                        "id": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Action ID. Required when kind is 'ActionsNode'."
                                         },
                                         "kind": {
-                                            "const": "ExperimentEventExposureConfig",
-                                            "default": "ExperimentEventExposureConfig",
+                                            "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
                                             "type": "string"
                                         },
                                         "properties": {
@@ -144,7 +161,7 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["event", "properties"],
+                                    "required": ["kind", "properties"],
                                     "type": "object"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
@@ -100,8 +100,16 @@
                                             "description": "Action ID. Required when kind is 'ActionsNode'."
                                         },
                                         "kind": {
-                                            "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
-                                            "type": "string"
+                                            "anyOf": [
+                                                {
+                                                    "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
                                         },
                                         "properties": {
                                             "description": "Event property filters. Pass an empty array if no filters needed.",
@@ -212,7 +220,7 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["kind", "properties"],
+                                    "required": ["properties"],
                                     "type": "object"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-duplicate.json
@@ -78,12 +78,29 @@
                                 {
                                     "properties": {
                                         "event": {
-                                            "description": "Custom exposure event name.",
-                                            "type": "string"
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."
+                                        },
+                                        "id": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Action ID. Required when kind is 'ActionsNode'."
                                         },
                                         "kind": {
-                                            "const": "ExperimentEventExposureConfig",
-                                            "default": "ExperimentEventExposureConfig",
+                                            "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
                                             "type": "string"
                                         },
                                         "properties": {
@@ -195,7 +212,7 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["event", "properties"],
+                                    "required": ["kind", "properties"],
                                     "type": "object"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -76,8 +76,16 @@
                                             "description": "Action ID. Required when kind is 'ActionsNode'."
                                         },
                                         "kind": {
-                                            "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
-                                            "type": "string"
+                                            "anyOf": [
+                                                {
+                                                    "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure."
                                         },
                                         "properties": {
                                             "description": "Event property filters. Pass an empty array if no filters needed.",
@@ -188,7 +196,7 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["kind", "properties"],
+                                    "required": ["properties"],
                                     "type": "object"
                                 },
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -54,12 +54,29 @@
                                 {
                                     "properties": {
                                         "event": {
-                                            "description": "Custom exposure event name.",
-                                            "type": "string"
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'."
+                                        },
+                                        "id": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Action ID. Required when kind is 'ActionsNode'."
                                         },
                                         "kind": {
-                                            "const": "ExperimentEventExposureConfig",
-                                            "default": "ExperimentEventExposureConfig",
+                                            "enum": ["ExperimentEventExposureConfig", "ActionsNode"],
                                             "type": "string"
                                         },
                                         "properties": {
@@ -171,7 +188,7 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["event", "properties"],
+                                    "required": ["kind", "properties"],
                                     "type": "object"
                                 },
                                 {


### PR DESCRIPTION
## Problem

Actions couldn't be used for experiment exposures via the MCP.

## Changes

Add actions