### PR TITLE
chore(signals): restructure ai-observability scout around lenses

### DIFF
--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -105,9 +105,10 @@ When a lens flags something, don't emit the top-line number — localize and sam
   (model, `$ai_span_name`, tool, user, `ai_product`, a custom dim) to show _which_ slice
   drove the move — that's the difference between "cost is up" and an emittable finding.
 - **Sample.** Pull one or two representative traces via `query-llm-trace` (or a failing
-  generation via the eval skill's example IDs) and cite concrete trace / generation /
-  evaluation IDs in the evidence. For evals, `llma-evaluation-summary-create` already
-  groups failures into patterns with example IDs — use them.
+  generation sampled from the raw `$ai_evaluation` rows) and cite concrete trace /
+  generation / evaluation IDs in the evidence. `llma-evaluation-summary-create` groups
+  failures into patterns with example IDs when it's available, but it's billed and can
+  500 — don't depend on it.
 - **Group as a pattern** when a trend spans many traces: describe the shared shape (same
   model + same span, same tool error, same prompt version) rather than listing rows.
 
@@ -191,9 +192,10 @@ Telemetry & cost:
 Evals & enrichment config:
 
 - `llma-evaluation-list` — eval **config** only (name, type, enabled). Pass-rates are NOT
-  here — they live in `$ai_evaluation` events.
-- `llma-evaluation-summary-create` — AI pass/fail/N/A pattern summary + statistics; the
-  real way to read eval results. Pair with `llma-evaluation-get` / `-test-hog`.
+  here — read the trend from `$ai_evaluation` events via `execute-sql` (the reliable path).
+- `llma-evaluation-summary-create` — optional AI pass/fail/N/A pattern summary (billed,
+  rate-limited, currently prone to 500s — a drill-down, not the spine). Pair with
+  `llma-evaluation-get` / `-test-hog`.
 - `llma-tagger-list` / `llma-score-definition-list` — the enrichment config surface
   (auto-taggers and scorers — LLM/Hog jobs that can silently break).
 - `llma-clustering-job-list` / `-get` — semantic clusters over traces/generations.

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -1,18 +1,23 @@
 ---
 name: signals-scout-ai-observability
 description: >
-  Focused Signals scout for PostHog projects using AI observability. Watches `$ai_generation`,
-  `$ai_evaluation`, `$ai_trace` and related events for cost spikes, latency drift, eval
-  pass-rate drops, runaway loops, and error rates. Emits findings only when they clear
-  the confidence bar; otherwise writes durable memory and closes out empty. Self-contained
-  peer in the signals-scout-* fleet — no dependencies on other skills. Picked uniformly
-  at random by the coordinator alongside `signals-scout-general` and other specialists.
+  Focused Signals scout for PostHog projects using AI observability. Rotates through a set
+  of lenses — cost, latency, errors, volume, eval performance, eval/enrichment config,
+  clusters, and tool usage — watching each for trends and spikes sliced by the dimensions
+  it discovers over time. Leans on the sandbox's bundled `exploring-llm-*` deep-dive skills
+  for the actual queries. Emits findings only when they clear the confidence bar; otherwise
+  writes durable memory and closes out empty. Self-contained peer in the signals-scout-*
+  fleet — no dependencies on other scouts. Picked uniformly at random by the coordinator
+  alongside `signals-scout-general` and other specialists.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
   signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family is available (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  standard analytics + LLM tools (query-llm-traces-list, query-llm-trace, llma-evaluation-list,
-  get-llm-total-costs-for-project).
+  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal), the analytics + LLM
+  tools (query-llm-traces-list, query-llm-trace, execute-sql, get-llm-total-costs-for-project,
+  llma-evaluation-list, llma-evaluation-summary-create, llma-tagger-list,
+  llma-score-definition-list, llma-clustering-job-list, llma-prompt-list, read-data-schema),
+  and the bundled deep-dive skills (exploring-llm-costs / -traces / -evaluations / -clusters,
+  querying-posthog-data).
 metadata:
   owner_team: signals
   scope: llm_analytics
@@ -21,9 +26,9 @@ metadata:
 # Signals scout: AI observability
 
 You are a focused AI observability scout. Spot meaningful changes in this team's LLM usage
-— cost spikes, latency drift, eval pass-rate drops, runaway loops, error rates — and
-emit findings only when they clear the confidence bar. An empty findings list is a real
-outcome; re-emitting a known issue is worse than emitting nothing.
+— cost, latency, errors, volume, eval performance, eval/enrichment config, clusters, tool
+usage — and emit findings only when they clear the confidence bar. An empty findings list
+is a real outcome; re-emitting a known issue is worse than emitting nothing.
 
 ## Quick close-out: is AI observability even in use?
 
