### PR TITLE
refactor(insights): use quill charts for lifecycle in MCP

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -2,9 +2,10 @@ import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { ChartLegend, TimeSeriesBarChart, legendItemsFromSeries } from '@posthog/quill-charts'
-import type { PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
+import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { getBarColorFromStatus } from 'lib/colors'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -16,6 +17,7 @@ import type { IndexedTrendResult } from 'scenes/trends/types'
 
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import type { LifecycleToggle } from '~/types'
 
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
@@ -26,7 +28,7 @@ import {
 } from '../shared/handleTrendsChartClick'
 import { buildTrendsSeriesMeta, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
 import { TrendsTooltip } from '../shared/TrendsTooltip'
-import { buildTrendsLifecycleConfig, buildTrendsLifecycleSeries } from './trendsLifecycleChartTransforms'
+import { buildLifecycleChartModel } from './trendsLifecycleChartTransforms'
 
 interface TrendsLifecycleChartProps {
     context?: QueryContext<InsightVizNode>
@@ -72,26 +74,20 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
         !!indexedResults[0].data &&
         indexedResults.some((r: IndexedTrendResult) => r.count !== 0)
 
-    const { series, labels } = useMemo(() => {
-        const lifecycleSeries = buildTrendsLifecycleSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
-            buildMeta: buildTrendsSeriesMeta,
-        })
-        return { series: lifecycleSeries, labels: currentPeriodResult?.labels ?? EMPTY_LABELS }
-    }, [indexedResults, currentPeriodResult?.labels])
-
-    const legendItems = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
-
     const valueLabelFormatter = useCallback(
         (value: number) => formatAggregationAxisValue(trendsFilter, value, baseCurrency),
         [trendsFilter, baseCurrency]
     )
 
-    const timeSeriesConfig: TimeSeriesBarChartConfig = useMemo(
+    const { series, labels, config } = useMemo(
         () =>
-            buildTrendsLifecycleConfig({
+            buildLifecycleChartModel<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
+                getColor: (status) => getBarColorFromStatus((status ?? 'new') as LifecycleToggle),
+                buildMeta: buildTrendsSeriesMeta,
+                labels: currentPeriodResult?.labels ?? EMPTY_LABELS,
+                isStacked,
                 trendsFilter,
                 baseCurrency,
-                isStacked,
                 yAxisScaleType,
                 interval,
                 timezone,
@@ -100,17 +96,21 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
                 tooltip: LIFECYCLE_TOOLTIP_CONFIG,
             }),
         [
+            indexedResults,
+            currentPeriodResult?.labels,
+            currentPeriodResult?.days,
+            isStacked,
             trendsFilter,
             baseCurrency,
-            isStacked,
             yAxisScaleType,
             interval,
             timezone,
-            currentPeriodResult?.days,
             showValuesOnSeries,
             valueLabelFormatter,
         ]
     )
+
+    const legendItems = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
 
@@ -199,7 +199,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             <TimeSeriesBarChart<TrendsSeriesMeta>
                 series={series}
                 labels={labels}
-                config={timeSeriesConfig}
+                config={config}
                 theme={theme}
                 tooltip={renderTooltip}
                 onPointClick={canHandleClick ? onPointClick : undefined}

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
@@ -1,21 +1,42 @@
-// Static color stub so the test doesn't depend on the runtime CSS variable.
-jest.mock('lib/colors', () => ({
-    ...jest.requireActual('lib/colors'),
-    getBarColorFromStatus: (status: string): string =>
-        ({
-            new: '#11ff11',
-            resurrecting: '#22ff22',
-            returning: '#33ff33',
-            dormant: '#44ff44',
-        })[status] ?? '#000000',
-}))
+import type { TimeInterval } from '@posthog/quill-charts'
 
+import type { CurrencyCode, TrendsFilter as SchemaTrendsFilter } from '~/queries/schema/schema-general'
+import type { IntervalType } from '~/types'
+
+import type { YFormatterFields } from '../shared/trendsChartDisplayOptions'
 import {
+    buildLifecycleChartModel,
     buildTrendsLifecycleConfig,
     buildTrendsLifecycleSeries,
+    filterToggledLifecycleResults,
     shortenLifecycleLabel,
     type TrendsLifecycleResultLike,
 } from './trendsLifecycleChartTransforms'
+
+// The neutral structural types in trendsLifecycleChartTransforms.ts exist so the shared chart code
+// stays free of `~/` and `lib/` imports (the MCP Vite bundle can't resolve them). These helpers'
+// return types enforce that the real schema types stay assignable to the neutral ones — if a schema
+// field ever changes shape, the returns fail to compile and flag the drift here.
+const asNeutralYFormatterFields = (f: NonNullable<SchemaTrendsFilter>): YFormatterFields => f
+const asNeutralCurrency = (c: CurrencyCode): string => c
+const asNeutralInterval = (i: IntervalType): TimeInterval => i
+
+// Static color stub injected via `getColor` — the transform no longer reads CSS variables itself.
+const STATUS_COLORS: Record<string, string> = {
+    new: '#11ff11',
+    resurrecting: '#22ff22',
+    returning: '#33ff33',
+    dormant: '#44ff44',
+}
+const getColor = (status: string | undefined): string => STATUS_COLORS[status ?? ''] ?? '#000000'
+
+describe('schema type firewall', () => {
+    it('keeps the schema TrendsFilter / CurrencyCode / IntervalType assignable to the neutral types', () => {
+        expect(asNeutralYFormatterFields({ decimalPlaces: 2 })).toMatchObject({ decimalPlaces: 2 })
+        expect(asNeutralCurrency('USD' as CurrencyCode)).toBe('USD')
+        expect(asNeutralInterval('day')).toBe('day')
+    })
+})
 
 describe('buildTrendsLifecycleSeries', () => {
     it('orders series dormant → returning → resurrecting → new regardless of input order', () => {
@@ -25,15 +46,16 @@ describe('buildTrendsLifecycleSeries', () => {
             { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1, -2, -3] },
             { id: 'resurrecting', status: 'resurrecting', label: 'Pageview - resurrecting', data: [1, 2, 3] },
         ]
-        const series = buildTrendsLifecycleSeries(results)
+        const series = buildTrendsLifecycleSeries(results, { getColor })
 
         expect(series.map((s) => s.key)).toEqual(['dormant', 'returning', 'resurrecting', 'new'])
     })
 
     it('preserves dormant data as negative — diverging stack relies on the sign', () => {
-        const series = buildTrendsLifecycleSeries([
-            { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-5, -6, -7] },
-        ])
+        const series = buildTrendsLifecycleSeries(
+            [{ id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-5, -6, -7] }],
+            { getColor }
+        )
 
         expect(series[0].data).toEqual([-5, -6, -7])
     })
@@ -45,15 +67,18 @@ describe('buildTrendsLifecycleSeries', () => {
             { id: 'returning', status: 'returning', label: 'Pageview - returning', data: [1, 2, 3] },
             { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1, -2, -3] },
         ]
-        const series = buildTrendsLifecycleSeries(results)
+        const series = buildTrendsLifecycleSeries(results, { getColor })
         expect(series.map((s) => s.color)).toEqual(['#44ff44', '#33ff33', '#22ff22', '#11ff11'])
     })
 
     it('shortens series labels to capitalized status — used by both legend and tooltip', () => {
-        const series = buildTrendsLifecycleSeries([
-            { id: 'new', status: 'new', label: 'Pageview - new', data: [1] },
-            { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1] },
-        ])
+        const series = buildTrendsLifecycleSeries(
+            [
+                { id: 'new', status: 'new', label: 'Pageview - new', data: [1] },
+                { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1] },
+            ],
+            { getColor }
+        )
         expect(series.find((s) => s.key === 'new')?.label).toBe('New')
         expect(series.find((s) => s.key === 'dormant')?.label).toBe('Dormant')
     })
