### PR TITLE
chore(azure-batch-exports): Raise non-retryable authorization failure

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -5,6 +5,7 @@ import dataclasses
 from django.conf import settings
 
 from azure.core.exceptions import HttpResponseError
+from azure.storage.blob import StorageErrorCode
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient, ExponentialRetry
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
@@ -94,6 +95,14 @@ class MissingRequiredPermissionsError(Exception):
 
     def __init__(self):
         super().__init__("Missing required permissions to run this batch export")
+
+
+def _is_authorization_failure_response_error(err: HttpResponseError) -> bool:
+    """Check if the provided response error is an authorization failure.
+
+    'error_code' is monkey-patched dynamically so we must use 'getattr' for type checkers.
+    """
+    return getattr(err, "error_code", None) == StorageErrorCode.AUTHORIZATION_FAILURE
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -227,7 +236,7 @@ class AzureBlobConsumer(Consumer):
                 max_concurrency=self.max_concurrency,
             )
         except HttpResponseError as exc:
-            if exc.error is not None and exc.error.code == "AuthorizationFailure":
+            if _is_authorization_failure_response_error(exc):
                 raise MissingRequiredPermissionsError()
             else:
                 raise
@@ -253,7 +262,7 @@ class AzureBlobConsumer(Consumer):
                 overwrite=True,
             )
         except HttpResponseError as exc:
-            if exc.error is not None and exc.error.code == "AuthorizationFailure":
+            if _is_authorization_failure_response_error(exc):
                 raise MissingRequiredPermissionsError()
             else:
                 raise


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

The response error does not have the error parameter set, we must instead rely on the dynamically set error_code to determine if this is an authorization failure, and raise the correct non-retryable error.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I haven't

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I used the robot to dig through the azure repo to find where this is set, and verified it myself, it's here: https://github.com/Azure/azure-sdk-for-python/blob/b1c1c091bbfda009d8bef15f9ac8e7db9dbf8bae/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py#L85.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
