### PR TITLE
fix(ingestion): keep a group at the event filter tree root

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4726,6 +4726,10 @@ snapshots:
         hash: v1.k794b7964.241ca6352364efc887eb32759aaa96ae0ff93d3cf21be7d8fbd5032bc7d58744.j-U61D5ssKdEhV9WCyEgR_571UQZK9m_iekEU1lzjOU
     scenes-app-data-pipelines-event-filtering--single-condition--light:
         hash: v1.k794b7964.654785f46f338c9d70eaca3ca79a94dab9fad11d53d181f8cceb47f5c63bc7fe.DbcJz_BltmCqPJ7Vt6ltmCkK93W0lSjHJC2yeBhOedE
+    scenes-app-data-pipelines-event-filtering--single-condition-root-is-editable--dark:
+        hash: v1.k794b7964.ec8d51d0f3575a14ff1d475fb7e80cee563a885b3e42c3e3013715e74b8c22f0.whV3GNR0rpMn7AQzwWDaLbgtDZ_0bCRcL_RDryWRdEU
+    scenes-app-data-pipelines-event-filtering--single-condition-root-is-editable--light:
+        hash: v1.k794b7964.ffc2f29fa56ddd5603428d5d0bf495be64ff40686fd6d73bcb5a9ac7d1f4e2fd.9NmyKM03GKv4v_V2pYq-CMXBWjFEE_YRfB5Es8FbMbM
     scenes-app-data-pipelines-event-filtering--switch-mode-to-dry-run--dark:
         hash: v1.k794b7964.6b80e9052b063c0763a074015093299d509932a53547c5e35ca654b76817fa02.Ky-1qxUDc4jUpY10x0Silq9QdkVjc0aAkRajQPW9oxM
     scenes-app-data-pipelines-event-filtering--switch-mode-to-dry-run--light:

--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.stories.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.stories.tsx
@@ -271,6 +271,48 @@ Expected to show:
     },
 }
 
