### PR TITLE
perf(llma): materialize property access in event taxonomy query

### DIFF
--- a/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
@@ -180,10 +180,7 @@ class EventTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[EventTax
                 ast.Or(
                     exprs=[
                         ast.CompareOperation(
-                            left=ast.Call(
-                                name="JSONExtractString",
-                                args=[ast.Field(chain=["properties"]), ast.Constant(value=prop)],
-                            ),
+                            left=self._property_expr(prop),
                             op=ast.CompareOperationOp.NotEq,
                             right=ast.Constant(value=""),
                         )
@@ -193,6 +190,13 @@ class EventTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[EventTax
             )
 
         return ast.And(exprs=filter_expr)
+
+    def _property_expr(self, prop: str) -> ast.Expr:
+        # Access the property through the HogQL property path rather than a raw JSONExtractString call so the
+        # printer can substitute a materialized column / property-group lookup in production instead of parsing
+        # the JSON blob at query time. toString keeps the ARRAY JOIN tuple element types homogeneous regardless
+        # of how the property value is stored.
+        return ast.Call(name="toString", args=[ast.Field(chain=["properties", prop])])
 
     def _get_subquery(self) -> ast.SelectQuery:
         if self.query.properties:
@@ -220,10 +224,7 @@ class EventTaxonomyQueryRunner(TaxonomyCacheMixin, AnalyticsQueryRunner[EventTax
                             ast.Tuple(
                                 exprs=[
                                     ast.Constant(value=prop),
-                                    ast.Call(
-                                        name="JSONExtractString",
-                                        args=[ast.Field(chain=["properties"]), ast.Constant(value=prop)],
-                                    ),
+                                    self._property_expr(prop),
                                 ]
                             )
                             for prop in self.query.properties


### PR DESCRIPTION
## Problem

`EventTaxonomyQueryRunner`'s "with properties" path built property access as literal `JSONExtractString(properties, prop)` **call** nodes — in both the `WHERE` filter and the `ARRAY JOIN` tuple projection.

The HogQL printer only applies materialized-column / property-group substitution when it visits a property **path** (`properties[prop]` → `PropertyType`). A literal `JSONExtractString` call is opaque to that machinery, so it stays a query-time JSON parse over the raw `properties` blob **in production too** — not just a test-fixture artifact. This path also has no row `LIMIT` (unlike the no-properties path, which caps at 100), so it parses JSON for every matching event over the 30-day window.

## Changes

Route both call sites through the property path via a small helper:

```python
def _property_expr(self, prop: str) -> ast.Expr:
    return ast.Call(name="toString", args=[ast.Field(chain=["properties", prop])])
```

In production the printer now emits the materialized column / property-group lookup in both the filter and the projection instead of `JSONExtract`-ing at query time. `toString` keeps the `ARRAY JOIN` tuple element types homogeneous regardless of stored type — the same pattern `actors_property_taxonomy_query_runner` already uses. Behavior is preserved: a missing property yields `toString(NULL)`, still excluded by the existing `IS NOT NULL` / `!= ''` guards.

## How did you test this code?

I'm an agent (PostHog Slack app). I could **not** run the test suite or regenerate snapshots — this environment has no Postgres/ClickHouse/docker. The change compiles and passes `ruff check`.

**Required before merge:**
- Regenerate the snapshot: `hogli test posthog/hogql_queries/ai/test/test_event_taxonomy_query_runner.py --snapshot-update`. The existing assertion-based tests (numeric / empty-string / missing / multi-property / partial-match) cover the semantic edge cases.
- Measure before/after on the Test Cluster (`read_bytes`, `query_duration_ms`) to quantify the materialization win.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Produced by running the `optimizing-clickhouse-and-hogql-queries` skill across three AI taxonomy query runners.

- **`event_taxonomy_query_runner`** (this PR): confirmed via `printer/test/test_printer.py` that property-path access against a materialized column prints a direct column read while a literal `JSONExtractString` call is never rewritten. Fixed.
- **`actors_property_taxonomy_query_runner`** (not changed — flagged for follow-up): already materializes correctly. Two opportunities: (1) the `ORDER BY created_at DESC` inside the `DISTINCT` subquery forces a per-actor `argMax(created_at)` plus a sort — but ClickHouse applies it *before* `DISTINCT`, so it provides recency-biased sample values; removing it is a genuine product/behavior tradeoff, left for a human to decide. (2) The props array is built twice (up to 200 materialized reads duplicated); ClickHouse may CSE it, worth measuring before restructuring.
- **`team_taxonomy_query_runner`** (not changed): already optimal — filters the sort-key prefix (`team_id`, `toDate(timestamp)`), reads only `event` + `timestamp`, groups by the sort-key column `event`. No smells.

Could not measure on the Test Cluster from this environment, so the materialization win is reasoned (query-time JSON parse → column read), not benchmarked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1781012454454829)*
