### PR TITLE
chore(signals): harden logs scout + wire it into the fuller logs MCP surface

### DIFF
--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -27,13 +27,30 @@ only when they clear the confidence bar. Logs live in their own ingestion pipeli
 distinct from `top_events`, so the project profile won't tell you whether logs are
 loud today; you have to ask.
 
+## The stream is a firehose — never count it unfiltered
+
+On a busy project the log stream runs to hundreds of millions of lines/hour. So an
+**unfiltered, wide-window `logs-count` (e.g. 24h, all severities) times out with a
+500** — it is the most expensive call you can make, not a cheap pre-flight. **Always
+bound every count** by `severityLevels` and/or `serviceNames`, or keep the window
+≤ ~3h. `fatal`-only over 24h is cheap (often < 100 rows) and a great first probe.
+
+**Date footgun:** relative units are `h` (hour) / `d` (day) / `m` (**month**) — there is
+**no minute unit**. `-30m` parses as 30 _months_ and silently returns a huge wrong count,
+not an error. For sub-hour precision pass explicit ISO `date_from`/`date_to`.
+
+Carry the team's baselines in `pattern:` memory (total lines/hour, error+fatal/hour, the
+busiest services) so future runs skip rediscovery.
+
 ## Quick close-out: are logs even in use?
 
-If `logs-count` over the last 24h returns zero or near-zero, this team isn't using
-logs. Write one scratchpad entry:
+If a **bounded** `logs-count` (`severityLevels=["error","fatal"]` over the last 1h, plus
+`severityLevels=["fatal"]` over 24h) returns zero, this team isn't using logs — don't
+read an unfiltered-count 500 as "no logs", that's the firehose, not silence. Write one
+scratchpad entry:
 
 - key: `not-in-use:logs:team{team_id}`
-- content: brief note ("checked at {timestamp}, logs-count over 24h ≈ 0")
+- content: brief note ("checked at {timestamp}, bounded error+fatal counts ≈ 0")
 
 Close out empty. Future logs runs will read this entry cold and short-circuit in
 seconds. Re-running with the same key idempotently refreshes the timestamp — the entry
@@ -52,8 +69,16 @@ Three cheap reads cold-start a run:
   from past logs-focused runs. **Entries with `pattern:`, `noise:`, `addressed:`, or
   `dedupe:` key prefixes tell you what's normal, what's already surfaced, what to skip.**
 - `signals-scout-runs-list` (last 7d) — what prior logs scouts found and ruled out.
-- `logs-count` over 24h vs `logs-count` over 7d-prior 24h baseline — the cheap
-  is-anything-loud-today check. `logs-count-ranges` adds severity / service breakdown.
+- **The cheap tripwire set** (runs in seconds, no firehose) — this is the
+  is-anything-loud-today check, _not_ an unfiltered baseline diff:
+  1. `logs-count` `severityLevels=["fatal"]` over 24h (add a `searchTerm` to count a
+     specific crash signature) — fatal is rare, so this is cheap and catches crash loops.
+  2. `logs-count` `severityLevels=["error","fatal"]` over the last 1h vs the team's
+     error+fatal/hr baseline (from `pattern:` memory) — a severity-shift proxy.
+  3. `logs-alerts-list` — only a _new_ firing alert beyond known-noise ones is interesting.
+
+  If all three are at baseline, close out empty. Only then localize a real spike with
+  `logs-count-ranges` (always severity- or service-filtered) and `query-logs`.
 
 ### Explore
 
@@ -61,10 +86,11 @@ Patterns to watch — these are starting points, not a checklist.
 
 #### Volume burst
 
-`logs-count` over 24h is materially above the 7d-prior baseline (≥ 2x). Localize by
-re-running `logs-count` (or `logs-count-ranges` for the time-bucketed shape) filtered
-by `severity` and by `service` — these tools count a filter, they don't group, so
-narrow with the filter and compare. Common causes: a stuck retry loop logging at
+A bounded `logs-count` (severity- or service-filtered) is materially above its baseline
+(≥ 2x). Localize by re-running `logs-count` (or `logs-count-ranges` for the time-bucketed
+shape) filtered by `severity` and by `service` — these tools count a filter, they don't
+group, so narrow with the filter and compare. Never widen to an unfiltered count to
+"see everything" — that 500s. Common causes: a stuck retry loop logging at
 `info`, a feature deploy that bumped log verbosity, a misconfigured logger emitting
 at `debug` in prod.
 
