### PR TITLE
refactor(insights): make lifecycle chart transforms bundle-neutral

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -2,9 +2,10 @@ import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { ChartLegend, TimeSeriesBarChart, legendItemsFromSeries } from '@posthog/quill-charts'
-import type { PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
+import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { getBarColorFromStatus } from 'lib/colors'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -16,6 +17,7 @@ import type { IndexedTrendResult } from 'scenes/trends/types'
 
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import type { LifecycleToggle } from '~/types'
 
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
@@ -26,7 +28,7 @@ import {
 } from '../shared/handleTrendsChartClick'
 import { buildTrendsSeriesMeta, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
 import { TrendsTooltip } from '../shared/TrendsTooltip'
-import { buildTrendsLifecycleConfig, buildTrendsLifecycleSeries } from './trendsLifecycleChartTransforms'
+import { buildLifecycleChartModel } from './trendsLifecycleChartTransforms'
 
 interface TrendsLifecycleChartProps {
     context?: QueryContext<InsightVizNode>
@@ -72,26 +74,20 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
         !!indexedResults[0].data &&
         indexedResults.some((r: IndexedTrendResult) => r.count !== 0)
 
-    const { series, labels } = useMemo(() => {
-        const lifecycleSeries = buildTrendsLifecycleSeries<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
-            buildMeta: buildTrendsSeriesMeta,
-        })
-        return { series: lifecycleSeries, labels: currentPeriodResult?.labels ?? EMPTY_LABELS }
-    }, [indexedResults, currentPeriodResult?.labels])
-
-    const legendItems = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
-
     const valueLabelFormatter = useCallback(
         (value: number) => formatAggregationAxisValue(trendsFilter, value, baseCurrency),
         [trendsFilter, baseCurrency]
     )
 
-    const timeSeriesConfig: TimeSeriesBarChartConfig = useMemo(
+    const { series, labels, config } = useMemo(
         () =>
-            buildTrendsLifecycleConfig({
+            buildLifecycleChartModel<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
+                getColor: (status) => getBarColorFromStatus((status ?? 'new') as LifecycleToggle),
+                buildMeta: buildTrendsSeriesMeta,
+                labels: currentPeriodResult?.labels ?? EMPTY_LABELS,
+                isStacked,
                 trendsFilter,
                 baseCurrency,
-                isStacked,
                 yAxisScaleType,
                 interval,
                 timezone,
@@ -100,17 +96,21 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
                 tooltip: LIFECYCLE_TOOLTIP_CONFIG,
             }),
         [
+            indexedResults,
+            currentPeriodResult?.labels,
+            currentPeriodResult?.days,
+            isStacked,
             trendsFilter,
             baseCurrency,
-            isStacked,
             yAxisScaleType,
             interval,
             timezone,
-            currentPeriodResult?.days,
             showValuesOnSeries,
             valueLabelFormatter,
         ]
     )
+
+    const legendItems = useMemo(() => legendItemsFromSeries(series, theme), [series, theme])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
 
@@ -199,7 +199,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             <TimeSeriesBarChart<TrendsSeriesMeta>
                 series={series}
                 labels={labels}
-                config={timeSeriesConfig}
+                config={config}
                 theme={theme}
                 tooltip={renderTooltip}
                 onPointClick={canHandleClick ? onPointClick : undefined}

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
@@ -1,21 +1,42 @@
-// Static color stub so the test doesn't depend on the runtime CSS variable.
-jest.mock('lib/colors', () => ({
-    ...jest.requireActual('lib/colors'),
-    getBarColorFromStatus: (status: string): string =>
-        ({
-            new: '#11ff11',
-            resurrecting: '#22ff22',
-            returning: '#33ff33',
-            dormant: '#44ff44',
-        })[status] ?? '#000000',
-}))
+import type { TimeInterval } from '@posthog/quill-charts'
 
+import type { CurrencyCode, TrendsFilter as SchemaTrendsFilter } from '~/queries/schema/schema-general'
+import type { IntervalType } from '~/types'
+
+import type { YFormatterFields } from '../shared/trendsChartDisplayOptions'
 import {
+    buildLifecycleChartModel,
     buildTrendsLifecycleConfig,
     buildTrendsLifecycleSeries,
+    filterToggledLifecycleResults,
     shortenLifecycleLabel,
     type TrendsLifecycleResultLike,
 } from './trendsLifecycleChartTransforms'
+
+// The neutral structural types in trendsLifecycleChartTransforms.ts exist so the shared chart code
+// stays free of `~/` and `lib/` imports (the MCP Vite bundle can't resolve them). These helpers'
+// return types enforce that the real schema types stay assignable to the neutral ones — if a schema
+// field ever changes shape, the returns fail to compile and flag the drift here.
+const asNeutralYFormatterFields = (f: NonNullable<SchemaTrendsFilter>): YFormatterFields => f
+const asNeutralCurrency = (c: CurrencyCode): string => c
+const asNeutralInterval = (i: IntervalType): TimeInterval => i
+
+// Static color stub injected via `getColor` — the transform no longer reads CSS variables itself.
+const STATUS_COLORS: Record<string, string> = {
+    new: '#11ff11',
+    resurrecting: '#22ff22',
+    returning: '#33ff33',
+    dormant: '#44ff44',
+}
+const getColor = (status: string | undefined): string => STATUS_COLORS[status ?? ''] ?? '#000000'
+
+describe('schema type firewall', () => {
+    it('keeps the schema TrendsFilter / CurrencyCode / IntervalType assignable to the neutral types', () => {
+        expect(asNeutralYFormatterFields({ decimalPlaces: 2 })).toMatchObject({ decimalPlaces: 2 })
+        expect(asNeutralCurrency('USD' as CurrencyCode)).toBe('USD')
+        expect(asNeutralInterval('day')).toBe('day')
+    })
+})
 
 describe('buildTrendsLifecycleSeries', () => {
     it('orders series dormant → returning → resurrecting → new regardless of input order', () => {
@@ -25,15 +46,16 @@ describe('buildTrendsLifecycleSeries', () => {
             { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1, -2, -3] },
             { id: 'resurrecting', status: 'resurrecting', label: 'Pageview - resurrecting', data: [1, 2, 3] },
         ]
-        const series = buildTrendsLifecycleSeries(results)
+        const series = buildTrendsLifecycleSeries(results, { getColor })
 
         expect(series.map((s) => s.key)).toEqual(['dormant', 'returning', 'resurrecting', 'new'])
     })
 
     it('preserves dormant data as negative — diverging stack relies on the sign', () => {
-        const series = buildTrendsLifecycleSeries([
-            { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-5, -6, -7] },
-        ])
+        const series = buildTrendsLifecycleSeries(
+            [{ id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-5, -6, -7] }],
+            { getColor }
+        )
 
         expect(series[0].data).toEqual([-5, -6, -7])
     })
@@ -45,15 +67,18 @@ describe('buildTrendsLifecycleSeries', () => {
             { id: 'returning', status: 'returning', label: 'Pageview - returning', data: [1, 2, 3] },
             { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1, -2, -3] },
         ]
-        const series = buildTrendsLifecycleSeries(results)
+        const series = buildTrendsLifecycleSeries(results, { getColor })
         expect(series.map((s) => s.color)).toEqual(['#44ff44', '#33ff33', '#22ff22', '#11ff11'])
     })
 
     it('shortens series labels to capitalized status — used by both legend and tooltip', () => {
-        const series = buildTrendsLifecycleSeries([
-            { id: 'new', status: 'new', label: 'Pageview - new', data: [1] },
-            { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1] },
-        ])
+        const series = buildTrendsLifecycleSeries(
+            [
+                { id: 'new', status: 'new', label: 'Pageview - new', data: [1] },
+                { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1] },
+            ],
+            { getColor }
+        )
         expect(series.find((s) => s.key === 'new')?.label).toBe('New')
         expect(series.find((s) => s.key === 'dormant')?.label).toBe('Dormant')
     })
