### PR TITLE
fix(hogli): reliably kill escaped processes on dev stack shutdown

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -333,13 +333,11 @@ start:
         description: Block until the detached dev stack is ready
         preserve_exit_code: true
     stop:
-        cmd: phrocs stop
-        description: Stop the detached dev stack gracefully
-        preserve_exit_code: true
+        click: hogli_commands.devenv.cli:dev_stop
+        description: Stop the detached dev stack gracefully and clean up any leftover processes
     down:
-        cmd: phrocs stop
+        click: hogli_commands.devenv.cli:dev_down
         description: Alias for `hogli stop`
-        preserve_exit_code: true
     start:backend:
         bin_script: start-backend
         description: Run Django development server on port 8000 with auto-reload

--- a/tools/hogli-commands/hogli_commands/devenv/cli.py
+++ b/tools/hogli-commands/hogli_commands/devenv/cli.py
@@ -380,7 +380,14 @@ def _stop_dev_stack(timeout: int, yes: bool, no_sweep: bool) -> None:
     if not no_sweep:
         # Safety net: phrocs now reaps escaped descendants itself, but processes
         # orphaned by an earlier unclean shutdown still linger — clean those too.
-        sweep_orphaned_processes(assume_yes=yes)
+        # The sweep is best-effort: stop already succeeded, so never let it mask
+        # phrocs' exit code (e.g. Ctrl+C at the confirm prompt, or a sweep bug).
+        try:
+            sweep_orphaned_processes(assume_yes=yes)
+        except click.Abort:
+            click.echo("Cleanup skipped — run `hogli doctor:zombies` later to remove leftovers.")
+        except Exception as exc:
+            click.echo(f"Cleanup sweep failed: {exc}", err=True)
 
     raise SystemExit(result.returncode)
 

--- a/tools/hogli-commands/hogli_commands/devenv/cli.py
+++ b/tools/hogli-commands/hogli_commands/devenv/cli.py
@@ -352,3 +352,59 @@ def docker_services_up(yes: bool) -> None:
     # cmd is built from internal config (intent-map.yaml), not user input
     result = subprocess.run(cmd, shell=True)  # nosemgrep: subprocess-shell-true
     raise SystemExit(result.returncode)
+
+
+def _stop_dev_stack(timeout: int, yes: bool, no_sweep: bool) -> None:
+    """Stop the detached dev stack via phrocs, then sweep up any dev processes
+    that escaped phrocs shutdown (build daemons, compilers) so nothing is left
+    serving stale content. The sweep stays silent when nothing leaked. Raises
+    SystemExit with phrocs' own exit code.
+    """
+    import shutil
+    import subprocess
+
+    from hogli.manifest import REPO_ROOT
+
+    from ..doctor import sweep_orphaned_processes
+
+    phrocs = shutil.which("phrocs")
+    if phrocs is None:
+        click.echo(click.style("💥 phrocs not found on PATH; cannot stop the dev stack", fg="red", bold=True), err=True)
+        raise SystemExit(127)
+
+    cmd = [phrocs, "stop", "--timeout", str(timeout)]
+    click.echo(f"🚀 {' '.join(cmd)}")
+    # phrocs stop owns its own exit-code contract; preserve it for callers.
+    result = subprocess.run(cmd, cwd=REPO_ROOT, check=False)
+
+    if not no_sweep:
+        # Safety net: phrocs now reaps escaped descendants itself, but processes
+        # orphaned by an earlier unclean shutdown still linger — clean those too.
+        sweep_orphaned_processes(assume_yes=yes)
+
+    raise SystemExit(result.returncode)
+
+
+_STOP_TIMEOUT_OPTION = click.option(
+    "--timeout", type=int, default=300, show_default=True, help="Seconds to wait for graceful shutdown"
+)
+_STOP_YES_OPTION = click.option("--yes", "-y", is_flag=True, help="Auto-confirm cleanup of any leftover processes")
+_STOP_NO_SWEEP_OPTION = click.option("--no-sweep", is_flag=True, help="Skip the post-shutdown cleanup sweep")
+
+
+@click.command(name="stop", help="Stop the detached dev stack gracefully and clean up any leftovers")
+@_STOP_TIMEOUT_OPTION
+@_STOP_YES_OPTION
+@_STOP_NO_SWEEP_OPTION
+def dev_stop(timeout: int, yes: bool, no_sweep: bool) -> None:
+    """Stop the detached dev stack and clean up any leftover processes."""
+    _stop_dev_stack(timeout, yes, no_sweep)
+
+
+@click.command(name="down", help="Alias for `hogli stop`")
+@_STOP_TIMEOUT_OPTION
+@_STOP_YES_OPTION
+@_STOP_NO_SWEEP_OPTION
+def dev_down(timeout: int, yes: bool, no_sweep: bool) -> None:
+    """Alias for `hogli stop`."""
+    _stop_dev_stack(timeout, yes, no_sweep)

