### PR TITLE
fix(marketing-analytics): resolve date_from='all' in warehouse trends path

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
@@ -163,6 +163,7 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                                 aggregationAxisPostfix:
                                     isCurrency && !currencyIsPrefix ? ` ${currencySymbol}` : undefined,
                             },
+                            tags: MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS,
                         },
                     },
                     showIntervalSelect: true,

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -312,7 +312,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         )
         flush_persons_and_events()
 
-        series = [ActionsNode(id=action.id), EventsNode(event="$pageleave")]
+        series: list[ActionsNode | EventsNode] = [ActionsNode(id=action.id), EventsNode(event="$pageleave")]
         earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
         self.assertEqual(earliest_timestamp, datetime.datetime(2019, 1, 1, 12, 0, 0, tzinfo=datetime.UTC))
 

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -355,6 +355,10 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
             ("date_string", "2023-05-01", datetime.datetime(2023, 5, 1, 0, 0, 0)),
             ("none", None, EARLIEST_EVENT_TIMESTAMP),
             ("unsupported", 12345, EARLIEST_EVENT_TIMESTAMP),
+            ("unparseable_na", "N/A", EARLIEST_EVENT_TIMESTAMP),
+            ("unparseable_null", "null", EARLIEST_EVENT_TIMESTAMP),
+            ("unparseable_empty", "", EARLIEST_EVENT_TIMESTAMP),
+            ("unparseable_freeform", "not a date at all", EARLIEST_EVENT_TIMESTAMP),
         ]
     )
     def test_coerce_to_datetime(self, _name, value, expected):

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -1,16 +1,23 @@
 import datetime
 
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
+from unittest.mock import patch
 
 from django.core.cache import cache
 from django.test import override_settings
 
 from dateutil import parser
+from parameterized import parameterized
 
-from posthog.schema import ActionsNode, DateRange, EventsNode, IntervalType
+from posthog.schema import ActionsNode, DataWarehouseNode, DateRange, EventsNode, IntervalType
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
+from posthog.hogql_queries.utils.timestamp_utils import (
+    EARLIEST_EVENT_TIMESTAMP,
+    _coerce_to_datetime,
+    format_label_date,
+    get_earliest_timestamp_from_series,
+)
 from posthog.models.team import WeekStartDay
 
 from products.actions.backend.models.action import Action
@@ -339,3 +346,55 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         # should still return the earliest timestamp from the first query
         cached_earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
         self.assertEqual(cached_earliest_timestamp, earliest_timestamp)
+
+    @parameterized.expand(
+        [
+            ("datetime", datetime.datetime(2023, 5, 1, 12, 30, 0), datetime.datetime(2023, 5, 1, 12, 30, 0)),
+            ("date", datetime.date(2023, 5, 1), datetime.datetime(2023, 5, 1, 0, 0, 0)),
+            ("string", "2023-05-01 12:30:00", datetime.datetime(2023, 5, 1, 12, 30, 0)),
+            ("date_string", "2023-05-01", datetime.datetime(2023, 5, 1, 0, 0, 0)),
+            ("none", None, EARLIEST_EVENT_TIMESTAMP),
+            ("unsupported", 12345, EARLIEST_EVENT_TIMESTAMP),
+        ]
+    )
+    def test_coerce_to_datetime(self, _name, value, expected):
+        self.assertEqual(_coerce_to_datetime(value), expected)
+
+    @parameterized.expand(
+        [
+            ("string_timestamp", "2022-03-15 08:00:00", datetime.datetime(2022, 3, 15, 8, 0, 0)),
+            ("date_only_string", "2022-03-15", datetime.datetime(2022, 3, 15, 0, 0, 0)),
+            ("date_object", datetime.date(2022, 3, 15), datetime.datetime(2022, 3, 15, 0, 0, 0)),
+        ]
+    )
+    def test_data_warehouse_all_time_resolves_string_timestamp(self, _name, raw_value, expected):
+        # Data warehouse tables can return a non-datetime min(timestamp); it must be
+        # coerced before reaching QueryDateRange, which calls .strftime() and compares with <.
+        node = DataWarehouseNode(
+            id="dw_table",
+            table_name="dw_table",
+            id_field="id",
+            distinct_id_field="distinct_id",
+            timestamp_field="ts",
+        )
+
+        with patch("posthog.hogql_queries.utils.timestamp_utils.execute_hogql_query") as mock_execute:
+            mock_execute.return_value.results = [[raw_value]]
+
+            earliest_timestamp = get_earliest_timestamp_from_series(self.team, [node])
+
+        self.assertIsInstance(earliest_timestamp, datetime.datetime)
+        self.assertEqual(earliest_timestamp, expected)
+
+        query_date_range = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="all"),
+            interval=IntervalType.DAY,
+            now=parser.isoparse("2025-06-21T00:00:00.000Z"),
+            earliest_timestamp_fallback=earliest_timestamp,
+        )
+
+        # These previously raised AttributeError / TypeError when date_from="all"
+        # resolved to a str instead of a datetime.
+        self.assertEqual(query_date_range.date_from(), expected)
+        self.assertEqual(query_date_range.date_from_str, expected.strftime("%Y-%m-%d %H:%M:%S"))

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -1,4 +1,5 @@
 import datetime
