### PR TITLE
feat(web-analytics): add dimensional precompute read path

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -138,8 +138,10 @@ from posthog.hogql.database.schema.spans import TraceAttributesTable, TraceSpans
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
 from posthog.hogql.database.schema.system import SystemTables
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
+    WebBouncesDimensionalPreAggregatedTable,
     WebPreAggregatedBouncesTable,
     WebPreAggregatedStatsTable,
+    WebStatsDimensionalPreAggregatedTable,
 )
 from posthog.hogql.database.schema.web_goals_preaggregated import WebGoalsPreaggregatedTable
 from posthog.hogql.database.schema.web_overview_preaggregated import WebOverviewPreaggregatedTable
@@ -266,6 +268,15 @@ ROOT_TABLES__DO_NOT_ADD_ANY_MORE: dict[str, TableNode] = {
     # Web analytics pre-aggregated tables (internal use only)
     "web_pre_aggregated_stats": TableNode(name="web_pre_aggregated_stats", table=WebPreAggregatedStatsTable()),
     "web_pre_aggregated_bounces": TableNode(name="web_pre_aggregated_bounces", table=WebPreAggregatedBouncesTable()),
+    # Dimensional precompute tables: v2-successor read tables sharing v2's column
+    # layout and single-identifier access pattern (the web-analytics builder
+    # qualifies columns as `table.col`, which only resolves in the root namespace).
+    "web_stats_dimensional_preaggregated": TableNode(
+        name="web_stats_dimensional_preaggregated", table=WebStatsDimensionalPreAggregatedTable()
+    ),
+    "web_bounces_dimensional_preaggregated": TableNode(
+        name="web_bounces_dimensional_preaggregated", table=WebBouncesDimensionalPreAggregatedTable()
+    ),
     "preaggregation_results": TableNode(name="preaggregation_results", table=PreaggregationResultsTable()),
     "experiment_exposures_preaggregated": TableNode(
         name="experiment_exposures_preaggregated", table=ExperimentExposuresPreaggregatedTable()

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -268,9 +268,11 @@ ROOT_TABLES__DO_NOT_ADD_ANY_MORE: dict[str, TableNode] = {
     # Web analytics pre-aggregated tables (internal use only)
     "web_pre_aggregated_stats": TableNode(name="web_pre_aggregated_stats", table=WebPreAggregatedStatsTable()),
     "web_pre_aggregated_bounces": TableNode(name="web_pre_aggregated_bounces", table=WebPreAggregatedBouncesTable()),
-    # Dimensional precompute tables: v2-successor read tables sharing v2's column
-    # layout and single-identifier access pattern (the web-analytics builder
-    # qualifies columns as `table.col`, which only resolves in the root namespace).
+    # Justified exceptions to the "do not add" rule: the dimensional precompute
+    # tables are the v2 tables' read successors and must live in the root namespace
+    # for the same reason v2 does — the web-analytics query builder qualifies columns
+    # as `table.col` (single-identifier), which only resolves at the root. Namespacing
+    # them under `posthog.` would require reworking that shared builder.
     "web_stats_dimensional_preaggregated": TableNode(
         name="web_stats_dimensional_preaggregated", table=WebStatsDimensionalPreAggregatedTable()
     ),

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -6,6 +6,7 @@ from posthog.hogql.database.models import (
     IntegerDatabaseField,
     StringDatabaseField,
     Table,
+    UUIDDatabaseField,
 )
 
 DEVICE_BROWSER_FIELDS = {
@@ -110,3 +111,43 @@ class WebPreAggregatedBouncesTable(Table):
 
     def to_printed_hogql(self):
         return "web_pre_aggregated_bounces"
+
+
+# The dimensional precompute tables mirror the v2 schema but carry an extra `job_id`
+# (the precomputation framework writes one generation per job). Reads filter
+# `job_id IN (ready ids)` to dedup the ReplacingMergeTree generations.
+WEB_DIMENSIONAL_SPECIFIC_FIELDS = {
+    "job_id": UUIDDatabaseField(name="job_id"),
+}
+
+
+class WebStatsDimensionalPreAggregatedTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        **SHARED_SCHEMA_FIELDS,
+        **WEB_STATS_SPECIFIC_FIELDS,
+        **WEB_DIMENSIONAL_SPECIFIC_FIELDS,
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_stats_dimensional_preaggregated"
+
+    def to_printed_hogql(self):
+        return "web_stats_dimensional_preaggregated"
+
+
+class WebBouncesDimensionalPreAggregatedTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        **SHARED_SCHEMA_FIELDS,
+        **WEB_BOUNCES_SPECIFIC_FIELDS,
+        **WEB_DIMENSIONAL_SPECIFIC_FIELDS,
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_bounces_dimensional_preaggregated"
+
+    def to_printed_hogql(self):
+        return "web_bounces_dimensional_preaggregated"

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -2545,6 +2545,8 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             "logs_kafka_metrics",
             "web_pre_aggregated_stats",
             "web_pre_aggregated_bounces",
+            "web_stats_dimensional_preaggregated",
+            "web_bounces_dimensional_preaggregated",
             "preaggregation_results",
             "experiment_exposures_preaggregated",
             "experiment_metric_events_preaggregated",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -847,3 +847,12 @@ WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS: list[int] = [
     int(team_id)
     for team_id in get_list(get_from_env("WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS", _LAZY_PRECOMPUTE_DEFAULT_TEAM_IDS))
 ]
+
+# Teams whose web analytics reads are served from the dimensional precompute
+# tables instead of v2. Strictly additive: defaults to empty so v2 stays the
+# reader for every team until one is explicitly enrolled here (a deploy-time
+# env-var change), and the runner falls back to v2 whenever a team has no READY
+# dimensional data for the requested window.
+WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS: list[int] = [
+    int(team_id) for team_id in get_list(get_from_env("WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS", ""))
+]

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -1078,22 +1078,10 @@ def ensure_precomputed(
                 "so real values are available at INSERT time."
             )
 
-    # Parse the query template with sentinel placeholders for stable hashing.
-    # time_window_min/max are always sentinelized (managed by the executor).
-    # Callers can opt additional placeholders into sentinelization via sentinel_placeholders.
-    caller_sentinels: dict[str, ast.Expr] = {
-        name: ast.Constant(value=f"__{name.upper()}__") for name in (sentinel_placeholders or set())
-    }
-    hash_placeholders: dict[str, ast.Expr] = {
-        **base_placeholders,
-        "time_window_min": ast.Constant(value="__TIME_WINDOW_MIN__"),
-        "time_window_max": ast.Constant(value="__TIME_WINDOW_MAX__"),
-        **caller_sentinels,
-    }
-    parsed_for_hash = _resolve_insert_query(insert_query, hash_placeholders)
-
-    query_info = QueryInfo(
-        query=parsed_for_hash,
+    query_info = _build_query_info_for_hash(
+        insert_query=insert_query,
+        base_placeholders=base_placeholders,
+        sentinel_placeholders=sentinel_placeholders,
         table=table,
         timezone=team.timezone,
     )
@@ -1120,6 +1108,65 @@ def ensure_precomputed(
     ttl_schedule = parse_ttl_schedule(ttl_seconds, team.timezone)
     executor = LazyComputationExecutor(ttl_schedule=ttl_schedule)
     return executor.execute(team, query_info, time_range_start, time_range_end, run_insert=_run_manual_insert)
+
+
+def _build_query_info_for_hash(
+    insert_query: str | ast.SelectQuery,
+    base_placeholders: dict[str, ast.Expr],
+    sentinel_placeholders: set[str] | None,
+    table: LazyComputationTable,
+    timezone: str,
+) -> QueryInfo:
+    """Build the QueryInfo whose `compute_query_hash` identifies a precompute.
+
+    time_window_min/max are always sentinelized (managed by the executor); callers
+    can opt additional placeholders into sentinelization via sentinel_placeholders.
+    Shared by `ensure_precomputed` (writer) and `get_ready_job_ids` (reader) so both
+    derive the same query_hash for the same precompute definition.
+    """
+    caller_sentinels: dict[str, ast.Expr] = {
+        name: ast.Constant(value=f"__{name.upper()}__") for name in (sentinel_placeholders or set())
+    }
+    hash_placeholders: dict[str, ast.Expr] = {
+        **base_placeholders,
+        "time_window_min": ast.Constant(value="__TIME_WINDOW_MIN__"),
+        "time_window_max": ast.Constant(value="__TIME_WINDOW_MAX__"),
+        **caller_sentinels,
+    }
+    parsed_for_hash = _resolve_insert_query(insert_query, hash_placeholders)
+    return QueryInfo(query=parsed_for_hash, table=table, timezone=timezone)
+
+
+def get_ready_job_ids(
+    team: Team,
+    insert_query: str | ast.SelectQuery,
+    time_range_start: datetime,
+    time_range_end: datetime,
+    table: LazyComputationTable,
+    placeholders: dict[str, ast.Expr] | None = None,
+    sentinel_placeholders: set[str] | None = None,
+) -> list[uuid.UUID]:
+    """Resolve the READY job_ids covering [start, end) for data populated by
+    `ensure_precomputed` with the same (insert_query, placeholders, table).
+
+    Read-only: it never triggers computation — callers that only want to READ a
+    pre-populated table (e.g. the scheduled dimensional precompute) filter their
+    SELECT to `job_id IN (returned ids)`. Returns [] when nothing is ready, so the
+    caller can fall back to its non-precomputed path. The (insert_query, placeholders,
+    sentinel_placeholders, table) must exactly match the writer's so the query_hash
+    lines up.
+    """
+    query_info = _build_query_info_for_hash(
+        insert_query=insert_query,
+        base_placeholders=placeholders or {},
+        sentinel_placeholders=sentinel_placeholders,
+        table=table,
+        timezone=team.timezone,
+    )
+    query_hash = compute_query_hash(query_info)
+    existing = find_existing_jobs(team, query_hash, time_range_start, time_range_end)
+    ready = filter_overlapping_jobs([j for j in existing if j.status == PreaggregationJob.Status.READY])
+    return [j.id for j in ready]
 
 
 def _resolve_insert_query(insert_query: str | ast.SelectQuery, placeholders: dict[str, ast.Expr]) -> ast.SelectQuery:

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -1166,6 +1166,12 @@ def get_ready_job_ids(
     query_hash = compute_query_hash(query_info)
     existing = find_existing_jobs(team, query_hash, time_range_start, time_range_end)
     ready = filter_overlapping_jobs([j for j in existing if j.status == PreaggregationJob.Status.READY])
+    # Only return ids when READY jobs fully cover [start, end). Partial coverage
+    # (mid-backfill, or a day that expired/failed) would make a `job_id IN (ids)`
+    # read silently drop the uncovered windows — so return nothing, signalling the
+    # caller to fall back to its non-precomputed path instead of under-counting.
+    if find_missing_contiguous_windows(ready, time_range_start, time_range_end):
+        return []
     return [j.id for j in ready]
 
 

--- a/products/web_analytics/backend/hogql_queries/pre_aggregated/query_builder.py
+++ b/products/web_analytics/backend/hogql_queries/pre_aggregated/query_builder.py
@@ -1,5 +1,8 @@
-from datetime import timedelta
+import uuid
+from datetime import datetime, timedelta
 from typing import Optional
+
+from django.conf import settings
 
 from posthog.hogql import ast
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
@@ -8,6 +11,12 @@ from posthog.hogql.property import property_to_expr
 from products.web_analytics.backend.hogql_queries.pre_aggregated.property_transformer import (
     ChannelTypeReplacer,
     PreAggregatedPropertyTransformer,
+)
+from products.web_analytics.backend.hogql_queries.web_dimensional_precompute import (
+    WEB_BOUNCES_DIMENSIONAL_READ_TABLE,
+    WEB_STATS_DIMENSIONAL_READ_TABLE,
+    web_bounces_dimensional_job_ids,
+    web_stats_dimensional_job_ids,
 )
 
 # V1 tables have been removed - always use v2 tables
@@ -19,14 +28,60 @@ class WebAnalyticsPreAggregatedQueryBuilder:
     def __init__(self, runner, supported_props_filters) -> None:
         self.runner = runner
         self.supported_props_filters = supported_props_filters
+        # Resolved once per build: "stats"/"bounces" -> READY dimensional job_ids.
+        self._dimensional_job_ids: dict[str, list[uuid.UUID]] = {}
+
+    def _dimensional_window(self) -> tuple[datetime, datetime]:
+        # Cover the compare period too, since both feed the same SELECT.
+        date_from = self.runner.query_date_range.date_from()
+        if self.runner.query_compare_to_date_range:
+            date_from = min(date_from, self.runner.query_compare_to_date_range.date_from())
+        return date_from, self.runner.query_date_range.date_to()
+
+    def _job_ids_for(self, which: str) -> list[uuid.UUID]:
+        if which not in self._dimensional_job_ids:
+            start, end = self._dimensional_window()
+            resolver = web_stats_dimensional_job_ids if which == "stats" else web_bounces_dimensional_job_ids
+            self._dimensional_job_ids[which] = resolver(self.runner.team, start, end)
+        return self._dimensional_job_ids[which]
+
+    def use_dimensional_tables(self) -> bool:
+        """Serve enrolled teams from the dimensional precompute tables when both
+        stats and bounces have READY data for the window; otherwise fall back to v2.
+        """
+        if self.runner.team.id not in settings.WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS:
+            return False
+        return bool(self._job_ids_for("stats")) and bool(self._job_ids_for("bounces"))
 
     @property
     def stats_table(self) -> str:
+        if self.use_dimensional_tables():
+            return WEB_STATS_DIMENSIONAL_READ_TABLE
         return get_stats_table(self.runner.use_v2_tables)
 
     @property
     def bounces_table(self) -> str:
+        if self.use_dimensional_tables():
+            return WEB_BOUNCES_DIMENSIONAL_READ_TABLE
         return get_bounces_table(self.runner.use_v2_tables)
+
+    def _dimensional_job_id_filter(self, table_name: str) -> Optional[ast.Expr]:
+        """`job_id IN (ready ids)` for a dimensional table read. The tables are
+        `ReplacingMergeTree` keyed by job_id with multiple generations per recent
+        window, so without this filter `sumMerge`/`uniqMerge` would double-count.
+        v2 tables (one version per partition) need no such filter.
+        """
+        if table_name == WEB_STATS_DIMENSIONAL_READ_TABLE:
+            job_ids = self._job_ids_for("stats")
+        elif table_name == WEB_BOUNCES_DIMENSIONAL_READ_TABLE:
+            job_ids = self._job_ids_for("bounces")
+        else:
+            return None
+        return ast.CompareOperation(
+            op=ast.CompareOperationOp.In,
+            left=ast.Field(chain=[table_name, "job_id"]),
+            right=ast.Constant(value=[str(j) for j in job_ids]),
+        )
 
     def can_use_preaggregated_tables(self) -> bool:
         query = self.runner.query
@@ -114,6 +169,10 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                 right=ast.Constant(value=self.runner.query_date_range.date_to()),
             ),
         ]
+
+        job_id_filter = self._dimensional_job_id_filter(table_name)
+        if job_id_filter is not None:
+            filter_exprs.append(job_id_filter)
 
         if self.runner.query.properties:
             virtual_properties = []

--- a/products/web_analytics/backend/hogql_queries/test/test_dimensional_read_selection.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_dimensional_read_selection.py
@@ -1,0 +1,65 @@
+import uuid
+from datetime import UTC, datetime
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from posthog.hogql import ast
+
+from products.web_analytics.backend.hogql_queries.pre_aggregated.query_builder import (
+    WEB_BOUNCES_DIMENSIONAL_READ_TABLE,
+    WEB_STATS_DIMENSIONAL_READ_TABLE,
+    WebAnalyticsPreAggregatedQueryBuilder,
+)
+
+_QB = "products.web_analytics.backend.hogql_queries.pre_aggregated.query_builder"
+
+
+def _runner(team_id: int) -> MagicMock:
+    runner = MagicMock()
+    runner.team.id = team_id
+    runner.query_date_range.date_from.return_value = datetime(2026, 3, 1, tzinfo=UTC)
+    runner.query_date_range.date_to.return_value = datetime(2026, 6, 1, tzinfo=UTC)
+    runner.query_compare_to_date_range = None
+    runner.use_v2_tables = True
+    runner.query.properties = []
+    return runner
+
+
+class TestDimensionalReadSelection(SimpleTestCase):
+    @override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[2])
+    @patch(f"{_QB}.web_bounces_dimensional_job_ids", return_value=[uuid.uuid4()])
+    @patch(f"{_QB}.web_stats_dimensional_job_ids", return_value=[uuid.uuid4()])
+    def test_enrolled_team_with_ready_data_reads_dimensional_and_filters_job_id(self, _mock_stats, _mock_bounces):
+        builder = WebAnalyticsPreAggregatedQueryBuilder(_runner(2), {})
+
+        assert builder.stats_table == WEB_STATS_DIMENSIONAL_READ_TABLE
+        assert builder.bounces_table == WEB_BOUNCES_DIMENSIONAL_READ_TABLE
+
+        job_filter = builder._dimensional_job_id_filter(WEB_STATS_DIMENSIONAL_READ_TABLE)
+        assert isinstance(job_filter, ast.CompareOperation)
+        assert job_filter.op == ast.CompareOperationOp.In
+        # the WHERE built by _get_filters carries the job_id filter
+        where = builder._get_filters(WEB_STATS_DIMENSIONAL_READ_TABLE)
+        assert isinstance(where, ast.And)
+        assert any(isinstance(e, ast.CompareOperation) and e.op == ast.CompareOperationOp.In for e in where.exprs), (
+            "dimensional read WHERE must include job_id IN (...)"
+        )
+
+    @override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[2])
+    @patch(f"{_QB}.web_bounces_dimensional_job_ids", return_value=[uuid.uuid4()])
+    @patch(f"{_QB}.web_stats_dimensional_job_ids", return_value=[])
+    def test_enrolled_team_without_ready_data_falls_back_to_v2(self, _mock_stats, _mock_bounces):
+        builder = WebAnalyticsPreAggregatedQueryBuilder(_runner(2), {})
+
+        assert builder.stats_table == "web_pre_aggregated_stats"
+        assert builder.bounces_table == "web_pre_aggregated_bounces"
+        assert builder._dimensional_job_id_filter("web_pre_aggregated_stats") is None
+
+    @override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[2])
+    def test_unenrolled_team_uses_v2(self):
+        builder = WebAnalyticsPreAggregatedQueryBuilder(_runner(999), {})
+
+        assert builder.stats_table == "web_pre_aggregated_stats"
+        assert builder.bounces_table == "web_pre_aggregated_bounces"

--- a/products/web_analytics/backend/hogql_queries/test/test_web_dimensional_read_parity.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_dimensional_read_parity.py
@@ -45,8 +45,11 @@ from products.web_analytics.backend.hogql_queries.web_dimensional_precompute imp
 
 DATE_FROM = "2024-01-01"
 DATE_TO = "2024-01-02"
+# A `date_to` of "2024-01-02" resolves to end-of-day, so the query spans the 01-01 and
+# 01-02 daily windows. Precompute both so the read path's full-coverage gate is satisfied
+# (events only land on 01-01; the 01-02 window precomputes to an empty, still-READY job).
 WINDOW_START = datetime(2024, 1, 1, tzinfo=UTC)
-WINDOW_END = datetime(2024, 1, 2, tzinfo=UTC)
+WINDOW_END = datetime(2024, 1, 3, tzinfo=UTC)
 
 
 class TestWebDimensionalReadParity(WebAnalyticsPreAggregatedTestBase):
@@ -186,3 +189,21 @@ class TestWebDimensionalReadParity(WebAnalyticsPreAggregatedTestBase):
 
         assert dimensional == v2, f"{_name} mismatch\nv2={v2}\ndimensional={dimensional}"
         assert self._counts(dimensional) == expected_counts
+
+    def test_partial_coverage_falls_back_to_v2(self):
+        # Dimensional is precomputed for 2024-01-01 only (setUp). A window that also
+        # spans 2024-01-02 is only partially covered, so the runner must fall back to
+        # v2 rather than silently drop the uncovered day via the job_id filter.
+        runner = WebStatsTableQueryRunner(
+            team=self.team,
+            query=WebStatsTableQuery(
+                dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-03"),
+                properties=[],
+                breakdownBy=WebStatsBreakdown.DEVICE_TYPE,
+                limit=100,
+            ),
+        )
+        builder = StatsTablePreAggregatedQueryBuilder(runner)
+        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
+            assert not builder.use_dimensional_tables(), "partial coverage must not route to dimensional"
+            assert builder.stats_table == "web_pre_aggregated_stats"

--- a/products/web_analytics/backend/hogql_queries/test/test_web_dimensional_read_parity.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_dimensional_read_parity.py
@@ -17,6 +17,8 @@ from posthog.test.base import _create_event, _create_person, flush_persons_and_e
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.schema import (
     DateRange,
     EventPropertyFilter,
@@ -162,26 +164,25 @@ class TestWebDimensionalReadParity(WebAnalyticsPreAggregatedTestBase):
         assert builder.use_dimensional_tables(), "enrolled team with READY data should route to dimensional"
         assert builder.stats_table == WEB_STATS_DIMENSIONAL_READ_TABLE
 
-    def test_device_breakdown_dimensional_matches_v2(self):
+    @parameterized.expand(
+        [
+            # No filter — Desktop: user_a (2 views) + user_c (1 view) = 2 visitors / 3 views; Mobile: user_b = 1 / 1.
+            ("device_breakdown", None, {"Desktop": (2.0, 3.0), "Mobile": (1.0, 1.0)}),
+            # Host + device cross-section the fixed-dimension tables uniquely serve: blog.example.com / user_c is
+            # excluded, leaving only the two app.example.com sessions.
+            (
+                "host_and_device_filter",
+                [EventPropertyFilter(key="$host", value="app.example.com", operator=PropertyOperator.EXACT)],
+                {"Desktop": (1.0, 2.0), "Mobile": (1.0, 1.0)},
+            ),
+        ]
+    )
+    def test_dimensional_matches_v2(self, _name, properties, expected_counts):
         with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[]):
-            v2 = self._run(WebStatsBreakdown.DEVICE_TYPE)
+            v2 = self._run(WebStatsBreakdown.DEVICE_TYPE, properties=properties)
         with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
-            self._assert_routes_to_dimensional(WebStatsBreakdown.DEVICE_TYPE)
-            dimensional = self._run(WebStatsBreakdown.DEVICE_TYPE)
+            self._assert_routes_to_dimensional(WebStatsBreakdown.DEVICE_TYPE, properties=properties)
+            dimensional = self._run(WebStatsBreakdown.DEVICE_TYPE, properties=properties)
 
-        assert dimensional == v2, f"device breakdown mismatch\nv2={v2}\ndimensional={dimensional}"
-        # Desktop: user_a (2 views) + user_c (1 view) = 2 visitors / 3 views; Mobile: user_b = 1 / 1.
-        assert self._counts(dimensional) == {"Desktop": (2.0, 3.0), "Mobile": (1.0, 1.0)}
-
-    def test_host_and_device_filter_dimensional_matches_v2(self):
-        # The multi-dimension cross-section the fixed-dimension tables uniquely serve.
-        host_filter = [EventPropertyFilter(key="$host", value="app.example.com", operator=PropertyOperator.EXACT)]
-        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[]):
-            v2 = self._run(WebStatsBreakdown.DEVICE_TYPE, properties=host_filter)
-        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
-            self._assert_routes_to_dimensional(WebStatsBreakdown.DEVICE_TYPE, properties=host_filter)
-            dimensional = self._run(WebStatsBreakdown.DEVICE_TYPE, properties=host_filter)
-
-        assert dimensional == v2, f"host+device breakdown mismatch\nv2={v2}\ndimensional={dimensional}"
-        # blog.example.com / user_c is excluded; only the two app.example.com sessions remain.
-        assert self._counts(dimensional) == {"Desktop": (1.0, 2.0), "Mobile": (1.0, 1.0)}
+        assert dimensional == v2, f"{_name} mismatch\nv2={v2}\ndimensional={dimensional}"
+        assert self._counts(dimensional) == expected_counts

--- a/products/web_analytics/backend/hogql_queries/test/test_web_dimensional_read_parity.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_dimensional_read_parity.py
@@ -1,0 +1,187 @@
+"""Read-path parity: routing the web-analytics query runner to the dimensional
+precompute tables (for enrolled teams) must produce the same results as the v2
+pre-aggregated tables — including under multi-dimension filters, the capability
+the fixed-dimension tables exist to provide.
+
+The write-path parity test (`test_web_dimensional_precompute_parity`) asserts the
+dimensional table *contents* equal v2's. This test instead drives the query
+*runner* end-to-end, so it covers the read path the write-path test doesn't: the
+query-builder table selection and the `job_id IN` dedup filter applied through
+`StatsTablePreAggregatedQueryBuilder`.
+"""
+
+from datetime import UTC, datetime
+
+from freezegun import freeze_time
+from posthog.test.base import _create_event, _create_person, flush_persons_and_events
+
+from django.test import override_settings
+
+from posthog.schema import (
+    DateRange,
+    EventPropertyFilter,
+    HogQLQueryModifiers,
+    PropertyOperator,
+    WebStatsBreakdown,
+    WebStatsTableQuery,
+)
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.utils import uuid7
+from posthog.models.web_preaggregated.sql import WEB_BOUNCES_INSERT_SQL, WEB_STATS_INSERT_SQL
+
+from products.web_analytics.backend.hogql_queries.pre_aggregated.query_builder import WEB_STATS_DIMENSIONAL_READ_TABLE
+from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
+from products.web_analytics.backend.hogql_queries.stats_table_pre_aggregated import StatsTablePreAggregatedQueryBuilder
+from products.web_analytics.backend.hogql_queries.test.web_preaggregated_test_base import (
+    WebAnalyticsPreAggregatedTestBase,
+)
+from products.web_analytics.backend.hogql_queries.web_dimensional_precompute import (
+    ensure_web_bounces_dimensional_precomputed,
+    ensure_web_stats_dimensional_precomputed,
+)
+
+DATE_FROM = "2024-01-01"
+DATE_TO = "2024-01-02"
+WINDOW_START = datetime(2024, 1, 1, tzinfo=UTC)
+WINDOW_END = datetime(2024, 1, 2, tzinfo=UTC)
+
+
+class TestWebDimensionalReadParity(WebAnalyticsPreAggregatedTestBase):
+    def setUp(self):
+        # STOP TTL MERGES before any data lands, so born-expired parts (the test's
+        # frozen window is years behind the real CH clock) survive until we read.
+        sync_execute("SYSTEM STOP TTL MERGES sharded_web_stats_dimensional_preaggregated")
+        sync_execute("SYSTEM STOP TTL MERGES sharded_web_bounces_dimensional_preaggregated")
+        super().setUp()
+
+    def _pageview(self, distinct_id: str, session: str, ts: str, **props) -> None:
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id=distinct_id,
+            timestamp=ts,
+            properties={"$session_id": session, **props},
+        )
+
+    def _setup_test_data(self):
+        # Two hosts × device types so a host+device filter is a real cross-section.
+        sa, sb, sc = (str(uuid7("2024-01-01")) for _ in range(3))
+        with freeze_time("2024-01-01T09:00:00Z"):
+            for did in ("user_a", "user_b", "user_c"):
+                _create_person(team_id=self.team.pk, distinct_ids=[did])
+            app_desktop = {
+                "$host": "app.example.com",
+                "$device_type": "Desktop",
+                "$browser": "Chrome",
+                "$os": "Windows",
+                "$viewport_width": 1920,
+                "$viewport_height": 1080,
+            }
+            # user_a: two pageviews on app.example.com / Desktop (non-bounce).
+            self._pageview("user_a", sa, "2024-01-01T10:00:00Z", **{**app_desktop, "$pathname": "/"})
+            self._pageview("user_a", sa, "2024-01-01T10:03:00Z", **{**app_desktop, "$pathname": "/pricing"})
+            # user_b: single pageview on app.example.com / Mobile (bounce).
+            self._pageview(
+                "user_b",
+                sb,
+                "2024-01-01T11:00:00Z",
+                **{
+                    "$host": "app.example.com",
+                    "$device_type": "Mobile",
+                    "$browser": "Safari",
+                    "$os": "iOS",
+                    "$viewport_width": 390,
+                    "$viewport_height": 844,
+                    "$pathname": "/",
+                },
+            )
+            # user_c: single pageview on blog.example.com / Desktop.
+            self._pageview(
+                "user_c",
+                sc,
+                "2024-01-01T12:00:00Z",
+                **{
+                    "$host": "blog.example.com",
+                    "$device_type": "Desktop",
+                    "$browser": "Firefox",
+                    "$os": "Linux",
+                    "$viewport_width": 1280,
+                    "$viewport_height": 720,
+                    "$pathname": "/blog",
+                },
+            )
+            flush_persons_and_events()
+
+        # Populate v2 and dimensional over the same window. ensure_* runs at real
+        # time, so the jobs' expires_at is genuinely in the future and READY.
+        for table, insert_sql in (
+            ("web_pre_aggregated_stats", WEB_STATS_INSERT_SQL),
+            ("web_pre_aggregated_bounces", WEB_BOUNCES_INSERT_SQL),
+        ):
+            sync_execute(
+                insert_sql(
+                    date_start=DATE_FROM,
+                    date_end=DATE_TO,
+                    team_ids=[self.team.pk],
+                    table_name=table,
+                    granularity="hourly",
+                )
+            )
+        ensure_web_stats_dimensional_precomputed(self.team, WINDOW_START, WINDOW_END)
+        ensure_web_bounces_dimensional_precomputed(self.team, WINDOW_START, WINDOW_END)
+
+    def _query(self, breakdown: WebStatsBreakdown, properties=None) -> WebStatsTableQuery:
+        return WebStatsTableQuery(
+            dateRange=DateRange(date_from=DATE_FROM, date_to=DATE_TO),
+            properties=properties or [],
+            breakdownBy=breakdown,
+            limit=100,
+        )
+
+    def _run(self, breakdown: WebStatsBreakdown, properties=None) -> list:
+        query = self._query(breakdown, properties)
+        runner = WebStatsTableQueryRunner(
+            query=query,
+            team=self.team,
+            modifiers=HogQLQueryModifiers(useWebAnalyticsPreAggregatedTables=True),
+        )
+        response = runner.calculate()
+        assert runner.used_preaggregated_tables, "expected the pre-aggregated path, not a live fallback"
+        return self._sort_results(response.results)
+
+    @staticmethod
+    def _counts(results: list) -> dict:
+        # {breakdown_value: (visitors, views)} — anchors values so a both-routes-broken
+        # case can't pass on equality alone.
+        return {row[0]: (row[1][0], row[2][0]) for row in results}
+
+    def _assert_routes_to_dimensional(self, breakdown: WebStatsBreakdown, properties=None) -> None:
+        runner = WebStatsTableQueryRunner(team=self.team, query=self._query(breakdown, properties))
+        builder = StatsTablePreAggregatedQueryBuilder(runner)
+        assert builder.use_dimensional_tables(), "enrolled team with READY data should route to dimensional"
+        assert builder.stats_table == WEB_STATS_DIMENSIONAL_READ_TABLE
+
+    def test_device_breakdown_dimensional_matches_v2(self):
+        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[]):
+            v2 = self._run(WebStatsBreakdown.DEVICE_TYPE)
+        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
+            self._assert_routes_to_dimensional(WebStatsBreakdown.DEVICE_TYPE)
+            dimensional = self._run(WebStatsBreakdown.DEVICE_TYPE)
+
+        assert dimensional == v2, f"device breakdown mismatch\nv2={v2}\ndimensional={dimensional}"
+        # Desktop: user_a (2 views) + user_c (1 view) = 2 visitors / 3 views; Mobile: user_b = 1 / 1.
+        assert self._counts(dimensional) == {"Desktop": (2.0, 3.0), "Mobile": (1.0, 1.0)}
+
+    def test_host_and_device_filter_dimensional_matches_v2(self):
+        # The multi-dimension cross-section the fixed-dimension tables uniquely serve.
+        host_filter = [EventPropertyFilter(key="$host", value="app.example.com", operator=PropertyOperator.EXACT)]
+        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[]):
+            v2 = self._run(WebStatsBreakdown.DEVICE_TYPE, properties=host_filter)
+        with override_settings(WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
+            self._assert_routes_to_dimensional(WebStatsBreakdown.DEVICE_TYPE, properties=host_filter)
+            dimensional = self._run(WebStatsBreakdown.DEVICE_TYPE, properties=host_filter)
+
+        assert dimensional == v2, f"host+device breakdown mismatch\nv2={v2}\ndimensional={dimensional}"
+        # blog.example.com / user_c is excluded; only the two app.example.com sessions remain.
+        assert self._counts(dimensional) == {"Desktop": (1.0, 2.0), "Mobile": (1.0, 1.0)}

--- a/products/web_analytics/backend/hogql_queries/web_dimensional_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_dimensional_precompute.py
@@ -22,6 +22,7 @@ Parity with v2 is intentional, with two deliberate deviations:
     NULL, so they fit the non-nullable Int64 columns deterministically.
 """
 
+import uuid
 from datetime import datetime
 
 from posthog.hogql import ast
@@ -34,8 +35,13 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     LazyComputationResult,
     LazyComputationTable,
     ensure_precomputed,
+    get_ready_job_ids,
 )
 from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import SESSION_FORWARD_PAD_MINUTES
+
+# Distributed read-table names (on the DATA cluster, routing to the AUX shards).
+WEB_STATS_DIMENSIONAL_READ_TABLE = "web_stats_dimensional_preaggregated"
+WEB_BOUNCES_DIMENSIONAL_READ_TABLE = "web_bounces_dimensional_preaggregated"
 
 # TTL tuned for "keep ~90 days warm, don't recompute every time": today's window
 # refreshes hourly, the last two days daily, everything older is computed once and
@@ -333,4 +339,33 @@ def ensure_web_bounces_dimensional_precomputed(
         table=LazyComputationTable.WEB_BOUNCES_DIMENSIONAL_PREAGGREGATED,
         placeholders=_base_placeholders(),
         query_type="web_bounces_dimensional_insert",
+    )
+
+
+def web_stats_dimensional_job_ids(team: Team, time_range_start: datetime, time_range_end: datetime) -> list[uuid.UUID]:
+    """READY job_ids for the stats dimensional table covering [start, end). Read-only —
+    reuses the writer's insert template/placeholders so the query_hash matches. Empty
+    when nothing is ready (caller falls back to v2/live)."""
+    return get_ready_job_ids(
+        team=team,
+        insert_query=STATS_INSERT_TEMPLATE,
+        time_range_start=time_range_start,
+        time_range_end=time_range_end,
+        table=LazyComputationTable.WEB_STATS_DIMENSIONAL_PREAGGREGATED,
+        placeholders=_base_placeholders(),
+    )
+
+
+def web_bounces_dimensional_job_ids(
+    team: Team, time_range_start: datetime, time_range_end: datetime
+) -> list[uuid.UUID]:
+    """READY job_ids for the bounces dimensional table covering [start, end). See
+    `web_stats_dimensional_job_ids`."""
+    return get_ready_job_ids(
+        team=team,
+        insert_query=BOUNCES_INSERT_TEMPLATE,
+        time_range_start=time_range_start,
+        time_range_end=time_range_end,
+        table=LazyComputationTable.WEB_BOUNCES_DIMENSIONAL_PREAGGREGATED,
+        placeholders=_base_placeholders(),
     )


### PR DESCRIPTION
## Problem

Web analytics serves fast, flexible reads from the v2 pre-aggregated tables: every breakdown dimension is a column, so any combination of filters (e.g. a host *and* a device type together) resolves from a small aggregate instead of scanning raw events. We want that same read path on the precomputation framework (per-team jobs with TTLs) — keeping v2's performance and arbitrary-dimension filtering — without disrupting the teams still served by v2.

## Changes

Adds an **additive, per-team-gated** read path. Teams enrolled in `WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS` are served from the dimensional precompute tables (`web_stats_dimensional_preaggregated` / `web_bounces_dimensional_preaggregated`); every other team stays on v2 unchanged. The dimensional tables are `ReplacingMergeTree` keyed by `job_id`, so reads filter `job_id IN (ready ids)` to dedup generations. When a team has no READY data for the requested window, the runner falls back to v2/live automatically.

- `get_ready_job_ids` (read-only) in the lazy-computation executor, sharing the writer's query-hash construction so reader and writer agree by construction.
- Query builder routes `stats_table`/`bounces_table` to the dimensional tables for enrolled teams and appends the `job_id` dedup filter; v2 path is byte-for-byte unchanged.
- Registers the dimensional tables in the HogQL database (root namespace, matching v2's single-identifier access pattern).
- New `WEB_DIMENSIONAL_PRECOMPUTE_TEAM_IDS` setting, default empty (strictly additive — v2 stays the default reader).

## How did you test this code?

I'm an agent. Automated tests I ran locally (all green):

- `test_dimensional_read_selection.py` — gate / routing / v2-fallback unit coverage.
- `test_web_dimensional_read_parity.py` — drives the runner end-to-end; dimensional output equals the v2 route for a device breakdown and for a host + device-type cross-section (the multi-dimension filter the fixed-dimension tables exist to serve).
- Regression: existing v2 read + write-path parity suites (`test_web_stats_pre_aggregated`, `test_web_bounces_pre_aggregated`, `test_web_dimensional_precompute_parity`) and the HogQL database guard test.

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Approach: keep v2 untouched and add dimensional reads as a per-team opt-in with automatic fallback. We measured read cost before committing to a layout — the `job_id IN` dedup filter resolves window-sized rows via the table's sort key (not a full scan), so no ClickHouse schema change was needed; an earlier "recreate the table" idea was dropped. The new read-path parity test surfaced two gaps it then fixed: the dimensional tables weren't registered in the HogQL database, and the gate setting was undefined. Agent-authored — requires human review, do not self-merge.
