### PR TITLE
fix(data-warehouse): normalize Shopify store id to reduce connection errors

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import dataclasses
 from collections.abc import Iterator
@@ -155,8 +156,43 @@ def _make_paginated_shopify_request(
                 resumable_source_manager.save_state(ShopifyResumeConfig(phase=phase, cursor=next_cursor))
 
 
+# A Shopify store subdomain is lowercase alphanumerics and hyphens.
+_SHOPIFY_SUBDOMAIN_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def normalize_store_id(raw: str) -> str:
+    """Reduce whatever the user pasted to the bare Shopify store subdomain.
+
+    The store id is interpolated into ``https://{}.myshopify.com/...``, so a value
+    that already carries a scheme, a path, or the ``.myshopify.com`` suffix builds a
+    broken host (e.g. ``store.myshopify.com.myshopify.com`` or a host of ``https``) —
+    the single biggest cause of Shopify connection failures. Accepts ``my-store``,
+    ``my-store.myshopify.com``, ``https://my-store.myshopify.com`` and the admin
+    deep-link ``https://admin.shopify.com/store/my-store``, all returning ``my-store``.
+
+    Raises ``ValueError`` if the result isn't a plain subdomain, which also pins
+    outbound traffic to ``*.myshopify.com`` (no breaking out to another host).
+    """
+    store_id = (raw or "").strip().lower()
+    store_id = store_id.removeprefix("https://").removeprefix("http://")
+    # Admin deep-link: admin.shopify.com/store/<store-id>[/...]
+    if store_id.startswith("admin.shopify.com/store/"):
+        store_id = store_id.removeprefix("admin.shopify.com/store/")
+    # Drop any path/query/fragment that rode along with a pasted URL.
+    store_id = store_id.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
+    # Strip the domain suffix, looping to collapse an accidental double suffix.
+    while store_id.endswith(".myshopify.com"):
+        store_id = store_id.removesuffix(".myshopify.com")
+    if not _SHOPIFY_SUBDOMAIN_RE.match(store_id):
+        raise ValueError(
+            f"Invalid Shopify store id {raw!r}. Enter just your store subdomain — the 'my-store' "
+            "in 'my-store.myshopify.com'."
+        )
+    return store_id
+
+
 def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, shopify_client_secret: str) -> str:
