### PR TITLE
feat(taxonomic-filter): surface bare key alongside complete recents

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2009,9 +2009,9 @@ snapshots:
     filters-taxonomic-filter--actions--light:
         hash: v1.k794b7964.fd0c661c7367ed6acbc1a0f7c3f081873768cb71f0cbe818079a40e006f251fd.b_vQO7-Lw4OI3NfIzBaEJsQI3cQRcr6rBfTVV0ivgAk
     filters-taxonomic-filter--autocapture-context-promotes-elements--dark:
-        hash: v1.k794b7964.8c5d02ec4c497a87a0df0cf32bb695ffb728e4efa6ac8b17eaf9063c5ce98170.5sdWMbFrLaEyW5syvARRnAsh5IkpWjdemV1wq35_4ow
+        hash: v1.k794b7964.cfa95574b47a8694ba49535c1defbb2730aad63200ab7a3b6ddad2643f2b8491.cIDfsRKX2II6PHGSbaQYQJJlV6arvQKuaIMH_eiQ1Tg
     filters-taxonomic-filter--autocapture-context-promotes-elements--light:
-        hash: v1.k794b7964.22b6c7c9ce49bc9ed622417764cc41b2bde28d5a71a9fbc7e92131551dcebb63.jaTvGGOP2Q4wYsPwae28Qzm8_iG70pdBcAc_aAshTy4
+        hash: v1.k794b7964.eb6cd0813ef8b398e812aaef440a71f15eb8daeb158c854cb9f13cf4f537268f.PShI3Mx9k6ygGCfyN5gFEc5i5UnlK_CPTWF5ucWDRHI
     filters-taxonomic-filter--empty-events-with-stale-toggle--dark:
         hash: v1.k794b7964.58cb6300564a2a703d96ce3e69b884cf4009c6fa3ff46b638915be0d7f3b5f02.16dqA1SviZenMIon-EhxXL-vwoIrRFEbDDIDGT3MIm0
     filters-taxonomic-filter--empty-events-with-stale-toggle--light:
@@ -2041,21 +2041,21 @@ snapshots:
     filters-taxonomic-filter--six-groups-default-layout--light:
         hash: v1.k794b7964.ff5b9b093dc72e16b163a87e1ca6b8717196e0a2e9f2b6f232285af80f78a7fd.WmGwg_w20XhcCHdVcg7Ia2ocWDAc_6LihIi7V5w3pco
     filters-taxonomic-filter--suggested-filters-five-recents-with-truncation--dark:
-        hash: v1.k794b7964.b670e1f49fce960dc042d85c2151f8663039532962d93e82c444e71d852e9602._vZUHL3HRT3-JAESZA0W3_tEuYpXtxKFclbN4sZ5Uh4
+        hash: v1.k794b7964.21ba961b89ba79ceb157d55573bf150638c2a6d808ea11ac2f77686f186a5e28.xd_kiA7IHD6WnqDhbjgFOESGCsiymbr19hSw_eEIDWE
     filters-taxonomic-filter--suggested-filters-five-recents-with-truncation--light:
-        hash: v1.k794b7964.371a28b35788cf0907f3deb707d65773dfcbc4c48162d4662b3eca0c312d7697.cpGyjzWpxOB8dYccKJ96Lg2la3Q-0L_NR36fdSZMX48
+        hash: v1.k794b7964.96433b8ecef485d6072c135f26be44eb8c8e0cd21827751e2b14af9e4ac48b2b.t3-Dw-w88wEWoLMN4s0mVUnv14-IY1UNQEKbntFvrnA
     filters-taxonomic-filter--suggested-filters-four-recents--dark:
-        hash: v1.k794b7964.faba0f7b7f13628356fad6583e2d06ad3a4bd5751b3d90e3cb78b7e7f58ef350.vXpVnly-mhnd-0x6RJwSWxNHOxZ6xu6nQQwPpBkxThk
+        hash: v1.k794b7964.7714bb450f764d7f180ace05d884564faee4b2ae86793b7e0ede4867ef94f018._uK_A9Nx7r29rbSMZvhXSevxLnTdPAHCtK-HqGDPQ3o
     filters-taxonomic-filter--suggested-filters-four-recents--light:
-        hash: v1.k794b7964.5edb70129be4b34deb2cb17a372a2fe76df37c319fb2a5bd2fe913e74a401a32.-M33rwmo_97cyTsF_VCOXSBLQmJnd-UxetGBNJwNy5U
+        hash: v1.k794b7964.8a9a202b44a8dccbfc74ddbfbf7b6329c1d590c1fb0b92e4e68bdb2c499d0848.PhO19tVqsRwRskP1OdeN8gqxX1fDP-oJRnnMqDSoCe4
     filters-taxonomic-filter--suggested-filters-no-recents--dark:
         hash: v1.k794b7964.012137ade9f589a3eca44504e4e62024f800f4465660cc193a2f72eb387ffeb5.q7SF2Oa_9DYK_458ZbQip_nm0Wnrxzm7ApfN3IHQKFA
     filters-taxonomic-filter--suggested-filters-no-recents--light:
         hash: v1.k794b7964.4f7f0d6e5b8df449b5186a4d9598960292eeb981a586beeef52f4888c818e617.AU50q0IrQI_PWD-mAVvrYvg-ufokF97G-eXw4Z7PYXk
     filters-taxonomic-filter--suggested-filters-one-recent--dark:
