### PR TITLE
fix(search): literal-substring matching for organization members

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -1,8 +1,6 @@
 from typing import Any, cast
 
-from django.contrib.postgres.search import TrigramWordSimilarity
-from django.db.models import F, Model, Prefetch, Q, QuerySet, Value
-from django.db.models.functions import Coalesce
+from django.db.models import F, Model, Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -26,10 +24,15 @@ from rest_framework.serializers import raise_errors_on_nested_writes
 from social_django.models import UserSocialAuth
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.shared import UserBasicSerializer
+from posthog.api.shared import SearchMatchTypeSerializerMixin, UserBasicSerializer
 from posthog.constants import INTERNAL_BOT_EMAIL_SUFFIX
 from posthog.event_usage import groups
-from posthog.helpers.trigram_search import MAX_SEARCH_LENGTH, MIN_NAME_TRIGRAM_SIMILARITY, normalize_search_term
+from posthog.helpers.trigram_search import (
+    MAX_SEARCH_LENGTH,
+    TrigramSearchField,
+    apply_trigram_search,
+    normalize_search_term,
+)
 from posthog.models import OrganizationMembership
 from posthog.models.user import User
 from posthog.models.webauthn_credential import WebauthnCredential
@@ -79,7 +82,7 @@ class OrganizationMemberObjectPermissions(BasePermission):
         return True
 
 
-class OrganizationMemberSerializer(serializers.ModelSerializer):
+class OrganizationMemberSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerializer):
     user = UserBasicSerializer(read_only=True)
     is_2fa_enabled = serializers.SerializerMethodField()
     has_social_auth = serializers.SerializerMethodField()
@@ -96,6 +99,7 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
             "is_2fa_enabled",
             "has_social_auth",
             "last_login",
+            "search_match_type",
         ]
         read_only_fields = ["id", "joined_at", "updated_at"]
 
@@ -141,7 +145,7 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
             OpenApiParameter(
                 name="search",
                 type=OpenApiTypes.STR,
-                description="Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.",
+                description="Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters.",
             ),
         ],
     ),
