### PR TITLE
fix(llma): self-heal llm-gateway venv via uv sync

### DIFF
--- a/bin/start-llm-gateway
+++ b/bin/start-llm-gateway
@@ -30,11 +30,7 @@ cd "$REPO_ROOT/services/llm-gateway"
 unset VIRTUAL_ENV
 export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
 
-if [ ! -d ".venv" ]; then
-    uv venv .venv
-fi
-
-uv pip install -e . --quiet
+uv sync --quiet
 
 exec .venv/bin/uvicorn llm_gateway.main:app \
     --host 0.0.0.0 \


### PR DESCRIPTION
## Problem

After the 3.13 bump, `hogli start` fails to launch llm-gateway for anyone who ran it pre-bump: `current Python version (3.12.12) does not satisfy Python>=3.13`. That error is `bin/start-llm-gateway` inside mprocs, not `dev:setup`.

**Root cause:** the script hand-rolled its venv and never reconciled it — `if [ ! -d ".venv" ]; then uv venv .venv; fi` reuses a venv built pre-bump (3.12.12), and `uv pip install -e .` can't change the interpreter. 3.13 just exposed it; the same guard would also serve stale deps after any pyproject/lock change.

## Changes

Replace the guard + `uv pip install -e .` with `uv sync --quiet` — `requires-python`-aware, so it rebuilds an incompatible venv, re-resolves on dep changes, no-ops when in sync. Now identical to the sibling service `bin/start-stripe-mock`; matches the README and CI. No Python pin added: the exact `==3.13.13` lives at the root (direnv→flox→uv) and the Dockerfile; services keep a `>=3.13` floor.

## How did you test this code?

Agent (Claude Code, agent-assisted), no CI claimed:
- Reproduced the error with `uv pip install -e .` against a 3.12 venv.
- Confirmed `uv sync` rebuilds a stale 3.12 venv on 3.13.13 with dev deps, uvicorn, and editable `llm_gateway` (`--reload` works).
- `bash -n` passes; venv block now diffs byte-for-byte vs `bin/start-stripe-mock`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None (`skip-inkeep-docs`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Raúl directed the work, assigned as DRI.

Claude Code. Rejected an initial "pin the service to `==3.13.13`" idea after reading the flox manifest/`.envrc`: pinning is a root-layer concern and stripe-mock uses the same `>=3.13` floor. Chose the minimal convention-matching fix: delegate the venv to `uv sync`.
