### PR TITLE
refactor(mcp): static import of @posthog/mcp instead of dynamic

### DIFF
--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -1,5 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
+import { instrument } from '@posthog/mcp-analytics'
+
 import { env } from '@/lib/env'
 
 import { getPostHogClient } from './client'
@@ -224,7 +226,6 @@ export async function initMcpAnalytics(
     }
 
     try {
-        const { instrument } = await import('@posthog/mcp-analytics') // Import only if needed
         const distinctId = await identity.getDistinctId()
 
         // `@posthog/mcp` 0.1.x: `instrument(server, posthogClient, options)` returns an


### PR DESCRIPTION
Stacked on #62412.

## What
Replaces the dynamic `await import('@posthog/mcp-analytics')` in `initMcpAnalytics` with a plain top-level import.

## Why
The dynamic import only deferred loading the SDK when analytics was unconfigured (no API key/host). In practice `initMcpAnalytics` runs on every connection and config is present in prod, so the SDK loads on the first connection anyway — the lazy form bought ~nothing while adding async indirection.

## Why it's safe in the Worker
The SDK's runtime deps — `posthog-node`, `@modelcontextprotocol/sdk`, `@posthog/core` — **already load at the Worker top level today** (`src/lib/posthog/client.ts` imports `posthog-node`; `mcp.ts` imports the MCP SDK). So a top-level `@posthog/mcp` import introduces no new module-eval surface.

## Verification
- ✅ typecheck clean (against the real `@posthog/mcp@0.1.16`)
- ✅ unit suite green, incl. the real-SDK `exec-description-emission` test
- ⚠️ I couldn't run `wrangler deploy --dry-run` locally (the wrangler CLI in this checkout mis-parses its own `deploy` subcommand regardless of invocation) — relying on CI to build the Worker bundle. Given the deps already load top-level, the bundle is expected to be unaffected.

If CI surfaces any Worker bundling issue, revert is trivial (one import line).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*