### PR TITLE
chore(aiobs): add integration tests for ai batch capture route

### DIFF
--- a/rust/capture/tests/integration_new_endpoints.rs
+++ b/rust/capture/tests/integration_new_endpoints.rs
@@ -10,8 +10,10 @@ use axum::http::StatusCode;
 use capture::config::CaptureMode;
 
 //
-// The /i/v0/e/ and /batch/ endpoints are all processed by event_next
-// and support the same request payload shapes and encodings.
+// The /i/v0/e/, /batch/, and /i/v0/ai/batch/ endpoints are all processed by
+// event_next and support the same request payload shapes and encodings. The
+// /i/v0/ai/batch path is a dedicated alias so the ingress can route $ai_* events
+// to the capture-ai deployment; the handler behavior is identical.
 //
 
 #[tokio::test]
@@ -85,6 +87,46 @@ async fn test_batch_endpoint_get_with_body() {
         .iter_mut()
         .for_each(|tc: &mut TestCase| {
             tc.base_path = "/batch";
+            tc.method = Method::GetWithBody;
+            tc.title = tc.title.replace("post-", "get_with_body-");
+        });
+
+    for unit in get_with_body_cases {
+        execute_test(&unit).await;
+    }
+}
+
+#[tokio::test]
+async fn test_ai_batch_endpoint_get() {
+    let base_path = "/i/v0/ai/batch";
+
+    // NOT currently supported by new capture endpoint handlers
+    for mut unit in get_cases() {
+        unit.base_path = base_path;
+        execute_test(&unit).await;
+    }
+}
+
+#[tokio::test]
+async fn test_ai_batch_endpoint_post() {
+    let base_path = "/i/v0/ai/batch";
+
+    // POST requests with payload in body, metadata in POST form or GET params
+    for mut unit in post_cases() {
+        unit.base_path = base_path;
+        execute_test(&unit).await;
+    }
+}
+
+#[tokio::test]
+async fn test_ai_batch_endpoint_get_with_body() {
+    // GET requests with a body payload are treated identically to POST requests
+    let mut get_with_body_cases = post_cases();
+
+    get_with_body_cases
+        .iter_mut()
+        .for_each(|tc: &mut TestCase| {
+            tc.base_path = "/i/v0/ai/batch";
             tc.method = Method::GetWithBody;
             tc.title = tc.title.replace("post-", "get_with_body-");
         });

--- a/rust/capture/tests/integration_new_endpoints.rs
+++ b/rust/capture/tests/integration_new_endpoints.rs
@@ -18,119 +18,45 @@ use capture::config::CaptureMode;
 
 #[tokio::test]
 async fn test_i_v0_e_endpoint() {
-    let base_path = "/i/v0/e";
+    run_endpoint_suite("/i/v0/e").await;
+}
 
-    // NOT currently supported by new capture endpoint handlers
+#[tokio::test]
+async fn test_batch_endpoint() {
+    run_endpoint_suite("/batch").await;
+}
+
+#[tokio::test]
+async fn test_ai_batch_endpoint() {
+    run_endpoint_suite("/i/v0/ai/batch").await;
+}
+
+// Exercises the full payload-shape/encoding matrix against a single base path.
+// Each case's title already encodes the request method (new_get-, new_post-,
+// get_with_body-), so a failing assertion still identifies both the path (test
+// name) and the specific case.
+async fn run_endpoint_suite(base_path: &'static str) {
+    // GET requests: only the subset of encodings the new handlers accept via query params
     for mut unit in get_cases() {
         unit.base_path = base_path;
         execute_test(&unit).await;
     }
-}
-
-#[tokio::test]
-async fn test_i_v0_e_endpoint_post() {
-    let base_path = "/i/v0/e";
 
     // POST requests with payload in body, metadata in POST form or GET params
     for mut unit in post_cases() {
         unit.base_path = base_path;
         execute_test(&unit).await;
     }
-}
 
-#[tokio::test]
-async fn test_i_v0_e_endpoint_get_with_body() {
     // GET requests with a body payload are treated identically to POST requests
     let mut get_with_body_cases = post_cases();
-
     get_with_body_cases
         .iter_mut()
         .for_each(|tc: &mut TestCase| {
-            tc.base_path = "/i/v0/e";
+            tc.base_path = base_path;
             tc.method = Method::GetWithBody;
             tc.title = tc.title.replace("post-", "get_with_body-");
         });
-
-    for unit in get_with_body_cases {
-        execute_test(&unit).await;
-    }
-}
-
-#[tokio::test]
-async fn test_batch_endpoint_get() {
-    let base_path = "/batch";
-
-    // NOT currently supported by new capture endpoint handlers
-    for mut unit in get_cases() {
-        unit.base_path = base_path;
-        execute_test(&unit).await;
-    }
-}
-
-#[tokio::test]
-async fn test_batch_endpoint_post() {
-    let base_path = "/batch";
-
-    // POST requests with payload in body, metadata in POST form or GET params
-    for mut unit in post_cases() {
-        unit.base_path = base_path;
-        execute_test(&unit).await;
-    }
-}
-
-#[tokio::test]
-async fn test_batch_endpoint_get_with_body() {
-    // GET requests with a body payload are treated identically to POST requests
-    let mut get_with_body_cases = post_cases();
-
-    get_with_body_cases
-        .iter_mut()
-        .for_each(|tc: &mut TestCase| {
-            tc.base_path = "/batch";
-            tc.method = Method::GetWithBody;
-            tc.title = tc.title.replace("post-", "get_with_body-");
-        });
-
-    for unit in get_with_body_cases {
-        execute_test(&unit).await;
-    }
-}
-
-#[tokio::test]
-async fn test_ai_batch_endpoint_get() {
-    let base_path = "/i/v0/ai/batch";
-
-    // NOT currently supported by new capture endpoint handlers
-    for mut unit in get_cases() {
-        unit.base_path = base_path;
-        execute_test(&unit).await;
-    }
-}
-
-#[tokio::test]
-async fn test_ai_batch_endpoint_post() {
-    let base_path = "/i/v0/ai/batch";
-
-    // POST requests with payload in body, metadata in POST form or GET params
-    for mut unit in post_cases() {
-        unit.base_path = base_path;
-        execute_test(&unit).await;
-    }
-}
-
-#[tokio::test]
-async fn test_ai_batch_endpoint_get_with_body() {
-    // GET requests with a body payload are treated identically to POST requests
-    let mut get_with_body_cases = post_cases();
-
-    get_with_body_cases
-        .iter_mut()
-        .for_each(|tc: &mut TestCase| {
-            tc.base_path = "/i/v0/ai/batch";
-            tc.method = Method::GetWithBody;
-            tc.title = tc.title.replace("post-", "get_with_body-");
-        });
-
     for unit in get_with_body_cases {
         execute_test(&unit).await;
     }


### PR DESCRIPTION
## Problem

PR #62345 registers the new `/i/v0/ai/batch` and `/i/v0/ai/batch/` routes as aliases of the existing analytics batch handler, but it added no test coverage for them — the existing `/i/v0/e` and `/batch` paths each have a full integration matrix and the new AI path should match.

## Changes

Add integration tests for `/i/v0/ai/batch` in `integration_new_endpoints.rs`, mirroring the existing `/batch` coverage (GET, POST, and GET-with-body across the full payload-shape/encoding matrix). The tests reuse the shared `post_cases()`/`get_cases()` helpers, so they exercise the same plain-JSON, base64, gzip, urlencoded-form, and lz64 variants for both single-event and batch payloads.

This is stacked on top of #62345 (the branch that adds the routes), since the tests fail to route without that change.

## How did you test this code?

I'm the PostHog Slack app (agent). I added the tests but could **not** compile or run them locally — there is no Rust toolchain in this environment. The additions only reuse already-compiling helpers and mirror the existing `/batch` tests one-to-one, so CI on this PR will be the first real compile/run. I verified by inspection that the new routes exist in the base branch and that `batch_router` (which now carries the AI routes) is merged for `CaptureMode::Events`, which these tests use.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal ingestion route test coverage.

## 🤖 Agent context

Authored by the PostHog Slack app at Josh/Carlos's request to add endpoint integration tests for the new AI batch routes in #62345, matching the existing coverage for `/i/v0/e` and `/batch`.

Rather than create a standalone test file, the tests were added to the existing `integration_new_endpoints.rs` so they reuse its `post_cases()`/`get_cases()` case generators — that file already documents that `/i/v0/e`, `/batch`, and now `/i/v0/ai/batch` share one handler. The test harness always appends a trailing slash when building paths, so these exercise the `/i/v0/ai/batch/` route variant, consistent with how the existing `/i/v0/e` and `/batch` tests behave. Requires human review; no manual testing claimed.