@@ -65,18 +90,17 @@ describe('buildTrendsLifecycleSeries', () => {
         ]
         const calls: Array<{ status: string; index: number }> = []
         buildTrendsLifecycleSeries(results, {
+            getColor,
             buildMeta: (r, i) => {
                 calls.push({ status: r.status!, index: i })
                 return r.status
             },
         })
         // dormant was at original index 0, new at original index 1 — order is preserved in the callback.
-        expect(calls).toEqual(
-            expect.arrayContaining([
-                { status: 'dormant', index: 0 },
-                { status: 'new', index: 1 },
-            ])
-        )
+        expect(calls).toEqual([
+            { status: 'dormant', index: 0 },
+            { status: 'new', index: 1 },
+        ])
     })
 
     it('marks excluded series with visibility.excluded so the chart skips them', () => {
@@ -85,6 +109,7 @@ describe('buildTrendsLifecycleSeries', () => {
             { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1] },
         ]
         const series = buildTrendsLifecycleSeries(results, {
+            getColor,
             getHidden: (r) => r.status === 'dormant',
         })
         const dormant = series.find((s) => s.key === 'dormant')
@@ -94,8 +119,71 @@ describe('buildTrendsLifecycleSeries', () => {
     })
 
     it('falls back to "None" label when the result label is null', () => {
-        const series = buildTrendsLifecycleSeries([{ id: 'new', status: 'new', label: null, data: [1] }])
+        const series = buildTrendsLifecycleSeries([{ id: 'new', status: 'new', label: null, data: [1] }], { getColor })
         expect(series[0].label).toBe('None')
+    })
+})
+
+describe('filterToggledLifecycleResults', () => {
+    const rows = [
+        { status: 'new', data: [1] },
+        { status: 'returning', data: [2] },
+        { status: 'dormant', data: [-3] },
+    ]
+
+    it('returns every row unchanged when no toggle is set', () => {
+        expect(filterToggledLifecycleResults(rows, undefined)).toBe(rows)
+    })
+
+    it('keeps only rows whose status is toggled on', () => {
+        expect(filterToggledLifecycleResults(rows, ['new', 'dormant'])).toEqual([
+            { status: 'new', data: [1] },
+            { status: 'dormant', data: [-3] },
+        ])
+    })
+
+    it('drops rows without a status once a toggle is active', () => {
+        const withUnstatused = [...rows, { status: undefined, data: [9] }]
+        expect(filterToggledLifecycleResults(withUnstatused, ['new'])).toEqual([{ status: 'new', data: [1] }])
+    })
+})
+
+describe('buildLifecycleChartModel', () => {
+    const results: TrendsLifecycleResultLike[] = [
+        { id: 'new', status: 'new', label: 'Pageview - new', data: [1, 2] },
+        { id: 'dormant', status: 'dormant', label: 'Pageview - dormant', data: [-1, -2] },
+    ]
+
+    it('assembles series + config and passes the host labels through', () => {
+        const model = buildLifecycleChartModel(results, {
+            getColor,
+            labels: ['Jun 1', 'Jun 2'],
+            isStacked: true,
+        })
+
+        expect(model.labels).toEqual(['Jun 1', 'Jun 2'])
+        expect(model.series.map((s) => s.key)).toEqual(['dormant', 'new'])
+        expect(model.config.barLayout).toBe('stacked')
+        expect(model.config.divergingStack).toBe(true)
+    })
+
+    it('applies the toggledLifecycles filter before building series', () => {
+        const model = buildLifecycleChartModel(results, {
+            getColor,
+            labels: ['Jun 1', 'Jun 2'],
+            isStacked: false,
+            toggledLifecycles: ['new'],
+        })
+
+        expect(model.series.map((s) => s.key)).toEqual(['new'])
+        expect(model.config.barLayout).toBe('grouped')
+    })
+
+    it('forwards the tooltip config through to the chart config', () => {
+        const tooltip = { pinnable: true, placement: 'top' as const }
+        const model = buildLifecycleChartModel(results, { getColor, labels: [], isStacked: true, tooltip })
+
+        expect(model.config.tooltip).toBe(tooltip)
     })
 })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.ts