@@ -194,30 +198,16 @@ class OrganizationMemberViewSet(
     @staticmethod
     @tracer.start_as_current_span("OrganizationMemberViewSet._apply_search")
     def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
-        search = normalize_search_term(search)
-        span = trace.get_current_span()
-        span.set_attribute("organization_member.search.length", len(search))
-        if not search:
-            return queryset
-
-        zero = Value(0.0)
-        first_name_score = Coalesce(TrigramWordSimilarity(search, "user__first_name"), zero)
-        last_name_score = Coalesce(TrigramWordSimilarity(search, "user__last_name"), zero)
-        email_score = Coalesce(TrigramWordSimilarity(search, "user__email"), zero)
-
-        return (
-            queryset.annotate(
-                _first_name_score=first_name_score,
-                _last_name_score=last_name_score,
-                _email_score=email_score,
-            )
-            .filter(
-                Q(_first_name_score__gt=MIN_NAME_TRIGRAM_SIMILARITY)
-                | Q(_last_name_score__gt=MIN_NAME_TRIGRAM_SIMILARITY)
-                | Q(_email_score__gt=MIN_NAME_TRIGRAM_SIMILARITY)
-            )
-            .annotate(_search_score=F("_first_name_score") + F("_last_name_score") + F("_email_score"))
-            .order_by("-_search_score", "user__first_name")
+        return apply_trigram_search(
+            queryset,
+            search,
+            span_prefix="organization_member.search",
+            fields=(
+                TrigramSearchField("user__first_name"),
+                TrigramSearchField("user__last_name"),
+                TrigramSearchField("user__email"),
+            ),
+            tiebreakers=("user__first_name",),
         )
 
     def safely_get_queryset(self, queryset) -> QuerySet:

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -527,6 +527,62 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
 
     @parameterized.expand(
         [
+            ("email with plus tag", "alice+ops@example.com"),
+            ("dotted email local part", "jane.q.public@example.com"),
+        ]
+    )
+    def test_list_organization_members_search_matches_literal_substring_below_trigram_threshold(self, _name, email):
+        User.objects.create_and_join(self.organization, email, None, first_name="Real", last_name="Person")
+        User.objects.create_and_join(
+            self.organization, "unrelated@example.com", None, first_name="Bob", last_name="Jones"
+        )
+
+        response = self.client.get(f"/api/organizations/@current/members/?search={email}")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        match_type_by_email = {r["user"]["email"]: r["search_match_type"] for r in results}
+        assert match_type_by_email.get(email) == "exact", (
+            "a literal email substring must match and be labelled exact even when it scores below the trigram thresholds"
+        )
+        assert "unrelated@example.com" not in match_type_by_email
+
+    def test_list_organization_members_search_returns_exact_first_with_match_type(self):
+        User.objects.create_and_join(
+            self.organization, "marketing@example.com", None, first_name="Marketing", last_name="Director"
+        )
+        User.objects.create_and_join(
+            self.organization, "promo@example.com", None, first_name="Marekting", last_name="Lead"
+        )
+        User.objects.create_and_join(
+            self.organization, "unrelated@example.com", None, first_name="Bob", last_name="Jones"
+        )
+
+        response = self.client.get("/api/organizations/@current/members/?search=marketing")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        emails = [r["user"]["email"] for r in results]
+        match_type_by_email = {r["user"]["email"]: r["search_match_type"] for r in results}
+
+        assert match_type_by_email.get("marketing@example.com") == "exact"
+        assert match_type_by_email.get("promo@example.com") == "similar"
+        assert "unrelated@example.com" not in emails
+        assert emails.index("marketing@example.com") < emails.index("promo@example.com"), (
+            f"exact match must rank ahead of the fuzzy-only match, got {emails}"
+        )
+
+    def test_list_organization_members_search_match_type_absent_without_search(self):
+        User.objects.create_and_join(self.organization, "extra@posthog.com", None)
+
+        response = self.client.get("/api/organizations/@current/members/")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        assert results
+        assert all("search_match_type" not in r for r in results)
+
+    @parameterized.expand(
+        [
             # (name, has_totp, passkeys_enabled_for_2fa, passkey_verified, expected)
             ("totp_only", True, False, False, True),
             ("passkeys_enabled_and_verified", False, True, True, True),

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -534,10 +534,10 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
     def test_list_organization_members_search_matches_literal_substring_below_trigram_threshold(self, _name, email):
         User.objects.create_and_join(self.organization, email, None, first_name="Real", last_name="Person")
         User.objects.create_and_join(
-            self.organization, "unrelated@example.com", None, first_name="Bob", last_name="Jones"
+            self.organization, "nomatch@unrelated.test", None, first_name="Bob", last_name="Jones"
         )
 
-        response = self.client.get(f"/api/organizations/@current/members/?search={email}")
+        response = self.client.get("/api/organizations/@current/members/", {"search": email})
         assert response.status_code == status.HTTP_200_OK
         results = response.json()["results"]
 
@@ -545,7 +545,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         assert match_type_by_email.get(email) == "exact", (
             "a literal email substring must match and be labelled exact even when it scores below the trigram thresholds"
         )
-        assert "unrelated@example.com" not in match_type_by_email
+        assert "nomatch@unrelated.test" not in match_type_by_email
 
     def test_list_organization_members_search_returns_exact_first_with_match_type(self):
         User.objects.create_and_join(

--- a/posthog/api/test/test_search_match_type_mixin.py
+++ b/posthog/api/test/test_search_match_type_mixin.py
@@ -1,6 +1,7 @@
 from parameterized import parameterized
 from rest_framework import serializers
 
+from posthog.api.organization_member import OrganizationMemberSerializer
 from posthog.api.shared import SearchMatchTypeSerializerMixin
 
 from products.product_analytics.backend.api.insight import InsightBasicSerializer, InsightSerializer
@@ -10,6 +11,7 @@ from products.product_analytics.backend.api.insight import InsightBasicSerialize
 SEARCH_LIST_SERIALIZERS = [
     ("insight_basic", InsightBasicSerializer),
     ("insight", InsightSerializer),
+    ("organization_member", OrganizationMemberSerializer),
 ]
 
 

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -295,6 +295,13 @@ export const OrganizationMembershipLevelEnumApi = {
     Number15: 15,
 } as const
 
+export type SearchMatchTypeEnumApi = (typeof SearchMatchTypeEnumApi)[keyof typeof SearchMatchTypeEnumApi]
+
+export const SearchMatchTypeEnumApi = {
+    Exact: 'exact',
+    Similar: 'similar',
+} as const
+
 export interface OrganizationMemberApi {
     readonly id: string
     readonly user: UserBasicApi
@@ -304,6 +311,8 @@ export interface OrganizationMemberApi {
     readonly is_2fa_enabled: boolean
     readonly has_social_auth: boolean
     readonly last_login: string
+    /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+    readonly search_match_type: SearchMatchTypeEnumApi | null
 }
 
 export interface PaginatedOrganizationMemberListApi {
@@ -324,6 +333,8 @@ export interface PatchedOrganizationMemberApi {
     readonly is_2fa_enabled?: boolean
     readonly has_social_auth?: boolean
     readonly last_login?: string
+    /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+    readonly search_match_type?: SearchMatchTypeEnumApi | null
 }
 
 export interface OrganizationPersonalAPIKeyOwnerApi {
@@ -856,7 +867,7 @@ export type MembersListParams = {
      */
     order?: string
     /**
-     * Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.
+     * Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters.
      */
     search?: string
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -24254,6 +24254,8 @@ export namespace Schemas {
       readonly is_2fa_enabled: boolean;
       readonly has_social_auth: boolean;
       readonly last_login: string;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     /**
@@ -31453,6 +31455,8 @@ export namespace Schemas {
       readonly is_2fa_enabled?: boolean;
       readonly has_social_auth?: boolean;
       readonly last_login?: string;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
     export interface PatchedParserRecipe {
@@ -47324,7 +47328,7 @@ export namespace Schemas {
      */
     order?: string;
     /**
-     * Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.
+     * Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters.
      */
     search?: string;
     };

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -33,7 +33,7 @@ export const MembersListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.'
+            "Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters."
         ),
 })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/org-members-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/org-members-list.json
@@ -14,7 +14,7 @@
             "type": "string"
         },
         "search": {
-            "description": "Fuzzy match against member `first_name`, `last_name`, and `email` using Postgres trigram word similarity. Supports typos and prefix-as-you-type. Capped at 200 characters.",
+            "description": "Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters.",
             "type": "string"
         }
     },


### PR DESCRIPTION
## Problem

Searching the organization members list by email is broken today. `GET /api/organizations/@current/members/?search=jane.q.public@example.com` returns **zero results even when a member's email is exactly `jane.q.public@example.com`** — pg_trgm word similarity ([#57433](https://github.com/PostHog/posthog/pull/57433)) tokenises the address at `.`/`@` and every fragment scores below the 0.3 threshold. Email is the most common way you'd search for a teammate, so this is the sharpest instance of the regression.

## Changes

Routes `OrganizationMemberViewSet._apply_search` through the shared `apply_trigram_search` helper (added in the base PR of this stack), searching `user__first_name`, `user__last_name`, and `user__email`. The helper OR's an `icontains` predicate into the pg_trgm word-similarity filter, so a literal substring of any of those fields matches and is labelled `exact` (ordered ahead of fuzzy hits). `OrganizationMemberSerializer` mixes in `SearchMatchTypeSerializerMixin` to expose `search_match_type`.

The search stays org-scoped — the helper is additive on the already-scoped queryset.

## How did you test this code?

I'm an agent (PostHog Code).

**The failing-today / working-now proof is the new test** `test_list_organization_members_search_matches_literal_substring_below_trigram_threshold`: it searches a full email / dotted local-part and asserts the member matches and is labelled `exact`. It **fails against master** (zero results) and **passes with this change**. Also added: exact-first ordering with `search_match_type`, and the field's absence on unsearched lists.

`test_search_match_type_mixin` gains the org-member serializer (MRO-ordering contract). `ruff` clean; SQL compiled against local Postgres (icontains `exact_q` + exact-first ordering present). Full Django API suite runs in CI (needs ClickHouse).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

Authored by PostHog Code. Part of a stack on top of the shared-helper base PR (#62358); this is the first product fix, sharpest regression first. Backend change is one delegating call + the serializer mixin; the rest is the regenerated `platform_features` schema and the new tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