+from zoneinfo import ZoneInfo
 
 from posthog.test.base import APIBaseTest, ClickhouseDestroyTablesMixin, _create_event, flush_persons_and_events
 from unittest.mock import patch
@@ -350,19 +351,32 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
 
     @parameterized.expand(
         [
+            # Naive inputs are interpreted in the passed (team) timezone, not UTC.
             (
                 "naive_datetime",
                 datetime.datetime(2023, 5, 1, 12, 30, 0),
-                datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC),
+                datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=ZoneInfo("America/New_York")),
             ),
             (
                 "aware_datetime",
                 datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC),
                 datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC),
             ),
-            ("date", datetime.date(2023, 5, 1), datetime.datetime(2023, 5, 1, 0, 0, 0, tzinfo=datetime.UTC)),
-            ("string", "2023-05-01 12:30:00", datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC)),
-            ("date_string", "2023-05-01", datetime.datetime(2023, 5, 1, 0, 0, 0, tzinfo=datetime.UTC)),
+            (
+                "date",
+                datetime.date(2023, 5, 1),
+                datetime.datetime(2023, 5, 1, 0, 0, 0, tzinfo=ZoneInfo("America/New_York")),
+            ),
+            (
+                "string",
+                "2023-05-01 12:30:00",
+                datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=ZoneInfo("America/New_York")),
+            ),
+            (
+                "date_string",
+                "2023-05-01",
+                datetime.datetime(2023, 5, 1, 0, 0, 0, tzinfo=ZoneInfo("America/New_York")),
+            ),
             ("none", None, EARLIEST_EVENT_TIMESTAMP),
             ("unsupported", 12345, EARLIEST_EVENT_TIMESTAMP),
             ("unparseable_na", "N/A", EARLIEST_EVENT_TIMESTAMP),
@@ -372,7 +386,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         ]
     )
     def test_coerce_to_datetime(self, _name, value, expected):
-        result = _coerce_to_datetime(value)
+        result = _coerce_to_datetime(value, ZoneInfo("America/New_York"))
         self.assertEqual(result, expected)
         # Must be timezone-aware so it can be compared against the tz-aware date_to.
         self.assertIsNotNone(result.tzinfo)

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -220,7 +220,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         series = [
             EventsNode(event="$pageview"),
         ]
-        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
+        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
 
         self.assertEqual(earliest_timestamp, datetime.datetime(2021, 1, 1, 12, 0, 0, tzinfo=datetime.UTC))
 
@@ -243,7 +243,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
             EventsNode(event="$pageview"),
             EventsNode(event="$pageleave"),
         ]
-        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
+        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
         self.assertEqual(earliest_timestamp, datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=datetime.UTC))
 
         earliest_timestamp_pageview = get_earliest_timestamp_from_series(self.team, [EventsNode(event="$pageview")])
@@ -291,7 +291,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         flush_persons_and_events()
 
         series = [ActionsNode(id=action1.id), ActionsNode(id=action2.id)]
-        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
+        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
         self.assertEqual(earliest_timestamp, datetime.datetime(2020, 1, 1, 12, 0, 0, tzinfo=datetime.UTC))
 
     def test_returns_earliest_timestamp_mixed_nodes(self):
@@ -313,7 +313,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         flush_persons_and_events()
 
         series = [ActionsNode(id=action.id), EventsNode(event="$pageleave")]
-        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
+        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
         self.assertEqual(earliest_timestamp, datetime.datetime(2019, 1, 1, 12, 0, 0, tzinfo=datetime.UTC))
 
     def test_caches_earliest_timestamp(self):
@@ -334,7 +334,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         series = [
             EventsNode(event="$pageview"),
         ]