+export const SingleConditionRootIsEditable: Story = {
+    // Regression: mirrors a real production record. The backend used to prune a
+    // one-condition filter down to a bare `condition` root, which the editor
+    // rendered with no enclosing group — and therefore no "Add condition" /
+    // "Add group" buttons, stranding the user. The logic now re-wraps a
+    // non-group root in an OR on load so the add affordances are always present.
+    render: withFilter({
+        mode: 'live',
+        filter_tree: { type: 'condition', field: 'distinct_id', operator: 'contains', value: 'bot-' },
+        test_cases: [{ event_name: '', distinct_id: 'bot-crawler', expected_result: 'drop' }],
+    }),
+    parameters: {
+        docs: {
+            description: {
+                story: `
+A filter loaded from the API as a bare \`condition\` root (no enclosing group).
+
+Expected to show:
+- The single \`distinct_id ~ "bot-"\` condition row, now hosted inside a root OR group
+- "Add condition" and "Add group" buttons present (the root is normalized to a group on load)
+- One test case with a green "Pass" tag
+                `,
+            },
+        },
+    },
+    play: async () => {
+        // Wait for the loaded condition to render.
+        await waitFor(() => {
+            if (!document.querySelector('input[value="bot-"]')) {
+                throw new Error('Tree not loaded')
+            }
+        })
+        // The root must be wrapped into a group so the add affordance exists.
+        // Before the fix this button is absent and the story fails here.
+        await waitFor(() => {
+            if (!document.querySelector('[data-attr="add-condition-root"]')) {
+                throw new Error('Add condition button missing for single-condition root')
+            }
+        })
+    },
+}
+
 export const EmptyGroupsInTree: Story = {
     render: withFilter({
         filter_tree: {

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
@@ -277,23 +277,17 @@ describe('normalizeRootToGroup', () => {
     // Regression: the backend prunes single-child groups, so a saved one-condition
     // filter loads back as a bare condition (or NOT) with no group to host the
     // "Add condition"/"Add group" buttons. Re-wrap any non-group root in an OR.
-    it('wraps a bare condition root in an OR group', () => {
-        expect(normalizeRootToGroup(cond('distinct_id', 'contains', 'bot'))).toEqual(
-            or(cond('distinct_id', 'contains', 'bot'))
-        )
+    it.each([
+        ['bare condition', cond('distinct_id', 'contains', 'bot')],
+        ['NOT node', not(cond())],
+    ])('wraps a %s root in an OR group', (_name, node) => {
+        expect(normalizeRootToGroup(node)).toEqual(or(node))
     })
 
-    it('wraps a NOT root in an OR group', () => {
-        expect(normalizeRootToGroup(not(cond()))).toEqual(or(not(cond())))
-    })
-
-    it('leaves an OR root unchanged (same reference)', () => {
-        const tree = or(cond(), cond('distinct_id', 'exact', 'u1'))
-        expect(normalizeRootToGroup(tree)).toBe(tree)
-    })
-
-    it('leaves an AND root unchanged (same reference)', () => {
-        const tree = and(cond())
+    it.each([
+        ['OR', or(cond(), cond('distinct_id', 'exact', 'u1'))],
+        ['AND', and(cond())],
+    ])('leaves an %s root unchanged (same reference)', (_name, tree) => {
         expect(normalizeRootToGroup(tree)).toBe(tree)
     })
 })

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
@@ -2,6 +2,7 @@ import {
     countConditions,
     evaluateFilterTree,
     FilterNode,
+    normalizeRootToGroup,
     treeHasConditions,
     treeHasEmptyValues,
     updateAtPath,
@@ -269,6 +270,31 @@ describe('updateAtPath', () => {
             // child1 should be the same reference — not copied
             expect((result as { type: 'or'; children: FilterNode[] }).children[1]).toBe(child1)
         })
+    })
+})
+
+describe('normalizeRootToGroup', () => {
+    // Regression: the backend prunes single-child groups, so a saved one-condition
+    // filter loads back as a bare condition (or NOT) with no group to host the
+    // "Add condition"/"Add group" buttons. Re-wrap any non-group root in an OR.
+    it('wraps a bare condition root in an OR group', () => {
+        expect(normalizeRootToGroup(cond('distinct_id', 'contains', 'bot'))).toEqual(
+            or(cond('distinct_id', 'contains', 'bot'))
+        )
+    })
+
+    it('wraps a NOT root in an OR group', () => {
+        expect(normalizeRootToGroup(not(cond()))).toEqual(or(not(cond())))
+    })
+
+    it('leaves an OR root unchanged (same reference)', () => {
+        const tree = or(cond(), cond('distinct_id', 'exact', 'u1'))
+        expect(normalizeRootToGroup(tree)).toBe(tree)
+    })
+
+    it('leaves an AND root unchanged (same reference)', () => {
+        const tree = and(cond())
+        expect(normalizeRootToGroup(tree)).toBe(tree)
     })
 })
 

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.ts
@@ -198,6 +198,20 @@ export function treeHasEmptyValues(node: FilterNode): boolean {
     }
 }
 
+/**
+ * Ensure the root is an and/or group. The editor can only add conditions or
+ * groups inside a group node, and the backend prunes single-child groups — so a
+ * saved one-condition filter loads back as a bare condition (or NOT) with no
+ * group to host the "Add condition"/"Add group" buttons. Wrap any non-group root
+ * in an OR so the add affordances are always present.
+ */
+export function normalizeRootToGroup(node: FilterNode): FilterNode {
+    if (node.type === 'and' || node.type === 'or') {
+        return node
+    }
+    return { type: 'or', children: [node] }
+}
+
 // --- Immutable tree updates ---
 
 /**
@@ -421,7 +435,7 @@ export const eventFilterLogic = kea<eventFilterLogicType>([
                 actions.setFilterFormValue('id', data.id)
                 actions.setFilterFormValue('mode', data.mode ?? 'disabled')
                 if (data.filter_tree?.type) {
-                    actions.setFilterFormValue('filter_tree', data.filter_tree)
+                    actions.setFilterFormValue('filter_tree', normalizeRootToGroup(data.filter_tree))
                 }
                 const testCases = (data.test_cases ?? []).map((tc: Omit<TestCase, '_key'>) => ({
                     ...tc,

--- a/posthog/api/test/test_event_filter_config.py
+++ b/posthog/api/test/test_event_filter_config.py
@@ -39,7 +39,7 @@ class TestEventFilterConfigAPI(APIBaseTest):
         self.assertFalse(EventFilterConfig.objects.filter(team=self.team).exists())
 
     def test_list_returns_existing_config(self):
-        tree = _cond()
+        tree = _or(_cond())
         EventFilterConfig.objects.create(team=self.team, mode=EventFilterMode.LIVE, filter_tree=tree)
 
         response = self.client.get(self._url())
@@ -89,7 +89,7 @@ class TestEventFilterConfigAPI(APIBaseTest):
 
     def test_create_upserts_filter_tree(self):
         seed = self._seed_config()
-        new_tree = _cond("distinct_id", "exact", "user-1")
+        new_tree = _or(_cond("distinct_id", "exact", "user-1"))
         new_test_cases = [
             {"distinct_id": "user-1", "expected_result": "drop"},
             {"distinct_id": "someone-else", "expected_result": "ingest"},
@@ -149,11 +149,12 @@ class TestEventFilterConfigAPI(APIBaseTest):
         self.assertEqual(EventFilterConfig.objects.filter(team=self.team).count(), 1)
 
     def test_create_prunes_filter_tree_on_save(self):
-        tree = _and(_cond())
+        # Empty/single-child nested groups are pruned, but the root stays a group.
+        tree = _or(_and(_cond()), {"type": "and", "children": []})
         response = self.client.post(self._url(), data={"filter_tree": tree}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["filter_tree"], _cond())
+        self.assertEqual(response.json()["filter_tree"], _or(_cond()))
 
     def test_create_timestamps_are_read_only(self):
         response = self.client.post(

--- a/posthog/models/event_filter_config.py
+++ b/posthog/models/event_filter_config.py
@@ -81,47 +81,46 @@ class EventFilterConfig(UUIDTModel):
         super().save(*args, **kwargs)
 
 
-def prune_filter_tree(node: dict, is_root: bool = True) -> dict | None:
+def prune_filter_tree(node: dict) -> dict | None:
     """
-    Remove empty groups and collapse single-child groups.
+    Remove empty groups and collapse single-child groups, keeping an and/or
+    group at the root.
 
-    The root is kept as an and/or group: the tree editor can only add conditions
-    or groups inside a group node, so collapsing the root down to a bare condition
-    (or NOT) leaves the user with no "Add condition" button. Nested single-child
-    groups still collapse as before.
+    The tree editor can only add conditions or groups inside a group node, so a
+    bare condition (or NOT) at the root leaves the user with no "Add condition"
+    button. We prune freely, then wrap a non-group root in an OR as a final pass.
     """
+    pruned = _prune_node(node)
+    if pruned is not None and pruned.get("type") not in ("and", "or"):
+        return {"type": "or", "children": [pruned]}
+    return pruned
+
+
+def _prune_node(node: dict) -> dict | None:
+    """Remove empty groups and collapse single-child groups, depth-first."""
     node_type = node.get("type")
 
     if node_type == "condition":
-        return _ensure_group_root(node, is_root)
+        return node
 
     if node_type == "not":
-        child = prune_filter_tree(node.get("child", {}), is_root=False)
+        child = _prune_node(node.get("child", {}))
         if child is None:
             return None
-        return _ensure_group_root({**node, "child": child}, is_root)
+        return {**node, "child": child}
 
     if node_type in ("and", "or"):
-        children = [prune_filter_tree(c, is_root=False) for c in node.get("children", [])]
-        children = [c for c in children if c is not None]
+        children: list[dict] = []
+        for child in node.get("children", []):
+            pruned_child = _prune_node(child)
+            if pruned_child is not None:
+                children.append(pruned_child)
         if len(children) == 0:
             return None
         if len(children) == 1:
-            only = children[0]
-            # Collapsing to the lone child is fine unless it would leave a
-            # non-group at the root — in that case keep this group as the wrapper.
-            if is_root and only.get("type") not in ("and", "or"):
-                return {**node, "children": children}
-            return only
+            return children[0]
         return {**node, "children": children}
 
-    return node
-
-
-def _ensure_group_root(node: dict, is_root: bool) -> dict:
-    """Wrap a non-group node in an OR group when it would otherwise be the root."""
-    if is_root and node.get("type") not in ("and", "or"):
-        return {"type": "or", "children": [node]}
     return node
 
 

--- a/posthog/models/event_filter_config.py
+++ b/posthog/models/event_filter_config.py
@@ -81,28 +81,47 @@ class EventFilterConfig(UUIDTModel):
         super().save(*args, **kwargs)
 
 
-def prune_filter_tree(node: dict) -> dict | None:
-    """Remove empty groups and collapse single-child groups."""
+def prune_filter_tree(node: dict, is_root: bool = True) -> dict | None:
+    """
+    Remove empty groups and collapse single-child groups.
+
+    The root is kept as an and/or group: the tree editor can only add conditions
+    or groups inside a group node, so collapsing the root down to a bare condition
+    (or NOT) leaves the user with no "Add condition" button. Nested single-child
+    groups still collapse as before.
+    """
     node_type = node.get("type")
 
     if node_type == "condition":
-        return node
+        return _ensure_group_root(node, is_root)
 
     if node_type == "not":
-        child = prune_filter_tree(node.get("child", {}))
+        child = prune_filter_tree(node.get("child", {}), is_root=False)
         if child is None:
             return None
-        return {**node, "child": child}
+        return _ensure_group_root({**node, "child": child}, is_root)
 
     if node_type in ("and", "or"):
-        children = [prune_filter_tree(c) for c in node.get("children", [])]
+        children = [prune_filter_tree(c, is_root=False) for c in node.get("children", [])]
         children = [c for c in children if c is not None]
         if len(children) == 0:
             return None
         if len(children) == 1:
-            return children[0]
+            only = children[0]
+            # Collapsing to the lone child is fine unless it would leave a
+            # non-group at the root — in that case keep this group as the wrapper.
+            if is_root and only.get("type") not in ("and", "or"):
+                return {**node, "children": children}
+            return only
         return {**node, "children": children}
 
+    return node
+
+
+def _ensure_group_root(node: dict, is_root: bool) -> dict:
+    """Wrap a non-group node in an OR group when it would otherwise be the root."""
+    if is_root and node.get("type") not in ("and", "or"):
+        return {"type": "or", "children": [node]}
     return node
 
 

--- a/posthog/models/test/test_event_filter_config.py
+++ b/posthog/models/test/test_event_filter_config.py
@@ -156,8 +156,10 @@ class TestPruneFilterTree(SimpleTestCase):
         self.assertIsNone(prune_filter_tree({"type": "and", "children": []}))
 
     def test_collapses_single_child_group(self):
+        # Nested single-child groups collapse; the root stays a group (see
+        # TestPruneFilterTreePreservesGroupRoot).
         cond = _cond()
-        self.assertEqual(prune_filter_tree(_and(cond)), cond)
+        self.assertEqual(prune_filter_tree(_and(_or(cond), _cond(value="keep"))), _and(cond, _cond(value="keep")))
 
     def test_removes_not_with_empty_child(self):
         self.assertIsNone(prune_filter_tree(_not({"type": "or", "children": []})))
@@ -167,9 +169,60 @@ class TestPruneFilterTree(SimpleTestCase):
         self.assertEqual(prune_filter_tree(tree), tree)
 
     def test_collapses_nested_single_child_groups(self):
+        # Deeply nested single-child groups collapse down to one group at the root.
         cond = _cond()
-        tree = _or(_and(cond))
-        self.assertEqual(prune_filter_tree(tree), cond)
+        self.assertEqual(prune_filter_tree(_or(_and(_or(cond)))), _or(cond))
+
+
+class TestPruneFilterTreePreservesGroupRoot(SimpleTestCase):
+    """
+    Regression: pruning must never leave a non-group (condition or NOT) at the
+    root. The tree editor can only add conditions/groups inside an and/or node,
+    so a bare-condition root strands the user with no "Add condition" button.
+    """
+
+    def test_root_or_with_single_condition_stays_a_group(self):
+        cond = _cond()
+        pruned = prune_filter_tree(_or(cond))
+        assert pruned is not None
+        self.assertEqual(pruned["type"], "or")
+        self.assertEqual(pruned["children"], [cond])
+
+    def test_root_and_with_single_condition_stays_a_group(self):
+        cond = _cond()
+        pruned = prune_filter_tree(_and(cond))
+        assert pruned is not None
+        self.assertEqual(pruned["type"], "and")
+        self.assertEqual(pruned["children"], [cond])
+
+    def test_bare_condition_root_is_wrapped_in_group(self):
+        cond = _cond("distinct_id", "contains", "bot")
+        pruned = prune_filter_tree(cond)
+        assert pruned is not None
+        self.assertIn(pruned["type"], ("and", "or"))
+        self.assertEqual(pruned["children"], [cond])
+
+    def test_bare_not_root_is_wrapped_in_group(self):
+        node = _not(_cond())
+        pruned = prune_filter_tree(node)
+        assert pruned is not None
+        self.assertIn(pruned["type"], ("and", "or"))
+        self.assertEqual(pruned["children"], [node])
+
+    def test_nested_single_child_group_collapses_but_root_stays_a_group(self):
+        cond = _cond()
+        pruned = prune_filter_tree(_or(_and(cond)))
+        assert pruned is not None
+        self.assertEqual(pruned["type"], "or")
+        self.assertEqual(pruned["children"], [cond])
+
+    def test_root_collapses_to_inner_group(self):
+        # The lone child is itself a group, so collapsing keeps a group root.
+        inner = _and(_cond(value="a"), _cond(value="b"))
+        self.assertEqual(prune_filter_tree(_or(inner)), inner)
+
+    def test_empty_root_group_still_returns_none(self):
+        self.assertIsNone(prune_filter_tree(_or()))
 
 
 class TestEvaluateFilterTree(SimpleTestCase):
@@ -359,13 +412,36 @@ class TestEventFilterConfigModel(BaseTest):
         self.assertIsNone(retrieved.filter_tree)
 
     def test_save_prunes_filter_tree(self):
-        tree = _and(_cond("event_name", "exact", "pageview"))
+        # Empty and single-child nested groups are pruned, but the root stays a group.
+        tree = _or(_and(_cond("event_name", "exact", "pageview")), {"type": "and", "children": []})
         config = EventFilterConfig.objects.create(
             team=self.team,
             mode=EventFilterMode.LIVE,
             filter_tree=tree,
         )
-        self.assertEqual(config.filter_tree, _cond("event_name", "exact", "pageview"))
+        self.assertEqual(config.filter_tree, _or(_cond("event_name", "exact", "pageview")))
+
+    def test_save_keeps_group_root_for_single_condition(self):
+        # Regression: a one-condition filter must round-trip as a group so the
+        # editor can still add conditions after reload.
+        config = EventFilterConfig.objects.create(
+            team=self.team,
+            mode=EventFilterMode.LIVE,
+            filter_tree=_or(_cond("distinct_id", "contains", "bot")),
+        )
+        self.assertIn(config.filter_tree["type"], ("and", "or"))
+        self.assertEqual(config.filter_tree, _or(_cond("distinct_id", "contains", "bot")))
+
+    def test_save_wraps_bare_condition_root(self):
+        # Heals the production bug: a filter stored as a bare condition gets a
+        # group root the next time it is saved.
+        config = EventFilterConfig.objects.create(
+            team=self.team,
+            mode=EventFilterMode.LIVE,
+            filter_tree=_cond("distinct_id", "contains", "bot"),
+        )
+        self.assertIn(config.filter_tree["type"], ("and", "or"))
+        self.assertEqual(config.filter_tree["children"], [_cond("distinct_id", "contains", "bot")])
 
     def test_save_rejects_invalid_filter_tree(self):
         with self.assertRaises(ValidationError):

--- a/posthog/models/test/test_event_filter_config.py
+++ b/posthog/models/test/test_event_filter_config.py
@@ -181,40 +181,20 @@ class TestPruneFilterTreePreservesGroupRoot(SimpleTestCase):
     so a bare-condition root strands the user with no "Add condition" button.
     """
 
-    def test_root_or_with_single_condition_stays_a_group(self):
-        cond = _cond()
-        pruned = prune_filter_tree(_or(cond))
-        assert pruned is not None
-        self.assertEqual(pruned["type"], "or")
-        self.assertEqual(pruned["children"], [cond])
-
-    def test_root_and_with_single_condition_stays_a_group(self):
-        cond = _cond()
-        pruned = prune_filter_tree(_and(cond))
-        assert pruned is not None
-        self.assertEqual(pruned["type"], "and")
-        self.assertEqual(pruned["children"], [cond])
-
-    def test_bare_condition_root_is_wrapped_in_group(self):
-        cond = _cond("distinct_id", "contains", "bot")
-        pruned = prune_filter_tree(cond)
+    @parameterized.expand(
+        [
+            ("root_or_single_condition", _or(_cond()), [_cond()]),
+            ("root_and_single_condition", _and(_cond()), [_cond()]),
+            ("bare_condition_root", _cond("distinct_id", "contains", "bot"), [_cond("distinct_id", "contains", "bot")]),
+            ("bare_not_root", _not(_cond()), [_not(_cond())]),
+            ("nested_single_child_collapses", _or(_and(_cond())), [_cond()]),
+        ]
+    )
+    def test_root_is_a_group_wrapping_children(self, _name: str, tree: dict, expected_children: list[dict]):
+        pruned = prune_filter_tree(tree)
         assert pruned is not None
         self.assertIn(pruned["type"], ("and", "or"))
-        self.assertEqual(pruned["children"], [cond])
-
-    def test_bare_not_root_is_wrapped_in_group(self):
-        node = _not(_cond())
-        pruned = prune_filter_tree(node)
-        assert pruned is not None
-        self.assertIn(pruned["type"], ("and", "or"))
-        self.assertEqual(pruned["children"], [node])
-
-    def test_nested_single_child_group_collapses_but_root_stays_a_group(self):
-        cond = _cond()
-        pruned = prune_filter_tree(_or(_and(cond)))
-        assert pruned is not None
-        self.assertEqual(pruned["type"], "or")
-        self.assertEqual(pruned["children"], [cond])
+        self.assertEqual(pruned["children"], expected_children)
 
     def test_root_collapses_to_inner_group(self):
         # The lone child is itself a group, so collapsing keeps a group root.
@@ -429,6 +409,7 @@ class TestEventFilterConfigModel(BaseTest):
             mode=EventFilterMode.LIVE,
             filter_tree=_or(_cond("distinct_id", "contains", "bot")),
         )
+        assert config.filter_tree is not None
         self.assertIn(config.filter_tree["type"], ("and", "or"))
         self.assertEqual(config.filter_tree, _or(_cond("distinct_id", "contains", "bot")))
 
@@ -440,6 +421,7 @@ class TestEventFilterConfigModel(BaseTest):
             mode=EventFilterMode.LIVE,
             filter_tree=_cond("distinct_id", "contains", "bot"),
         )
+        assert config.filter_tree is not None
         self.assertIn(config.filter_tree["type"], ("and", "or"))
         self.assertEqual(config.filter_tree["children"], [_cond("distinct_id", "contains", "bot")])
 


### PR DESCRIPTION
## Problem

In the event ingestion filtering UI ("Drop events matching"), a user who saved a filter with a single condition came back to find a lone condition row and **no way to add more conditions** — the "Add condition" / "Add group" buttons were gone.

Root cause: `prune_filter_tree` collapsed any single-child group into its bare child on every save, so a one-condition filter (`or{[condition]}`) was persisted as a bare `condition` root. The tree editor can only add conditions/groups inside an `and`/`or` node — a `condition` root renders through `ConditionEditor`, which has no add affordance — so the filter became uneditable after reload. This was found via a session replay of a real account whose saved config was `{"type":"condition", ...}` at the root.

## Changes

Keep an `and`/`or` group at the root of the filter tree in both layers:

- **Backend** (`prune_filter_tree`): nested single-child groups still collapse, but the root is never collapsed below a group, and a bare `condition`/`not` root is wrapped in an `OR`. Existing broken records self-heal on their next save.
- **Frontend** (`normalizeRootToGroup`, applied in `eventFilterLogic.afterMount`): re-wraps a non-group root on load, so already-saved bare-condition configs become editable again immediately — the add buttons reappear.

No schema/migration change (pure pruning + load-normalization logic).

## How did you test this code?

I'm an agent (PostHog Code); I did not manually click through the UI. I followed TDD — wrote the regression tests first and confirmed they failed against the old code, then implemented the fix. Automated tests run:

- **Backend** `hogli test posthog/models/test/test_event_filter_config.py posthog/api/test/test_event_filter_config.py --create-db` → **108 passed**. New: `TestPruneFilterTreePreservesGroupRoot`, plus model tests `test_save_keeps_group_root_for_single_condition` and `test_save_wraps_bare_condition_root` (proves legacy rows heal). Updated the existing tests that codified the old collapse behavior.
- **Frontend** `hogli test frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts` → **75 passed**, including the new `normalizeRootToGroup` block.
- **Visual/interaction story** `SingleConditionRootIsEditable` in `EventFilterScene.stories.tsx` loads the exact broken shape (bare `distinct_id contains` condition, live mode) and its play function asserts the `add-condition-root` button is present — it errors before the fix, passes after, and produces a snapshot.
- `tsc --noEmit` clean for the changed files; ruff + oxlint clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Investigation started from a session replay where the user couldn't find the "add condition" button. Initial hypothesis (UI discoverability / disabled buttons) was wrong; the human pointed out the saved config had a bare-condition root, which led to finding the unconditional single-child collapse in `prune_filter_tree`. Chose a defense-in-depth fix (backend guarantees a group root going forward; frontend normalizes on load to repair existing records) over a frontend-only patch, since existing broken rows needed healing too. Tests were written failing-first per the human's instruction.

Tools: PostHog Code (agent), with the `posthog` MCP (session-recording + execute-sql) for the replay investigation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
