### PR TITLE
chore(devex): backfill query ownership in CODEOWNERS-soft

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -45,6 +45,8 @@ frontend/src/scenes/hog-functions/ @PostHog/team-workflows
 # Web Analytics - owned by @PostHog/team-web-analytics
 frontend/src/scenes/web-analytics/** @PostHog/team-web-analytics
 posthog/hogql_queries/web_analytics/** @PostHog/team-web-analytics
+posthog/models/web_preaggregated/** @PostHog/team-web-analytics
+posthog/models/channel_type/** @PostHog/team-web-analytics
 frontend/src/toolbar/web-vitals/** @PostHog/team-web-analytics
 rust/common/cookieless/** @PostHog/team-web-analytics
 nodejs/src/ingestion/cookieless/** @PostHog/team-web-analytics
@@ -72,6 +74,10 @@ posthog/hogql/database/schema/sessions*\*.py @PostHog/team-analytics-platform
 posthog/models/raw_sessions/** @PostHog/team-analytics-platform
 posthog/models/schema.py @PostHog/team-analytics-platform
 posthog/models/sessions/** @PostHog/team-analytics-platform
+posthog/hogql_queries/sessions_query_runner.py @PostHog/team-analytics-platform
+posthog/hogql_queries/sessions_timeline_query_runner.py @PostHog/team-analytics-platform
+posthog/dags/sessions.py @PostHog/team-analytics-platform
+ee/clickhouse/materialized_columns/** @PostHog/team-analytics-platform
 posthog/tasks/alerts/** @PostHog/team-analytics-platform
 posthog/tasks/exports/** @PostHog/team-analytics-platform
 posthog/temporal/alerts/ @PostHog/team-analytics-platform
@@ -95,6 +101,7 @@ posthog/api/cohort.py @PostHog/team-feature-flags
 posthog/models/cohort/ @PostHog/team-feature-flags
 frontend/src/scenes/cohorts/ @PostHog/team-feature-flags
 posthog/tasks/calculate_cohort.py @PostHog/team-feature-flags
+posthog/hogql_queries/hogql_cohort_query.py @PostHog/team-feature-flags
 
 # Feature Flags frontend - owned by @PostHog/team-feature-flags
 frontend/src/scenes/feature-flags/ @PostHog/team-feature-flags
@@ -115,6 +122,7 @@ posthog/temporal/data_modeling/** @PostHog/team-data-modeling
 # HogQL - owned by @PostHog/team-data-tools
 # and also hard owned by the @PostHog/hogql on `CODEOWNERS` file
 posthog/hogql/\*\* @PostHog/team-data-tools
+posthog/hogql_queries/hogql_query_runner.py @PostHog/team-data-tools
 
 # Tracing/Metrics — owned by @PostHog/logs (logs itself comes from products/logs/product.yaml)
 products/tracing/** @PostHog/logs
@@ -127,8 +135,6 @@ products/error_tracking/frontend/** @PostHog/team-error-tracking
 products/error_tracking/mcp/** @PostHog/team-error-tracking
 products/error_tracking/skills/** @PostHog/team-error-tracking
 cli/** @PostHog/team-error-tracking
-posthog/hogql_queries/error_tracking/error_tracking_query_runner.py @PostHog/team-error-tracking
-posthog/hogql_queries/error_tracking/error_tracking_issue_correlation_query_runner.py @PostHog/team-error-tracking
 rust/cymbal/** @PostHog/team-error-tracking
 
 # Notebooks - owned by @PostHog/team-platform-features
@@ -264,9 +270,17 @@ frontend/src/scenes/groups/ @PostHog/team-product-analytics
 frontend/src/scenes/persons/ @PostHog/team-product-analytics
 frontend/src/scenes/persons-management/ @PostHog/team-product-analytics
 posthog/api/event_definition.py @PostHog/team-product-analytics
+posthog/api/event.py @PostHog/team-product-analytics
+posthog/api/element.py @PostHog/team-product-analytics
+posthog/api/person.py @PostHog/team-product-analytics
 posthog/models/action/ @PostHog/team-product-analytics
 posthog/hogql_queries/insights/ @PostHog/team-product-analytics
 posthog/hogql_queries/groups/ @PostHog/team-product-analytics
+posthog/hogql_queries/events_query_runner.py @PostHog/team-product-analytics
+posthog/hogql_queries/actors_query_runner.py @PostHog/team-product-analytics
+posthog/hogql_queries/property_values_query_runner.py @PostHog/team-product-analytics
+ee/clickhouse/views/groups.py @PostHog/team-product-analytics
+ee/clickhouse/queries/related_actors_query.py @PostHog/team-product-analytics
 posthog/temporal/product_analytics/ @PostHog/team-product-analytics
 posthog/temporal/mcp_analytics/ @PostHog/team-product-analytics
 frontend/src/scenes/themes/ @PostHog/team-product-analytics
@@ -286,6 +300,8 @@ frontend/src/scenes/max/ @PostHog/team-signals
 frontend/src/scenes/inbox/ @PostHog/team-signals
 ee/hogai/ @PostHog/team-signals
 ee/support_sidebar_max/ @PostHog/team-signals
+posthog/models/ai/** @PostHog/team-signals
+posthog/hogql_queries/document_embeddings_query_runner.py @PostHog/team-signals
 
 # Billing - owned by @PostHog/team-billing
 frontend/src/scenes/billing/ @PostHog/team-billing
@@ -305,6 +321,11 @@ posthog/caching/ @PostHog/team-query-performance
 posthog/temporal/delete_persons/ @PostHog/team-ingestion
 posthog/temporal/sync_person_distinct_ids/ @PostHog/team-ingestion
 posthog/tasks/split_person.py @PostHog/team-ingestion
+posthog/models/person/** @PostHog/team-ingestion
+posthog/dags/detach_distinct_id.py @PostHog/team-ingestion
+posthog/dags/fix_missing_person_overrides.py @PostHog/team-ingestion
+posthog/dags/fix_person_id_overrides.py @PostHog/team-ingestion
+posthog/dags/person_property_reconciliation.py @PostHog/team-ingestion
 
 # User interviews - owned by individuals (no team); product.yaml only auto-assigns team slugs
 products/user_interviews/** @pauldambra @fivestarspicy @ksvat


### PR DESCRIPTION
## Problem

I asked claude to help me check that CODEOWNERS-soft is up to date for all hogql/clickhouse queries.

Claude code continues:

`CODEOWNERS` (hard, blocking) intentionally covers almost no query code — only `posthog/clickhouse/migrations/**` and `posthog/hogql/**`. Everything else relies on `CODEOWNERS-soft` and `products/*/product.yaml` for non-blocking reviewer assignment. That soft layer has drifted: as ClickHouse/HogQL query files were added next to already-owned directories, split into new model packages, or moved between trees, nobody backfilled the soft entries. A sweep of all query-bearing files (raw `sync_execute`, `parse_select`/`ast.SelectQuery`, `HogQLQuery(...)`, frontend `hogql\`` tags) found ~117 of 494 unowned — many of them clearly belonging to a specific team.

