### PR TITLE
fix(data-warehouse): tolerate a missing https scheme on Convex deploy URLs

### DIFF
--- a/posthog/temporal/data_imports/sources/convex/convex.py
+++ b/posthog/temporal/data_imports/sources/convex/convex.py
@@ -39,7 +39,13 @@ def validate_deploy_url(deploy_url: str) -> str:
     Enforces https scheme, host matching *.convex.cloud, no query/fragment.
     Returns the validated base URL (scheme + host, no trailing slash).
     """
-    parsed = urlparse(deploy_url.strip())
+    deploy_url = deploy_url.strip()
+    # Tolerate a missing scheme — users routinely paste the bare host. We only add
+    # https when no scheme is present; an explicit http:// is still rejected below.
+    if deploy_url and "://" not in deploy_url:
+        deploy_url = f"https://{deploy_url}"
+
+    parsed = urlparse(deploy_url)
 
     if parsed.scheme != "https":
         raise InvalidDeployUrlError(

--- a/posthog/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/posthog/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -53,10 +53,17 @@ class TestValidateDeployUrl:
                 "https://clever-falcon-77.us-east-1.convex.cloud",
                 "https://clever-falcon-77.us-east-1.convex.cloud",
             ),
+            # missing scheme — normalized by prepending https://
+            ("no_scheme", "swift-lemur-123.convex.cloud", "https://swift-lemur-123.convex.cloud"),
+            (
+                "no_scheme_regional",
+                "breezy-otter-42.eu-west-1.convex.cloud",
+                "https://breezy-otter-42.eu-west-1.convex.cloud",
+            ),
+            ("no_scheme_trailing_slash", "swift-lemur-123.convex.cloud/", "https://swift-lemur-123.convex.cloud"),
             # invalid — should raise
             ("http", "http://swift-lemur-123.convex.cloud", None),
             ("ftp", "ftp://swift-lemur-123.convex.cloud", None),
-            ("no_scheme", "swift-lemur-123.convex.cloud", None),
             ("wrong_tld", "https://swift-lemur-123.convex.io", None),
             ("two_extra_subdomains", "https://extra.foo.swift-lemur-123.convex.cloud", None),
             ("lookalike", "https://convex.cloud.evil.com", None),


### PR DESCRIPTION
## Problem

Some Convex data warehouse connection failures are "Deployment URL must use the https scheme" — users paste the bare deployment host (`your-deployment-123.convex.cloud`, or a regional `your-deployment.eu-west-1.convex.cloud`) without the `https://` prefix, and `validate_deploy_url` rejects it outright instead of just adding the scheme.

(The related "host must match `.convex.cloud`" rejections for *regional* URLs were already fixed in `0180bba533d`; the production occurrences of that are an older deployment, so there's nothing to change there.)

## Changes

- In `validate_deploy_url`, prepend `https://` when the input has no scheme at all, before parsing. An explicit `http://` (or any non-https scheme) is still rejected, and the `*.convex.cloud` host allowlist — including the regional `<name>.<region>.convex.cloud` form — is unchanged, so the existing SSRF guarantees (no IP literals, no look-alike domains, no extra subdomains) still hold: a non-Convex host with no scheme just becomes `https://<that-host>` and fails the allowlist.

This is one of a set of independent per-source PRs reducing data warehouse source connection errors, each scoped to a single source.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). No manual UI testing. Automated tests run locally, all passing:

- Updated the `validate_deploy_url` parametrized test: the previously-rejected `no_scheme` case now normalizes to `https://...`, plus added no-scheme regional and trailing-slash cases. All existing rejection cases (http, ftp, wrong TLD, extra subdomains, look-alikes, IP literals, localhost, metadata IP, query/fragment) still raise.
- Full `test_convex.py` (31) passes.
- `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by extending the `warehouse credentials invalid` analysis into the mid-tail sources. Convex's larger error buckets (Professional-plan requirement, invalid deploy key) aren't code-fixable, and the regional-host rejection is already fixed in master — so this PR is just the small, safe scheme-normalization win. Kept the host allowlist untouched so the security properties are unchanged.
