### PR TITLE
chore: prompt for mermaid diagrams in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Examples:
 Do not invent a different format.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 Keep descriptions high-level, focusing on rationale and architecture for the human reviewer.
+Include a mermaid diagram when it clarifies a non-trivial change — architecture, data or control flow, error routing, or a key decision (GitHub renders ```mermaid fenced blocks).
+Skip it for trivial or mechanical changes; don't force a diagram where prose is clearer.
 NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 Pass the description straight to the `body` argument of the PR-creation tool (the GitHub MCP `create_pull_request` `body` param, or `gh pr create --body-file -` via stdin). Do NOT write the body to a temporary file first — it adds a step, can race with parallel tool calls, and the `body` argument already preserves markdown and newlines verbatim (the no-hard-wrap rule still applies).
 


### PR DESCRIPTION
## Problem

PR descriptions for non-trivial changes (architecture, control/data flow, error routing, key decisions) are clearer with a diagram, but there was no guidance to include one — so agent- and human-authored PRs rarely did.

## Changes

Add a conditional guideline to the `### PR descriptions` section of AGENTS.md (= CLAUDE.md): include a mermaid diagram when it clarifies a non-trivial change, and skip it for trivial/mechanical PRs so we don't force diagrams where prose is clearer. Instructions-only; conditional, not mandatory.

## How did you test this code?

I'm an agent (Claude Code); docs-only change, no tests. Semantic line breaks match the surrounding file style.

## 🤖 Agent context

Authored with Claude Code. Came out of a stack where reasoning diagrams (two-pass flow, error-class routing, persistence flow) made the PRs much easier to review; we decided to standardize the practice. Kept it to AGENTS.md/CLAUDE.md (not the PR template) and conditional rather than a hard "always", to avoid diagram-noise on trivial PRs.
