### PR TITLE
chore(mcp): Add trimmed mode to pydantic_schema helper

### DIFF
--- a/products/posthog_ai/scripts/pydantic_schema/__init__.py
+++ b/products/posthog_ai/scripts/pydantic_schema/__init__.py
@@ -75,8 +75,8 @@ def pydantic_schema(dotted_path: str, indent: int = 2, inline_defs: bool = True)
     shared building blocks (e.g. ``EventsNode``) once and reference them by name.
     """
     model_cls = _import_model(dotted_path)
-    schema = model_cls.model_json_schema()
+    raw = model_cls.model_json_schema()
+    schema: object = raw
     if not inline_defs:
-        schema = {k: v for k, v in schema.items() if k != "$defs"}
-        schema = _shorten_refs(schema)  # type: ignore[assignment]
+        schema = _shorten_refs({k: v for k, v in raw.items() if k != "$defs"})
     return json.dumps(schema, indent=indent)

--- a/products/posthog_ai/scripts/pydantic_schema/__init__.py
+++ b/products/posthog_ai/scripts/pydantic_schema/__init__.py
@@ -48,7 +48,19 @@ def json_schema_type_label(prop: dict) -> str:
     return t
 
 
-def pydantic_schema(dotted_path: str, indent: int = 2) -> str:
+def _shorten_refs(obj: object) -> object:
+    """Rewrite ``{"$ref": "#/$defs/EventsNode"}`` to ``{"$ref": "EventsNode"}`` recursively."""
+    if isinstance(obj, dict):
+        return {
+            k: (v.rsplit("/", 1)[-1] if k == "$ref" and isinstance(v, str) else _shorten_refs(v))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_shorten_refs(v) for v in obj]
+    return obj
+
+
+def pydantic_schema(dotted_path: str, indent: int = 2, inline_defs: bool = True) -> str:
     """Return the JSON Schema of a Pydantic model as a formatted JSON string.
 
     Usage in a template::
@@ -56,7 +68,15 @@ def pydantic_schema(dotted_path: str, indent: int = 2) -> str:
         ```json
         {{ pydantic_schema("products.feature_flags.backend.max_tools.FeatureFlagCreationSchema") }}
         ```
+
+    ``inline_defs=False`` drops the ``$defs`` block and shortens ``$ref``
+    pointers to bare type names, leaving just the model's own fields — avoids
+    inlining the full property-filter/query-node unions on every call. Render
+    shared building blocks (e.g. ``EventsNode``) once and reference them by name.
     """
     model_cls = _import_model(dotted_path)
     schema = model_cls.model_json_schema()
+    if not inline_defs:
+        schema = {k: v for k, v in schema.items() if k != "$defs"}
+        schema = _shorten_refs(schema)  # type: ignore[assignment]
     return json.dumps(schema, indent=indent)

--- a/products/posthog_ai/scripts/pydantic_schema/test/test_pydantic_schema.py
+++ b/products/posthog_ai/scripts/pydantic_schema/test/test_pydantic_schema.py
@@ -74,3 +74,24 @@ def test_pydantic_schema_renders_json(register_fake_module: Callable[..., None])
     assert schema["properties"]["name"]["type"] == "string"
     assert schema["properties"]["count"]["type"] == "integer"
     assert "name" in schema.get("required", [])
+
+
+class Inner(BaseModel):
+    value: str
+
+
+class Outer(BaseModel):
+    inner: Inner
+
+
+def test_pydantic_schema_inline_defs_false_drops_defs_and_shortens_refs(
+    register_fake_module: Callable[..., None],
+) -> None:
+    register_fake_module("_test_defs_models", "Outer", Outer)
+    inlined = json.loads(pydantic_schema("_test_defs_models.Outer"))
+    assert "$defs" in inlined
+    assert inlined["properties"]["inner"]["$ref"] == "#/$defs/Inner"
+
+    trimmed = json.loads(pydantic_schema("_test_defs_models.Outer", inline_defs=False))
+    assert "$defs" not in trimmed
+    assert trimmed["properties"]["inner"]["$ref"] == "Inner"


### PR DESCRIPTION
## Problem

The "writing-skills" skill suggests using `pydantic_schema()`. It however renders a model's full JSON Schema, inlining every transitive `$defs`. This can lead to very long boilerplate, especially for union-heavy models.

## Changes

- Add `inline_defs=False` parameter: drops the `$defs` block and shortens `$ref`s to bare type names, leaving just the model's own fields
- Default unchanged; nothing consumes it yet

## How did you test this code?

- added a unit test for the trimmed mode

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of an experiments-skill change where rendering four full metric schemas produced a ~13k-line reference (~93% duplicated `$defs`). Added a reusable trimmed mode rather than hand-editing generated output.
