### PR TITLE
fix: don't auto-login SSO-enforced users on email verification

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -864,6 +864,24 @@ class TestUserAPI(APIBaseTest):
         # No password-backend session is handed out for an SSO-enforced account; they must log in via SSO.
         mock_login.assert_not_called()
 
+    @patch("posthog.api.user.login")
+    @patch("posthog.tasks.email.send_email_change_emails.delay")
+    def test_initial_email_verification_skips_auto_login_for_sso_enforced_domain(self, _, mock_login):
+        self.user.email = "alice@example.com"
+        self.user.pending_email = None
+        self.user.save()
+
+        with patch(
+            "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
+            side_effect=lambda email, organization=None: "google-oauth2" if email == "alice@example.com" else None,
+        ):
+            token = email_verification_token_generator.make_token(self.user)
+            response = self.client.post("/api/users/verify_email/", {"uuid": self.user.uuid, "token": token})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["requires_sso"] is True
+        mock_login.assert_not_called()
+
     @patch("posthog.api.user.is_email_available", return_value=True)
     @patch("posthog.tasks.email.send_email_change_emails.delay")
     def test_no_notifications_when_user_email_is_changed_and_only_case_differs(

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -844,6 +844,26 @@ class TestUserAPI(APIBaseTest):
         assert UserSocialAuth.objects.filter(id=social_auth.id).exists()
         mock_send_email_change_emails.assert_not_called()
 
+    @patch("posthog.api.user.login")
+    @patch("posthog.tasks.email.send_email_change_emails.delay")
+    def test_email_change_verification_skips_auto_login_for_sso_enforced_domain(self, _, mock_login):
+        self.user.pending_email = "alice@example.com"
+        self.user.save()
+
+        with patch(
+            "posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address",
+            side_effect=lambda email, organization=None: "google-oauth2" if email == "alice@example.com" else None,
+        ):
+            token = email_verification_token_generator.make_token(self.user)
+            response = self.client.post("/api/users/verify_email/", {"uuid": self.user.uuid, "token": token})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["requires_sso"] is True
+        self.user.refresh_from_db()
+        assert self.user.email == "alice@example.com"
+        # No password-backend session is handed out for an SSO-enforced account; they must log in via SSO.
+        mock_login.assert_not_called()
+
     @patch("posthog.api.user.is_email_available", return_value=True)
     @patch("posthog.tasks.email.send_email_change_emails.delay")
     def test_no_notifications_when_user_email_is_changed_and_only_case_differs(

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -934,6 +934,11 @@ class UserViewSet(
         if default_device(user) or passkeys_enabled_for_2fa:
             return Response({"success": True, "token": token, "requires_2fa": True})
 
+        # Don't hand a non-SSO session to an account whose domain enforces SSO — verifying an email
+        # must not become a password-backend login path around the IdP. The user logs in via SSO.
+        if OrganizationDomain.objects.get_sso_enforcement_for_email_address(user.email):
+            return Response({"success": True, "token": token, "requires_sso": True})
+
         login(self.request, user, backend="django.contrib.auth.backends.ModelBackend")
         set_two_factor_verified_in_session(self.request)
         report_user_logged_in(user)


### PR DESCRIPTION
## Problem

An SSO-enforced account should only get a session from the IdP.

`verify_email` establishes a session via `ModelBackend` once a verification token is accepted. For an account whose domain **enforces SSO**, that's a login path that doesn't go through the IdP — so verifying an email (or completing an email change) can hand out a session the org intended to only ever be granted via SSO.

Surfaced while reviewing #62392

## Changes

- In `posthog/api/user.py::verify_email`, skip the `ModelBackend` auto-login when the email's domain enforces SSO, and return `requires_sso` so the client completes the SSO flow.
- The verification itself still completes (email promoted, social auth reset) — we only avoid minting a non-SSO session. An existing valid session isn't touched.

## How did you test this code?

`hogli test posthog/api/test/test_user.py::TestUserAPI::test_verify_email_does_not_auto_login_when_domain_enforces_sso` 
(plus the existing verify_email tests still pass)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No