### PR TITLE
feat(taxonomic-filter): default url and path filters to contains

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -353,20 +353,24 @@ describe('createDefaultPropertyFilter()', () => {
         )
     })
 
-    it('creates a standard event property filter with Exact operator', () => {
+    it.each([
+        ['$browser', PropertyOperator.Exact],
+        ['$current_url', PropertyOperator.IContains],
+        ['$pathname', PropertyOperator.IContains],
+    ])('defaults the %s event property filter to the %s operator', (propertyKey, expectedOperator) => {
         const result = createDefaultPropertyFilter(
             null,
-            '$browser',
+            propertyKey,
             PropertyFilterType.Event,
             makeGroup(TaxonomicFilterGroupType.EventProperties),
             noopDescribeProperty
         )
         expect(result).toEqual(
             expect.objectContaining({
-                key: '$browser',
+                key: propertyKey,
                 value: null,
                 type: PropertyFilterType.Event,
-                operator: PropertyOperator.Exact,
+                operator: expectedOperator,
             })
         )
     })

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -601,6 +601,8 @@ export function createDefaultPropertyFilter(
     const propertyValueType = describeProperty(propertyKey, apiType, taxonomicGroup.groupTypeIndex)
     const property_name_to_default_operator_override: Partial<Record<string | number, PropertyOperator>> = {
         $active_feature_flags: PropertyOperator.IContains,
+        $current_url: PropertyOperator.IContains,
+        $pathname: PropertyOperator.IContains,
     }
     const propValueTypeToDefaultOpOverride = {
         [PropertyType.Duration]: PropertyOperator.GreaterThan,

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1115,6 +1115,79 @@ describe('TaxonomicFilter', () => {
         })
     })
 
+    describe('promoted properties float to position 0 on search', () => {
+        // The API deliberately returns the promoted property *last* (after the decoys)
+        // so a passing assertion can only mean promotion reordered it, not the server order.
+        // Rows render the property's display label, while the decoys render their raw names.
+        const promotedFixtures: Record<string, { label: string; name: string; decoys: string[] }> = {
+            url: { label: 'Current URL', name: '$current_url', decoys: ['referrer_url', 'initial_url'] },
+            path: { label: 'Path name', name: '$pathname', decoys: ['file_path', 'initial_path'] },
+        }
+
+        beforeEach(() => {
+            // Recents persist to localStorage across tests; a leftover promoted property
+            // from an earlier test would otherwise render before our mock response loads.
+            localStorage.clear()
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                    '/api/projects/:team/property_definitions': (req: { url: URL }) => {
+                        const search = req.url.searchParams.get('search') ?? ''
+                        const fixture = promotedFixtures[search]
+                        const names = fixture ? [...fixture.decoys, fixture.name] : []
+                        return [
+                            200,
+                            {
+                                results: names.map((name, index) => ({
+                                    ...mockEventPropertyDefinition,
+                                    id: `promoted-fixture-${index}`,
+                                    name,
+                                })),
+                                count: names.length,
+                            },
+                        ]
+                    },
+                    '/api/projects/:team/actions': { results: [] },
+                },
+                post: {
+                    '/api/environments/:team/query': { results: [] },
+                },
+            })
+        })
+
+        const rowIndexFor = (text: string): number =>
+            parseInt(
+                (Array.from(document.querySelectorAll('[data-attr^="prop-filter-event_properties-"]'))
+                    .find((el) => el.textContent?.includes(text))
+                    ?.getAttribute('data-attr')
+                    ?.split('-')
+                    .pop() as string) ?? 'NaN'
+            )
+
+        it.each([['url'], ['path']])('searching %p floats the promoted property to row 0', async (searchTerm) => {
+            const { label, decoys } = promotedFixtures[searchTerm]
+            renderFilter({ taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties] })
+
+            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), searchTerm)
+
+            // Activate the event-properties list so we assert on its rows, not the
+            // aggregated Suggested-filters tab that may be active by default.
+            await userEvent.click(screen.getByTestId('taxonomic-tab-event_properties'))
+
+            // Wait on a decoy (only present in our mock response) so we assert order
+            // after the real fetch rendered, not on a leftover/top-match promoted row.
+            await waitFor(() => {
+                expect(rowIndexFor(decoys[0])).toBeGreaterThan(-1)
+            })
+
+            expect(rowIndexFor(label)).toBe(0)
+            // the decoys the API returned first are pushed below the promoted row
+            for (const decoy of decoys) {
+                expect(rowIndexFor(decoy)).toBeGreaterThan(0)
+            }
+        })
+    })
+
     describe('log attribute value-match indicator', () => {
         const mockLogAttributes = {
             results: [

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -312,13 +312,19 @@ describe('MenuFilterCombobox', () => {
         expect(pageviewRows).toHaveLength(1)
     })
 
-    it('floats $email to the top of the content when searching "email"', async () => {
+    it.each([
+        ['email', '$email'],
+        ['url', '$current_url'],
+        ['path', '$pathname'],
+    ])('floats the promoted property to the top of the content when searching %p', async (searchTerm, promotedName) => {
         apiGet.mockImplementation((url: string) => {
             if (url.includes('property_definitions')) {
+                // The decoy is returned first so a passing assertion can only mean
+                // promotion reordered the result, not the server order.
                 return Promise.resolve({
                     results: [
                         { id: 1, name: 'other_prop' },
-                        { id: 2, name: '$email' },
+                        { id: 2, name: promotedName },
                     ],
                     count: 2,
                 })
@@ -326,14 +332,14 @@ describe('MenuFilterCombobox', () => {
             return Promise.resolve({ results: [], count: 0 })
         })
 
-        renderAll({ groupTypes: [TaxonomicFilterGroupType.EventProperties], searchQuery: 'email' })
+        renderAll({ groupTypes: [TaxonomicFilterGroupType.EventProperties], searchQuery: searchTerm })
 
         await waitFor(() => expect(screen.getByText('other_prop')).toBeInTheDocument())
         const rows = rowTexts()
-        const emailIdx = rows.findIndex((t) => t.includes('$email'))
+        const promotedIdx = rows.findIndex((t) => t.includes(promotedName))
         const otherIdx = rows.findIndex((t) => t.includes('other_prop'))
-        expect(emailIdx).toBeGreaterThanOrEqual(0)
-        expect(emailIdx).toBeLessThan(otherIdx)
+        expect(promotedIdx).toBeGreaterThanOrEqual(0)
+        expect(promotedIdx).toBeLessThan(otherIdx)
     })
 
     it('drops the recents/pinned prefix once the query no longer matches them', async () => {

--- a/frontend/src/lib/components/TaxonomicFilter/utils/promoteProperties.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/promoteProperties.test.ts
@@ -1,0 +1,30 @@
+import { promoteMatchingBy } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
+
+describe('promoteMatchingBy', () => {
+    const getName = (item: { name: string }): string => item.name
+    const items = [{ name: '$browser' }, { name: '$pathname' }, { name: '$current_url' }, { name: '$email' }]
+
+    it.each([
+        ['url', '$current_url'],
+        ['path', '$pathname'],
+        ['email', '$email'],
+        ['URL', '$current_url'],
+        ['  path  ', '$pathname'],
+    ])('floats the promoted property to position 0 when searching %p', (query, expectedFirst) => {
+        const result = promoteMatchingBy(items, query, getName)
+        expect(getName(result[0])).toBe(expectedFirst)
+        expect(result).toHaveLength(items.length)
+    })
+
+    it.each([['browser'], [''], ['  '], ['random']])(
+        'leaves order untouched when %p has no promoted property',
+        (query) => {
+            expect(promoteMatchingBy(items, query, getName)).toEqual(items)
+        }
+    )
+
+    it('returns items unchanged when the promoted property is absent from the list', () => {
+        const withoutUrl = [{ name: '$browser' }, { name: '$os' }]
+        expect(promoteMatchingBy(withoutUrl, 'url', getName)).toEqual(withoutUrl)
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/utils/promoteProperties.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/promoteProperties.ts
@@ -3,6 +3,7 @@ import { SkeletonItem, TaxonomicDefinitionTypes, isSkeletonItem } from 'lib/comp
 /** Search terms mapped to properties that should be promoted when that exact term is searched. */
 export const PROMOTED_PROPERTIES_BY_SEARCH_TERM: Record<string, string[]> = {
     url: ['$current_url'],
+    path: ['$pathname'],
     email: ['$email'],
 }
 


### PR DESCRIPTION
## Problem

When filtering by a web address in the taxonomic filter, picking **Current URL** (`$current_url`) defaulted to the **equals** operator. Telemetry on saved URL/path filters shows this is the wrong default: contains-family operators (`icontains` / `not_icontains`) are ~80% of real URL filters, while exact is only ~11%. Users typically want "all pages under /checkout", not one exact URL — and they search for URL *fragments* (`checkout`, `pricing`, `/`), which is contains-thinking.

Separately, searching `path` had no promoted property and fell through to an exact-defaulting `$pathname`, even though `path` is ~8% of taxonomic-filter searches.

## Changes

- `$current_url` and `$pathname` now default to the `contains` (`IContains`) operator wherever they're picked as a property filter (`PropertyFilters/utils.ts`).
- Searching `path` now promotes `$pathname` to position 0, mirroring the existing `url` -> `$current_url` promotion (`promoteProperties.ts`). A single edit covers both the `control` and `pill` dropdown variants since both consume the same map.
- `Screens` (`$screen_name`) and email are unchanged — they keep `exact`, correct for low-cardinality values.
- This is a default only; users can still switch the operator to `equals` manually.

## How did you test this code?

I'm an agent (PostHog Code) and did not perform manual UI testing. Automated tests I added and ran (green locally and on a devbox):

- Parameterized unit test for the operator default (`$browser` -> exact, `$current_url`/`$pathname` -> icontains) in `PropertyFilters/utils.test.ts`.
- New unit suite for `promoteMatchingBy` covering url/path/email promotion, whitespace/case, and no-op cases (`promoteProperties.test.ts`).
- New RTL test asserting `url`/`path` searches float the promoted property to row 0 even when the API returns it last (`TaxonomicFilter.test.tsx`).

No visual-regression story was added: the change is behavioural (the operator lives in the resulting filter; promotion ordering depends on a live search), which a static snapshot can't capture.

## 🤖 Agent context

Authored with PostHog Code (Claude). The direction came from a telemetry investigation into whether the `pageview_urls` taxonomic category earns its keep: it's low-retention, but URL *filtering* demand is real and overwhelmingly wants contains semantics, and the promoted `$current_url` was defaulting to exact. We deliberately scoped this PR to the operator default + `path` promotion and did **not** introduce new taxonomic group types (large blast radius across every consumer) — a follow-up will explore replacing the `pageview_urls` value-picker with a single promoted results item. Per taxonomic-filter conventions, promotion/default-operator changes need human sign-off, so this requires human review before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
