### PR TITLE
feat(cdp): add 'new' badge to CDP backfills tab

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4957,29 +4957,29 @@ snapshots:
     scenes-app-heatmaps-saved--list--light:
         hash: v1.k794b7964.8ae29c72fee0e6960689e1f92aefc34e7f3d3651634153b55986ee0d35c50517.ZCk1DAGSxoNVXd8Cru1kNNy0UPN77rAJPoCzxtXko4I
     scenes-app-hogfunctions-destination--backfills-empty--dark:
-        hash: v1.k794b7964.7e02778c6298c427362da8e20a78550beda553dbcdd7bead1c9f12a3a5dc18d4.7APlOgRFem3d3icRBbxPVAIvJ34CKLDi4-BErrcQlNE
+        hash: v1.k794b7964.17eed1890c138b4db78d7e0ccdfb8e7d97990e433c31a03d721843b88b05095d.473_uhmmznWwvYlUn9g3mu7p-pJmmJ6j-zIaiOEDZQM
     scenes-app-hogfunctions-destination--backfills-empty--light:
-        hash: v1.k794b7964.7533a29afb90e0f3d6192cfd8b8798926dbde36987b14d51c9c9227d0d1edb0f.b8iR_xTqGH_hnWtLc2qHI2zB2MxG9uyNzSlhP2iTg2Q
+        hash: v1.k794b7964.0261f593c96c99b1be8931fcc9463e810777cf8e9046759d7ef6f706b09d79fb.38TBuO_ndoDE_NXjC3m5fqZrvbQq1qwKXe7IcasiXNk
     scenes-app-hogfunctions-destination--backfills-with-data--dark:
-        hash: v1.k794b7964.64c2e73049101ffdc44a145247740839060db1cf2b5435ed669c5ffd87e77a04.m_-NGA3sH-7ZZmznGLgZfsPT8jbSnPQB7v0EbCFb4_0
+        hash: v1.k794b7964.6bd3af267dbd99f02f787391afab1d643a9430bbb415987a29c25ae243344e9c.y7TO3979lXyq2hUErMszsa-Qnw7FNYghEgAtIlOdNvg
     scenes-app-hogfunctions-destination--backfills-with-data--light:
-        hash: v1.k794b7964.4bd1a8e74ee230324b839b5447d7fcf2e40f643994ad72d43256b5ebe8372d51.x_DJEsteqnn9N0ySQb77TshEN45fAU72n3uzsPxxdIA
+        hash: v1.k794b7964.60db48a34874feb744dc933eaf79c4b382996ddc6100cabb6e96aa04a6e7bfd2.VGEugng8L3ZcwmPUm4nqe-oylK_dsi6Xoz_fCS1P1rs
     scenes-app-hogfunctions-destination--configuration--dark:
-        hash: v1.k794b7964.b1c1af53c0a648a989cc3e7567389e74b0626f269133254b862f3b641c35905e.FXN00w3PSSscrHc2QC-mc97qGwh1a8dnVDL1OjegjJc
+        hash: v1.k794b7964.4947f06455042031427ae2a5f1677d3cd0f25aacf83b9041fb4a659241bb98c5.BGORqjaiNrbMf3NySbKUf0j8PAE2GdEd4C2l8H5FPCA
     scenes-app-hogfunctions-destination--configuration--light:
-        hash: v1.k794b7964.e16f7f589e20d284b3d920f52f4c6f663f233330c433d0089eac4c2e5937c4a8.4erwuYxi0HdTVRIQch3BpGdvImzdiyECz1ggJ4u2FAE
+        hash: v1.k794b7964.1f55b872709218aa08caa34a7a759f9c03a61e9037c11a8f4a66c48d4fbfb17d.kOgE7mbNXb-EInqnbC04Jqlm_yTmrQolj9l-lU3kc0M
     scenes-app-hogfunctions-destination--logs--dark:
-        hash: v1.k794b7964.c2981719b084c469bd319c0106da206ffde7b5860c82ea63c9f29be66dd2c312.ddYkr8ghbExxIxWgcIqm7p6Ef-QGftk6FLVpw0qM0Lc
+        hash: v1.k794b7964.9f6e346b5bdaaa41dc9434d8b787dc48d6843ead5931ab214e180d2aa6e1c54f.FmPRcWiNIOxvN_Gq0lmIpoRe4rZZuhdFbc1gnExmu0k
     scenes-app-hogfunctions-destination--logs--light:
-        hash: v1.k794b7964.3b4233f47359363b461956f085f01701a06deaebdf59607f3a5130240b7c80b7.FFip0XKWMG8-o4J6jlQbalumuDeQjCWtoSdKGHNyPxI
+        hash: v1.k794b7964.87763d76e0c5f6d7270fb321c9debf2138a8b785c8bd5b482aa4a6e3a056e73f.M0Uj81qJB83l4pViEUuTQ59PU3kHixcHPLxtADi_YTE
     scenes-app-hogfunctions-destination--runs-empty--dark:
