### PR TITLE
chore(docs): move shipped plans to `plans/shipped/` and update roadmap

### DIFF
--- a/docs/agent-platform/README.md
+++ b/docs/agent-platform/README.md
@@ -4,12 +4,19 @@ This tree splits **what exists** from **what's planned**:
 
 ```text
 docs/agent-platform/
-├── docs/    — implemented; references for operating + extending the platform today
-└── plans/   — designs / open questions; nothing has been built yet, or only partially
+├── docs/            — implemented; references for operating + extending the platform today
+└── plans/           — designs / open questions; mostly partially built (each plan's status
+    │                  header + _ROADMAP.md track exactly how much landed)
+    └── shipped/     — plans whose core design has fully landed as code; kept as rationale-of-record
 ```
 
-Move a file from `plans/` to `docs/` when the design lands as code (and prune
-the "open questions" section once they're answered by the implementation).
+Most plans are now **partially shipped** — a v0 slice has landed and later
+versions remain open. The per-plan status header and
+[`plans/_ROADMAP.md`](plans/_ROADMAP.md) are the source of truth for what's
+done. When a plan's core design has fully landed, move it into
+[`plans/shipped/`](plans/shipped/) (and prune its "open questions" once the
+implementation answers them). The operating references in `docs/` capture the
+running-system shape independently of any one plan.
 
 ## docs/ (what exists)
 
@@ -26,11 +33,16 @@ shape (services, DBs, sandbox lifecycle); a `database-schema.md` with every
 table + which DB owns it; the canonical `authoring-skill.md` once the templates
 layer lands._
 
-## plans/ (what we'd need to build)
+## plans/ (designs — many partially built)
 
 Start with [`_ROADMAP.md`](plans/_ROADMAP.md) for the sequenced view across
-all plans and the shared cross-cuts between them. [`_TODO.md`](plans/_TODO.md)
-is the queue of features waiting for a plan.
+all plans, the per-plan rollout status (`v0 ✅` etc.), and the shared
+cross-cuts between them. [`_TODO.md`](plans/_TODO.md) is the queue of features
+waiting for a plan; [`plans/shipped/`](plans/shipped/) holds the ones that have
+fully landed.
+
+The descriptions below are the original framing of each plan; consult the
+roadmap or each plan's status header for how much has since shipped.
 
 - [`agent-authoring-flow.md`](plans/agent-authoring-flow.md) — speculative
   end-to-end design for an MCP-driven authoring AI: discovery → spec → secrets

--- a/docs/agent-platform/plans/_APP_IDEAS.md
+++ b/docs/agent-platform/plans/_APP_IDEAS.md
@@ -40,12 +40,13 @@ Cross-cutting status (refreshed against current code):
   Backend, MCP write tools, freeze-time resolution, frontend
   pages, concierge skill — see
   [`skill-templates.md`](skill-templates.md).
-- 📋 **Cron trigger** — schema slot exists in `TriggerSchema`,
-  janitor side (the scheduler that fires sessions on schedule)
-  is not implemented. Plan:
-  [`cron-trigger-scheduler.md`](cron-trigger-scheduler.md).
-  Every weekly / monthly app below assumes cron and is
-  currently blocked on this — but it's a small piece of work.
+- ✅ **Cron trigger** — shipped. The `cron` `TriggerSchema` variant
+  plus `cronTick()` in the janitor
+  ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts))
+  fire sessions on schedule, with catch-up modes and `idempotency_key`
+  dedup. Plan: [`cron-trigger-scheduler.md`](shipped/cron-trigger-scheduler.md).
+  Every weekly / monthly app below is now unblocked on the time-based
+  half.
 - ✅ **Bring-your-own HTTP services via `@posthog/http-request`** —
   generic GET/POST/PUT/PATCH/DELETE tool with `${SECRET_NAME}`
   substitution in url, headers, and body. The author drops a bearer
@@ -437,9 +438,9 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger — schema slot exists; scheduler not built.
+- [x] ✅ Cron trigger — shipped; `cronTick()` in the janitor fires on schedule.
       Plan:
-      [`cron-trigger-scheduler.md`](cron-trigger-scheduler.md).
+      [`cron-trigger-scheduler.md`](shipped/cron-trigger-scheduler.md).
 - [x] ✅ Slack post tool —
       [`slack.v1.ts`](../../../services/agent-tools/src/tools/slack.v1.ts).
 - [ ] 📋 Runtime MCP (the GitHub MCP server covers PR listing) —
@@ -488,7 +489,7 @@ reasoning: high # the dedup is the hard part
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [ ] 📋 GitHub access via runtime MCP —
       [`runtime-mcps.md`](runtime-mcps.md).
 - [x] ✅ Slack read-channel — see Marketing agent.
@@ -537,7 +538,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [x] ✅ Webhook trigger.
 - [x] ✅ PostHog query tool.
 - [x] ✅ Web-fetch for competitor pages.
@@ -585,7 +586,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [x] ✅ Web-fetch.
 - [ ] ⚠️ **Inbound email trigger / per-agent mailbox** for
       newsletter subscription. **Gap.**
@@ -630,7 +631,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [x] ✅ Webhook trigger.
 - [x] ✅ Long-running sessions —
       [`long-running-sessions.md`](long-running-sessions.md);
@@ -734,7 +735,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [x] ✅ PostHog query tool.
 - [x] ✅ Sandboxed code execution / coding-agent target for
       "fix the missing instrumentation" —
@@ -784,7 +785,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [ ] 📋 GitHub + ticketing access via runtime MCP —
       [`runtime-mcps.md`](runtime-mcps.md).
 - [ ] ⚠️ Agent-to-agent invocation (see Growth review).
@@ -829,7 +830,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [ ] 📋 Runtime MCP — [`runtime-mcps.md`](runtime-mcps.md).
       Once wired, every external financial provider with an MCP
       server drops in.
@@ -871,7 +872,7 @@ skills:
 
 **Platform prerequisites.**
 
-- [ ] 📋 Cron trigger.
+- [x] ✅ Cron trigger — shipped ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts)).
 - [x] ✅ Sandboxed code execution for forecasting math —
       [`sandboxed-agent-inference.md`](sandboxed-agent-inference.md).
 - [ ] 📋 Runtime MCP for Warpstream + Grafana —
@@ -933,7 +934,7 @@ Highest-leverage next picks given the matrix:
 **What's shipped vs. what's left.** This branch closed the two
 biggest blocks on the matrix:
 
-- **Cron scheduler** ([`cron-trigger-scheduler.md`](cron-trigger-scheduler.md))
+- **Cron scheduler** ([`cron-trigger-scheduler.md`](shipped/cron-trigger-scheduler.md))
   ✅ shipped. Unblocked the time-based half of Marketing, Feature
   prioritization, Industry intel, Customer research, Growth
   review, Gap analysis, Financial reconciliation, Warpstream

--- a/docs/agent-platform/plans/_ROADMAP.md
+++ b/docs/agent-platform/plans/_ROADMAP.md
@@ -11,6 +11,21 @@ For the raw queue of features still _waiting_ for a plan, see
 [`_TODO.md`](_TODO.md). Every bullet there now has a corresponding
 plan; this file is the order we'd build them in.
 
+## Fully shipped — moved to [`shipped/`](shipped/)
+
+Plans whose core design has fully landed as code now live in
+[`plans/shipped/`](shipped/) as rationale-of-record. They keep their
+inline roadmap entries below for context:
+
+- [`session-restart-and-state-machine.md`](shipped/session-restart-and-state-machine.md) (A.3)
+- [`cron-trigger-scheduler.md`](shipped/cron-trigger-scheduler.md) (C.5)
+- [`typed-bundle-authoring-api.md`](shipped/typed-bundle-authoring-api.md) (authoring infra)
+- [`approvals-ui.md`](shipped/approvals-ui.md) (console half of B.2 v1)
+- [`container-builds.md`](shipped/container-builds.md) (infra)
+
+Many other plans are **partially shipped** (v0 landed, later versions
+open) and stay here with `v0 ✅`-style annotations.
+
 ## Layers
 
 We group the plans into five layers, roughly:
