### PR TITLE
fix(search): literal-substring matching for alerts

### DIFF
--- a/posthog/api/test/test_search_match_type_mixin.py
+++ b/posthog/api/test/test_search_match_type_mixin.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from posthog.api.organization_member import OrganizationMemberSerializer
 from posthog.api.shared import SearchMatchTypeSerializerMixin
 
+from products.alerts.backend.api.alert import AlertSerializer
 from products.cdp.backend.api.hog_function import HogFunctionMinimalSerializer, HogFunctionSerializer
 from products.dashboards.backend.api.dashboard import DashboardBasicSerializer
 from products.product_analytics.backend.api.insight import InsightBasicSerializer, InsightSerializer
@@ -21,6 +22,7 @@ SEARCH_LIST_SERIALIZERS = [
     ("hog_function", HogFunctionSerializer),
     ("survey", SurveySerializer),
     ("product_tour", ProductTourSerializer),
+    ("alert", AlertSerializer),
 ]
 
 

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -1,9 +1,7 @@
 import uuid
 from zoneinfo import ZoneInfo
 
-from django.contrib.postgres.search import TrigramSimilarity, TrigramWordSimilarity
-from django.db.models import F, OuterRef, Q, QuerySet, Subquery, Value
-from django.db.models.functions import Coalesce
+from django.db.models import OuterRef, QuerySet, Subquery
 
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, extend_schema, extend_schema_view
 from rest_framework import serializers, viewsets