-        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
+        earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
 
         # create an earlier event to test caching
         _create_event(
@@ -346,7 +346,7 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         flush_persons_and_events()
 
         # should still return the earliest timestamp from the first query
-        cached_earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)  # type: ignore
+        cached_earliest_timestamp = get_earliest_timestamp_from_series(self.team, series)
         self.assertEqual(cached_earliest_timestamp, earliest_timestamp)
 
     @parameterized.expand(

--- a/posthog/hogql_queries/utils/test/test_timestamp_utils.py
+++ b/posthog/hogql_queries/utils/test/test_timestamp_utils.py
@@ -11,6 +11,7 @@ from parameterized import parameterized
 
 from posthog.schema import ActionsNode, DataWarehouseNode, DateRange, EventsNode, IntervalType
 
+from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags, tags_context
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.timestamp_utils import (
     EARLIEST_EVENT_TIMESTAMP,
@@ -349,10 +350,19 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
 
     @parameterized.expand(
         [
-            ("datetime", datetime.datetime(2023, 5, 1, 12, 30, 0), datetime.datetime(2023, 5, 1, 12, 30, 0)),
-            ("date", datetime.date(2023, 5, 1), datetime.datetime(2023, 5, 1, 0, 0, 0)),
-            ("string", "2023-05-01 12:30:00", datetime.datetime(2023, 5, 1, 12, 30, 0)),
-            ("date_string", "2023-05-01", datetime.datetime(2023, 5, 1, 0, 0, 0)),
+            (
+                "naive_datetime",
+                datetime.datetime(2023, 5, 1, 12, 30, 0),
+                datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC),
+            ),
+            (
+                "aware_datetime",
+                datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC),
+                datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC),
+            ),
+            ("date", datetime.date(2023, 5, 1), datetime.datetime(2023, 5, 1, 0, 0, 0, tzinfo=datetime.UTC)),
+            ("string", "2023-05-01 12:30:00", datetime.datetime(2023, 5, 1, 12, 30, 0, tzinfo=datetime.UTC)),
+            ("date_string", "2023-05-01", datetime.datetime(2023, 5, 1, 0, 0, 0, tzinfo=datetime.UTC)),
             ("none", None, EARLIEST_EVENT_TIMESTAMP),
             ("unsupported", 12345, EARLIEST_EVENT_TIMESTAMP),
             ("unparseable_na", "N/A", EARLIEST_EVENT_TIMESTAMP),
@@ -362,13 +372,16 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         ]
     )
     def test_coerce_to_datetime(self, _name, value, expected):
-        self.assertEqual(_coerce_to_datetime(value), expected)
+        result = _coerce_to_datetime(value)
+        self.assertEqual(result, expected)
+        # Must be timezone-aware so it can be compared against the tz-aware date_to.
+        self.assertIsNotNone(result.tzinfo)
 
     @parameterized.expand(
         [
-            ("string_timestamp", "2022-03-15 08:00:00", datetime.datetime(2022, 3, 15, 8, 0, 0)),
-            ("date_only_string", "2022-03-15", datetime.datetime(2022, 3, 15, 0, 0, 0)),
-            ("date_object", datetime.date(2022, 3, 15), datetime.datetime(2022, 3, 15, 0, 0, 0)),
+            ("string_timestamp", "2022-03-15 08:00:00", datetime.datetime(2022, 3, 15, 8, 0, 0, tzinfo=datetime.UTC)),
+            ("date_only_string", "2022-03-15", datetime.datetime(2022, 3, 15, 0, 0, 0, tzinfo=datetime.UTC)),
+            ("date_object", datetime.date(2022, 3, 15), datetime.datetime(2022, 3, 15, 0, 0, 0, tzinfo=datetime.UTC)),
         ]
     )
     def test_data_warehouse_all_time_resolves_string_timestamp(self, _name, raw_value, expected):
@@ -402,3 +415,30 @@ class TestTimestampUtils(APIBaseTest, ClickhouseDestroyTablesMixin):
         # resolved to a str instead of a datetime.
         self.assertEqual(query_date_range.date_from(), expected)
         self.assertEqual(query_date_range.date_from_str, expected.strftime("%Y-%m-%d %H:%M:%S"))
