### PR TITLE
fix(data-warehouse): write synced timestamps as UTC, not timestamp_ntz

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -621,18 +621,53 @@ class TestEvolveSchemaFirstPass:
         assert values[1] == 3661.0
         assert values[2] is None
 
-    def test_nanosecond_timestamp_normalized_to_microseconds(self):
+    def test_nanosecond_timestamp_normalized_to_microsecond_utc(self):
         ns_ts = pa.array([1_000_000_000, 2_000_000_000], type=pa.timestamp("ns"))
         arrow_table = pa.table({"ts": ns_ts})
         result = evolve_pyarrow_schema(arrow_table, None)
-        assert result.schema.field("ts").type == pa.timestamp("us")
+        assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
 
-    def test_tz_timestamp_stripped_to_utc_microseconds(self):
+    def test_naive_timestamp_gets_utc_preserving_wall_clock(self):
+        # Snowflake TIMESTAMP_NTZ (and Postgres "timestamp without time zone") arrive
+        # tz-naive. UTC must be attached without shifting the wall-clock value, otherwise
+        # delta-rs writes the unqueryable `timestamp_ntz` Delta type.
+        naive_ts = pa.array([datetime.datetime(2026, 1, 1, 14, 0, 0), None], type=pa.timestamp("us"))
+        arrow_table = pa.table({"ts": naive_ts})
+        result = evolve_pyarrow_schema(arrow_table, None)
+        assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+        assert result.column("ts").to_pylist() == [
+            datetime.datetime(2026, 1, 1, 14, 0, 0, tzinfo=datetime.UTC),
+            None,
+        ]
+
+    def test_zoned_timestamp_converted_to_utc_microseconds(self):
         tz_ts = pa.array([1_000_000, 2_000_000], type=pa.timestamp("us", tz="America/New_York"))
         arrow_table = pa.table({"ts": tz_ts})
         result = evolve_pyarrow_schema(arrow_table, None)
-        assert result.schema.field("ts").type == pa.timestamp("us")
-        assert result.schema.field("ts").type.tz is None
+        assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+        # tz-aware pyarrow timestamps store the UTC instant; only the displayed zone changes.
+        assert result.column("ts").to_pylist() == [
+            datetime.datetime(1970, 1, 1, 0, 0, 1, tzinfo=datetime.UTC),
+            datetime.datetime(1970, 1, 1, 0, 0, 2, tzinfo=datetime.UTC),
+        ]
+
+    def test_naive_timestamp_written_to_delta_is_not_timestamp_ntz(self, tmp_path):
+        # Regression guard for the actual ClickHouse-breaking condition: delta-rs writes
+        # tz-naive pyarrow timestamps as `timestamp_ntz`, which ClickHouse's DeltaLake
+        # reader cannot read. The evolved table must produce a readable `timestamp` column.
+        arrow_table = pa.table(
+            {
+                "id": pa.array([1], type=pa.int64()),
+                "ts": pa.array([datetime.datetime(2026, 1, 1, 14, 0, 0)], type=pa.timestamp("us")),
+            }
+        )
+        evolved = evolve_pyarrow_schema(arrow_table, None)
+
+        delta_path = str(tmp_path / "table")
+        deltalake.write_deltalake(delta_path, evolved, mode="overwrite")
+        schema_json = deltalake.DeltaTable(delta_path).schema().to_json()
+        assert "timestamp_ntz" not in schema_json
+        assert '"type":"timestamp"' in schema_json
 
 
 class TestEvolveSchemaSecondPassMissingColumns:

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -194,13 +194,19 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
             )
             incoming_column = incoming_table.column(column_name)
 
-        # Normalize timestamps to microseconds and no timezone.
+        # Normalize timestamps to microsecond UTC. delta-rs writes timezone-naive
+        # pyarrow timestamps as the Delta `timestamp_ntz` logical type, which
+        # ClickHouse's DeltaLake reader rejects ("Unsupported DeltaLake type:
+        # timestamp_ntz") — the rows land in S3 but the table is unqueryable.
+        # Attaching UTC makes delta-rs emit the readable `timestamp` type instead.
+        # Naive inputs (e.g. Snowflake TIMESTAMP_NTZ) keep their wall-clock value with
+        # UTC attached; zoned inputs are converted to the equivalent UTC instant.
         if pa.types.is_timestamp(incoming_field.type) and (
-            incoming_field.type.unit == "ns" or incoming_field.type.tz is not None
+            incoming_field.type.unit != "us" or incoming_field.type.tz != "UTC"
         ):
-            microsecond_timestamps = pc.cast(incoming_column, pa.timestamp("us"), safe=False).combine_chunks()
+            utc_timestamps = pc.cast(incoming_column, pa.timestamp("us", tz="UTC"), safe=False).combine_chunks()
             incoming_table = incoming_table.set_column(
-                incoming_table.schema.get_field_index(column_name), column_name, microsecond_timestamps
+                incoming_table.schema.get_field_index(column_name), column_name, utc_timestamps
             )
 
     if not delta_schema:


### PR DESCRIPTION
## Problem

Data warehouse syncs of tables with timezone-naive timestamp columns (e.g. Snowflake `TIMESTAMP_NTZ`, Postgres `timestamp without time zone`) report **Completed** — rows are written to S3 — but no queryable table is produced. On a first sync the schema is left showing **Synced table: Not yet synced** with no row count; on a re-sync of an existing table, the table exists but every query fails at schema-read time.

The root cause is a type-system mismatch between the writer and the reader:

- `evolve_pyarrow_schema` normalizes every timestamp to a **timezone-naive** `timestamp[us]` before the Delta write (the normalization explicitly stripped the timezone).
- `delta-rs` (pinned at `deltalake==1.4.0`) writes a tz-naive pyarrow timestamp as the Delta **`timestamp_ntz`** logical type.
- ClickHouse's `deltaLake()` reader does **not** support `timestamp_ntz` — it throws `Code: 36. DB::Exception: Unsupported DeltaLake type: timestamp_ntz (BAD_ARGUMENTS)` while building the table structure, before reading any row.

Why the sync still reports **Completed** with no table: on a first sync, `validate_schema_and_update_table` creates the `DataWarehouseTable` and then calls `get_columns()` (which runs the ClickHouse Delta introspection) inside a single `transaction.atomic()` block. The introspection raises on `timestamp_ntz`, so the transaction rolls back — the table creation is undone and `schema.table` is never linked — even though the rows were physically written to S3 and the sync activity finished. A prior change downgraded the user-facing log for this error to `debug`, which silenced the only visible signal.

This affects any tz-naive source timestamp, and (because the normalization stripped the zone off zoned columns too) zoned columns were being funneled into the same unreadable type.

## Changes

Normalize synced timestamps to **microsecond UTC** instead of stripping the timezone, in `evolve_pyarrow_schema` (the single normalization point shared by pipeline v2 and v3, including the first-sync path):

- **Naive inputs** (e.g. `TIMESTAMP_NTZ`) get UTC attached **without shifting the wall-clock value** — `2026-01-01 14:00` stays `14:00Z`.
- **Zoned inputs** are converted to the equivalent UTC instant.
- delta-rs then emits the readable Delta `timestamp` type, which ClickHouse reads as `DateTime64(6, 'UTC')`. `get_columns()` introspection succeeds, so the table is created, linked to the schema, and queryable.

The downstream HogQL column type is unchanged — `HogQLSchema` already maps any timestamp (naive or tz-aware) to `DateTimeDatabaseField`.

**Scope note:** this fixes newly-created tables and any table that is reset + fully re-synced. Existing tables already written with `timestamp_ntz` columns keep that type in their Delta log (delta-rs cannot change a column's type in place), so they still need a reset + full re-sync to recover — that is inherent to Delta, not something this PR can retroactively fix.

## How did you test this code?

I'm an agent (Claude Code). I did **not** run a manual end-to-end sync. Automated tests I actually ran locally (all green):

- Updated/added unit tests in `test_pipeline_utils.py` covering the first-pass normalization: naive → UTC (wall-clock preserved), `ns` → `us` UTC, and zoned → UTC instant.
- Added a regression test that runs the evolved table through a real `write_deltalake` and asserts the resulting Delta logical type is `timestamp`, **not** `timestamp_ntz` — this directly guards the ClickHouse-breaking condition.
- `pytest test_pipeline_utils.py test_delta_table_helper.py test_hogql_schema.py` → 124 passed.
- `ruff check` / `ruff format` clean; lint-staged (`ty check`) passed on commit.

I also empirically confirmed against `deltalake==1.4.0` that tz-naive pyarrow timestamps write as Delta `timestamp_ntz` while tz-aware UTC ones write as `timestamp`, and that the UTC cast preserves wall-clock for naive values.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a customer Snowflake sync that reported Completed but produced no queryable table (schema showed "Not yet synced", no row count). Traced the `Unsupported DeltaLake type: timestamp_ntz` error through `get_columns` introspection → the `transaction.atomic()` table-registration rollback → `evolve_pyarrow_schema` → the delta-rs write, and confirmed the writer/reader mismatch empirically with a local `write_deltalake` probe on the pinned `deltalake==1.4.0`.

Considered a narrower fix that only coerced `TIMESTAMP_NTZ` source columns, but rejected it: under delta-rs 1.4.0 the normalization produces an unreadable type for **all** tz-naive output, so fixing it at the normalization layer (normalize-to-UTC rather than strip-to-naive) is the correct and complete fix. Compared against how upstream Airbyte handles this — it preserves the without-timezone distinction end-to-end and relies on Iceberg-aware readers (Trino/Spark) that support it; PostHog's ClickHouse-over-Delta reader does not, so coercing to UTC at write time (which Airbyte itself does for zoned Snowflake types) is the right call here.

Tooling: Claude Code (Opus 4.8).