@@ -1,15 +1,16 @@
-import type { Series, TimeSeriesBarChartConfig } from '@posthog/quill-charts'
-
-import { getBarColorFromStatus } from 'lib/colors'
-import { capitalizeFirstLetter } from 'lib/utils'
-
-import type { CurrencyCode, TrendsFilter } from '~/queries/schema/schema-general'
-import type { IntervalType, LifecycleToggle } from '~/types'
+import type { Series, TimeInterval, TimeSeriesBarChartConfig } from '@posthog/quill-charts'
 
 import { buildTrendsYAxisConfig } from '../shared/trendsAxisFormat'
-import { LIFECYCLE_STATUS_ORDER } from '../shared/trendsSeriesMeta'
+import type { YFormatterFields } from '../shared/trendsChartDisplayOptions'
 
-// Shape both IndexedTrendResult (kea) and lighter fixtures satisfy.
+// Canonical lifecycle status enumeration: new → resurrecting → returning → dormant. Declared here
+// (rather than imported from trendsSeriesMeta, which pulls in `~/` types) so this module stays free
+// of `~/`/`lib/` deps and compiles in the MCP Vite bundle, which only resolves `products/*` and
+// `@posthog/*`. The lifecycle chart renders series in the reverse order (dormant first) to match the
+// legacy chart (`trendsDataLogic.ts:197`).
+const LIFECYCLE_STATUS_ORDER: readonly string[] = ['new', 'resurrecting', 'returning', 'dormant']
+
+// Shape both IndexedTrendResult (kea) and lighter fixtures (e.g. the MCP UI app) satisfy.
 export interface TrendsLifecycleResultLike {
     id?: string | number
     label?: string | null
@@ -20,27 +21,36 @@ export interface TrendsLifecycleResultLike {
 }
 
 function lifecycleStatusOrder(status: string | undefined): number {
-    const i = LIFECYCLE_STATUS_ORDER.indexOf(status as LifecycleToggle)
+    const i = LIFECYCLE_STATUS_ORDER.indexOf(status ?? '')
     return i === -1 ? LIFECYCLE_STATUS_ORDER.length : i
 }
 
-// `dormant` is the only lifecycle status whose values are emitted as negatives,
-// so a diverging stack lays it below the zero baseline. The non-dormant series
-// are pinned to their fixed lifecycle colors regardless of the data-color theme.
-// Unknown statuses fall through to `getBarColorFromStatus`, which throws — we
-// surface the bad data rather than silently miscoloring it as the "new" series.
-function lifecycleColor(status: string | undefined): string {
-    return getBarColorFromStatus((status ?? 'new') as LifecycleToggle)
+/** Drops rows whose lifecycle status is toggled off — mirrors the main app's legend toggles, which
+ *  the MCP host honors from the query (the web chart toggles interactively instead). With no toggle
+ *  set every row passes; once a toggle is active, a row without a status is dropped. */
+export function filterToggledLifecycleResults<R extends { status?: string }>(
+    results: R[],
+    toggledLifecycles: readonly string[] | undefined
+): R[] {
+    if (!toggledLifecycles) {
+        return results
+    }
+    return results.filter((r) => !!r.status && toggledLifecycles.includes(r.status))
 }
 
 export interface BuildTrendsLifecycleSeriesOpts<R extends TrendsLifecycleResultLike, M = unknown> {
+    // Injected so the transform stays free of `lib/colors` (the MCP bundle can't resolve it). Web
+    // passes `getBarColorFromStatus`, which throws on unknown statuses — surfacing bad data rather
+    // than silently miscoloring it. `dormant` is the only status emitted as negatives, so a diverging
+    // stack lays it below the zero baseline regardless of color.
+    getColor: (status: string | undefined) => string
     getHidden?: (r: R, index: number) => boolean
     buildMeta?: (r: R, index: number) => M
 }
 
 export function buildTrendsLifecycleSeries<R extends TrendsLifecycleResultLike, M = unknown>(
     results: R[],
-    opts: BuildTrendsLifecycleSeriesOpts<R, M> = {}
+    opts: BuildTrendsLifecycleSeriesOpts<R, M>
 ): Series<M>[] {
     // Stable lifecycle order: dormant → returning → resurrecting → new — matches the
     // legacy lifecycle chart (`trendsDataLogic.ts:197`) so the legend reads top-down the
@@ -60,7 +70,7 @@ export function buildTrendsLifecycleSeries<R extends TrendsLifecycleResultLike, 
             // shortened here so both legend and tooltip pick up the clean form.
             label: shortenLifecycleLabel(r.label),
             data: r.data,
-            color: lifecycleColor(r.status),
+            color: opts.getColor(r.status),
             meta,
             visibility: excluded ? { excluded: true } : undefined,
         }
@@ -68,11 +78,11 @@ export function buildTrendsLifecycleSeries<R extends TrendsLifecycleResultLike, 
 }
 
 export interface BuildTrendsLifecycleConfigOpts {
-    trendsFilter?: TrendsFilter | null
-    baseCurrency?: CurrencyCode
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     isStacked: boolean
     yAxisScaleType?: string | null
-    interval?: IntervalType | null
+    interval?: TimeInterval | null
     timezone?: string
     allDays?: string[]
     valueLabels?: TimeSeriesBarChartConfig['valueLabels']
@@ -99,10 +109,48 @@ export function buildTrendsLifecycleConfig(opts: BuildTrendsLifecycleConfigOpts)
     }
 }
 