-        hash: v1.k794b7964.365c112ae930d7563e7ea77b3a933f5d0d2b20a731d5de65c9b957be553f0772.8UeAAAWo4i-Y6t6IezyS0ClSsAlfZFJ1l55nbBlJto4
+        hash: v1.k794b7964.de1de4019281d77933c411ec711facacb3c65c78749145b32ad0e944d82ecc52.ZxRDrXJJW7eCKl_iZs201AhvRRyNOMvrGy8dquSEmzI
     scenes-app-hogfunctions-destination--runs-empty--light:
-        hash: v1.k794b7964.c94c92b0e7640f93228a4f2c377e775b1d0e0d58e073289ae9c2a0fd623bb769.vZH9ChSTn3wsNoEPrCkhkptvtkFXFAQ4gHrkxp6Yt58
+        hash: v1.k794b7964.e7e8c73e37b2a470b16014558f6b31b61e35b92677f60f9ebfbb446de501fc3b.uS290Tb5fuAXPI99Y1B2OjudsCyQO0ZVJo8MPOkP6eM
     scenes-app-hogfunctions-destination--runs-with-data--dark:
-        hash: v1.k794b7964.401f886623209927d45afdd68a115ce9f7bbf4a90bae0b585a1c336181036d40.67DXufCWmqD9lCySw8cLAoYvZVwa0vsZMlPbCBEJwgg
+        hash: v1.k794b7964.ccbdd94e59c1029a025b82b148e055fc0f95bbf3d9b22c2e9ec0f6056d573e5b.NZwaV6bkwoSS9a6zSlfpSKp-RCZwNns1fXt5iZawOgI
     scenes-app-hogfunctions-destination--runs-with-data--light:
-        hash: v1.k794b7964.975ffc352039167638eda3d741a6fb3677ef20c7e08be9c4e4e19f38b4c60535.t_VcheImU5EI_08rGFTNzdJOUKvtwcMfW71rpAZcCSA
+        hash: v1.k794b7964.0096a479368226c8e814746b035ce360a9345b27a081ffc2083cf6e855489432.jMrGy2vE-erlaH_1tAskw0DDuKX-SdTXXjE32rc2uI0
     scenes-app-insights-boldnumber--compare-null-previous--dark:
         hash: v1.k794b7964.740b2306ae975e77739d9c4ff65993c554b635eeab9bbfbec410f10d4277dace.R7fAb_Em3P8l4hNZsC15VVzEbFobuwzIKb2P9tM6CRM
     scenes-app-insights-boldnumber--compare-null-previous--light:

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -448,7 +448,7 @@ export function HogFunctionScene(): JSX.Element {
                   label: (
                       <div className="flex flex-row">
                           <div>Backfills</div>
-                          <LemonTag className="ml-2 float-right uppercase" type="primary">
+                          <LemonTag className="ml-2 uppercase" type="primary">
                               New
                           </LemonTag>
                       </div>

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -11,6 +11,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { DataPipelinesNewSceneKind } from 'scenes/data-pipelines/DataPipelinesNewScene'
@@ -444,7 +445,14 @@ export function HogFunctionScene(): JSX.Element {
 
         supportsBackfills && featureFlags[FEATURE_FLAGS.BACKFILL_WORKFLOWS_DESTINATION]
             ? {
-                  label: 'Backfills',
+                  label: (
+                      <div className="flex flex-row">
+                          <div>Backfills</div>
+                          <LemonTag className="ml-2 float-right uppercase" type="primary">
+                              New
+                          </LemonTag>
+                      </div>
+                  ),
                   key: 'backfills',
                   content: <HogFunctionBackfills id={id} />,
               }

--- a/frontend/src/scenes/hog-functions/backfills/HogFunctionBackfills.tsx
+++ b/frontend/src/scenes/hog-functions/backfills/HogFunctionBackfills.tsx
@@ -16,7 +16,12 @@ export function HogFunctionBackfills({ id }: BatchExportBackfillsLogicProps): JS
 
     return (
         <BindLogic logic={batchExportDataLogic} props={{ id: configuration.batch_export_id! }}>
-            <BatchExportBackfills id={configuration.batch_export_id!} context="hog_function" />
+            <div className="flex flex-col gap-3">
+                <p className="text-secondary mb-0">
+                    Backfills re-run this destination against historical events from a time range you choose.
+                </p>
+                <BatchExportBackfills id={configuration.batch_export_id!} context="hog_function" />
+            </div>
         </BindLogic>
     )
 }


### PR DESCRIPTION
## Problem

We're about to launch CDP backfills, but people might not be aware they exist and what they do.

## Changes

- Add a 'NEW' badge so people can discover backfills
- Add a brief description so people know what they do (we will be adding docs soon too)

<img width="683" height="245" alt="image" src="https://github.com/user-attachments/assets/b2802a33-341c-43db-917d-8a4b05a27741" />


## How did you test this code?

Ran stack locally to verify

## Automatic notifications

- [ ] Publish to changelog? (not yet)
- [ ] Alert Sales and Marketing teams?

## Docs update

Not yet

## 🤖 Agent context

Asked PostHog code to implement this, by copying the badge that Feature Flags has on its 'Testing' tab