@@ -88,9 +114,10 @@ A service that normally accounts for a meaningful share of total log volume drop
 near-zero. Different shape from error tracking entirely — there's no exception, the
 service is just gone.
 
-Validate: `logs-attribute-values-list` on `service` for active services, then
-`logs-count-ranges` per service over today vs 7d-prior to confirm the missing service
-was active before. Cross-check `top_events` for the service's expected user-facing
+Validate: `logs-attribute-values-list` for active services (pass
+`attribute_type: "resource"` with key `service.name` — service is a resource-level
+attribute, and the tool defaults to log-level), then `logs-count-ranges` per service
+over today vs 7d-prior to confirm the missing service was active before. Cross-check `top_events` for the service's expected user-facing
 events — if those also dropped, the service is genuinely down.
 
 #### Fresh message pattern
@@ -178,7 +205,8 @@ When in doubt, write a memory entry instead of emitting.
 
 Direct calls (read-only):
 
-- `logs-count` — start here. Total volume over a window.
+- `logs-count` — bounded volume over a window (always severity/service-filtered or ≤3h;
+  unfiltered wide counts 500 — see the firehose note above).
 - `logs-count-ranges` — compare windows (today vs 7d-prior, this hour vs same hour
   yesterday); supports breakdowns.
 - `logs-sparkline-query` — sparkline shape; useful for spotting a sharp burst vs a

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -13,7 +13,8 @@ compatibility: >
   signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family is available (project-profile-get, runs-list,
   scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
   the logs tool family (logs-count, logs-count-ranges, logs-sparkline-query, query-logs,
-  logs-attributes-list, logs-attribute-values-list, logs-alerts-list).
+  logs-services-create, logs-attributes-list, logs-attribute-values-list, logs-alerts-list,
+  logs-alerts-events-list).
 metadata:
   owner_team: signals
   scope: logs
@@ -104,9 +105,16 @@ Total volume flat but `error` / `fatal` proportion rising. Captures the kind of 
 error tracking misses: caught-and-logged exceptions, retry-with-eventual-success patterns,
 degraded-but-functional dependencies (slow DB, cold cache, partial third-party outage).
 
-Validate via `query-logs` filtered to `severity ∈ {error, fatal}` over the recent window,
-grouped by `service` or `module`. A single service accounting for the rise is
-high-confidence; a uniform rise across services suggests an upstream platform issue.
+Validate in one call with `logs-services-create` (read-only despite the name) over the
+recent window — it returns the top-25 services with `error_count`, `error_rate`, and
+`volume_share_pct`, so you see _which_ service carries the rise without walking
+per-service counts. **Read only the `services` list and ignore the bundled `sparkline`** —
+the sparkline is hundreds of KB and overflows the budget to a file; the `services` list
+itself is tiny. Call it _without_ a severity filter to get each service's `error_rate`,
+or _with_ `severityLevels=["error","fatal"]` to rank services by error volume. A single
+service accounting for the rise is high-confidence; a uniform rise across services
+suggests an upstream platform issue. Drop to `query-logs` only for module-level detail
+within the culprit service.
 
 #### Service silence
 
@@ -114,10 +122,12 @@ A service that normally accounts for a meaningful share of total log volume drop
 near-zero. Different shape from error tracking entirely — there's no exception, the
 service is just gone.
 
-Validate: `logs-attribute-values-list` for active services (pass
-`attribute_type: "resource"` with key `service.name` — service is a resource-level
-attribute, and the tool defaults to log-level), then `logs-count-ranges` per service
-over today vs 7d-prior to confirm the missing service was active before. Cross-check `top_events` for the service's expected user-facing
+Validate: `logs-services-create` (read-only; read the `services` list, ignore the
+`sparkline`) ranks active services by `volume_share_pct` in one call — a service that
+held meaningful share before and is now absent from the list is the signal. Confirm with
+`logs-count-ranges` for that service over today vs 7d-prior (use `logs-count-ranges`, not
+`logs-sparkline-query` — the sparkline endpoint 500s on busy services over multi-hour
+windows). Cross-check `top_events` for the service's expected user-facing
 events — if those also dropped, the service is genuinely down.
 
 #### Fresh message pattern
