### PR TITLE
feat(ingestion): add clientwarnings pipeline to event restrictions

### DIFF
--- a/posthog/models/event_ingestion_restriction_config.py
+++ b/posthog/models/event_ingestion_restriction_config.py
@@ -16,6 +16,7 @@ INGESTION_PIPELINES = [
     {"value": "analytics", "label": "Analytics Pipeline"},
     {"value": "session_recordings", "label": "Session Recordings Pipeline"},
     {"value": "errortracking", "label": "Error Tracking Pipeline"},
+    {"value": "clientwarnings", "label": "Client Warnings Pipeline"},
 ]
 
 
@@ -35,6 +36,7 @@ class IngestionPipeline(models.TextChoices):
     ANALYTICS = "analytics"
     SESSION_RECORDINGS = "session_recordings"
     ERRORTRACKING = "errortracking"
+    CLIENTWARNINGS = "clientwarnings"
 
 
 class EventIngestionRestrictionConfig(UUIDTModel):


### PR DESCRIPTION
## Problem

We now have a dedicated `clientwarnings` ingestion pipeline with its own event restrictions. The Node.js restriction manager and the Redis zod schema already accept `clientwarnings` as a pipeline value, but Django had no way to create or store restrictions targeting it — the admin form and model validation only knew about `analytics`, `session_recordings`, and `errortracking`. As a result, the `clientwarnings` pipeline could not be selected when configuring an event ingestion restriction.

## Changes

Added `clientwarnings` to `EventIngestionRestrictionConfig` in two places:

- The `INGESTION_PIPELINES` list, which the admin form reads to build the pipeline multi-select and which `clean()` uses to whitelist valid pipeline values. This makes `clientwarnings` both selectable in the admin and accepted by model validation.
- The `IngestionPipeline` TextChoices enum, to keep it in sync with the list.

No migration is required — `pipelines` is an existing `ArrayField` of strings, and the Redis regeneration serializes whatever values are stored. Downstream consumers (Node.js manager, Redis schema) already understand `clientwarnings`.

Note: the Rust `capture` side still lacks a `ClientWarnings` variant in its pipeline enum — that's tracked separately and is out of scope here.

## How did you test this code?

I'm an agent. I did not perform manual testing. The change is additive and the existing test suite in `posthog/models/test/test_event_ingestion_restriction_config.py` continues to apply — those tests drive pipeline values dynamically and none assert a closed set of valid pipelines, so they remain valid. I did not run the suite locally.

## 🤖 Agent context

Authored by Claude Code (Opus 4.8). The task was to extend Django's event ingestion restriction support to the new `clientwarnings` pipeline. After exploring the existing pattern (how `errortracking` and others are wired through `INGESTION_PIPELINES`, the enum, the admin form, and `clean()` validation), the fix was a minimal additive change in the model file — the admin and validation both read the list dynamically, so no further wiring was needed.
