### PR TITLE
chore(ci): diagnostic loop to capture batch-exports teardown hang

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -595,17 +595,21 @@ jobs:
                   MATRIX_GROUP: ${{ matrix.group }}
                   PYTEST_ADDOPTS: >-
                       --reuse-db
-                      --timeout=180 --timeout-method=signal
+                      --timeout=120 --timeout-method=thread
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations --durations-path ../../.test_durations' || '' }}
               run: |
                   # DIAGNOSTIC (do not merge): the batch-exports teardown hang is intermittent
                   # (~1 in 7 runs), so loop its ~2-min non-temporal suite to make one CI run very
-                  # likely to catch it. The per-test signal timeout (env above) dumps the blocked
-                  # worker's stack when it fires. Other matrix groups run unchanged.
+                  # likely to catch it. A first run with --timeout-method=signal did NOT fire: the
+                  # hang is wedged in a native C call (gRPC/libpq) that never returns to the Python
+                  # interpreter, so SIGALRM can't run. --timeout-method=thread uses a watchdog
+                  # thread (blocking C calls release the GIL, so it runs), dumps every thread's
+                  # stack, then os._exit()s — which kills the iteration but prints the stack first.
+                  # That's why thread is right for diagnosis (and wrong for a permanent guardrail).
                   if [[ "$MATRIX_GROUP" == *batch-exports* ]]; then
                       echo "DIAGNOSTIC: warm-up pass (generous timeout) so a cold-cache migration in DB setup can't trip the timed loop"
-                      PYTEST_ADDOPTS="--reuse-db --timeout=900 --timeout-method=signal" \
+                      PYTEST_ADDOPTS="--reuse-db --timeout=900 --timeout-method=thread" \
                           pnpm turbo run backend:test --filter=@posthog/products-batch-exports --concurrency=1 --output-logs=full --force --log-order=stream || echo "DIAGNOSTIC warm-up exited non-zero (possible hang dump above)"
                       deadline=$(( $(date +%s) + 1200 ))
                       iter=0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -586,12 +586,39 @@ jobs:
               env:
                   # --reuse-db: keep the test database between sequential product runs to avoid
                   # ClickHouse drop/create race conditions with ReplicatedMergeTree ZK metadata.
+                  # DIAGNOSTIC (do not merge): --timeout with the DEFAULT func_only=false arms the
+                  # clock around setup+call+teardown, so the intermittent batch-exports teardown
+                  # hang is interrupted and signal dumps the blocked worker's stack. Safe here
+                  # because this runs as a PR (schema-prime keeps django_db_setup fast); it would
+                  # false-kill cold-cache migrations on master, so it must NOT ship as-is.
                   # On master, also collect timing data for pytest-split sharding.
+                  MATRIX_GROUP: ${{ matrix.group }}
                   PYTEST_ADDOPTS: >-
                       --reuse-db
+                      --timeout=180 --timeout-method=signal
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations --durations-path ../../.test_durations' || '' }}
-              run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
+              run: |
+                  # DIAGNOSTIC (do not merge): the batch-exports teardown hang is intermittent
+                  # (~1 in 7 runs), so loop its ~2-min non-temporal suite to make one CI run very
+                  # likely to catch it. The per-test signal timeout (env above) dumps the blocked
+                  # worker's stack when it fires. Other matrix groups run unchanged.
+                  if [[ "$MATRIX_GROUP" == *batch-exports* ]]; then
+                      echo "DIAGNOSTIC: warm-up pass (generous timeout) so a cold-cache migration in DB setup can't trip the timed loop"
+                      PYTEST_ADDOPTS="--reuse-db --timeout=900 --timeout-method=signal" \
+                          pnpm turbo run backend:test --filter=@posthog/products-batch-exports --concurrency=1 --output-logs=full --force --log-order=stream || echo "DIAGNOSTIC warm-up exited non-zero (possible hang dump above)"
+                      deadline=$(( $(date +%s) + 1200 ))
+                      iter=0
+                      while [ "$(date +%s)" -lt "$deadline" ]; do
+                          iter=$((iter + 1))
+                          echo "::group::DIAGNOSTIC batch-exports iteration $iter ($(date -u +%H:%M:%S)Z)"
+                          pnpm turbo run backend:test --filter=@posthog/products-batch-exports --concurrency=1 --output-logs=full --force --log-order=stream || echo "DIAGNOSTIC iteration $iter exited non-zero (possible hang dump above)"
+                          echo "::endgroup::"
+                      done
+                      echo "DIAGNOSTIC complete: $iter timed iterations after warm-up"
+                  else
+                      pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
+                  fi
 
             - name: Upload timing data
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/products/batch_exports/backend/tests/test_service.py
+++ b/products/batch_exports/backend/tests/test_service.py
@@ -1,3 +1,5 @@
+# DIAGNOSTIC (do not merge): touch to trigger the batch-exports product shard so the
+# instrumented per-test timeout can dump the intermittent teardown hang's stack.
 import uuid
 import datetime as dt
 


### PR DESCRIPTION
## Problem

**Do not merge — throwaway diagnostic (draft).** A test in the batch-exports product shard hangs intermittently in async fixture setup/teardown. With no per-test timeout, the hung test burns the product-test job to its 40-min `timeout-minutes` cap; the job is then cancelled, which fails the `Django Tests Pass` aggregate check. Because pytest prints a node id only on completion, the hung test never names itself and the run dies with no stack.

This PR is an instrument to capture that stack, not a fix.

## Changes

- Product-test step: add `--timeout=180 --timeout-method=signal` to `PYTEST_ADDOPTS`. With the default `func_only=false` the timer covers setup + call + **teardown** — where the hang lives — and `signal` dumps the blocked worker thread's stack while failing only that one test, so the run continues.
- For the `batch-exports` matrix group only, loop the ~2-min non-temporal suite for ~20 min (after one warm-up pass that absorbs any cold-cache migration) so a single CI run is very likely to hit the ~1-in-7 intermittent hang. Every other group runs unchanged.
- Touch `test_service.py` so the shard is selected.

Runs as a PR (not master), where the schema cache primes `django_db_setup` and setup stays fast, so the timer does not false-trip on migrations — which is also exactly why this config must **not** ship to master as-is.

## How did you test this code?

I'm an agent (Claude Code), agent-assisted — no manual run. Static verification only: `yaml.safe_load` parses the workflow; `pytest-timeout` 2.4.0 is installed and (confirmed against the plugin source) arms the timer around the full runtest protocol when `func_only=false`. The deliverable is the stack dump in the `Product tests (batch-exports, …)` job log.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Raúl directed this.

Split from the per-test-timeout work for product jobs. The existing draft there uses `timeout_func_only=true`, which times only the test body and therefore cannot catch this hang: the investigation traced the stall to async fixture setup/teardown (the next, pure-sync test never prints, and the product `conftest.py` already documents an uncancellable `sync_to_async`-on-gRPC teardown hang). This branch flips to `func_only=false` and loops the suite to force the dump. Once the blocking call is identified it will be bounded at the source; the permanent guardrail stays `func_only=true` to avoid false-killing cold-cache migrations on master. Authored with Claude Code.