@@ -142,6 +152,14 @@ convergence pattern logs enables.
 `logs-alerts-list` exposes the team's configured alerts. An alert with `state =
 firing` whose underlying condition isn't already in `inbox-reports-list` is a
 high-confidence finding — the team has the alert plumbing but not the inbox surface.
+
+Before trusting a `firing` state, check the alert's history with `logs-alerts-events-list`
+(`id` = the alert's UUID) — it returns fires/resolves/flaps/threshold changes. A _fresh_
+fire (a new fire event in the recent window) is real; an alert that has sat `firing`
+indefinitely is usually a misconfigured always-on threshold (record it under a `noise:`
+key), not a new signal. (This endpoint rejects personal API keys with a 403; the scout's
+internal token should reach it — if it 403s for you too, fall back to `logs-alerts-list`
+state plus a `logs-count` over the alert's filter to gauge whether it's genuinely firing.)
 
 ### Save memory as you go
 
@@ -207,14 +225,21 @@ Direct calls (read-only):
 
 - `logs-count` — bounded volume over a window (always severity/service-filtered or ≤3h;
   unfiltered wide counts 500 — see the firehose note above).
-- `logs-count-ranges` — compare windows (today vs 7d-prior, this hour vs same hour
-  yesterday); supports breakdowns.
-- `logs-sparkline-query` — sparkline shape; useful for spotting a sharp burst vs a
-  sustained shift.
+- `logs-count-ranges` — locate _when_ in a window the volume sits (today vs 7d-prior,
+  this hour vs same hour yesterday). The robust localizer — survives busy services where
+  `logs-sparkline-query` 500s.
+- `logs-services-create` — **read-only despite the name** (it's a POST-backed aggregation,
+  not a write). One call returns the top-25 services with `error_count` / `error_rate` /
+  `volume_share_pct` — the cheap entry point for service-level triage. Read the `services`
+  list and **ignore the oversized `sparkline`** it bundles (overflows to a file).
+- `logs-sparkline-query` — severity/service sparkline. Use sparingly: 500s on busy
+  services over multi-hour windows — prefer `logs-count-ranges` for the time-bucketed shape.
 - `query-logs` — drill into individual records. Filter by severity, service, message
   text, attribute values, time range.
 - `logs-attributes-list` / `logs-attribute-values-list` — discover the team's log shape.
 - `logs-alerts-list` / `logs-alerts-retrieve` — configured alerts and current state.
+- `logs-alerts-events-list` — an alert's firing history (fires/resolves/flaps); tells a
+  fresh fire from a chronically-firing misconfigured one. May 403 on a personal key.
 - `inbox-reports-list` — verify a finding isn't already in the inbox.
 - `query-error-tracking-issues-list` — cross-check whether a log error already has an issue;
   error tracking owns those findings.

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -30,11 +30,13 @@ loud today; you have to ask.
 
 ## The stream is a firehose — never count it unfiltered
 
-On a busy project the log stream runs to hundreds of millions of lines/hour. So an
-**unfiltered, wide-window `logs-count` (e.g. 24h, all severities) times out with a
-500** — it is the most expensive call you can make, not a cheap pre-flight. **Always
-bound every count** by `severityLevels` and/or `serviceNames`, or keep the window
-≤ ~3h. `fatal`-only over 24h is cheap (often < 100 rows) and a great first probe.
+On a busy project the log stream runs to hundreds of millions of lines/hour, the bulk of
+it `info`/`warn`. So an **unfiltered `logs-count` times out with a 500 at _any_ window** —
+it 500s even over a few minutes, so it is never a safe pre-flight. **Always bound every
+count** by `severityLevels` and/or `serviceNames`. `fatal`-only over 24h is cheap (often
+< 100 rows) and a great first probe. For an _all-severity_ read (total volume / "is
+anything logging"), use **`logs-services-create`** — it's an aggregation that survives the
+firehose where a raw count 500s (read its `services` list, ignore the `sparkline`).
 
 **Date footgun:** relative units are `h` (hour) / `d` (day) / `m` (**month**) — there is
 **no minute unit**. `-30m` parses as 30 _months_ and silently returns a huge wrong count,
@@ -45,13 +47,15 @@ busiest services) so future runs skip rediscovery.
 
 ## Quick close-out: are logs even in use?
 
-If a **bounded** `logs-count` (`severityLevels=["error","fatal"]` over the last 1h, plus
-`severityLevels=["fatal"]` over 24h) returns zero, this team isn't using logs — don't
-read an unfiltered-count 500 as "no logs", that's the firehose, not silence. Write one
-scratchpad entry:
+Check with **`logs-services-create`** over a short window (e.g. `-15m`) — it's an
+all-severity aggregation that survives the firehose. **Zero services back = genuinely not
+using logs.** Do _not_ decide this from error/fatal counts alone: a team that logs only at
+`info`/`warn` (common — one line per request) would read as "no logs" and get permanently
+short-circuited. And don't read a `logs-count` 500 as "no logs" — that's the firehose, not
+silence. Write one scratchpad entry:
 
 - key: `not-in-use:logs:team{team_id}`
-- content: brief note ("checked at {timestamp}, bounded error+fatal counts ≈ 0")
+- content: brief note ("checked at {timestamp}, logs-services-create returned 0 services")
 
 Close out empty. Future logs runs will read this entry cold and short-circuit in
 seconds. Re-running with the same key idempotently refreshes the timestamp — the entry
@@ -72,14 +76,22 @@ Three cheap reads cold-start a run:
 - `signals-scout-runs-list` (last 7d) — what prior logs scouts found and ruled out.
 - **The cheap tripwire set** (runs in seconds, no firehose) — this is the
   is-anything-loud-today check, _not_ an unfiltered baseline diff:
-  1. `logs-count` `severityLevels=["fatal"]` over 24h (add a `searchTerm` to count a
-     specific crash signature) — fatal is rare, so this is cheap and catches crash loops.
-  2. `logs-count` `severityLevels=["error","fatal"]` over the last 1h vs the team's
-     error+fatal/hr baseline (from `pattern:` memory) — a severity-shift proxy.
-  3. `logs-alerts-list` — only a _new_ firing alert beyond known-noise ones is interesting.
+  1. `logs-services-create` over a short window (read the `services` list, ignore the
+     `sparkline`) — the **all-severity** volume + per-service share in one call. This is
+     what catches an `info`/`warn` flood (e.g. a stuck retry loop logging at `info`) that
+     the severity-filtered probes below would miss, and it names the hot service for
+     localization.
+  2. `logs-count` `severityLevels=["fatal"]` over 24h (add a `searchTerm` for a specific
+     crash signature) — fatal is rare, so this is cheap and catches crash loops.
+  3. `logs-count` `severityLevels=["error","fatal"]` over the last 1h vs the team's
+     error+fatal/hr baseline. **No baseline in memory yet (first run)? Derive one cheaply
+     before judging — error+fatal over the same clock hour 24h (or 7d) ago via explicit
+     ISO `date_from`/`date_to` — don't assume the current hour is normal.**
+  4. `logs-alerts-list` — only a _new_ firing alert beyond known-noise ones is interesting.
 
-  If all three are at baseline, close out empty. Only then localize a real spike with
-  `logs-count-ranges` (always severity- or service-filtered) and `query-logs`.
+  If all are at baseline, close out empty. To localize a spike, **scope `logs-count-ranges`
+  to the hot service** from step 1 — a severity-only range still buckets the whole stream
+  and can 500 — then `query-logs`.
 
 ### Explore
 

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -47,12 +47,14 @@ busiest services) so future runs skip rediscovery.
 
 ## Quick close-out: are logs even in use?
 
-Check with **`logs-services-create`** over a short window (e.g. `-15m`) — it's an
+Check with **`logs-services-create`** over `-24h` (`m` = month and there is no minute unit,
+so don't write `-15m`; `-24h`/`-7d` or explicit ISO are the safe forms) — it's an
 all-severity aggregation that survives the firehose. **Zero services back = genuinely not
-using logs.** Do _not_ decide this from error/fatal counts alone: a team that logs only at
-`info`/`warn` (common — one line per request) would read as "no logs" and get permanently
-short-circuited. And don't read a `logs-count` 500 as "no logs" — that's the firehose, not
-silence. Write one scratchpad entry:
+using logs.** Use a day-plus window, not minutes, so a batch/sparse project that only logs
+periodically isn't misread as silent. Do _not_ decide this from error/fatal counts alone: a
+team that logs only at `info`/`warn` (common — one line per request) would read as "no logs"
+and get permanently short-circuited. And don't read a `logs-count` 500 as "no logs" — that's
+the firehose, not silence. Write one scratchpad entry:
 
 - key: `not-in-use:logs:team{team_id}`
 - content: brief note ("checked at {timestamp}, logs-services-create returned 0 services")
@@ -76,8 +78,9 @@ Three cheap reads cold-start a run:
 - `signals-scout-runs-list` (last 7d) — what prior logs scouts found and ruled out.
 - **The cheap tripwire set** (runs in seconds, no firehose) — this is the
   is-anything-loud-today check, _not_ an unfiltered baseline diff:
-  1. `logs-services-create` over a short window (read the `services` list, ignore the
-     `sparkline`) — the **all-severity** volume + per-service share in one call. This is
+  1. `logs-services-create` over `-1h` (read the `services` list, ignore the `sparkline`;
+     `-1h`/`-24h` are valid, `-Nm` is months) — the **all-severity** volume + per-service
+     share in one call. This is
      what catches an `info`/`warn` flood (e.g. a stuck retry loop logging at `info`) that
      the severity-filtered probes below would miss, and it names the hot service for
      localization.
@@ -170,8 +173,10 @@ Before trusting a `firing` state, check the alert's history with `logs-alerts-ev
 fire (a new fire event in the recent window) is real; an alert that has sat `firing`
 indefinitely is usually a misconfigured always-on threshold (record it under a `noise:`
 key), not a new signal. (This endpoint rejects personal API keys with a 403; the scout's
-internal token should reach it — if it 403s for you too, fall back to `logs-alerts-list`
-state plus a `logs-count` over the alert's filter to gauge whether it's genuinely firing.)
+internal token should reach it — if it 403s for you too, read the alert's filter with
+`logs-alerts-retrieve` (`logs-alerts-list` returns only id/name/state/threshold, not
+`filters`), then run a bounded `logs-count` over that filter to gauge whether it's
+genuinely firing.)
 
 ### Save memory as you go
 