@@ -96,7 +111,7 @@ spec shape it introduces.
 - No new state, no new columns, no compaction, no runner rehydrate
   for v0. Those land later if real usage demands it.
 
-- [`session-restart-and-state-machine.md`](session-restart-and-state-machine.md)
+- [`session-restart-and-state-machine.md`](shipped/session-restart-and-state-machine.md)
   — **Ben** — the load-bearing state machine
   `queued → running → completed → closed` (plus `cancelled`,
   `failed`) every trigger and resume path consumes. **v0 ✅ shipped:**
@@ -133,9 +148,10 @@ the call before dispatch; `agent_tool_approval_request` table with
 canonical-args idempotency; janitor `/approvals/*` HTTP surface;
 Django proxy via janitor_client (team-admin auth); non-blocking
 session — model receives a synthetic queued tool_result and continues.
-v1 adds the session-detail approvals tab + team-level inbox UI,
-notification fan-out, and richer approver scopes (depends on B.1's
-principal model).
+v1 adds notification fan-out and richer approver scopes (depends on
+B.1's principal model). The **console approvals UI** half of v1 — fleet
+inbox, per-agent tab, detail/decision drawer, count badges — has
+already shipped; see [`shipped/approvals-ui.md`](shipped/approvals-ui.md).
 
 **Cross-cut with C.2 — gating MCP tools is unresolved.** The v0
 dispatcher only gates entries in `spec.tools`; MCP tools materialise
@@ -244,12 +260,15 @@ from ClickHouse on resume / display (TODO B8). Depends on **A** for
 the source-of-truth contract (conversation JSONB is canonical for
 live state; ClickHouse is the audit log for display).
 
-### C.5 [`cron-trigger-scheduler.md`](cron-trigger-scheduler.md) — **Danilo** (after A)
+### C.5 [`cron-trigger-scheduler.md`](shipped/cron-trigger-scheduler.md) — **Danilo** — ✅ shipped
 
 Wakes `cron`-trigger agents from the janitor. Small platform piece
-sitting under C because it's a capability extension; depends on **A**
-for the `external_key_reuse` policy that lets recurring firings
-coalesce into one long-running session. Required for **D.2** v3.
+sitting under C because it's a capability extension; coalesces
+recurring firings into one long-running session via `external_key`.
+**v0 (the whole thing) ✅ shipped** — `cronTick()` alongside the
+janitor sweep, catch-up modes, `idempotency_key` dedup, manual-fire
+endpoint, e2e coverage. Only §10 v1 polish remains. Required for
+**D.2** v3.
 
 ### C.6 [`revision-routing.md`](revision-routing.md)
 
@@ -471,16 +490,17 @@ Assuming no parallelism, a reasonable order:
    `repo-write`, then `repo-pr`. Each tier expands trust and depends
    on the prior layers' enforcement.
 7. **C.2 / C.3 / C.4 / C.5** — runtime MCPs, skill templates,
-   resumable conversations, cron scheduler. Independent; ship in
-   parallel based on demand. **C.5** is a small janitor extension and
-   is the cheapest of the four.
-   _C.6 revision-routing v0 ✅ shipped (local-dev suffix), v1
-   partially shipped; C.7 streaming-and-reasoning v0a ✅ shipped
-   (reasoning knob), stream surface pending._
+   resumable conversations, cron scheduler. Independent; shipped in
+   parallel based on demand. _C.2 runtime-mcps ✅ shipped; C.3
+   skill-templates v0 ✅ shipped; C.5 cron-trigger-scheduler ✅
+   shipped; C.4 resumable-conversations still next-epoch. C.6
+   revision-routing v0 ✅ shipped (local-dev suffix), v1 partially
+   shipped; C.8 streaming-and-reasoning v0a/v0b/v1 ✅ shipped, v2
+   delta-filtering pending._
 8. **D.1** — agent authoring flow. Test-run + judge infrastructure.
 9. **D.2 §11 v1+** — the rest of self-healing. Manual introspection
    first, then replay-and-grade once D.1's test infrastructure
-   exists, then cron-driven runs once **C.5** lands.
+   exists, then cron-driven runs (C.5 cron now shipped).
 10. **E.1** — agent console website. Read-mostly v0 (overview,
     bundle, revisions, sessions) ships on top of **A** + **C.streaming**
     - **C.routing** alone — does not strictly require **D.1** to land
@@ -501,6 +521,24 @@ Small, known loose ends — captured here so they're not lost. Each is a deliber
 
 - **Modal sandbox e2e is gated on an explicit `SANDBOX_HOST_IMAGE`** alongside `MODAL_TOKEN_*`. Default tag is `ghcr.io/posthog/posthog-agent-sandbox-host:master`, which lags any in-flight branch — without the explicit gate, every local `pnpm test` with Modal creds surfaces "image build failed" red. Fix path: resolve the tag from `state.yaml` per branch, or pin a known-stable digest. (`services/agent-shared/src/sandbox/sandbox-modal.test.ts`)
 - **`S3JsonlTabularStore` ETag canary skipped on SeaweedFS.** SeaweedFS's S3 API doesn't honour `If-Match` strictly enough for the racing-append assertion to converge — its read-after-write window lets a retry write against a stale ETag and SeaweedFS accepts it. Real S3 still runs the canary in CI. Fix path: switch the optimistic-concurrency primitive (sidecar lock / per-row file), or upgrade SeaweedFS if a newer release tightens If-Match. (`services/agent-shared/src/memory/s3-tabular-store.test.ts`)
+
+## Newer plans not yet placed in the layer map
+
+Designed since the layer map above was drawn; not yet sequenced into a
+workstream. All are console/observability/infra surfaces that sit
+above or beside **E.1**:
+
+- [`sessions-world-map.md`](sessions-world-map.md) — fleet world-map
+  view of session origins in the console. **Not built** (needs a
+  session `origin` column + GeoIP + a janitor breakdown endpoint).
+  This is the concrete shape of the "agent fleet view" gap noted below.
+- [`session-failure-observability.md`](session-failure-observability.md)
+  — surface why a session failed (failure reason + scrubbed log tail +
+  detail banner). **Not built.** Owner: dylan.
+- [`public-subdomain-routing.md`](public-subdomain-routing.md) — the
+  ops/infra sequencing companion to **C.6** revision-routing
+  (Terraform / wildcard cert / DNS live in `posthog-cloud-infra`).
+  Routing-layer code is ready; infra apply is the remaining step.
 
 ## What's _not_ in scope here
 

--- a/docs/agent-platform/plans/_TODO.md
+++ b/docs/agent-platform/plans/_TODO.md
@@ -72,17 +72,18 @@ file (and out of this list) once the design lands.
       lever — wasted tokens add up fast on long-running chat agents
       with idle UIs.
 
-- [ ] **Cron trigger scheduler** (Dylan — picking up after runtime-mcps
-      PR 7) — see
-      [`cron-trigger-scheduler.md`](cron-trigger-scheduler.md).
-      Janitor runs `cronTick()` alongside its sweep; catch-up modes
-      (`all` / `most_recent` / `skip`) bound the outage-recovery blast
-      radius; `agent_cron_firing` table dedups across replicas; firings
-      coalesce into long-running sessions via `external_key_reuse`.
-      Plan was checked off prematurely — the most recent commit on the
-      plan file is `078ce5bb89 wip — cron plan, auth refresh, hogli
-  ai-gateway slot`; no `cronTick` or `agent_cron_firing` exist in
-      the codebase yet.
+- [x] ~~**Cron trigger scheduler**~~ — ✅ shipped; see
+      [`cron-trigger-scheduler.md`](shipped/cron-trigger-scheduler.md).
+      Janitor runs `cronTick()`
+      ([`cron-tick.ts`](../../../services/agent-janitor/src/cron-tick.ts))
+      alongside its sweep; catch-up modes (`all` / `most_recent` /
+      `skip`) bound the outage-recovery blast radius; firings coalesce
+      into long-running sessions via `external_key`. Dedup is via the
+      session `idempotency_key` partial unique index
+      ([`1780346228100_agent_session_idempotency_key.sql`](../../../services/agent-migrations/migrations/1780346228100_agent_session_idempotency_key.sql))
+      — the `agent_cron_firing` table the earlier draft imagined was
+      never needed. e2e coverage in
+      [`cron-trigger.test.ts`](../../../services/agent-tests/src/cases/cron-trigger.test.ts).
 
 - [x] ~~**Streaming deltas + unified reasoning knob**~~ — see
       [`streaming-and-reasoning.md`](streaming-and-reasoning.md).
@@ -249,17 +250,16 @@ message, session_id? })` tool, sessions exposed as MCP
       refuses non-live invokes without it. Draft's own
       `spec.auth.mode` is unchanged — this is a layer above it.
 
-- [ ] **Bundle manifest schema** — **superseded** by
-      [`typed-bundle-authoring-api.md`](typed-bundle-authoring-api.md).
-      Original idea (spec-derived path allowlist on a generic file
-      API) is moot when the file API itself goes away — see
-      [`bundle-manifest-schema.md`](bundle-manifest-schema.md) for
-      the archived design. Keep the bullet here as a back-reference
-      until the typed API ships and we archive both entries
-      together.
+- [x] ~~**Bundle manifest schema**~~ — **superseded** by
+      [`typed-bundle-authoring-api.md`](shipped/typed-bundle-authoring-api.md)
+      (now shipped). Original idea (spec-derived path allowlist on a
+      generic file API) is moot now the file API has gone away — see
+      [`bundle-manifest-schema.md`](bundle-manifest-schema.md) for the
+      archived design.
 
-- [ ] **Typed bundle authoring API + full janitor e2e suite** — see
-      [`typed-bundle-authoring-api.md`](typed-bundle-authoring-api.md).
+- [x] ~~**Typed bundle authoring API + full janitor e2e suite**~~ — ✅
+      shipped; see
+      [`typed-bundle-authoring-api.md`](shipped/typed-bundle-authoring-api.md).
       Replace the generic `/file?path=X` bundle store with typed
       resource endpoints (`/agent_md`, `/skills/:id`, `/tools/:id`,
       `/bundle` for GET+PUT). `spec.skills[]` / `spec.tools[]`

--- a/docs/agent-platform/plans/agent-concierge.md
+++ b/docs/agent-platform/plans/agent-concierge.md
@@ -414,24 +414,21 @@ calling it from the concierge ("here's a test run id, grade it
 against rubric R"). The judge could itself be a deployed agent,
 which is the nicest dogfooding.
 
-### 8.10 Multi-mode auth on a single revision
+### 8.10 Multi-mode auth on a single revision — ✅ shipped
 
-**Status:** today's `spec.auth.mode` is a single enum
-(`public` | `pat` | `posthog_internal` | `shared_secret`).
+**Status:** ✅ shipped. `spec.auth.modes` is now an array of
+`AuthModeSchema` discriminated variants
+([`spec.ts`](../../../services/agent-shared/src/spec/spec.ts) —
+`AuthConfigSchema.modes`), accepting `public` / `pat` / `oauth` /
+`jwt` / `shared_secret` / `posthog_internal` in any combination on a
+single revision; the ingress verifier tries each in order, first match
+wins. The concierge fixture already declares
+`["oauth", "pat", "posthog_internal"]`.
 
-**Why it matters:** the concierge needs to serve console
-(`posthog_internal`), IDE (`oauth`), and scripts (`pat`) at the
-same time — without a multi-mode shape, one revision can serve
-only one surface and we'd need multiple deployments.
-
-**What's needed:**
-
-- `spec.auth.modes: string[]` (or `spec.auth: AuthModeSchema | AuthModeSchema[]`).
-- New `oauth` mode + `oauth` config (`{ provider, scopes[] }`).
-- The ingress trigger handler discriminates by request shape
-  (Bearer token type / presence of MCP OAuth headers).
-- `oauth-proxy` mints MCP-OAuth-shaped tokens; the runner
-  validates against the same provider.
+This closes what was the blocking gap here. The remaining concierge
+dependencies are the **runtime-MCP per-tool approval gating** and the
+`session_principal` approver scope (see §8.2 + `_TODO.md`'s "MCP tool
+approval gating" entry), not auth modes.
 
 ### 8.11 MCP-tool-level approval policies
 

--- a/docs/agent-platform/plans/agent-console-website.md
+++ b/docs/agent-platform/plans/agent-console-website.md
@@ -1,11 +1,23 @@
 # Design — agent console website (read-mostly UI + agent-mediated editing)
 
-**Status:** draft. **Owner:** ben.
+**Status:** v0 ✅ shipped; later surfaces ongoing. **Owner:** ben.
 
-> The MCP gives the authoring AI a complete surface. Humans don't have
-> one yet — today the only way to inspect an agent (spec, bundle,
-> revisions, sessions, logs) is to either drive the MCP directly or
-> read JSON out of `psql`. This plan adds a standalone website that
+The standalone Next.js app at
+[`services/agent-console/`](../../../services/agent-console/), the
+reusable [`@posthog/agent-chat`](../../../packages/agent-chat/) dock
+package, PostHog OAuth login, the read surfaces (overview / sessions /
+revisions / config / logs / memory), and the **client-fulfilled tools**
+protocol (`kind: "client"` + `client.handles[]`, with `focus_*` /
+`toast` / `get_context` / `set_secret` handlers) have all landed. The
+approvals surface shipped too — see
+[`shipped/approvals-ui.md`](shipped/approvals-ui.md). Remaining work is
+incremental (e.g. the [`sessions-world-map.md`](sessions-world-map.md)
+fleet view and richer authoring affordances).
+
+> The MCP gives the authoring AI a complete surface. Humans didn't have
+> one — the only way to inspect an agent (spec, bundle, revisions,
+> sessions, logs) was to either drive the MCP directly or read JSON out
+> of `psql`. This plan adds a standalone website that
 > renders all of that, and folds the editing flow into a single chat
 > with a concierge agent rather than a wall of forms.
 

--- a/docs/agent-platform/plans/framework-system-prompt.md
+++ b/docs/agent-platform/plans/framework-system-prompt.md
@@ -21,7 +21,7 @@ Three forces pushing on the system prompt right now:
    make sense in the context of the platform's state machine — the kind
    of guidance that belongs in a framework preamble, not in every
    author's `agent.md`. See
-   [`session-restart-and-state-machine.md`](session-restart-and-state-machine.md).
+   [`session-restart-and-state-machine.md`](shipped/session-restart-and-state-machine.md).
 2. **The approval-gated tools change taught models a new pattern**:
    receive a synthetic queued `tool_result`, surface the link, wait. We
    currently lean on `agent.md` to teach the agent to recognise it, but

--- a/docs/agent-platform/plans/long-running-sessions.md
+++ b/docs/agent-platform/plans/long-running-sessions.md
@@ -14,7 +14,7 @@ TTL is the only piece those downstream plans strictly need.
 
 > **Note on history.** An earlier draft of this plan was written against the
 > pre-cutover state machine that included a `waiting` state. That state was
-> removed when [`session-restart-and-state-machine.md`](session-restart-and-state-machine.md)
+> removed when [`session-restart-and-state-machine.md`](shipped/session-restart-and-state-machine.md)
 > shipped — `completed` is now the open-but-idle state.
 >
 > A subsequent draft introduced a `suspended` parked-cold state alongside

--- a/docs/agent-platform/plans/shipped/README.md
+++ b/docs/agent-platform/plans/shipped/README.md
@@ -1,0 +1,22 @@
+# Shipped plans
+
+Design docs whose core design has fully landed as code. They live on here
+(rather than being deleted) as the rationale-of-record for what shipped and
+why. Each file's status header links to the implementation.
+
+Only optional polish / future-work tails may remain open on these — anything
+load-bearing that's still pending keeps a plan in the parent `plans/` folder
+instead.
+
+- [`session-restart-and-state-machine.md`](session-restart-and-state-machine.md)
+  — the `queued → running → completed → closed` (+ `cancelled` / `failed`)
+  state machine every trigger and resume path consumes.
+- [`cron-trigger-scheduler.md`](cron-trigger-scheduler.md) — `cronTick()` in
+  the janitor wakes `cron`-trigger agents; dedup via session `idempotency_key`.
+- [`typed-bundle-authoring-api.md`](typed-bundle-authoring-api.md) — typed
+  resource endpoints with server-derived `spec.skills[]` / `spec.tools[]` and
+  an AST + esbuild shape check at upload.
+- [`approvals-ui.md`](approvals-ui.md) — the agent-console approvals surface
+  (fleet list, per-agent tab, detail drawer, count badges).
+- [`container-builds.md`](container-builds.md) — Docker images + CI for the
+  node services and the console.

--- a/docs/agent-platform/plans/shipped/approvals-ui.md
+++ b/docs/agent-platform/plans/shipped/approvals-ui.md
@@ -1,40 +1,43 @@
 # Plan — approvals UI in agent-console
 
-**Status:** drafting. **Owner:** ben.
+**Status:** ✅ shipped. **Owner:** ben.
 
 Backend for approval-gated tools shipped in v0 (see
-[approval-gated-tools.md](approval-gated-tools.md) §10).
-Frontend is empty.
-This plan ships the console UI on top of the existing janitor + Django surface.
+[approval-gated-tools.md](../approval-gated-tools.md) §10).
+The console UI on top of the existing janitor + Django surface has now
+landed: fleet-wide [`ApprovalsList.tsx`](../../../../services/agent-console/src/components/ApprovalsList.tsx),
+per-agent `Approvals.tsx` screen, [`ApprovalDetail.tsx`](../../../../services/agent-console/src/components/ApprovalDetail.tsx)
+drawer with the edit/decision flow, sidebar + tab count badges, and the
+session-detail cross-link.
 
 ## 1. Context (don't re-derive)
 
 Already on disk:
 
 - Runtime store: `agent_tool_approval_request` table,
-  [PgApprovalStore.listByTeam / listByApplication / listBySession](../../../services/agent-shared/src/persistence/pg-approval-store.ts).
+  [PgApprovalStore.listByTeam / listByApplication / listBySession](../../../../services/agent-shared/src/persistence/pg-approval-store.ts).
 - Janitor HTTP: `GET /approvals?application_id=…`,
   `GET /approvals/:id`, `POST /approvals/:id/decide` in
-  [server.ts:529-644](../../../services/agent-janitor/src/server.ts).
+  [server.ts:529-644](../../../../services/agent-janitor/src/server.ts).
 - Django proxy: `agent_applications_approvals_{list,retrieve,decide}` in
-  [api.py:1343-1466](../../../products/agent_platform/backend/api.py),
+  [api.py:1343-1466](../../../../products/agent_platform/backend/api.py),
   team-admin gated.
 - Generated FE types: `AgentApprovalRequest`, `DecideApprovalRequest` etc.
-  in [products/agent_platform/frontend/generated/api.schemas.ts](../../../products/agent_platform/frontend/generated/api.schemas.ts).
+  in [products/agent_platform/frontend/generated/api.schemas.ts](../../../../products/agent_platform/frontend/generated/api.schemas.ts).
 - e2e backend coverage:
-  [services/agent-tests/src/cases/approval-gated.test.ts](../../../services/agent-tests/src/cases/approval-gated.test.ts).
+  [services/agent-tests/src/cases/approval-gated.test.ts](../../../../services/agent-tests/src/cases/approval-gated.test.ts).
 - Existing fleet shell: `/agent_fleet/stats/` + `/agent_fleet/live_sessions/`
-  in [api.py:2560](../../../products/agent_platform/backend/api.py),
-  consumed by [agent-console/src/lib/apiClient.ts:getFleetStats](../../../services/agent-console/src/lib/apiClient.ts).
+  in [api.py:2560](../../../../products/agent_platform/backend/api.py),
+  consumed by [agent-console/src/lib/apiClient.ts:getFleetStats](../../../../services/agent-console/src/lib/apiClient.ts).
 
 Console gaps:
 
 - `getFleetStats` hardcodes `approvalsPendingCount: 0`
-  ([apiClient.ts:744-751](../../../services/agent-console/src/lib/apiClient.ts)).
+  ([apiClient.ts:744-751](../../../../services/agent-console/src/lib/apiClient.ts)).
 - No fleet-wide approvals list endpoint (only per-app exists).
 - No screen / route / detail surface in the console.
 - `awaiting_approval` SessionState dot in
-  [runnerReducer.ts:177-178](../../../services/agent-console/src/lib/runnerReducer.ts)
+  [runnerReducer.ts:177-178](../../../../services/agent-console/src/lib/runnerReducer.ts)
   - SessionsList / LiveNowPanel / AgentOverview is **misleading** —
     the runner doesn't park on approval gates per the plan. Clean up alongside.
 
@@ -72,7 +75,7 @@ Console gaps:
 
 ### 3.1 Janitor — fleet-wide list
 
-[services/agent-janitor/src/server.ts](../../../services/agent-janitor/src/server.ts):
+[services/agent-janitor/src/server.ts](../../../../services/agent-janitor/src/server.ts):
 
 - Extend `ListApprovalsQuerySchema` to accept `team_id` **or**
   `application_id` (one required, mutually exclusive).
@@ -87,8 +90,8 @@ Console gaps:
 
 Cheaper than a second round-trip from the fleet-stats endpoint.
 
-[services/agent-shared/src/persistence/queue.ts](../../../services/agent-shared/src/persistence/queue.ts) +
-[pg-queue.ts](../../../services/agent-shared/src/persistence/pg-queue.ts):
+[services/agent-shared/src/persistence/queue.ts](../../../../services/agent-shared/src/persistence/queue.ts) +
+[pg-queue.ts](../../../../services/agent-shared/src/persistence/pg-queue.ts):
 
 - Don't touch `AggregateStats` (queue concern).
 - Instead extend the janitor's `/sessions/stats` (or `/fleet/stats`,
@@ -100,7 +103,7 @@ Cheaper than a second round-trip from the fleet-stats endpoint.
 
 ### 3.3 Django proxy
 
-[products/agent_platform/backend/api.py](../../../products/agent_platform/backend/api.py):
+[products/agent_platform/backend/api.py](../../../../products/agent_platform/backend/api.py):
 
 - New `AgentFleetViewSet.approvals` action:
   `GET /agent_fleet/approvals/?state=queued&agent_id=…&limit=…&offset=…`.
@@ -110,7 +113,7 @@ Cheaper than a second round-trip from the fleet-stats endpoint.
   application_id for cross-checking ownership).
 - `_AGENT_AGGREGATE_STATS` serializer gains `pendingApprovalsCount`
   field — schema annotation flows into generated types automatically.
-- [janitor_client.py](../../../products/agent_platform/backend/janitor_client.py):
+- [janitor_client.py](../../../../products/agent_platform/backend/janitor_client.py):
   add `list_approvals_for_team(team_id, state=…, agent_id=…, limit=…, offset=…)`.
 
 ### 3.4 Regen types
@@ -120,16 +123,16 @@ hogli build:openapi
 ```
 
 Will update both