-    access_token_url = SHOPIFY_ACCESS_TOKEN_URL.format(shopify_store_id)
+    access_token_url = SHOPIFY_ACCESS_TOKEN_URL.format(normalize_store_id(shopify_store_id))
     access_data = {
         "client_id": shopify_client_id,
         "client_secret": shopify_client_secret,
@@ -184,7 +220,7 @@ def shopify_source(
     resumable_source_manager: ResumableSourceManager[ShopifyResumeConfig],
     should_use_incremental_field: bool = False,
 ):
-    api_url = SHOPIFY_API_URL.format(shopify_store_id, SHOPIFY_API_VERSION)
+    api_url = SHOPIFY_API_URL.format(normalize_store_id(shopify_store_id), SHOPIFY_API_VERSION)
     shopify_access_token = _get_shopify_access_token(shopify_store_id, shopify_client_id, shopify_client_secret)
     schema_name = resolve_schema_name(graphql_object_name)
 
@@ -289,7 +325,7 @@ def validate_credentials(shopify_store_id: str, shopify_client_id: str, shopify_
     - Raise ShopifyPermissionError if the access token is valid but lacks permissions for specific resources
     - Raise Exception if the access token is invalid or there's any other error
     """
-    api_url = SHOPIFY_API_URL.format(shopify_store_id, SHOPIFY_API_VERSION)
+    api_url = SHOPIFY_API_URL.format(normalize_store_id(shopify_store_id), SHOPIFY_API_VERSION)
     shopify_access_token = _get_shopify_access_token(shopify_store_id, shopify_client_id, shopify_client_secret)
     sess = make_tracked_session(
         headers={

--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -192,7 +192,8 @@ def normalize_store_id(raw: str) -> str:
 
 
 def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, shopify_client_secret: str) -> str:
-    access_token_url = SHOPIFY_ACCESS_TOKEN_URL.format(normalize_store_id(shopify_store_id))
+    # Callers pass an already-normalized store id (see normalize_store_id).
+    access_token_url = SHOPIFY_ACCESS_TOKEN_URL.format(shopify_store_id)
     access_data = {
         "client_id": shopify_client_id,
         "client_secret": shopify_client_secret,
@@ -220,8 +221,9 @@ def shopify_source(
     resumable_source_manager: ResumableSourceManager[ShopifyResumeConfig],
     should_use_incremental_field: bool = False,
 ):
-    api_url = SHOPIFY_API_URL.format(normalize_store_id(shopify_store_id), SHOPIFY_API_VERSION)
-    shopify_access_token = _get_shopify_access_token(shopify_store_id, shopify_client_id, shopify_client_secret)
+    store_id = normalize_store_id(shopify_store_id)
+    api_url = SHOPIFY_API_URL.format(store_id, SHOPIFY_API_VERSION)
+    shopify_access_token = _get_shopify_access_token(store_id, shopify_client_id, shopify_client_secret)
     schema_name = resolve_schema_name(graphql_object_name)
 
     def get_rows():
@@ -325,8 +327,9 @@ def validate_credentials(shopify_store_id: str, shopify_client_id: str, shopify_
     - Raise ShopifyPermissionError if the access token is valid but lacks permissions for specific resources
     - Raise Exception if the access token is invalid or there's any other error
     """
-    api_url = SHOPIFY_API_URL.format(normalize_store_id(shopify_store_id), SHOPIFY_API_VERSION)
-    shopify_access_token = _get_shopify_access_token(shopify_store_id, shopify_client_id, shopify_client_secret)
+    store_id = normalize_store_id(shopify_store_id)
+    api_url = SHOPIFY_API_URL.format(store_id, SHOPIFY_API_VERSION)
+    shopify_access_token = _get_shopify_access_token(store_id, shopify_client_id, shopify_client_secret)
     sess = make_tracked_session(
         headers={
             "Content-Type": "application/json",

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -54,7 +54,11 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
                         label="Store id",
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
-                        placeholder="my-store-id",
+                        placeholder="my-store",
+                        caption=(
+                            "Your store subdomain — the `my-store` in `my-store.myshopify.com`. "
+                            "Pasting the full store URL works too."
+                        ),
                         secret=False,
                     ),
                     SourceFieldInputConfig(

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_store_id.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_store_id.py
@@ -41,13 +41,6 @@ def test_normalize_store_id_rejects_invalid(raw):
         normalize_store_id(raw)
 
 
-def _patched_token_call(response: mock.MagicMock):
-    return mock.patch(
-        "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
-        return_value=mock.MagicMock(post=mock.MagicMock(return_value=response)),
-    )
-
-
 def test_access_token_url_has_no_doubled_suffix_for_messy_input():
     response = mock.MagicMock()
     response.ok = True
@@ -58,7 +51,9 @@ def test_access_token_url_has_no_doubled_suffix_for_messy_input():
         "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
         return_value=session,
     ):
-        _get_shopify_access_token("https://my-store.myshopify.com", "client-id", "client-secret")
+        # Callers normalize before threading the store id through, so messy input has
+        # already collapsed to the bare subdomain by the time it reaches this function.
+        _get_shopify_access_token(normalize_store_id("https://my-store.myshopify.com"), "client-id", "client-secret")
 
     called_url = session.post.call_args.args[0]
     assert called_url == "https://my-store.myshopify.com/admin/oauth/access_token"

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_store_id.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_store_id.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.shopify.shopify import _get_shopify_access_token, normalize_store_id
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("my-store", "my-store"),
+        ("MY-STORE", "my-store"),
+        ("  my-store  ", "my-store"),
+        ("my-store.myshopify.com", "my-store"),
+        ("https://my-store.myshopify.com", "my-store"),
+        ("http://my-store.myshopify.com/", "my-store"),
+        ("my-store.myshopify.com/admin/api", "my-store"),
+        ("https://admin.shopify.com/store/my-store", "my-store"),
+        ("https://admin.shopify.com/store/my-store/products", "my-store"),
+        # Accidental double suffix collapses back to the bare subdomain.
+        ("my-store.myshopify.com.myshopify.com", "my-store"),
+        ("store123", "store123"),
+    ],
+)
+def test_normalize_store_id_accepts_common_paste_forms(raw, expected):
+    assert normalize_store_id(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "https://evil.com",
+        "my_store",
+        "store with spaces",
+        "-leading-hyphen",
+    ],
+)
+def test_normalize_store_id_rejects_invalid(raw):
+    with pytest.raises(ValueError):
+        normalize_store_id(raw)
+
+
+def _patched_token_call(response: mock.MagicMock):
+    return mock.patch(
+        "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
+        return_value=mock.MagicMock(post=mock.MagicMock(return_value=response)),
+    )
+
+
+def test_access_token_url_has_no_doubled_suffix_for_messy_input():
+    response = mock.MagicMock()
+    response.ok = True
+    response.json.return_value = {"access_token": "shpat_x"}
+    session = mock.MagicMock(post=mock.MagicMock(return_value=response))
+
+    with mock.patch(
+        "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
+        return_value=session,
+    ):
+        _get_shopify_access_token("https://my-store.myshopify.com", "client-id", "client-secret")
+
+    called_url = session.post.call_args.args[0]
+    assert called_url == "https://my-store.myshopify.com/admin/oauth/access_token"


