### PR TITLE
feat(web-analytics): move precompute badge to bottom-right on metric cards

### DIFF
--- a/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
+++ b/frontend/src/lib/components/PreAggregatedBadge/PreAggregatedBadge.tsx
@@ -1,11 +1,20 @@
+import clsx from 'clsx'
+
 import { IconBolt, IconDatabaseBolt } from '@posthog/icons'
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 export type PreAggregatedBadgeVariant = 'preagg' | 'precomputed'
+export type PreAggregatedBadgePosition = 'top-right' | 'bottom-right'
 
 interface PreAggregatedBadgeProps {
     variant?: PreAggregatedBadgeVariant
+    position?: PreAggregatedBadgePosition
+}
+
+const POSITION_CLASS: Record<PreAggregatedBadgePosition, string> = {
+    'top-right': 'top-2 right-2',
+    'bottom-right': 'bottom-2 right-2',
 }
 
 const VARIANT_CONFIG: Record<
@@ -24,11 +33,14 @@ const VARIANT_CONFIG: Record<
     },
 }
 
-export function PreAggregatedBadge({ variant = 'preagg' }: PreAggregatedBadgeProps = {}): JSX.Element {
+export function PreAggregatedBadge({
+    variant = 'preagg',
+    position = 'top-right',
+}: PreAggregatedBadgeProps = {}): JSX.Element {
     const { tooltip, iconClassName, Icon } = VARIANT_CONFIG[variant]
     return (
         <Tooltip title={tooltip}>
-            <div className="absolute top-2 right-2 z-10">
+            <div className={clsx('absolute z-10', POSITION_CLASS[position])}>
                 <Icon className={iconClassName} />
             </div>
         </Tooltip>

--- a/frontend/src/queries/nodes/OverviewGrid/OverviewMetricCardGrid.tsx
+++ b/frontend/src/queries/nodes/OverviewGrid/OverviewMetricCardGrid.tsx
@@ -103,9 +103,9 @@ function MetricCardCell({
             aria-pressed={clickable ? !!item.selected : undefined}
         >
             {usedLazyPrecompute ? (
-                <PreAggregatedBadge variant="precomputed" />
+                <PreAggregatedBadge variant="precomputed" position="bottom-right" />
             ) : usedPreAggregatedTables ? (
-                <PreAggregatedBadge variant="preagg" />
+                <PreAggregatedBadge variant="preagg" position="bottom-right" />
             ) : null}
             <MetricCard
                 title={<MetricCardTitle label={labelFromKey(item.key)} item={item} />}


### PR DESCRIPTION
## Problem

On the new web analytics metric overview cards (`OverviewMetricCardGrid`), the precompute/preaggregated badge sat in the top-right corner. Moving it to the bottom-right places it in the otherwise-empty corner opposite the left-aligned "vs. X prior" subtitle, for a cleaner card.

## Changes

- Added an optional `position` prop (`'top-right' | 'bottom-right'`) to `PreAggregatedBadge`, defaulting to `top-right` so existing usages (`DataTable`, `WebVitalsPathBreakdown`, the older `OverviewGrid`) are unchanged.
- `OverviewMetricCardGrid` now renders the badge with `position="bottom-right"` for both the `preagg` and `precomputed` variants.

## How did you test this code?

I'm an agent (Claude Code). No manual/visual testing was performed. The change is a small, type-safe optional prop with a preserved default; no automated tests were added or run for this change. The full-repo `tsc` typecheck could not complete locally (out-of-memory abort, environment limit) — CI will run it.

## 🤖 Agent context

Authored with Claude Code. The badge's position was hardcoded `top-2 right-2` in the shared `PreAggregatedBadge` component, used in four places. Rather than fork the component or override layout from the call site, I parameterized position via an optional prop defaulting to the current behavior, keeping the three other call sites byte-identical and scoping the move to the new metric cards only. Requires human review.
