### PR TITLE
refactor(temporal): Multiple secret string format handling

### DIFF
--- a/posthog/management/commands/rotate_temporal_schedule_encryption_key.py
+++ b/posthog/management/commands/rotate_temporal_schedule_encryption_key.py
@@ -318,7 +318,7 @@ async def _as_async_iter(
 async def _payloads_use_main_key(payloads) -> bool:
     if not payloads:
         return True
-    main_key_codec = codec.EncryptionCodec(codec._prepare_key(settings.TEMPORAL_SECRET_KEY), [])
+    main_key_codec = codec.EncryptionCodec(codec._prepare_key(codec._load_as_bytes(settings.TEMPORAL_SECRET_KEY)), [])
     try:
         await main_key_codec.decode(payloads)
     except InvalidToken:

--- a/posthog/temporal/common/codec.py
+++ b/posthog/temporal/common/codec.py
@@ -16,13 +16,40 @@ class _RequiredSettings(typing.Protocol):
     DEBUG: bool
 
 
-def _prepare_key(key: str | bytes) -> bytes:
+def _load_as_bytes(raw: str | bytes, /, check_length: bool = True) -> bytes:
+    if isinstance(raw, bytes):
+        loaded = raw
+
+    else:
+        prefix, sep, secret = raw.partition(":")
+
+        if sep and prefix == "hex":
+            loaded = bytes.fromhex(secret)
+
+        elif sep and prefix == "base64-urlsafe":
+            loaded = base64.urlsafe_b64decode(secret)
+
+        elif sep and prefix == "base64":
+            loaded = base64.b64decode(secret, validate=True)
+
+        else:
+            # Legacy format, kept for backwards compatibility
+            # TODO: Remove this branch & raise after rotating secrets
+            loaded = raw.encode()
+
+    # TODO: Also, make the check exact after removing legacy format
+    if check_length and len(loaded) < 32:
+        raise ValueError(f"Expected at least 32 bytes, got '{len(loaded)}'")
+
+    return loaded
+
+
+def _prepare_key(key: bytes) -> bytes:
     """Prepare an encryption key by padding or truncating it, and encoding it.
 
     We require a URL-safe, base64 encoded, 32 byte key.
     """
-    key_bytes = key.encode() if isinstance(key, str) else key
-    resized_key = _resize_key(key_bytes)
+    resized_key = _resize_key(key)
     encoded_key = base64.urlsafe_b64encode(resized_key)
     return encoded_key
 
@@ -71,15 +98,15 @@ class EncryptionCodec(PayloadCodec):
             ValueError: If a key with less than 32 bytes is used in non-TEST non-DEBUG
                 environments.
         """
-        if not settings.TEST and not settings.DEBUG:
-            if any(
-                len(key.encode() if isinstance(key, str) else key) < 32
-                for key in (settings.TEMPORAL_SECRET_KEY, *settings.TEMPORAL_FALLBACK_SECRET_KEYS)
-            ):
-                raise ValueError("Keys must be at least 32 bytes")
-
-        main_key = _prepare_key(settings.TEMPORAL_SECRET_KEY)
-        fallback_keys = map(_prepare_key, settings.TEMPORAL_FALLBACK_SECRET_KEYS)
+        should_check_length = not settings.TEST and not settings.DEBUG
+        main_key = _prepare_key(_load_as_bytes(settings.TEMPORAL_SECRET_KEY, check_length=should_check_length))
+        fallback_keys = map(
+            _prepare_key,
+            (
+                _load_as_bytes(secret, check_length=should_check_length)
+                for secret in settings.TEMPORAL_FALLBACK_SECRET_KEYS
+            ),
+        )
 
         return cls(main_key, fallback_keys)
 

--- a/posthog/temporal/tests/test_encryption_codec.py
+++ b/posthog/temporal/tests/test_encryption_codec.py
@@ -14,7 +14,7 @@ from temporalio.api.enums.v1 import EventType
 from temporalio.client import Client
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from posthog.temporal.common.codec import EncryptionCodec, _prepare_key, _resize_key
+from posthog.temporal.common.codec import EncryptionCodec, _load_as_bytes, _prepare_key, _resize_key
 
 from products.batch_exports.backend.service import NoOpInputs
 from products.batch_exports.backend.temporal.noop import NoOpWorkflow, noop_activity
@@ -57,6 +57,29 @@ def test_prepare_key(key: bytes, expected: bytes) -> None:
     result = _prepare_key(key)
     assert result == expected
     assert base64.urlsafe_b64decode(result) == _resize_key(key)
+
+
+# The presence of '?' is important as it encodes differently in standard and
+# urlsafe base64 ('/' vs '_').
+BYTES = b"decaf???" * 4  # 32 bytes
+TEST_HEX_STRING = "hex:" + (BYTES).hex()
+TEST_BASE64_URLSAFE_STRING = "base64-urlsafe:" + base64.urlsafe_b64encode(BYTES).decode()
+TEST_BASE64_STRING = "base64:" + base64.b64encode(BYTES).decode()
+
+
+@pytest.mark.parametrize(
+    "raw,check_length,expected",
+    [
+        (b"a", False, b"a"),
+        (TEST_HEX_STRING, True, BYTES),
+        (TEST_BASE64_URLSAFE_STRING, True, BYTES),
+        (TEST_BASE64_STRING, True, BYTES),
+        ("any string", False, b"any string"),
+    ],
+)
+def test_load_as_bytes(raw: str | bytes, check_length: bool, expected: bytes) -> None:
+    result = _load_as_bytes(raw, check_length=check_length)
+    assert result == expected
 
 
 def test_codec_rejects_short_keys_when_not_debug_or_test():


### PR DESCRIPTION


<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The encryption codec currently takes a string and encodes it to generate at least 128-bits of entropy (32-bytes).

The problem is that the string may represent different things:
1. A 64 character hex string generated by, e.g., openssl rand -hex 32.
2. 44 base64 encoded bytes, decoded as a string, generated by, e.g., cryptography.fernet.Fernet.generate_key() a. Even further the base64 encoded bytes may be urlsafe (as generated by Fernet) or standard, as generated by, e.g., openssl rand -base64.
3. Some random characters

Each of these require different treatment:
1. We need to call bytes.fromhex to obtain the raw bytes, then encode them, and use them as the key.
2. We can pass the key along as it is, or decode first, and then re-encode.
3. We encode them, take the first 32 bytes, base64 encode them, and use that as our key.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

To make this distinction clear, this PR introduces a new function to load the encryption secret which looks at a prefix in the string, and determines what to do based on that.

If no valid prefix is found, we maintain backwards compatibility by calling encode on whatever we are fed.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added/extended unit tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I had claude help me generate some bytes that encode differently in urlsafe and standard base64. Otherwise it was just me getting confused as I was generating secrets and thinking how to share this with our app.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
