### PR TITLE
fix(search): literal-substring matching for product tours

### DIFF
--- a/posthog/api/test/test_search_match_type_mixin.py
+++ b/posthog/api/test/test_search_match_type_mixin.py
@@ -7,6 +7,7 @@ from posthog.api.shared import SearchMatchTypeSerializerMixin
 from products.cdp.backend.api.hog_function import HogFunctionMinimalSerializer, HogFunctionSerializer
 from products.dashboards.backend.api.dashboard import DashboardBasicSerializer
 from products.product_analytics.backend.api.insight import InsightBasicSerializer, InsightSerializer
+from products.product_tours.backend.api.product_tour import ProductTourSerializer
 from products.surveys.backend.api.survey import SurveySerializer
 
 # Each product that migrates its saved-list search onto apply_trigram_search appends its
@@ -19,6 +20,7 @@ SEARCH_LIST_SERIALIZERS = [
     ("hog_function_minimal", HogFunctionMinimalSerializer),
     ("hog_function", HogFunctionSerializer),
     ("survey", SurveySerializer),
+    ("product_tour", ProductTourSerializer),
 ]
 
 

--- a/products/product_tours/backend/api/product_tour.py
+++ b/products/product_tours/backend/api/product_tour.py
@@ -4,10 +4,8 @@ import itertools
 from typing import Any, cast
 
 from django.conf import settings
-from django.contrib.postgres.search import TrigramSimilarity, TrigramWordSimilarity
 from django.db import transaction
-from django.db.models import F, Q, QuerySet, Value
-from django.db.models.functions import Coalesce
+from django.db.models import QuerySet
 from django.http import HttpResponse, JsonResponse
 from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
@@ -23,19 +21,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.shared import UserBasicSerializer
+from posthog.api.shared import SearchMatchTypeSerializerMixin, UserBasicSerializer
 from posthog.api.utils import get_token
 from posthog.cloud_utils import is_cloud
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX
 from posthog.event_usage import report_user_action
 from posthog.exceptions import generate_exception_response
-from posthog.helpers.trigram_search import (
-    DESCRIPTION_SCORE_WEIGHT,
-    MAX_SEARCH_LENGTH,
-    MIN_DESCRIPTION_TRIGRAM_SIMILARITY,
-    MIN_NAME_TRIGRAM_SIMILARITY,
-    normalize_search_term,
-)
+from posthog.helpers.trigram_search import DESCRIPTION_FIELD, MAX_SEARCH_LENGTH, NAME_FIELD, apply_trigram_search
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.team.team import Team
 from posthog.models.user import User
@@ -101,7 +93,7 @@ def _validate_step_targeting(step: dict, idx: int):
         raise serializers.ValidationError(f"Step {idx + 1} requires an element to be selected")
 
 
-class ProductTourSerializer(serializers.ModelSerializer):
+class ProductTourSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerializer):
     """Read-only serializer for ProductTour."""
 
     internal_targeting_flag = MinimalFeatureFlagSerializer(read_only=True)
@@ -130,6 +122,7 @@ class ProductTourSerializer(serializers.ModelSerializer):
             "created_by",
             "updated_at",
             "archived",
+            "search_match_type",
         ]
         read_only_fields = ["id", "created_at", "created_by", "updated_at"]
 
@@ -795,33 +788,12 @@ class ProductTourViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, view
     @staticmethod
     @tracer.start_as_current_span("ProductTourViewSet._apply_search")
     def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