@@ -65,18 +90,17 @@ describe('buildTrendsLifecycleSeries', () => {
         ]
         const calls: Array<{ status: string; index: number }> = []
         buildTrendsLifecycleSeries(results, {
+            getColor,
             buildMeta: (r, i) => {
                 calls.push({ status: r.status!, index: i })
                 return r.status
             },
         })
         // dormant was at original index 0, new at original index 1 — order is preserved in the callback.
-        expect(calls).toEqual(
-            expect.arrayContaining([
-                { status: 'dormant', index: 0 },
-                { status: 'new', index: 1 },
-            ])
-        )
+        expect(calls).toEqual([
+            { status: 'dormant', index: 0 },
+            { status: 'new', index: 1 },
+        ])
     })
 
     it('marks excluded series with visibility.excluded so the chart skips them', () => {
@@ -85,6 +109,7 @@ describe('buildTrendsLifecycleSeries', () => {
             { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1] },
         ]
         const series = buildTrendsLifecycleSeries(results, {
+            getColor,
             getHidden: (r) => r.status === 'dormant',
         })
         const dormant = series.find((s) => s.key === 'dormant')
@@ -94,8 +119,71 @@ describe('buildTrendsLifecycleSeries', () => {
     })
 
     it('falls back to "None" label when the result label is null', () => {
-        const series = buildTrendsLifecycleSeries([{ id: 'new', status: 'new', label: null, data: [1] }])
+        const series = buildTrendsLifecycleSeries([{ id: 'new', status: 'new', label: null, data: [1] }], { getColor })
         expect(series[0].label).toBe('None')
+    })
+})
+
+describe('filterToggledLifecycleResults', () => {
+    const rows = [
+        { status: 'new', data: [1] },
+        { status: 'returning', data: [2] },
+        { status: 'dormant', data: [-3] },
+    ]
+
+    it('returns every row unchanged when no toggle is set', () => {
+        expect(filterToggledLifecycleResults(rows, undefined)).toBe(rows)
+    })
+
+    it('keeps only rows whose status is toggled on', () => {
+        expect(filterToggledLifecycleResults(rows, ['new', 'dormant'])).toEqual([
+            { status: 'new', data: [1] },
+            { status: 'dormant', data: [-3] },
+        ])
+    })
+
+    it('drops rows without a status once a toggle is active', () => {
+        const withUnstatused = [...rows, { status: undefined, data: [9] }]
+        expect(filterToggledLifecycleResults(withUnstatused, ['new'])).toEqual([{ status: 'new', data: [1] }])
+    })
+})
+
+describe('buildLifecycleChartModel', () => {
+    const results: TrendsLifecycleResultLike[] = [
+        { id: 'new', status: 'new', label: 'Pageview - new', data: [1, 2] },
+        { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1, -2] },
+    ]
+
+    it('assembles series + config and passes the host labels through', () => {
+        const model = buildLifecycleChartModel(results, {
+            getColor,
+            labels: ['Jun 1', 'Jun 2'],
+            isStacked: true,
+        })
+
+        expect(model.labels).toEqual(['Jun 1', 'Jun 2'])
+        expect(model.series.map((s) => s.key)).toEqual(['dormant', 'new'])
+        expect(model.config.barLayout).toBe('stacked')
+        expect(model.config.divergingStack).toBe(true)
+    })
+
+    it('applies the toggledLifecycles filter before building series', () => {
+        const model = buildLifecycleChartModel(results, {
+            getColor,
+            labels: ['Jun 1', 'Jun 2'],
+            isStacked: false,
+            toggledLifecycles: ['new'],
+        })
+
+        expect(model.series.map((s) => s.key)).toEqual(['new'])
+        expect(model.config.barLayout).toBe('grouped')
+    })
+
+    it('forwards the tooltip config through to the chart config', () => {
+        const tooltip = { pinnable: true, placement: 'top' as const }
+        const model = buildLifecycleChartModel(results, { getColor, labels: [], isStacked: true, tooltip })
+
+        expect(model.config.tooltip).toBe(tooltip)
     })
 })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.ts
