### PR TITLE
fix(data-warehouse): let MongoDB take the database name as a separate field

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -578,6 +578,7 @@ class MondaySourceConfig(config.Config):
 @config.config
 class MongoDBSourceConfig(config.Config):
     connection_string: str
+    database_name: str | None = None
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -276,8 +276,20 @@ def _get_partition_settings(
         return None
 
 
-def _parse_connection_string(connection_string: str) -> dict[str, Any]:
-    """Parse MongoDB connection string and extract connection parameters."""
+DATABASE_NAME_REQUIRED_ERROR = (
+    "Database name is required. Add it to your connection string "
+    "(e.g. ...mongodb.net/my_database) or fill in the Database name field."
+)
+
+
+def _parse_connection_string(connection_string: str, database_override: str | None = None) -> dict[str, Any]:
+    """Parse MongoDB connection string and extract connection parameters.
+
+    ``database_override`` is the value of the separate "Database name" field. Atlas
+    ``mongodb+srv://...`` strings routinely omit the database from the path, so we fall
+    back to the override when the string doesn't carry one — an explicit database in the
+    connection string still wins.
+    """
     from urllib.parse import parse_qs, urlparse
 
     # TODO require TLS
@@ -294,6 +306,8 @@ def _parse_connection_string(connection_string: str) -> dict[str, Any]:
     host = parsed.hostname or "localhost"
     port = parsed.port or (27017 if parsed.scheme == "mongodb" else None)
     database = parsed.path.lstrip("/") if parsed.path else None
+    if not database and database_override:
+        database = database_override.strip() or None
     user = parsed.username
     password = parsed.password
 
@@ -408,11 +422,11 @@ def get_schemas(
 ) -> dict[str, list[tuple[str, str]]]:
     """Get all collections from MongoDB source database to sync."""
 
-    connection_params = _parse_connection_string(config.connection_string)
+    connection_params = _parse_connection_string(config.connection_string, config.database_name)
 
     with mongo_client(config.connection_string, team_id=team_id) as client:
         if not connection_params["database"]:
-            raise ValueError("Database name is required in connection string")
+            raise ValueError(DATABASE_NAME_REQUIRED_ERROR)
 
         db = client[connection_params["database"]]
         schema_list: dict[str, list[tuple[str, str]]] = collections.defaultdict(list)
@@ -438,10 +452,10 @@ def get_schemas(
 
 
 def get_collection_names(config: MongoDBSourceConfig, team_id: int) -> list[str]:
-    connection_params = _parse_connection_string(config.connection_string)
+    connection_params = _parse_connection_string(config.connection_string, config.database_name)
     with mongo_client(config.connection_string, team_id=team_id) as client:
         if not connection_params["database"]:
-            raise ValueError("Database name is required in connection string")
+            raise ValueError(DATABASE_NAME_REQUIRED_ERROR)
         db = client[connection_params["database"]]
         return db.list_collection_names(authorizedCollections=True)
 
@@ -471,11 +485,12 @@ def mongo_source(
     db_incremental_field_last_value: Optional[Any],
     incremental_field: Optional[str] = None,
     incremental_field_type: Optional[IncrementalFieldType] = None,
+    database_name: Optional[str] = None,
 ) -> SourceResponse:
-    connection_params = _parse_connection_string(connection_string)
+    connection_params = _parse_connection_string(connection_string, database_name)
 
     if not connection_params["database"]:
-        raise ValueError("Database name is required in connection string")
+        raise ValueError(DATABASE_NAME_REQUIRED_ERROR)
 
     # Create MongoDB client
     with mongo_client(connection_string, team_id=team_id) as client:

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -15,6 +15,7 @@ from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from posthog.temporal.data_imports.sources.mongodb.mongo import (
+    DATABASE_NAME_REQUIRED_ERROR,
     _parse_connection_string,
     filter_mongo_incremental_fields,
     get_collection_names,
@@ -68,7 +69,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
     ) -> list[SourceSchema]:
         mongo_schemas = get_mongo_schemas(config, team_id=team_id, names=names)
 
-        connection_params = _parse_connection_string(config.connection_string)
+        connection_params = _parse_connection_string(config.connection_string, config.database_name)
         leading_keys_by_collection: dict[str, set[str] | None] = {}
         with mongo_client(config.connection_string, team_id=team_id) as client:
             db = client[connection_params["database"]]
@@ -108,12 +109,12 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         from pymongo.errors import OperationFailure
 
         try:
-            connection_params = _parse_connection_string(config.connection_string)
+            connection_params = _parse_connection_string(config.connection_string, config.database_name)
         except:
             return False, "Invalid connection string"
 
         if not connection_params.get("database"):
-            return False, "Database name is required in connection string"
+            return False, DATABASE_NAME_REQUIRED_ERROR
 
         if not connection_params["is_srv"]:
             # For SRV connections the hostname is a DNS namespace (e.g.
@@ -148,6 +149,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             incremental_field_type=inputs.incremental_field_type,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value,
             team_id=inputs.team_id,
+            database_name=config.database_name,
         )
 
     @property
@@ -169,7 +171,19 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
                         required=True,
                         placeholder="mongodb://username:password@host:port/database?authSource=admin&tls=true",
                         secret=True,
-                    )
+                    ),
+                    SourceFieldInputConfig(
+                        name="database_name",
+                        label="Database name",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="my_database",
+                        caption=(
+                            "Only needed if your connection string doesn't already include the database "
+                            "(Atlas `mongodb+srv://...` strings usually don't)."
+                        ),
+                        secret=False,
+                    ),
                 ],
             ),
         )

