### PR TITLE
fix(data-warehouse): catch Supabase direct host and point users at the pooler

### DIFF
--- a/posthog/temporal/data_imports/sources/supabase/source.py
+++ b/posthog/temporal/data_imports/sources/supabase/source.py
@@ -4,7 +4,12 @@ from typing import Optional
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
+    SourceFieldFileUploadConfig,
     SourceFieldInputConfig,
+    SourceFieldOauthConfig,
+    SourceFieldSelectConfig,
+    SourceFieldSSHTunnelConfig,
+    SourceFieldSwitchGroupConfig,
 )
 
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
@@ -12,6 +17,15 @@ from posthog.temporal.data_imports.sources.generated_configs import PostgresSour
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
+
+_SourceField = (
+    SourceFieldInputConfig
+    | SourceFieldSwitchGroupConfig
+    | SourceFieldSelectConfig
+    | SourceFieldOauthConfig
+    | SourceFieldFileUploadConfig
+    | SourceFieldSSHTunnelConfig
+)
 
 # Supabase's direct connection host (`db.<ref>.supabase.co`) is IPv6-only and so is
 # unreachable from PostHog's IPv4 egress — by far the biggest cause of Supabase
@@ -35,23 +49,22 @@ class SupabaseSource(PostgresSource):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SUPABASE
 
+    @staticmethod
+    def _adjust_field(field: _SourceField) -> _SourceField:
+        if isinstance(field, SourceFieldInputConfig) and field.name == "schema":
+            return field.model_copy(update={"required": True, "label": "Schema", "caption": None})
+        if isinstance(field, SourceFieldInputConfig) and field.name == "host":
+            return field.model_copy(
+                update={
+                    "placeholder": "aws-0-us-east-1.pooler.supabase.com",
+                    "caption": _SUPABASE_POOLER_HOST_CAPTION,
+                }
+            )
+        return field
+
     @property
     def get_source_config(self) -> SourceConfig:
-        fields = []
-        for field in super().get_source_config.fields:
-            if isinstance(field, SourceFieldInputConfig) and field.name == "schema":
-                fields.append(field.model_copy(update={"required": True, "label": "Schema", "caption": None}))
-            elif isinstance(field, SourceFieldInputConfig) and field.name == "host":
-                fields.append(
-                    field.model_copy(
-                        update={
-                            "placeholder": "aws-0-us-east-1.pooler.supabase.com",
-                            "caption": _SUPABASE_POOLER_HOST_CAPTION,
-                        }
-                    )
-                )
-            else:
-                fields.append(field)
+        fields = [self._adjust_field(field) for field in super().get_source_config.fields]
 
         return SourceConfig(
             name=SchemaExternalDataSourceType.SUPABASE,

--- a/posthog/temporal/data_imports/sources/supabase/source.py
+++ b/posthog/temporal/data_imports/sources/supabase/source.py
@@ -1,3 +1,6 @@
+import re
+from typing import Optional
+
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
     SourceConfig,
@@ -5,9 +8,22 @@ from posthog.schema import (
 )
 
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.generated_configs import PostgresSourceConfig
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
+
+# Supabase's direct connection host (`db.<ref>.supabase.co`) is IPv6-only and so is
+# unreachable from PostHog's IPv4 egress — by far the biggest cause of Supabase
+# connection failures. Users need the connection pooler host instead.
+_SUPABASE_DIRECT_HOST_RE = re.compile(r"^db\.[a-z0-9]+\.supabase\.co$", re.IGNORECASE)
+
+_SUPABASE_POOLER_HOST_CAPTION = (
+    "Use the **Session pooler** host from Supabase (Project settings → Database → "
+    "Connection pooling), e.g. `aws-0-<region>.pooler.supabase.com`, with username "
+    "`postgres.<project-ref>`. The direct host `db.<ref>.supabase.co` is IPv6-only and "
+    "won't be reachable."
+)
 
 
 @SourceRegistry.register
@@ -21,12 +37,21 @@ class SupabaseSource(PostgresSource):
 
     @property
     def get_source_config(self) -> SourceConfig:
-        fields = [
-            field.model_copy(update={"required": True, "label": "Schema", "caption": None})
-            if isinstance(field, SourceFieldInputConfig) and field.name == "schema"
-            else field
-            for field in super().get_source_config.fields
-        ]
+        fields = []
+        for field in super().get_source_config.fields:
+            if isinstance(field, SourceFieldInputConfig) and field.name == "schema":
+                fields.append(field.model_copy(update={"required": True, "label": "Schema", "caption": None}))
+            elif isinstance(field, SourceFieldInputConfig) and field.name == "host":
+                fields.append(
+                    field.model_copy(
+                        update={
+                            "placeholder": "aws-0-us-east-1.pooler.supabase.com",
+                            "caption": _SUPABASE_POOLER_HOST_CAPTION,
+                        }
+                    )
+                )
+            else:
+                fields.append(field)
 
         return SourceConfig(
             name=SchemaExternalDataSourceType.SUPABASE,
@@ -37,3 +62,17 @@ class SupabaseSource(PostgresSource):
             releaseStatus="beta",
             featureFlag="supabase-dwh",
         )
+
+    def validate_credentials(
+        self, config: PostgresSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        # Catch the IPv6-only direct host before the generic Postgres connect attempt
+        # times out with an opaque "could not connect to the host on the port given".
+        if _SUPABASE_DIRECT_HOST_RE.match((config.host or "").strip()):
+            return False, (
+                "This looks like the Supabase direct database host (db.<ref>.supabase.co), which is "
+                "IPv6-only and unreachable from PostHog. Use the Session pooler host instead "
+                "(aws-0-<region>.pooler.supabase.com) with username postgres.<project-ref> — find it "
+                "under Project settings → Database → Connection pooling."
+            )
+        return super().validate_credentials(config, team_id, schema_name=schema_name)

--- a/posthog/temporal/data_imports/sources/supabase/test_supabase_source.py
+++ b/posthog/temporal/data_imports/sources/supabase/test_supabase_source.py
@@ -1,14 +1,71 @@
+import pytest
+from unittest import mock
+
 from posthog.schema import SourceFieldInputConfig
 
+from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 from posthog.temporal.data_imports.sources.supabase.source import SupabaseSource
 
 
-def test_supabase_requires_schema_field():
-    source_config = SupabaseSource().get_source_config
-    schema_field = next(
-        field for field in source_config.fields if isinstance(field, SourceFieldInputConfig) and field.name == "schema"
+def _field(name: str) -> SourceFieldInputConfig:
+    return next(
+        field
+        for field in SupabaseSource().get_source_config.fields
+        if isinstance(field, SourceFieldInputConfig) and field.name == name
     )
+
+
+def test_supabase_requires_schema_field():
+    schema_field = _field("schema")
 
     assert schema_field.required is True
     assert schema_field.label == "Schema"
     assert schema_field.caption is None
+
+
+def test_supabase_host_field_points_at_the_pooler():
+    host_field = _field("host")
+
+    assert "pooler.supabase.com" in host_field.placeholder
+    assert host_field.caption is not None
+    assert "pooler" in host_field.caption.lower()
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "db.abcdefghijklmnop.supabase.co",
+        "DB.ABCDEFGH.SUPABASE.CO",
+        "  db.abcdefgh.supabase.co  ",
+    ],
+)
+def test_direct_host_is_rejected_with_pooler_guidance(host):
+    config = mock.MagicMock(host=host)
+
+    with mock.patch.object(PostgresSource, "validate_credentials") as super_validate:
+        success, error = SupabaseSource().validate_credentials(config, team_id=1)
+
+    assert success is False
+    assert error is not None
+    assert "pooler" in error.lower()
+    # We short-circuit before attempting the generic Postgres connection.
+    super_validate.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "aws-0-us-east-1.pooler.supabase.com",
+        "db.example.com",
+        "my-db.internal",
+    ],
+)
+def test_pooler_and_other_hosts_delegate_to_postgres(host):
+    config = mock.MagicMock(host=host)
+
+    with mock.patch.object(PostgresSource, "validate_credentials", return_value=(True, None)) as super_validate:
+        success, error = SupabaseSource().validate_credentials(config, team_id=1)
+
+    assert success is True
+    assert error is None
+    super_validate.assert_called_once()