+        # A Date-typed column yields a naive datetime; comparing it against the tz-aware
+        # date_to raised "can't compare offset-naive and offset-aware datetimes" here.
+        self.assertGreater(len(query_date_range.all_values()), 0)
+
+    @override_settings(IN_UNIT_TESTING=False)
+    @patch("posthog.hogql_queries.utils.timestamp_utils._get_earliest_timestamp_from_node")
+    def test_multi_node_propagates_query_tags_to_threads(self, mock_node):
+        # Multiple nodes resolve their earliest timestamp via ThreadPoolExecutor, which does not
+        # inherit contextvars. Without copying the context, the worker threads' sync_execute calls
+        # run untagged and raise UntaggedQueryError in dev (DEBUG and not TEST).
+        captured: dict[str, object] = {}
+
+        def capture(team, node):
+            captured[node.table_name] = get_query_tags().product
+            return datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
+
+        mock_node.side_effect = capture
+        nodes = [
+            DataWarehouseNode(id="a", table_name="a", id_field="id", distinct_id_field="id", timestamp_field="ts"),
+            DataWarehouseNode(id="b", table_name="b", id_field="id", distinct_id_field="id", timestamp_field="ts"),
+        ]
+
+        with tags_context(product=Product.MARKETING_ANALYTICS, feature=Feature.QUERY):
+            get_earliest_timestamp_from_series(self.team, nodes)
+
+        self.assertEqual(captured["a"], Product.MARKETING_ANALYTICS)
+        self.assertEqual(captured["b"], Product.MARKETING_ANALYTICS)

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -1,6 +1,7 @@
 import contextvars
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta, tzinfo
 from typing import Any, Union
 
 from django.conf import settings
@@ -126,7 +127,7 @@ def _get_earliest_timestamp_cache_key(
         raise ValueError(f"Unsupported node type: {type(node)}")
 
 
-def _coerce_to_datetime(value: Any) -> datetime:
+def _coerce_to_datetime(value: Any, tz: tzinfo) -> datetime:
     """Normalize a min(timestamp) result to a timezone-aware ``datetime``.
 
     Data warehouse tables may declare their timestamp field as a String or Date
@@ -136,19 +137,21 @@ def _coerce_to_datetime(value: Any) -> datetime:
 
     The result must be timezone-aware: this value becomes the "all time" date_from,
     which is compared against the timezone-aware date_to. A naive datetime would
-    raise "can't compare offset-naive and offset-aware datetimes". We normalize to
-    UTC, matching the events path and ``EARLIEST_EVENT_TIMESTAMP``.
+    raise "can't compare offset-naive and offset-aware datetimes". Naive values
+    (e.g. from a ``Date`` column) are interpreted in the team's timezone — the same
+    timezone QueryDateRange buckets in — so the lower bound lines up with the day
+    boundaries the rest of the range uses, rather than UTC midnight.
     """
     if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+        return value if value.tzinfo is not None else value.replace(tzinfo=tz)
     if isinstance(value, date):
-        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+        return datetime(value.year, value.month, value.day, tzinfo=tz)
     if isinstance(value, str):
         try:
             parsed = parse_datetime(value)
         except (ValueError, TypeError, OverflowError):
             return EARLIEST_EVENT_TIMESTAMP
-        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=tz)
     return EARLIEST_EVENT_TIMESTAMP
 
 