There was also one concretely stale entry: two lines pointed at `posthog/hogql_queries/error_tracking/`, a directory that no longer exists.

## Changes

Backfills soft ownership in `CODEOWNERS-soft` for team-specific query code, routed to the team that already owns the adjacent surface:

| Team | Added |
| --- | --- |
| web-analytics | `models/web_preaggregated/**`, `models/channel_type/**` |
| analytics-platform | `hogql_queries/sessions_query_runner.py`, `sessions_timeline_query_runner.py`, `dags/sessions.py`, `ee/clickhouse/materialized_columns/**` |
| product-analytics | `hogql_queries/{events,actors,property_values}_query_runner.py`, `ee/clickhouse/views/groups.py`, `ee/clickhouse/queries/related_actors_query.py`, `api/{event,element,person}.py` |
| feature-flags | `hogql_queries/hogql_cohort_query.py` |
| data-tools | `hogql_queries/hogql_query_runner.py` |
| signals | `models/ai/**`, `hogql_queries/document_embeddings_query_runner.py` |
| ingestion | `models/person/**`, four `dags/*person*` override jobs |

Also **removes** the two stale `posthog/hogql_queries/error_tracking/*` lines — those runners now live in `products/error_tracking/backend/hogql_queries/`, already covered by `products/error_tracking/backend/**`, so ownership is preserved.

Attributions were grounded in each file's location plus commit-history scope tags (e.g. `materialized_columns` was added under `feat(analytics-platform)`; `models/ai` is Max embeddings under `feat(max)`). Genuinely shared infrastructure (`hogql_queries/query_runner.py` base class, `frontend/src/queries/`, ops/debug management commands) and mixed-ownership files (`models/async_deletion/`, `models/tophog/`) were intentionally left unowned rather than mis-assigned.

## How did you test this code?

I'm an agent (PostHog Code). No manual testing — this is a config-only change to a non-blocking file with no required-reviewer or CI-validation consumer.

- Wrote a CODEOWNERS resolver (gitignore-style matching, last-match-wins, plus `product.yaml` owners) and confirmed coverage improved 377 → 405 owned files, with the remaining unowned set being shared infra or deliberately-deferred mixed-ownership paths.
- Ran a multi-agent review over the diff. It surfaced one real issue, since fixed: PostHog's auto-assigner (`assign-reviewers.js`) compiles a trailing `/` to an unbounded `.*`, so `models/ai/` would have cross-matched `models/ai_events/` (ai-observability) and `models/person/` would have over-matched `person_overrides/`/`personal_api_key.py`. Both directory entries now use the bounded `/**` form; re-ran the resolver to confirm `ai_events` resolves only to ai-observability and the person/ai query files stay owned.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie asked which teams own ClickHouse/HogQL queries via CODEOWNERS, then to gauge how stale CODEOWNERS is and tighten `CODEOWNERS-soft`. Tooling: PostHog Code (Opus). I built a CODEOWNERS coverage resolver to find unowned query files, attributed them using file location + git commit scopes, and ran a parallel QA review (security, compatibility, reliability, copy, plus two generalists). The compatibility and adversarial-generalist reviewers independently caught the trailing-slash over-match in the auto-assigner — that drove the `/**` fix applied here. Low-confidence/mixed-ownership paths were deliberately left unowned and called out rather than guessed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
