### PR TITLE
feat(signals): anomaly scout writes up findings in a notebook before emitting

### DIFF
--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -12,11 +12,13 @@ description: >
   empty. Self-contained peer in the signals-scout-* fleet.
 compatibility: >
   Runs as the PostHog Signals scout in a Claude sandbox with read-only analytics scopes plus
-  signal_scout_internal:write (scratchpad + emit). Uses the signals-scout MCP family
+  signal_scout_internal:write (scratchpad + emit) and notebook:write (write-up artifact).
+  Uses the signals-scout MCP family
   (project-profile-get, runs-list, runs-retrieve, scratchpad-search/-remember/-forget,
   emit-signal) plus dashboard/insight tools (insights-trending-retrieve, insight-get,
   insight-query, dashboards-get-all, dashboard-get, dashboard-insights-run, insights-list),
   alert-simulate (the anomaly-detection simulator — primary scorer for saved insights),
+  notebooks-create (the durable write-up that backs each emitted finding),
   execute-sql, read-data-schema, inbox-reports-list.
 metadata:
   owner_team: signals
@@ -147,9 +149,14 @@ For each candidate anomaly, classify against prior runs and the scratchpad
 (net-new / material-update / already-covered / addressed-or-noise — full classifier in
 [`references/watchlist-and-memory.md`](references/watchlist-and-memory.md)), then:
 
-- **Emit** via `signals-scout-emit-signal` when it clears the bar. The emit contract —
-  schema, weight/confidence rubrics, severity, dedupe keys, description prose, worked
-  example — is in [`references/emit-contract.md`](references/emit-contract.md). For this
+- **Emit** via `signals-scout-emit-signal` when it clears the bar. **Before you emit, write
+  the finding up in a notebook** (`notebooks-create`) — the inbox description is a 3–6 sentence
+  hook, but the notebook is the durable artifact a human opens to see the charts, the baseline
+  math, and the attribution behind the call. Build it first, then put its URL in the emitted
+  finding's description and an evidence entry so the signal links straight to the write-up. The
+  emit contract _and_ the notebook structure — schema, weight/confidence rubrics, severity,
+  dedupe keys, description prose, the notebook layout + embedded-chart recipe, worked example —
+  are in [`references/emit-contract.md`](references/emit-contract.md). For this
   scout a strong finding is: robust z ≥ ~3.5 on the latest complete bucket, the move is not
   explained by seasonality or a known data-pipeline gap, weight ≥ 0.7, confidence ≥ 0.85,
   with the insight `short_id`, the bucket value, the baseline, the z-score, and the time
@@ -200,6 +207,13 @@ Direct (read-only):
   non-saved series or custom baselines.
 - `read-data-schema` — confirm events/properties before any SQL.
 - `inbox-reports-list` — check whether the move is already reported before emitting.
+
+Write (user-facing, gated on `notebook:write`):
+
+- `notebooks-create` — the durable write-up that backs an emitted finding. Build it _before_
+  emitting and reference its URL from the signal. Layout + embedded-chart recipe (embed the
+  anomalous insight with a `SavedInsightNode`; chart a SQL-fallback series with a
+  `DataVisualizationNode`) is in [`references/emit-contract.md`](references/emit-contract.md).
 
 Harness-level: `signals-scout-project-profile-get`, `signals-scout-scratchpad-search`,
 `signals-scout-runs-list`, `signals-scout-runs-retrieve` (orientation + dedupe);

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -97,7 +97,7 @@ go). Tools, primary first:
   the menu, the proven defaults, and the must-know gotchas (give every ensemble sub-detector
   an explicit `window`; `diffs_n` does **not** default to 1; target a time-series, not a
   single-value, insight).
-- `insight-query` (`insightId`, `output_format=json`) — fetch a saved insight's raw series (to read the bucket values behind a simulator hit, or to feed the hand-rolled fallback). **It returns the insight's own date range (often just `-7d`), so widen it with `filters_override` (e.g. `{"date_from": "-63d"}`).**
+- `insight-query` (`insightId`, `output_format=json`) — fetch a saved insight's raw series (to read the bucket values behind a simulator hit, or to feed the hand-rolled fallback). **It returns the insight's own date range (often just `-7d`), so widen it with `filters_override` (e.g. `{"date_from": "-63d"}`).** Caveat: a SQL (`DataVisualizationNode`) insight whose HogQL hard-codes its own date filter ignores `filters_override` — you get the query's native window regardless (and a monthly/cumulative metric like MRR/ARR has no scoreable daily bucket). For those, read the event(s) via `insight-get` and build a clean daily/hourly series with `execute-sql`.
 - `dashboard-insights-run` (`id`, `output_format=json`, `refresh=blocking`, `filters_override`)
   — runs every tile on a dashboard at once; efficient for sweeping a whole high-value
   dashboard. Pass `output_format=json` — the default `optimized` returns prose summaries, not

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -18,7 +18,8 @@ compatibility: >
   emit-signal) plus dashboard/insight tools (insights-trending-retrieve, insight-get,
   insight-query, dashboards-get-all, dashboard-get, dashboard-insights-run, insights-list),
   alert-simulate (the anomaly-detection simulator — primary scorer for saved insights),
