### PR TITLE
fix(signals): skip inbox notification when implementation task opens no PR

### DIFF
--- a/products/signals/backend/management/AGENTS.md
+++ b/products/signals/backend/management/AGENTS.md
@@ -41,7 +41,8 @@ python manage.py list_signal_reports --team-id 1 --signals --json
 7. On reaching `ready`, the summary workflow starts `signal-report-inbox-notification` to post the Slack
    inbox notification. If the report auto-started an implementation task, that workflow waits for the PR to
    open (bounded by `SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS`) so the card can show a "Review PR"
-   button; reports with no auto-start task notify immediately.
+   button; if that task never opens a PR (fails, is cancelled, or the wait times out) no notification is
+   sent. Reports with no auto-start task notify immediately.
 8. `ready` reports accumulate new signals silently. After enough new signals (`signal_count >= signals_at_run`),
    the report is re-promoted and the summary workflow runs again — reusing the previous repo selection and
    lightly validating previous findings instead of re-researching from scratch.

--- a/products/signals/backend/temporal/inbox_notification.py
+++ b/products/signals/backend/temporal/inbox_notification.py
@@ -1,8 +1,10 @@
-"""Decides when to send a report's inbox Slack notification.
+"""Decides when (and whether) to send a report's inbox Slack notification.
 
 A report that auto-starts an implementation task waits for the PR to open (so the card can
-carry a "Review PR" button), bounded by a timeout. A report with no auto-start task notifies
-immediately. Posting itself stays in `dispatch_inbox_item_notifications`; this governs timing.
+carry a "Review PR" button), bounded by a timeout. If that task never opens a PR (it fails,
+is cancelled, or the wait times out), no notification is sent — there's nothing actionable to
+link. A report with no auto-start task notifies immediately. Posting itself stays in
+`dispatch_inbox_item_notifications`; this governs timing and suppression.
 """
 
 from __future__ import annotations
@@ -127,6 +129,16 @@ class SignalReportInboxNotificationWorkflow:
                 state = await self._fetch_state(inputs)
                 if state.pr_available or state.task_terminal:
                     break
+
+        # An implementation task that never opened a PR (failed, cancelled, or timed out) has
+        # nothing actionable to link, so suppress its notification. `workflow.patched` keeps
+        # in-flight workflows from before this change on the previous always-notify behavior.
+        if workflow.patched("signals-inbox-skip-no-pr") and state.has_implementation_task and not state.pr_available:
+            workflow.logger.info(
+                "inbox notification skipped: implementation task produced no PR",
+                extra={"report_id": inputs.report_id, "team_id": inputs.team_id},
+            )
+            return 0
 
         return await workflow.execute_activity(
             send_report_inbox_notifications_activity,

--- a/products/signals/backend/test/test_inbox_notification_workflow.py
+++ b/products/signals/backend/test/test_inbox_notification_workflow.py
@@ -154,21 +154,20 @@ async def test_workflow_waits_then_notifies_when_pr_opens():
 
 
 @pytest.mark.asyncio
-@override_settings(SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS=10, SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS=1)
-async def test_workflow_skips_when_task_terminal_without_pr():
-    recorder = _Recorder([WAIT, TERMINAL])
-    sent = await _run_workflow(recorder)
+@pytest.mark.parametrize(
+    "states,timeout_seconds",
+    [
+        ([WAIT, TERMINAL], 10),  # task reaches a terminal state without ever opening a PR
+        ([WAIT], 3),  # PR never opens, so the wait runs out the timeout
+    ],
+)
+async def test_workflow_skips_when_no_pr_is_produced(states, timeout_seconds):
+    recorder = _Recorder(states)
+    with override_settings(
+        SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS=timeout_seconds,
+        SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS=1,
+    ):
+        sent = await _run_workflow(recorder)
     assert sent == 0
-    assert recorder.state_calls == 2
-    assert recorder.dispatch_calls == 0
-
-
-@pytest.mark.asyncio
-@override_settings(SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS=3, SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS=1)
-async def test_workflow_skips_after_timeout_when_pr_never_opens():
-    recorder = _Recorder([WAIT])  # always WAIT
-    sent = await _run_workflow(recorder)
-    assert sent == 0
-    # initial fetch + one fetch per poll until elapsed reaches the timeout
-    assert recorder.state_calls >= 2
+    assert recorder.state_calls >= 2  # initial fetch + at least one poll before giving up
     assert recorder.dispatch_calls == 0

--- a/products/signals/backend/test/test_inbox_notification_workflow.py
+++ b/products/signals/backend/test/test_inbox_notification_workflow.py
@@ -155,20 +155,20 @@ async def test_workflow_waits_then_notifies_when_pr_opens():
 
 @pytest.mark.asyncio
 @override_settings(SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS=10, SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS=1)
-async def test_workflow_stops_waiting_when_task_terminal():
+async def test_workflow_skips_when_task_terminal_without_pr():
     recorder = _Recorder([WAIT, TERMINAL])
     sent = await _run_workflow(recorder)
-    assert sent == 1
+    assert sent == 0
     assert recorder.state_calls == 2
-    assert recorder.dispatch_calls == 1
+    assert recorder.dispatch_calls == 0
 
 
 @pytest.mark.asyncio
 @override_settings(SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS=3, SIGNALS_INBOX_PR_NOTIFICATION_POLL_SECONDS=1)
-async def test_workflow_notifies_after_timeout_when_pr_never_opens():
+async def test_workflow_skips_after_timeout_when_pr_never_opens():
     recorder = _Recorder([WAIT])  # always WAIT
     sent = await _run_workflow(recorder)
-    assert sent == 1
+    assert sent == 0
     # initial fetch + one fetch per poll until elapsed reaches the timeout
     assert recorder.state_calls >= 2
-    assert recorder.dispatch_calls == 1
+    assert recorder.dispatch_calls == 0


### PR DESCRIPTION
## Problem

The `signal-report-inbox-notification` Temporal workflow always posted a Slack inbox
notification once a report reached `ready` and its PR-wait resolved — including the case
where the auto-started implementation task failed, was cancelled, or timed out without
ever opening a PR. Those notification cards have no "Review PR" action to link to, so
sending them just adds noise to the inbox.

## Changes

- The workflow now suppresses the notification when the report has an implementation task
  that never produced a PR (task terminal-without-PR, or the PR-wait timed out).
- Reports with **no** implementation task are unchanged — they still notify immediately
  (there is no PR concept for them).
- The new suppression is gated behind `workflow.patched("signals-inbox-skip-no-pr")` so
  workflows already in flight at deploy time keep the previous always-notify behavior on
  replay.

## How did you test this code?

I'm an agent (PostHog Slack app). I updated and ran the existing workflow unit tests in
`test_inbox_notification_workflow.py`:

- `test_workflow_skips_when_task_terminal_without_pr` and
  `test_workflow_skips_after_timeout_when_pr_never_opens` now assert no notification is
  dispatched.
- `test_workflow_notifies_immediately_without_task` and
  `test_workflow_waits_then_notifies_when_pr_opens` still pass unchanged.

The four workflow-logic tests pass locally. The DB-backed state tests in the same file
could not run in this sandbox (no Postgres available) and were not modified.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app on request to stop sending signal inbox notifications
when there is no PR. Scope decision: I limited suppression to reports that started an
implementation task but produced no PR, rather than suppressing every report without a PR
— gating reports that never auto-implement would silence the common inbox case, which the
PR-gating workflow was never meant to cover. Used the `workflow.patched` migration guard
to keep in-flight workflows deterministic across the deploy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1781005340307639?thread_ts=1781005340.307639&cid=C0B8ZE81ZT7)*
