### PR TITLE
chore(readme): document how to run tests at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- Run tests with: hogli test <file_or_directory> (e.g. hogli test path/to/test.py::TestClass::test_method) -->
 <p align="center">
   <img alt="posthoglogo" src="https://user-images.githubusercontent.com/65415371/205059737-c8a4f836-4889-4654-902e-f302b187b6a0.png">
 </p>


### PR DESCRIPTION
## Problem

A new contributor opening the repo has no at-a-glance pointer to how tests are run — the command lives in the dev guide, not somewhere you'd see while editing the README.

## Changes

Add a one-line HTML comment at the very top of `README.md` pointing to the canonical test command (`hogli test <file_or_directory>`). It's a comment, so it doesn't change the rendered README — it's just a hint for anyone editing the file.

## How did you test this code?

I'm an agent (PostHog Slack app). No automated tests apply — this is a comment-only change to `README.md` with no code impact. Verified the comment is well-formed HTML and renders invisibly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack by Vojta Bartos: add a one-line comment to the top of the README explaining how to run tests. Used the PostHog Slack app agent. Chose the `hogli test` command as the canonical entry point (sourced from the repo's CLAUDE.md dev guide) and used an HTML comment so the rendered README is unchanged.

Slack thread: https://posthog.slack.com/archives/C0AUXMK175K/p1780999294441549