--- a/tools/hogli-commands/hogli_commands/doctor.py
+++ b/tools/hogli-commands/hogli_commands/doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 import enum
 import time
 import shutil
@@ -1066,6 +1067,47 @@ def doctor_zombies(dry_run: bool, yes: bool, include_all: bool) -> None:
         click.echo(f"   {failed} process(es) could not be killed")
 
     _record()
+
+
+def sweep_orphaned_processes(*, assume_yes: bool) -> int:
+    """Find PostHog dev processes that escaped phrocs shutdown and offer to kill them.
+
+    Used by `hogli stop`/`down` as a post-shutdown safety net: after phrocs exits,
+    any dev process it didn't manage to reap is now reparented (orphaned), which is
+    exactly what `_scan_posthog_processes` flags. Stays silent when nothing leaked.
+    Returns the number of processes killed.
+    """
+
+    from hogli.manifest import REPO_ROOT
+
+    orphans = [p for p in _scan_posthog_processes(REPO_ROOT) if p.is_orphan]
+    if not orphans:
+        return 0
+
+    click.echo(f"\n⚠️  {len(orphans)} dev process(es) survived shutdown and are still running:\n")
+    _display_process_table(orphans, "Leftover processes", REPO_ROOT)
+    total_rss = sum(p.memory_rss_kb for p in orphans)
+    click.echo(f"   Total: {len(orphans)} process(es) using ~{_format_rss(total_rss)}\n")
+
+    if assume_yes:
+        selected = orphans
+    elif not sys.stdin.isatty():
+        click.echo("Not an interactive terminal; leaving them running. Run `hogli doctor:zombies` to clean up.")
+        return 0
+    elif click.confirm(f"   Kill these {len(orphans)} leftover process(es)?", default=True):
+        selected = orphans
+    else:
+        click.echo("Left running. Run `hogli doctor:zombies` later to clean up.")
+        return 0
+
+    killed_pids, failed = _kill_processes(selected)
+    freed_rss = sum(p.memory_rss_kb for p in selected if p.pid in killed_pids)
+    click.echo(f"\nCleaned up {len(killed_pids)} leftover process(es).")
+    if freed_rss > 0:
+        click.echo(f"   Freed ~{_format_rss(freed_rss)} RSS")
+    if failed > 0:
+        click.echo(f"   {failed} process(es) could not be killed")
+    return len(killed_pids)
 
 
 def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:

--- a/tools/hogli-commands/hogli_commands/tests/test_detached.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_detached.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import subprocess
 from typing import Any
 
 import pytest
 
 from click.testing import CliRunner
 from hogli.cli import cli
+from hogli.manifest import REPO_ROOT
 
 runner = CliRunner()
 
@@ -72,35 +74,65 @@ def test_wait_forwards_args_and_preserves_exit_code(monkeypatch: pytest.MonkeyPa
     assert captured["kwargs"]["preserve_exit_code"] is True
 
 
-def test_stop_forwards_timeout_and_preserves_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, Any] = {}
+def _patch_stop(monkeypatch: pytest.MonkeyPatch, returncode: int) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Stub out the phrocs subprocess and the post-stop sweep for stop/down tests.
 