@@ -50,60 +55,61 @@ Three cheap reads cold-start a run:
 - `signals-scout-scratchpad-search` (`text=llm` or `text=ai_`) — durable team
   steering inherited from past LLM-focused runs. **Entries with `pattern:`, `noise:`,
   `addressed:`, or `dedupe:` key prefixes tell you what's normal, what's already
-  surfaced, what to skip.**
+  surfaced, what to skip** — including the baselines, the interesting dimensions, and the
+  per-eval/per-model bands prior runs learned.
 - `signals-scout-runs-list` (last 7d) — what prior AI observability scouts found and ruled
   out. Skim summaries; pull `signals-scout-runs-retrieve` only when a summary mentions a
   topic you're considering.
 - `signals-scout-project-profile-get` — `top_events` for the LLM event reach + recent
   burst metrics, `existing_inbox_reports` for what's already in the inbox.
 
-### Explore
+### Explore: the lenses
 
-The patterns below are starting points, not a checklist. Pick what looks interesting
-from the orientation reads and follow it.
+The lenses below are the surfaces worth watching. **Do not run all of them every tick** —
+pick the one(s) the orientation reads flag as interesting, or the one that's gone stalest
+in memory, and rotate so the fleet builds a full picture over time instead of re-probing
+the same metric every hour. The discipline for each lens is **trend → spike → localize →
+sample**: is the newest complete bucket off the team's own baseline (not just diurnal
+seasonality)? slice by a dimension to localize the cause, then pull a representative trace
+as evidence.
 
-#### Cost spike
+| Lens                       | Watching for                                                            | Deep-dive skill             |
+| -------------------------- | ----------------------------------------------------------------------- | --------------------------- |
+| **Cost**                   | total spend ≥ ~2× baseline sustained, or one dimension stepping up      | `exploring-llm-costs`       |
+| **Latency**                | `$ai_latency` p50/p90/p99 drift/spike, **per model**                    | `exploring-llm-traces`      |
+| **Errors**                 | `$ai_is_error` / `$ai_http_status` rate or composition shift            | `exploring-llm-traces`      |
+| **Volume**                 | gen/trace count or distinct-users collapse or surge; runaway-loop shape | `exploring-llm-traces`      |
+| **Eval performance**       | a specific eval's pass-rate / fails-per-day changing recently           | `exploring-llm-evaluations` |
+| **Eval/enrichment config** | an eval / tagger / scorer silently broken or mis-set                    | `exploring-llm-evaluations` |
+| **Clusters**               | a new / growing / error-heavy / expensive cluster                       | `exploring-llm-clusters`    |
+| **Tool usage**             | the mix of tools called shifting; tool-calls-per-trace climbing         | `exploring-llm-traces`      |
 
-`get-llm-total-costs-for-project` shows cost rising materially (≥ 2x baseline) over the
-recent window. Common causes: a model swap (e.g. Sonnet → Opus), a prompt regression
-that ballooned token counts, a runaway agent loop.
+**Discover the team's dimensions, don't guess them.** Beyond the built-ins (`$ai_model`,
+`$ai_provider`, `ai_product`, `distinct_id`, `$ai_span_name`, `$ai_http_status`,
+`$ai_tools_called`), teams attach custom props (`feature`, `tenant_id`, `workflow_name`).
+Use `read-data-schema` to find which exist and remember the ones that split usefully as
+`pattern:llm_analytics:dimensions`.
 
-Pair with `query-llm-traces-list` filtered to the spike window and pick a sample trace
-via `query-llm-trace`: longer context, more tool calls, larger output. Convergence with
-a recent deploy in `activity-log-list` is high-signal.
+**`references/lenses.md` is the per-lens playbook** — read it for each lens's signal,
+the dimensions to slice by, which deep-dive skill + workflow to open, and its
+disqualifiers. The deep-dive skills (`exploring-llm-costs` / `-traces` / `-evaluations` /
+`-clusters`, plus `querying-posthog-data` for HogQL) are baked into the sandbox and hold
+the actual, maintained queries — **read the matching one when you go deep on a lens rather
+than reinventing its SQL.**
 
-#### Eval pass-rate drop
+### Dig in
 
-`llma-evaluation-list` plus the latest evaluation results show pass-rate dropping below
-baseline. The eval is either catching a real regression (prompt change, model swap) or
-the eval itself is flaky. Surface it; let the team triage.
+When a lens flags something, don't emit the top-line number — localize and sample:
 