-        hash: v1.k794b7964.c64354c69dcb83029f1410415b22702e96db96728d30696ad77d213f7ee204dd.Cbn-CLijRd7pvDH0bqxsrZiBgIgOivh2rtI90mRuKgg
+        hash: v1.k794b7964.acc48a8784ebc260d291fb06eeb1122d94212b38d921d81a2ec091c98d0e77b9.YOxIP0_6sdAg_vkMu9gQxUaOHBMU_Oy25kYfB1LZL3A
     filters-taxonomic-filter--suggested-filters-one-recent--light:
-        hash: v1.k794b7964.194a8b995a3585272ea39dbaf50c1c605693d4b5e2c96c4d0e8045cbdd6517a3.LT5oF32psILV3x2-zczjDmDRSeJozhOn86niMQZQA2M
+        hash: v1.k794b7964.31af851cf3ffbdbeecc64120c2447a9d62cf11735e66e59bf35fa103630abb82.x2GJ8OTVdPYu3-Avfl-5jH_VdjihWE2YwYgdtbDORG0
     filters-taxonomic-filter--three-groups-default-layout--dark:
         hash: v1.k794b7964.e503fd34c51bed2938ea70593de2a34e2bb44585a94779268dbe9caa6a430c38.td6RRIB5rlR-53hCaS6Mlj7-wA7vEPm6EOydbtul8xE
     filters-taxonomic-filter--three-groups-default-layout--light:

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
@@ -159,6 +159,11 @@ describe('PropertyFilters recent selections', () => {
         expect(screen.getByTestId(`prop-filter-suggested_filters-${index}`)).toHaveTextContent(pattern)
     }
 
+    function expectBareKeyBeforeFullRecent(valuePattern: RegExp, fullPattern: RegExp): void {
+        expect(screen.getByTestId('prop-filter-suggested_filters-0')).not.toHaveTextContent(valuePattern)
+        expectRecentInSuggestedFilters(1, fullPattern)
+    }
+
     function expectRecentCount(count: number): void {
         expect(recentTaxonomicFiltersLogic.values.recentFilters).toHaveLength(count)
     }
@@ -177,6 +182,7 @@ describe('PropertyFilters recent selections', () => {
             searchQuery: 'example',
             itemTestId: 'prop-filter-pageview_urls-0',
             expectedRecentPattern: /Current URL.*∋.*example\.com\/pricing/i,
+            expectedValuePattern: /example\.com\/pricing/i,
         },
         {
             description: 'screen name',
@@ -188,6 +194,7 @@ describe('PropertyFilters recent selections', () => {
             searchQuery: 'Home',
             itemTestId: 'prop-filter-screens-0',
             expectedRecentPattern: /Screen Name.*=.*HomeScreen/i,
+            expectedValuePattern: /HomeScreen/i,
         },
         {
             description: 'email address',
@@ -199,10 +206,19 @@ describe('PropertyFilters recent selections', () => {
             searchQuery: 'alice',
             itemTestId: 'prop-filter-email_addresses-0',
             expectedRecentPattern: /email.*=.*alice@example\.com/i,
+            expectedValuePattern: /alice@example\.com/i,
         },
     ])(
         'shortcut group: selecting a $description records and displays it in recents',
-        async ({ taxonomicGroupTypes, mockOverrides, tabTestId, searchQuery, itemTestId, expectedRecentPattern }) => {
+        async ({
+            taxonomicGroupTypes,
+            mockOverrides,
+            tabTestId,
+            searchQuery,
+            itemTestId,
+            expectedRecentPattern,
+            expectedValuePattern,
+        }) => {
             useSetupMocks(mockOverrides)
             const { onChange } = renderFilters({ taxonomicGroupTypes })
 
@@ -216,7 +232,7 @@ describe('PropertyFilters recent selections', () => {
             await openNewFilter()
 
             await waitFor(() => {
-                expectRecentInSuggestedFilters(0, expectedRecentPattern)
+                expectBareKeyBeforeFullRecent(expectedValuePattern, expectedRecentPattern)
             })
         }
     )
@@ -243,7 +259,7 @@ describe('PropertyFilters recent selections', () => {
         await openNewFilter()
 
         await waitFor(() => {
-            expectRecentInSuggestedFilters(0, /Browser.*=.*Chrome/i)
+            expectBareKeyBeforeFullRecent(/Chrome/i, /Browser.*=.*Chrome/i)
         })
     })
 
@@ -272,7 +288,7 @@ describe('PropertyFilters recent selections', () => {
         await openNewFilter()
 
         await waitFor(() => {
-            expectRecentInSuggestedFilters(0, /Current URL.*∋.*example\.com\/first/i)
+            expectBareKeyBeforeFullRecent(/example\.com\/first/i, /Current URL.*∋.*example\.com\/first/i)
         })
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterKeyOnly.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterKeyOnly.test.tsx
@@ -187,7 +187,7 @@ describe('TaxonomicFilter selectingKeyOnly mode', () => {
             expect(row.textContent).not.toMatch(/Chrome/)
         })
 
-        it('renders complete recents WITH their value label in default (non-selectingKeyOnly) mode', async () => {
+        it('renders complete recents with their value label AND a separate bare key row in default mode', async () => {
             preloadCompleteRecent('$browser', 'Chrome')
 
             renderFilter()
@@ -198,7 +198,32 @@ describe('TaxonomicFilter selectingKeyOnly mode', () => {
             await waitFor(() => {
                 expect(screen.getByTestId('prop-filter-recent_filters-0')).toBeInTheDocument()
             })
-            expect(screen.getByTestId('prop-filter-recent_filters-0').textContent).toMatch(/Chrome/)
+            const bareKeyRow = screen.getByTestId('prop-filter-recent_filters-0')
+            expect(bareKeyRow.textContent).toMatch(/Browser/)
+            expect(bareKeyRow.textContent).not.toMatch(/Chrome/)
+            expect(screen.getByTestId('prop-filter-recent_filters-1').textContent).toMatch(/Chrome/)
+        })
+
+        it('selecting the bare key row hands back an item with no propertyFilter so the user picks a fresh value', async () => {
+            preloadCompleteRecent('$browser', 'Chrome')
+            const onChange = jest.fn()
+
+            renderFilter({ onChange })
+
+            await waitForTestId('taxonomic-tab-recent_filters')
+            await userEvent.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-recent_filters-1')).toBeInTheDocument()
+            })
+            await userEvent.click(screen.getByTestId('prop-filter-recent_filters-0'))
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalled()
+            })
+            const [, value, item] = onChange.mock.calls[0]
+            expect(value).toBe('$browser')
+            expect(item?._recentContext?.propertyFilter).toBeUndefined()
         })
 
         it('dedups multiple complete recents for the same key into one row in selectingKeyOnly mode', async () => {

--- a/frontend/src/lib/components/TaxonomicFilter/headless/Panel.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/Panel.tsx
@@ -2,7 +2,10 @@ import { ReactNode, useEffect, useRef } from 'react'
 
 import { Empty, EmptyHeader, EmptyTitle, ItemMenuItem, Spinner } from '@posthog/quill'
 
+import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
+
 import { useGroupList, UseGroupListResult } from '../hooks/useGroupList'
+import { hasRecentContext } from '../recentTaxonomicFiltersLogic'
 import { TaxonomicDefinitionTypes, TaxonomicFilterGroup } from '../types'
 import { useTaxonomicFilterContext } from './context'
 
@@ -129,6 +132,10 @@ function TaxonomicFilterActivePanel({
                 if (renderRow) {
                     return <div key={index}>{renderRow({ item, index, isActive, onSelect, onMouseEnter, group })}</div>
                 }
+                const label =
+                    hasRecentContext(item) && item._recentContext.propertyFilter
+                        ? formatPropertyLabel(item._recentContext.propertyFilter, {})
+                        : (group.getName?.(item) ?? ('name' in item ? (item as { name?: string }).name : ''))
                 return (
                     <ItemMenuItem
                         key={index}
@@ -139,7 +146,7 @@ function TaxonomicFilterActivePanel({
                         onClick={onSelect}
                         onMouseEnter={onMouseEnter}
                     >
-                        {group.getName?.(item) ?? ('name' in item ? (item as { name?: string }).name : '')}
+                        {label}
                     </ItemMenuItem>
                 )
             })}

--- a/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
@@ -9,8 +9,10 @@ import { actionsModel } from '~/models/actionsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { performQuery } from '~/queries/query'
 import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { __clearTaxonomicResourceCache } from '../hooks/useTaxonomicResource'
+import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
 import { TaxonomicFilterGroupType } from '../types'
 import { TaxonomicFilterHeadless } from './index'
 
@@ -157,5 +159,51 @@ describe('TaxonomicFilterHeadless integration', () => {
         await user.click(screen.getByTestId('taxonomic-tab-wildcard'))
         await user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'no-match-zzz')
         await waitFor(() => expect(screen.getByTestId('empty')).toBeInTheDocument())
+    })
+
+    it('renders a complete recent as both a full row and a bare key row', async () => {
+        apiGet.mockResolvedValue({ results: [], count: 0 })
+        const recents = recentTaxonomicFiltersLogic.build()
+        recents.mount()
+        recents.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$browser',
+            item: { name: '$browser' },
+            propertyFilter: {
+                type: PropertyFilterType.Event,
+                key: '$browser',
+                operator: PropertyOperator.Exact,
+                value: 'Chrome',
+            },
+        })
+
+        render(
+            <Provider>
+                <TaxonomicFilterHeadless.Root
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.RecentFilters,
+                    ]}
+                    onChange={onChangeMock}
+                >
+                    <TaxonomicFilterHeadless.Input />
+                    <TaxonomicFilterHeadless.Categories />
+                    <TaxonomicFilterHeadless.Panel />
+                </TaxonomicFilterHeadless.Root>
+            </Provider>
+        )
+
+        await user.click(screen.getByTestId('taxonomic-tab-recent_filters'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('taxonomic-row-recent_filters-0')).toBeInTheDocument()
+        })
+        const bareKeyRow = screen.getByTestId('taxonomic-row-recent_filters-0')
+        expect(bareKeyRow.textContent).toMatch(/browser/i)
+        expect(bareKeyRow.textContent).not.toMatch(/Chrome/)
+        expect(screen.getByTestId('taxonomic-row-recent_filters-1').textContent).toMatch(/Chrome/)
+
+        recents.unmount()
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
@@ -22,6 +22,8 @@
  */
 import { useMemo, useState } from 'react'
 
+import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
+import { hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import {
     isQuickFilterItem,
     ListStorage,
@@ -157,7 +159,11 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
         const haystack = filteredLocalItems.map((item) => {
             const name = group.getName?.(item) ?? ('name' in item ? (item as { name?: string }).name : '') ?? ''
             const posthogName = getCoreFilterDefinition(name, group.type)?.label
-            return { name, posthogName, recentLabel: undefined, item }
+            const recentLabel =
+                hasRecentContext(item) && item._recentContext.propertyFilter
+                    ? formatPropertyLabel(item._recentContext.propertyFilter, {})
+                    : undefined
+            return { name, posthogName, recentLabel, item }
         })
         return createFuse(haystack, { keys: ['name', 'posthogName', 'recentLabel'], ignoreLocation: true })
     }, [filteredLocalItems, group])

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
@@ -30,8 +30,10 @@ import {
 } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import {
     AllowedProperties,
+    ExcludedOperators,
     ExcludedProperties,
     SelectedProperties,
+    SelectingKeyOnly,
     SimpleOption,
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
@@ -88,6 +90,8 @@ export interface UseTaxonomicFilterOptions {
     enableKeywordShortcuts?: boolean
     selectFirstItem?: boolean
     autoSelectItem?: boolean
+    selectingKeyOnly?: SelectingKeyOnly
+    excludedOperators?: ExcludedOperators
 }
 
 export interface TaxonomicFilterApi {
@@ -129,6 +133,8 @@ export interface TaxonomicFilterApi {
 
     // value passthroughs
     value?: TaxonomicFilterValue
+    selectingKeyOnly?: SelectingKeyOnly
+    excludedOperators?: ExcludedOperators
 
     // headless-component prop bags
     rootProps: { onKeyDown: (e: React.KeyboardEvent<any>) => void }
@@ -253,6 +259,8 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         enableKeywordShortcuts,
         selectFirstItem,
         autoSelectItem,
+        selectingKeyOnly,
+        excludedOperators,
     } = opts
 
     const ctx = useTaxonomicGroupsContext({
@@ -273,12 +281,17 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
 
     const allGroups = useMemo(() => buildTaxonomicGroups(ctx), [ctx])
     const allGroupTypes = useMemo(() => new Set(allGroups.map((g) => g.type)), [allGroups])
-    const getLocalOverride = useTaxonomicLocalOverrides()
 
     const groupTypes = useMemo(
         () => resolveTaxonomicGroupTypes(taxonomicGroupTypes, allGroupTypes, eventNames ?? []),
         [taxonomicGroupTypes, allGroupTypes, eventNames]
     )
+
+    const getLocalOverride = useTaxonomicLocalOverrides({
+        taxonomicGroupTypes: groupTypes,
+        excludedOperators,
+        selectingKeyOnly,
+    })
 
     const groups = useMemo(() => {
         const byType = new Map(allGroups.map((g) => [g.type, g]))
@@ -518,6 +531,8 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         registerActiveList,
         getGroupListInput,
         value,
+        selectingKeyOnly,
+        excludedOperators,
         rootProps: { onKeyDown },
         inputProps: {
             value: searchQuery,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
@@ -14,7 +14,13 @@ import { useCallback } from 'react'
 
 import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import { taxonomicFilterPinnedPropertiesLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
-import { TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import {
+    ExcludedOperators,
+    SelectingKeyOnly,
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroupType,
+} from 'lib/components/TaxonomicFilter/types'
+import { filterRecentsForContext } from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
 import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic'
 import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
 
@@ -25,7 +31,12 @@ import { joinsLogic } from 'products/data_warehouse/frontend/shared/logics/joins
 
 export type GetLocalOverride = (groupType: TaxonomicFilterGroupType) => TaxonomicDefinitionTypes[] | undefined
 
-export function useTaxonomicLocalOverrides(): GetLocalOverride {
+export function useTaxonomicLocalOverrides(context: {
+    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+    excludedOperators?: ExcludedOperators
+    selectingKeyOnly?: SelectingKeyOnly
+}): GetLocalOverride {
+    const { taxonomicGroupTypes, excludedOperators, selectingKeyOnly } = context
     const { actionsSorted } = useValues(actionsModel)
     const { recentFilterItems } = useValues(recentTaxonomicFiltersLogic)
     const { pinnedFilterItems } = useValues(taxonomicFilterPinnedPropertiesLogic)
@@ -40,7 +51,12 @@ export function useTaxonomicLocalOverrides(): GetLocalOverride {
                 case TaxonomicFilterGroupType.Actions:
                     return actionsSorted as unknown as TaxonomicDefinitionTypes[]
                 case TaxonomicFilterGroupType.RecentFilters:
-                    return recentFilterItems
+                    return filterRecentsForContext(
+                        recentFilterItems,
+                        taxonomicGroupTypes,
+                        excludedOperators,
+                        selectingKeyOnly
+                    )
                 case TaxonomicFilterGroupType.PinnedFilters:
                     return pinnedFilterItems
                 case TaxonomicFilterGroupType.Dashboards:
@@ -63,6 +79,9 @@ export function useTaxonomicLocalOverrides(): GetLocalOverride {
             experiments,
             dataWarehouseTablesAndViews,
             columnsJoinedToPersons,
+            taxonomicGroupTypes,
+            excludedOperators,
+            selectingKeyOnly,
         ]
     )
 }

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -966,10 +966,31 @@ describe('infiniteListLogic', () => {
             const filtered = listLogic.values.contextFilteredRecentItems
             const cohortValues = filtered
                 .filter(onlyWithRecentContext)
-                .filter((i) => i._recentContext.sourceGroupType === TaxonomicFilterGroupType.Cohorts)
+                .filter(
+                    (i) =>
+                        i._recentContext.sourceGroupType === TaxonomicFilterGroupType.Cohorts &&
+                        i._recentContext.propertyFilter
+                )
                 .map((i) => i._recentContext.propertyFilter?.value)
             expect(cohortValues).toEqual([1])
             expect(filtered.some((i) => 'name' in i && i.name === '$browser')).toBe(true)
+        })
+
+        it('surfaces a bare key alongside each complete recent in value mode', () => {
+            seedRecents([recentEventProperty])
+
+            const listLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: 'recents-bare-key-test',
+                listGroupType: TaxonomicFilterGroupType.RecentFilters,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.RecentFilters],
+                showNumericalPropsOnly: false,
+            })
+            listLogic.mount()
+
+            const items = listLogic.values.contextFilteredRecentItems.filter(onlyWithRecentContext)
+            expect(items).toHaveLength(2)
+            expect(items[0]._recentContext.propertyFilter).toBeUndefined()
+            expect(items[1]._recentContext.propertyFilter).not.toBeUndefined()
         })
 
         it('keeps cohort recents whose operator is undefined even when excludedOperators is set', () => {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -6,6 +6,7 @@ import posthog from 'posthog-js'
 import api from 'lib/api'
 import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
 import {
+    expandRecentsForDisplay,
     hasRecentContext,
     recentTaxonomicFiltersLogic,
 } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
@@ -448,27 +449,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     }
                     return true
                 })
-                if (!selectingKeyOnly) {
-                    return inScope
-                }
-                const seen = new Set<string>()
-                const dedupedItems: TaxonomicDefinitionTypes[] = []
-                for (const item of inScope) {
-                    if (!hasRecentContext(item)) {
-                        continue
-                    }
-                    // Dedup by the persisted storage key (groupType + value), not by item.name —
-                    // for groups like Cohorts/Actions name is a display label that may be unstable
-                    // or duplicated across distinct ids.
-                    const dedupKey = `${item._recentContext.sourceGroupType}::${item._recentContext.sourceValue ?? ''}`
-                    if (seen.has(dedupKey)) {
-                        continue
-                    }
-                    seen.add(dedupKey)
-                    const { propertyFilter: _propertyFilter, ...restContext } = item._recentContext
-                    dedupedItems.push({ ...item, _recentContext: restContext } as unknown as TaxonomicDefinitionTypes)
-                }
-                return dedupedItems
+                return expandRecentsForDisplay(inScope, selectingKeyOnly)
             },
         ],
         contextFilteredPinnedItems: [

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -312,6 +312,25 @@ describe('MenuFilterCombobox', () => {
         expect(pageviewRows).toHaveLength(1)
     })
 
+    it('shows a complete recent as both a full value row and a separate bare key row', async () => {
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.EventProperties],
+            recentEntries: [
+                {
+                    ...makeEntry(TaxonomicFilterGroupType.EventProperties, '$browser', 'Event properties'),
+                    recentPropertyFilter: { key: '$browser', operator: 'exact', value: 'Chrome' },
+                    recentLabel: 'Browser = Chrome',
+                },
+                makeEntry(TaxonomicFilterGroupType.EventProperties, '$browser', 'Event properties'),
+            ],
+        })
+
+        await waitFor(() => expect(rowTexts().length).toBeGreaterThan(0))
+        const texts = rowTexts()
+        expect(texts.some((t) => t.includes('Browser = Chrome'))).toBe(true)
+        expect(texts.some((t) => t.includes('$browser') && !t.includes('Chrome'))).toBe(true)
+    })
+
     it.each([
         ['email', '$email'],
         ['url', '$current_url'],

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -54,7 +54,7 @@ import { VerificationBadge } from './VerificationBadge'
 // `ignoreLocation` switch so a typo near the end of the string still
 // matches).
 const FUSE_OPTIONS = {
-    keys: ['name', 'friendlyLabel'],
+    keys: ['name', 'friendlyLabel', 'recentLabel'],
     ignoreLocation: true,
 }
 
@@ -88,14 +88,18 @@ export const SEARCH_QUERY_DEBOUNCE_MS = 500
 /** Identity for an entry's underlying definition — source group + value.
  *  Uses `::` as separator to serve as a dedup key (distinct from DOM ids). */
 function entryKey(entry: MenuFilterEntry): string {
-    return `${entry.group.type}::${String(entry.group.getValue?.(entry.item) ?? entry.name)}`
+    return `${entry.group.type}::${String(entry.group.getValue?.(entry.item) ?? entry.name)}${
+        entry.recentPropertyFilter ? '::full' : ''
+    }`
 }
 
 /** Stable DOM id for a menu row — used for scroll-into-view, checkmark
  *  lookups, and `aria-activedescendant`. The format must be identical
  *  everywhere it is constructed. */
 function rowDomId(entry: MenuFilterEntry): string {
-    return `menu-filter-row-${entry.group.type}-${String(entry.group.getValue?.(entry.item) ?? entry.name)}`
+    return `menu-filter-row-${entry.group.type}-${String(entry.group.getValue?.(entry.item) ?? entry.name)}${
+        entry.recentPropertyFilter ? '-full' : ''
+    }`
 }
 
 function fuseMatchEntries(entries: MenuFilterEntry[], query: string): MenuFilterEntry[] {
@@ -885,6 +889,9 @@ interface RowProps {
  * the value cell.
  */
 function resolveRowCells(entry: MenuFilterEntry): { name: string; value?: string; category: string } {
+    if (entry.recentLabel) {
+        return { name: entry.recentLabel, category: entry.group.name }
+    }
     const friendly = entry.friendlyLabel
     const url = parseUrl(entry.name)
     if (url) {

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -39,10 +39,11 @@ import {
     PopoverTrigger,
 } from '@posthog/quill'
 
+import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
 import { isDefinitionStale } from 'lib/utils/definitions'
 
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
-import { EventDefinition } from '~/types'
+import { AnyPropertyFilter, EventDefinition } from '~/types'
 
 import { useTaxonomicFilterContext } from '../headless/context'
 import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
@@ -150,7 +151,8 @@ export function TaxonomicFilterMenu({
     defaultOpen = false,
     triggerAccessory,
 }: TaxonomicFilterMenuProps): JSX.Element {
-    const { groups, selectItem, inputProps, searchQuery } = useTaxonomicFilterContext()
+    const { groups, selectItem, inputProps, searchQuery, selectingKeyOnly, excludedOperators } =
+        useTaxonomicFilterContext()
     const [state, setState] = useState<MenuFilterState>({ kind: 'closed' })
 
     // Telemetry — track open dwell + commit funnel so we can compare
@@ -281,11 +283,13 @@ export function TaxonomicFilterMenu({
             mapShortcutItems(
                 filterRecentsForContext(
                     recentFilterItems as TaxonomicDefinitionTypes[],
-                    taxonomicGroupTypes
+                    taxonomicGroupTypes,
+                    excludedOperators,
+                    selectingKeyOnly
                 ) as ShortcutItem[],
                 groups
             ),
-        [recentFilterItems, taxonomicGroupTypes, groups]
+        [recentFilterItems, taxonomicGroupTypes, groups, excludedOperators, selectingKeyOnly]
     )
     const pinnedEntries = useMemo<MenuFilterEntry[]>(
         () =>
@@ -661,7 +665,11 @@ interface ShortcutItem {
     // shape exists. See `taxonomicFilterPinnedPropertiesLogic` /
     // `recentTaxonomicFiltersLogic`.
     _pinnedContext?: { sourceGroupType?: TaxonomicFilterGroupType; value?: unknown }
-    _recentContext?: { sourceGroupType?: TaxonomicFilterGroupType; sourceValue?: unknown }
+    _recentContext?: {
+        sourceGroupType?: TaxonomicFilterGroupType
+        sourceValue?: unknown
+        propertyFilter?: AnyPropertyFilter
+    }
 }
 
 /**
@@ -721,11 +729,15 @@ function mapShortcutItems(items: ShortcutItem[], groups: TaxonomicFilterGroup[])
                 return null
             }
             const name = (item.name as string) ?? group.getName?.(item as TaxonomicDefinitionTypes) ?? ''
+            const recentPropertyFilter = item._recentContext?.propertyFilter
             return {
                 item: item as TaxonomicDefinitionTypes,
                 group,
                 name,
                 friendlyLabel: getCoreFilterDefinition(name, group.type)?.label,
+                ...(recentPropertyFilter
+                    ? { recentPropertyFilter, recentLabel: formatPropertyLabel(recentPropertyFilter, {}) }
+                    : {}),
             } as MenuFilterEntry
         })
         .filter((e): e is MenuFilterEntry => e != null)

--- a/frontend/src/lib/components/TaxonomicFilter/menu/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/types.ts
@@ -3,6 +3,8 @@
  *
  * See `../headless/UX_SPEC.md` for the full design.
  */
+import { AnyPropertyFilter } from '~/types'
+
 import {
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroup,
@@ -21,6 +23,8 @@ export interface MenuFilterEntry {
     group: TaxonomicFilterGroup
     name: string
     friendlyLabel?: string
+    recentPropertyFilter?: AnyPropertyFilter
+    recentLabel?: string
 }
 
 /** Synthetic categories the combobox panel can be drilled into. */

--- a/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts
@@ -7,7 +7,14 @@ import { permanentlyMount } from 'lib/utils/kea-logic-builders'
 import { AnyPropertyFilter } from '~/types'
 
 import type { recentTaxonomicFiltersLogicType } from './recentTaxonomicFiltersLogicType'
-import { META_GROUP_TYPES, TaxonomicDefinitionTypes, TaxonomicFilterGroupType, TaxonomicFilterValue } from './types'
+import {
+    isKeyOnlyForGroup,
+    META_GROUP_TYPES,
+    SelectingKeyOnly,
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from './types'
 
 export const MAX_RECENT_FILTERS = 20
 export const RECENT_FILTER_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
@@ -51,7 +58,7 @@ export function stripRecentContext<T extends Record<string, any>>(item: T): Omit
     return clean
 }
 
-function isCompleteRecentPropertyFilter(propertyFilter: AnyPropertyFilter | undefined): boolean {
+export function isCompleteRecentPropertyFilter(propertyFilter: AnyPropertyFilter | undefined): boolean {
     if (!propertyFilter) {
         return false
     }
@@ -61,6 +68,60 @@ function isCompleteRecentPropertyFilter(propertyFilter: AnyPropertyFilter | unde
         !(Array.isArray(propertyFilter.value) && propertyFilter.value.length === 0)
     const op = 'operator' in propertyFilter ? propertyFilter.operator : undefined
     return hasValue || (!!op && isOperatorFlag(op))
+}
+
+type RecentDisplayItem = Record<string, any> & { _recentContext: RecentItemContext }
+
+function recentStorageKey(item: RecentDisplayItem): string {
+    return `${item._recentContext.sourceGroupType}::${item._recentContext.sourceValue ?? ''}`
+}
+
+function toBareKeyRecent(item: RecentDisplayItem): TaxonomicDefinitionTypes {
+    const { propertyFilter: _propertyFilter, ...restContext } = item._recentContext
+    return { ...item, _recentContext: restContext } as unknown as TaxonomicDefinitionTypes
+}
+
+export function expandRecentsForDisplay(
+    scopedRecentItems: TaxonomicDefinitionTypes[],
+    selectingKeyOnly?: SelectingKeyOnly
+): TaxonomicDefinitionTypes[] {
+    const keysWithExplicitBareRecent = new Set<string>()
+    for (const item of scopedRecentItems) {
+        if (hasRecentContext(item) && !isCompleteRecentPropertyFilter(item._recentContext.propertyFilter)) {
+            keysWithExplicitBareRecent.add(recentStorageKey(item))
+        }
+    }
+
+    const emittedBareKey = new Set<string>()
+    const result: TaxonomicDefinitionTypes[] = []
+    for (const item of scopedRecentItems) {
+        if (!hasRecentContext(item)) {
+            result.push(item)
+            continue
+        }
+        const key = recentStorageKey(item)
+
+        if (isKeyOnlyForGroup(selectingKeyOnly, item._recentContext.sourceGroupType)) {
+            if (!emittedBareKey.has(key)) {
+                emittedBareKey.add(key)
+                result.push(toBareKeyRecent(item))
+            }
+            continue
+        }
+
+        if (!isCompleteRecentPropertyFilter(item._recentContext.propertyFilter)) {
+            emittedBareKey.add(key)
+            result.push(item)
+            continue
+        }
+
+        if (!keysWithExplicitBareRecent.has(key) && !emittedBareKey.has(key)) {
+            emittedBareKey.add(key)
+            result.push(toBareKeyRecent(item))
+        }
+        result.push(item)
+    }
+    return result
 }
 
 function isDuplicateRecentFilter(

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
@@ -63,6 +63,70 @@ describe('suggestedContextFilters', () => {
         })
     })
 
+    describe('filterRecentsForContext bare-key expansion (value mode)', () => {
+        const complete = (key: string, value: string): Record<string, unknown> => ({
+            propertyFilter: { key, operator: PropertyOperator.Exact, value },
+        })
+        const propertyFilterOf = (item: TaxonomicDefinitionTypes): unknown =>
+            (item as unknown as { _recentContext: { propertyFilter?: unknown } })._recentContext.propertyFilter
+
+        it('prepends a bare key before a complete recent', () => {
+            const out = filterRecentsForContext(
+                [recent(EventProperties, 'host', complete('host', 'us'))],
+                [EventProperties]
+            )
+            expect(names(out)).toEqual(['host', 'host'])
+            expect(propertyFilterOf(out[0])).toBeUndefined()
+            expect(propertyFilterOf(out[1])).toBeTruthy()
+        })
+
+        it('does not append a bare key for an incomplete recent', () => {
+            expect(filterRecentsForContext([recent(EventProperties, 'host')], [EventProperties])).toHaveLength(1)
+        })
+
+        it('emits two fulls and a single bare key for two complete recents of the same key', () => {
+            const out = filterRecentsForContext(
+                [
+                    recent(EventProperties, 'host', complete('host', 'us')),
+                    recent(EventProperties, 'host', complete('host', 'eu')),
+                ],
+                [EventProperties]
+            )
+            expect(out).toHaveLength(3)
+            expect(out.filter((i) => propertyFilterOf(i) === undefined)).toHaveLength(1)
+        })
+
+        it('does not expand in key-only mode', () => {
+            const out = filterRecentsForContext(
+                [recent(EventProperties, 'host', complete('host', 'us'))],
+                [EventProperties],
+                undefined,
+                true
+            )
+            expect(out).toHaveLength(1)
+            expect(propertyFilterOf(out[0])).toBeUndefined()
+        })
+
+        it('honors a per-group key-only dict: key-only group stripped, value group expanded', () => {
+            const out = filterRecentsForContext(
+                [recent(Cohorts, '1', complete('id', '1')), recent(EventProperties, 'host', complete('host', 'us'))],
+                [Cohorts, EventProperties],
+                undefined,
+                { [Cohorts]: true }
+            )
+            const groupOf = (i: TaxonomicDefinitionTypes): TaxonomicFilterGroupType =>
+                (i as unknown as { _recentContext: { sourceGroupType: TaxonomicFilterGroupType } })._recentContext
+                    .sourceGroupType
+            const cohortRows = out.filter((i) => groupOf(i) === Cohorts)
+            const propRows = out.filter((i) => groupOf(i) === EventProperties)
+            expect(cohortRows).toHaveLength(1)
+            expect(propertyFilterOf(cohortRows[0])).toBeUndefined()
+            expect(propRows).toHaveLength(2)
+            expect(propRows.filter((i) => propertyFilterOf(i) === undefined)).toHaveLength(1)
+            expect(propRows.filter((i) => propertyFilterOf(i) !== undefined)).toHaveLength(1)
+        })
+    })
+
     describe.each([
         ['only in-scope kept', [pinned(Events, 'a'), pinned(Cohorts, 'c')], [Events], ['a']],
         ['all out-of-scope dropped', [pinned(Cohorts, 'c')], [Events], []],

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -1,7 +1,8 @@
-import { hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { expandRecentsForDisplay, hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
 import {
     ExcludedOperators,
+    SelectingKeyOnly,
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
@@ -23,7 +24,7 @@ export function filterRecentsForContext(
     recentFilterItems: TaxonomicDefinitionTypes[],
     taxonomicGroupTypes: TaxonomicFilterGroupType[],
     excludedOperators?: ExcludedOperators,
-    selectingKeyOnly?: boolean
+    selectingKeyOnly?: SelectingKeyOnly
 ): TaxonomicDefinitionTypes[] {
     if (!recentFilterItems?.length) {
         return []
@@ -43,27 +44,7 @@ export function filterRecentsForContext(
         }
         return true
     })
-    if (!selectingKeyOnly) {
-        return inScope
-    }
-    const seen = new Set<string>()
-    const dedupedItems: TaxonomicDefinitionTypes[] = []
-    for (const item of inScope) {
-        if (!hasRecentContext(item)) {
-            continue
-        }
-        // Dedup by the persisted storage key (source group + value), not by
-        // item.name — for groups like Cohorts/Actions the name is a display
-        // label that can be unstable, while the stored value is canonical.
-        const dedupKey = `${item._recentContext.sourceGroupType}::${item._recentContext.sourceValue ?? ''}`
-        if (seen.has(dedupKey)) {
-            continue
-        }
-        seen.add(dedupKey)
-        const { propertyFilter: _propertyFilter, ...restContext } = item._recentContext
-        dedupedItems.push({ ...item, _recentContext: restContext } as unknown as TaxonomicDefinitionTypes)
-    }
-    return dedupedItems
+    return expandRecentsForDisplay(inScope, selectingKeyOnly)
 }
 
 /** Pinned items whose source group is one of the picker's groups. */


### PR DESCRIPTION
oh, that shows up in the visual regression snapshots

previously if you had "host contains us.posthog.com" as a recent
but you wanted a different host, you had to pick the recent and then edit it (customer in slack found that confusing)
so this breaks into two rows and you'd see

host
host contains us.posthog.com

that way if you have something you regularly pick you have option 2, and something you regularly vary you have option 1

## What

When a recent filter is a complete property filter (e.g. `host = us.posthog.com`), the recents list now **also** surfaces the bare key (`host`) as a separate option — so you can jump straight to the key but pick a *different* value than the one you recently used. The bare key is listed **before** its with-value entry (you land on the key first). In key-only contexts only the bare key shows. Recents stay searchable by both the key and the full value label.

## How

A shared `withBareKeyRecents` helper (in `recentTaxonomicFiltersLogic.ts`) prepends a bare-key row before each complete recent in value-selecting mode (deduped; skipped when a key-only recent for that key already exists). It's wired into both context-filters that feed the surfaces:

- **Rebuild** (`filterRecentsForContext`) → the menu (`TaxonomicFilterMenu` / `Combobox`) and the headless `Panel` (via `useTaxonomicLocalOverrides`, with `selectingKeyOnly` / `excludedOperators` now threaded through `useTaxonomicFilter`).
- **Legacy pill** (`infiniteListLogic.contextFilteredRecentItems`).

A bare-key entry is the same item with `propertyFilter` stripped from `_recentContext`, which the existing selection path already treats as "drill into a fresh value" (it skips `onComplete`). The menu distinguishes the full vs bare-key rows via a marker in its dedup / DOM-id keys and renders the full `host = …` label.

## Tests

- `suggestedContextFilters.test.ts` — bare-key prepended in value mode, none in key-only mode, a single bare key for repeated keys
- `infiniteListLogic.test.ts` — legacy selector emits bare key then full
- `TaxonomicFilterKeyOnly.test.tsx` — the UI shows both rows (bare key first); selecting the bare key hands back an item with no `propertyFilter`
- `headless/headless.test.tsx` + `menu/Combobox.test.tsx` — both new-rebuild surfaces render bare key + full
- Full `TaxonomicFilter/` suite green; typecheck + oxlint + oxfmt clean

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*