-        search = normalize_search_term(search)
-        span = trace.get_current_span()
-        span.set_attribute("product_tour.search.length", len(search))
-        if not search:
-            return queryset
-
-        zero = Value(0.0)
-        name_word_score = Coalesce(TrigramWordSimilarity(search, "name"), zero)
-        name_full_score = Coalesce(TrigramSimilarity("name", search), zero)
-        description_word_score = Coalesce(TrigramWordSimilarity(search, "description"), zero)
-
-        return (
-            queryset.annotate(
-                _name_word=name_word_score,
-                _name_full=name_full_score,
-                _description_word=description_word_score,
-            )
-            .filter(
-                Q(_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY)
-                | Q(_description_word__gt=MIN_DESCRIPTION_TRIGRAM_SIMILARITY)
-            )
-            .annotate(
-                _name_match_score=F("_name_word") + F("_name_full"),
-                _description_match_score=F("_description_word"),
-            )
-            .annotate(_search_score=F("_name_match_score") + F("_description_match_score") * DESCRIPTION_SCORE_WEIGHT)
-            .order_by("-_search_score", "name")
+        return apply_trigram_search(
+            queryset,
+            search,
+            span_prefix="product_tour.search",
+            fields=(NAME_FIELD, DESCRIPTION_FIELD),
+            tiebreakers=("name",),
         )
 
     def safely_get_queryset(self, queryset):

--- a/products/product_tours/backend/api/test/test_product_tour.py
+++ b/products/product_tours/backend/api/test/test_product_tour.py
@@ -284,7 +284,7 @@ class TestProductTour(APIBaseTest):
         for name in tour_names:
             ProductTour.objects.create(team=self.team, name=name, content={"steps": []})
 
-        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/?search={search}")
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/", {"search": search})
         assert response.status_code == status.HTTP_200_OK
         result_names = [r["name"] for r in response.json()["results"]]
 
@@ -320,7 +320,7 @@ class TestProductTour(APIBaseTest):
         a = ProductTour.objects.create(team=self.team, name="Alpha", content={"steps": []})
         b = ProductTour.objects.create(team=self.team, name="Beta", content={"steps": []})
 
-        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/?search={search}")
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/", {"search": search})
         assert response.status_code == status.HTTP_200_OK
         result_ids = {r["id"] for r in response.json()["results"]}
 
@@ -358,6 +358,55 @@ class TestProductTour(APIBaseTest):
             body = response.json()
             assert body["attr"] == "search", f"expected error scoped to 'search', got {body}"
             assert "200 characters" in body["detail"], f"expected error detail to mention the cap, got {body['detail']}"
+
+    @parameterized.expand(
+        [
+            ("email in name", "alerts+ops@example.com", "alerts+ops@example.com"),
+            ("uuid in name", "run 1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed", "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"),
+            ("dotted identifier", "com.acme.billing tour", "com.acme.billing"),
+        ]
+    )
+    def test_list_filter_by_search_matches_literal_substring_below_trigram_threshold(self, _name, tour_name, search):
+        matching = ProductTour.objects.create(team=self.team, name=tour_name, content={"steps": []})
+        ProductTour.objects.create(team=self.team, name="Totally unrelated", content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/", {"search": search})
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        match_type_by_id = {r["id"]: r["search_match_type"] for r in results}
+        assert match_type_by_id.get(str(matching.id)) == "exact", (
+            "a literal substring must match and be labelled exact even when it scores below the trigram thresholds"
+        )
+        assert all(r["name"] != "Totally unrelated" for r in results)
+
+    def test_list_filter_by_search_returns_exact_first_with_match_type(self):
+        for name in ("onboarding tour", "tour for onboarding", "onbarding flow", "Engineering tour"):
+            ProductTour.objects.create(team=self.team, name=name, content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/?search=onboarding")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        match_type_by_name = {r["name"]: r["search_match_type"] for r in results}
+        assert match_type_by_name == {
+            "onboarding tour": "exact",
+            "tour for onboarding": "exact",
+            "onbarding flow": "similar",
+        }
+
+        match_types = [r["search_match_type"] for r in results]
+        assert match_types == ["exact", "exact", "similar"], f"exact matches must rank first, got {match_types}"
+
+    def test_list_filter_by_search_match_type_absent_without_search(self):
+        ProductTour.objects.create(team=self.team, name="Alpha", content={"steps": []})
+
+        response = self.client.get(f"/api/projects/{self.team.id}/product_tours/")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+
+        assert results
+        assert all("search_match_type" not in r for r in results)
 
 
 class TestProductTourAnalyticsMetadata(APIBaseTest):

--- a/products/product_tours/frontend/generated/api.schemas.ts
+++ b/products/product_tours/frontend/generated/api.schemas.ts
@@ -119,6 +119,13 @@ export interface UserBasicApi {
     role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | null
 }
 
+export type SearchMatchTypeEnumApi = (typeof SearchMatchTypeEnumApi)[keyof typeof SearchMatchTypeEnumApi]
+
+export const SearchMatchTypeEnumApi = {
+    Exact: 'exact',
+    Similar: 'similar',
+} as const
+
 /**
  * Return the targeting flag filters, excluding the base exclusion properties.
  * @nullable
@@ -152,6 +159,8 @@ export interface ProductTourApi {
     readonly created_by: UserBasicApi
     readonly updated_at: string
     archived?: boolean
+    /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+    readonly search_match_type: SearchMatchTypeEnumApi | null
 }
 
 export interface PaginatedProductTourListApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26127,6 +26127,8 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly updated_at: string;
       archived?: boolean;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface PaginatedProductTourList {


### PR DESCRIPTION
## Problem

Searching the product tours list — `?search=com.acme.billing`, an email, a UUID — returns **zero results even when a tour's name is exactly that**, because pg_trgm word similarity ([#57433](https://github.com/PostHog/posthog/pull/57433)) tokenises the query at the punctuation and every fragment scores below threshold.

## Changes

Routes `ProductTourViewSet._apply_search` through the shared `apply_trigram_search` helper (base PR of this stack), searching `name` + `description` with an `icontains` fallback so literal substrings match and are labelled `exact` (ordered ahead of fuzzy hits). `ProductTourSerializer` mixes in `SearchMatchTypeSerializerMixin`.

## How did you test this code?

I'm an agent (PostHog Code).

**Failing-today / working-now proof:** the new `test_list_filter_by_search_matches_literal_substring_below_trigram_threshold` searches an email / UUID / dotted identifier and asserts the tour matches, labelled `exact`. It **fails against master** (zero results) and **passes here**. Plus exact-first ordering with `search_match_type` and absence-without-search.

`test_search_match_type_mixin` gains the product-tour serializer. `ruff` clean; SQL compiled against local Postgres (icontains `exact_q` + exact-first present). Full Django API suite runs in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

Authored by PostHog Code. Stacked on the surveys fix (→ hog functions → dashboards → org members → shared-helper base PR #62358). Backend change is one delegating call + the serializer mixin; rest is the regenerated product-tours schema/MCP and the new tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
