### PR TITLE
fix(insights): prevent overlapping x-axis labels on horizontal bar charts

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
@@ -108,9 +108,11 @@ export const HorizontalAggregatedSingle: Story = {
     },
 }
 
-// Regression guard for the horizontal value-tick de-overlap pass: thousands-separated value labels
-// (e.g. "1,500,000") in a narrow panel. d3 packs more ticks than fit, so without the de-overlap pass
-// the x-axis smears into "0 500,0001,000,000…"; with it, the survivors stay evenly spaced and legible.
+// Exercises the horizontal value-tick de-overlap: wide thousands-separated labels (millions) in a
+// compact panel, where consecutive ticks genuinely collide. The de-overlap pass hides the colliding
+// ones so the axis reads cleanly instead of smearing into "0 500,0001,000,000…" — gridlines stay at
+// every tick, labels only at the survivors. Remove the pass and the labels overlap again; the exact
+// gap that decides which survive is pinned by AxisLabels.test.ts.
 export const HorizontalWideValueLabels: Story = {
     render: () => {
         const theme = useReactiveTheme()
@@ -122,10 +124,10 @@ export const HorizontalWideValueLabels: Story = {
         }
         const labels = ['/pricing', '/signup', '/product', '/docs', '/blog']
         const series: Series[] = [
-            { key: 'total', label: 'Total', color: '', data: [1_840_000, 1_210_000, 760_000, 430_000, 180_000] },
+            { key: 'views', label: 'Views', color: '', data: [2_300_000, 1_510_000, 940_000, 460_000, 180_000] },
         ]
         return (
-            <Stage width={300} height={280}>
+            <Stage width={340} height={280}>
                 <BarChart series={series} labels={labels} config={config} theme={theme} />
             </Stage>
         )

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
@@ -108,6 +108,30 @@ export const HorizontalAggregatedSingle: Story = {
     },
 }
 
+// Regression guard for the horizontal value-tick de-overlap pass: thousands-separated value labels
+// (e.g. "1,500,000") in a narrow panel. d3 packs more ticks than fit, so without the de-overlap pass
+// the x-axis smears into "0 500,0001,000,000…"; with it, the survivors stay evenly spaced and legible.
+export const HorizontalWideValueLabels: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: BarChartConfig = {
+            axisOrientation: 'horizontal',
+            showGrid: true,
+            yTickFormatter: (v) => v.toLocaleString('en-US'),
+            bars: { cornerRadius: 4, fitToHeight: true },
+        }
+        const labels = ['/pricing', '/signup', '/product', '/docs', '/blog']
+        const series: Series[] = [
+            { key: 'total', label: 'Total', color: '', data: [1_840_000, 1_210_000, 760_000, 430_000, 180_000] },
+        ]
+        return (
+            <Stage width={300} height={280}>
+                <BarChart series={series} labels={labels} config={config} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
 export const SingleSeries: Story = {
     render: () => {
         const theme = useReactiveTheme()

--- a/packages/quill/packages/charts/src/core/bar-scales.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-scales.test.ts
@@ -211,11 +211,36 @@ describe('hog-charts bar scales', () => {
         })
     })
 
+    describe('createBarScales — fitToHeight value domain', () => {
+        // minBandSize == plotHeight forces maxBands = 1, so only the leading row survives.
+        const dropToFirst = {
+            axisOrientation: 'horizontal' as const,
+            fitToHeight: true,
+            minBandSize: dimensions.plotHeight,
+        }
+
+        it('scales the value axis to only the rows fitToHeight keeps', () => {
+            const series = [makeSeries({ key: 's1', data: [5, 10, 999] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, dropToFirst)
+            // 999 sits in a dropped row, so it must not stretch the domain past the kept value.
+            expect(value.domain()[1]).toBeLessThan(999)
+        })
+
+        it('keeps a large value in the domain when its row survives', () => {
+            const series = [makeSeries({ key: 's1', data: [999, 5, 10] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, dropToFirst)
+            expect(value.domain()[1]).toBeGreaterThanOrEqual(999)
+        })
+
+        it('leaves the domain spanning every row when no rows are dropped', () => {
+            const series = [makeSeries({ key: 's1', data: [5, 10, 999] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { axisOrientation: 'horizontal' })
+            expect(value.domain()[1]).toBeGreaterThanOrEqual(999)
+        })
+    })
+
     describe('groupedBandSlot', () => {
-        const series = [
-            makeSeries({ key: 's1', data: [1, 2] }),
-            makeSeries({ key: 's2', data: [3, 4] }),
-        ]
+        const series = [makeSeries({ key: 's1', data: [1, 2] }), makeSeries({ key: 's2', data: [3, 4] })]
         const grouped = createBarScales(series, ['a', 'b'], dimensions, { barLayout: 'grouped' })
 
         it("returns the series' band-axis slot within the band", () => {

--- a/packages/quill/packages/charts/src/core/scales.ts
+++ b/packages/quill/packages/charts/src/core/scales.ts
@@ -457,9 +457,27 @@ export function createBarScales(
         ? [dimensions.plotLeft, dimensions.plotLeft + dimensions.plotWidth]
         : [dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop]
 
+    // When fitToHeight drops rows, the value axis must scale to only the rendered bars — a dropped
+    // off-screen bar (e.g. a dominant "Other" bucket) would otherwise stretch the domain and crush
+    // every visible bar. domainLabels is a leading slice, so the kept rows are each series's first
+    // `keptCount` data points.
+    const keptCount = domainLabels.length
+    const restrictToKept = (s: Series): Series =>
+        keptCount < labels.length ? { ...s, data: s.data.slice(0, keptCount) } : s
+    const valueSeries = series.map(restrictToKept)
+    const valueStackedSeries = stackedSeries?.map(restrictToKept)
+
     return {
         band,
-        value: buildBarValueScale(series, valueRange, tickCount, barLayout, scaleType, stackedSeries, valueDomain),
+        value: buildBarValueScale(
+            valueSeries,
+            valueRange,
+            tickCount,
+            barLayout,
+            scaleType,
+            valueStackedSeries,
+            valueDomain
+        ),
         group,
     }
 }

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.test.ts
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.test.ts
@@ -60,6 +60,20 @@ describe('computeVisibleValueTicks', () => {
         }
     })
 
+    it('keeps numeric ticks separated by a small but legible gap', () => {
+        // Two wide labels whose boxes sit ~14px apart: comfortably readable, but under the 20px gap
+        // the category-label path enforces — value ticks must not inherit that aggressive culling.
+        const ticks = [100_000, 120_000]
+        const [w0, w1] = ticks.map((t) => measureLabelWidth(fmt(t)))
+        const x0 = w0 / 2 + 10
+        const x1 = x0 + w0 / 2 + 14 + w1 / 2
+        const valueToCoord = (v: number): number => (v === ticks[0] ? x0 : x1)
+
+        const visible = computeVisibleValueTicks(ticks, valueToCoord, fmt)
+
+        expect(visible.map((v) => v.tick)).toEqual(ticks)
+    })
+
     it.each([
         {
             description: 'keeps every tick when they are spread far apart',

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.test.ts
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.test.ts
@@ -1,5 +1,5 @@
 import { measureLabelWidth } from '../utils/text-measure'
-import { computeVisibleXLabels } from './AxisLabels'
+import { computeVisibleValueTicks, computeVisibleXLabels } from './AxisLabels'
 
 describe('computeVisibleXLabels', () => {
     const longUrl = 'https://app.posthog.com/project/1/insights/abc123/edit?with=a&very=long&query=string'
@@ -37,5 +37,44 @@ describe('computeVisibleXLabels', () => {
         const visible = computeVisibleXLabels(labels, (label) => (label === 'a' ? 0 : undefined))
 
         expect(visible.map((v) => v.index)).toEqual([0])
+    })
+})
+
+describe('computeVisibleValueTicks', () => {
+    const fmt = (v: number): string => v.toLocaleString('en-US')
+
+    it('drops value ticks whose wide labels would overlap, always keeping the first', () => {
+        // 10 ticks packed into ~120px (every ~13px) — far too tight for "450,000"-style labels.
+        const ticks = Array.from({ length: 10 }, (_, i) => i * 50_000)
+        const valueToCoord = (v: number): number => (v / 450_000) * 120
+
+        const visible = computeVisibleValueTicks(ticks, valueToCoord, fmt)
+
+        expect(visible.length).toBeLessThan(ticks.length)
+        expect(visible[0].tick).toBe(0)
+        // Survivors stay strictly left-to-right with no measured-label overlap.
+        for (let i = 1; i < visible.length; i++) {
+            const prevRight = visible[i - 1].x + measureLabelWidth(visible[i - 1].text) / 2
+            const currLeft = visible[i].x - measureLabelWidth(visible[i].text) / 2
+            expect(currLeft).toBeGreaterThanOrEqual(prevRight)
+        }
+    })
+
+    it('keeps every tick when they are spread far apart', () => {
+        const ticks = [0, 100, 200]
+        const valueToCoord = (v: number): number => v * 10
+
+        const visible = computeVisibleValueTicks(ticks, valueToCoord, fmt)
+
+        expect(visible.map((v) => v.tick)).toEqual([0, 100, 200])
+    })
+
+    it('skips ticks whose coordinate is not finite', () => {
+        const ticks = [0, 50, 100]
+        const valueToCoord = (v: number): number => (v === 50 ? NaN : v * 10)
+
+        const visible = computeVisibleValueTicks(ticks, valueToCoord, fmt)
+
+        expect(visible.map((v) => v.tick)).toEqual([0, 100])
     })
 })

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.test.ts
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.test.ts
@@ -60,21 +60,22 @@ describe('computeVisibleValueTicks', () => {
         }
     })
 
-    it('keeps every tick when they are spread far apart', () => {
-        const ticks = [0, 100, 200]
-        const valueToCoord = (v: number): number => v * 10
-
+    it.each([
+        {
+            description: 'keeps every tick when they are spread far apart',
+            ticks: [0, 100, 200],
+            valueToCoord: (v: number): number => v * 10,
+            expected: [0, 100, 200],
+        },
+        {
+            description: 'skips ticks whose coordinate is not finite',
+            ticks: [0, 50, 100],
+            valueToCoord: (v: number): number => (v === 50 ? NaN : v * 10),
+            expected: [0, 100],
+        },
+    ])('$description', ({ ticks, valueToCoord, expected }) => {
         const visible = computeVisibleValueTicks(ticks, valueToCoord, fmt)
 
-        expect(visible.map((v) => v.tick)).toEqual([0, 100, 200])
-    })
-
-    it('skips ticks whose coordinate is not finite', () => {
-        const ticks = [0, 50, 100]
-        const valueToCoord = (v: number): number => (v === 50 ? NaN : v * 10)
-
-        const visible = computeVisibleValueTicks(ticks, valueToCoord, fmt)
-
-        expect(visible.map((v) => v.tick)).toEqual([0, 100])
+        expect(visible.map((v) => v.tick)).toEqual(expected)
     })
 })

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -20,7 +20,11 @@ interface AxisLabelsProps {
     maxCategoryLabelWidth?: number
 }
 
-const LABEL_PADDING = 20
+// Minimum gap (px) required between adjacent kept labels. Category labels are often words and get
+// generous breathing room; uniformly-spaced numeric value ticks read clearly much closer, so forcing
+// the category gap on them culls ticks that have plenty of room.
+const CATEGORY_LABEL_PADDING = 20
+const VALUE_TICK_LABEL_PADDING = 8
 
 interface XLabelCandidate {
     index: number
@@ -38,8 +42,8 @@ function truncateWithTitle(fullText: string, maxCategoryLabelWidth: number): { t
 }
 
 /** Greedily keep entries left→right, dropping any whose centered label would collide with the
- *  previously kept one (within LABEL_PADDING). Entries must be sorted by ascending `x`. */
-function dropOverlappingLabels<T extends { text: string; x: number }>(candidates: T[]): T[] {
+ *  previously kept one (closer than `padding` px). Entries must be sorted by ascending `x`. */
+function dropOverlappingLabels<T extends { text: string; x: number }>(candidates: T[], padding: number): T[] {
     if (candidates.length === 0) {
         return []
     }
@@ -57,7 +61,7 @@ function dropOverlappingLabels<T extends { text: string; x: number }>(candidates
         const halfWidth = ctx.measureText(candidate.text).width / 2
         const leftEdge = candidate.x - halfWidth
 
-        if (leftEdge >= lastRightEdge + LABEL_PADDING) {
+        if (leftEdge >= lastRightEdge + padding) {
             visible.push(candidate)
             lastRightEdge = candidate.x + halfWidth
         }
@@ -87,7 +91,7 @@ export function computeVisibleXLabels(
         candidates.push({ index: i, text, title, x })
     }
 
-    return dropOverlappingLabels(candidates)
+    return dropOverlappingLabels(candidates, CATEGORY_LABEL_PADDING)
 }
 
 interface ValueTickCandidate {
@@ -115,7 +119,7 @@ export function computeVisibleValueTicks(
         candidates.push({ tick, text: formatter ? formatter(tick) : String(tick), x })
     }
 
-    return dropOverlappingLabels(candidates)
+    return dropOverlappingLabels(candidates, VALUE_TICK_LABEL_PADDING)
 }
 
 const TICK_STYLE_BASE: React.CSSProperties = {

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -236,6 +236,14 @@ export const AxisLabels = React.memo(function AxisLabels({
         [hideXAxis, labels, scales.x, xTickFormatter, orientation, maxCategoryLabelWidth]
     )
 
+    // Mirror the vertical branch's memoization so an unrelated prop change (e.g. axisColor)
+    // doesn't re-run the per-tick `ctx.measureText` measurements in `dropOverlappingLabels`.
+    const visibleValueTicks = useMemo(
+        () =>
+            hideXAxis || orientation !== 'horizontal' ? [] : computeVisibleValueTicks(yTicks, scales.y, yTickFormatter),
+        [hideXAxis, orientation, yTicks, scales.y, yTickFormatter]
+    )
+
     const rightFormatter = yRightTickFormatter ?? yTickFormatter
 
     if (orientation === 'horizontal') {
@@ -268,17 +276,16 @@ export const AxisLabels = React.memo(function AxisLabels({
                             />
                         )
                     })}
-                {!hideXAxis &&
-                    computeVisibleValueTicks(yTicks, scales.y, yTickFormatter).map(({ tick, text, x }) => (
-                        <XTickLabel
-                            key={`x-val-${tick}`}
-                            x={x}
-                            box={dimensions}
-                            text={text}
-                            color={axisColor}
-                            dataAttr="hog-chart-axis-tick-x"
-                        />
-                    ))}
+                {visibleValueTicks.map(({ tick, text, x }) => (
+                    <XTickLabel
+                        key={`x-val-${tick}`}
+                        x={x}
+                        box={dimensions}
+                        text={text}
+                        color={axisColor}
+                        dataAttr="hog-chart-axis-tick-x"
+                    />
+                ))}
             </>
         )
     }

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -37,6 +37,35 @@ function truncateWithTitle(fullText: string, maxCategoryLabelWidth: number): { t
     return { text, title: text === fullText ? undefined : fullText }
 }
 
+/** Greedily keep entries left→right, dropping any whose centered label would collide with the
+ *  previously kept one (within LABEL_PADDING). Entries must be sorted by ascending `x`. */
+function dropOverlappingLabels<T extends { text: string; x: number }>(candidates: T[]): T[] {
+    if (candidates.length === 0) {
+        return []
+    }
+
+    const ctx = getTextMeasureCtx()
+    if (!ctx) {
+        return candidates
+    }
+    ctx.font = AXIS_LABEL_FONT
+
+    const visible: T[] = []
+    let lastRightEdge = -Infinity
+
+    for (const candidate of candidates) {
+        const halfWidth = ctx.measureText(candidate.text).width / 2
+        const leftEdge = candidate.x - halfWidth
+
+        if (leftEdge >= lastRightEdge + LABEL_PADDING) {
+            visible.push(candidate)
+            lastRightEdge = candidate.x + halfWidth
+        }
+    }
+
+    return visible
+}
+
 export function computeVisibleXLabels(
     labels: string[],
     xScale: (label: string) => number | undefined,
@@ -58,32 +87,35 @@ export function computeVisibleXLabels(
         candidates.push({ index: i, text, title, x })
     }
 
-    if (candidates.length === 0) {
-        return []
-    }
+    return dropOverlappingLabels(candidates)
+}
 
-    const ctx = getTextMeasureCtx()
-    if (!ctx) {
-        return candidates
-    }
-    ctx.font = AXIS_LABEL_FONT
+interface ValueTickCandidate {
+    tick: number
+    text: string
+    x: number
+}
 
-    const widths = candidates.map((c) => ctx.measureText(c.text).width)
-
-    const visible: XLabelCandidate[] = []
-    let lastRightEdge = -Infinity
-
-    for (let i = 0; i < candidates.length; i++) {
-        const halfWidth = widths[i] / 2
-        const leftEdge = candidates[i].x - halfWidth
-
-        if (leftEdge >= lastRightEdge + LABEL_PADDING) {
-            visible.push(candidates[i])
-            lastRightEdge = candidates[i].x + halfWidth
+/** Value-axis ticks for a horizontal bar chart map onto the x-axis, where wide numeric labels
+ *  (e.g. "450,000") collide far more readily than stacked y-axis labels do. Greedily drop the
+ *  ones that would overlap so the axis stays legible — the same pass `computeVisibleXLabels`
+ *  applies to a vertical chart's category axis. Ticks arrive value-sorted, so ascending value
+ *  maps to ascending x for an increasing value scale. */
+export function computeVisibleValueTicks(
+    ticks: number[],
+    valueToCoord: (value: number) => number,
+    formatter?: (value: number) => string
+): ValueTickCandidate[] {
+    const candidates: ValueTickCandidate[] = []
+    for (const tick of ticks) {
+        const x = valueToCoord(tick)
+        if (!isFinite(x)) {
+            continue
         }
+        candidates.push({ tick, text: formatter ? formatter(tick) : String(tick), x })
     }
 
-    return visible
+    return dropOverlappingLabels(candidates)
 }
 
 const TICK_STYLE_BASE: React.CSSProperties = {
@@ -237,23 +269,16 @@ export const AxisLabels = React.memo(function AxisLabels({
                         )
                     })}
                 {!hideXAxis &&
-                    yTicks.map((tick: number) => {
-                        const x = scales.y(tick)
-                        if (!isFinite(x)) {
-                            return null
-                        }
-                        const label = yTickFormatter ? yTickFormatter(tick) : String(tick)
-                        return (
-                            <XTickLabel
-                                key={`x-val-${tick}`}
-                                x={x}
-                                box={dimensions}
-                                text={label}
-                                color={axisColor}
-                                dataAttr="hog-chart-axis-tick-x"
-                            />
-                        )
-                    })}
+                    computeVisibleValueTicks(yTicks, scales.y, yTickFormatter).map(({ tick, text, x }) => (
+                        <XTickLabel
+                            key={`x-val-${tick}`}
+                            x={x}
+                            box={dimensions}
+                            text={text}
+                            color={axisColor}
+                            dataAttr="hog-chart-axis-tick-x"
+                        />
+                    ))}
             </>
         )
     }


### PR DESCRIPTION
## Problem

On horizontal bar charts — most visibly the trends bar value MCP app — the x-axis (value) tick labels overlap and smear into an unreadable run of digits (`0 50,000100,000150,000…`), which reads as a broken/wrong axis scale.

The root cause: vertical charts run their category labels through `computeVisibleXLabels`, which greedily drops any label that would collide with its neighbor. The **horizontal** branch of `AxisLabels` rendered **every** value tick with no such pass. The tick count comes from `floor(plotWidth / 50)`, a heuristic tuned for short vertically-stacked y-labels, not wide numeric labels like `"450,000"` — so on a narrow panel ~10 ticks pile on top of each other.

## Changes

- Extracted the greedy overlap-avoidance loop into a reusable `dropOverlappingLabels<T>()` helper (preserving `computeVisibleXLabels`'s existing behavior exactly).
- Added `computeVisibleValueTicks()`, which applies the same pass to the horizontal value-axis ticks: it measures each formatted label and drops those that would collide. Because d3 ticks are uniformly spaced, greedy dropping yields evenly-spaced survivors (e.g. `0 · 150,000 · 300,000 · 450,000`).
- Wired it into the horizontal branch of `AxisLabels`.

Grid lines are still drawn at every tick (they're faint, so denser-than-labels is standard), so bars, gridlines, and labels stay aligned.

## How did you test this code?

I'm an agent. I ran the automated Jest suites (no manual/visual testing):

- Added 3 tests for `computeVisibleValueTicks` (overlap dropping, spread-apart pass-through, non-finite coordinate skipping). `AxisLabels.test.ts`: 6/6 pass.
- Full `@posthog/quill-charts` suite: 1216 tests pass. (One unrelated suite, `theme.test.ts`, fails only because `@posthog/quill-tokens` wasn't built in the partial install used here.)
- `oxfmt` clean; no type errors in the edited file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a report that the trends bar chart MCP app had a wrong-looking x-axis with overlapping labels. Traced the active render path (`TrendsVisualizer` → `@posthog/quill-charts` `BarChart` with `axisOrientation: 'horizontal'`) and confirmed the value scale domain itself is correct (`[0, max].nice()` mapped to the plot width, bars share the same scale) — ruled out a genuine scaling bug. Also verified the `fitToHeight` row-dropping assumes value-sorted input (which PostHog breakdown results are), so the axis max always corresponds to a visible bar. The single defect was the missing overlap pass on horizontal value-tick labels, which made the axis look "wrong". Fixed by reusing the existing greedy de-overlap logic.

Authored with Claude Code (Agent tool for codebase exploration).
