### PR TITLE
fix: convert app metrics window bounds to UTC before querying ClickHouse

### DIFF
--- a/posthog/api/app_metrics2.py
+++ b/posthog/api/app_metrics2.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, cast
 
 from drf_spectacular.utils import extend_schema
@@ -127,8 +127,10 @@ def fetch_app_metrics_trends(
     clickhouse_kwargs["team_id"] = team_id
     clickhouse_kwargs["app_source"] = app_source
     clickhouse_kwargs["app_source_id"] = app_source_id
-    clickhouse_kwargs["after"] = after.strftime("%Y-%m-%dT%H:%M:%S")
-    clickhouse_kwargs["before"] = before.strftime("%Y-%m-%dT%H:%M:%S")
+    # Convert to UTC before formatting — the naive string is read as UTC by toDateTime64, so a
+    # team-timezone-aware bound would otherwise shift the window by the team's offset.
+    clickhouse_kwargs["after"] = after.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+    clickhouse_kwargs["before"] = before.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S")
     clickhouse_kwargs["instance_id"] = instance_id
     clickhouse_kwargs["name"] = name
     clickhouse_kwargs["kind"] = kind
@@ -205,12 +207,14 @@ def fetch_app_metric_totals(
     name = name or []
     kind = kind or []
 
+    # Convert to UTC before formatting — the naive string is read as UTC by toDateTime64, so a
+    # team-timezone-aware bound would otherwise shift the window by the team's offset.
     clickhouse_kwargs: dict[str, Any] = {
         "team_id": team_id,
         "app_source": app_source,
         "app_source_id": app_source_id,
-        "after": after.strftime("%Y-%m-%dT%H:%M:%S") if after else None,
-        "before": before.strftime("%Y-%m-%dT%H:%M:%S") if before else None,
+        "after": after.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S") if after else None,
+        "before": before.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S") if before else None,
     }
 
     clickhouse_query = f"""

--- a/posthog/api/test/test_app_metrics2.py
+++ b/posthog/api/test/test_app_metrics2.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from posthog.api.app_metrics2 import fetch_app_metric_totals
+from posthog.test.fixtures import create_app_metric2
+
+# America/Los_Angeles is UTC-7 in June (PDT), so PT midnight is 07:00 UTC.
+LA = ZoneInfo("America/Los_Angeles")
+
+
+class TestAppMetrics2Timezone(ClickhouseTestMixin, BaseTest):
+    def _seed(self, hour_utc: int):
+        create_app_metric2(
+            team_id=self.team.pk,
+            app_source="hog_function",
+            app_source_id="fn-1",
+            metric_kind="success",
+            metric_name="succeeded",
+            timestamp=datetime(2026, 6, 8, hour_utc, 0, 0, tzinfo=UTC),
+        )
+
+    def test_totals_window_bound_is_utc_not_team_local(self):
+        self._seed(6)  # 06:00 UTC — before the 07:00 UTC bound
+        self._seed(8)  # 08:00 UTC — after it
+        result = fetch_app_metric_totals(
+            team_id=self.team.pk,
+            app_source="hog_function",
+            app_source_id="fn-1",
+            after=datetime(2026, 6, 8, 0, 0, 0, tzinfo=LA),
+            before=datetime(2026, 6, 9, 0, 0, 0, tzinfo=LA),
+        )
+        # Only the 08:00 UTC row is inside the PT-midnight window; a naive bound read as 00:00 UTC
+        # would have counted both. `fetch_app_metrics_trends` shares the identical UTC conversion,
+        # so this also guards that path (and day-grain trends can't isolate the offset anyway).
+        assert result.totals == {"success": 1}

--- a/posthog/api/test/test_app_metrics2.py
+++ b/posthog/api/test/test_app_metrics2.py
@@ -1,37 +1,50 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from posthog.test.base import BaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
+
 from posthog.api.app_metrics2 import fetch_app_metric_totals
 from posthog.test.fixtures import create_app_metric2
 
-# America/Los_Angeles is UTC-7 in June (PDT), so PT midnight is 07:00 UTC.
-LA = ZoneInfo("America/Los_Angeles")
-
 
 class TestAppMetrics2Timezone(ClickhouseTestMixin, BaseTest):
-    def _seed(self, hour_utc: int):
+    def _seed(self, when_utc: datetime):
         create_app_metric2(
             team_id=self.team.pk,
             app_source="hog_function",
             app_source_id="fn-1",
             metric_kind="success",
             metric_name="succeeded",
-            timestamp=datetime(2026, 6, 8, hour_utc, 0, 0, tzinfo=UTC),
+            timestamp=when_utc,
         )
 
-    def test_totals_window_bound_is_utc_not_team_local(self):
-        self._seed(6)  # 06:00 UTC — before the 07:00 UTC bound
-        self._seed(8)  # 08:00 UTC — after it
+    @parameterized.expand(
+        [
+            ("America/Los_Angeles",),  # -07:00 (PDT in June)
+            ("Asia/Kolkata",),  # +05:30 (half-hour offset)
+            ("Pacific/Auckland",),  # +12:00 (wraps to the previous UTC day)
+        ]
+    )
+    def test_totals_window_bound_is_utc_not_team_local(self, tz_name: str):
+        tz = ZoneInfo(tz_name)
+        after_local = datetime(2026, 6, 8, 0, 0, 0, tzinfo=tz)
+        before_local = datetime(2026, 6, 9, 0, 0, 0, tzinfo=tz)
+        bound_utc = after_local.astimezone(UTC)
+        self._seed(bound_utc - timedelta(hours=1))  # an hour before the true bound — excluded
+        self._seed(bound_utc + timedelta(hours=1))  # an hour after — included
+
         result = fetch_app_metric_totals(
             team_id=self.team.pk,
             app_source="hog_function",
             app_source_id="fn-1",
-            after=datetime(2026, 6, 8, 0, 0, 0, tzinfo=LA),
-            before=datetime(2026, 6, 9, 0, 0, 0, tzinfo=LA),
+            after=after_local,
+            before=before_local,
         )
-        # Only the 08:00 UTC row is inside the PT-midnight window; a naive bound read as 00:00 UTC
-        # would have counted both. `fetch_app_metrics_trends` shares the identical UTC conversion,
-        # so this also guards that path (and day-grain trends can't isolate the offset anyway).
-        assert result.totals == {"success": 1}
+
+        # Local-midnight `after` must resolve to its true UTC instant. A naive bound (the offset
+        # dropped, read as UTC) would shift the window and miscount the row near the boundary —
+        # for negative offsets it pulls in the earlier row, for positive ones it drops both.
+        # `fetch_app_metrics_trends` shares the identical conversion, so this guards it too.
+        assert result.totals == {"success": 1}, tz_name


### PR DESCRIPTION
## Problem

`fetch_app_metric_totals` and `fetch_app_metrics_trends` (`posthog/api/app_metrics2.py`) format the `after`/`before` window bounds with `.strftime("%Y-%m-%dT%H:%M:%S")`. But those bounds come from `relative_date_parse_with_delta_mapping`, which returns a datetime **aware in the team's timezone**. `strftime` drops the offset, and `toDateTime64(<str>, 6)` then reads the naive string as **UTC** against the UTC `timestamp` column — so the query window is shifted by the team's UTC offset.

It's invisible for UTC (and near-UTC) teams, and barely matters at day grain (which is why it's gone unnoticed), but it's wrong for narrow windows on far-offset teams — e.g. a PT team asking "how's this destination doing in the last 3 hours" gets a window that's ~7–8h off.

## Changes

- Convert `after`/`before` to UTC (`.astimezone(UTC)`) before formatting, in both `fetch_app_metric_totals` and `fetch_app_metrics_trends`, so the naive string matches the UTC column.
- Add `posthog/api/test/test_app_metrics2.py` — parametrized across negative (`America/Los_Angeles` −7), half-hour (`Asia/Kolkata` +5:30) and large-positive (`Pacific/Auckland` +12, wraps a UTC day) offsets, asserting the totals window boundary resolves at the true UTC instant. The two helpers share the identical conversion, so the totals test guards both (day-grain trends can't isolate the offset anyway).

This is a follow-up to the same fix already shipped for the workflows invocation/stats queries in #61655 — this PR closes the gap in the shared aggregate helpers.

## Impact

**Read-path only — no migration, no backfill, stored data untouched.** Effective immediately on deploy, fully reversible (revert the PR). Numbers **shift to correct, they don't break** — no errors, no empty states.

- **UTC teams: zero change.**
- **Non-UTC teams:** the metrics window moves by their offset, so events in the boundary hours (~offset-width) move in/out of the window.
  - **Long windows (the `-7d` default): small.** A few hours' shift is a sliver of a 7-day window, and the time-series *shape* barely moves because buckets are already UTC-aligned (`toStartOfInterval`) — mostly just the first/last bucket gains or loses a little.
  - **Short windows ("last 1h / 3h") on far-offset teams: material** — and this is exactly the case that was wrong before and is now corrected.

**Affected surfaces** (all read through these two helpers):

| Surface | `app_source` | Owner |
|---|---|---|
| CDP pipeline destinations — Metrics tab (`HogFunctionViewSet`) | `hog_function` | CDP |
| Workflows — workflow metrics (`HogFlowViewSet`) | `hog_flow` | Workflows |
| Event filters — metrics (`EventFilterConfigViewSet`) | `event_filter` | Ingestion |

**Not affected:** batch exports — they write `app_metrics2` but read metrics via a separate path (no `AppMetricsMixin`, not a caller here).

No alerting/billing coupling that I can see — these endpoints feed the metrics UI, not alerts (which run off insights/HogQL) or billing — but a one-line confirm from CDP/Ingestion is welcome. The main user-visible effect is a non-UTC customer noticing their destination / workflow / event-filter delivery numbers for a given window shift slightly (more correct) after deploy.

## How did you test this code?

- New `test_app_metrics2.py::TestAppMetrics2Timezone` (3 offsets) passes; confirmed each fails without the conversion (negative offsets over-count, positive offsets under-count).
- `ruff` clean.

## 🤖 Agent context

- Scoped deliberately to the two shared `app_metrics2` helpers. The behavioral effect is non-UTC-teams-only; no existing `app_metrics2` tests assert the old formatting, so nothing else changes.
- Worth a glance from CDP/Ingestion: the destinations Metrics tab + event-filter metrics now use correct UTC window boundaries for non-UTC teams — values shift slightly at window edges (more correct), not in shape.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
