### PR TITLE
feat(signals): Estimate dollar value in priority judgement

### DIFF
--- a/products/signals/backend/custom_agent/examples/cookie_poem_agent.py
+++ b/products/signals/backend/custom_agent/examples/cookie_poem_agent.py
@@ -56,6 +56,7 @@ class CookiePoemAgent(CustomSignalAgent):
             PriorityAssessment(
                 priority=Priority.P0,
                 explanation="Cookies are top priority.",
+                dollar_value=1000000.0,
             )
         )
         self.register_assignees([])

--- a/products/signals/backend/report_generation/fixtures/analyze_report_funnel_research_output.json
+++ b/products/signals/backend/report_generation/fixtures/analyze_report_funnel_research_output.json
@@ -65,7 +65,8 @@
     },
     "priority": {
       "explanation": "All three verified signals (1-3) are feature enhancement requests with workarounds available (HogQL breakdown for comparison, adjusting bin count manually, using the existing median_conversion_time from the regular funnel steps view). None represent broken functionality - funnels work correctly, they just lack advanced statistical options. The unverified bug report (signal 4) could not be corroborated by any code regression in git history, and no funnel logic changes were found in the relevant timeframe. The signals carry 0.5 weight each (low confidence) except signal 4 at 0.8 which could not be verified. These are clear improvement opportunities with existing workarounds, fitting P2.",
-      "priority": "P2"
+      "priority": "P2",
+      "dollar_value": null
     }
   }
 }

--- a/products/signals/backend/report_generation/fixtures/analyze_report_funnel_research_output.json
+++ b/products/signals/backend/report_generation/fixtures/analyze_report_funnel_research_output.json
@@ -66,7 +66,7 @@
     "priority": {
       "explanation": "All three verified signals (1-3) are feature enhancement requests with workarounds available (HogQL breakdown for comparison, adjusting bin count manually, using the existing median_conversion_time from the regular funnel steps view). None represent broken functionality - funnels work correctly, they just lack advanced statistical options. The unverified bug report (signal 4) could not be corroborated by any code regression in git history, and no funnel logic changes were found in the relevant timeframe. The signals carry 0.5 weight each (low confidence) except signal 4 at 0.8 which could not be verified. These are clear improvement opportunities with existing workarounds, fitting P2.",
       "priority": "P2",
-      "dollar_value": null
+      "dollar_value": 15000.0
     }
   }
 }

--- a/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
+++ b/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
@@ -26,7 +26,7 @@
     "priority": {
       "explanation": "Low-risk, low-impact, but immediately actionable and suitable for agent autonomy testing.",
       "priority": "P1",
-      "dollar_value": null
+      "dollar_value": 0.0
     }
   }
 }

--- a/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
+++ b/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
@@ -25,7 +25,8 @@
     },
     "priority": {
       "explanation": "Low-risk, low-impact, but immediately actionable and suitable for agent autonomy testing.",
-      "priority": "P1"
+      "priority": "P1",
+      "dollar_value": null
     }
   }
 }

--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -103,9 +103,10 @@ class PriorityAssessment(BaseModel):
     dollar_value: float | None = Field(
         default=None,
         description=(
-            "Estimated real dollar value of merging the fix/change this report leads to, in USD. "
-            "Trace the causal path from merging to business outcomes and quantify it. "
-            "None when the value cannot be reasonably estimated from the available data."
+            "Peak estimate (USD) of the real dollar value of merging the fix/change this report leads to. "
+            "Reason internally about a plausible value range first; set this to the most likely point "
+            "within that range (the peak of your belief distribution). Should align with the assigned "
+            "priority. Nullable for backward compatibility only — prefer a best-effort peak over null."
         ),
     )
 
@@ -461,12 +462,15 @@ Base your priority on **evidence from your research** — quantified user impact
 
 ## Dollar value estimation
 
-Also estimate the **real dollar value** (in USD) of merging the fix or change this report leads to. This is a best-effort economic estimate, not a priority proxy — a low-priority change can be high-value and vice versa.
+`dollar_value` is internal — do not elaborate on it in `explanation` (users see that field).
+
+Put a **real dollar value** (in USD) on merging the fix or change this report leads to. Treat this as the concrete monetary realization of the priority you just assigned: priority captures both how important and how urgent the change is, and dollar value is downstream of both. A higher-priority report should generally carry a higher dollar value — if your estimate contradicts the priority (e.g. a high estimate on a P4, or a near-zero estimate on a P0), revisit your reasoning before settling on it.
+
+Before setting `dollar_value`, **reason internally about a plausible USD range** where the real value is likely to land given your uncertainty. Then set `dollar_value` to the **peak of that belief distribution** — the single most likely outcome within the range, not the midpoint or a conservative floor.
 
 - **Trace the causal path** from merging the change to business outcomes. Be explicit with yourself about each link: merge → behavior change → user/revenue/cost outcome. Only count value you can actually justify from the evidence; if a link is speculative, discount it heavily.