@@ -1,15 +1,16 @@
-import type { Series, TimeSeriesBarChartConfig } from '@posthog/quill-charts'
-
-import { getBarColorFromStatus } from 'lib/colors'
-import { capitalizeFirstLetter } from 'lib/utils'
-
-import type { CurrencyCode, TrendsFilter } from '~/queries/schema/schema-general'
-import type { IntervalType, LifecycleToggle } from '~/types'
+import type { Series, TimeInterval, TimeSeriesBarChartConfig } from '@posthog/quill-charts'
 
 import { buildTrendsYAxisConfig } from '../shared/trendsAxisFormat'
-import { LIFECYCLE_STATUS_ORDER } from '../shared/trendsSeriesMeta'
+import type { YFormatterFields } from '../shared/trendsChartDisplayOptions'
 
-// Shape both IndexedTrendResult (kea) and lighter fixtures satisfy.
+// Canonical lifecycle status enumeration: new → resurrecting → returning → dormant. Declared here
+// (rather than imported from trendsSeriesMeta, which pulls in `~/` types) so this module stays free
+// of `~/`/`lib/` deps and compiles in the MCP Vite bundle, which only resolves `products/*` and
+// `@posthog/*`. The lifecycle chart renders series in the reverse order (dormant first) to match the
+// legacy chart (`trendsDataLogic.ts:197`).
+const LIFECYCLE_STATUS_ORDER: readonly string[] = ['new', 'resurrecting', 'returning', 'dormant']
+
+// Shape both IndexedTrendResult (kea) and lighter fixtures (e.g. the MCP UI app) satisfy.
 export interface TrendsLifecycleResultLike {
     id?: string | number
     label?: string | null
@@ -20,27 +21,36 @@ export interface TrendsLifecycleResultLike {
 }
 
 function lifecycleStatusOrder(status: string | undefined): number {
-    const i = LIFECYCLE_STATUS_ORDER.indexOf(status as LifecycleToggle)
+    const i = LIFECYCLE_STATUS_ORDER.indexOf(status ?? '')
     return i === -1 ? LIFECYCLE_STATUS_ORDER.length : i
 }
 
-// `dormant` is the only lifecycle status whose values are emitted as negatives,
-// so a diverging stack lays it below the zero baseline. The non-dormant series
-// are pinned to their fixed lifecycle colors regardless of the data-color theme.
-// Unknown statuses fall through to `getBarColorFromStatus`, which throws — we
-// surface the bad data rather than silently miscoloring it as the "new" series.
-function lifecycleColor(status: string | undefined): string {
-    return getBarColorFromStatus((status ?? 'new') as LifecycleToggle)
+/** Drops rows whose lifecycle status is toggled off — mirrors the main app's legend toggles, which
+ *  the MCP host honors from the query (the web chart toggles interactively instead). With no toggle
+ *  set every row passes; once a toggle is active, a row without a status is dropped. */
+export function filterToggledLifecycleResults<R extends { status?: string }>(
+    results: R[],
+    toggledLifecycles: readonly string[] | undefined
+): R[] {
+    if (!toggledLifecycles) {
+        return results
+    }
+    return results.filter((r) => !!r.status && toggledLifecycles.includes(r.status))
 }
 
 export interface BuildTrendsLifecycleSeriesOpts<R extends TrendsLifecycleResultLike, M = unknown> {
+    // Injected so the transform stays free of `lib/colors` (the MCP bundle can't resolve it). Web
+    // passes `getBarColorFromStatus`, which throws on unknown statuses — surfacing bad data rather
+    // than silently miscoloring it. `dormant` is the only status emitted as negatives, so a diverging
+    // stack lays it below the zero baseline regardless of color.
+    getColor: (status: string | undefined) => string
     getHidden?: (r: R, index: number) => boolean
     buildMeta?: (r: R, index: number) => M
 }
 
 export function buildTrendsLifecycleSeries<R extends TrendsLifecycleResultLike, M = unknown>(
     results: R[],
-    opts: BuildTrendsLifecycleSeriesOpts<R, M> = {}
+    opts: BuildTrendsLifecycleSeriesOpts<R, M>
 ): Series<M>[] {
     // Stable lifecycle order: dormant → returning → resurrecting → new — matches the
     // legacy lifecycle chart (`trendsDataLogic.ts:197`) so the legend reads top-down the
@@ -60,7 +70,7 @@ export function buildTrendsLifecycleSeries<R extends TrendsLifecycleResultLike, 
             // shortened here so both legend and tooltip pick up the clean form.
             label: shortenLifecycleLabel(r.label),
             data: r.data,
-            color: lifecycleColor(r.status),
+            color: opts.getColor(r.status),
             meta,
             visibility: excluded ? { excluded: true } : undefined,
         }
@@ -68,11 +78,11 @@ export function buildTrendsLifecycleSeries<R extends TrendsLifecycleResultLike, 
 }
 
 export interface BuildTrendsLifecycleConfigOpts {
-    trendsFilter?: TrendsFilter | null
-    baseCurrency?: CurrencyCode
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     isStacked: boolean
     yAxisScaleType?: string | null
-    interval?: IntervalType | null
+    interval?: TimeInterval | null
     timezone?: string
     allDays?: string[]
     valueLabels?: TimeSeriesBarChartConfig['valueLabels']
@@ -99,10 +109,48 @@ export function buildTrendsLifecycleConfig(opts: BuildTrendsLifecycleConfigOpts)
     }
 }
 