-[frontend/generated/api.schemas.ts](../../../products/agent_platform/frontend/generated/api.schemas.ts)
+[frontend/generated/api.schemas.ts](../../../../products/agent_platform/frontend/generated/api.schemas.ts)
 and
-[services/agent-console/src/generated/agent-platform.api.schemas.ts](../../../services/agent-console/src/generated/agent-platform.api.schemas.ts)
+[services/agent-console/src/generated/agent-platform.api.schemas.ts](../../../../services/agent-console/src/generated/agent-platform.api.schemas.ts)
 (check both regenerate — the console pulls a separate snapshot).
 
 ## 4. Frontend — agent-console
 
 ### 4.1 Wire pendingApprovalsCount
 
-[services/agent-console/src/lib/apiClient.ts](../../../services/agent-console/src/lib/apiClient.ts) —
+[services/agent-console/src/lib/apiClient.ts](../../../../services/agent-console/src/lib/apiClient.ts) —
 in `getFleetStats`, replace the hardcoded `0` with the new field.
 Existing Overview / AgentsList tiles will light up automatically.
 
@@ -206,10 +209,10 @@ route page under `services/agent-console/src/app/approvals/page.tsx`:
 - Drawer-style detail uses
   `<Dialog>` / `<Sheet>` from Quill — pick whichever the existing
   surfaces use (SessionDetail's secret edit dialog is the precedent
-  via [SecretEditDialog.tsx](../../../services/agent-console/src/components/SecretEditDialog.tsx)).
+  via [SecretEditDialog.tsx](../../../../services/agent-console/src/components/SecretEditDialog.tsx)).
 
 Add to the sidebar:
-[AppShell.tsx](../../../services/agent-console/src/components/AppShell.tsx) —
+[AppShell.tsx](../../../../services/agent-console/src/components/AppShell.tsx) —
 new `<SidebarTooltip label="Approvals">` icon block between Agents and
 "Tools & skills".
 `CheckSquareIcon` from lucide is the natural pick.
@@ -219,7 +222,7 @@ Gate the sidebar item on `is_team_admin`.
 
 ### 4.5 Per-agent tab
 
-[AgentLayout.tsx](../../../services/agent-console/src/components/AgentLayout.tsx) —
+[AgentLayout.tsx](../../../../services/agent-console/src/components/AgentLayout.tsx) —
 extend `TABS` and `TAB_DEFS`:
 
 ```ts
@@ -238,39 +241,39 @@ for this agent (cheap — already filtered list response carries the count).
 
 ### 4.6 Cross-link from session detail
 
-[SessionLogs.tsx](../../../services/agent-console/src/components/SessionLogs.tsx) —
+[SessionLogs.tsx](../../../../services/agent-console/src/components/SessionLogs.tsx) —
 when a `tool_result` payload parses as
 `{ approval: { request_id, state: "queued", approval_url } }`,
 render the tool name with a "Pending approval" chip that opens the
 drawer directly (preload the row by `request_id` via the per-app
 retrieve endpoint).
 Same parse logic the harness uses in
-[approval-gated.test.ts:parseApprovalPayload](../../../services/agent-tests/src/cases/approval-gated.test.ts) —
+[approval-gated.test.ts:parseApprovalPayload](../../../../services/agent-tests/src/cases/approval-gated.test.ts) —
 factor that out into the runtime types package so it's shared.
 
 ### 4.7 Cleanup — misleading awaiting_approval state
 
 Last commit of the stack.
 
-- [runnerReducer.ts:177-178](../../../services/agent-console/src/lib/runnerReducer.ts) —
+- [runnerReducer.ts:177-178](../../../../services/agent-console/src/lib/runnerReducer.ts) —
   remove the `awaiting_approval` case; map the `waiting` event to
   `awaiting_user_input` (a new state) or fold into the existing
   `awaiting_client_tool` bucket if semantics line up.
   Verify by reading what triggers the `waiting` SSE event in
-  [services/agent-runner/src/loop/bus.ts](../../../services/agent-runner/src/loop/bus.ts) /
-  [agent-ingress/src/triggers/chat.ts](../../../services/agent-ingress/src/triggers/chat.ts).
+  [services/agent-shared/src/runtime/bus.ts](../../../../services/agent-shared/src/runtime/bus.ts) /
+  [agent-ingress/src/triggers/chat.ts](../../../../services/agent-ingress/src/triggers/chat.ts).
 - Remove the `awaiting_approval` branch from
-  [SessionsList.tsx:158-159](../../../services/agent-console/src/components/SessionsList.tsx),
-  [LiveNowPanel.tsx:130-131](../../../services/agent-console/src/components/LiveNowPanel.tsx),
-  [AgentOverview.tsx:286-287](../../../services/agent-console/src/components/AgentOverview.tsx).
+  [SessionsList.tsx:158-159](../../../../services/agent-console/src/components/SessionsList.tsx),
+  [LiveNowPanel.tsx:130-131](../../../../services/agent-console/src/components/LiveNowPanel.tsx),
+  [AgentOverview.tsx:286-287](../../../../services/agent-console/src/components/AgentOverview.tsx).
 - Remove `awaiting_approval` from `LIVE_STATES` in
-  [SessionsList.tsx:30](../../../services/agent-console/src/components/SessionsList.tsx).
+  [SessionsList.tsx:30](../../../../services/agent-console/src/components/SessionsList.tsx).
 
 ## 5. Test paths
 
 ### 5.1 Backend
 
-[services/agent-tests/src/cases/approval-gated.test.ts](../../../services/agent-tests/src/cases/approval-gated.test.ts)
+[services/agent-tests/src/cases/approval-gated.test.ts](../../../../services/agent-tests/src/cases/approval-gated.test.ts)
 already covers the runtime loop.
 Extend it (or sibling case) for the new wire shapes:
 
@@ -296,7 +299,7 @@ Steps to verify locally:
 
 1. `hogli start` + `pnpm --filter @posthog/agent-console dev`.
 2. Use the concierge agent OR the
-   [agent-tests/src/examples/agent-concierge](../../../services/agent-tests/src/examples/agent-concierge)
+   [agent-tests/src/examples/agent-concierge](../../../../services/agent-tests/src/examples/agent-concierge)
    fixture as a seed.
    Add a single gated tool to its `spec.json` —
    `requires_approval: true` on something cheap like

--- a/docs/agent-platform/plans/shipped/container-builds.md
+++ b/docs/agent-platform/plans/shipped/container-builds.md
@@ -1,33 +1,39 @@
 # Agent platform: container build + deploy plan
 
+**Status:** ✅ shipped. The multi-service [`services/agents/Dockerfile`](../../../../services/agents/Dockerfile)
+and the Next.js [`services/agent-console/Dockerfile`](../../../../services/agent-console/Dockerfile)
+both exist, and CI builds/pushes on master + PRs
+(`.github/workflows/ci-agents.yml`, `ci-agent-console.yml`,
+`ci-agent-container.yml`).
+
 ## Context
 
 The agent platform now has three production Node services that have stayed
 local-only:
 
-- [services/agent-ingress/](../../../services/agent-ingress/) — HTTP entry (chat, webhook, slack, MCP) → enqueues sessions
-- [services/agent-runner/](../../../services/agent-runner/) — queue worker that drives sessions through pi-ai + tools
-- [services/agent-janitor/](../../../services/agent-janitor/) — authoring HTTP proxy + queue sweep timer
+- [services/agent-ingress/](../../../../services/agent-ingress/) — HTTP entry (chat, webhook, slack, MCP) → enqueues sessions
+- [services/agent-runner/](../../../../services/agent-runner/) — queue worker that drives sessions through pi-ai + tools
+- [services/agent-janitor/](../../../../services/agent-janitor/) — authoring HTTP proxy + queue sweep timer
 
 …a migration runner that owns the `AGENT_DB_URL` schema:
 
-- [services/agent-migrations/](../../../services/agent-migrations/) — SQL-only [node-pg-migrate](https://github.com/salsita/node-pg-migrate) runner + the migrations themselves. Run as a one-shot Job (chart hook / init container) before each rollout. Equivalent to the rust `sqlx-migrate` image.
+- [services/agent-migrations/](../../../../services/agent-migrations/) — SQL-only [node-pg-migrate](https://github.com/salsita/node-pg-migrate) runner + the migrations themselves. Run as a one-shot Job (chart hook / init container) before each rollout. Equivalent to the rust `sqlx-migrate` image.
 
 …plus a UI service:
 
-- [services/agent-console/](../../../services/agent-console/) — Next.js authoring console
+- [services/agent-console/](../../../../services/agent-console/) — Next.js authoring console
 
-The deploy runbook ([docs/agent-platform/docs/deploy-runbook.md](../docs/deploy-runbook.md))
+The deploy runbook ([docs/agent-platform/docs/deploy-runbook.md](../../docs/deploy-runbook.md))
 already specifies env vars per service, but there is no Dockerfile or CI
 workflow producing images. Right now the only agent Dockerfile in tree is
-[services/agent-sandbox-host/Dockerfile](../../../services/agent-sandbox-host/Dockerfile)
+[services/agent-sandbox-host/Dockerfile](../../../../services/agent-sandbox-host/Dockerfile)
 (a tiny Alpine sidecar with no build step).
 
 Goal: get these services built and pushed on every master commit and PR,
 and trigger a charts deploy on master, using the same conventions as
-[Dockerfile.node](../../../Dockerfile.node) /
-[ci-nodejs-container.yml](../../../.github/workflows/ci-nodejs-container.yml)
-and the rust pattern in [.github/rust-images.yml](../../../.github/rust-images.yml).
+[Dockerfile.node](../../../../Dockerfile.node) /
+[ci-nodejs-container.yml](../../../../.github/workflows/ci-nodejs-container.yml)
+and the rust pattern in [.github/rust-images.yml](../../../../.github/rust-images.yml).
 
 The three runtime services + the migration runner share Node 24, ESM,
 tsx, pg, and (for the services) agent-shared. Their entrypoints are
@@ -42,7 +48,7 @@ structurally different (Next.js, Node 20+).
    bundles (`ingress.mjs`, `runner.mjs`, `janitor.mjs`, `migrate.mjs`)
    plus the migration SQL files. `CMD` selects which service runs in each
    replica or one-shot job. Modelled on
-   [services/mcp/Dockerfile](../../../services/mcp/Dockerfile). Folding
+   [services/mcp/Dockerfile](../../../../services/mcp/Dockerfile). Folding
    the migrator in is deliberate: it guarantees `migrate.mjs` and the
    services that read the schema ship as the same SHA, so a rollout is
    "run the migrate Job at SHA X, then roll the services at SHA X."
@@ -61,7 +67,7 @@ new — empty other than the Dockerfile, a tiny package.json, the build
 script, and a short README explaining the multi-service image). Build
 context is the repo root so pnpm can resolve the workspace.
 
-Structure (mirrors [services/mcp/Dockerfile](../../../services/mcp/Dockerfile)):
+Structure (mirrors [services/mcp/Dockerfile](../../../../services/mcp/Dockerfile)):
 
 - `ARG NODE_VERSION=24.13.0` pinned from `.nvmrc`
 - **Build stage**
@@ -80,7 +86,7 @@ Structure (mirrors [services/mcp/Dockerfile](../../../services/mcp/Dockerfile)):
   - Copy sources for the same six packages
   - Bundle each service entrypoint to a self-contained ESM file via
     esbuild (same approach as
-    [services/mcp/scripts/build-hono.ts](../../../services/mcp/scripts/build-hono.ts)).
+    [services/mcp/scripts/build-hono.ts](../../../../services/mcp/scripts/build-hono.ts)).
     Add `services/agents/scripts/build.ts` that takes a service name and
     emits `dist/<service>.mjs`. Run it four times in the build stage —
     once per entrypoint (ingress, runner, janitor, migrate).
@@ -101,7 +107,7 @@ Structure (mirrors [services/mcp/Dockerfile](../../../services/mcp/Dockerfile)):
   - `EXPOSE 8080 8082` so the same image can serve either HTTP service.
 
 **Migrations layout detail.**
-[services/agent-migrations/src/lib.ts](../../../services/agent-migrations/src/lib.ts)
+[services/agent-migrations/src/lib.ts](../../../../services/agent-migrations/src/lib.ts)
 resolves the migrations directory as
 `resolve(dirname(import.meta.url), '../migrations')`. After bundling, the
 final `migrate.mjs` lives at `/code/dist/migrate.mjs` so the runtime
@@ -137,12 +143,12 @@ This image is **only** the console UI. Storybook is dev-time only.
 ### 3. `services/agent-sandbox-host/Dockerfile` — unchanged
 
 Already correct
-([services/agent-sandbox-host/Dockerfile](../../../services/agent-sandbox-host/Dockerfile)).
+([services/agent-sandbox-host/Dockerfile](../../../../services/agent-sandbox-host/Dockerfile)).
 Just needs CI wiring.
 
 ### 4. `.dockerignore` updates
 
-Edit root [.dockerignore](../../../.dockerignore) — it's allowlist-style,
+Edit root [.dockerignore](../../../../.dockerignore) — it's allowlist-style,
 so the new paths must be explicitly let through:
 
 ```text
