### PR TITLE
fix(logs): fail open when the drop-rule cache can't reach Postgres

### DIFF
--- a/nodejs/src/logs-ingestion/sampling/sampling-rules-cache.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/sampling-rules-cache.test.ts
@@ -1,0 +1,75 @@
+import { PostgresRouter } from '~/utils/db/postgres'
+
+import { SamplingRulesCache } from './sampling-rules-cache'
+
+const RULE_ROW = {
+    id: 'r1',
+    rule_type: 'rate_limit',
+    scope_service: null,
+    scope_path_pattern: null,
+    scope_attribute_filters: [],
+    config: { kb_per_second: 1, burst_kb: 10 },
+    version: '1',
+}
+
+function cacheWith(query: jest.Mock): SamplingRulesCache {
+    return new SamplingRulesCache({ query } as unknown as PostgresRouter)
+}
+
+describe('SamplingRulesCache', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+        jest.useRealTimers()
+    })
+
+    it('compiles rules fetched from postgres', async () => {
+        const cache = cacheWith(jest.fn().mockResolvedValue({ rows: [RULE_ROW] }))
+        const ruleSet = await cache.getCompiledRuleSet(1)
+        expect(ruleSet.rules).toHaveLength(1)
+        expect(ruleSet.hasRateLimitRules).toBe(true)
+    })
+
+    it('fails open to passthrough (empty) when the fetch throws and nothing is cached', async () => {
+        const cache = cacheWith(jest.fn().mockRejectedValue(new Error('getaddrinfo ENOTFOUND pgbouncer-cloud-read')))
+        // Must not throw — a read-replica outage cannot be allowed to DLQ log ingestion.
+        const ruleSet = await cache.getCompiledRuleSet(1)
+        expect(ruleSet).toEqual({ rules: [], hasRateLimitRules: false })
+    })
+
+    it('serves the last-good ruleset when a later fetch throws', async () => {
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0)
+        const query = jest
+            .fn()
+            .mockResolvedValueOnce({ rows: [RULE_ROW] })
+            .mockRejectedValueOnce(new Error('ENOTFOUND pgbouncer-cloud-read'))
+        const cache = cacheWith(query)
+
+        const first = await cache.getCompiledRuleSet(1)
+        expect(first.hasRateLimitRules).toBe(true)
+
+        // Expire the cache window so the next call refetches — and that fetch fails.
+        nowSpy.mockReturnValue(31_000)
+        const second = await cache.getCompiledRuleSet(1)
+        expect(second.hasRateLimitRules).toBe(true) // stale served, not empty
+        expect(query).toHaveBeenCalledTimes(2)
+    })
+
+    it('backs off to one retry per refresh window after an error (no per-message refetch)', async () => {
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0)
+        const query = jest.fn().mockRejectedValue(new Error('boom'))
+        const cache = cacheWith(query)
+
+        await cache.getCompiledRuleSet(1) // fails open, caches empty + stamps fetchedAtMs
+        nowSpy.mockReturnValue(5_000) // still within the 30s window
+        await cache.getCompiledRuleSet(1) // cache hit — must not hit the failing query again
+        expect(query).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails open when the fetch hangs past the timeout', async () => {
+        jest.useFakeTimers()
+        const cache = cacheWith(jest.fn().mockReturnValue(new Promise(() => {}))) // never resolves
+        const promise = cache.getCompiledRuleSet(1)
+        await jest.advanceTimersByTimeAsync(5_001)
+        await expect(promise).resolves.toEqual({ rules: [], hasRateLimitRules: false })
+    })
+})

--- a/nodejs/src/logs-ingestion/sampling/sampling-rules-cache.ts
+++ b/nodejs/src/logs-ingestion/sampling/sampling-rules-cache.ts
@@ -1,14 +1,35 @@
 import { trace } from '@opentelemetry/api'
+import { Counter } from 'prom-client'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 import { PostgresRouter, PostgresUse } from '~/utils/db/postgres'
+import { logger } from '~/utils/logger'
 
 import { type SamplingRuleRow, compileRuleSet } from './compile-rules'
 import type { CompiledRuleSet } from './evaluate'
 
 const REFRESH_MS = 30_000
 
