### PR TITLE
feat(tasks): add pretty-print and hide-debug toggles to task log view

### DIFF
--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { TextMorph } from 'torph/react'
 
 import { IconCopy } from '@posthog/icons'
-import { LemonButton, LemonTag, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
@@ -208,12 +208,23 @@ export function TaskSessionView({
     initialPrompt,
     run,
 }: TaskSessionViewProps): JSX.Element {
+    // Debug lines are noise by default; opt in to show them.
+    const [showDebug, setShowDebug] = useState(false)
     const parsedLogs = useMemo(() => parseLogs(logs), [logs])
     // Use stream entries when available (real-time), otherwise fall back to parsed S3 logs
     const entries = useMemo(() => {
         const sourceEntries = streamEntries.length > 0 ? streamEntries : parsedLogs
         return filterDuplicateInitialPromptEntry(mergeDuplicateUserPromptEntries(sourceEntries), initialPrompt)
     }, [initialPrompt, parsedLogs, streamEntries])
+
+    const debugCount = useMemo(
+        () => entries.filter((entry) => entry.type === 'console' && entry.level === 'debug').length,
+        [entries]
+    )
+    const visibleEntries = useMemo(
+        () => (showDebug ? entries : entries.filter((entry) => !(entry.type === 'console' && entry.level === 'debug'))),
+        [entries, showDebug]
+    )
 
     const handleCopyLogs = (): void => {
         navigator.clipboard.writeText(logs).then(
@@ -242,14 +253,25 @@ export function TaskSessionView({
             <div className="flex justify-between items-center px-4 py-2 border-b">
                 <div className="flex items-center gap-2">
                     {run && <TaskRunStatusBadge run={run} />}
-                    <span className="text-sm font-semibold">Logs ({entries.length})</span>
+                    <span className="text-sm font-semibold">Logs ({visibleEntries.length})</span>
                 </div>
-                <LemonButton size="xsmall" icon={<IconCopy />} onClick={handleCopyLogs}>
-                    Copy
-                </LemonButton>
+                <div className="flex items-center gap-2">
+                    {debugCount > 0 && (
+                        <LemonSwitch
+                            label={`Show debug (${debugCount})`}
+                            checked={showDebug}
+                            onChange={setShowDebug}
+                            size="xsmall"
+                            bordered
+                        />
+                    )}
+                    <LemonButton size="xsmall" icon={<IconCopy />} onClick={handleCopyLogs}>
+                        Copy
+                    </LemonButton>
+                </div>
             </div>
             <div className="flex-1 overflow-auto p-4 font-mono text-sm bg-bg-3000">
-                {entries.map((entry) => (
+                {visibleEntries.map((entry) => (
                     <LogEntryRenderer key={entry.id} entry={entry} />
                 ))}
                 {(isPolling || isStreaming) && <HedgehogStatus />}

--- a/products/tasks/frontend/components/session/ToolCallEntry.tsx
+++ b/products/tasks/frontend/components/session/ToolCallEntry.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { IconChevronRight, IconTerminal } from '@posthog/icons'
-import { LemonTag, Spinner } from '@posthog/lemon-ui'
+import { LemonSwitch, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { ToolStatus } from '../../lib/parse-logs'
 
@@ -20,8 +20,75 @@ const STATUS_CONFIG: Record<ToolStatus, { label: string; type: 'default' | 'prim
     error: { label: 'Failed', type: 'danger' },
 }
 
+function isTextPart(item: unknown): item is { type: 'text'; text: string } {
+    return (
+        typeof item === 'object' &&
+        item !== null &&
+        (item as Record<string, unknown>).type === 'text' &&
+        typeof (item as Record<string, unknown>).text === 'string'
+    )
+}
+
+// Returns the parsed value only when the string is a JSON object/array, otherwise undefined.
+function tryParseJson(text: string): unknown {
+    const trimmed = text.trim()
+    const first = trimmed[0]
+    if (first !== '{' && first !== '[') {
+        return undefined
+    }
+    try {
+        return JSON.parse(trimmed)
+    } catch {
+        return undefined
+    }
+}
+
+// Recursively expand any string that is itself JSON, so double-encoded payloads render as real structure.
+function expandEmbeddedJson(value: unknown): unknown {
+    if (typeof value === 'string') {
+        const parsed = tryParseJson(value)
+        return parsed !== undefined ? expandEmbeddedJson(parsed) : value
+    }
+    if (Array.isArray(value)) {
+        return value.map(expandEmbeddedJson)
+    }
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).map(([key, val]) => [key, expandEmbeddedJson(val)])
+        )
+    }
+    return value
+}
+
+// MCP tool results usually arrive as [{ type: 'text', text: '...' }]; pull the text out so newlines render.
+function extractTextParts(value: unknown): string | null {
+    const items = Array.isArray(value) ? value : [value]
+    const texts: string[] = []
+    for (const item of items) {
+        if (!isTextPart(item)) {
+            return null
+        }
+        texts.push(item.text)
+    }
+    return texts.length ? texts.join('\n\n') : null
+}
+
+function formatValue(value: unknown, pretty: boolean): string {
+    if (!pretty) {
+        return typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+    }
+    const text = extractTextParts(value)
+    const candidate = text ?? (typeof value === 'string' ? value : null)
+    if (candidate !== null) {
+        const parsed = tryParseJson(candidate)
+        return parsed !== undefined ? JSON.stringify(expandEmbeddedJson(parsed), null, 2) : candidate
+    }
+    return JSON.stringify(expandEmbeddedJson(value), null, 2)
+}
+
 export function ToolCallEntry({ toolName, status, args, result, timestamp }: ToolCallEntryProps): JSX.Element {
     const [isOpen, setIsOpen] = useState(false)
+    const [pretty, setPretty] = useState(true)
     const config = STATUS_CONFIG[status]
     const hasContent = args || result !== undefined
     const isLoading = status === 'pending' || status === 'running'
@@ -59,11 +126,20 @@ export function ToolCallEntry({ toolName, status, args, result, timestamp }: Too
 
             {isOpen && hasContent && (
                 <div className="ml-5 mt-1 rounded bg-bg-light p-2 overflow-hidden">
+                    <div className="flex justify-end mb-1">
+                        <LemonSwitch
+                            label="Pretty print"
+                            checked={pretty}
+                            onChange={setPretty}
+                            size="xsmall"
+                            bordered
+                        />
+                    </div>
                     {args && (
                         <div className="mb-2">
                             <div className="text-xs font-medium text-muted mb-1">Arguments</div>
                             <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
-                                {JSON.stringify(args, null, 2)}
+                                {formatValue(args, pretty)}
                             </pre>
                         </div>
                     )}
@@ -71,7 +147,7 @@ export function ToolCallEntry({ toolName, status, args, result, timestamp }: Too
                         <div>
                             <div className="text-xs font-medium text-muted mb-1">Result</div>
                             <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
-                                {typeof result === 'string' ? result : JSON.stringify(result, null, 2)}
+                                {formatValue(result, pretty)}
                             </pre>
                         </div>
                     )}


### PR DESCRIPTION
## Problem

The task run log view renders MCP tool call arguments and results as raw `JSON.stringify` output. Because results arrive as `[{ type: 'text', text: '...' }]`, stringifying the whole array escapes every real newline in the text into literal `\n` characters and keeps nested/double-encoded JSON as one giant escaped blob — long skill descriptions and scratchpad payloads become an unreadable wall of `\n` soup. Separately, `DEBUG`-level console lines (server boot, heartbeats, token counts) add noise that buries the actual agent/tool activity.

## Changes

<img width="3794" height="1754" alt="image" src="https://github.com/user-attachments/assets/4d33e868-9357-4d4b-b132-317de93b0c2d" />


- **Pretty-print toggle on tool call entries** (`ToolCallEntry.tsx`), on by default. In pretty mode it detects the MCP `[{ type: 'text', text }]` shape and renders the text directly so real newlines and markdown show, and recursively expands any string that is itself JSON so double-encoded payloads display as indented structure. Toggling off restores the exact previous raw `JSON.stringify` output. Plain-string results pass through unchanged.
- **"Show debug (N)" toggle in the log header** (`TaskSessionView.tsx`). Debug console lines (`level: 'debug'`) are hidden by default to reduce noise and shown on demand; the "Logs (N)" count reflects what's visible. The toggle only appears when debug lines exist.

Both toggles use local component state (matching the existing expand/collapse pattern); no logic or API changes.

## How did you test this code?

I'm an agent (Claude Code, via the `make-pr` skill). Automated checks I actually ran locally on the two changed files: `oxlint` (0 warnings/errors) and `oxfmt`. No new unit tests were added.

For manual verification I seeded a dummy task in a local dev stack with realistic payloads (a long multi-line skill-get result, an embedded-JSON scratchpad result, a plain-string result, and several debug console lines) and confirmed the pretty/raw difference and the debug show/hide behavior render as intended. The seed script lives outside the repo and is not part of this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @andrewm4894, assigned as DRI.

- Agent: Claude Code (Opus). Tools used: repo exploration/edit tools, local Django shell to seed test data via the PostHog dev stack, and the `make-pr` skill from the PostHog skills store.
- Decisions: defaulted pretty-print **on** (the readability win is the point) but kept a lossless raw mode so nothing is hidden; chose to hide debug lines **by default** per reviewer preference, surfacing them behind a counted toggle. Kept everything as local UI state rather than lifting into kea/localStorage — flagged stickiness as an easy follow-up if desired. Scoped "debug" to `console` entries with `level: 'debug'` only, leaving info/warn/error visible.
- This is a small, frontend-only, low-risk change (no auth/migrations/API schema) — a reasonable candidate for stamphog-assisted approval, but still requires human review.