@@ -166,7 +172,7 @@ services/agent-tests
 ### 5. CI workflow — `.github/workflows/ci-agent-container.yml`
 
 Single workflow with a matrix over the three images. Modelled on
-[ci-nodejs-container.yml](../../../.github/workflows/ci-nodejs-container.yml)
+[ci-nodejs-container.yml](../../../../.github/workflows/ci-nodejs-container.yml)
 but with a small matrix instead of a single image — closer to the rust
 shape, lighter than splitting into 3 workflow files.
 
@@ -206,12 +212,12 @@ Jobs:
   - `depot/setup-action`, `docker/setup-buildx-action`,
     `docker/setup-qemu-action`
   - Use the shared
-    [./.github/actions/docker-meta](../../../.github/actions/docker-meta/action.yml)
+    [./.github/actions/docker-meta](../../../../.github/actions/docker-meta/action.yml)
     composite for login (GHCR + ECR) and tag generation. Each image gets
     its own Depot project ID — the workflow ships with
     `REPLACE_WITH_DEPOT_PROJECT_ID` placeholders that must be filled in
     once the three Depot projects are created (same as
-    [.github/rust-images.yml](../../../.github/rust-images.yml)). The
+    [.github/rust-images.yml](../../../../.github/rust-images.yml)). The
     workflow will fail at the depot build step until they're set.
   - `depot/build-push-action` with
     `platforms: linux/arm64,linux/amd64`, `push: true`, `COMMIT_HASH`
