### PR TITLE
fix(error-tracking): show full range in rate limit previews

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/issueRateLimitConfigLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/issueRateLimitConfigLogic.ts
@@ -130,6 +130,7 @@ export const issueRateLimitConfigLogic = kea<issueRateLimitConfigLogicType>([
                               AND toString(issue_id_v2) = '${issueId}'
                             GROUP BY bucket
                             ORDER BY bucket
+                            LIMIT ${option.bucketCount + 1}
                         `,
                         tags: { productKey: ProductKey.ERROR_TRACKING },
                     })) as HogQLQueryResponse

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/rateLimitConfigLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/rateLimitConfigLogic.ts
@@ -133,6 +133,7 @@ export const rateLimitConfigLogic = kea<rateLimitConfigLogicType>([
                               AND timestamp >= now() - INTERVAL ${totalMinutes} MINUTE
                             GROUP BY bucket
                             ORDER BY bucket
+                            LIMIT ${option.bucketCount + 1}
                         `,
                             tags: { productKey: ProductKey.ERROR_TRACKING },
                         },
@@ -167,6 +168,7 @@ export const rateLimitConfigLogic = kea<rateLimitConfigLogicType>([
                               AND timestamp >= now() - INTERVAL ${totalMinutes} MINUTE
                             GROUP BY bucket, metric_name
                             ORDER BY bucket
+                            LIMIT ${(option.bucketCount + 1) * 2}
                         `,
                             tags: { productKey: ProductKey.ERROR_TRACKING },
                         },


### PR DESCRIPTION
Preview charts for rate limits are broken on prod :(

I missed this because on my local instance I didn't have all the buckets filled and it looked ok