-- **Quantify from the data you gathered** — affected user counts, conversion or retention deltas, error frequency, request volume, revenue per user, or engineering time saved. Convert these into dollars using the most defensible figures available; state your assumptions in the explanation.
+- **Quantify from the data you gathered** — affected user counts, conversion or retention deltas, error frequency, request volume, revenue per user, or engineering time saved. Convert these into dollars using the most defensible figures available; state assumptions in your internal reasoning, not in `explanation`.
 - **Factor in value over time.** Some fixes deliver a one-off gain; others compound or recur (e.g. an ongoing error suppressed every day, a conversion lift that persists). Reason about an appropriate horizon and apply **decay** where the value erodes (the issue would likely be fixed another way, traffic shifts, the feature is deprecated). Prefer a present-value-style estimate over a naive perpetual sum.
-- If the available data does not support a defensible estimate, set `dollar_value` to `null` rather than guessing wildly. Briefly note in the explanation how you arrived at the figure (or why you couldn't).
 
 Respond with a JSON object matching this schema:
 

--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -100,6 +100,14 @@ class PriorityAssessment(BaseModel):
         ),
     )
     priority: Priority = Field(description="Priority (P0-P4)")
+    dollar_value: float | None = Field(
+        default=None,
+        description=(
+            "Estimated real dollar value of merging the fix/change this report leads to, in USD. "
+            "Trace the causal path from merging to business outcomes and quantify it. "
+            "None when the value cannot be reasonably estimated from the available data."
+        ),
+    )
 
     @field_validator("explanation")
     @classmethod
@@ -450,6 +458,15 @@ def build_priority_prompt(
 {previous_priority_context}
 
 Base your priority on **evidence from your research** — quantified user impact, error frequency, or scope of affected code paths — not just the signal descriptions.
+
+## Dollar value estimation
+
+Also estimate the **real dollar value** (in USD) of merging the fix or change this report leads to. This is a best-effort economic estimate, not a priority proxy — a low-priority change can be high-value and vice versa.
+
+- **Trace the causal path** from merging the change to business outcomes. Be explicit with yourself about each link: merge → behavior change → user/revenue/cost outcome. Only count value you can actually justify from the evidence; if a link is speculative, discount it heavily.
+- **Quantify from the data you gathered** — affected user counts, conversion or retention deltas, error frequency, request volume, revenue per user, or engineering time saved. Convert these into dollars using the most defensible figures available; state your assumptions in the explanation.
+- **Factor in value over time.** Some fixes deliver a one-off gain; others compound or recur (e.g. an ongoing error suppressed every day, a conversion lift that persists). Reason about an appropriate horizon and apply **decay** where the value erodes (the issue would likely be fixed another way, traffic shifts, the feature is deprecated). Prefer a present-value-style estimate over a naive perpetual sum.
+- If the available data does not support a defensible estimate, set `dollar_value` to `null` rather than guessing wildly. Briefly note in the explanation how you arrived at the figure (or why you couldn't).
 
 Respond with a JSON object matching this schema:
 

--- a/products/signals/backend/test/test_agentic_report_activity.py
+++ b/products/signals/backend/test/test_agentic_report_activity.py
@@ -82,6 +82,7 @@ def _build_research_output() -> ReportResearchOutput:
         priority=PriorityAssessment(
             explanation="The regression affects a core onboarding flow and should be addressed quickly.",
             priority=Priority.P1,
+            dollar_value=5000.0,
         ),
     )
 
@@ -303,7 +304,7 @@ async def test_run_agentic_report_activity_persists_artefacts(monkeypatch, ateam
         assert priority_content == {
             "priority": "P1",
             "explanation": "The regression affects a core onboarding flow and should be addressed quickly.",
-            "dollar_value": None,
+            "dollar_value": 5000.0,
         }
 
         repo_selection_content = json.loads(artefacts[2].content)

--- a/products/signals/backend/test/test_agentic_report_activity.py
+++ b/products/signals/backend/test/test_agentic_report_activity.py
@@ -303,6 +303,7 @@ async def test_run_agentic_report_activity_persists_artefacts(monkeypatch, ateam
         assert priority_content == {
             "priority": "P1",
             "explanation": "The regression affects a core onboarding flow and should be addressed quickly.",
+            "dollar_value": None,
         }
 
         repo_selection_content = json.loads(artefacts[2].content)


### PR DESCRIPTION
## Problem

We want to explore outcome-based pricing for autonomous Signals work. Pricing per line of code is meaningless, even priority is only a rough proxy. If the research agent already has the data and context to judge priority, it can also take a stab at the _real_ dollar value of the change it leads to.

Will this work? Let's see!

## Changes

Adding an optional `dollar_value` to the priority judgement. Take a look at the prompt for the logic of it.

It will cost some extra tokens, but I think that's entirely worth the experiment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1781020153754339?thread_ts=1781020153.754339&cid=C09SK2PAGKF)*
