### PR TITLE
fix(devex): match CODEOWNERS dir patterns at the directory boundary

### DIFF
--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -154,8 +154,12 @@ function globToRegex(pattern) {
         .replace(/\*/g, '[^/]*')
         .replace(/__DOUBLESTAR__/g, '.*')
 
+    // A trailing-slash pattern is a directory: keep the slash so it matches only
+    // files inside the directory, not sibling paths sharing the name as a prefix
+    // (e.g. `models/ai/` must not match `models/ai_events/`). Mirrors GitHub's
+    // own CODEOWNERS semantics, where `dir/` is a directory boundary.
     if (pattern.endsWith('/')) {
-        regex = regex.slice(0, -1) + '.*'
+        regex = regex + '.*'
     }
 
     return new RegExp(`^${regex}$`)

--- a/.github/scripts/assign-reviewers.test.js
+++ b/.github/scripts/assign-reviewers.test.js
@@ -6,6 +6,7 @@ const {
     isSubstantive,
     classifyOwners,
     buildReviewerComment,
+    fileMatchesPattern,
 } = require('./assign-reviewers')
 
 const file = (filename, additions = 0, deletions = 0) => ({
@@ -31,6 +32,29 @@ describe('assign-reviewers', () => {
             ['frontend/src/scenes/surveys/Survey.tsx', false],
         ])('%s -> %s', (filename, expected) => {
             expect(isExcludedFile(filename)).toBe(expected)
+        })
+    })
+
+    describe('fileMatchesPattern', () => {
+        test.each([
+            // a trailing slash is a directory boundary, not a name prefix
+            ['posthog/models/ai/utils.py', 'posthog/models/ai/', true],
+            ['posthog/models/ai/sub/deep.py', 'posthog/models/ai/', true],
+            ['posthog/models/ai_events/event.py', 'posthog/models/ai/', false],
+            ['posthog/models/person/util.py', 'posthog/models/person/', true],
+            ['posthog/models/person_overrides/x.py', 'posthog/models/person/', false],
+            ['posthog/models/personal_api_key.py', 'posthog/models/person/', false],
+            // /** is bounded to the directory, same as a trailing slash
+            ['posthog/models/ai/utils.py', 'posthog/models/ai/**', true],
+            ['posthog/models/ai_events/event.py', 'posthog/models/ai/**', false],
+            // a single star stays within one path segment
+            ['posthog/dags/sessions.py', 'posthog/dags/*.py', true],
+            ['posthog/dags/sub/sessions.py', 'posthog/dags/*.py', false],
+            // exact-file patterns match only that file
+            ['posthog/api/person.py', 'posthog/api/person.py', true],
+            ['posthog/api/person_other.py', 'posthog/api/person.py', false],
+        ])('%s vs %s', (filename, pattern, expected) => {
+            expect(fileMatchesPattern(filename, pattern)).toBe(expected)
         })
     })
 


### PR DESCRIPTION
## Problem

Fix a bug where 
`posthog/models/ai/`
matches
`posthog/models/ai_events.py`

(the slash is not handled correctly)

Posthog Code continues:

The reviewer auto-assigner (`.github/scripts/assign-reviewers.js`) compiles CODEOWNERS-soft patterns to regexes. For a trailing-slash directory pattern it stripped the slash before appending `.*`, turning `posthog/models/ai/` into `^posthog/models/ai.*$` — a bare name prefix rather than a directory boundary. So that rule also matched sibling paths like `posthog/models/ai_events/…`, and a PR touching only `ai_events` would additionally soft-request the owner of `models/ai/`. GitHub's own CODEOWNERS parser treats `dir/` as a directory boundary, so the script silently diverged from the file it's interpreting.

This was found while backfilling query ownership (companion PR to `CODEOWNERS-soft`) — it's the root cause that made the `/` vs `/**` distinction matter.

## Changes

- One-line fix in `globToRegex`: keep the trailing slash so the regex becomes `posthog/models/ai/.*`. Empirically this changes matching for only 7 of 112 trailing-slash patterns in `CODEOWNERS-soft`; most over-matched a same-owner sibling (harmless), and one was a genuine cross-team mis-assignment (`scenes/health/` was pulling growth into analytics-platform's `scenes/health-alerts/`). A couple of paths accidentally owned today via the loose match (`models/cohortmembership/`, a few top-level `scenes/` logic files) become unowned after this — both non-blocking soft owners; flagging for a trivial follow-up in `CODEOWNERS-soft` if desired.
- Adds `fileMatchesPattern` coverage to the existing `assign-reviewers.test.js` (directory-boundary, `/**`, single-star and exact-file forms).

Note: `assign-reviewers.test.js` is jest-style and isn't wired into any runner today, so the new test passes locally but does not yet gate CI. Converting that suite to `node --test` and adding it to `ci-scripts.yml` is intentionally left as a separate follow-up, to keep this PR a focused behavioural change rather than bundling a runner migration.

## How did you test this code?

I'm an agent (PostHog Code) — no manual testing.

- Ran the suite locally with jest → 42/42 pass. Red/green confirmed: reverting the one-line change fails exactly the 3 sibling-prefix cases (`ai/`↔`ai_events/`, `person/`↔`person_overrides/`, `person/`↔`personal_api_key.py`).
- Separately compared old-vs-new regex for every trailing-slash pattern in `CODEOWNERS-soft` against all tracked files to bound the behaviour change to the 7 patterns above.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie asked whether to fix this at the source after a multi-agent review of the companion `CODEOWNERS-soft` PR independently surfaced the over-match (the compatibility and adversarial reviewers both read `assign-reviewers.js` and traced it to `globToRegex`). Tooling: PostHog Code (Opus). Routed as its own PR because `assign-reviewers.js` is hard-owned by @PostHog/team-security in `CODEOWNERS` and warrants their review independent of the ownership backfill.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