+// Hard ceiling on a single rule fetch. A read replica that is unreachable or slow
+// (e.g. DATABASE_READONLY_URL pointing at a host that no longer resolves) must never
+// block log ingestion — the fetch is bounded and fails open past this.
+const FETCH_TIMEOUT_MS = 5_000
+
+const EMPTY_RULE_SET: CompiledRuleSet = { rules: [], hasRateLimitRules: false }
+
 const samplingCacheInstrumentOpts = { measureTime: false, sendException: false } as const
+
+/**
+ * Incremented when a rule fetch throws or times out. The cache then fails open — serving
+ * the last-good ruleset, or passthrough (empty) when there is none — so a Postgres
+ * read-replica outage can never DLQ or stall log ingestion. Mirrors the fail-open
+ * posture of the per-record evaluator and the Redis rate limiter.
+ */
+export const samplingRuleFetchErrorCounter = new Counter({
+    name: 'logs_ingestion_sampling_rule_fetch_error_total',
+    help: 'Rule fetch from Postgres threw or timed out; cache failed open (served stale or passthrough).',
+    labelNames: ['team_id', 'served'],
+})
 
 type CacheEntry = {
     compiled: CompiledRuleSet
@@ -39,19 +60,67 @@ export class SamplingRulesCache {
                     })
                     return existing.compiled
                 }
-                const rows = await this.fetchRules(teamId)
-                const compiled = compileRuleSet(rows)
-                const vw = rows.reduce((m, r) => Math.max(m, r.version ?? 0), 0)
-                this.cache.set(teamId, { compiled, versionWatermark: vw, fetchedAtMs: now })
-                trace.getActiveSpan()?.setAttributes({
-                    'logs.sampling.cache_hit': false,
-                    'logs.sampling.db_row_count': rows.length,
-                    'logs.sampling.rule_count': compiled.rules.length,
-                    'logs.sampling.version_watermark': vw,
-                })
-                return compiled
+                try {
+                    const rows = await this.fetchRulesWithTimeout(teamId)
+                    const compiled = compileRuleSet(rows)
+                    const vw = rows.reduce((m, r) => Math.max(m, r.version ?? 0), 0)
+                    this.cache.set(teamId, { compiled, versionWatermark: vw, fetchedAtMs: now })
+                    trace.getActiveSpan()?.setAttributes({
+                        'logs.sampling.cache_hit': false,
+                        'logs.sampling.db_row_count': rows.length,
+                        'logs.sampling.rule_count': compiled.rules.length,
+                        'logs.sampling.version_watermark': vw,
+                    })
+                    return compiled
+                } catch (err) {
+                    // Fail open. A throwing or hanging read replica must not block or DLQ log
+                    // ingestion — serve the last-good ruleset if we have one, else passthrough
+                    // (empty). Stamp `fetchedAtMs` so we back off to one retry per REFRESH_MS
+                    // instead of re-hitting the failing query on every message.
+                    const served = existing ? 'stale' : 'empty'
+                    const fallback = existing?.compiled ?? EMPTY_RULE_SET
+                    this.cache.set(teamId, {
+                        compiled: fallback,
+                        versionWatermark: existing?.versionWatermark ?? 0,
+                        fetchedAtMs: now,
+                    })
+                    samplingRuleFetchErrorCounter.inc({ team_id: String(teamId), served })
+                    logger.warn('[logs-sampling] rule fetch failed — failing open', {
+                        teamId,
+                        served,
+                        error: err instanceof Error ? err.message : String(err),
+                    })
+                    trace.getActiveSpan()?.setAttributes({
+                        'logs.sampling.cache_hit': false,
+                        'logs.sampling.fetch_error': true,
+                        'logs.sampling.fetch_error_served': served,
+                        'logs.sampling.rule_count': fallback.rules.length,
+                    })
+                    return fallback
+                }
             }
         )