@@ -235,8 +240,9 @@ When in doubt, write a memory entry instead of emitting.
 
 Direct calls (read-only):
 
-- `logs-count` — bounded volume over a window (always severity/service-filtered or ≤3h;
-  unfiltered wide counts 500 — see the firehose note above).
+- `logs-count` — bounded volume over a window. **Always** severity- and/or
+  service-filtered; an unfiltered count 500s at any window (even minutes), so a filter is
+  mandatory, not window length — see the firehose note above.
 - `logs-count-ranges` — locate _when_ in a window the volume sits (today vs 7d-prior,
   this hour vs same hour yesterday). The robust localizer — survives busy services where
   `logs-sparkline-query` 500s.

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -80,17 +80,19 @@ Three cheap reads cold-start a run:
   is-anything-loud-today check, _not_ an unfiltered baseline diff:
   1. `logs-services-create` over `-1h` (read the `services` list, ignore the `sparkline`;
      `-1h`/`-24h` are valid, `-Nm` is months) — the **all-severity** volume + per-service
-     share in one call. This is
-     what catches an `info`/`warn` flood (e.g. a stuck retry loop logging at `info`) that
-     the severity-filtered probes below would miss, and it names the hot service for
-     localization.
+     share in one call, vs the team's lines/hour + busiest-services baseline. This is what
+     catches an `info`/`warn` flood (e.g. a stuck retry loop logging at `info`) that the
+     severity-filtered probes below would miss, and it names the hot service for localization.
   2. `logs-count` `severityLevels=["fatal"]` over 24h (add a `searchTerm` for a specific
      crash signature) — fatal is rare, so this is cheap and catches crash loops.
   3. `logs-count` `severityLevels=["error","fatal"]` over the last 1h vs the team's