+export interface BuildLifecycleChartModelOpts<
+    R extends TrendsLifecycleResultLike,
+    M = unknown,
+> extends BuildTrendsLifecycleConfigOpts {
+    /** Final x-axis labels (already formatted by the host — kea dates vs the MCP `formatDate`). */
+    labels: string[]
+    getColor: (status: string | undefined) => string
+    /** Client-side legend toggle state. Omit on hosts that toggle interactively (the web chart). */
+    toggledLifecycles?: readonly string[]
+    getHidden?: (r: R, index: number) => boolean
+    buildMeta?: (r: R, index: number) => M
+}
+
+/** The complete input a host hands to quill's `TimeSeriesBarChart` for a lifecycle chart. */
+export interface LifecycleChartModel<M = unknown> {
+    series: Series<M>[]
+    labels: string[]
+    config: TimeSeriesBarChartConfig
+}
+
+/** Assembles the full lifecycle chart model (filter → series → config) so both the web container and
+ *  the MCP visualizer share one tested path; each injects only host-specific bits (color, labels,
+ *  tooltip, meta, interactivity flags). */
+export function buildLifecycleChartModel<R extends TrendsLifecycleResultLike, M = unknown>(
+    results: R[],
+    opts: BuildLifecycleChartModelOpts<R, M>
+): LifecycleChartModel<M> {
+    const visible = filterToggledLifecycleResults(results, opts.toggledLifecycles)
+    const series = buildTrendsLifecycleSeries<R, M>(visible, {
+        getColor: opts.getColor,
+        getHidden: opts.getHidden,
+        buildMeta: opts.buildMeta,
+    })
+    const config = buildTrendsLifecycleConfig(opts)
+    return { series, labels: opts.labels, config }
+}
+
 /** Lifecycle series labels arrive as "Pageview - new", "Pageview - returning", etc.
  *  Returns just the capitalized status ("New", "Returning"). */
 export function shortenLifecycleLabel(label: string | null | undefined): string {
     const parts = label?.split(' - ')
     const tail = parts?.[parts.length - 1] ?? label ?? 'None'
-    return capitalizeFirstLetter(tail)
+    // Inlined rather than imported from `lib/utils` so this module stays MCP-bundle-safe.
+    return tail.charAt(0).toUpperCase() + tail.slice(1)
 }

--- a/products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta.ts
@@ -2,7 +2,7 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
 import type { Noun } from '~/models/groupsModel'