@@ -180,7 +183,7 @@ def _get_earliest_timestamp_from_node(
     earliest_timestamp = EARLIEST_EVENT_TIMESTAMP
     result = execute_hogql_query(query=query, team=team)
     if result and len(result.results) > 0 and len(result.results[0]) > 0 and result.results[0][0] is not None:
-        earliest_timestamp = _coerce_to_datetime(result.results[0][0])
+        earliest_timestamp = _coerce_to_datetime(result.results[0][0], team.timezone_info)
 
     cache.set(cache_key, earliest_timestamp, timeout=EARLIEST_TIMESTAMP_CACHE_TTL)
     return earliest_timestamp
@@ -188,7 +191,7 @@ def _get_earliest_timestamp_from_node(
 
 def get_earliest_timestamp_from_series(
     team: Team,
-    series: list[
+    series: Sequence[
         Union[
             EventsNode, ActionsNode, DataWarehouseNode, FunnelsDataWarehouseNode, LifecycleDataWarehouseNode, GroupNode
         ]

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -138,7 +138,10 @@ def _coerce_to_datetime(value: Any) -> datetime:
     if isinstance(value, date):
         return datetime(value.year, value.month, value.day)
     if isinstance(value, str):
-        return parse_datetime(value)
+        try:
+            return parse_datetime(value)
+        except (ValueError, TypeError, OverflowError):
+            return EARLIEST_EVENT_TIMESTAMP
     return EARLIEST_EVENT_TIMESTAMP
 
 

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -1,5 +1,6 @@
+import contextvars
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, Union
 
 from django.conf import settings
@@ -126,22 +127,28 @@ def _get_earliest_timestamp_cache_key(
 
 
 def _coerce_to_datetime(value: Any) -> datetime:
-    """Normalize a min(timestamp) result to a ``datetime``.
+    """Normalize a min(timestamp) result to a timezone-aware ``datetime``.
 
     Data warehouse tables may declare their timestamp field as a String or Date
     column, so the query can return a ``str`` or ``date`` instead of a ``datetime``.
     Leaving those unconverted breaks downstream date math (``.strftime()`` and
     ``<`` comparisons), so we resolve them to a concrete ``datetime`` here.
+
+    The result must be timezone-aware: this value becomes the "all time" date_from,
+    which is compared against the timezone-aware date_to. A naive datetime would
+    raise "can't compare offset-naive and offset-aware datetimes". We normalize to
+    UTC, matching the events path and ``EARLIEST_EVENT_TIMESTAMP``.
     """
     if isinstance(value, datetime):
-        return value
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
     if isinstance(value, date):
-        return datetime(value.year, value.month, value.day)
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
     if isinstance(value, str):
         try:
-            return parse_datetime(value)
+            parsed = parse_datetime(value)
         except (ValueError, TypeError, OverflowError):
             return EARLIEST_EVENT_TIMESTAMP
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
     return EARLIEST_EVENT_TIMESTAMP
 
 
@@ -212,7 +219,12 @@ def get_earliest_timestamp_from_series(
 
     else:
         with ThreadPoolExecutor(max_workers=min(len(nodes), 4)) as executor:
-            futures = [executor.submit(_get_earliest_timestamp_from_node, team, node) for node in nodes]
+            # ThreadPoolExecutor does not inherit contextvars (query tags) by default; copy the
+            # current context into each worker so tagged sync_execute calls don't fail untagged.
+            futures = [
+                executor.submit(contextvars.copy_context().run, _get_earliest_timestamp_from_node, team, node)
+                for node in nodes
+            ]
             timestamps = [future.result() for future in futures]
 
     return min(timestamps)

--- a/posthog/hogql_queries/utils/timestamp_utils.py
+++ b/posthog/hogql_queries/utils/timestamp_utils.py
@@ -1,10 +1,11 @@
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, timedelta
-from typing import Union
+from typing import Any, Union
 
 from django.conf import settings
 from django.core.cache import cache
 
+from dateutil.parser import parse as parse_datetime
 from dateutil.relativedelta import MO, SU, relativedelta
 
 from posthog.schema import (
@@ -124,6 +125,23 @@ def _get_earliest_timestamp_cache_key(
         raise ValueError(f"Unsupported node type: {type(node)}")
 
 
+def _coerce_to_datetime(value: Any) -> datetime:
+    """Normalize a min(timestamp) result to a ``datetime``.
+
+    Data warehouse tables may declare their timestamp field as a String or Date
+    column, so the query can return a ``str`` or ``date`` instead of a ``datetime``.
+    Leaving those unconverted breaks downstream date math (``.strftime()`` and
+    ``<`` comparisons), so we resolve them to a concrete ``datetime`` here.
+    """
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    if isinstance(value, str):
+        return parse_datetime(value)
+    return EARLIEST_EVENT_TIMESTAMP
+
+
 def _get_earliest_timestamp_from_node(
     team: Team,
     node: Union[EventsNode, ActionsNode, DataWarehouseNode, FunnelsDataWarehouseNode, LifecycleDataWarehouseNode],
@@ -151,8 +169,8 @@ def _get_earliest_timestamp_from_node(
 
     earliest_timestamp = EARLIEST_EVENT_TIMESTAMP
     result = execute_hogql_query(query=query, team=team)
-    if result and len(result.results) > 0 and len(result.results[0]) > 0:
-        earliest_timestamp = result.results[0][0]
+    if result and len(result.results) > 0 and len(result.results[0]) > 0 and result.results[0][0] is not None:
+        earliest_timestamp = _coerce_to_datetime(result.results[0][0])
 
     cache.set(cache_key, earliest_timestamp, timeout=EARLIEST_TIMESTAMP_CACHE_TTL)
     return earliest_timestamp


### PR DESCRIPTION
## Problem

Cost trend tiles on the Marketing analytics scene issue `TrendsQuery`s over data-warehouse tables with `dateRange.date_from = "all"` ("All time" range). Loading the page with that range selected returned a 500 from the query endpoint. Investigation surfaced a chain of distinct bugs on the "All time" + data-warehouse path — each only reachable once the previous one was fixed, which is why a single patch wasn't enough:

1. **`str` earliest timestamp.** The "All time" lower bound for a warehouse series is resolved by `min(timestamp_field)`. Unlike the events table, a warehouse table can type its timestamp column as `String` (or `Date`), so the query returns a `str`/`date`. That value flowed into `QueryDateRange`, where `.strftime()` / `<` then raised `AttributeError: 'str' object has no attribute 'strftime'` / `TypeError: '<' not supported between 'str' and 'datetime.date'`.
2. **Naive datetime.** Coercing the above to a `datetime` is not enough — a `Date` column yields a *naive* datetime, which is then compared against the timezone-aware `date_to`, raising `TypeError: can't compare offset-naive and offset-aware datetimes`.
3. **Untagged threaded queries.** With multiple sources, the earliest-timestamp lookups run in a `ThreadPoolExecutor`, which does not inherit `contextvars`. The query tags set on the request thread were lost in the workers, so the internal `sync_execute` calls ran untagged and raised `UntaggedQueryError` (hard failure in local dev; untagged queries in production).
4. **Missing product attribution.** The cost trend tiles did not declare a `productKey`, so `product` was never tagged for these queries (its sibling Marketing analytics queries already use `MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS`). This is what left the context without a `product` tag in the first place.

All four only manifest together on "All time" with one or more configured warehouse sources; a fixed date range never resolves the earliest timestamp and so never hits #1–#3.

## Changes

- `_coerce_to_datetime` (`posthog/hogql_queries/utils/timestamp_utils.py`) normalizes the raw `min(timestamp)` to a **timezone-aware** `datetime` before it is cached or compared. Naive values (e.g. from a `Date` column, or a timezone-less string) are interpreted in the **team's timezone** — the same timezone `QueryDateRange` buckets in — so the "All time" lower bound lands on the team's day boundary rather than UTC midnight (which, for teams far from UTC, could otherwise exclude the earliest day's data). Values that already carry a timezone are kept as-is; unparseable/`None`/unsupported fall back to the existing `EARLIEST_EVENT_TIMESTAMP` sentinel. (covers #1 and #2)
- `get_earliest_timestamp_from_series` now copies the current `contextvars` context into each `ThreadPoolExecutor` worker (`contextvars.copy_context().run`), so query tags propagate to the threaded earliest-timestamp lookups. Its `series` parameter is also widened to `Sequence` (read-only). (covers #3)
- The Marketing analytics cost trend tile now tags its `TrendsQuery` with `MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS` (`productKey: marketing_analytics`), matching the scene's other queries. (covers #4)

## How did you test this code?

I'm an agent (Claude Code). I added automated tests only — no manual UI testing was performed. I also reproduced the exact failing query path (the real two-source cost `TrendsQuery` with `compareFilter` and `date_from="all"`) against a local stack via a throwaway script to confirm each fix in turn, and confirmed the final state resolves successfully.

Added to `posthog/hogql_queries/utils/test/test_timestamp_utils.py`:

- Parameterized unit tests for `_coerce_to_datetime` covering naive/aware `datetime`, `date`, datetime/date strings, unparseable strings, `None`, and unsupported types — asserting naive inputs adopt the passed (team) timezone and the result is always timezone-aware.
- Tests that simulate a warehouse series returning a `str`/`date` `min(timestamp)` and assert `QueryDateRange(date_from="all", ...)` resolves `date_from()`, `date_from_str`, and `all_values()` without raising (the naive-vs-aware comparison guard).
- A test asserting query tags propagate from the calling context into the `ThreadPoolExecutor` workers for a multi-node series.

Command run (35 tests in the file green):

```
hogli test posthog/hogql_queries/utils/test/test_timestamp_utils.py
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus 4.8).
- The 500 was traced from the Marketing analytics cost tiles to the "All time" earliest-timestamp resolution for warehouse series. Because the failure was Python-side (never reached ClickHouse), it did not appear in `system.query_log`; it was pinned down by reproducing the exact request payload against a local stack and by file-based logging in the live path, which revealed the layered root causes above.
- Each fix was applied at the resolution layer rather than guarding symptoms: coerce-to-tz-aware (in the team's timezone) at the single read site, context propagation at the thread boundary, and product attribution at the query source. Verified that the fixes together resolve the exact multi-source "All time" query.
