### PR TITLE
chore(property-vals): cut TTL from 30 to 7 days

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/local-aux.hcl
@@ -1044,7 +1044,7 @@ database "posthog" {
 
   table "property_values" {
     order_by = ["team_id", "property_type", "property_key", "property_value"]
-    ttl      = "last_seen + toIntervalDay(30)"
+    ttl      = "last_seen + toIntervalDay(7)"
     settings = {
       index_granularity = "8192"
     }

--- a/posthog/clickhouse/hcl/golden/prod-eu-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu-aux.hcl
@@ -1003,7 +1003,7 @@ database "posthog" {
 
   table "property_values" {
     order_by = ["team_id", "property_type", "property_key", "property_value"]
-    ttl      = "last_seen + toIntervalDay(30)"
+    ttl      = "last_seen + toIntervalDay(7)"
     settings = {
       index_granularity = "8192"
     }

--- a/posthog/clickhouse/hcl/golden/prod-us-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us-aux.hcl
@@ -1041,7 +1041,7 @@ database "posthog" {
 
   table "property_values" {
     order_by = ["team_id", "property_type", "property_key", "property_value"]
-    ttl      = "last_seen + toIntervalDay(30)"
+    ttl      = "last_seen + toIntervalDay(7)"
     settings = {
       index_granularity = "8192"
     }

--- a/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
@@ -1341,7 +1341,7 @@ database "posthog" {
   }
   table "property_values" {
     order_by = ["team_id", "property_type", "property_key", "property_value"]
-    ttl      = "last_seen + toIntervalDay(30)"
+    ttl      = "last_seen + toIntervalDay(7)"
     settings = {
       index_granularity = "8192"
     }

--- a/posthog/clickhouse/hcl/sql/local-aux.sql
+++ b/posthog/clickhouse/hcl/sql/local-aux.sql
@@ -166,7 +166,7 @@ CREATE TABLE posthog.property_values (
   property_count SimpleAggregateFunction(sum, UInt64),
   last_seen SimpleAggregateFunction(max, DateTime) DEFAULT now(),
   INDEX idx_property_value_ngrambf lower(property_value) TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.property_values', '{replica}-{shard}') ORDER BY (team_id, property_type, property_key, property_value) TTL last_seen + toIntervalDay(30) SETTINGS index_granularity = 8192;
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.property_values', '{replica}-{shard}') ORDER BY (team_id, property_type, property_key, property_value) TTL last_seen + toIntervalDay(7) SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.property_values_distributed (
   team_id Int64 CODEC(DoubleDelta, ZSTD(1)),
   property_type LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/prod-eu-aux.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu-aux.sql
@@ -153,7 +153,7 @@ CREATE TABLE posthog.property_values (
   property_count SimpleAggregateFunction(sum, UInt64),
   last_seen SimpleAggregateFunction(max, DateTime) DEFAULT now(),
   INDEX idx_property_value_ngrambf lower(property_value) TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.property_values', '{replica}-{shard}') ORDER BY (team_id, property_type, property_key, property_value) TTL last_seen + toIntervalDay(30) SETTINGS index_granularity = 8192;
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.property_values', '{replica}-{shard}') ORDER BY (team_id, property_type, property_key, property_value) TTL last_seen + toIntervalDay(7) SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.property_values_distributed (
   team_id Int64 CODEC(DoubleDelta, ZSTD(1)),
   property_type LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/prod-us-aux.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us-aux.sql
@@ -153,7 +153,7 @@ CREATE TABLE posthog.property_values (
   property_count SimpleAggregateFunction(sum, UInt64),
   last_seen SimpleAggregateFunction(max, DateTime) DEFAULT now(),
   INDEX idx_property_value_ngrambf lower(property_value) TYPE ngrambf_v1(3, 32768, 3, 0) GRANULARITY 1
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.property_values', '{replica}-{shard}') ORDER BY (team_id, property_type, property_key, property_value) TTL last_seen + toIntervalDay(30) SETTINGS index_granularity = 8192;
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.property_values', '{replica}-{shard}') ORDER BY (team_id, property_type, property_key, property_value) TTL last_seen + toIntervalDay(7) SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.property_values_distributed (
   team_id Int64 CODEC(DoubleDelta, ZSTD(1)),
   property_type LowCardinality(String),

--- a/posthog/clickhouse/migrations/0288_property_values_ttl_7_days.py
+++ b/posthog/clickhouse/migrations/0288_property_values_ttl_7_days.py
@@ -1,0 +1,18 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_values import TABLE_NAME
+
+if settings.CLOUD_DEPLOYMENT == "DEV":
+    _ROLES = [NodeRole.DATA]
+else:
+    _ROLES = [NodeRole.AUX]
+
+operations = [
+    run_sql_with_exceptions(
+        f"ALTER TABLE {TABLE_NAME} MODIFY TTL last_seen + INTERVAL 7 DAY DELETE SETTINGS materialize_ttl_after_modify = 1",
+        node_roles=_ROLES,
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0287_events_recent_inserted_at_not_nullable
+0288_property_values_ttl_7_days

--- a/posthog/clickhouse/property_values.py
+++ b/posthog/clickhouse/property_values.py
@@ -43,7 +43,7 @@ def PROPERTY_VALUES_TABLE_SQL() -> str:
         PROPERTY_VALUES_TABLE_BASE_SQL
         + """
 ORDER BY (team_id, property_type, property_key, property_value)
-TTL last_seen + INTERVAL 30 DAY DELETE
+TTL last_seen + INTERVAL 7 DAY DELETE
 SETTINGS
     index_granularity = 8192
 """

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -4544,7 +4544,7 @@
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.property_values', '{replica}-{shard}')
   
   ORDER BY (team_id, property_type, property_key, property_value)
-  TTL last_seen + INTERVAL 30 DAY DELETE
+  TTL last_seen + INTERVAL 7 DAY DELETE
   SETTINGS
       index_granularity = 8192
   
@@ -10194,7 +10194,7 @@
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.property_values', '{replica}-{shard}')
   
   ORDER BY (team_id, property_type, property_key, property_value)
-  TTL last_seen + INTERVAL 30 DAY DELETE
+  TTL last_seen + INTERVAL 7 DAY DELETE
   SETTINGS
       index_granularity = 8192
   


### PR DESCRIPTION
## Problem

`property_values` serves substring autocomplete through an `ngrambf_v1` skip index. That bloom filter is rebuilt from the raw values on every merge, which is what makes merges on this table so expensive. The fix for the CPU is switching to a ClickHouse text index with the same ngram tokenizer: it matches the bloom filter's pruning on `LIKE` queries but merges incrementally according to ClickHouse docs: 

> When data parts are merged, the text index does not need to be rebuilt from scratch

[clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes](https://clickhouse.com/docs/engines/table-engines/mergetree-family/textindexes)

The blocker for the text index is disk, and that is what this PR addresses:

- Local benchmark (ClickHouse 26.3.10.60, 1.2M synthetic URL rows): `text(tokenizer = ngrams(3))` builds a 68 MiB index over 33 MiB of compressed data, about 2.1x the data size. An earlier production sample measured 2.78x. The current bloom index is ~5% of data for comparison.
- The table today holds ~191B rows, ~3.6 TiB compressed (~3.9 TiB on disk) per replica at the 30-day TTL, and is still growing into its 30-day steady state.
- At 2.1-2.8x, a text index over the 30-day table is roughly 7.5-10 TiB per replica on top of the ~4 TiB of data which approaches the 15TB space on nvme. 

The app only reads the last 7 days (`last_seen >= now() - INTERVAL 7 DAY` in the autocomplete query), so we don't need 30d TTL. Sampling the highest-volume keys, roughly a quarter to a third of rows fall inside the 7-day window. At 7-day retention the table is on the order of 1 TiB of data plus 2-3 TiB of text index per replica, which fits with headroom.

## Changes

Cut the `property_values` TTL from 30 days to 7 days, matching the read window in the app.

## How did you test this code?

CI

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

Authored with Claude Code while diagnosing aux-cluster load after the property-values autocomplete read path was enabled US-wide. Profiling (`system.part_log` merge attribution plus `system.query_log` CPU attribution) showed the ngram bloom filter rebuild dominates merge CPU, and a local A/B showed a text index eliminates that rebuild while pruning identically; this PR clears the text index's disk prerequisite. Index-size ratios come from a local ClickHouse 26.3 benchmark on synthetic URL data; table sizes from `system.parts` on the live cluster.