-     error+fatal/hr baseline. **No baseline in memory yet (first run)? Derive one cheaply
-     before judging — error+fatal over the same clock hour 24h (or 7d) ago via explicit
-     ISO `date_from`/`date_to` — don't assume the current hour is normal.**
+     error+fatal/hr baseline — a severity-shift proxy.
   4. `logs-alerts-list` — only a _new_ firing alert beyond known-noise ones is interesting.
+
+  **Cold start (no `pattern:` baseline yet):** the comparison tripwires — #1 (all-severity
+  volume / per-service share) _and_ #3 (error+fatal/hr) — have nothing to diff against on a
+  first run. Derive each baseline from the same clock hour 24h (or 7d) ago via explicit ISO
+  `date_from`/`date_to` before judging; don't assume the current window is normal.
 
   If all are at baseline, close out empty. To localize a spike, **scope `logs-count-ranges`
   to the hot service** from step 1 — a severity-only range still buckets the whole stream


### PR DESCRIPTION
## Problem

Two issues with the canonical `signals-scout-logs` skill — the body the headless Signals agent loads verbatim every run — surfaced while dogfooding it against the dogfood project:

1. **Its cheapest prescribed first move 500s on any busy project.** Both the "are logs in use?" close-out and the "get oriented" baseline check told a cold run to issue an *unfiltered 24h `logs-count`*, which scans the entire log stream (hundreds of millions of lines/hour) and times out. The fleet only worked because each team independently re-learned a "tight-run recipe" into per-team scratchpad — new teams pay the timeout tax on every cold start.
2. **It used only a fraction of the read-only logs MCP surface.** Newer tools (a one-call service-stats aggregation, alert firing-history) that directly improve its recipes weren't referenced at all, so the scout did service triage the slow way and judged alerts off current state alone.