+    }
+
+    /**
+     * Bound a rule fetch so a slow or unreachable read replica cannot stall the hot path.
+     * On timeout the losing fetch is abandoned (its late rejection is swallowed to avoid an
+     * unhandled rejection); the caller treats the timeout as a fetch failure and fails open.
+     */
+    private async fetchRulesWithTimeout(teamId: number): Promise<SamplingRuleRow[]> {
+        const fetchPromise = this.fetchRules(teamId)
+        fetchPromise.catch(() => {})
+        let timer: ReturnType<typeof setTimeout> | undefined
+        const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(`rule fetch exceeded ${FETCH_TIMEOUT_MS}ms`)), FETCH_TIMEOUT_MS)
+        })
+        try {
+            return await Promise.race([fetchPromise, timeout])
+        } finally {
+            if (timer) {
+                clearTimeout(timer)
+            }
+        }
     }
 
     private async fetchRules(teamId: number): Promise<SamplingRuleRow[]> {


### PR DESCRIPTION
## Problem

The logs drop-rule sampling cache (`SamplingRulesCache`) fetches rules from Postgres via `PostgresUse.COMMON_READ`. When that connection is unreachable or slow — e.g. `DATABASE_READONLY_URL` points at a read replica whose host no longer resolves (`getaddrinfo ENOTFOUND pgbouncer-cloud-read`) — the fetch either threw or hung:

- **Threw:** `getCompiledRuleSet` had no error handling, so the throw propagated to the consumer, which routed the message to the **DLQ**.
- **Hung:** the fetch blocked the hot path until the operation timeout fired (observed in prod as `⌛ Timeout warning for 'logsIngestion.sampling.getCompiledRuleSet'`).

Either way, a read-replica blip disrupted log ingestion for **every sampling-enabled team** (all teams under the default `LOGS_SAMPLING_ENABLED_TEAMS='*'`). This is a regression the drop-rules feature introduced — it added the first per-message `COMMON_READ` dependency on the logs hot path.

## Changes

Make the cache **fail open**, matching the rest of the sampling pipeline (the per-record evaluator keeps records on a thrown rule, and the Redis rate limiter fails open on Redis errors):

- Bound each fetch with a **5s timeout** so a hanging/unreachable replica can't stall the hot path (the abandoned query's late rejection is swallowed to avoid an unhandled rejection).
- On any fetch error or timeout, serve the **last-good ruleset**, or **passthrough (empty)** when nothing is cached — never throw, never DLQ.
- Stamp the cache timestamp on the failure path so we **retry at most once per refresh window** (30s) instead of re-hitting the failing query on every message.
- New counter `logs_ingestion_sampling_rule_fetch_error_total{team_id, served}` for observability.

Behavior on a healthy DB is unchanged. This does not fix the underlying connectivity (the read-replica host still needs to be reachable, or `DATABASE_READONLY_URL` unset for that worker) — it ensures that outage degrades to "rate limiting / drop rules briefly stop applying" instead of "logs get DLQ'd".

## How did you test this code?

I'm an agent; automated tests only (no manual cluster testing):

- New `sampling-rules-cache.test.ts` (5 tests): compiles rules on success; **fails open to passthrough when the fetch throws with no cache**; **serves the last-good ruleset when a later fetch throws**; backs off to one retry per refresh window (no per-message refetch after an error); and **fails open when the fetch hangs past the timeout** (fake timers). All green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Authored with PostHog Code (Claude). Root-caused from a prod log line (`getaddrinfo ENOTFOUND pgbouncer-cloud-read` + a `getCompiledRuleSet` timeout warning) while working on the logs drop-rules feature. Traced it to `COMMON_READ` → `DATABASE_READONLY_URL` and the cache's lack of error handling. Chose fail-open (stale-then-empty) with a bounded fetch + per-window backoff to mirror the existing fail-open posture of the evaluator and rate limiter, rather than retry/circuit-breaker complexity. Separate concern from the two open drop-rules PRs (rate-limit unit fix, byte-preview), so it's its own branch.

Agent-authored; requires human review. Reviewer note: this is the code-resilience half — the environment also needs `DATABASE_READONLY_URL` reachable from the logs ingestion worker (or unset so it falls back to the primary).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