--- a/posthog/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/posthog/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch
+
+from posthog.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
+from posthog.temporal.data_imports.sources.mongodb.mongo import DATABASE_NAME_REQUIRED_ERROR, _parse_connection_string
+from posthog.temporal.data_imports.sources.mongodb.source import MongoDBSource
+
+_SRV_NO_DB = "mongodb+srv://user:pass@cluster.abc.mongodb.net/?retryWrites=true&w=majority"
+_SRV_WITH_DB = "mongodb+srv://user:pass@cluster.abc.mongodb.net/realdb?retryWrites=true"
+
+
+class TestParseConnectionStringDatabaseOverride:
+    def test_uses_override_when_connection_string_omits_database(self):
+        # Atlas SRV strings routinely have no `/<db>` path — the separate field fills it.
+        params = _parse_connection_string(_SRV_NO_DB, database_override="mydb")
+        assert params["database"] == "mydb"
+
+    def test_connection_string_database_wins_over_override(self):
+        params = _parse_connection_string(_SRV_WITH_DB, database_override="ignored")
+        assert params["database"] == "realdb"
+
+    @pytest.mark.parametrize("override", [None, "", "   "])
+    def test_no_usable_override_leaves_database_empty(self, override):
+        # The trailing `/` makes the parsed path empty, so `database` is falsy
+        # (the downstream "is db missing" checks treat "" and None the same).
+        params = _parse_connection_string(_SRV_NO_DB, database_override=override)
+        assert not params["database"]
+
+
+class TestMongoValidateCredentialsDatabaseName:
+    def test_missing_database_everywhere_returns_actionable_error(self):
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_NO_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == DATABASE_NAME_REQUIRED_ERROR
+
+    @patch("posthog.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_database_name_field_satisfies_requirement(self, mock_get_collections):
+        mock_get_collections.return_value = ["users"]
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_NO_DB, "database_name": "mydb"})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is True
+        assert err is None


### PR DESCRIPTION
## Problem

The top MongoDB data warehouse connection failure is "Database name is required in connection string" (by far the most common MongoDB error). MongoDB Atlas gives users an SRV connection string of the form `mongodb+srv://user:pass@cluster.xxx.mongodb.net/?retryWrites=true&w=majority` — note there's **no `/<database>` in the path**. Users paste it verbatim and the source rejects it, because we extract the database name purely from the connection-string path. The only way out today is for the user to know they must hand-edit the string and splice in the database name.

## Changes

- Add an optional **Database name** field to the MongoDB source. When the connection string omits the database (Atlas SRV strings almost always do), we fall back to this field. An explicit database in the connection string still takes precedence, so existing sources are unaffected.
- Thread the override through `_parse_connection_string` and every consumer (`validate_credentials`, `get_schemas`, `get_collection_names`, `mongo_source`).
- The "database required" error now points at both options (add it to the string *or* fill in the field), via a shared `DATABASE_NAME_REQUIRED_ERROR` constant.
- Regenerated `MongoDBSourceConfig` to add `database_name: str | None = None` (only the MongoDB line — the full generator output also contained unrelated pre-existing drift/reformatting, which I deliberately left out of this PR).

This is one of a set of independent per-source PRs reducing data warehouse source connection errors, each scoped to a single source.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). No manual UI testing. Automated tests run locally, all passing:

- New `posthog/temporal/data_imports/sources/mongodb/test_database_name.py`: `_parse_connection_string` override precedence (override fills when the string omits the db; the string's db wins when present; blank/None override is ignored) and `validate_credentials` (missing db everywhere returns the actionable error; the new field satisfies the requirement, with `get_collection_names` mocked).
- Existing `test_mongo.py` (46) and `test_generated_configs.py` (23) still pass.
- `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by extending the `warehouse credentials invalid` analysis into the mid-tail sources over the last 7–45 days. Chose a separate optional field (matching how the other DB sources expose `database`) over heavier connection-string rewriting, keeping it fully backward compatible. Note on the generated file: running `generate_source_configs` surfaced unrelated drift in other sources (e.g. MySQL) plus formatting churn; I reverted that and applied only the single MongoDB line so this PR stays scoped — the rest is a pre-existing regen-drift issue for a separate cleanup.