-    def fake_run(command, **kwargs) -> None:
+    Returns (captured_run, sweep_calls): the args passed to subprocess.run and the
+    kwargs each sweep invocation received.
+    """
+    captured: dict[str, Any] = {}
+    sweep_calls: dict[str, Any] = {}
+
+    def fake_run(command, **kwargs) -> subprocess.CompletedProcess:
         captured["command"] = command
         captured["kwargs"] = kwargs
-        raise SystemExit(2)
+        return subprocess.CompletedProcess(command, returncode)
 
-    monkeypatch.setattr("hogli.command_types._run", fake_run)
+    def fake_sweep(**kwargs) -> int:
+        sweep_calls.update(kwargs)
+        sweep_calls["called"] = True
+        return 0
+
+    monkeypatch.setattr("shutil.which", lambda name: "phrocs")
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("hogli_commands.doctor.sweep_orphaned_processes", fake_sweep)
+    return captured, sweep_calls
+
+
+def test_stop_forwards_timeout_and_preserves_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured, sweep_calls = _patch_stop(monkeypatch, returncode=2)
 
     result = runner.invoke(cli, ["stop", "--timeout", "42"])
 
     assert result.exit_code == 2
     assert captured["command"] == ["phrocs", "stop", "--timeout", "42"]
-    assert captured["kwargs"]["preserve_exit_code"] is True
+    assert captured["kwargs"]["cwd"] == REPO_ROOT
+    assert sweep_calls == {"assume_yes": False, "called": True}
 
 
 def test_down_forwards_timeout_and_preserves_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, Any] = {}
-
-    def fake_run(command, **kwargs) -> None:
-        captured["command"] = command
-        captured["kwargs"] = kwargs
-        raise SystemExit(2)
-
-    monkeypatch.setattr("hogli.command_types._run", fake_run)
+    captured, sweep_calls = _patch_stop(monkeypatch, returncode=2)
 
     result = runner.invoke(cli, ["down", "--timeout", "42"])
 
     assert result.exit_code == 2
     assert captured["command"] == ["phrocs", "stop", "--timeout", "42"]
-    assert captured["kwargs"]["preserve_exit_code"] is True
+    assert sweep_calls == {"assume_yes": False, "called": True}
+
+
+def test_stop_yes_flag_auto_confirms_sweep(monkeypatch: pytest.MonkeyPatch) -> None:
+    _captured, sweep_calls = _patch_stop(monkeypatch, returncode=0)
+
+    result = runner.invoke(cli, ["stop", "--yes"])
+
+    assert result.exit_code == 0
+    assert sweep_calls == {"assume_yes": True, "called": True}
+
+
+def test_stop_no_sweep_skips_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    _captured, sweep_calls = _patch_stop(monkeypatch, returncode=0)
+
+    result = runner.invoke(cli, ["stop", "--no-sweep"])
+
+    assert result.exit_code == 0
+    assert sweep_calls == {}

--- a/tools/hogli-commands/hogli_commands/tests/test_detached.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_detached.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+import click
 from click.testing import CliRunner
 from hogli.cli import cli
 from hogli.manifest import REPO_ROOT
@@ -136,3 +137,18 @@ def test_stop_no_sweep_skips_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert result.exit_code == 0
     assert sweep_calls == {}
+
+
+def test_stop_sweep_failure_does_not_mask_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    # stop already succeeded; a failing/aborted cleanup sweep must still surface
+    # phrocs' own exit code rather than the swept exception.
+    _patch_stop(monkeypatch, returncode=2)
+
+    def boom(**kwargs) -> int:
+        raise click.Abort()
+
+    monkeypatch.setattr("hogli_commands.doctor.sweep_orphaned_processes", boom)
+
+    result = runner.invoke(cli, ["stop"])
+
+    assert result.exit_code == 2

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -25,6 +25,11 @@ import (
 const metricsSampleInterval = 1 * time.Second
 const flushInterval = 16 * time.Millisecond
 const stopGracePeriod = 3 * time.Second
+
+// stragglerGracePeriod is the brief window we give descendants that escaped the
+// tracked process group (build daemons, pnpm-spawned workers) to honor the
+// earlier SIGTERM before we force-kill them on shutdown.
+const stragglerGracePeriod = 500 * time.Millisecond
 const defaultShell = "/bin/bash"
 
 type Status int
@@ -824,39 +829,56 @@ func (p *Process) stopSignal() syscall.Signal {
 	}
 }
 
-// killProcessGroup sends the configured stop signal to the process group
-// and walks the tree to catch escaped descendants. Must hold p.mu.
-func (p *Process) killProcessGroup() {
+// killProcessGroup sends the configured stop signal to the process group and
+// walks the tree to catch escaped descendants. It returns the PIDs of every
+// process it signalled (the tracked process plus all descendants found while
+// the tree was still intact) so the caller can force-kill any that outlive the
+// group kill. Must hold p.mu.
+func (p *Process) killProcessGroup() []int {
 	if p.cmd == nil || p.cmd.Process == nil {
-		return
+		return nil
 	}
 	// If the tracked command has already exited, avoid signaling based on a potentially reused PID.
 	if p.waitDone != nil {
 		select {
 		case <-p.waitDone:
-			return
+			return nil
 		default:
 		}
 	}
 
 	sig := p.stopSignal()
 	pid := p.cmd.Process.Pid
+
+	// Capture the full process tree BEFORE signalling. If we signalled first, a
+	// fast-exiting parent could reparent its escaped descendants to init before
+	// the walk runs, and we'd never find them again to force-kill them later.
+	var treePIDs []int
+	if ps, err := gops.NewProcess(int32(pid)); err == nil {
+		for _, proc := range collectProcessTree(ps) {
+			treePIDs = append(treePIDs, int(proc.Pid))
+		}
+	}
+
+	// Signal the whole group in one shot (catches same-group descendants), then
+	// every captured PID directly to reach those that escaped into their own
+	// process group (e.g. pnpm spawns node as a detached child).
 	if err := syscall.Kill(-pid, sig); err != nil {
 		_ = p.cmd.Process.Signal(sig)
 	}
-	// Walk the full process tree to catch any descendants that escaped the
-	// process group (e.g. pnpm spawns node as a detached child).
-	if ps, err := gops.NewProcess(int32(pid)); err == nil {
-		for _, proc := range collectProcessTree(ps) {
-			_ = proc.SendSignal(sig)
+	for _, dpid := range treePIDs {
+		if dpid != pid {
+			_ = syscall.Kill(dpid, sig)
 		}
 	}
+	return treePIDs
 }
 
-// Stop sends SIGTERM, waits for exit, and escalates to SIGKILL.
+// Stop sends SIGTERM, waits for exit, escalates to SIGKILL, and finally reaps
+// any descendant that escaped the tracked process group.
 func (p *Process) Stop() {
 	p.mu.Lock()
-	p.killProcessGroup()
+	treePIDs := p.killProcessGroup()
 	if p.ptmx != nil {
 		_ = p.ptmx.Close()
 		p.ptmx = nil
@@ -873,25 +895,66 @@ func (p *Process) Stop() {
 	if cmd == nil || cmd.Process == nil {
 		return
 	}
+	pid := cmd.Process.Pid
 
-	// Wait for graceful exit, then escalate to SIGKILL
+	// Wait for graceful exit, then escalate to SIGKILL on the tracked group.
 	if waitDone != nil {
 		select {
 		case <-waitDone:
-			return
 		case <-time.After(stopGracePeriod):
+			if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+				_ = cmd.Process.Kill()
+			}
+			// Give the kernel a moment to reap after SIGKILL
+			select {
+			case <-waitDone:
+			case <-time.After(200 * time.Millisecond):
+			}
 		}
+	}
 
-		pid := cmd.Process.Pid
-		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-			_ = cmd.Process.Kill()
-		}
+	// A single kill(-pid) only reaches the tracked process group. Descendants
+	// that set up their own session (build daemons, pnpm-spawned workers)
+	// survive it and keep serving stale content, so reap the tree we captured
+	// before teardown — this is what prevents dangling builders/compilers.
+	p.reapEscapedDescendants(treePIDs, pid)
+}
 
-		// Give the kernel a moment to reap after SIGKILL
-		select {
-		case <-waitDone:
-		case <-time.After(200 * time.Millisecond):
+// reapEscapedDescendants force-kills any captured descendant that is still alive
+// after the tracked process has been stopped. The PIDs were collected while the
+// tree was still intact; we give well-behaved descendants a brief grace to honor
+// the earlier SIGTERM, then SIGKILL whatever remains. PIDs may have been recycled
+// during the grace window, so this is best-effort by design.
+func (p *Process) reapEscapedDescendants(pids []int, mainPID int) {
+	self := os.Getpid()
+	survivors := func() []int {
+		var out []int
+		for _, pid := range pids {
+			// Skip the tracked process (already handled), our own PID, and
+			// init — never signal those.
+			if pid <= 1 || pid == mainPID || pid == self {
+				continue
+			}
+			if syscall.Kill(pid, syscall.Signal(0)) == nil {
+				out = append(out, pid)
+			}
 		}
+		return out
+	}
+
+	remaining := survivors()
+	if len(remaining) == 0 {
+		return
+	}
+	deadline := time.Now().Add(stragglerGracePeriod)
+	for time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		if remaining = survivors(); len(remaining) == 0 {
+			return
+		}
+	}
+	for _, pid := range remaining {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
 	}
 }
 

--- a/tools/phrocs/internal/process/proc_test.go
+++ b/tools/phrocs/internal/process/proc_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"syscall"
@@ -274,6 +275,82 @@ func TestStop_kills_entire_process_group(t *testing.T) {
 	}
 	if pidAlive(grandchildPID) {
 		t.Errorf("grandchild PID %d still alive after Stop — process group kill didn't work", grandchildPID)
+	}
+	if p.Status() != StatusStopped {
+		t.Errorf("status: got %s, want stopped", p.Status())
+	}
+}
+
+func TestStop_kills_escaped_process_group(t *testing.T) {
+	// Reproduces the dangling-builder leak: a descendant that escapes into its
+	// own session (setsid → new pgid) AND ignores SIGTERM (like a build daemon
+	// that doesn't shut down gracefully) is reached by neither the group kill
+	// (wrong pgid) nor the tree-walk SIGTERM (ignored). Stop() must capture the
+	// tree before teardown and force-kill it anyway.
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid not available; cannot create an escaped process group")
+	}
+
+	// The trailing `true` stops bash from exec-replacing itself with sleep,
+	// which would drop the SIGTERM trap.
+	p := NewProcess("test-escaped", config.ProcConfig{
+		Shell: `setsid bash -c 'trap "" TERM; sleep 999; true' & echo "ESCAPED_PID=$!"; wait`,
+	}, 1000, "")
+
+	send, _, _ := collectMsgs()
+	if err := p.Start(send); err != nil {
+		t.Skipf("skipping: cannot spawn subprocess: %v", err)
+	}
+
+	var escapedPID int
+	deadline := time.After(5 * time.Second)
+	for escapedPID == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for escaped PID in output")
+		default:
+		}
+		for _, line := range p.Lines() {
+			if strings.HasPrefix(line, "ESCAPED_PID=") {
+				_, _ = fmt.Sscanf(line, "ESCAPED_PID=%d", &escapedPID)
+			}
+		}
+		if escapedPID == 0 {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	// Never leak the escaped process if an assertion below fails — it ignores
+	// SIGTERM, so without this a failing run leaves it running.
+	t.Cleanup(func() { _ = syscall.Kill(escapedPID, syscall.SIGKILL) })
+
+	if !pidAlive(escapedPID) {
+		t.Fatalf("escaped PID %d not alive before Stop", escapedPID)
+	}
+	// Confirm it really escaped into its own process group, otherwise the test
+	// would pass trivially via the group kill rather than exercising the reap.
+	if pgid, err := syscall.Getpgid(escapedPID); err == nil && pgid == p.PID() {
+		t.Fatalf("escaped PID %d shares the tracked process group (pgid %d); test setup invalid", escapedPID, pgid)
+	}
+
+	p.Stop()
+
+	// Poll for actual death: a just-SIGKILLed process lingers as a zombie until
+	// its reparented init reaps it, and kill(pid, 0) still succeeds during that
+	// window, so a single immediate check would be racy.
+	dead := false
+	deadline = time.After(2 * time.Second)
+	for !dead {
+		select {
+		case <-deadline:
+			t.Errorf("escaped PID %d still alive after Stop — tree reap didn't reach it", escapedPID)
+			return
+		default:
+		}
+		dead = !pidAlive(escapedPID)
+		if !dead {
+			time.Sleep(50 * time.Millisecond)
+		}
 	}
 	if p.Status() != StatusStopped {
 		t.Errorf("status: got %s, want stopped", p.Status())

--- a/tools/phrocs/main.go
+++ b/tools/phrocs/main.go
@@ -175,6 +175,12 @@ func runInteractive(configPath string, debug bool) int {
 	mgr := process.NewManager(cfg)
 	m := tui.New(mgr, cfg, resolved, logger)
 
+	// Safety net: tear down all child processes on every exit path, not just the
+	// quit keybinding. StopAll is idempotent, so the explicit call in the quit
+	// handler is harmless; this catches early returns and Run() errors that would
+	// otherwise leave orphaned builders/compilers behind.
+	defer mgr.StopAll()
+
 	// If stdout isn't a TTY (e.g. Zed task runner, wrapped launches), open
 	// /dev/tty directly so Bubble Tea can query terminal size and render.
 	var opts []tea.ProgramOption


### PR DESCRIPTION
## Problem

Turning off the local dev stack (`hogli stop`/`down`, or quitting the phrocs TUI) sometimes left dangling processes behind — build daemons and compilers (vite, esbuild, tsc, cargo, pnpm-spawned node) that kept running and serving stale content into the next session.

The cause: phrocs' graceful pass walked the whole process tree and sent `SIGTERM` to escaped descendants, but the **`SIGKILL` escalation only force-killed the tracked process group** (`kill(-pid)`). Any descendant that ran in its own session/process group, or ignored `SIGTERM`, survived. There was also no final verification sweep.

## Changes

**phrocs shutdown hardening (`tools/phrocs/internal/process/proc.go`)**
- `killProcessGroup` now captures the full descendant PID set **before** signalling — a fast-exiting parent would otherwise reparent its escaped children to init before the tree walk runs, losing track of them — then signals the group *and* every captured PID directly.
- `Stop()` ends with a new `reapEscapedDescendants` step: after the tracked process is handled, escaped descendants get a brief grace (500 ms) to honor the earlier `SIGTERM`, then anything still alive is `SIGKILL`ed. In the common case (nothing escaped) it returns instantly, so there's no added shutdown latency. This runs on **every** teardown path: `hogli stop`/`down`, `q`/Ctrl-C in the TUI, and external `SIGTERM`/`SIGHUP`.

**Interactive safety net (`tools/phrocs/main.go`)**
- Added `defer mgr.StopAll()` so children are torn down on any exit path from the TUI, not just the quit keybinding (`StopAll` is idempotent).

**Confirmation-gated auto-sweep on stop (`hogli.yaml`, `devenv/cli.py`, `doctor.py`)**
- `hogli stop` / `hogli down` now stop phrocs and then sweep for any dev processes that escaped shutdown (including orphans from an earlier unclean exit), **prompting before killing**. Defaults to yes; `-y` auto-confirms, `--no-sweep` skips, and it stays silent when nothing leaked and never kills unattended in a non-interactive shell. Implemented as `dev_stop`/`dev_down` plus a reusable `sweep_orphaned_processes` helper that reuses the existing `doctor:zombies` scanning logic.

The existing `hogli doctor:zombies` command remains the dedicated tool to manually see (`--dry-run`) and kill orphaned dev processes.

## How did you test this code?

I'm an agent (Claude Code); I ran only automated checks — no manual stack run.

- Downloaded a matching Go toolchain and ran: `go build ./...`, `go vet`, `gofmt -l` (all clean), and the full phrocs test suite (`go test ./...`) — all packages pass.
- Added `TestStop_kills_escaped_process_group`, which spawns a `setsid` descendant in its own session that *ignores* `SIGTERM`. It fails on the old escalation and passes on the new reap path; verified green 10×/3× with no flakiness (it polls for actual death to avoid a zombie/`kill(pid,0)` race).
- Python: `ruff check` passes and `ruff format` applied; `hogli stop`/`hogli down --help` resolve; ran the `sweep_orphaned_processes` helper live and confirmed it refuses to kill anything in a non-interactive shell without `-y`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8) at the request of @fercgomes. Tooling used: file search/read/edit, Bash for building and running Go/Python tests.

Key decisions:
- Root-caused the leak to the group-only `SIGKILL` escalation; the fix is to record the descendant tree *before* signalling (so we don't lose children that reparent to init when the parent exits) and reap survivors directly. A short straggler grace keeps well-behaved children's graceful shutdown intact while still guaranteeing nothing lingers.
- For the manual "see/kill" command, reused the existing `hogli doctor:zombies` rather than adding a new command, since it already covers it.
- For `hogli stop`/`down`, chose a confirmation-gated sweep (prompt by default, silent when clean, never auto-kill in non-interactive shells) to avoid surprising kills while still making `down` reliably leave nothing behind.