### PR TITLE
refactor(insights): use quill charts for retention in MCP

### DIFF
--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
@@ -1,14 +1,30 @@
 import type { Series, TooltipConfig } from '@posthog/quill-charts'
 
+import type { RetentionTrendPayload } from 'scenes/retention/types'
+
 import type { GoalLine as SchemaGoalLine } from '~/queries/schema/schema-general'
+
+import type { GoalLineLike } from 'products/product_analytics/frontend/insights/trends/shared/trendsChartDisplayOptions'
 
 import {
     buildRetentionBarChartConfig,
+    buildRetentionChartModel,
     buildRetentionLineChartConfig,
     buildRetentionSeries,
+    type RetentionCohortLike,
+    computeRetentionSeriesValue,
+    type RetentionResultLike,
     type RetentionSeriesMeta,
     type RetentionTrendSeriesEntry,
+    sortRetentionCohorts,
 } from './retentionChartTransforms'
+
+// The neutral structural types in retentionChartTransforms.ts exist so the shared chart code stays
+// free of `~/` and `scenes/` imports (the MCP Vite bundle can't resolve them). These helpers' return
+// types enforce that the real schema types stay assignable to the neutral ones — if a schema field
+// ever changes shape, the returns fail to compile and flag the drift here rather than at a call site.
+const asNeutralRetentionResult = (r: RetentionTrendPayload): RetentionResultLike => r
+const asNeutralGoalLine = (g: SchemaGoalLine): GoalLineLike => g
 
 const makeEntry = (overrides: Partial<RetentionTrendSeriesEntry> = {}): RetentionTrendSeriesEntry => ({
     count: 100,
@@ -23,6 +39,21 @@ const makeEntry = (overrides: Partial<RetentionTrendSeriesEntry> = {}): Retentio
 const TOOLTIP: TooltipConfig = { pinnable: true, placement: 'top' }
 
 describe('retentionChartTransforms', () => {
+    describe('schema type firewall', () => {
+        it('keeps the schema RetentionTrendPayload / GoalLine assignable to the neutral structural types', () => {
+            expect(
+                asNeutralRetentionResult({
+                    count: 100,
+                    data: [100, 50],
+                    days: ['2024-01-01', '2024-01-02'],
+                    labels: ['Day 0', 'Day 1'],
+                    index: 0,
+                })
+            ).toMatchObject({ count: 100 })
+            expect(asNeutralGoalLine({ label: 'goal', value: 10 })).toMatchObject({ label: 'goal', value: 10 })
+        })
+    })
+
     describe('buildRetentionSeries', () => {
         it('builds one series per payload, keyed by row index', () => {
             const series = buildRetentionSeries([makeEntry({ index: 0 }), makeEntry({ index: 1 })], {
@@ -197,6 +228,93 @@ describe('retentionChartTransforms', () => {
         it('passes the tooltip config through unchanged', () => {
             const config = buildRetentionBarChartConfig({ isPercentage: true, series: baseSeries, tooltip: TOOLTIP })
             expect(config.tooltip).toBe(TOOLTIP)
+        })
+    })
+
+    describe('computeRetentionSeriesValue', () => {
+        const values = [{ count: 100 }, { count: 50 }, { count: 0 }]
+
+        it.each([
+            { intervalIndex: 0, reference: 'total', expected: 100, desc: 'total: interval 0 is 100%' },
+            { intervalIndex: 1, reference: 'total', expected: 50, desc: 'total: percentage of baseline' },
+            { intervalIndex: 0, reference: 'previous', expected: 100, desc: 'previous: interval 0 is 100%' },
+            { intervalIndex: 1, reference: 'previous', expected: 50, desc: 'previous: percentage of prior interval' },
+        ])('count aggregation — $desc', ({ intervalIndex, reference, expected }) => {
+            expect(computeRetentionSeriesValue(values, intervalIndex, 'count', reference)).toBe(expected)
+        })
+
+        it.each([
+            { values: [{ count: 0 }, { count: 5 }], desc: 'baseline of 0' },
+            { values: [{ count: 100 }], desc: 'missing interval' },
+        ])('count aggregation returns 0 for $desc', ({ values: vals }) => {
+            expect(computeRetentionSeriesValue(vals, 1, 'count', 'total')).toBe(0)
+        })
+
+        it('non-count aggregation surfaces aggregation_value directly', () => {
+            expect(computeRetentionSeriesValue([{ count: 1, aggregation_value: 42 }], 0, 'sum', 'total')).toBe(42)
+        })
+    })
+
+    describe('sortRetentionCohorts', () => {
+        it('orders cohorts chronologically and keeps dateless cohorts last in original order', () => {
+            const cohorts: RetentionCohortLike[] = [
+                { date: '2024-03-01', values: [] },
+                { date: null, values: [], breakdown_value: 'first-dateless' },
+                { date: '2024-01-01', values: [] },
+                { date: null, values: [], breakdown_value: 'second-dateless' },
+            ]
+            expect(sortRetentionCohorts(cohorts).map((c) => c.date ?? c.breakdown_value)).toEqual([
+                '2024-01-01',
+                '2024-03-01',
+                'first-dateless',
+                'second-dateless',
+            ])
+        })
+    })
+
+    describe('buildRetentionChartModel', () => {
+        const colorAt = (i: number): string => `c${i}`
+        const cohort = (date: string, counts: number[]): RetentionCohortLike => ({
+            date,
+            values: counts.map((count) => ({ count })),
+        })
+
+        it('caps to maxCohorts but reports the full total, and labels by period', () => {
+            const cohorts = [
+                cohort('2024-01-01', [100, 50]),
+                cohort('2024-01-02', [80, 40]),
+                cohort('2024-01-03', [60, 30]),
+            ]
+            const model = buildRetentionChartModel(cohorts, {
+                aggregationType: 'count',
+                reference: 'total',
+                period: 'Day',
+                getColor: colorAt,
+                maxCohorts: 2,
+            })
+
+            expect(model.totalCohorts).toBe(3)
+            expect(model.series).toHaveLength(2)
+            expect(model.series.map((s) => s.color)).toEqual(['c0', 'c1'])
+            expect(model.labels).toEqual(['Day 0', 'Day 1'])
+            expect(model.series[0].data).toEqual([100, 50])
+        })
+
+        it.each([
+            { aggregationType: 'count', expectedLabel: 'Retention %', expectedFormat: 'percentage' },
+            { aggregationType: 'sum', expectedLabel: 'Sum', expectedFormat: 'numeric' },
+            { aggregationType: 'avg', expectedLabel: 'Avg', expectedFormat: 'numeric' },
+        ])('labels the y-axis for $aggregationType', ({ aggregationType, expectedLabel, expectedFormat }) => {
+            const model = buildRetentionChartModel([cohort('2024-01-01', [100, 50])], {
+                aggregationType,
+                reference: 'total',
+                period: 'Day',
+                getColor: colorAt,
+                maxCohorts: 6,
+            })
+            expect(model.lineConfig.yAxis?.label).toBe(expectedLabel)
+            expect(model.barConfig.yAxis?.label).toBe(expectedLabel)
+            expect(model.lineConfig.yAxis?.format).toBe(expectedFormat)
         })
     })
 })

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
@@ -7,15 +7,26 @@ import type {
     TrendLineConfig,
 } from '@posthog/quill-charts'
 
-import type { RetentionTrendPayload } from 'scenes/retention/types'
-
-import type { GoalLine as SchemaGoalLine } from '~/queries/schema/schema-general'
-
 import { schemaGoalLinesToConfigs } from 'products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter'
+import type { GoalLineLike } from 'products/product_analytics/frontend/insights/trends/shared/trendsChartDisplayOptions'
+
+// Dependency-neutral shape both the kea `RetentionTrendPayload` and lighter fixtures (e.g. the MCP
+// UI app) satisfy. Declared structurally rather than imported from `scenes/retention/types` so this
+// module stays free of `~/`/`scenes/` deps and compiles in the MCP Vite bundle, which only resolves
+// `products/*` and `@posthog/*`. The real `RetentionTrendPayload` is assignable to this (asserted in
+// retentionChartTransforms.test.ts), so web callers pass it unchanged.
+export interface RetentionResultLike {
+    count: number
+    data: number[]
+    days?: string[]
+    labels?: string[]
+    index?: number
+    breakdown_value?: string | number | null
+}
 
 // `retentionGraphLogic.trendSeries` spreads `cohortRetention` onto each entry, so the
 // runtime shape includes a cohort `label` field that the declared type doesn't list.
-export type RetentionTrendSeriesEntry = RetentionTrendPayload & { label?: string }
+export type RetentionTrendSeriesEntry = RetentionResultLike & { label?: string }
 
 export interface RetentionSeriesMeta {
     /** Original row index from the unfiltered results — drives modal opens in non-interval view. */
@@ -68,7 +79,7 @@ export function buildRetentionSeries(
 
 export interface BuildRetentionChartConfigOpts {
     isPercentage: boolean
-    goalLines?: SchemaGoalLine[] | null
+    goalLines?: GoalLineLike[] | null
     showTrendLines?: boolean
     series: Series<RetentionSeriesMeta>[]
     tooltip?: TooltipConfig
@@ -84,7 +95,7 @@ function buildTrendLines(
     return series.map((s) => ({ seriesKey: s.key, kind: 'linear' }))
 }
 
-function buildGoalLines(goalLines: SchemaGoalLine[] | null | undefined): GoalLineConfig[] | undefined {
+function buildGoalLines(goalLines: GoalLineLike[] | null | undefined): GoalLineConfig[] | undefined {
     return schemaGoalLinesToConfigs(goalLines)
 }
 
@@ -112,5 +123,174 @@ export function buildRetentionBarChartConfig(opts: BuildRetentionChartConfigOpts
         barLayout: 'grouped',
         goalLines: buildGoalLines(opts.goalLines),
         tooltip: opts.tooltip,
+    }
+}
+
+// --- Cohort shaping ----------------------------------------------------------------------------
+// Turns a raw retention query result into chart entries. Lives here (not in the MCP host) so the
+// cohort math is unit-tested. Structural/neutral so it stays MCP-bundle-safe.
+
+/** Structural cohort shape the MCP `RetentionResultItem` satisfies. */
+export interface RetentionCohortLike {
+    date?: string | null
+    breakdown_value?: string | number | null
+    values: { count: number; aggregation_value?: number | null }[]
+}
+
+function formatCohortStartDate(date: string | null | undefined, period: string): string | null {
+    if (!date) {
+        return null
+    }
+    const d = new Date(date)
+    if (Number.isNaN(d.getTime())) {
+        return null
+    }
+    if (period === 'Hour') {
+        return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric' })
+    }
+    if (period === 'Month') {
+        return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+    }
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+export function formatRetentionCohortLabel(cohort: RetentionCohortLike, cohortNumber: number, period: string): string {
+    const startDate = formatCohortStartDate(cohort.date, period)
+    const breakdown =
+        cohort.breakdown_value !== undefined && cohort.breakdown_value !== null && cohort.breakdown_value !== ''
+            ? String(cohort.breakdown_value)
+            : null
+    const base = `Cohort ${cohortNumber}`
+    if (breakdown) {
+        return startDate ? `${base} (${breakdown}, ${startDate})` : `${base} (${breakdown})`
+    }
+    return startDate ? `${base} (${startDate})` : base
+}
+
+/** Mirrors retentionLogic: `count` aggregation → percentage of the reference cohort size
+ *  (`total` = interval 0, `previous` = preceding interval); other aggregations surface
+ *  `aggregation_value` directly. */
+export function computeRetentionSeriesValue(
+    values: RetentionCohortLike['values'],
+    intervalIndex: number,
+    aggregationType: string,
+    reference: string
+): number {
+    const current = values[intervalIndex]
+    if (!current) {
+        return 0
+    }
+    if (aggregationType !== 'count') {
+        return current.aggregation_value ?? 0
+    }
+    if (reference === 'previous') {
+        if (intervalIndex === 0) {
+            return 100
+        }
+        const prev = values[intervalIndex - 1]
+        if (!prev || prev.count === 0) {
+            return 0
+        }
+        return (current.count / prev.count) * 100
+    }
+    const baseline = values[0]?.count ?? 0
+    if (baseline === 0) {
+        return 0
+    }
+    return (current.count / baseline) * 100
+}
+
+/** Sorts cohorts chronologically; cohorts with a missing/invalid date keep their order at the end. */
+export function sortRetentionCohorts<C extends RetentionCohortLike>(cohorts: C[]): C[] {
+    return [...cohorts].sort((a, b) => {
+        const ta = a.date ? new Date(a.date).getTime() : Number.POSITIVE_INFINITY
+        const tb = b.date ? new Date(b.date).getTime() : Number.POSITIVE_INFINITY
+        const aMissing = Number.isNaN(ta) || !Number.isFinite(ta)
+        const bMissing = Number.isNaN(tb) || !Number.isFinite(tb)
+        if (aMissing && bMissing) {
+            return 0
+        }
+        if (aMissing) {
+            return 1
+        }
+        if (bMissing) {
+            return -1
+        }
+        return ta - tb
+    })
+}
+
+function retentionYAxisLabel(aggregationType: string): string {
+    if (aggregationType === 'count') {
+        return 'Retention %'
+    }
+    if (aggregationType === 'sum') {
+        return 'Sum'
+    }
+    return 'Avg'
+}
+
+export interface BuildRetentionChartModelOpts {
+    aggregationType: string
+    reference: string
+    period: string
+    showTrendLines?: boolean
+    getColor: (index: number) => string
+    tooltip?: TooltipConfig
+    /** Cohorts beyond this are dropped so each line keeps a distinct palette color. */
+    maxCohorts: number
+}
+
+export interface RetentionChartModel {
+    series: Series<RetentionSeriesMeta>[]
+    labels: string[]
+    lineConfig: TimeSeriesLineChartConfig
+    barConfig: TimeSeriesBarChartConfig
+    /** Cohort count before the `maxCohorts` cap — lets the host show a truncation notice. */
+    totalCohorts: number
+}
+
+/** Assembles the full retention chart model (sort → cap → per-interval values → series → line/bar
+ *  configs) so the MCP visualizer stays presentational and the cohort math is tested here. */
+export function buildRetentionChartModel<C extends RetentionCohortLike>(
+    cohorts: C[],
+    opts: BuildRetentionChartModelOpts
+): RetentionChartModel {
+    const sorted = sortRetentionCohorts(cohorts)
+    const limited = sorted.slice(0, opts.maxCohorts)
+    const numIntervals = limited.reduce((max, c) => Math.max(max, c.values.length), 0)
+    const labels = Array.from({ length: numIntervals }, (_, i) => `${opts.period} ${i}`)
+
+    const entries: RetentionTrendSeriesEntry[] = limited.map((cohort, idx) => ({
+        count: cohort.values[0]?.count ?? 0,
+        data: Array.from({ length: numIntervals }, (_, i) =>
+            computeRetentionSeriesValue(cohort.values, i, opts.aggregationType, opts.reference)
+        ),
+        labels,
+        index: idx,
+        label: formatRetentionCohortLabel(cohort, idx + 1, opts.period),
+    }))
+
+    const series = buildRetentionSeries(entries, { isIntervalView: false }).map((s, i) => ({
+        ...s,
+        color: opts.getColor(i),
+    }))
+
+    const isPercentage = opts.aggregationType === 'count'
+    const yAxisLabel = retentionYAxisLabel(opts.aggregationType)
+    const lineBase = buildRetentionLineChartConfig({
+        isPercentage,
+        showTrendLines: opts.showTrendLines,
+        series,
+        tooltip: opts.tooltip,
+    })
+    const barBase = buildRetentionBarChartConfig({ isPercentage, series, tooltip: opts.tooltip })
+
+    return {
+        series,
+        labels,
+        lineConfig: { ...lineBase, yAxis: { ...lineBase.yAxis, label: yAxisLabel } },
+        barConfig: { ...barBase, yAxis: { ...barBase.yAxis, label: yAxisLabel } },
+        totalCohorts: sorted.length,
     }
 }

--- a/products/product_analytics/mcp/apps/Retention.stories.tsx
+++ b/products/product_analytics/mcp/apps/Retention.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ReactElement } from 'react'
+
+import { McpThemeDecorator } from '@posthog/mcp-ui/storybook/decorator'
+import { TimeSeriesBarChart, TimeSeriesLineChart } from '@posthog/quill-charts'
+import type { ChartTheme } from '@posthog/quill-charts'
+
+import {
+    buildRetentionBarChartConfig,
+    buildRetentionLineChartConfig,
+    buildRetentionSeries,
+    type RetentionTrendSeriesEntry,
+} from '../../frontend/insights/retention/shared/retentionChartTransforms'
+
+// PostHog brand palette — mirrors services/mcp/src/ui-apps/components/charts/theme.ts
+const CHART_COLORS = ['#1d4aff', '#621da6', '#00d683', '#f54e00', '#f7a501', '#dc2626']
+
+const CHART_THEME: ChartTheme = {
+    colors: CHART_COLORS,
+    backgroundColor: '#ffffff',
+    axisColor: '#9ca3af',
+    gridColor: 'rgba(128,128,128,0.2)',
+    crosshairColor: 'rgba(128,128,128,0.5)',
+    tooltipBackground: '#ffffff',
+    tooltipColor: '#111827',
+}
+
+// Three cohorts measured over five intervals — each `data` value is a retention percentage (0..100).
+const COHORTS: RetentionTrendSeriesEntry[] = [
+    {
+        count: 100,
+        data: [100, 64, 48, 39, 30],
+        labels: ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4'],
+        index: 0,
+        label: 'Cohort 1 (May 26)',
+    },
+    {
+        count: 120,
+        data: [100, 71, 55, 44, 36],
+        labels: ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4'],
+        index: 1,
+        label: 'Cohort 2 (May 27)',
+    },
+    {
+        count: 90,
+        data: [100, 58, 41, 33, 25],
+        labels: ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4'],
+        index: 2,
+        label: 'Cohort 3 (May 28)',
+    },
+]
+
+const LABELS = ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4']
+
+const meta: Meta = {
+    title: 'MCP Apps/Retention',
+    decorators: [McpThemeDecorator],
+    parameters: {
+        testOptions: {
+            skipDarkMode: true,
+        },
+    },
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+function RetentionChartDemo({
+    entries,
+    mode,
+}: {
+    entries: RetentionTrendSeriesEntry[]
+    mode: 'line' | 'bar'
+}): ReactElement {
+    const series = buildRetentionSeries(entries, { isIntervalView: false }).map((s, i) => ({
+        ...s,
+        color: CHART_COLORS[i % CHART_COLORS.length]!,
+    }))
+    return (
+        // Fixed pixel size, not width:100% — the chart sizes its canvas off a ResizeObserver, which
+        // measures 0 for a percentage width at mount in the headless snapshot runner and draws nothing.
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ display: 'flex', flexDirection: 'column', width: 640, height: 320 }}>
+            {mode === 'bar' ? (
+                <TimeSeriesBarChart
+                    series={series}
+                    labels={LABELS}
+                    theme={CHART_THEME}
+                    config={buildRetentionBarChartConfig({ isPercentage: true, series })}
+                />
+            ) : (
+                <TimeSeriesLineChart
+                    series={series}
+                    labels={LABELS}
+                    theme={CHART_THEME}
+                    config={buildRetentionLineChartConfig({ isPercentage: true, series })}
+                />
+            )}
+        </div>
+    )
+}
+
+export const LineChart: Story = {
+    render: () => <RetentionChartDemo entries={COHORTS} mode="line" />,
+    name: 'Line chart',
+}
+
+export const BarChart: Story = {
+    render: () => <RetentionChartDemo entries={COHORTS} mode="bar" />,
+    name: 'Bar chart',
+}
+
+export const SingleCohort: Story = {
+    render: () => <RetentionChartDemo entries={[COHORTS[0]!]} mode="line" />,
+    name: 'Single cohort',
+}

--- a/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/RetentionVisualizer.tsx
@@ -2,16 +2,13 @@ import { type ReactElement, useMemo, useState } from 'react'
 
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
+import { TimeSeriesBarChart, TimeSeriesLineChart, type TooltipConfig } from '@posthog/quill-charts'
 
-import { BarChart, LineChart, Select, type Series } from './charts'
-import type {
-    RetentionAggregationType,
-    RetentionPeriod,
-    RetentionReference,
-    RetentionResult,
-    RetentionResultItem,
-    RetentionVisualizerProps,
-} from './types'
+import { buildRetentionChartModel } from 'products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms'
+
+import { Select } from './charts'
+import { CHART_COLORS, CHART_THEME, colorAt } from './charts/theme'
+import type { RetentionVisualizerProps } from './types'
 
 type ChartMode = 'line' | 'bar'
 
@@ -20,142 +17,34 @@ const CHART_MODE_OPTIONS = [
     { value: 'bar' as const, label: 'Bar' },
 ]
 
-function formatStartDate(cohort: RetentionResultItem, period: RetentionPeriod): string | null {
-    if (!cohort.date) {
-        return null
-    }
-    const d = new Date(cohort.date)
-    if (Number.isNaN(d.getTime())) {
-        return null
-    }
-    if (period === 'Hour') {
-        return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric' })
-    }
-    if (period === 'Month') {
-        return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
-    }
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-}
-
-function formatCohortLegendLabel(cohort: RetentionResultItem, cohortNumber: number, period: RetentionPeriod): string {
-    const startDate = formatStartDate(cohort, period)
-    const breakdown =
-        cohort.breakdown_value !== undefined && cohort.breakdown_value !== null && cohort.breakdown_value !== ''
-            ? String(cohort.breakdown_value)
-            : null
-    const base = `Cohort ${cohortNumber}`
-    if (breakdown) {
-        return startDate ? `${base} (${breakdown}, ${startDate})` : `${base} (${breakdown})`
-    }
-    return startDate ? `${base} (${startDate})` : base
-}
-
-// Mirrors the math in `retentionLogic.ts`: each cohort's interval values become a percentage of the
-// reference cohort size (`total` = day-0, `previous` = preceding interval). For non-count aggregations
-// we surface `aggregation_value` directly without normalization.
-function computeSeriesValue(
-    values: RetentionResultItem['values'],
-    intervalIndex: number,
-    aggregationType: RetentionAggregationType,
-    reference: RetentionReference
-): number {
-    const current = values[intervalIndex]
-    if (!current) {
-        return 0
-    }
-    if (aggregationType !== 'count') {
-        return current.aggregation_value ?? 0
-    }
-    if (reference === 'previous') {
-        if (intervalIndex === 0) {
-            return 100
-        }
-        const prev = values[intervalIndex - 1]
-        if (!prev || prev.count === 0) {
-            return 0
-        }
-        return (current.count / prev.count) * 100
-    }
-    const baseline = values[0]?.count ?? 0
-    if (baseline === 0) {
-        return 0
-    }
-    return (current.count / baseline) * 100
-}
-
-function buildXAxisLabels(numIntervals: number, period: RetentionPeriod): string[] {
-    return Array.from({ length: numIntervals }, (_, i) => `${period} ${i}`)
-}
-
-// Sort chronologically so "Cohort 1" is the earliest start date. Cohorts without a parseable date
-// preserve their original order at the end of the list.
-function sortCohorts(results: RetentionResult): RetentionResult {
-    return [...results].sort((a, b) => {
-        const ta = a.date ? new Date(a.date).getTime() : Number.POSITIVE_INFINITY
-        const tb = b.date ? new Date(b.date).getTime() : Number.POSITIVE_INFINITY
-        // `ta`/`tb` can each be a finite ms timestamp, NaN (invalid `date`), or POSITIVE_INFINITY
-        // (missing `date`). `ta - tb` returns NaN whenever both are non-finite (Inf-Inf or NaN-*),
-        // which violates the sort comparator contract — handle those pairings explicitly.
-        const aMissing = Number.isNaN(ta) || !Number.isFinite(ta)
-        const bMissing = Number.isNaN(tb) || !Number.isFinite(tb)
-        if (aMissing && bMissing) {
-            return 0
-        }
-        if (aMissing) {
-            return 1
-        }
-        if (bMissing) {
-            return -1
-        }
-        return ta - tb
-    })
-}
+const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 
 // Cap at the size of the shared chart palette so each cohort gets its own distinct color rather
 // than cycling — beyond this the lines blur into noise anyway.
-const MAX_COHORTS = 8
+const MAX_COHORTS = CHART_COLORS.length
 
 export function RetentionVisualizer({ query, results }: RetentionVisualizerProps): ReactElement {
-    const aggregationType: RetentionAggregationType = query?.retentionFilter?.aggregationType ?? 'count'
-    const reference: RetentionReference = query?.retentionFilter?.retentionReference ?? 'total'
-    const period: RetentionPeriod = query?.retentionFilter?.period ?? 'Day'
-    const isPercentage = aggregationType === 'count'
-
     const [chartMode, setChartMode] = useState<ChartMode>('line')
 
-    const { series, labels, maxValue, totalCohorts } = useMemo(() => {
-        if (!results || results.length === 0) {
-            return { series: [] as Series[], labels: [] as string[], maxValue: 0, totalCohorts: 0 }
-        }
-        const sorted = sortCohorts(results)
-        // Cap to MAX_COHORTS so each line gets a distinct palette color rather than wrapping back
-        // to the first color. Older cohorts have the most observed intervals so we keep those.
-        const limited = sorted.slice(0, MAX_COHORTS)
-        const numIntervals = limited.reduce((m, c) => Math.max(m, c.values.length), 0)
-        const xLabels = buildXAxisLabels(numIntervals, period)
-        let computedMax = 0
-
-        const built: Series[] = limited.map((cohort, idx) => {
-            const points = Array.from({ length: numIntervals }, (_, i) => {
-                const y = computeSeriesValue(cohort.values, i, aggregationType, reference)
-                if (y > computedMax) {
-                    computedMax = y
-                }
-                return { x: i, y, label: xLabels[i] ?? `${i}` }
-            })
-            return {
-                label: formatCohortLegendLabel(cohort, idx + 1, period),
-                points,
-            }
-        })
-
-        return {
-            series: built,
-            labels: xLabels,
-            maxValue: computedMax || 1,
-            totalCohorts: sorted.length,
-        }
-    }, [results, aggregationType, reference, period])
+    const { series, labels, lineConfig, barConfig, totalCohorts } = useMemo(
+        () =>
+            buildRetentionChartModel(results ?? [], {
+                aggregationType: query?.retentionFilter?.aggregationType ?? 'count',
+                reference: query?.retentionFilter?.retentionReference ?? 'total',
+                period: query?.retentionFilter?.period ?? 'Day',
+                showTrendLines: query?.retentionFilter?.showTrendLines ?? false,
+                getColor: colorAt,
+                tooltip: TOOLTIP_CONFIG,
+                maxCohorts: MAX_COHORTS,
+            }),
+        [
+            results,
+            query?.retentionFilter?.aggregationType,
+            query?.retentionFilter?.retentionReference,
+            query?.retentionFilter?.period,
+            query?.retentionFilter?.showTrendLines,
+        ]
+    )
 
     if (!results || results.length === 0 || series.length === 0 || labels.length === 0) {
         return (
@@ -168,31 +57,23 @@ export function RetentionVisualizer({ query, results }: RetentionVisualizerProps
         )
     }
 
-    const yAxisLabel = isPercentage ? 'Retention %' : aggregationType === 'sum' ? 'Sum' : 'Avg'
     const truncationNotice =
         totalCohorts > MAX_COHORTS ? `Showing first ${MAX_COHORTS} of ${totalCohorts} cohorts (oldest first)` : null
 
     return (
         <div>
-            <div
-                style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    marginBottom: '0.5rem',
-                }}
-            >
-                <span style={{ fontSize: '0.75rem', color: 'var(--color-text-secondary, #6b7280)' }}>
-                    {truncationNotice}
-                </span>
+            <div className="mb-2 flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">{truncationNotice}</span>
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <Select value={chartMode} onChange={setChartMode} options={CHART_MODE_OPTIONS} />
             </div>
-            {chartMode === 'bar' ? (
-                <BarChart series={series} labels={labels} maxValue={maxValue} yAxisLabel={yAxisLabel} />
-            ) : (
-                <LineChart series={series} labels={labels} maxValue={maxValue} yAxisLabel={yAxisLabel} />
-            )}
+            <div className="flex flex-col w-full h-[400px]">
+                {chartMode === 'bar' ? (
+                    <TimeSeriesBarChart series={series} labels={labels} theme={CHART_THEME} config={barConfig} />
+                ) : (
+                    <TimeSeriesLineChart series={series} labels={labels} theme={CHART_THEME} config={lineConfig} />
+                )}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

[PR #61809](https://github.com/PostHog/posthog/pull/61809) moved the MCP trends app to render with `@posthog/quill-charts` by reusing the web frontend's chart transforms. The other insight types shown in MCP UI apps — retention, lifecycle, and funnels — still rendered with the old bespoke SVG/canvas chart components. This brings **retention** onto the same quill-based path, so the MCP app looks consistent with the product and we maintain one set of chart-building logic.

This is one of three PRs split out of [#62254](https://github.com/PostHog/posthog/pull/62254) (the others cover lifecycle and funnels). Each is independent and based on `master`.

## Changes

Applies the same principle as the trends PR to retention: keep the chart-building logic as pure transforms in `products/product_analytics/frontend/insights/retention/shared`, make the module dependency-neutral (free of `~/`, `lib/`, and `scenes/` imports the MCP Vite bundle can't resolve), and have the MCP visualizer import it and feed quill's chart components directly.

- `retentionChartTransforms` no longer imports `scenes/retention/types` or the schema `GoalLine`; it declares a structural `RetentionResultLike` and reuses the trends `GoalLineLike`. `buildRetentionChartModel` does the cohort sort/cap/percentage math so the visualizer stays computation-free.
- `RetentionVisualizer` renders quill `TimeSeriesLineChart` / `TimeSeriesBarChart` (line/bar toggle preserved).
- The neutral structural types are guarded by a compile-time "firewall" test that asserts the real schema types stay assignable to them, matching the pattern from the trends PR. An MCP Storybook story is added.

## How did you test this code?

I'm an agent (Claude Code). I ran only automated checks — and in this split-out branch the JS toolchain wasn't provisioned locally, so I relied on CI:

- The transform, test, and visualizer files are carried over unchanged from #62254, where `jest` (72 tests across the four transform suites) and `tsc --noEmit` for both `@posthog/mcp` and the frontend passed.
- The only hand-adapted file here is the Storybook story (inlined its palette/wrapper so the PR adds no shared helper) — stories are covered by CI visual snapshots.

Storybook visual baselines for the new story will be generated by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #62254 at the author's request into three independent, single-insight PRs (retention / lifecycle / funnels), each rebased onto current `master` now that the trends PR (#61809) has merged. Retention is fully self-contained — it touches no shared MCP chart infrastructure. The story was adapted to inline its chart palette and fixed-size wrapper (rather than depend on a shared `ChartDemoFrame`/barrel) so the three split PRs don't conflict on shared new files.