@@ -23,9 +21,9 @@ from posthog.schema import (
 from posthog.api.documentation import extend_schema_field
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
-from posthog.api.shared import UserBasicSerializer
+from posthog.api.shared import SearchMatchTypeSerializerMixin, UserBasicSerializer
 from posthog.event_usage import get_request_analytics_properties
-from posthog.helpers.trigram_search import MAX_SEARCH_LENGTH, MIN_NAME_TRIGRAM_SIMILARITY, normalize_search_term
+from posthog.helpers.trigram_search import MAX_SEARCH_LENGTH, NAME_FIELD, apply_trigram_search
 from posthog.models import User
 from posthog.resource_limits import LimitKey, check_count_limit
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -180,7 +178,7 @@ class RelativeDateTimeField(serializers.DateTimeField):
         return data
 
 
-class AlertSerializer(serializers.ModelSerializer):
+class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     checks = AlertCheckSerializer(
         many=True,
@@ -301,6 +299,7 @@ class AlertSerializer(serializers.ModelSerializer):
             "investigation_agent_enabled",
             "investigation_gates_notifications",
             "investigation_inconclusive_action",
+            "search_match_type",
         ]
         read_only_fields = [
             "id",
@@ -787,22 +786,12 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @staticmethod
     def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
-        search = normalize_search_term(search)
-        if not search:
-            return queryset
-
-        zero = Value(0.0)
-        name_word_score = Coalesce(TrigramWordSimilarity(search, "name"), zero)
-        name_full_score = Coalesce(TrigramSimilarity("name", search), zero)
-
-        return (
-            queryset.annotate(
-                _name_word=name_word_score,
-                _name_full=name_full_score,
-            )
-            .filter(Q(_name_word__gt=MIN_NAME_TRIGRAM_SIMILARITY) | Q(_name_full__gt=MIN_NAME_TRIGRAM_SIMILARITY))
-            .annotate(_search_score=F("_name_word") + F("_name_full"))
-            .order_by("-_search_score", "-created_at")
+        return apply_trigram_search(
+            queryset,
+            search,
+            span_prefix="alert.search",
+            fields=(NAME_FIELD,),
+            tiebreakers=("-created_at",),
         )
 
     CHECKS_DEFAULT_LIMIT = 5

--- a/products/alerts/backend/api/test/test_alert.py
+++ b/products/alerts/backend/api/test/test_alert.py
@@ -1353,6 +1353,54 @@ class TestAlertListFilters(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("email in name", "alerts+ops@example.com", "alerts+ops@example.com"),
+            ("uuid in name", "run 1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed", "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"),
+            ("dotted identifier", "com.acme.billing alert", "com.acme.billing"),
+        ]
+    )
+    def test_list_filter_by_search_matches_literal_substring_below_trigram_threshold(
+        self, _name: str, alert_name: str, search: str
+    ) -> None:
+        self._create_alert(alert_name)
+        self._create_alert("Totally unrelated")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts", {"search": search})
+        results = response.json()["results"]
+
+        match_type_by_name = {a["name"]: a["search_match_type"] for a in results}
+        assert match_type_by_name.get(alert_name) == "exact", (
+            "a literal substring must match and be labelled exact even when it scores below the trigram thresholds"
+        )
+        assert all(a["name"] != "Totally unrelated" for a in results)
+
+    def test_list_filter_by_search_returns_exact_first_with_match_type(self) -> None:
+        for name in ("revenue spike", "spike in revenue", "reveneu drop", "Unrelated alert"):
+            self._create_alert(name)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts", {"search": "revenue"})
+        results = response.json()["results"]
+
+        match_type_by_name = {a["name"]: a["search_match_type"] for a in results}
+        assert match_type_by_name == {
+            "revenue spike": "exact",
+            "spike in revenue": "exact",
+            "reveneu drop": "similar",
+        }
+
+        match_types = [a["search_match_type"] for a in results]
+        assert match_types == ["exact", "exact", "similar"], f"exact matches must rank first, got {match_types}"
+
+    def test_list_filter_by_search_match_type_absent_without_search(self) -> None:
+        self._create_alert("Revenue spike")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts")
+        results = response.json()["results"]
+
+        assert results
+        assert all("search_match_type" not in a for a in results)
+
+    @parameterized.expand(
+        [
             ("search_length_cap", {"search": "a" * 201}, "search"),
             ("invalid_created_by_uuid", {"created_by": "not-a-uuid"}, "created_by"),
         ]

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -421,6 +421,13 @@ export const InvestigationInconclusiveActionEnumApi = {
     Suppress: 'suppress',
 } as const
 
+export type SearchMatchTypeEnumApi = (typeof SearchMatchTypeEnumApi)[keyof typeof SearchMatchTypeEnumApi]
+
+export const SearchMatchTypeEnumApi = {
+    Exact: 'exact',
+    Similar: 'similar',
+} as const
+
 export interface AlertApi {
     readonly id: string
     readonly created_by: UserBasicApi
@@ -489,6 +496,8 @@ export interface AlertApi {
      * * `notify` - Notify
      * * `suppress` - Suppress */
     investigation_inconclusive_action?: InvestigationInconclusiveActionEnumApi
+    /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+    readonly search_match_type: SearchMatchTypeEnumApi | null
 }
 
 export interface PaginatedAlertListApi {
@@ -568,6 +577,8 @@ export interface PatchedAlertApi {
      * * `notify` - Notify
      * * `suppress` - Suppress */
     investigation_inconclusive_action?: InvestigationInconclusiveActionEnumApi
+    /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+    readonly search_match_type?: SearchMatchTypeEnumApi | null
 }
 
 export interface AlertSimulateApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7575,6 +7575,8 @@ export namespace Schemas {
        * * `notify` - Notify
        * * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
     export interface AlertSimulate {
@@ -29286,6 +29288,8 @@ export namespace Schemas {
        * * `notify` - Notify
        * * `suppress` - Suppress */
       investigation_inconclusive_action?: InvestigationInconclusiveActionEnum;
+      /** How this row matched the `search` query parameter: `exact` (the term is a case-insensitive substring of a searched field) or `similar` (a fuzzy trigram match only). Results are ordered exact-first. Null when the list is not filtered by `search`. */
+      readonly search_match_type?: SearchMatchTypeEnum | null;
     }
 
     export interface PatchedAnnotation {


### PR DESCRIPTION
## Problem

Searching the alerts list — `?search=alerts+ops@example.com`, a UUID, a dotted identifier — returns **zero results even when an alert's name is exactly that**, because pg_trgm word similarity ([#57433](https://github.com/PostHog/posthog/pull/57433)) tokenises the query at the punctuation and every fragment scores below threshold.

## Changes

Routes `AlertViewSet._apply_search` through the shared `apply_trigram_search` helper (base PR of this stack), searching `name` with an `icontains` fallback so a literal substring matches and is labelled `exact` (ordered ahead of fuzzy hits, `-created_at` tiebreak preserved). `AlertSerializer` mixes in `SearchMatchTypeSerializerMixin`.

The alert search previously also thresholded on full-string similarity; that clause is dropped because `word_similarity >= similarity` always holds (the full string is one extent the word metric already considers), so the word threshold implies it — confirmed by inspecting the compiled SQL.

## How did you test this code?

I'm an agent (PostHog Code).

**Failing-today / working-now proof:** the new `test_list_filter_by_search_matches_literal_substring_below_trigram_threshold` searches an email / UUID / dotted identifier and asserts the alert matches, labelled `exact`. It **fails against master** (zero results) and **passes here**. Plus exact-first ordering with `search_match_type` and absence-without-search.

`test_search_match_type_mixin` gains the alert serializer (the final one — all seven saved-list serializers are now pinned). `ruff` clean; SQL compiled against local Postgres (icontains `exact_q` + exact-first, redundant full-similarity threshold gone). Full Django API suite runs in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

Authored by PostHog Code. Top of the stack (→ product tours → surveys → hog functions → dashboards → org members → shared-helper base PR #62358). Backend change is one delegating call + the serializer mixin, plus dropping the now-redundant full-similarity threshold; rest is the regenerated alerts schema/MCP and the new tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
