### PR TITLE
fix: Don't require connection_string when changing host

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -293,6 +293,14 @@ def ssh_tunnel_connection_changed(existing: Any, incoming: Any) -> bool:
 # ServiceNow `auth_method`) keep their secrets one level down, not at the top level.
 _NESTED_AUTH_CONTAINERS = ("auth_method", "auth_type")
 
+# Secrets excluded from the re-entry gate because the edit form can never re-supply them, so
+# gating on them would permanently block host changes. `connection_string` is parsed into the
+# individual host/user/password fields on create, then stripped from API reads and hidden in the
+# edit form; it isn't the live connection target either (SQL sources connect via the individual
+# fields, `password` stays gated). Safe only while no source both connects via `connection_string`
+# and exposes a gated host field — MongoDB connects via it but has no host field, so it never gates.
+_CREATION_ONLY_SECRET_FIELDS = frozenset({"connection_string"})
+
 
 def has_preserved_credentials(existing: dict[str, Any], incoming: dict[str, Any], sensitive_fields: set[str]) -> bool:
     """True if any stored secret would be reused because the update didn't re-supply it.
@@ -796,7 +804,10 @@ class ExternalDataSourceSerializers(UserAccessControlSerializerMixin, serializer
             manifest_host_added = bool(new_hosts - existing_hosts)
 
         if connection_host_changed or ssh_tunnel_changed or manifest_host_added:
-            if has_preserved_credentials(existing_job_inputs, incoming_job_inputs, sensitive_fields):
+            # Exclude creation-only secrets that the edit form can't re-supply, so they don't
+            # permanently block host changes. The later merge still preserves their stored values.
+            gate_sensitive_fields = sensitive_fields - _CREATION_ONLY_SECRET_FIELDS
+            if has_preserved_credentials(existing_job_inputs, incoming_job_inputs, gate_sensitive_fields):
                 if ssh_tunnel_changed:
                     raise ValidationError("Changing the SSH tunnel requires re-entering your database credentials.")
                 if manifest_host_added:

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -293,12 +293,10 @@ def ssh_tunnel_connection_changed(existing: Any, incoming: Any) -> bool:
 # ServiceNow `auth_method`) keep their secrets one level down, not at the top level.
 _NESTED_AUTH_CONTAINERS = ("auth_method", "auth_type")
 
-# Secrets excluded from the re-entry gate because the edit form can never re-supply them, so
-# gating on them would permanently block host changes. `connection_string` is parsed into the
-# individual host/user/password fields on create, then stripped from API reads and hidden in the
-# edit form; it isn't the live connection target either (SQL sources connect via the individual
-# fields, `password` stays gated). Safe only while no source both connects via `connection_string`
-# and exposes a gated host field — MongoDB connects via it but has no host field, so it never gates.
+# Secrets the edit form can never re-supply (parsed into the individual fields on create, then
+# stripped from API reads and hidden in the edit form), so gating credential re-entry on them would
+# permanently block host changes. Excluded from the gate but still preserved by the merge: MongoDB
+# connects via `connection_string`, while SQL sources use the individual fields and gate `password`.
 _CREATION_ONLY_SECRET_FIELDS = frozenset({"connection_string"})
 
 
@@ -804,8 +802,6 @@ class ExternalDataSourceSerializers(UserAccessControlSerializerMixin, serializer
             manifest_host_added = bool(new_hosts - existing_hosts)
 
         if connection_host_changed or ssh_tunnel_changed or manifest_host_added:
-            # Exclude creation-only secrets that the edit form can't re-supply, so they don't
-            # permanently block host changes. The later merge still preserves their stored values.
             gate_sensitive_fields = sensitive_fields - _CREATION_ONLY_SECRET_FIELDS
             if has_preserved_credentials(existing_job_inputs, incoming_job_inputs, gate_sensitive_fields):
                 if ssh_tunnel_changed:

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -4082,6 +4082,60 @@ class TestExternalDataSource(APIBaseTest):
         assert source.job_inputs["password"] == "new_password"
         mock_validate_credentials.assert_called_once()
 
+    @parameterized.expand([("with_password", {"password": "new_password"}, 200), ("without_password", {}, 400)])
+    @patch(
+        "posthog.temporal.data_imports.sources.postgres.source.PostgresSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_update_host_change_with_stored_connection_string(
+        self, _name, extra_creds, expected_status, mock_validate_credentials
+    ):
+        # A source created via a connection string stores the raw URI under `connection_string`,
+        # which the edit form can never re-supply, so it must not block a host change. The real
+        # secret, `password`, stays gated: re-entering it succeeds, omitting it is still rejected.
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type="Postgres",
+            created_by=self.user,
+            prefix="test_host_conn_string",
+            job_inputs={
+                "source_type": "Postgres",
+                "connection_string": "postgresql://dbuser:original_password@db.example.com:5432/mydb",
+                "host": "db.example.com",
+                "port": "5432",
+                "database": "mydb",
+                "user": "dbuser",
+                "password": "original_password",
+                "schema": "public",
+            },
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/",
+            data={"job_inputs": {"host": "new-host.example.com", **extra_creds}},
+        )
+
+        assert response.status_code == expected_status, response.json()
+        assert ("re-entering your credentials" in str(response.json())) == (expected_status == 400)
+        source.refresh_from_db()
+        # connection_string is excluded from the re-entry gate but still carried through the merge:
+        # connection-string-based sources (e.g. MongoDB) connect via it and never re-supply it on
+        # edit, so dropping it would break them.
+        assert (
+            source.job_inputs["connection_string"] == "postgresql://dbuser:original_password@db.example.com:5432/mydb"
+        )
+        if expected_status == 200:
+            assert source.job_inputs["host"] == "new-host.example.com"
+            assert source.job_inputs["password"] == "new_password"
+            mock_validate_credentials.assert_called_once()
+        else:
+            assert source.job_inputs["host"] == "db.example.com"
+            assert source.job_inputs["password"] == "original_password"
+            mock_validate_credentials.assert_not_called()
+
     @patch(
         "posthog.temporal.data_imports.sources.freshdesk.source.FreshdeskSource.validate_credentials",
         return_value=(True, None),

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -4090,9 +4090,8 @@ class TestExternalDataSource(APIBaseTest):
     def test_update_host_change_with_stored_connection_string(
         self, _name, extra_creds, expected_status, mock_validate_credentials
     ):
-        # A source created via a connection string stores the raw URI under `connection_string`,
-        # which the edit form can never re-supply, so it must not block a host change. The real
-        # secret, `password`, stays gated: re-entering it succeeds, omitting it is still rejected.
+        # A stored `connection_string` (never re-suppliable via the edit form) must not block a host
+        # change, while `password` stays gated: re-entering it succeeds, omitting it is still rejected.
         source = ExternalDataSource.objects.create(
             team_id=self.team.pk,
             source_id=str(uuid.uuid4()),
@@ -4121,9 +4120,7 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == expected_status, response.json()
         assert ("re-entering your credentials" in str(response.json())) == (expected_status == 400)
         source.refresh_from_db()
-        # connection_string is excluded from the re-entry gate but still carried through the merge:
-        # connection-string-based sources (e.g. MongoDB) connect via it and never re-supply it on
-        # edit, so dropping it would break them.
+        # Preserved by the merge regardless of outcome — connection-string-based sources rely on this.
         assert (
             source.job_inputs["connection_string"] == "postgresql://dbuser:original_password@db.example.com:5432/mydb"
         )


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/59899 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61151)

Updating the host was failing even when supplying a password for a Supabase source:

<img width="464" height="113" alt="CleanShot 2026-06-09 at 15 21 43" src="https://github.com/user-attachments/assets/f8f226ea-e487-48e3-932a-c18bf7ef7a92" />


## Changes

Don't require an updated connection string when changing the host. This felt a bit weird, because in effect we're left storing a stale `connection_string` - but we don't actually use this for Postgres/Supabase, we use the component host/port etc instead.

MongoDB is the only one where we use the connection string directly, but this isn't exposed in the edit form so there's no way to update it right now anyway.

## How did you test this code?

Unit test + verified locally

## 🤖 Agent context

  **Autonomy:** Human-driven (agent-assisted)

  Diagnosed and implemented with Claude Code. The agent traced the failure to the VERIA-311 credential re-entry gate: `has_preserved_credentials` counts every `secret=True` field, and Postgres/Supabase mark `connection_string` secret — but that field is stripped from API reads and hidden in the edit form, so it can never be re-supplied, making the gate unsatisfiable on any host change for connection-string-created sources.

  - Chose to exclude `connection_string` from the gate (not from the merge) so the stored value is still preserved — which MongoDB depends on, since it connects via `connection_string` and can't re-supply it on edit.
  - Considered but rejected dropping the stale `connection_string` on host change: it's a half-measure (doesn't cover password-only edits) and risks MongoDB; the real wart is SQL sources persisting it at creation, left as a follow-up.
  - A code-review agent independently verified the connect paths for all six SQL sources + MongoDB to confirm no credential-exfiltration regression.
  - Automated tests run by the agent: the new parameterized `test_update_host_change_with_stored_connection_string` plus the surrounding host-change / credential-gate suite.