-  notebooks-create (the durable write-up that backs each emitted finding),
+  notebooks-create / notebooks-destroy (the durable write-up that backs each emitted
+  finding, removed if the emit is preflight-skipped),
   execute-sql, read-data-schema, inbox-reports-list.
 metadata:
   owner_team: signals
@@ -214,6 +215,9 @@ Write (user-facing, gated on `notebook:write`):
   emitting and reference its URL from the signal. Layout + embedded-chart recipe (embed the
   anomalous insight with a `SavedInsightNode`; chart a SQL-fallback series with a
   `DataVisualizationNode`) is in [`references/emit-contract.md`](references/emit-contract.md).
+- `notebooks-destroy` — clean up the write-up if the emit is preflight-skipped (dry-run /
+  gated / source disabled) so a non-emitting run leaves no orphan artifact. See
+  [`references/emit-contract.md`](references/emit-contract.md).
 
 Harness-level: `signals-scout-project-profile-get`, `signals-scout-scratchpad-search`,
 `signals-scout-runs-list`, `signals-scout-runs-retrieve` (orientation + dedupe);

--- a/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/anomaly-methods.md
@@ -34,6 +34,12 @@ configs and a detector-selection guide, read the `anomaly-alerts`, `signals-aler
   use the ensemble.)
 - **Target a time-series insight.** A single-value / BoldNumber insight returns one point and
   scores nothing — point the simulator at a trend displayed over time.
+- **`alert-simulate` only accepts `TrendsQuery` insights.** A SQL-backed saved insight
+  (`DataVisualizationNode` wrapping a `HogQLQuery` — most revenue, MRR/ARR, and LLM-cost
+  insights are this) is rejected outright with `Only TrendsQuery insights are supported`. Don't
+  burn a call discovering this: check the insight's `query.kind` first (via `insight-get`), and
+  if it's a `DataVisualizationNode`, score it with the SQL fallback below instead of the
+  simulator.
 - **Breakdown insights return a per-series block per breakdown value plus a meaningless
   rolled-up total.** `series_index` does not cleanly isolate one breakdown value — read the
   per-series sub-blocks, or prefer a non-breakdown insight for a clean read.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
@@ -118,7 +118,48 @@ Charts are `{type: "ph-query", attrs: {nodeId: "<unique>", query: <query>}}` nod
   `{kind: "InsightVizNode", source: {kind: "TrendsQuery", ...}}`.
 
 Prefer embedding the saved insight you scored — it stays in sync with the source and is the
-thing the human will open next. Give each `ph-query` node a distinct `nodeId`.
+thing the human will open next. Give each `ph-query` node a distinct `nodeId`. `notebooks-create`
+returns the new notebook's URL in `_posthogUrl` — surface that verbatim, don't hand-build it.
+
+`content` is a ProseMirror doc (the tool documents no node schema, so use this skeleton). Text
+is `paragraph` / `heading` (with `attrs.level`) / `bulletList` → `listItem` → `paragraph`;
+charts are `ph-query` nodes. A minimal working shape:
+
+```json
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "heading",
+      "attrs": { "level": 1 },
+      "content": [{ "type": "text", "text": "Anomaly: <metric> <direction> (<date>)" }]
+    },
+    { "type": "paragraph", "content": [{ "type": "text", "text": "<the quantified hook>" }] },
+    {
+      "type": "ph-query",
+      "attrs": { "nodeId": "scored-insight", "query": { "kind": "SavedInsightNode", "shortId": "<short_id>" } }
+    },
+    { "type": "heading", "attrs": { "level": 2 }, "content": [{ "type": "text", "text": "Baseline & method" }] },
+    {
+      "type": "bulletList",
+      "content": [
+        {
+          "type": "listItem",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "<baseline median + MAD, the z, partial bucket excluded>" }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+For a SQL-fallback chart, swap the `ph-query` query for
+`{ "kind": "DataVisualizationNode", "source": { "kind": "HogQLQuery", "query": "SELECT ..." }, "display": "ActionsLineGraph" }`.
 
 ### Wire it into the emit
 

--- a/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
@@ -61,7 +61,74 @@ Cite the insight `short_id` and dashboard id inline so a human pivots straight t
 Each entry `{source_product, summary, entity_id?}`, ≤ 20. Cite every concrete claim. For this
 scout: `source_product: query_runs` (the SQL/insight-query reads), `entity_id` = the insight
 `short_id`; add `signals_scout` entries to cite a prior run/finding. Put the bucket value,
-the baseline median, the z-score, and the time window in the summaries.
+the baseline median, the z-score, and the time window in the summaries. Add one
+`source_product: notebook` entry whose `entity_id` is the notebook `short_id` and whose
+summary is the notebook URL (see below) — that is the durable artifact the human opens.
+
+## The notebook write-up
+
+The inbox description is a 3–6 sentence hook; the **notebook is the durable artifact** behind
+it — the place a human lands to see the charts, the baseline math, and the attribution that
+justify the call. **Build the notebook _before_ you emit**, then reference its URL from the
+signal. One notebook per emitted finding.
+
+### Create it
+
+Call `notebooks-create` with a `title` and `content` (ProseMirror rich-text JSON). The
+response carries the new notebook's `short_id` and a clickable URL (the tool enriches the
+result with `/notebooks/{short_id}`) — that URL is what you wire into the emit. If you ever
+need to build the link yourself, it is `generate-app-url` with `url=/notebooks/{shortId}`.
+
+- **Title** — name the metric, the direction, and the date, e.g.
+  `Anomaly: daily signups dropped ~60% (2026-06-06)`. A human scanning a notebook list should
+  recognise it.
+- **One notebook per finding** — never append a new anomaly to a prior run's notebook. A
+  recurrence on a later day is a new notebook citing the prior one, mirroring the dedupe-key
+  convention.
+
+### What goes in it
+
+Lead with the same hook the inbox sees, then the evidence the 3–6 sentences can't hold:
+
+1. **Summary** — the quantified hook (bucket value vs baseline, robust z, severity), one or
+   two sentences. Same claim as the description, so the notebook stands alone.
+2. **The chart** — embed the anomalous series so the spike/drop is visible. Embed the saved
+   insight directly with a `SavedInsightNode` (it already carries the right query + display);
+   for a SQL-fallback series that isn't a saved insight, chart it with a `DataVisualizationNode`
+   wrapping the same HogQL you scored with. Widen the window (e.g. `-63d`) so the baseline and
+   the break are both on screen.
+3. **Baseline & method** — the seasonality-matched baseline (median + MAD per bucket), the
+   z-score, which detector(s) `alert-simulate` fired, and that the partial bucket was excluded.
+   This is the math that doesn't fit the inbox hook.
+4. **Attribution** — which breakdown segment(s) drove the move (the attribution read from the
+   investigation), and whether it's broad (regression) or one segment (often expected).
+5. **Hypothesis & next step** — suspected cause and what to check, matching the emit hypothesis.
+
+### Embedded-chart recipe
+
+Charts are `{type: "ph-query", attrs: {nodeId: "<unique>", query: <query>}}` nodes inside
+`content`. `query` is one of:
+
+- **Embed the anomalous saved insight** (the common case here) —
+  `{kind: "SavedInsightNode", shortId: "<short_id>"}`.
+- **Chart a SQL-fallback series** —
+  `{kind: "DataVisualizationNode", source: {kind: "HogQLQuery", query: "SELECT ..."}, display: "ActionsLineGraph"}`.
+  Do **not** wrap a `HogQLQuery` in an `InsightVizNode`.
+- **Build an ad-hoc product-analytics chart** —
+  `{kind: "InsightVizNode", source: {kind: "TrendsQuery", ...}}`.
+
+Prefer embedding the saved insight you scored — it stays in sync with the source and is the
+thing the human will open next. Give each `ph-query` node a distinct `nodeId`.
+
+### Wire it into the emit
+
+- **Description** — add a closing clause: "Full write-up with charts: `<notebook-url>`."
+- **Evidence** — one `{source_product: notebook, entity_id: <short_id>, summary: <url>}` entry.
+- **dedupe_keys** — optionally add `notebook:<short_id>` so the artifact is traceable from the
+  signal's `extra`.
+
+Skipping the notebook is only acceptable if `notebooks-create` fails — then emit anyway (the
+finding still matters) and note the missing artifact in the description.
 
 ## Dedupe keys
 
@@ -99,19 +166,28 @@ evidence:
       'Daily signups' (insight 9aBcDeF on dashboard Growth/41233): yesterday 412 vs
       8-same-weekday median 1,048 (MAD 95) → robust z = 4.8. Prior 7 same-weekdays all
       within ±1.5 z. Latest complete day only; today's partial bucket excluded.
+  - source_product: notebook
+    entity_id: aB12cD34
+    summary: >
+      Write-up with the -63d chart, the per-weekday baseline, and the segment attribution:
+      https://us.posthog.com/project/41233/notebooks/aB12cD34
 time_range: { date_from: 2026-06-06T00:00:00Z, date_to: 2026-06-07T00:00:00Z }
 dedupe_keys:
   - insight:9aBcDeF
   - metric_anomaly:9aBcDeF:2026-06-06
+  - notebook:aB12cD34
 description: |
   Daily signups dropped to 412 yesterday (2026-06-06) against an ~1,048 same-weekday baseline
   (robust z = 4.8, MAD 95) on insight 9aBcDeF, pinned to the Growth dashboard (41233). This is
   a single complete-day drop of ~60%, well outside the weekday rhythm — the last 8 same
   weekdays were all within ±1.5 z, so it's not seasonality. Likely a broken signup flow or a
   tracking regression from a recent deploy. Recommend opening insight 9aBcDeF, checking
-  whether the drop is broad or segment-specific, and correlating with today's deploys.
+  whether the drop is broad or segment-specific, and correlating with today's deploys. Full
+  write-up with charts: https://us.posthog.com/project/41233/notebooks/aB12cD34.
 ```
 
 Why it's good: quantified hook with the baseline and z, seasonality explicitly ruled out,
 partial bucket excluded, actionable recommendation, dual dedupe keys (insight + dated
 metric anomaly), P1 justified by business impact, confidence 0.88 because the read is clean.
+The notebook the scout built before emitting is cited in the evidence and linked from the
+description, so the human lands on the charts and baseline math in one click.

--- a/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/references/emit-contract.md
@@ -63,7 +63,8 @@ scout: `source_product: query_runs` (the SQL/insight-query reads), `entity_id` =
 `short_id`; add `signals_scout` entries to cite a prior run/finding. Put the bucket value,
 the baseline median, the z-score, and the time window in the summaries. Add one
 `source_product: notebook` entry whose `entity_id` is the notebook `short_id` and whose
-summary is the notebook URL (see below) — that is the durable artifact the human opens.
+summary is a brief description of the write-up followed by the notebook URL (see below) —
+that is the durable artifact the human opens.
 
 ## The notebook write-up
 
@@ -92,11 +93,13 @@ Lead with the same hook the inbox sees, then the evidence the 3–6 sentences ca
 
 1. **Summary** — the quantified hook (bucket value vs baseline, robust z, severity), one or
    two sentences. Same claim as the description, so the notebook stands alone.
-2. **The chart** — embed the anomalous series so the spike/drop is visible. Embed the saved
-   insight directly with a `SavedInsightNode` (it already carries the right query + display);
-   for a SQL-fallback series that isn't a saved insight, chart it with a `DataVisualizationNode`
-   wrapping the same HogQL you scored with. Widen the window (e.g. `-63d`) so the baseline and
-   the break are both on screen.
+2. **The chart** — embed the anomalous series so the spike/drop is visible, and make sure the
+   window is wide enough (e.g. `-63d`) that the baseline _and_ the break are both on screen. A
+   `SavedInsightNode` renders the insight's own saved date range and carries no date override —
+   so use it only when that saved range already shows the baseline; if the insight is saved to a
+   short window (often `-7d`), embed an inline widened `DataVisualizationNode` (or
+   `InsightVizNode`) for the scored window instead, so the write-up keeps the very evidence it
+   exists to preserve.
 3. **Baseline & method** — the seasonality-matched baseline (median + MAD per bucket), the
    z-score, which detector(s) `alert-simulate` fired, and that the partial bucket was excluded.
    This is the math that doesn't fit the inbox hook.
@@ -109,8 +112,9 @@ Lead with the same hook the inbox sees, then the evidence the 3–6 sentences ca
 Charts are `{type: "ph-query", attrs: {nodeId: "<unique>", query: <query>}}` nodes inside
 `content`. `query` is one of:
 
-- **Embed the anomalous saved insight** (the common case here) —
-  `{kind: "SavedInsightNode", shortId: "<short_id>"}`.
+- **Embed the anomalous saved insight** —
+  `{kind: "SavedInsightNode", shortId: "<short_id>"}`. Renders the insight's _saved_ date range
+  (no override); fine when that range shows the baseline, otherwise prefer a widened node below.
 - **Chart a SQL-fallback series** —
   `{kind: "DataVisualizationNode", source: {kind: "HogQLQuery", query: "SELECT ..."}, display: "ActionsLineGraph"}`.
   Do **not** wrap a `HogQLQuery` in an `InsightVizNode`.
@@ -164,12 +168,20 @@ For a SQL-fallback chart, swap the `ph-query` query for
 ### Wire it into the emit
 
 - **Description** — add a closing clause: "Full write-up with charts: `<notebook-url>`."
-- **Evidence** — one `{source_product: notebook, entity_id: <short_id>, summary: <url>}` entry.
+- **Evidence** — one `{source_product: notebook, entity_id: <short_id>, summary: <brief description + url>}` entry.
 - **dedupe_keys** — optionally add `notebook:<short_id>` so the artifact is traceable from the
   signal's `extra`.
 
-Skipping the notebook is only acceptable if `notebooks-create` fails — then emit anyway (the
-finding still matters) and note the missing artifact in the description.
+**Clean up if the emit doesn't land.** `signals-scout-emit-signal` is preflight-gated — on a
+dry-run config (`emit=False`), un-approved AI processing, or a disabled source it returns a
+`skipped_reason` and writes **no** signal. The notebook, gated only by `notebook:write`, has
+already been created — so an orphaned user-facing artifact would leak into the project,
+breaking the dry-run/source-disabled contract. **If the emit result is skipped (not emitted),
+delete the just-created notebook with `notebooks-destroy`.** Only a notebook attached to a real
+emitted signal should survive the run.
+
+Skipping notebook _creation_ is only acceptable if `notebooks-create` fails — then emit anyway
+(the finding still matters) and note the missing artifact in the description.
 
 ## Dedupe keys
 


### PR DESCRIPTION
## Problem

The `signals-scout-anomaly-detection` scout emits a finding into the Signals inbox as a 3–6 sentence description. That hook is good for triage, but it can't hold the charts, the seasonality-matched baseline math, or the segment attribution that justify the call — so a human has to reconstruct the investigation by hand to decide whether to act.

The scout already carries the `notebook:write` scope (in `SCOUT_USER_WRITE_SCOPES`) and the `notebooks-create` MCP tool is enabled, but the skill never told it to produce a durable write-up. This change closes that gap.

## Changes

Edits the canonical `signals-scout-anomaly-detection` skill (synced to each enrolled team's `LLMSkill` rows by `lazy_seed` on the next coordinator tick) so that, **before emitting a signal**, the scout:

- creates a notebook (`notebooks-create`) titled for the metric/direction/date, with a summary, an embedded chart of the anomalous series, the baseline + detector math, the segment attribution, and the hypothesis;
- wires the notebook URL into the emitted finding's description and adds a `source_product: notebook` evidence entry (plus an optional `notebook:<short_id>` dedupe key) so the signal links straight to the write-up.

Specifically:

- `SKILL.md` — notes `notebook:write` / `notebooks-create` in the compatibility block, makes the notebook a required pre-step in the **Emit** path, and lists `notebooks-create` under a new "Write" group in the MCP tools section.
- `references/emit-contract.md` — adds a "The notebook write-up" section (when to build, title convention, what goes in it, the embedded-chart recipe — `SavedInsightNode` for the anomalous saved insight, `DataVisualizationNode` for a SQL-fallback series — and how to reference it from the emit), and updates the worked example to cite the notebook in evidence + description.

No code or schema changes: the scout already has the scope and tool. The skill content hash change drives the `lazy_seed` version bump automatically.

## How did you test this code?

I'm an agent (Claude Code, via Andy). This is a documentation/skill-content change only — no automated tests were added or run. The frontmatter remains valid YAML and the referenced tool (`notebooks-create`) and scope (`notebook:write`) were verified to already be wired into the scout's OAuth posture (`posthog/temporal/oauth.py`) and the notebooks MCP `tools.yaml`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked to have the anomaly-detection scout produce a notebook for its findings whenever it emits a signal, with a write-up plus charts/visualizations, and to make the change by editing the canonical skill.

Investigation confirmed the enabling pieces already existed — the scout holds `notebook:write` via `SCOUT_USER_WRITE_SCOPES`, `notebooks-create` is an enabled MCP tool that supports embedding saved insights and HogQL charts, and the create tool enriches its result with the notebook URL — so the work was purely instructional: teach the skill to build and reference the notebook. Kept the `SKILL.md` body lean (per the fleet convention that every line is a per-run token cost) and pushed the detailed notebook layout + embedded-chart recipe into the existing `emit-contract.md` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
