### PR TITLE
feat(tasks): show draft signal on New task button for unsubmitted text

### DIFF
--- a/products/tasks/frontend/components/TaskCreateModal.tsx
+++ b/products/tasks/frontend/components/TaskCreateModal.tsx
@@ -14,7 +14,9 @@ export function TaskCreateModal({ isOpen, onClose }: TaskCreateModalProps): JSX.
     const { submitNewTask, resetNewTaskData, setNewTaskData } = useActions(taskTrackerSceneLogic)
     const { newTaskData, isSubmittingTask } = useValues(taskTrackerSceneLogic)
 
-    const handleCancel = (): void => {
+    // Soft-closing the modal (X, click outside, escape) keeps the typed text so it surfaces as a
+    // draft on the "New task" button. "Cancel" is the explicit discard path that clears it.
+    const handleDiscard = (): void => {
         resetNewTaskData()
         onClose()
     }
@@ -22,12 +24,12 @@ export function TaskCreateModal({ isOpen, onClose }: TaskCreateModalProps): JSX.
     return (
         <LemonModal
             isOpen={isOpen}
-            onClose={handleCancel}
+            onClose={onClose}
             title="Create new task"
             width={800}
             footer={
                 <div className="flex gap-2">
-                    <LemonButton type="secondary" onClick={handleCancel}>
+                    <LemonButton type="secondary" onClick={handleDiscard}>
                         Cancel
                     </LemonButton>
                     <LemonButton type="primary" onClick={submitNewTask} loading={isSubmittingTask}>

--- a/products/tasks/frontend/components/TasksList.tsx
+++ b/products/tasks/frontend/components/TasksList.tsx
@@ -28,7 +28,7 @@ import { TaskStatusBadge } from './TaskStatusBadge'
 import { UserFilter } from './UserFilter'
 
 export function TasksList(): JSX.Element {
-    const { searchQuery, repository, status, showInternal, isStaff, isCreateModalOpen } =
+    const { searchQuery, repository, status, showInternal, isStaff, isCreateModalOpen, hasDraftTask } =
         useValues(taskTrackerSceneLogic)
     const { tasks, tasksLoading, repositories } = useValues(tasksLogic)
     const { setSearchQuery, setRepository, setStatus, setShowInternal, openCreateModal, closeCreateModal } =
@@ -150,7 +150,18 @@ export function TasksList(): JSX.Element {
                         />
                     )}
                 </div>
-                <LemonButton type="primary" icon={<IconPlus />} onClick={openCreateModal}>
+                <LemonButton
+                    type="primary"
+                    icon={<IconPlus />}
+                    onClick={openCreateModal}
+                    sideIcon={
+                        hasDraftTask ? (
+                            <LemonTag type="completion" size="small">
+                                Draft
+                            </LemonTag>
+                        ) : undefined
+                    }
+                >
                     New task
                 </LemonButton>
             </div>

--- a/products/tasks/frontend/components/TasksList.tsx
+++ b/products/tasks/frontend/components/TasksList.tsx
@@ -156,7 +156,7 @@ export function TasksList(): JSX.Element {
                     onClick={openCreateModal}
                     sideIcon={
                         hasDraftTask ? (
-                            <LemonTag type="completion" size="small">
+                            <LemonTag type="highlight" size="small">
                                 Draft
                             </LemonTag>
                         ) : undefined

--- a/products/tasks/frontend/logics/taskTrackerSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskTrackerSceneLogic.ts
@@ -123,6 +123,9 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
 
     selectors({
         isStaff: [(s) => [s.user], (user): boolean => user?.is_staff ?? false],
+        // True when the create-task form holds unsubmitted text, so the "New task" button can
+        // surface a draft signal once the modal is closed without submitting.
+        hasDraftTask: [(s) => [s.newTaskData], (newTaskData): boolean => newTaskData.description.trim().length > 0],
         // All filters are pushed down to the backend via `loadTasks(listParams)` so results are
         // not limited by list pagination. The scene renders `tasks` (the loader output) directly.
         listParams: [


### PR DESCRIPTION
## Problem

In the Tasks product, when you open the "New task" modal, start typing a description, then leave the modal without submitting (clicking outside, the X, or pressing escape), the typed text was silently discarded and there was no indication you had work in progress. There was no way to tell from the list view that you had an unsubmitted draft.

## Changes

- Closing the create-task modal via a soft close (X / click outside / escape) now **preserves** the typed description instead of resetting it.
- The "New task" button shows a **"Draft"** tag whenever the create form holds unsubmitted text, signaling unsaved changes.
- The footer **Cancel** button remains the explicit discard path (clears the draft); successful submission also clears it.

Implementation:
- Added a `hasDraftTask` selector to `taskTrackerSceneLogic` (true when the form description is non-empty).
- `TaskCreateModal` now routes `onClose` (soft close) to a plain close that keeps state, while Cancel discards.
- `TasksList` renders a `LemonTag` as the button's `sideIcon` when `hasDraftTask` is true.

## How did you test this code?

I'm an agent. Frontend tooling (oxfmt / tsc) was not available in this environment, so I could not run the formatter, type check, or tests locally. No automated tests were added. Reviewer should run `pnpm --filter=@posthog/frontend format` and `typescript:check`, and verify the behavior manually in the Tasks scene.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code at the user's request. The user asked that an in-progress task input show a "Draft" signal on the "New task" button once the modal is left without submitting.

Key decision: rather than a separate persisted draft store, I reused the existing `newTaskData` reducer (which already holds the form contents) and simply stopped resetting it on soft-close. The "Draft" tag is driven by a new `hasDraftTask` selector. Cancel was kept as the explicit discard action so users still have a one-click way to clear the draft; clearing the textarea also removes the signal reactively.
