### PR TITLE
fix(dev): build llm-gateway venv with python 3.13

### DIFF
--- a/bin/start-llm-gateway
+++ b/bin/start-llm-gateway
@@ -30,11 +30,14 @@ cd "$REPO_ROOT/services/llm-gateway"
 unset VIRTUAL_ENV
 export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
 
+# llm-gateway requires Python >=3.13; pin it so the venv isn't built with the
+# repo's default interpreter (3.12), and target the venv explicitly so the
+# editable install resolves against 3.13 rather than the discovered interpreter.
 if [ ! -d ".venv" ]; then
-    uv venv .venv
+    uv venv --python 3.13 .venv
 fi
 
-uv pip install -e . --quiet
+uv pip install -e . --python .venv/bin/python --quiet
 
 exec .venv/bin/uvicorn llm_gateway.main:app \
     --host 0.0.0.0 \


### PR DESCRIPTION
## Problem

`services/llm-gateway` declares `requires-python = ">=3.13"`, but `bin/start-llm-gateway` created its virtualenv with `uv venv .venv` (no `--python`), so it used the repo's default interpreter (3.12). The subsequent `uv pip install -e .` then failed to resolve (`the current Python version (3.12.x) does not satisfy Python>=3.13`), and the local `llm-gateway` dev service crashed on boot.

## Changes

- `uv venv --python 3.13 .venv` so the venv is built with a 3.13 interpreter (uv fetches a managed one if needed).
- `uv pip install -e . --python .venv/bin/python` so the editable install resolves against the venv's 3.13 rather than the discovered interpreter.

Local-dev tooling only; no app code touched.

## How did you test this code?

I'm an agent (Claude Code). Rebuilt the venv with the new command (`uv` provisioned CPython 3.13.13), reinstalled the package, and rebooted the `llm-gateway` process — it now starts cleanly (`Uvicorn running on http://0.0.0.0:3308`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes.

## 🤖 Agent context

Authored by an agent (Claude Code) while getting the local stack healthy for unrelated testing. Small, self-contained dev-tooling fix. Requires human review; not for self-merge.
