### PR TITLE
feat(signals): nudge scouts to format findings for the inbox

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -78,6 +78,27 @@ When you call `signals-scout-emit-signal`:
   traceability. It does NOT dedupe: emitting the same id twice creates two
   signals, so emit each finding exactly once and never retry an emit.
 
+# Writing the description (how it renders in the inbox)
+
+Your `description` is rendered as GitHub-flavored markdown in the inbox and
+**collapsed to the first ~300 characters** behind a "Show more" toggle. Write for
+that surface:
+
+- **Front-load the verdict.** The first one or two sentences are the entire
+  preview most readers see. Lead with what's wrong (or worth knowing) and the
+  single number that proves it — not setup, methodology, or caveats. End that
+  lead with a blank line so the preview truncates at a clean paragraph break, not
+  mid-sentence.
+- **Structure the body, don't write a wall.** After the lead, use short
+  paragraphs, `**bold**` labels, and `-` / numbered lists for evidence, volume,
+  and the recommended next step. Close with a one-line `Recommend: …`. A single
+  run-on paragraph is hard to scan; tables and `code` spans render too.
+
+These are defaults for when your skill body says nothing about format. If your
+skill defines its own description structure (a fixed template, required sections,
+a machine-parseable shape), follow that instead — the skill body owns the prose
+contract.
+
 # Dedupe rules
 
 - If a recent run already covers this hypothesis with the same evidence, don't

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -167,6 +167,10 @@ class TestPromptBuilder(BaseTest):
         # agent-feedback tool so the scout system improves over time.
         assert "Report operational friction" in prompt
         assert "agent-feedback" in prompt
+        # The base prompt teaches scouts to format the description for the inbox
+        # surface (markdown, front-loaded into the ~300-char collapsed preview),
+        # while leaving a skill body free to impose its own structure.
+        assert "Writing the description (how it renders in the inbox)" in prompt
 
 
 # Orchestration tests run as plain pytest functions because the async runner uses


### PR DESCRIPTION
## Problem

Signals scouts emit a finding `description` that gets rendered for humans in the Signals inbox, but the output quality is inconsistent. Pulling recent scout emissions, they split into two camps: some are well-structured (bold labels, `WHAT:`/`VOLUME:`/`NEXT STEP:` sections, lists) and scan beautifully, while others are a single run-on wall of prose with the verdict buried behind setup and parenthetical stats.

This matters because of how the inbox renders the text:

- The `description` is rendered as **GitHub-flavored markdown** (so structure — headings, bold, bullets, tables — actually renders), and
- the signal card **collapses to the first ~300 characters** behind a "Show more" toggle. So the opening sentence is the entire preview most readers see. A wall-of-prose finding gets truncated mid-sentence with the verdict still buried.

The base harness prompt delegated all of this to each skill body ("your skill body owns the prose contract"), so there was no shared guidance — and most of the 8 scout skills don't specify formatting. How content renders in the shared inbox is a cross-cutting harness concern, not skill-specific investigation logic, so the guidance belongs in the base prompt.

## Changes

Adds a short **"Writing the description (how it renders in the inbox)"** section to the base scout harness prompt (`_BASE_PROMPT_TAIL` in `products/signals/backend/scout_harness/prompt.py`). It teaches scouts to:

- **Front-load the verdict** into the first sentence + a clean paragraph break, so the ~300-char collapsed preview is informative and doesn't truncate mid-sentence.
- **Structure the body** with markdown (short paragraphs, bold labels, lists, a one-line `Recommend: …`) instead of a single run-on paragraph.

The guidance is explicitly framed as **defaults a skill body can override** — if a skill defines its own description structure (a fixed template, required sections, a machine-parseable shape), that still wins. This preserves the existing "skill body owns the prose contract" flexibility.

This only steers prose. It does not touch the emit contract, tool surface, finding schema, or pipeline.

## How did you test this code?

I'm an agent (Claude, agent-assisted). I added an assertion to the existing prompt-builder test covering the new section and ran it:

- `products/signals/backend/test/test_scout_harness.py::TestPromptBuilder::test_renders_identity_bootstrap_and_universal_sections` — **passes** (run against a fresh test DB).

No manual/runtime testing of live scout output was performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy investigated scout-emitted signal quality by reading recent emissions from the `signals_signals` / `signals_scouts_runs` data-warehouse views and inspecting the inbox rendering path in the Code app (`SignalCard` → `CollapsibleBody` → `MarkdownRenderer`, with `COLLAPSE_THRESHOLD = 300`). That confirmed two facts that shaped the fix: content is rendered as markdown, and only the first ~300 chars show by default.

Decision: put the guidance in the base harness prompt rather than each skill (cross-cutting render concern, matches the harness's "keep the loop generic" rule), and keep it as overridable defaults so a scout that wants a structured/templated emit format is unaffected. Verified no existing skill body had conflicting formatting guidance before adding it.