### PR DESCRIPTION
## Problem

Supabase has the highest connection-failure volume of any data warehouse source, and the dominant error by a wide margin is an opaque "Could not connect to the host on the port given".

The cause is well-known to Supabase users: the direct database host `db.<ref>.supabase.co` is IPv6-only, so it's unreachable from PostHog's IPv4 egress and the connection simply times out. The fix on the user's side is to use the **connection pooler** host (`aws-0-<region>.pooler.supabase.com`) with the pooler username (`postgres.<project-ref>`). Today nothing in the form or the error guides them there — the host field inherits the generic Postgres `localhost` placeholder with no caption.

## Changes

`SupabaseSource` (which extends `PostgresSource`):

- Override `validate_credentials` to detect the direct-host pattern `db.<ref>.supabase.co` and return an actionable message telling the user to switch to the Session pooler host with username `postgres.<project-ref>`, short-circuiting before the generic Postgres connect attempt times out with the opaque error.
- Update the host field's placeholder (`aws-0-us-east-1.pooler.supabase.com`) and add a caption pointing at the Session pooler, so users get it right up front.

Scoped entirely to Supabase — the inherited Postgres behaviour is unchanged. This is one of a small set of independent per-source PRs reducing data warehouse source connection errors.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). No manual UI testing. Automated tests run locally, all passing:

- Updated `test_supabase_source.py`: the host field exposes pooler placeholder/caption; the direct host (incl. uppercase and whitespace-padded) is rejected with pooler guidance and does *not* fall through to the Postgres connect path; pooler and other hosts delegate to `PostgresSource.validate_credentials` as before.
- Existing schema-required test still passes.
- `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Identified from an analysis of the `warehouse credentials invalid` event broken down by source type and error message — Supabase's failures are overwhelmingly the generic host-connect timeout, which maps to the IPv6-only direct host. The detection is deliberately narrow (only the exact `db.<ref>.supabase.co` shape) and fails closed to the existing Postgres validation for every other host, so there's no behaviour change for pooler or self-hosted connections.