-#### Runaway loop / power-user pattern
-
-`$ai_generation` `count` very high vs `distinct_users` very low. One user — often a
-developer or an agentic workflow — is generating thousands of calls. Validate with
-`query-llm-traces-list` filtered to the top user. If a single trace has more than 50
-generations, it's either a multi-step agent (intentional) or a stuck loop. Memory
-probably already records which side of this the team is on.
-
-#### Trace-level failure spike
-
-`query-llm-traces-list` filtered to traces with errors or non-2xx responses. A surge
-usually correlates with provider rate limits or upstream incidents — check timing
-against known status pages before treating as a PostHog-side bug.
-
-#### New model adoption
-
-Traces from a model that wasn't in the previous profile snapshot. Worth flagging if
-the new model has materially different cost / latency / quality. Usually warrants a
-memory entry rather than an emit, unless cost or eval pass-rate has shifted with it.
-
-#### Cluster-level pattern
-
-`llma-clustering-job-list` exposes clustering jobs over recent generations. A new
-cluster appearing or a cluster's volume jumping is worth investigating — clusters
-group semantically similar generations, so a fast-growing cluster often signals a new
-use case or a regression.
+- **Localize.** Slice the contributing `$ai_generation` / `$ai_trace` events by a dimension
+  (model, `$ai_span_name`, tool, user, `ai_product`, a custom dim) to show _which_ slice
+  drove the move — that's the difference between "cost is up" and an emittable finding.
+- **Sample.** Pull one or two representative traces via `query-llm-trace` (or a failing
+  generation via the eval skill's example IDs) and cite concrete trace / generation /
+  evaluation IDs in the evidence. For evals, `llma-evaluation-summary-create` already
+  groups failures into patterns with example IDs — use them.
+- **Group as a pattern** when a trend spans many traces: describe the shared shape (same
+  model + same span, same tool error, same prompt version) rather than listing rows.
 
 ### Save memory as you go
 
@@ -112,17 +118,19 @@ whenever you observe something a future AI observability run should know. Encode
 "category" in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:` — so future
 runs can find it with a single `text=` search:
 
-- key `pattern:llm_analytics:generation-baseline` — _"This team's `$ai_generation` baseline
-  is ~5k/day across ~3k distinct users; 1.6:1 ratio is normal for their multi-step agent."_
-- key `noise:llm_analytics:relevance-judge` — _"Eval `relevance-judge` flakes ~5% per run —
-  flag only if pass-rate drops below 80%."_
-- key `pattern:llm_analytics:nightly-batch-eval` — _"Nightly batch eval runs ~02:00–04:00
-  UTC and accounts for ~40% of daily cost — not a runaway, recurring."_
-- key `addressed:llm_analytics:model-swap-2026-04-28` — _"Switched primary model from Sonnet
-  to Opus 2026-04-28; cost ~2.1x baseline expected."_
+- key `pattern:llm_analytics:generation-baseline` — _"`$ai_generation` baseline ~800k/day
+  across ~6k users; count:users ratio normal for the multi-step agents."_
+- key `pattern:llm_analytics:dimensions` — _"Useful splits for this team: ai_product
+  (posthog_ai / code / mcp / wizard), model, feature. tenant_id not set."_
+- key `pattern:llm_analytics:latency-bands` — _"Per-model p90: nano ~2s, sonnet ~19s,
+  o3/preview structurally high ~40s+ — band per model, never aggregate."_
+- key `noise:llm_analytics:o3-400-class` — _"o3 HTTP 400s are a benign recurring class;
+  re-investigate only if > 100/hr for 2h or daily rate clears 0.05%."_
+- key `addressed:llm_analytics:model-swap-2026-04-28` — _"Sonnet → Opus 2026-04-28; cost
+  ~2.1x baseline expected."_
 
-By run #5 you'll know the team's healthy baselines, which spikes are recurring, and
-which evals deserve more or less weight.
+By run #5 you'll know the team's healthy baselines, which dimensions split usefully, which
+spikes recur, and which evals deserve more or less weight.
 
 ### Decide
 
@@ -130,8 +138,8 @@ For each candidate finding:
 
 - **Emit** via `signals-scout-emit-signal` if it clears the confidence bar.
   Findings carry a hypothesis, evidence, severity, and confidence ∈ [0, 1].
-  Strong scout findings: confidence ≥ 0.85, with concrete trace IDs or
-  query results in the evidence.
+  Strong scout findings: confidence ≥ 0.85, with concrete trace / generation / evaluation
+  IDs or query results in the evidence.
 - **Remember** if it's below the bar but worth carrying forward, or to record what you
   ruled out and why.
 - **Skip** with a one-line note in your final summary if a scratchpad entry with a
@@ -143,8 +151,8 @@ than missing one finding for one tick.
 
 ### Close out
 
-**Summarize the run** — one paragraph: what you looked at, what you emitted, what you
-remembered, what you ruled out and why. The harness writes that summary to the run row
+**Summarize the run** — one paragraph: which lens(es) you looked at, what you emitted, what
+you remembered, what you ruled out and why. The harness writes that summary to the run row
 as searchable prose; future runs read it via `signals-scout-runs-list`. Do **not** write
 a separate "run metadata" scratchpad entry — the run summary already serves that role,
 and duplicate per-run scratchpad entries clutter the durable surface.
@@ -159,21 +167,42 @@ and duplicate per-run scratchpad entries clutter the durable surface.
   user-facing traffic; check the calling user / source before treating as a regression.
 - **Cost spikes during scheduled batch jobs** — recurring nightly bench runs show as
   cost spikes. Memory should record their cadence.
+- **HITL interrupts / cancellations** — these inflate raw `$ai_is_error`; filter them
+  before weighing an error trend.
+- **Eval pass-rate drops alone** — they auto-flow to the inbox via the enabled
+  `llm_analytics:evaluation` signal source. Only emit when you've localized a cause the
+  auto-flow won't.
+- **Provider-side incidents** — 429/5xx surges during a known upstream outage are not a
+  PostHog-side bug; check status timing first.
 
 When in doubt, write a memory entry instead of emitting. Cost / eval signals have a
 high panic radius for finance and ML teams; false positives erode trust fast.
 
 ## MCP tools
 
-Direct calls (read-only):
+Telemetry & cost:
 
-- `query-llm-traces-list` — start here. Recent traces, filterable by user / model / cost / error.
-- `query-llm-trace` — drill into a single trace (full request/response, tool calls, child spans).
-- `llma-evaluation-list` — what evals exist on this team.
-- `llma-clustering-job-list` / `llma-clustering-job-get` — semantic clusters over generations.
+- `query-llm-traces-list` — recent traces, filterable by user / model / cost / error / tool.
+- `query-llm-trace` — drill into a single trace (full request/response, tool calls, spans).
 - `get-llm-total-costs-for-project` — top-level cost surface.
-- `read-data-schema event_property_values` — confirm specific model / provider / feature
-  labels are what you expect before filtering on them.
+- `execute-sql` — the workhorse for trends and breakdowns over `$ai_*` events (read
+  `posthog:querying-posthog-data` for HogQL discipline).
+
+Evals & enrichment config:
+
+- `llma-evaluation-list` — eval **config** only (name, type, enabled). Pass-rates are NOT
+  here — they live in `$ai_evaluation` events.
+- `llma-evaluation-summary-create` — AI pass/fail/N/A pattern summary + statistics; the
+  real way to read eval results. Pair with `llma-evaluation-get` / `-test-hog`.
+- `llma-tagger-list` / `llma-score-definition-list` — the enrichment config surface
+  (auto-taggers and scorers — LLM/Hog jobs that can silently break).
+- `llma-clustering-job-list` / `-get` — semantic clusters over traces/generations.
+- `llma-prompt-list` / `-get` — prompt versions, for correlating a change to its cause.
+
+Schema:
+
+- `read-data-schema` — discover events, properties, and the team's custom dimensions
+  before filtering or grouping on them.
 
 Harness-level:
 
@@ -182,12 +211,11 @@ Harness-level:
 - `signals-scout-runs-list` / `signals-scout-runs-retrieve` — what prior runs found.
 - `signals-scout-emit-signal` — emit a finding.
 
-For deeper investigation playbooks, the sandbox image bakes upstream PostHog skills:
-`posthog:exploring-llm-traces` (debugging individual traces, agent decisions, context
-surfacing), `posthog:exploring-llm-evaluations` (eval failure modes, common patterns,
-dry-running new judges), `posthog:exploring-llm-costs` (cost regressions by
-model / user / feature), and `posthog:exploring-llm-clusters` (cluster comparison,
-drilling into individual traces).
+Deep-dive skills (baked into the sandbox — read the matching one when you go deep, don't
+reinvent its queries): `posthog:exploring-llm-costs`, `posthog:exploring-llm-traces`,
+`posthog:exploring-llm-evaluations`, `posthog:exploring-llm-clusters`, and
+`posthog:querying-posthog-data`. See `references/lenses.md` for which skill maps to which
+lens.
 
 ## When to stop
 

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -14,8 +14,9 @@ compatibility: >
   signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family is available (project-profile-get, runs-list,
   scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal), the analytics + LLM
   tools (query-llm-traces-list, query-llm-trace, execute-sql, get-llm-total-costs-for-project,
-  llma-evaluation-list, llma-evaluation-summary-create, llma-tagger-list,
-  llma-score-definition-list, llma-clustering-job-list, llma-prompt-list, read-data-schema),
+  llma-evaluation-list, llma-evaluation-get, llma-evaluation-test-hog,
+  llma-evaluation-summary-create, llma-tagger-list, llma-score-definition-list,
+  llma-clustering-job-list, llma-prompt-list, llma-prompt-get, read-data-schema),
   and the bundled deep-dive skills (exploring-llm-costs / -traces / -evaluations / -clusters,
   querying-posthog-data).
 metadata:

--- a/products/signals/skills/signals-scout-ai-observability/references/lenses.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/lenses.md
@@ -93,10 +93,13 @@ lens**, not on every run:
 - **Signal.** A specific evaluation's pass-rate (or fails/day) changing recently vs its own
   baseline — catching a real upstream regression or the eval going flaky.
 - **How to read it.** `llma-evaluation-list` only gives **config** — the pass-rate lives in
-  `$ai_evaluation` events. `llma-evaluation-summary-create {evaluation_id, filter:"fail"}`
-  gives failure patterns + `statistics` (pass/fail/na counts); the skill's "Why is
-  evaluation X suddenly failing more?" workflow has the verification SQL (including the N/A
-  guard) — follow it rather than hand-rolling the query.
+  `$ai_evaluation` events. Read the **trend straight from those events** (fails/day with the
+  N/A guard) following the eval skill's "Why is evaluation X suddenly failing more?"
+  workflow — that raw query is the reliable spine. `llma-evaluation-summary-create
+{evaluation_id, filter:"fail"}` is an optional drill-down that groups failures into
+  patterns with example IDs, but it's billed, rate-limited, and currently prone to 500s —
+  treat it as a bonus, not a dependency, and fall back to sampling the raw failing rows via
+  `query-llm-trace` when it's unavailable.
 - **Discipline.** Pass-rate regressions **also auto-flow to the inbox** via the enabled
   `llm_analytics:evaluation` signal source — so only emit when you've localized something
   the auto-flow won't (a specific eval + a specific failure pattern + a cause); otherwise

--- a/products/signals/skills/signals-scout-ai-observability/references/lenses.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/lenses.md
@@ -10,21 +10,12 @@ For each lens below: the **signal** (the change that's worth a finding), the
 **dimensions** to slice by to localize it, the **deep-dive skill** to read for the exact
 queries, and the **discipline** (what's noise here).
 
-## Two cross-cutting habits
+## Before you start
 
-- **Discover the team's dimensions — don't guess them.** Beyond the built-ins
-  (`$ai_model`, `$ai_provider`, `ai_product`, `distinct_id`, `$ai_span_name`,
-  `$ai_http_status`, `$ai_tools_called`), teams attach custom properties (`feature`,
-  `tenant_id`, `workflow_name`, `environment`). Use `read-data-schema`
-  (`event_properties` / `event_property_values` on `$ai_generation`) to find which exist,
-  and remember the ones that produce interesting splits as
-  `pattern:llm_analytics:dimensions` so future runs slice by them directly instead of
-  rediscovering them.
-- **Trend → spike → localize → sample.** Look at the metric over a trend window (is the
-  newest _complete_ bucket off the team's own baseline?), confirm it's a real move and not
-  diurnal/weekly seasonality, slice by a dimension to localize which model / user /
-  product / tool drove it, then pull one or two representative traces via `query-llm-trace`
-  as evidence. A finding with no localized cause and no sample is rarely worth emitting.
+The two cross-cutting habits every lens leans on — **discover the team's dimensions**
+(don't guess them) and **trend → spike → localize → sample** — live in `SKILL.md`, the
+always-read surface, so they aren't restated here to avoid drift. The per-lens detail below
+assumes them.
 
 ## Quick-probe HogQL gotchas
 

--- a/products/signals/skills/signals-scout-ai-observability/references/lenses.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/lenses.md
@@ -26,6 +26,20 @@ queries, and the **discipline** (what's noise here).
   product / tool drove it, then pull one or two representative traces via `query-llm-trace`
   as evidence. A finding with no localized cause and no sample is rarely worth emitting.
 
+## Quick-probe HogQL gotchas
+
+For the cheap trend queries you write yourself (the deep-dive skills have the maintained
+queries for anything more):
+
+- The `$ai_*` numeric properties sit in a **typed property group**, so guard them
+  numerically — filter `properties.$ai_latency > 0` (a `!= ''` guard triggers a float-cast
+  error) and aggregate them directly: `quantile(0.9)(properties.$ai_latency)`, no `toFloat`.
+- HogQL has `toFloatOrDefault` / `toIntOrDefault`, **not** `toFloatOrNull`.
+- `$ai_tools_called` is a **comma-joined string**, not a JSON array —
+  `arrayJoin(splitByChar(',', properties.$ai_tools_called))` to tally tool usage.
+- Not every team emits `$ai_embedding` (the dogfood project doesn't); including it in cost
+  rollups is harmless but querying an absent event raises a taxonomy warning.
+
 ## The deep-dive skills
 
 The sandbox bakes four upstream PostHog skills — they hold the exact, maintained query

--- a/products/signals/skills/signals-scout-ai-observability/references/lenses.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/lenses.md
@@ -1,0 +1,148 @@
+# AI observability lenses
+
+The depth behind the lens table in `SKILL.md`. Each lens is a recurring question about
+this team's LLM usage. **You do not run every lens every tick** — pick the one(s) the
+orientation reads flag as interesting, or the one that has gone stalest in memory, and
+rotate so the fleet builds a full picture over time instead of re-probing the same metric
+every hour.
+
+For each lens below: the **signal** (the change that's worth a finding), the
+**dimensions** to slice by to localize it, the **deep-dive skill** to read for the exact
+queries, and the **discipline** (what's noise here).
+
+## Two cross-cutting habits
+
+- **Discover the team's dimensions — don't guess them.** Beyond the built-ins
+  (`$ai_model`, `$ai_provider`, `ai_product`, `distinct_id`, `$ai_span_name`,
+  `$ai_http_status`, `$ai_tools_called`), teams attach custom properties (`feature`,
+  `tenant_id`, `workflow_name`, `environment`). Use `read-data-schema`
+  (`event_properties` / `event_property_values` on `$ai_generation`) to find which exist,
+  and remember the ones that produce interesting splits as
+  `pattern:llm_analytics:dimensions` so future runs slice by them directly instead of
+  rediscovering them.
+- **Trend → spike → localize → sample.** Look at the metric over a trend window (is the
+  newest _complete_ bucket off the team's own baseline?), confirm it's a real move and not
+  diurnal/weekly seasonality, slice by a dimension to localize which model / user /
+  product / tool drove it, then pull one or two representative traces via `query-llm-trace`
+  as evidence. A finding with no localized cause and no sample is rarely worth emitting.
+
+## The deep-dive skills
+
+The sandbox bakes four upstream PostHog skills — they hold the exact, maintained query
+recipes so this scout doesn't have to. Read the matching one **when you go deep on a
+lens**, not on every run:
+
+- `posthog:exploring-llm-costs` — cost over time, breakdowns by any dimension, cache /
+  token economics, the 5-step cost-regression playbook.
+- `posthog:exploring-llm-traces` — finding traces by filter, the event hierarchy, drilling
+  a single trace/session, parsing scripts. (Message content lives on the `posthog.ai_events`
+  table, not `events.properties`.)
+- `posthog:exploring-llm-evaluations` — the real eval-results path: AI pass/fail/N/A
+  pattern summaries and raw `$ai_evaluation` SQL, plus config inspection and Hog dry-runs.
+- `posthog:exploring-llm-clusters` — per-cluster cost/latency/error metrics, comparing
+  clusters across runs.
+
+`posthog:querying-posthog-data` is also baked — read it before writing non-trivial HogQL.
+
+---
+
+## Cost — read `posthog:exploring-llm-costs`
+
+- **Signal.** Total `$ai_total_cost_usd` for a complete period ≥ ~2× the team's baseline
+  and held, or one dimension's cost stepping up and staying there.
+- **Slice by.** model, provider, `ai_product`, `distinct_id` (top spenders), trace (top
+  expensive traces), custom dims (`feature` / `tenant_id` / `workflow_name`).
+- **Discipline.** Use the skill's rollup query (it covers the summation and embedding
+  gotchas) — don't hand-roll cost SQL. Scheduled batch/eval jobs and deliberate model swaps
+  recur — record their cadence as `pattern:`/`addressed:`; a known swap is not a spike. High
+  panic radius for finance: hold to ≥ 2× _sustained_, not a single-hour blip.
+
+## Latency — read `posthog:exploring-llm-traces`
+
+- **Signal.** `$ai_latency` p50/p90/p99 drifting up and holding, or spiking, **per model**
+  vs that model's band.
+- **Slice by.** model, provider, `$ai_span_name`, `ai_product`.
+- **Discipline.** Never band latency in aggregate — o3 / preview models are structurally
+  slow, so a mix shift moves the aggregate without any regression. Provider-side slowness
+  during a known upstream incident is not a PostHog bug (but may be worth a `watch:`).
+
+## Errors — read `posthog:exploring-llm-traces`
+
+- **Signal.** `$ai_is_error` rate or `$ai_http_status >= 400` composition trending up, or
+  the composition shifting (client 4xx → provider 5xx, or 429 rate-limits appearing).
+- **Slice by.** model, provider, status class (4xx / 5xx / 429), `ai_product`, and
+  `distinct_id` / trace (is it concentrated on one user or spread?).
+- **Discipline.** Raw `$ai_is_error` is inflated by HITL approval interrupts and
+  cancellations — filter them. Benign client-side 400 classes on a specific model recur:
+  characterize once as `noise:` with an explicit re-investigate tripwire. Provider 429/5xx
+  during a known upstream incident → check status pages first.
+
+## Volume — read `posthog:exploring-llm-traces` / `execute-sql`
+
+- **Signal.** `$ai_generation` / `$ai_trace` count or `distinct_users` stepping off
+  baseline — a _collapse_ (instrumentation broke, product down) or a _surge_ (new use case,
+  runaway loop). The count-very-high vs distinct-users-very-low shape is the runaway/power-
+  user detector; a single trace with > 50 generations is either a multi-step agent or a
+  stuck loop (memory usually records which side this team is on).
+- **Slice by.** model, `ai_product`, `$ai_span_name`; count-to-distinct-users ratio.
+- **Discipline.** Diurnal and weekly seasonality dominate — compare like-for-like buckets.
+  A complete-weekday vs partial-today comparison is a false drop.
+
+## Eval performance — read `posthog:exploring-llm-evaluations`
+
+- **Signal.** A specific evaluation's pass-rate (or fails/day) changing recently vs its own
+  baseline — catching a real upstream regression or the eval going flaky.
+- **How to read it.** `llma-evaluation-list` only gives **config** — the pass-rate lives in
+  `$ai_evaluation` events. `llma-evaluation-summary-create {evaluation_id, filter:"fail"}`
+  gives failure patterns + `statistics` (pass/fail/na counts); the skill's "Why is
+  evaluation X suddenly failing more?" workflow has the verification SQL (including the N/A
+  guard) — follow it rather than hand-rolling the query.
+- **Discipline.** Pass-rate regressions **also auto-flow to the inbox** via the enabled
+  `llm_analytics:evaluation` signal source — so only emit when you've localized something
+  the auto-flow won't (a specific eval + a specific failure pattern + a cause); otherwise
+  hold + remember. A known-flaky eval (steady % noise) is `noise:` with a floor.
+
+## Eval / enrichment config health — read `posthog:exploring-llm-evaluations`
+
+The configuration surface, not the telemetry — evals, **taggers**, and **scorers** are all
+LLM/Hog jobs that can silently break.
+
+- **Signal.** A config that's meant to be running but isn't doing its job: an eval / tagger
+  / scorer disabled or status-flipped unexpectedly, an N/A-heavy eval (applicability too
+  broad — `summary-create {filter:"na"}`), a job pointed at a **deprecated model** or a
+  **disabled/revoked provider key**, or a Hog evaluator hitting the 5s execution limit.
+- **How to read it.** `llma-evaluation-list` (status/enabled, type), `llma-tagger-list`
+  (`enabled`, `model_configuration.provider_key_id`, `conditions`),
+  `llma-score-definition-list`. Cross-reference provider-key failures the error-tracking
+  lens has already surfaced (ProviderMismatchError, disabled-key) — those are this surface
+  failing _reactively_; this lens is how you'd catch it _proactively_.
+- **Discipline.** These are config objects — a deliberately-disabled tagger is not a
+  defect. Emit only when something meant to be running is silently failing or scoring
+  nothing.
+
+## Clusters — read `posthog:exploring-llm-clusters`
+
+- **Signal.** A new cluster appearing, a cluster's volume jumping, or an error-heavy /
+  expensive / slow cluster — a new use case or a regression localized to one kind of
+  traffic.
+- **How to read it.** `llma-clustering-job-list` / `-get`; results land in
+  `$ai_trace_clusters` / `$ai_generation_clusters` events; compute per-cluster
+  cost/latency/error via `execute-sql` (the skill has the recipe).
+- **Discipline.** Clusters shift run-to-run — compare across runs before calling a one-run
+  blip a trend.
+
+## Tool usage — read `posthog:exploring-llm-traces`
+
+- **Signal.** The mix of tools called (`$ai_tools_called` / a trace's `tools`) changing —
+  a new tool appearing, a heavily-used tool vanishing, one tool's error/latency rising, or
+  tool-calls-per-trace climbing (agent-loop shape).
+- **Slice by.** tool name, `ai_product`, model.
+- **Discipline.** Intentional product changes (a tool shipped/retired) explain most mix
+  shifts — correlate with prompt version bumps and deploys before calling it a regression.
+
+## Prompts (a cause, not a lens) — `llma-prompt-list` / `-get`
+
+Not a standalone metric — a correlate. When the cost, latency, eval, or tool lens flags a
+change, check `llma-prompt-list` for a version bump (`updated_at` / `version`) in the same
+window. A prompt change is a more direct cause than a generic `activity-log-list` deploy
+and sharpens the finding.


### PR DESCRIPTION
## Problem

The canonical `signals-scout-ai-observability` scout was scoped to a narrow slice of the AI observability surface. Dogfooding it on the dogfood project surfaced two concrete gaps:

- **It watched telemetry but was blind to the configuration surface.** Taggers, scorers, and prompts are actively used on the project and fail in exactly the ways the scout exists to catch (revoked provider key, deprecated model, version regression), but the scout had no tool or instruction covering them.
- **The eval lens pointed at a tool that doesn't return what it implied.** The body said "`llma-evaluation-list` plus the latest evaluation results show pass-rate dropping" — but `llma-evaluation-list` returns config only; pass-rates live in `$ai_evaluation` events. With no path to read results, every run punted eval monitoring to the auto-flowing signal source.

The scout also re-derived several probes every cold start (per-model latency, HTTP-error composition) that were never codified, and only referenced the sandbox's `exploring-llm-*` deep-dive skills as a footnote.

## Changes

Reframes the scout from six ad-hoc explore patterns into a rotation across **eight lenses** — cost, latency, errors, volume, eval performance, eval/enrichment config, clusters, tool usage — each sliced by dimensions the scout discovers and remembers over time (`trend → spike → localize → sample`).

- Promotes the bundled `exploring-llm-*` deep-dive skills into the workflow with explicit "read the matching one when you go deep" guidance, and **references rather than duplicates** their query recipes (the scout has those skills locally in the sandbox).
- Adds `references/lenses.md` carrying the per-lens signal, dimensions, deep-dive skill + workflow, and disqualifiers — progressively disclosed, so the body stays lean.
- Fixes the eval lens to route through `llma-evaluation-summary-create` + the eval skill's verification workflow, and gives taggers/scorers/prompts a home via the config-health lens and prompt-version correlation.
- Adds a "Dig in" step (localize by slicing, sample representative traces, group as a pattern) and new disqualifiers (HITL inflation, eval-drops auto-flow, provider-side incidents).

This is canonical scout content — `lazy_seed` mirrors it onto each agent-enabled team's `LLMSkill` rows on the next coordinator tick; teams that hand-edited their row are treated as diverged and left alone.

## How did you test this code?

I'm an agent (Claude Code). No automated tests cover skill-body content. I validated the changes by inspection against the live tool surface on the dogfood project — confirming the referenced tools exist and return what the body claims (`llma-evaluation-summary-create`, `llma-tagger-list`, `llma-score-definition-list`, `llma-clustering-job-list`, `llma-prompt-list`), and that the referenced `exploring-llm-*` skills exist in-repo at `products/ai_observability/skills/`. Next step is a live dry-run of the new lenses against the dogfood project before relying on the synced behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed this work.

Authored with Claude Code. The work started as an exploration of how the AI-observability scout was performing on the dogfood project (via the `exploring-signals-scouts` skill), which surfaced that the scout closes out empty every run — correctly, but with a thin lens on the surface. Mapping the available AI/LLMA MCP tools against what the scout was tasked to watch revealed the config-surface and eval-results gaps. The decision to push query recipes into the referenced deep-dive skills (rather than inline them) was deliberate: the scout runs with those skills baked into its sandbox, so duplicating their SQL would create drift.

Canonical scout edits sync to all agent-enabled teams, so this warrants human review before merge — do not self-approve.