+export interface BuildLifecycleChartModelOpts<
+    R extends TrendsLifecycleResultLike,
+    M = unknown,
+> extends BuildTrendsLifecycleConfigOpts {
+    /** Final x-axis labels (already formatted by the host — kea dates vs the MCP `formatDate`). */
+    labels: string[]
+    getColor: (status: string | undefined) => string
+    /** Client-side legend toggle state. Omit on hosts that toggle interactively (the web chart). */
+    toggledLifecycles?: readonly string[]
+    getHidden?: (r: R, index: number) => boolean
+    buildMeta?: (r: R, index: number) => M
+}
+
+/** The complete input a host hands to quill's `TimeSeriesBarChart` for a lifecycle chart. */
+export interface LifecycleChartModel<M = unknown> {
+    series: Series<M>[]
+    labels: string[]
+    config: TimeSeriesBarChartConfig
+}
+
+/** Assembles the full lifecycle chart model (filter → series → config) so both the web container and
+ *  the MCP visualizer share one tested path; each injects only host-specific bits (color, labels,
+ *  tooltip, meta, interactivity flags). */
+export function buildLifecycleChartModel<R extends TrendsLifecycleResultLike, M = unknown>(
+    results: R[],
+    opts: BuildLifecycleChartModelOpts<R, M>
+): LifecycleChartModel<M> {
+    const visible = filterToggledLifecycleResults(results, opts.toggledLifecycles)
+    const series = buildTrendsLifecycleSeries<R, M>(visible, {
+        getColor: opts.getColor,
+        getHidden: opts.getHidden,
+        buildMeta: opts.buildMeta,
+    })
+    const config = buildTrendsLifecycleConfig(opts)
+    return { series, labels: opts.labels, config }
+}
+
 /** Lifecycle series labels arrive as "Pageview - new", "Pageview - returning", etc.
  *  Returns just the capitalized status ("New", "Returning"). */
 export function shortenLifecycleLabel(label: string | null | undefined): string {
     const parts = label?.split(' - ')
     const tail = parts?.[parts.length - 1] ?? label ?? 'None'
-    return capitalizeFirstLetter(tail)
+    // Inlined rather than imported from `lib/utils` so this module stays MCP-bundle-safe.
+    return tail.charAt(0).toUpperCase() + tail.slice(1)
 }

