### PR TITLE
fix(sql-editor): prevent crash when query URL param is non-string

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -1018,6 +1018,25 @@ describe('sqlEditorLogic', () => {
             expect(router.values.hashParams.q).toEqual('SELECT 1')
             expect(router.values.hashParams.output_tab).toEqual(OutputTab.Both)
         })
+
+        it('coerces a numeric query hash param to a string instead of crashing splitQueryRanges', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            // kea-router decodes `q=42` back to the number 42, which used to reach queryInput unchanged
+            router.actions.push(urls.sqlEditor(), undefined, { q: 42 })
+
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+            expect(logic.values.queryInput).toEqual('42')
+            // Reading splitQueryRanges threw "e.trim is not a function" when queryInput was the number 42
+            expect(() => logic.values.splitQueryRanges).not.toThrow()
+            expect(logic.values.splitQueryRanges).toHaveLength(1)
+        })
     })
 
     describe('source URL parameter', () => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -2355,8 +2355,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     tabAdded = true
                     router.actions.replace(urls.sqlEditor(), undefined, getTabHash(values))
                 } else if (searchParams.open_query) {
-                    // Open query string
-                    actions.createTab(searchParams.open_query)
+                    // kea-router decodes numeric/JSON-shaped URL values to non-strings; coerce so queryInput stays a string
+                    actions.createTab(String(searchParams.open_query))
                     tabAdded = true
                 } else if (
                     hashParams.q &&
@@ -2365,9 +2365,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     !insightShortIdFromUrl &&
                     (values.queryInput === null ||
                         !activeTabMatchesUrlTarget(values.activeTab, {}) ||
-                        values.queryInput !== hashParams.q)
+                        values.queryInput !== String(hashParams.q))
                 ) {
-                    actions.createTab(hashParams.q)
+                    // kea-router decodes numeric/JSON-shaped URL values to non-strings; coerce so queryInput stays a string
+                    actions.createTab(String(hashParams.q))
                     tabAdded = true
                 } else if (values.queryInput === null) {
                     actions.createTab('')


### PR DESCRIPTION
## Problem

Opening the SQL editor with a numeric query in the URL (e.g. `/sql#q=42`) crashed the editor with `TypeError: e.trim is not a function`. kea-router's URL decoder coerces numeric- and JSON-shaped values into actual numbers/objects, so the `q` (and `open_query`) param reached the `queryInput` reducer as a number despite its declared `string | null` type. That non-string then blew up `splitQueries(input.trim())` in the `splitQueryRanges` selector — and would have broken other `queryInput` consumers (other `.trim()` call sites, the Monaco editor) too.

We've had something similar to this that was fixed here: https://github.com/PostHog/posthog/pull/59370

Surfaced via production error tracking: https://us.posthog.com/error_tracking/019db9fd-c393-76c2-a899-9f4115f2d771

## Changes

Coerce the `open_query` and `q` URL params to strings at the `urlToAction` boundary in `sqlEditorLogic`, so `queryInput` always honours its `string | null` contract. `String(x)` is a no-op for real strings and recovers the original text for the realistic numeric case (`String(42) === '42'`). Fixing at the source protects every downstream consumer rather than patching the single crashing selector, so `multiQueryUtils.ts` is left unchanged.

## How did you test this code?

I'm an agent; I did not manually test in a browser. Automated tests I ran:

- Added a regression test to `sqlEditorLogic.test.ts` that pushes `{ q: 42 }` (decoded back to the number `42`) and asserts `queryInput === '42'` and that `splitQueryRanges` no longer throws.
- `sqlEditorLogic.test.ts`: 57 passed (incl. the new test).
- `multiQueryUtils.test.ts`: 31 passed (unchanged file, no regression).
- `tsc`: the changed files are type-clean. (Local typecheck reports unrelated pre-existing errors from stale `kea-typegen` output, which CI regenerates before checking.)

## 🤖 Agent context

Authored with Claude Code (PostHog Code). The investigation traced the crash from the `splitQueryRanges` selector back through `createTab` → `setQueryInput` to the `urlToAction` handler, and confirmed kea-router's coercion behaviour against existing tests (e.g. the `raw: '1'` param already read back via `String(...)`). Considered guarding inside `splitQueries`, but rejected it as an incomplete symptom fix since other consumers of a non-string `queryInput` would still break — chose to restore the type invariant at the URL boundary instead.