### PR DESCRIPTION
## Problem

Shopify is one of the highest-volume sources for failed connections. The dominant failure is `Failed to retrieve Shopify access token`, and a large share of the underlying errors show malformed hosts like `host='deego-design.myshopify.com.myshopify.com'` (the `.myshopify.com` suffix is doubled) or `host='https'`.

The cause is the `shopify_store_id` field: it's interpolated verbatim into `https://{}.myshopify.com/admin/...`. The field is labelled "Store id" with placeholder `my-store-id`, so users reasonably paste their full store URL (`https://my-store.myshopify.com`), a domain that already includes `.myshopify.com`, or the admin deep-link (`https://admin.shopify.com/store/my-store`). Any of those builds a broken host and the OAuth token request fails.

## Changes

- Add `normalize_store_id()` in `shopify.py` that reduces whatever the user pasted to the bare store subdomain: strips the scheme, path, query/fragment and surrounding whitespace, collapses a trailing `.myshopify.com` (handling an accidental double suffix), and extracts the subdomain from an `admin.shopify.com/store/<id>` deep-link. It raises `ValueError` on anything that isn't a plain `[a-z0-9-]` subdomain — which also keeps outbound traffic pinned to `*.myshopify.com` (no breaking out to another host).
- Apply it at every call site that builds a Shopify URL (`_get_shopify_access_token`, `shopify_source`, `validate_credentials`), so both create-time validation and ongoing sync are robust.
- Update the setup field caption to explain it wants the subdomain and that pasting the full URL is fine.

This is one of a small set of independent per-source PRs reducing data warehouse source connection errors, each scoped to a single source.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). No manual UI testing. Automated tests run locally, all passing:

- New `posthog/temporal/data_imports/sources/shopify/tests/test_store_id.py` — parametrized coverage of `normalize_store_id` (bare subdomain, mixed case, whitespace, `.myshopify.com`, full URLs, admin deep-link, doubled suffix) and its rejection of non-subdomain input, plus a test asserting the access-token URL has no doubled suffix for messy input.
- Existing `test_access_token.py` still passes (no regressions).
- `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Identified from an analysis of the `warehouse credentials invalid` event broken down by source type and error message: Shopify failures were dominated by malformed `*.myshopify.com.myshopify.com` / `host='https'` hosts, pointing at un-normalized user input. Followed the existing precedent set by WooCommerce's `normalize_store_url` and Pipedrive's `normalize_company_domain` (strip-and-validate, raise on non-subdomain). Chose to raise rather than silently coerce so SSRF-shaped input can't slip through to an arbitrary host.