@@ -247,14 +253,14 @@ Jobs:
   other side picks up the new SHA and runs `node dist/migrate.mjs up`
   before the service Deployments roll. Equivalent to how
   `sqlx-migrate` is shipped in
-  [rust-docker-build.yml](../../../.github/workflows/rust-docker-build.yml).
+  [rust-docker-build.yml](../../../../.github/workflows/rust-docker-build.yml).
   Each dispatches to `PostHog/charts` via
   `peter-evans/repository-dispatch` with the standard `commit_state_update`
   payload, using the deployer GitHub App (same step structure as the
   rust deploy job).
 
 Optional follow-up: a smoke-test workflow analogous to
-[rust-smoke-test-build.yml](../../../.github/workflows/rust-smoke-test-build.yml)
+[rust-smoke-test-build.yml](../../../../.github/workflows/rust-smoke-test-build.yml)
 that builds without pushing on PRs that don't change
 `services/agent-*/**`. Not in scope for v1.
 
@@ -276,7 +282,7 @@ deploys, [PostHog/charts](https://github.com/PostHog/charts) needs:
 - A separate `agent-console` release.
 - An `agent-sandbox-host` release if the runner-side prod sandbox
   pattern requires it. Per
-  [deploy-runbook.md](../docs/deploy-runbook.md), ingress/runner/janitor
+  [deploy-runbook.md](../../docs/deploy-runbook.md), ingress/runner/janitor
   are deployable today; prod sandbox topology may use Modal — confirm
   before wiring this release.
 
@@ -297,11 +303,11 @@ New:
 
 Edited:
 
-- [.dockerignore](../../../.dockerignore) — allowlist new service paths,
+- [.dockerignore](../../../../.dockerignore) — allowlist new service paths,
   ignore `dist/`, `node_modules/`, `agent-tests/`, `.next/`
 - `services/agent-console/next.config.*` — add `output: 'standalone'`
   if missing
-- [docs/agent-platform/docs/deploy-runbook.md](../docs/deploy-runbook.md)
+- [docs/agent-platform/docs/deploy-runbook.md](../../docs/deploy-runbook.md)
   — add a "Container images" section linking image refs and noting the
   per-service command
 
@@ -327,7 +333,7 @@ docker build -f services/agent-console/Dockerfile -t posthog-agent-console:dev .
 docker run --rm -p 3040:3040 posthog-agent-console:dev
 ```
 
-E2E smoke (matches [deploy-runbook.md](../docs/deploy-runbook.md) §1–§5):
+E2E smoke (matches [deploy-runbook.md](../../docs/deploy-runbook.md) §1–§5):
 
 - `curl $INGRESS/healthz` → 200
 - `curl $JANITOR/healthz` → 200

--- a/docs/agent-platform/plans/shipped/cron-trigger-scheduler.md
+++ b/docs/agent-platform/plans/shipped/cron-trigger-scheduler.md
@@ -1,15 +1,27 @@
 # Design — cron trigger scheduler
 
-**Status:** draft. **Owner:** ben.
+**Status:** ✅ shipped (v0 — the whole thing). **Owner:** ben.
 
-[`TriggerSchema`](../../../services/agent-shared/src/spec/spec.ts) already
-carries a `cron` variant with `schedule` + `timezone`. Nothing wakes
-those agents up, and the existing shape is too thin — it tells you
-_when_ but not _what to do_. This plan fixes both.
+v0 landed in full: `cronTick()` runs alongside the janitor sweep
+([`cron-tick.ts`](../../../../services/agent-janitor/src/cron-tick.ts)),
+the `idempotency_key` column + partial unique index
+([`1780346228100_agent_session_idempotency_key.sql`](../../../../services/agent-migrations/migrations/1780346228100_agent_session_idempotency_key.sql)),
+the job-shaped `cron` `TriggerSchema` variant, `POST /revisions/:id/cron/fire`,
+catch-up modes, placeholder expansion, and e2e coverage
+([`cron-trigger.test.ts`](../../../../services/agent-tests/src/cases/cron-trigger.test.ts)).
+Dedup is via the session `idempotency_key` — no `agent_cron_firing`
+table was ever needed. Only the §10 **v1 polish** items remain.
+
+Original plan text follows.
+
+[`TriggerSchema`](../../../../services/agent-shared/src/spec/spec.ts) already
+carried a `cron` variant with `schedule` + `timezone`. Nothing woke
+those agents up, and the existing shape was too thin — it told you
+_when_ but not _what to do_. This plan fixed both.
 
 ## 1. The shift: each cron entry is a job, not a ping
 
-The cron-shaped agents in [`_APP_IDEAS.md`](_APP_IDEAS.md) all share a
+The cron-shaped agents in [`_APP_IDEAS.md`](../_APP_IDEAS.md) all share a
 problem: a single agent has a lot of context (a digest agent knows how
 to read the warehouse, format prose, post to Slack) and is triggered
 in multiple shapes — chat ("redo last week's digest"), webhook
@@ -63,7 +75,7 @@ tools, finishes the turn.
 ## 2. What "fire" actually means
 
 A firing is a single call into the same
-[`enqueueOrResume()`](../../../services/agent-ingress/src/enqueue/enqueue.ts)
+[`enqueueOrResume()`](../../../../services/agent-ingress/src/enqueue/enqueue.ts)
 that chat, webhook, and Slack already use. It carries:
 
 - The application + the live revision id (cron only fires through the
@@ -93,7 +105,7 @@ Slack / chat / webhook today. The cron config has an optional
 Placeholders: `fired_at:iso`, `fired_at:date`, `fired_at:week`,
 `schedule`, `cron_name`. Expanded at firing time. **No new resume
 concept is invented** — the underlying mechanism is the existing
-`external_key` resume from [long-running-sessions.md](long-running-sessions.md) §4.
+`external_key` resume from [long-running-sessions.md](../long-running-sessions.md) §4.
 
 ## 4. The firing message
 
@@ -127,7 +139,7 @@ prompt: 'Produce the digest for the week ending {fired_at:date}.'
 ## 5. Where the scheduler runs
 
 **Janitor.** It already runs `sweepOnce` every 30s
-([`sweep.ts`](../../../services/agent-janitor/src/sweep.ts)), already
+([`sweep.ts`](../../../../services/agent-janitor/src/sweep.ts)), already
 holds the `PgRevisionStore`, already opens the two PG pools. Adding a
 `cronTick()` alongside the sweep is the smallest possible addition —
 no new deploy unit, no new shape to operate.
@@ -268,7 +280,7 @@ to 7 days at validation.
 ```
 
 Freeze-time validation in
-[`validate-spec.ts`](../../../services/agent-janitor/src/validate-spec.ts):
+[`validate-spec.ts`](../../../../services/agent-janitor/src/validate-spec.ts):
 
 - `name` matches `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`
 - All `name`s across `triggers[]` are unique
@@ -289,7 +301,7 @@ and no-ops.
 
 **Runaway crons** (`schedule: '* * * * *'`). Goes through the same
 admission check as every other trigger
-([`rate-limiting-sessions.md`](rate-limiting-sessions.md) §5).
+([`rate-limiting-sessions.md`](../rate-limiting-sessions.md) §5).
 Recommended setup: `max_concurrent_sessions: 1` plus append-mode
 `external_key` so subsequent firings coalesce into `pending_inputs`
 rather than stacking sessions. Document in the registry-vendored
@@ -320,7 +332,7 @@ cron-firings table or endpoint.
 **v0** (the whole thing, since authoring depends on every piece):
 
 - `idempotency_key` column + partial unique index on `agent_session`
-  ([`services/agent-migrations/migrations/`](../../../services/agent-migrations/migrations/))
+  ([`services/agent-migrations/migrations/`](../../../../services/agent-migrations/migrations/))
 - `enqueueOrResume()` gains the `idempotencyKey` argument; webhook
   trigger wired to forward provider-supplied keys
 - `cron-parser` dep on `agent-janitor`
@@ -358,10 +370,10 @@ compose without modification.
 **What this unblocks:**
 
 - The time-based half of eight apps in
-  [`_APP_IDEAS.md`](_APP_IDEAS.md) (Marketing update, Feature
+  [`_APP_IDEAS.md`](../_APP_IDEAS.md) (Marketing update, Feature
   prioritization, Industry intelligence, Customer research, Growth
   review, Gap analysis, Financial reconciliation, Warpstream
-  forecasting) plus [`self-healing-agents.md`](self-healing-agents.md)
+  forecasting) plus [`self-healing-agents.md`](../self-healing-agents.md)
   v3. **The single largest unblock per the feasibility matrix.**
 - **Webhook double-delivery safety as a side effect.** The
   `idempotency_key` primitive lets the webhook trigger forward

--- a/docs/agent-platform/plans/shipped/session-restart-and-state-machine.md
+++ b/docs/agent-platform/plans/shipped/session-restart-and-state-machine.md
@@ -1,6 +1,6 @@
 # Design — session state machine + restart
 
-**Status:** shipped (v0). **Owner:** ben.
+**Status:** ✅ shipped (v0 — the contract is the whole deliverable). **Owner:** ben.
 
 This is the contract the platform now operates under for session lifecycle.
 Replaces the older `queued / running / waiting / completed / failed` state
@@ -50,7 +50,7 @@ ones spawn a fresh session.
 
 Three always-on meta tools the runner intercepts. The system prompt
 should teach the model which to reach for and when — see
-[`framework-system-prompt.md`](framework-system-prompt.md) §3.1.
+[`framework-system-prompt.md`](../framework-system-prompt.md) §3.1.
 
 ### `@posthog/meta-end-turn`
 
@@ -173,7 +173,7 @@ Shipped in one branch. Backwards-compat notes:
   `tool_result` and user messages into the session, no state-machine
   interaction. A session that's parked on an approval lands at
   `completed` (open); after the approval the runner picks it back up.
-- [`framework-system-prompt.md`](framework-system-prompt.md) — the new
+- [`framework-system-prompt.md`](../framework-system-prompt.md) — the new
   meta tools need explicit guidance about when to use each; that plan
   owns the preamble.
 - `long-running-sessions.md` — the `idleCompletedThresholdMs` sweep

--- a/docs/agent-platform/plans/shipped/typed-bundle-authoring-api.md
+++ b/docs/agent-platform/plans/shipped/typed-bundle-authoring-api.md
@@ -1,6 +1,15 @@
 # Design — typed bundle authoring API (full replace of file-grain bundle writes)
 
-**Status:** draft. **Owner:** Ben. **Tracking:** [`_TODO.md`](_TODO.md).
+**Status:** ✅ shipped. **Owner:** Ben. **Tracking:** [`_TODO.md`](../_TODO.md).
+
+Typed resource endpoints, server-derived `spec.skills[]` / `spec.tools[]`
+at freeze, the static-AST tool shape check + esbuild compile
+([`compile-custom-tools.ts`](../../../../services/agent-janitor/src/compile-custom-tools.ts),
+[`typed-bundle.ts`](../../../../services/agent-janitor/src/api/typed-bundle.ts)),
+the one-shot migrator, and the comprehensive e2e suite
+([`typed-bundle-authoring.test.ts`](../../../../services/agent-tests/src/cases/typed-bundle-authoring.test.ts))
+all landed. Only the §11 open questions (per-tool monotonic versioning,
+frontmatter shape enforcement) remain as future work.
 
 ## 1. Problem
 
@@ -234,7 +243,7 @@ of support-conversation we no longer have:
 - **The `mode: replace | merge` flag on `/bundle`** — deleted. PUT-full vs
   per-resource is clearer.
 - **The hand-rolled "what files are allowed in a bundle" allowlist** (see
-  [`bundle-manifest-schema.md`](bundle-manifest-schema.md)) — moot. The only
+  [`bundle-manifest-schema.md`](../bundle-manifest-schema.md)) — moot. The only
   files in the bundle are the ones the typed endpoints write.
 - **About a third of the `authoring-new-agents` skill** — the file-shape and
   spec-shape worked examples become server-enforced and don't need to be in
