### PR TITLE
fix(auth): allow email change between an org's SSO-enforced domains

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -29,7 +29,6 @@ from posthog.models import Team, User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.organization import Organization, OrganizationMembership
-from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
@@ -758,26 +757,19 @@ class TestUserAPI(APIBaseTest):
 
     @patch("posthog.api.user.is_email_available", return_value=True)
     @patch("posthog.api.user.EmailVerifier.create_token_and_send_email_verification")
-    def test_email_change_allowed_between_verified_domains_of_same_org(
+    def test_email_change_allowed_between_two_sso_enforced_domains(
         self,
         mock_send_email_verification,
         mock_is_email_available,
     ):
         self.user.email = "alice@example.com"
         self.user.save()
-        OrganizationDomain.objects.create(
-            organization=self.organization,
-            domain="example.com",
-            verified_at=timezone.now(),
-            sso_enforcement="google-oauth2",
-        )
-        OrganizationDomain.objects.create(
-            organization=self.organization, domain="example.org", verified_at=timezone.now()
-        )
 
         with patch(
             "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
-            side_effect=lambda email, organization=None: "google-oauth2" if email.endswith("@example.com") else None,
+            side_effect=lambda email, organization=None: "google-oauth2"
+            if email.split("@")[-1] in ("example.com", "example.org")
+            else None,
         ):
             with self.is_cloud(True):
                 response = self.client.patch("/api/users/@me/", {"email": "alice@example.org"})
@@ -786,37 +778,6 @@ class TestUserAPI(APIBaseTest):
         self.user.refresh_from_db()
         assert self.user.pending_email == "alice@example.org"
         mock_send_email_verification.assert_called_once()
-
-    @patch("posthog.api.user.is_email_available", return_value=True)
-    @patch("posthog.tasks.email.send_email_change_emails.delay")
-    def test_email_change_blocked_to_domain_verified_by_a_different_org(
-        self,
-        mock_send_email_change_emails,
-        mock_is_email_available,
-    ):
-        self.user.email = "alice@example.com"
-        self.user.save()
-        OrganizationDomain.objects.create(
-            organization=self.organization,
-            domain="example.com",
-            verified_at=timezone.now(),
-            sso_enforcement="google-oauth2",
-        )
-        other_org = Organization.objects.create(name="Other Org")
-        OrganizationDomain.objects.create(organization=other_org, domain="example.net", verified_at=timezone.now())
-
-        with patch(
-            "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
-            side_effect=lambda email, organization=None: "google-oauth2" if email.endswith("@example.com") else None,
-        ):
-            with self.is_cloud(True):
-                response = self.client.patch("/api/users/@me/", {"email": "alice@example.net"})
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["code"] == "sso_enforced_current_email"
-        self.user.refresh_from_db()
-        assert self.user.email == "alice@example.com"
-        assert self.user.pending_email is None
 
     @patch("posthog.tasks.email.send_email_change_emails.delay")
     def test_verify_email_without_pending_email_keeps_social_auth_connections(self, mock_send_email_change_emails):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -29,6 +29,7 @@ from posthog.models import Team, User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
@@ -757,13 +758,20 @@ class TestUserAPI(APIBaseTest):
 
     @patch("posthog.api.user.is_email_available", return_value=True)
     @patch("posthog.api.user.EmailVerifier.create_token_and_send_email_verification")
-    def test_email_change_allowed_between_two_sso_enforced_domains(
+    def test_email_change_allowed_between_two_sso_enforced_domains_of_same_org(
         self,
         mock_send_email_verification,
         mock_is_email_available,
     ):
         self.user.email = "alice@example.com"
         self.user.save()
+        for domain in ("example.com", "example.org"):
+            OrganizationDomain.objects.create(
+                organization=self.organization,
+                domain=domain,
+                verified_at=timezone.now(),
+                sso_enforcement="google-oauth2",
+            )
 
         with patch(
             "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
@@ -778,6 +786,44 @@ class TestUserAPI(APIBaseTest):
         self.user.refresh_from_db()
         assert self.user.pending_email == "alice@example.org"
         mock_send_email_verification.assert_called_once()
+
+    @patch("posthog.api.user.is_email_available", return_value=True)
+    @patch("posthog.tasks.email.send_email_change_emails.delay")
+    def test_email_change_blocked_to_sso_enforced_domain_of_another_org(
+        self,
+        mock_send_email_change_emails,
+        mock_is_email_available,
+    ):
+        self.user.email = "alice@example.com"
+        self.user.save()
+        OrganizationDomain.objects.create(
+            organization=self.organization,
+            domain="example.com",
+            verified_at=timezone.now(),
+            sso_enforcement="google-oauth2",
+        )
+        other_org = Organization.objects.create(name="Attacker Org")
+        OrganizationDomain.objects.create(
+            organization=other_org,
+            domain="example.net",
+            verified_at=timezone.now(),
+            sso_enforcement="google-oauth2",
+        )
+
+        with patch(
+            "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
+            side_effect=lambda email, organization=None: "google-oauth2"
+            if email.split("@")[-1] in ("example.com", "example.net")
+            else None,
+        ):
+            with self.is_cloud(True):
+                response = self.client.patch("/api/users/@me/", {"email": "alice@example.net"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "sso_enforced_current_email"
+        self.user.refresh_from_db()
+        assert self.user.email == "alice@example.com"
+        assert self.user.pending_email is None
 
     @patch("posthog.tasks.email.send_email_change_emails.delay")
     def test_verify_email_without_pending_email_keeps_social_auth_connections(self, mock_send_email_change_emails):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -29,6 +29,7 @@ from posthog.models import Team, User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
@@ -754,6 +755,68 @@ class TestUserAPI(APIBaseTest):
         assert self.user.email == "alpha@example.com"
         assert self.user.pending_email is None
         mock_send_email_change_emails.assert_not_called()
+
+    @patch("posthog.api.user.is_email_available", return_value=True)
+    @patch("posthog.api.user.EmailVerifier.create_token_and_send_email_verification")
+    def test_email_change_allowed_between_verified_domains_of_same_org(
+        self,
+        mock_send_email_verification,
+        mock_is_email_available,
+    ):
+        self.user.email = "alice@example.com"
+        self.user.save()
+        OrganizationDomain.objects.create(
+            organization=self.organization,
+            domain="example.com",
+            verified_at=timezone.now(),
+            sso_enforcement="google-oauth2",
+        )
+        OrganizationDomain.objects.create(
+            organization=self.organization, domain="example.org", verified_at=timezone.now()
+        )
+
+        with patch(
+            "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
+            side_effect=lambda email, organization=None: "google-oauth2" if email.endswith("@example.com") else None,
+        ):
+            with self.is_cloud(True):
+                response = self.client.patch("/api/users/@me/", {"email": "alice@example.org"})
+
+        assert response.status_code == status.HTTP_200_OK
+        self.user.refresh_from_db()
+        assert self.user.pending_email == "alice@example.org"
+        mock_send_email_verification.assert_called_once()
+
+    @patch("posthog.api.user.is_email_available", return_value=True)
+    @patch("posthog.tasks.email.send_email_change_emails.delay")
+    def test_email_change_blocked_to_domain_verified_by_a_different_org(
+        self,
+        mock_send_email_change_emails,
+        mock_is_email_available,
+    ):
+        self.user.email = "alice@example.com"
+        self.user.save()
+        OrganizationDomain.objects.create(
+            organization=self.organization,
+            domain="example.com",
+            verified_at=timezone.now(),
+            sso_enforcement="google-oauth2",
+        )
+        other_org = Organization.objects.create(name="Other Org")
+        OrganizationDomain.objects.create(organization=other_org, domain="example.net", verified_at=timezone.now())
+
+        with patch(
+            "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
+            side_effect=lambda email, organization=None: "google-oauth2" if email.endswith("@example.com") else None,
+        ):
+            with self.is_cloud(True):
+                response = self.client.patch("/api/users/@me/", {"email": "alice@example.net"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "sso_enforced_current_email"
+        self.user.refresh_from_db()
+        assert self.user.email == "alice@example.com"
+        assert self.user.pending_email is None
 
     @patch("posthog.tasks.email.send_email_change_emails.delay")
     def test_verify_email_without_pending_email_keeps_social_auth_connections(self, mock_send_email_change_emails):

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -662,19 +662,28 @@ class UserSerializer(serializers.ModelSerializer):
             and is_email_available()
         ):
             new_email = validated_data["email"]
-            # Moving between two SSO-enforced domains is a domain migration, not an SSO bypass.
+            # Moving between two SSO-enforced domains of the same org is a domain migration, not an SSO bypass.
             # SSO enforcement can only be set on a verified domain, so an enforced domain is always verified.
             current_sso_enforced = OrganizationDomain.objects.get_sso_enforcement_for_email_address(instance.email)
             new_sso_enforced = OrganizationDomain.objects.get_sso_enforcement_for_email_address(new_email)
+            current_domain = OrganizationDomain.objects.get_verified_for_email_address(instance.email)
+            new_domain = OrganizationDomain.objects.get_verified_for_email_address(new_email)
+            is_same_org_migration = (
+                bool(current_sso_enforced)
+                and bool(new_sso_enforced)
+                and current_domain is not None
+                and new_domain is not None
+                and current_domain.organization_id == new_domain.organization_id
+            )
 
             # Block bypass: a user on an SSO-enforced domain can't move off of it.
-            if current_sso_enforced and not new_sso_enforced:
+            if current_sso_enforced and not is_same_org_migration:
                 raise serializers.ValidationError(
                     "You can't change your email because SSO is enforced on your current email's domain.",
                     code="sso_enforced_current_email",
                 )
             # Block lockout: moving to an SSO-enforced domain blocks password reset and login.
-            if new_sso_enforced and not current_sso_enforced:
+            if new_sso_enforced and not is_same_org_migration:
                 raise serializers.ValidationError(
                     "You can't change your email to a domain where SSO is enforced.",
                     code="sso_enforced_new_email",

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -662,30 +662,19 @@ class UserSerializer(serializers.ModelSerializer):
             and is_email_available()
         ):
             new_email = validated_data["email"]
-            current_domain = OrganizationDomain.objects.get_verified_for_email_address(instance.email)
-            new_domain = OrganizationDomain.objects.get_verified_for_email_address(new_email)
-            # Moving between two verified domains owned by the same org is a domain migration, not an
-            # SSO bypass — the org controls both, so we let it through even when SSO is enforced.
-            is_same_org_migration = (
-                current_domain is not None
-                and new_domain is not None
-                and current_domain.organization_id == new_domain.organization_id
-            )
+            # Moving between two SSO-enforced domains is a domain migration, not an SSO bypass.
+            # SSO enforcement can only be set on a verified domain, so an enforced domain is always verified.
+            current_sso_enforced = OrganizationDomain.objects.get_sso_enforcement_for_email_address(instance.email)
+            new_sso_enforced = OrganizationDomain.objects.get_sso_enforcement_for_email_address(new_email)
 
             # Block bypass: a user on an SSO-enforced domain can't move off of it.
-            if (
-                OrganizationDomain.objects.get_sso_enforcement_for_email_address(instance.email)
-                and not is_same_org_migration
-            ):
+            if current_sso_enforced and not new_sso_enforced:
                 raise serializers.ValidationError(
                     "You can't change your email because SSO is enforced on your current email's domain.",
                     code="sso_enforced_current_email",
                 )
             # Block lockout: moving to an SSO-enforced domain blocks password reset and login.
-            if (
-                OrganizationDomain.objects.get_sso_enforcement_for_email_address(new_email)
-                and not is_same_org_migration
-            ):
+            if new_sso_enforced and not current_sso_enforced:
                 raise serializers.ValidationError(
                     "You can't change your email to a domain where SSO is enforced.",
                     code="sso_enforced_new_email",

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -662,14 +662,30 @@ class UserSerializer(serializers.ModelSerializer):
             and is_email_available()
         ):
             new_email = validated_data["email"]
+            current_domain = OrganizationDomain.objects.get_verified_for_email_address(instance.email)
+            new_domain = OrganizationDomain.objects.get_verified_for_email_address(new_email)
+            # Moving between two verified domains owned by the same org is a domain migration, not an
+            # SSO bypass — the org controls both, so we let it through even when SSO is enforced.
+            is_same_org_migration = (
+                current_domain is not None
+                and new_domain is not None
+                and current_domain.organization_id == new_domain.organization_id
+            )
+
             # Block bypass: a user on an SSO-enforced domain can't move off of it.
-            if OrganizationDomain.objects.get_sso_enforcement_for_email_address(instance.email):
+            if (
+                OrganizationDomain.objects.get_sso_enforcement_for_email_address(instance.email)
+                and not is_same_org_migration
+            ):
                 raise serializers.ValidationError(
                     "You can't change your email because SSO is enforced on your current email's domain.",
                     code="sso_enforced_current_email",
                 )
             # Block lockout: moving to an SSO-enforced domain blocks password reset and login.
-            if OrganizationDomain.objects.get_sso_enforcement_for_email_address(new_email):
+            if (
+                OrganizationDomain.objects.get_sso_enforcement_for_email_address(new_email)
+                and not is_same_org_migration
+            ):
                 raise serializers.ValidationError(
                     "You can't change your email to a domain where SSO is enforced.",
                     code="sso_enforced_new_email",


### PR DESCRIPTION
## Problem

A user whose email is on an **SSO-enforced domain** can't change their email at all — the guard blocks any move off an enforced domain to prevent bypassing SSO. But an org migrating domains (e.g. `.co` → `.com`, both SSO-enforced) hits this too: the user can't update their email, the request silently 400s, and downstream features that match on email break (the Slack integration matches your Slack email to your PostHog email).

## Changes

Allow the email change only when **both** the current and target domains are SSO-enforced **and owned by the same org**:

- **both enforced** → the user stays behind SSO either way, so there's no drop to password auth.
- **same org** → the IdP stays the org's own, so the account can't be re-homed onto another (possibly attacker-controlled) org's IdP.

Everything else stays blocked: leaving an enforced domain for a non-enforced one (escape), moving onto an enforced domain from a non-enforced one (lockout), and moving to another org's enforced domain (re-homing). Same error codes as before.

> Changing your email domain is never how you move between orgs — org membership lives on `OrganizationMembership` and is managed via invites, independent of your email. So requiring same-org blocks no legitimate use case; the only thing cross-org migration achieves is keeping one org's data while authenticating through another's IdP.

> Email changes already require a recently-authenticated (sensitive) session via `TimeSensitiveActionPermission`, so this is never remotely triggerable — but the guards still need to hold for a self-service / insider-persistence path.

## How did you test this code?

I'm an agent — automated tests only, `hogli test posthog/api/test/test_user.py::TestUserAPI::<name>`:

- `test_email_change_allowed_between_two_sso_enforced_domains_of_same_org` — both enforced + same org → succeeds.
- `test_email_change_blocked_to_sso_enforced_domain_of_another_org` — both enforced but different orgs → blocked.
- `test_email_change_blocked_when_sso_is_enforced` (existing, both params) — enforced→unenforced and unenforced→enforced still blocked.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8) from a support investigation. The check landed in three commits as two security passes tightened it: (1) allow any same-org *verified*-domain migration → flagged for letting a user drop to password auth via a co-owned non-enforced domain; (2) require both domains *SSO-enforced* → flagged for letting a user re-home onto a different org's IdP; (3) require both — enforced **and** same org. The commits are kept separate so the reasoning is reviewable.