--- a/products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta.ts
@@ -2,7 +2,7 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
 import type { Noun } from '~/models/groupsModel'
-import type { ActionFilter, LifecycleToggle } from '~/types'
+import type { ActionFilter } from '~/types'
 
 export type TrendsSeriesMeta = {
     action?: ActionFilter
@@ -12,11 +12,6 @@ export type TrendsSeriesMeta = {
     order?: number
     filter?: SeriesDatum['filter']
 }
-
-/** Canonical lifecycle status enumeration: new → resurrecting → returning → dormant.
- *  The lifecycle chart renders series in the reverse order (dormant first) to match the
- *  legacy chart (`trendsDataLogic.ts:197`); see `trendsLifecycleChartTransforms.ts`. */
-export const LIFECYCLE_STATUS_ORDER: readonly LifecycleToggle[] = ['new', 'resurrecting', 'returning', 'dormant']
 
 export const buildTrendsSeriesMeta = (r: IndexedTrendResult): TrendsSeriesMeta => ({
     action: r.action,


### PR DESCRIPTION
## Problem

[PR #61809](https://github.com/PostHog/posthog/pull/61809) moved the MCP trends app to render with `@posthog/quill-charts` by reusing the web frontend's chart transforms. We're bringing the remaining insight types onto the same path. This is the **prep half** for lifecycle: making the chart-building transforms dependency-neutral so the MCP Vite bundle can reuse them.

This is part 1 of 2 for lifecycle — the follow-up PR swaps the MCP visualizer onto quill. Split out of [#62254](https://github.com/PostHog/posthog/pull/62254) / [#62402](https://github.com/PostHog/posthog/pull/62402) to keep each PR under ~500 LOC.

## Changes

- `trendsLifecycleChartTransforms` takes an injected `getColor` instead of importing `lib/colors`, and inlines the capitalize helper and the lifecycle status order so it no longer pulls `~/` types via `trendsSeriesMeta`.
- The `LIFECYCLE_STATUS_ORDER` constant (whose only consumer was this transform) moves out of `trendsSeriesMeta` and is inlined here.
- The web `TrendsLifecycleChart` now passes `getBarColorFromStatus` through the new `getColor` injection point — behaviour unchanged on the web side.
- Tightens the transform tests.

## How did you test this code?

I'm an agent (Claude Code). Automated checks only; the JS toolchain wasn't provisioned in this split-out environment, so I relied on CI:

- These files are carried over unchanged from [#62254](https://github.com/PostHog/posthog/pull/62254), where `jest` (the transform suites) and `tsc --noEmit` for both `@posthog/mcp` and the frontend passed.
- Verified `LIFECYCLE_STATUS_ORDER`'s only consumer was this transform, so moving it out of `trendsSeriesMeta` is safe.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #62254 at the author's request, then further halved (web-transform-prep vs MCP-render) to keep each PR under ~500 LOC. This is the prep half; the MCP-render PR stacks on it.
