### PR TITLE
fix(data-warehouse): accept any Google Ads customer ID format

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/configs.py
+++ b/posthog/temporal/data_imports/sources/google_ads/configs.py
@@ -8,6 +8,7 @@ protobuf descriptors. Nothing here imports the SDK — that import is deferred t
 run path in ``source.py``. See ``google_ads.py`` for the SDK-backed functions.
 """
 
+import re
 import dataclasses
 
 from posthog.temporal.data_imports.sources.common import config
@@ -26,14 +27,17 @@ class GoogleAdsResumeConfig:
 
 
 def clean_customer_id(s: str | None) -> str | None:
-    """Clean customer IDs from Google Ads.
+    """Normalize a Google Ads customer ID to its bare digits.
 
-    Customer IDs can contain dashes, but we need the ID without them.
+    The Google Ads UI shows customer IDs as ``123-456-7890`` but the API wants the
+    bare ``1234567890``. Users paste them with dashes, spaces, or surrounding
+    whitespace, so strip everything that isn't a digit — any of those forms then
+    works rather than getting rejected at setup time.
     """
     if not s:
         return s
 
-    return s.strip().replace("-", "")
+    return re.sub(r"\D", "", s)
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -189,19 +189,26 @@ class GoogleAdsSource(
     def validate_config(self, job_inputs: dict) -> tuple[bool, list[str]]:
         is_valid, errors = super().validate_config(job_inputs)
 
-        customer_id = job_inputs.get("customer_id", "")
-        if customer_id and not re.match(r"^\d{3}-\d{3}-\d{4}$", customer_id):
+        # Normalize before validating: `clean_customer_id` strips dashes, spaces and
+        # whitespace, so `123-456-7890`, `1234567890`, or a copy-pasted value all pass.
+        # The same normalization is applied wherever the id is sent to the API. We guard
+        # on the raw value so a non-numeric entry (which normalizes to empty) is still
+        # rejected rather than silently slipping through.
+        raw_customer_id = job_inputs.get("customer_id", "")
+        if raw_customer_id and not re.fullmatch(r"\d{10}", clean_customer_id(raw_customer_id) or ""):
             errors.append(
-                "Please enter a valid Google Ads customer ID. This should be 10-digits and in XXX-XXX-XXXX format."
+                "Please enter a valid Google Ads customer ID — the 10-digit number from your "
+                "Google Ads account (dashes optional)."
             )
             is_valid = False
 
         is_mcc_account = job_inputs.get("is_mcc_account", {})
         if is_mcc_account.get("enabled"):
-            mcc_client_id = is_mcc_account.get("mcc_client_id", "")
-            if mcc_client_id and not re.match(r"^\d{3}-\d{3}-\d{4}$", mcc_client_id):
+            raw_mcc_client_id = is_mcc_account.get("mcc_client_id", "")
+            if raw_mcc_client_id and not re.fullmatch(r"\d{10}", clean_customer_id(raw_mcc_client_id) or ""):
                 errors.append(
-                    "Please enter a valid Google Ads manager customer ID. This should be 10-digits and in XXX-XXX-XXXX format."
+                    "Please enter a valid Google Ads manager customer ID — the 10-digit number from "
+                    "your manager account (dashes optional)."
                 )
                 is_valid = False
 

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -31,6 +31,10 @@ class TestGoogleAdsValidateConfig:
         _, errors = self.source.validate_config(job_inputs)
         return [e for e in errors if _CUSTOMER_ID_ERROR in e]
 
+    def _manager_id_errors(self, job_inputs: dict) -> list[str]:
+        _, errors = self.source.validate_config(job_inputs)
+        return [e for e in errors if _MANAGER_ID_ERROR in e]
+
     @pytest.mark.parametrize(
         "customer_id",
         ["123-456-7890", "1234567890", "123 456 7890", "  123-456-7890  "],
@@ -45,21 +49,23 @@ class TestGoogleAdsValidateConfig:
     def test_rejects_invalid_customer_id(self, customer_id):
         assert len(self._customer_id_errors({"customer_id": customer_id})) == 1
 
-    def test_accepts_undashed_manager_customer_id(self):
+    @pytest.mark.parametrize(
+        "mcc_client_id",
+        ["123-456-7890", "1234567890", "123 456 7890", "  123-456-7890  "],
+    )
+    def test_accepts_any_common_manager_customer_id_format(self, mcc_client_id):
         job_inputs = {
             "customer_id": "1234567890",
-            "is_mcc_account": {"enabled": True, "mcc_client_id": "0987654321"},
+            "is_mcc_account": {"enabled": True, "mcc_client_id": mcc_client_id},
         }
-        _, errors = self.source.validate_config(job_inputs)
-        assert not [e for e in errors if _MANAGER_ID_ERROR in e]
+        assert self._manager_id_errors(job_inputs) == []
 
     def test_rejects_invalid_manager_customer_id(self):
         job_inputs = {
             "customer_id": "1234567890",
             "is_mcc_account": {"enabled": True, "mcc_client_id": "123"},
         }
-        _, errors = self.source.validate_config(job_inputs)
-        assert len([e for e in errors if _MANAGER_ID_ERROR in e]) == 1
+        assert len(self._manager_id_errors(job_inputs)) == 1
 
 
 class TestGoogleAdsNonRetryableErrors:

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -1,6 +1,65 @@
 import pytest
 
+from posthog.temporal.data_imports.sources.google_ads.configs import clean_customer_id
 from posthog.temporal.data_imports.sources.google_ads.source import GoogleAdsSource
+
+_CUSTOMER_ID_ERROR = "valid Google Ads customer ID"
+_MANAGER_ID_ERROR = "valid Google Ads manager customer ID"
+
+
+class TestCleanCustomerId:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("123-456-7890", "1234567890"),
+            ("1234567890", "1234567890"),
+            ("  123-456-7890  ", "1234567890"),
+            ("123 456 7890", "1234567890"),
+            ("", ""),
+            (None, None),
+        ],
+    )
+    def test_strips_to_bare_digits(self, raw, expected):
+        assert clean_customer_id(raw) == expected
+
+
+class TestGoogleAdsValidateConfig:
+    def setup_method(self):
+        self.source = GoogleAdsSource()
+
+    def _customer_id_errors(self, job_inputs: dict) -> list[str]:
+        _, errors = self.source.validate_config(job_inputs)
+        return [e for e in errors if _CUSTOMER_ID_ERROR in e]
+
+    @pytest.mark.parametrize(
+        "customer_id",
+        ["123-456-7890", "1234567890", "123 456 7890", "  123-456-7890  "],
+    )
+    def test_accepts_any_common_customer_id_format(self, customer_id):
+        assert self._customer_id_errors({"customer_id": customer_id}) == []
+
+    @pytest.mark.parametrize(
+        "customer_id",
+        ["12345", "123-456-789", "abcd", "123-456-78901"],
+    )
+    def test_rejects_invalid_customer_id(self, customer_id):
+        assert len(self._customer_id_errors({"customer_id": customer_id})) == 1
+
+    def test_accepts_undashed_manager_customer_id(self):
+        job_inputs = {
+            "customer_id": "1234567890",
+            "is_mcc_account": {"enabled": True, "mcc_client_id": "0987654321"},
+        }
+        _, errors = self.source.validate_config(job_inputs)
+        assert not [e for e in errors if _MANAGER_ID_ERROR in e]
+
+    def test_rejects_invalid_manager_customer_id(self):
+        job_inputs = {
+            "customer_id": "1234567890",
+            "is_mcc_account": {"enabled": True, "mcc_client_id": "123"},
+        }
+        _, errors = self.source.validate_config(job_inputs)
+        assert len([e for e in errors if _MANAGER_ID_ERROR in e]) == 1
 
 
 class TestGoogleAdsNonRetryableErrors:

--- a/posthog/temporal/tests/data_imports/test_google_ads_source.py
+++ b/posthog/temporal/tests/data_imports/test_google_ads_source.py
@@ -394,13 +394,16 @@ class TestGoogleAdsSourceValidation:
     @pytest.mark.parametrize(
         "customer_id,expected_valid",
         [
+            # Any value that normalizes to exactly 10 digits is accepted, regardless of dashes/spaces.
             ("123-456-7890", True),
             ("000-000-0000", True),
             ("999-999-9999", True),
-            ("1234567890", False),
+            ("1234567890", True),
+            ("123-4567-890", True),
+            ("12-3456-7890", True),
+            ("123 456 7890", True),
+            # Fewer or more than 10 digits, or non-numeric input, is rejected.
             ("123-456-789", False),
-            ("123-4567-890", False),
-            ("12-3456-7890", False),
             ("abc-def-ghij", False),
             ("", True),  # Empty is valid at config level, caught by required field validation
         ],


### PR DESCRIPTION
## Problem

Google Ads is one of the highest-volume sources for failed connections, and after the OAuth-scope error the next biggest bucket is customer-ID format rejection: "Please enter a valid Google Ads customer ID. This should be 10-digits and in XXX-XXX-XXXX format." (hundreds of occurrences), plus the manager-customer-ID variant.

The create-time validator required the *exact* dashed `XXX-XXX-XXXX` form and rejected everything else. But users routinely enter the 10-digit id without dashes (`1234567890`), with spaces, or copy-pasted with surrounding whitespace. Meanwhile the runtime already normalizes the id down to bare digits via `clean_customer_id` before sending it to the Google Ads API — so the strict gate rejected valid input that the rest of the code would have handled fine.

## Changes

- Widen `clean_customer_id` to strip *any* non-digit (previously only dashes + outer whitespace), so spaces inside the id are handled too. This is the same helper used on the sync path, so validation and the API call stay consistent.
- In `validate_config`, normalize the customer ID and manager customer ID before checking, and validate against the canonical 10-digit form (`\d{10}`). Dashed, undashed, and whitespace-padded values now all pass. The raw value is still guarded so a non-numeric entry (which normalizes to empty) is rejected rather than slipping through.
- Reworded the error messages to say "the 10-digit number from your Google Ads account (dashes optional)".

This is one of a small set of independent per-source PRs reducing data warehouse source connection errors, each scoped to a single source.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). No manual UI testing. Automated tests run locally, all passing:

- New tests in `tests/test_google_ads_source.py`: parametrized `clean_customer_id` coverage (dashed/undashed/spaced/whitespace/empty/None) and `validate_config` coverage accepting all common customer-ID and manager-ID formats while still rejecting too-short / non-numeric / too-long values.
- Existing non-retryable-error tests still pass (no regressions).
- `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Identified from an analysis of the `warehouse credentials invalid` event broken down by source type and error message. Confirmed the runtime already calls `clean_customer_id` on every API-bound path, so widening it and moving normalization ahead of the format check is low-risk and removes a redundant, overly-strict gate rather than loosening a real constraint.