## Changes

### 1. Harden against the firehose + a date footgun
- **New "firehose" note** — always bound counts by `severityLevels`/`serviceNames` or keep the window ≤ ~3h; `fatal`-only/24h as the cheap first probe.
- **Documented the `-Nm` date footgun** — there is no minute unit; `m` = month, so `-30m` silently parses as 30 *months* and returns wrong data with no error.
- **Replaced the naive 24h-vs-7d baseline diff** with the cheap tripwire set (fatal/24h → error+fatal/1h vs baseline → alerts-list), and fixed the not-in-use probe to be bounded.

### 2. Wire in the fuller logs surface
- **`logs-services-create`** (read-only despite the `-create` name) — one call returns the top-25 services with `error_rate` + `volume_share_pct`; now the entry point for the service-silence and severity-shift recipes, replacing the per-service attribute-values + count walk. The body tells the scout to read the `services` list and **ignore the oversized `sparkline`** it bundles (it always overflows to a file).
- **`logs-alerts-events-list`** — an alert's firing history, so the alert-coverage recipe can tell a *fresh* fire from a chronically-firing misconfigured one. Body notes it 403s on personal keys (the scout's internal token should reach it, with a documented fallback).
- **Demoted `logs-sparkline-query`** — dogfooding showed it 500s on busy services over multi-hour windows where `logs-count-ranges` survives, so `logs-count-ranges` is the localizer and sparkline is use-sparingly.
- Noted the `attribute_type: "resource"` requirement for service discovery.

Source-of-truth edit only; `dist/skills/` is a gitignored build artifact and `lazy_seed` mirrors the change onto enrolled teams' `LLMSkill` rows on the next coordinator tick (diverged/hand-edited rows are left alone).

## How did you test this code?

I'm an agent (Claude Code). No automated tests cover skill-body markdown — validation was empirical against the live dogfood project via the PostHog MCP logs tools:

- Reproduced the failure mode: unfiltered `logs-count {-24h}` → HTTP 500; `logs-count {-24h, fatal}` → 95 rows instantly.
- Confirmed the `-Nm` footgun: `logs-count {-30m, fatal}` returned 7,828 — larger than the true 24h fatal count — i.e. `-30m` was read as 30 months.
- Verified the tripwire recipe end-to-end: error+fatal/1h = 2.99M project-wide, localized to 1.31M (43.9%) on a single service in two cheap calls.
- Confirmed `logs-services-create` returns a clean 25-row services list (~5.5KB) bundled with an ~844KB sparkline that overflows to a file regardless of window (even -15m).
- Confirmed the sparkline-vs-ranges contrast: `logs-sparkline-query` 500'd on `posthog-feature-flags` (error+fatal, -3h) while `logs-count-ranges` returned the bucketed shape cleanly on the same query.
- `logs-alerts-events-list` returned 403 "does not support personal API key access" for my key — documented as a caveat rather than asserting scout-token behavior I couldn't verify.

Separately filed an `agent-feedback` report to the PostHog MCP team on the two `logs-services-create` defects this surfaced: the `-create` name on a read-only tool, and the 844KB sparkline overflowing a triage call.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed the work; assigned as DRI.

Explored the scout fleet with the `exploring-signals-scouts` skill, then dogfooded `signals-scout-logs` against the dogfood project using the PostHog MCP logs tools (`logs-count`, `logs-count-ranges`, `logs-services-create`, `logs-sparkline-query`, `logs-attribute-values-list`, `logs-alerts-events-list`, and the `signals-scout-*` introspection tools). The first commit folds the corrected first-move recipe into the body so cold starts don't repeat the timeout the fleet learned around. The second commit audits the skill against the full `logs-*` tool family and wires in the read-only tools that improve its recipes — each with a dogfood-verified caveat (the services-list sparkline overflow, the sparkline-query 500s, the alert-events 403). Where I couldn't verify behavior from a personal key (alert-events history), the skill documents the uncertainty rather than asserting it. Two of the issues are MCP-tool-side rather than skill-side and are filed via `agent-feedback`; the skill edits defend against them until the tool fixes land.

Tooling: Claude Code (Opus).
