### PR TITLE
chore: move sessions tables codeownership to query performance

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -70,10 +70,7 @@ ee/tasks/subscriptions/** @PostHog/team-analytics-platform
 frontend/src/scenes/data-management/schema/** @PostHog/team-analytics-platform
 frontend/src/scenes/dashboard/ @PostHog/team-analytics-platform
 posthog/api/schema_property_group.py @PostHog/team-analytics-platform
-posthog/hogql/database/schema/sessions*\*.py @PostHog/team-analytics-platform
-posthog/models/raw_sessions/** @PostHog/team-analytics-platform
 posthog/models/schema.py @PostHog/team-analytics-platform
-posthog/models/sessions/** @PostHog/team-analytics-platform
 posthog/hogql_queries/sessions_query_runner.py @PostHog/team-analytics-platform
 posthog/hogql_queries/sessions_timeline_query_runner.py @PostHog/team-analytics-platform
 posthog/dags/sessions.py @PostHog/team-analytics-platform
@@ -316,6 +313,9 @@ posthog/temporal/quota_limiting/ @PostHog/team-billing
 # Query performance - owned by @PostHog/team-query-performance
 posthog/queries/ @PostHog/team-query-performance
 posthog/caching/ @PostHog/team-query-performance
+posthog/hogql/database/schema/sessions*\*.py @PostHog/team-query-performance
+posthog/models/raw_sessions/** @PostHog/team-query-performance
+posthog/models/sessions/** @PostHog/team-query-performance
 
 # Ingestion (persons identity pipeline) - owned by @PostHog/team-ingestion
 posthog/temporal/delete_persons/ @PostHog/team-ingestion


### PR DESCRIPTION
## Problem

The sessions ClickHouse tables (raw sessions + sessions models, and the HogQL session table definitions) are moving under the Query performance team. The `CODEOWNERS-soft` file still attributed them to Analytics Platform.

## Changes

Move the following soft-codeowner entries from `@PostHog/team-analytics-platform` to `@PostHog/team-query-performance`:

- `posthog/hogql/database/schema/sessions*\*.py`
- `posthog/models/raw_sessions/**`
- `posthog/models/sessions/**`

Query runners (`sessions_query_runner.py`, `sessions_timeline_query_runner.py`), DAGs, and frontend scenes remain with Analytics Platform — this change is scoped to the table definitions only.

> There is a companion change in `posthog/posthog.com` for the same move; this PR covers `posthog/posthog`.

## How did you test this code?

I'm an agent — no automated tests apply to a CODEOWNERS-soft edit. Change verified by inspecting the diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Robbie Coomber requested moving code ownership of the sessions tables to the Query performance team. Identified the three table-definition glob entries under the Analytics Platform block in `.github/CODEOWNERS-soft` (matching `raw_sessions/`, `sessions/`, and the `sessions_v*.py` HogQL definitions) and relocated them to the Query performance block, leaving query runners and frontend scenes with Analytics Platform.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1780996999377719?thread_ts=1780996999.377719&cid=C02E3BKC78F)*