@@ -303,8 +312,8 @@ Why this matters more in the typed-API world than the file-API world:
 
 The whole feature lives or dies on having comprehensive e2e tests against
 the janitor. Lives in
-[`services/agent-tests/`](../../services/agent-tests/) using the real-cluster
-harness ([`buildCluster()`](../../services/agent-tests/src/harness/cluster.ts)) —
+[`services/agent-tests/`](../../../../services/agent-tests/) using the real-cluster
+harness ([`buildCluster()`](../../../../services/agent-tests/src/harness/cluster.ts)) —
 real Postgres, real S3 (SeaweedFS), real janitor HTTP server, no fakes. New
 file: `services/agent-tests/src/cases/typed-bundle-authoring.test.ts`.
 
@@ -525,14 +534,14 @@ to gRPC — without re-litigating "does the typed API still work."
 
 ## 12. Coupled / superseded plans
 
-- [`bundle-manifest-schema.md`](bundle-manifest-schema.md) — **superseded.**
+- [`bundle-manifest-schema.md`](../bundle-manifest-schema.md) — **superseded.**
   The "allowed paths" allowlist is moot when the only paths are the ones
   the typed endpoints write. The plan document can be archived in the same
   PR that ships the typed API.
-- [`agent-authoring-flow.md`](agent-authoring-flow.md) — needs an update
+- [`agent-authoring-flow.md`](../agent-authoring-flow.md) — needs an update
   pass: the file-grain MCP calls (`agent-applications-revisions-file-update`)
   get replaced with the typed resource calls.