-import type { ActionFilter, LifecycleToggle } from '~/types'
+import type { ActionFilter } from '~/types'
 
 export type TrendsSeriesMeta = {
     action?: ActionFilter
@@ -12,11 +12,6 @@ export type TrendsSeriesMeta = {
     order?: number
     filter?: SeriesDatum['filter']
 }
-
-/** Canonical lifecycle status enumeration: new → resurrecting → returning → dormant.
- *  The lifecycle chart renders series in the reverse order (dormant first) to match the
- *  legacy chart (`trendsDataLogic.ts:197`); see `trendsLifecycleChartTransforms.ts`. */
-export const LIFECYCLE_STATUS_ORDER: readonly LifecycleToggle[] = ['new', 'resurrecting', 'returning', 'dormant']
 
 export const buildTrendsSeriesMeta = (r: IndexedTrendResult): TrendsSeriesMeta => ({
     action: r.action,

--- a/products/product_analytics/mcp/apps/Lifecycle.stories.tsx
+++ b/products/product_analytics/mcp/apps/Lifecycle.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ReactElement } from 'react'
+
+import { McpThemeDecorator } from '@posthog/mcp-ui/storybook/decorator'
+import { ChartLegend, TimeSeriesBarChart, legendItemsFromSeries } from '@posthog/quill-charts'
+import type { ChartTheme } from '@posthog/quill-charts'
+
+import {
+    buildTrendsLifecycleConfig,
+    buildTrendsLifecycleSeries,
+    type TrendsLifecycleResultLike,
+} from '../../frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms'
+
+// PostHog brand palette — mirrors services/mcp/src/ui-apps/components/charts/theme.ts
+const CHART_THEME: ChartTheme = {
+    colors: ['#1d4aff', '#621da6', '#00d683', '#f54e00', '#f7a501', '#dc2626'],
+    backgroundColor: '#ffffff',
+    axisColor: '#9ca3af',
+    gridColor: 'rgba(128,128,128,0.2)',
+    crosshairColor: 'rgba(128,128,128,0.5)',
+    tooltipBackground: '#ffffff',
+    tooltipColor: '#111827',
+}
+
+// Conventional lifecycle bucket colors — mirrors LIFECYCLE_COLORS in the MCP chart theme.
+const LIFECYCLE_COLORS: Record<string, string> = {
+    new: '#1d4aff',
+    returning: '#388600',
+    resurrecting: '#a56eff',
+    dormant: '#db3707',
+}
+const lifecycleColor = (status: string | undefined): string => LIFECYCLE_COLORS[status ?? 'new'] ?? LIFECYCLE_COLORS.new
+
+const LABELS = ['Jun 1', 'Jun 2', 'Jun 3', 'Jun 4', 'Jun 5', 'Jun 6', 'Jun 7']
+
+// `dormant` values come back negated from the backend so a diverging stack lays them below zero.
+const RESULTS: TrendsLifecycleResultLike[] = [
+    { id: 'new', status: 'new', label: 'Pageview - new', data: [40, 35, 50, 45, 60, 55, 70] },
+    { id: 'returning', status: 'returning', label: 'Pageview - returning', data: [20, 30, 35, 40, 45, 50, 55] },
+    { id: 'resurrecting', status: 'resurrecting', label: 'Pageview - resurrecting', data: [10, 8, 12, 9, 14, 11, 16] },
+    { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-15, -20, -18, -25, -22, -30, -28] },
+]
+
+const meta: Meta = {
+    title: 'MCP Apps/Lifecycle',
+    decorators: [McpThemeDecorator],
+    parameters: {
+        testOptions: {
+            skipDarkMode: true,
+        },
+    },
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+function LifecycleChartDemo({
+    results,
+    isStacked,
+}: {
+    results: TrendsLifecycleResultLike[]
+    isStacked: boolean
+}): ReactElement {
+    const series = buildTrendsLifecycleSeries(results, { getColor: lifecycleColor })
+    const config = buildTrendsLifecycleConfig({ isStacked })
+    const legendItems = legendItemsFromSeries(series, CHART_THEME)
+    return (
+        <ChartLegend show items={legendItems} position="top">
+            {/* Fixed pixel size, not width:100% — the chart sizes its canvas off a ResizeObserver, which
+                measures 0 for a percentage width at mount in the headless snapshot runner and draws nothing. */}
+            {/* eslint-disable-next-line react/forbid-dom-props */}
+            <div style={{ display: 'flex', flexDirection: 'column', width: 640, height: 320 }}>
+                <TimeSeriesBarChart series={series} labels={LABELS} theme={CHART_THEME} config={config} />
+            </div>
+        </ChartLegend>
+    )
+}
+
+export const Stacked: Story = {
+    render: () => <LifecycleChartDemo results={RESULTS} isStacked />,
+    name: 'Stacked',
+}
+
+export const Grouped: Story = {
+    render: () => <LifecycleChartDemo results={RESULTS} isStacked={false} />,
+    name: 'Grouped',
+}

--- a/services/mcp/src/ui-apps/components/LifecycleVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/LifecycleVisualizer.tsx
@@ -1,281 +1,59 @@
-import { type ReactElement } from 'react'
+import { type ReactElement, useMemo } from 'react'
 
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
+import { ChartLegend, TimeSeriesBarChart, legendItemsFromSeries } from '@posthog/quill-charts'
 
-import type { LifecycleResultItem, LifecycleStatus, LifecycleVisualizerProps } from './types'
-import { formatDate, formatNumber } from './utils'
+import { buildLifecycleChartModel } from 'products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms'
 
-const CHART_HEIGHT = 320
-const CHART_WIDTH = 600
-const PADDING = { top: 24, right: 24, bottom: 48, left: 56 }
+import { CHART_THEME, lifecycleColor } from './charts/theme'
+import type { LifecycleVisualizerProps } from './types'
+import { formatDate } from './utils'
 
-// Conventional lifecycle bucket colors — mirrors --color-lifecycle-* in frontend/src/styles/base.scss.
-const LIFECYCLE_COLORS: Record<LifecycleStatus, string> = {
-    new: '#1d4aff',
-    returning: '#388600',
-    resurrecting: '#a56eff',
-    dormant: '#db3707',
-}
-
-// Stack order — positive buckets stack upward, dormant goes below zero.
-const POSITIVE_STATUSES: LifecycleStatus[] = ['new', 'returning', 'resurrecting']
-const NEGATIVE_STATUSES: LifecycleStatus[] = ['dormant']
-const ALL_STATUSES: LifecycleStatus[] = [...POSITIVE_STATUSES, ...NEGATIVE_STATUSES]
-
-interface SeriesByStatus {
-    status: LifecycleStatus
-    label: string
-    data: number[]
-}
-
-function groupByStatus(results: LifecycleResultItem[]): {
-    byStatus: Map<LifecycleStatus, SeriesByStatus>
-    labels: string[]
-} {
-    const labels = results[0]?.days || results[0]?.labels || []
-    const byStatus = new Map<LifecycleStatus, SeriesByStatus>()
-
-    for (const item of results) {
-        if (!item.status || !ALL_STATUSES.includes(item.status)) {
-            continue
-        }
-        // Multiple series can share the same status (e.g. when grouping by event).
-        // Sum element-wise.
-        const existing = byStatus.get(item.status)
-        const data = item.data ?? []
-        if (existing) {
-            for (let i = 0; i < data.length; i++) {
-                existing.data[i] = (existing.data[i] ?? 0) + (data[i] ?? 0)
-            }
-        } else {
-            byStatus.set(item.status, {
-                status: item.status,
-                label: item.status,
-                data: [...data],
-            })
-        }
-    }
-
-    return { byStatus, labels }
-}
-
-function computeBounds(
-    byStatus: Map<LifecycleStatus, SeriesByStatus>,
-    dataLength: number,
-    isVisible: (status: LifecycleStatus) => boolean
-): { max: number; min: number } {
-    let max = 0
-    let min = 0
-    for (let i = 0; i < dataLength; i++) {
-        let positiveStack = 0
-        let negativeStack = 0
-        for (const status of POSITIVE_STATUSES) {
-            if (!isVisible(status)) {
-                continue
-            }
-            const value = byStatus.get(status)?.data[i] ?? 0
-            if (value > 0) {
-                positiveStack += value
-            }
-        }
-        for (const status of NEGATIVE_STATUSES) {
-            if (!isVisible(status)) {
-                continue
-            }
-            const value = byStatus.get(status)?.data[i] ?? 0
-            if (value < 0) {
-                negativeStack += value
-            }
-        }
-        if (positiveStack > max) {
-            max = positiveStack
-        }
-        if (negativeStack < min) {
-            min = negativeStack
-        }
-    }
-    return { max, min }
-}
+const LIFECYCLE_TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
 
 export function LifecycleVisualizer({ query, results }: LifecycleVisualizerProps): ReactElement {
-    const renderEmpty = (): ReactElement => (
-        <Empty>
-            <EmptyHeader>
-                <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
-                <EmptyDescription>No data available</EmptyDescription>
-            </EmptyHeader>
-        </Empty>
-    )
-
-    if (!results || results.length === 0) {
-        return renderEmpty()
-    }
-
-    const { byStatus, labels } = groupByStatus(results)
-    const dataLength = labels.length
-    if (dataLength === 0 || byStatus.size === 0) {
-        return renderEmpty()
-    }
-
-    // `toggledLifecycles` is a client-side filter in the main app: the backend always returns
-    // all four buckets and the UI hides the toggled-off ones. Mirror that here.
-    const toggledLifecycles = query?.lifecycleFilter?.toggledLifecycles
-    const isVisible = (status: LifecycleStatus): boolean =>
-        byStatus.has(status) && (!toggledLifecycles || toggledLifecycles.includes(status))
-    const visibleBuckets = ALL_STATUSES.filter(isVisible)
     const showLegend = query?.lifecycleFilter?.showLegend ?? true
 
-    const { max, min } = computeBounds(byStatus, dataLength, isVisible)
-    const range = Math.max(max - min, 1)
+    const { series, labels, config } = useMemo(
+        () =>
+            buildLifecycleChartModel(
+                (results ?? []).map((item, i) => ({
+                    id: i,
+                    label: item.label,
+                    data: item.data ?? [],
+                    status: item.status,
+                    days: item.days,
+                })),
+                {
+                    getColor: lifecycleColor,
+                    labels: (results?.[0]?.days ?? results?.[0]?.labels ?? []).map(formatDate),
+                    isStacked: query?.lifecycleFilter?.stacked ?? true,
+                    toggledLifecycles: query?.lifecycleFilter?.toggledLifecycles,
+                    tooltip: LIFECYCLE_TOOLTIP_CONFIG,
+                }
+            ),
+        [results, query?.lifecycleFilter?.stacked, query?.lifecycleFilter?.toggledLifecycles]
+    )
 
-    const innerWidth = CHART_WIDTH - PADDING.left - PADDING.right
-    const innerHeight = CHART_HEIGHT - PADDING.top - PADDING.bottom
-    const zeroY = PADDING.top + (max / range) * innerHeight
-    const valueToY = (value: number): number => zeroY - (value / range) * innerHeight
-    const barGroupWidth = innerWidth / dataLength
-    const barWidth = Math.min(barGroupWidth * 0.7, 36)
+    const legendItems = useMemo(() => legendItemsFromSeries(series, CHART_THEME), [series])
 
-    // Tick values: 0 plus a few evenly-spaced positions above and below.
-    const positiveTicks = [0.25, 0.5, 0.75, 1].map((ratio) => max * ratio).filter((v) => v > 0)
-    const negativeTicks = [0.25, 0.5, 0.75, 1].map((ratio) => min * ratio).filter((v) => v < 0)
-    const ticks = [...negativeTicks.reverse(), 0, ...positiveTicks]
+    if (!results || results.length === 0 || series.length === 0 || labels.length === 0) {
+        return (
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
+                    <EmptyDescription>No data available</EmptyDescription>
+                </EmptyHeader>
+            </Empty>
+        )
+    }
 
     return (
-        <div>
-            <svg viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`} style={{ width: '100%' }}>
-                {/* Y-axis grid + labels */}
-                {ticks.map((value) => {
-                    const y = valueToY(value)
-                    return (
-                        <g key={value}>
-                            <line
-                                x1={PADDING.left}
-                                y1={y}
-                                x2={CHART_WIDTH - PADDING.right}
-                                y2={y}
-                                stroke="var(--color-border-primary, #e5e7eb)"
-                                strokeDasharray={value === 0 ? '0' : '4,4'}
-                            />
-                            <text
-                                x={PADDING.left - 8}
-                                y={y + 4}
-                                textAnchor="end"
-                                fontSize="10"
-                                fill="var(--color-text-secondary, #6b7280)"
-                            >
-                                {formatNumber(value)}
-                            </text>
-                        </g>
-                    )
-                })}
-
-                {/* X-axis labels — thin out when crowded. */}
-                {labels.map((label, i) => {
-                    if (labels.length > 8 && i % Math.ceil(labels.length / 8) !== 0) {
-                        return null
-                    }
-                    const x = PADDING.left + (i + 0.5) * barGroupWidth
-                    return (
-                        <text
-                            key={i}
-                            x={x}
-                            y={CHART_HEIGHT - 16}
-                            textAnchor="middle"
-                            fontSize="10"
-                            fill="var(--color-text-secondary, #6b7280)"
-                        >
-                            {formatDate(label)}
-                        </text>
-                    )
-                })}
-
-                {/* Stacked bars — positive buckets stack upward, dormant extends downward. */}
-                {Array.from({ length: dataLength }).map((_, i) => {
-                    const groupX = PADDING.left + i * barGroupWidth
-                    const x = groupX + (barGroupWidth - barWidth) / 2
-
-                    let positiveCursor = 0
-                    let negativeCursor = 0
-                    return (
-                        <g key={i}>
-                            {POSITIVE_STATUSES.map((status) => {
-                                if (!isVisible(status)) {
-                                    return null
-                                }
-                                const series = byStatus.get(status)
-                                const value = series?.data[i] ?? 0
-                                if (value <= 0) {
-                                    return null
-                                }
-                                const yTop = valueToY(positiveCursor + value)
-                                const yBottom = valueToY(positiveCursor)
-                                positiveCursor += value
-                                return (
-                                    <rect
-                                        key={`${status}-${i}`}
-                                        x={x}
-                                        y={yTop}
-                                        width={barWidth}
-                                        height={Math.max(yBottom - yTop, 0)}
-                                        fill={LIFECYCLE_COLORS[status]}
-                                    />
-                                )
-                            })}
-                            {NEGATIVE_STATUSES.map((status) => {
-                                if (!isVisible(status)) {
-                                    return null
-                                }
-                                const series = byStatus.get(status)
-                                const value = series?.data[i] ?? 0
-                                if (value >= 0) {
-                                    return null
-                                }
-                                const yTop = valueToY(negativeCursor)
-                                const yBottom = valueToY(negativeCursor + value)
-                                negativeCursor += value
-                                return (
-                                    <rect
-                                        key={`${status}-${i}`}
-                                        x={x}
-                                        y={yTop}
-                                        width={barWidth}
-                                        height={Math.max(yBottom - yTop, 0)}
-                                        fill={LIFECYCLE_COLORS[status]}
-                                    />
-                                )
-                            })}
-                        </g>
-                    )
-                })}
-            </svg>
-
-            {showLegend && visibleBuckets.length > 0 && (
-                <div
-                    style={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: '1rem',
-                        justifyContent: 'center',
-                        marginTop: '0.5rem',
-                        fontSize: '0.75rem',
-                    }}
-                >
-                    {visibleBuckets.map((status) => (
-                        <div key={status} style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-                            <div
-                                style={{
-                                    width: '12px',
-                                    height: '12px',
-                                    borderRadius: '2px',
-                                    backgroundColor: LIFECYCLE_COLORS[status],
-                                }}
-                            />
-                            <span style={{ color: 'var(--color-text-secondary, #6b7280)' }}>{status}</span>
-                        </div>
-                    ))}
-                </div>
-            )}
-        </div>
+        <ChartLegend show={showLegend} items={legendItems} position="top">
+            <div className="flex flex-col w-full h-[400px]">
+                <TimeSeriesBarChart series={series} labels={labels} theme={CHART_THEME} config={config} />
+            </div>
+        </ChartLegend>
     )
 }

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -1,5 +1,7 @@
 import { type ChartTheme } from '@posthog/quill-charts'
 
+import type { LifecycleStatus } from '../types'
+
 // PostHog brand palette. Canvas can't read CSS custom properties, so we hand the
 // chart concrete hexes. The chart picks one per series by index; legends use the
 // same array to stay in sync.
@@ -14,6 +16,17 @@ export const CHART_COLORS = [
 
 // Picks a palette color by index, wrapping when there are more series than colors.
 export const colorAt = (index: number): string => CHART_COLORS[index % CHART_COLORS.length]!
+
+// Conventional lifecycle bucket colors — mirrors --color-lifecycle-* in frontend/src/styles/base.scss.
+export const LIFECYCLE_COLORS: Record<LifecycleStatus, string> = {
+    new: '#1d4aff',
+    returning: '#388600',
+    resurrecting: '#a56eff',
+    dormant: '#db3707',
+}
+
+export const lifecycleColor = (status: string | undefined): string =>
+    LIFECYCLE_COLORS[(status ?? 'new') as LifecycleStatus] ?? LIFECYCLE_COLORS.new
 
 // Single mid-gray for axis labels — readable on both light and dark hosts. Claude
 // Desktop's iframe doesn't set `prefers-color-scheme`, so we can't detect the host


### PR DESCRIPTION
## Problem

[PR #61809](https://github.com/PostHog/posthog/pull/61809) moved the MCP trends app to render with `@posthog/quill-charts` by reusing the web frontend's chart transforms. The other insight types shown in MCP UI apps — retention, lifecycle, and funnels — still rendered with the old bespoke SVG/canvas chart components. This brings **lifecycle** onto the same quill-based path, so the MCP app looks consistent with the product and we maintain one set of chart-building logic.

This is one of three PRs split out of [#62254](https://github.com/PostHog/posthog/pull/62254) (the others cover retention and funnels). Each is independent and based on `master`.

## Changes

Applies the same principle as the trends PR to lifecycle: keep the chart-building logic as pure transforms in `products/product_analytics/frontend/insights/trends/TrendsLifecycleChart`, make the module dependency-neutral, and have the MCP visualizer feed quill's chart components directly.

- `trendsLifecycleChartTransforms` takes an injected `getColor` instead of importing `lib/colors`, and inlines the capitalize helper and the lifecycle status order so it no longer pulls `~/` types via `trendsSeriesMeta`. The `LIFECYCLE_STATUS_ORDER` constant (whose only consumer was this transform) moves out of `trendsSeriesMeta` and is inlined here.
- The web `TrendsLifecycleChart` now passes `getBarColorFromStatus` through the new `getColor` injection point — behaviour unchanged on the web side.
- `LifecycleVisualizer` renders the quill diverging stacked `TimeSeriesBarChart` with a legend; lifecycle bucket colors are added to the MCP chart theme.
- An MCP Storybook story is added and the transform tests tightened.

## How did you test this code?

I'm an agent (Claude Code). I ran only automated checks — and in this split-out branch the JS toolchain wasn't provisioned locally, so I relied on CI:

- The transform, test, web-chart, and visualizer files are carried over unchanged from #62254, where `jest` (72 tests across the four transform suites) and `tsc --noEmit` for both `@posthog/mcp` and the frontend passed.
- The only hand-adapted file here is the Storybook story (inlined its palette/`lifecycleColor`/wrapper so the PR adds no shared helper) — stories are covered by CI visual snapshots.

Storybook visual baselines for the new story will be generated by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #62254 at the author's request into three independent, single-insight PRs (retention / lifecycle / funnels), each rebased onto current `master` now that the trends PR (#61809) has merged. Lifecycle touches the shared MCP chart theme only additively (lifecycle bucket colors) and moves `LIFECYCLE_STATUS_ORDER` out of `trendsSeriesMeta` into the transform that uses it. The story was adapted to inline its palette and fixed-size wrapper so the three split PRs don't conflict on shared new files.
