### PR TITLE
fix(llma): strip slack channel name suffix in eval report delivery

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/delivery.py
@@ -311,6 +311,11 @@ def deliver_slack_report(
         # ID, so strip the "|#name" suffix before sending. Mirrors the subscriptions path in
         # ee/tasks/subscriptions/slack_subscriptions.py, which splits the same composite value.
         channel_id = channel.split("|")[0]
+        if not channel_id:
+            error_msg = f"Failed to send Slack message to {channel}: no channel ID in target value"
+            logger.warning(error_msg)
+            errors.append(error_msg)
+            continue
 
         try:
             integration = Integration.objects.get(id=integration_id, team_id=team_id, kind="slack")

--- a/posthog/temporal/ai_observability/eval_reports/delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/delivery.py
@@ -306,6 +306,12 @@ def deliver_slack_report(
         if not integration_id or not channel:
             continue
 
+        # The Slack channel picker stores the target as "<channel_id>|#<channel_name>"
+        # (e.g. "C0B5CHB0JQH|#tech-devops-cron"). chat.postMessage only accepts the channel
+        # ID, so strip the "|#name" suffix before sending. Mirrors the subscriptions path in
+        # ee/tasks/subscriptions/slack_subscriptions.py, which splits the same composite value.
+        channel_id = channel.split("|")[0]
+
         try:
             integration = Integration.objects.get(id=integration_id, team_id=team_id, kind="slack")
             client = SlackIntegration(integration).client
@@ -336,7 +342,7 @@ def deliver_slack_report(
                 )
 
             result = client.chat_postMessage(
-                channel=channel,
+                channel=channel_id,
                 blocks=blocks,
                 text=header_text,
             )
@@ -347,7 +353,7 @@ def deliver_slack_report(
                 for section in content.sections[1:]:
                     mrkdwn_text = _render_section_mrkdwn(section.title, section.content, project_id, citation_map)
                     client.chat_postMessage(
-                        channel=channel,
+                        channel=channel_id,
                         thread_ts=thread_ts,
                         text=mrkdwn_text[:3000],
                     )

--- a/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
@@ -11,6 +11,7 @@ from posthog.temporal.ai_observability.eval_reports.delivery import (
     _render_section_mrkdwn,
     _strip_redundant_leading_heading,
     deliver_report,
+    deliver_slack_report,
 )
 from posthog.temporal.ai_observability.eval_reports.report_agent.schema import (
     Citation,
@@ -393,3 +394,73 @@ class TestDeliverReport(SimpleTestCase):
         deliver_report("report-id", "run-id")
 
         self.assertEqual(run.delivery_status, "partial_failure")
+
+
+class TestDeliverSlackReport(SimpleTestCase):
+    """Tests for the Slack delivery path, with the Slack client mocked."""
+
+    def _make_report_run(self, sections=None):
+        if sections is None:
+            sections = [ReportSection(title="Summary", content="All good.")]
+        run = MagicMock()
+        run.content = EvalReportContent(
+            title="A nice punchline",
+            sections=sections,
+            citations=[],
+            metrics=EvalReportMetrics(total_runs=10, pass_count=9, pass_rate=90.0),
+        ).to_dict()
+        run.report_id = "report-id"
+        run.id = "run-id"
+        return run
+
+    @patch("posthog.models.integration.SlackIntegration")
+    @patch("posthog.models.integration.Integration")
+    def test_strips_channel_name_suffix_before_sending(self, mock_integration, mock_slack_integration):
+        # Regression: the channel picker stores "<id>|#<name>" (e.g. "C0B5CHB0JQH|#tech-devops-cron").
+        # chat.postMessage only accepts the channel ID, so the "|#name" suffix must be stripped or
+        # Slack returns channel_not_found.
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ts": "123.456"}
+        mock_slack_integration.return_value.client = client
+
+        targets = [{"type": "slack", "integration_id": 1, "channel": "C0B5CHB0JQH|#tech-devops-cron"}]
+        errors = deliver_slack_report(
+            self._make_report_run(),
+            targets,
+            evaluation_name="Test Eval",
+            team_id=1,
+            project_id=1,
+            period_start="2026-03-01T00:00:00+00:00",
+            period_end="2026-03-02T00:00:00+00:00",
+        )
+
+        self.assertEqual(errors, [])
+        client.chat_postMessage.assert_called_once()
+        self.assertEqual(client.chat_postMessage.call_args.kwargs["channel"], "C0B5CHB0JQH")
+
+    @patch("posthog.models.integration.SlackIntegration")
+    @patch("posthog.models.integration.Integration")
+    def test_thread_replies_use_channel_id(self, mock_integration, mock_slack_integration):
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ts": "123.456"}
+        mock_slack_integration.return_value.client = client
+
+        sections = [
+            ReportSection(title="Summary", content="All good."),
+            ReportSection(title="Details", content="More detail."),
+        ]
+        targets = [{"type": "slack", "integration_id": 1, "channel": "C0B5CHB0JQH|#tech-devops-cron"}]
+        errors = deliver_slack_report(
+            self._make_report_run(sections=sections),
+            targets,
+            evaluation_name="Test Eval",
+            team_id=1,
+            project_id=1,
+            period_start="2026-03-01T00:00:00+00:00",
+            period_end="2026-03-02T00:00:00+00:00",
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(client.chat_postMessage.call_count, 2)
+        for call in client.chat_postMessage.call_args_list:
+            self.assertEqual(call.kwargs["channel"], "C0B5CHB0JQH")

--- a/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
@@ -454,3 +454,27 @@ class TestDeliverSlackReport(SimpleTestCase):
         self.assertEqual(client.chat_postMessage.call_count, expected_call_count)
         for call in client.chat_postMessage.call_args_list:
             self.assertEqual(call.kwargs["channel"], "C0B5CHB0JQH")
+
+    @patch("posthog.models.integration.SlackIntegration")
+    @patch("posthog.models.integration.Integration")
+    def test_empty_channel_id_fails_gracefully(self, mock_integration, mock_slack_integration):
+        # A malformed target like "|#name" passes the non-empty channel check but splits to an
+        # empty channel ID, which Slack rejects with channel_not_found. Skip the send, record an
+        # error, and never call chat.postMessage.
+        client = MagicMock()
+        mock_slack_integration.return_value.client = client
+
+        targets = [{"type": "slack", "integration_id": 1, "channel": "|#tech-devops-cron"}]
+        errors = deliver_slack_report(
+            self._make_report_run(),
+            targets,
+            evaluation_name="Test Eval",
+            team_id=1,
+            project_id=1,
+            period_start="2026-03-01T00:00:00+00:00",
+            period_end="2026-03-02T00:00:00+00:00",
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("|#tech-devops-cron", errors[0])
+        client.chat_postMessage.assert_not_called()

--- a/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
+
 from posthog.temporal.ai_observability.eval_reports.delivery import (
     _format_period_for_display,
     _inline_email_styles,
@@ -413,42 +415,30 @@ class TestDeliverSlackReport(SimpleTestCase):
         run.id = "run-id"
         return run
 
+    @parameterized.expand(
+        [
+            ("one_section_no_thread", [ReportSection(title="Summary", content="All good.")], 1),
+            (
+                "two_sections_with_thread_reply",
+                [
+                    ReportSection(title="Summary", content="All good."),
+                    ReportSection(title="Details", content="More detail."),
+                ],
+                2,
+            ),
+        ]
+    )
     @patch("posthog.models.integration.SlackIntegration")
     @patch("posthog.models.integration.Integration")
-    def test_strips_channel_name_suffix_before_sending(self, mock_integration, mock_slack_integration):
+    def test_channel_id_is_used(self, _name, sections, expected_call_count, mock_integration, mock_slack_integration):
         # Regression: the channel picker stores "<id>|#<name>" (e.g. "C0B5CHB0JQH|#tech-devops-cron").
         # chat.postMessage only accepts the channel ID, so the "|#name" suffix must be stripped or
-        # Slack returns channel_not_found.
+        # Slack returns channel_not_found. Covers both the single-section (no thread) and
+        # multi-section (thread replies) paths.
         client = MagicMock()
         client.chat_postMessage.return_value = {"ts": "123.456"}
         mock_slack_integration.return_value.client = client
 
-        targets = [{"type": "slack", "integration_id": 1, "channel": "C0B5CHB0JQH|#tech-devops-cron"}]
-        errors = deliver_slack_report(
-            self._make_report_run(),
-            targets,
-            evaluation_name="Test Eval",
-            team_id=1,
-            project_id=1,
-            period_start="2026-03-01T00:00:00+00:00",
-            period_end="2026-03-02T00:00:00+00:00",
-        )
-
-        self.assertEqual(errors, [])
-        client.chat_postMessage.assert_called_once()
-        self.assertEqual(client.chat_postMessage.call_args.kwargs["channel"], "C0B5CHB0JQH")
-
-    @patch("posthog.models.integration.SlackIntegration")
-    @patch("posthog.models.integration.Integration")
-    def test_thread_replies_use_channel_id(self, mock_integration, mock_slack_integration):
-        client = MagicMock()
-        client.chat_postMessage.return_value = {"ts": "123.456"}
-        mock_slack_integration.return_value.client = client
-
-        sections = [
-            ReportSection(title="Summary", content="All good."),
-            ReportSection(title="Details", content="More detail."),
-        ]
         targets = [{"type": "slack", "integration_id": 1, "channel": "C0B5CHB0JQH|#tech-devops-cron"}]
         errors = deliver_slack_report(
             self._make_report_run(sections=sections),
@@ -461,6 +451,6 @@ class TestDeliverSlackReport(SimpleTestCase):
         )
 
         self.assertEqual(errors, [])
-        self.assertEqual(client.chat_postMessage.call_count, 2)
+        self.assertEqual(client.chat_postMessage.call_count, expected_call_count)
         for call in client.chat_postMessage.call_args_list:
             self.assertEqual(call.kwargs["channel"], "C0B5CHB0JQH")


### PR DESCRIPTION
## Problem

A customer configured a daily evaluation report to deliver to a Slack channel. Every send fails with `channel_not_found`, even though the channel exists and is set up correctly:

> Failed to send Slack message to `CCCCCCCC|#example`: ... `'error': 'channel_not_found'`

The Slack channel picker stores a delivery target as a composite `"<channel_id>|#<channel_name>"` string (e.g. `CCCCCCCC|#example`). The evaluation report delivery code passed that whole value straight to Slack's `chat.postMessage`, which only accepts a bare channel ID, so Slack could not resolve it. The error code itself corroborates this: a bot that is not in a channel returns `not_in_channel`, whereas `channel_not_found` means the channel argument could not be resolved at all.

The mature insight-subscriptions delivery path already handles this by splitting on `|` (`channel = subscription.target_value.split("|")[0]`). The evaluation reports path, added later, never did the split, so it affected every Slack delivery target configured via the picker.

## Changes

- In `deliver_slack_report`, split the stored channel value and pass only the channel ID to `chat.postMessage` (both the main message and threaded replies), mirroring the subscriptions path. Handles both the composite `id|#name` format and a bare ID.
- Added regression tests that exercise `deliver_slack_report` with the real `id|#name` picker format and assert the channel ID is what reaches Slack (main message and thread replies). Existing tests always mocked the whole function, which is why this slipped through.

## How did you test this code?

I'm an agent (Claude Code). I did not run a live end-to-end Slack delivery. I ran the automated tests only:

- `hogli test posthog/temporal/ai_observability/eval_reports/test/test_delivery.py` — all 45 tests pass, including the two new regression tests (`TestDeliverSlackReport`).
- `ruff check` on the changed files — clean.

Manual verification suggestion for a reviewer with a connected Slack integration: configure an evaluation report with a Slack delivery target, trigger the manual `generate` endpoint, and confirm the report run's `delivery_status` is `delivered` and the message lands in the channel.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code from a customer report of `channel_not_found` on evaluation report Slack delivery. Traced the stored channel format from the `SlackChannelPicker` (emits `id|#name`) through the serializer (stores it verbatim) to `deliver_slack_report` (passed it raw to `chat.postMessage`). Compared against the insight-subscriptions path, which splits the same composite value, confirming the eval-reports path was the outlier. Verified the bug has existed since the feature shipped and that no fix is on master and no open PR addresses it. Fix mirrors the proven subscriptions approach.