-- [`framework-system-prompt.md`](framework-system-prompt.md) — orthogonal
+- [`framework-system-prompt.md`](../framework-system-prompt.md) — orthogonal
   but worth re-checking: the framework system prompt currently talks about
   bundle paths; it can be tightened to talk about typed resources instead.
 


### PR DESCRIPTION
## Problem

The agent platform plans documentation had grown to include several designs whose core implementation has fully landed as code. These shipped plans were scattered throughout `plans/` alongside active designs, making it harder to distinguish what's actually built from what's still pending. The roadmap needed updating to reflect the current state of multiple completed features.

## Changes

Reorganized the plans documentation to separate shipped designs from active work:

- Created `docs/agent-platform/plans/shipped/` directory with a new `README.md` explaining the purpose
- Moved five fully-shipped plans to `shipped/`:
  - `session-restart-and-state-machine.md` — the core session state machine contract
  - `cron-trigger-scheduler.md` — janitor-based cron firing with `idempotency_key` dedup
  - `typed-bundle-authoring-api.md` — typed resource endpoints with server-derived spec
  - `approvals-ui.md` — agent-console approvals surface (fleet list, per-agent tab, detail drawer)
  - `container-builds.md` — Docker images and CI for node services and console

- Updated each shipped plan's status header to mark as `✅ shipped` and link to implementation
- Updated `_ROADMAP.md` to:
  - Add a new "Fully shipped" section explaining the `shipped/` folder
  - Update cross-references to point to `shipped/` for completed plans
  - Clarify that many plans are "partially shipped" (v0 landed, later versions open)
  - Add a new "Newer plans not yet placed" section for console/observability designs
  - Update sequencing notes to reflect what's actually shipped (e.g., C.5 cron scheduler ✅, C.2 runtime-mcps ✅)

- Updated `_TODO.md` to mark cron scheduler and typed-bundle-authoring as complete with links to shipped plans
- Updated `_APP_IDEAS.md` to reflect cron trigger as shipped with links to implementation
- Updated `agent-console-website.md` status to `v0 ✅ shipped` with implementation links
- Updated `agent-concierge.md` to mark multi-mode auth as shipped
- Updated main `README.md` to explain the new structure and clarify that most plans are partially built

All relative path references in moved files were updated to account for the new `shipped/` subdirectory depth (e.g., `../../../services/` → `../../../../services/`).

## How did you test this code?

This is a documentation reorganization with no code changes. Verified:
- All relative links in moved files resolve correctly (adjusted path depth for `shipped/` subdirectory)
- Cross-references in `_ROADMAP.md`, `_TODO.md`, and `_APP_IDEAS.md` point to correct locations
- Status headers accurately reflect implementation state based on code references
- No broken markdown or formatting issues

## 🤖 Agent context

**Autonomy:** Fully autonomous

This was a documentation-only reorganization to improve clarity about which designs have shipped. The changes reflect the actual state of the codebase — all five moved plans have their core implementations fully landed (with only optional polish remaining). The updates to roadmap and TODO files are factual corrections based on what's actually in the repository.

https://claude.ai/code/session_013XkXy7RwBrmvQr8od41FyV