### PR TITLE
chore(batch-exports): time-bound async fixture teardown

### DIFF
--- a/products/batch_exports/backend/tests/conftest.py
+++ b/products/batch_exports/backend/tests/conftest.py
@@ -5,7 +5,7 @@ from asgiref.sync import sync_to_async
 
 from posthog.models import Organization, Team
 
-from products.batch_exports.backend.tests.teardown import adelete_best_effort
+from products.batch_exports.backend.tests.teardown import arun_best_effort
 
 
 @pytest_asyncio.fixture
@@ -15,7 +15,7 @@ async def aorganization(db):
 
     yield org
 
-    await adelete_best_effort(org)
+    await arun_best_effort(org.delete, label="organization")
 
 
 @pytest_asyncio.fixture
@@ -27,6 +27,5 @@ async def ateam(aorganization):
     yield team
     # team.delete() CASCADE-deletes BatchExport rows; Temporal schedules in CI don't
     # need explicit removal. The cascade can block indefinitely on an uncancellable
-    # backend call (sync_to_async threads blocked on gRPC can't be cancelled by
-    # asyncio), so the delete is time-bounded — see adelete_best_effort.
-    await adelete_best_effort(team)
+    # backend call, so it's run time-bounded — see arun_best_effort.
+    await arun_best_effort(team.delete, label="team")

--- a/products/batch_exports/backend/tests/conftest.py
+++ b/products/batch_exports/backend/tests/conftest.py
@@ -5,6 +5,8 @@ from asgiref.sync import sync_to_async
 
 from posthog.models import Organization, Team
 
+from products.batch_exports.backend.tests.teardown import adelete_best_effort
+
 
 @pytest_asyncio.fixture
 async def aorganization(db):
@@ -13,7 +15,7 @@ async def aorganization(db):
 
     yield org
 
-    await sync_to_async(org.delete)()
+    await adelete_best_effort(org)
 
 
 @pytest_asyncio.fixture
@@ -23,8 +25,8 @@ async def ateam(aorganization):
     team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
 
     yield team
-    # Skip Temporal schedule cleanup — team.delete() CASCADE-deletes BatchExport
-    # rows from the DB, and Temporal schedules in CI don't need explicit removal.
-    # Calling delete_batch_exports() here can hang indefinitely because
-    # sync_to_async threads blocked on gRPC cannot be cancelled by asyncio.
-    await sync_to_async(team.delete)()
+    # team.delete() CASCADE-deletes BatchExport rows; Temporal schedules in CI don't
+    # need explicit removal. The cascade can block indefinitely on an uncancellable
+    # backend call (sync_to_async threads blocked on gRPC can't be cancelled by
+    # asyncio), so the delete is time-bounded — see adelete_best_effort.
+    await adelete_best_effort(team)

--- a/products/batch_exports/backend/tests/teardown.py
+++ b/products/batch_exports/backend/tests/teardown.py
@@ -1,0 +1,57 @@
+import sys
+import asyncio
+import threading
+from typing import Protocol
+
+# A fresh test org/team owns no person, cohort, or group rows, so its cascade
+# delete is sub-second. A teardown delete that runs longer than this is wedged on
+# an uncancellable backend call — historically a personhog gRPC delete that blocks
+# the sync_to_async worker thread, which asyncio cannot cancel. When that happens
+# the product-test shard burns its wall-clock cap and is cancelled, blocking
+# unrelated PRs and the deploy gate. Bounding the call trades a leaked row
+# (harmless: randomized names, reused/rebuilt test DB) for a session that always
+# makes progress.
+DEFAULT_TEARDOWN_DELETE_TIMEOUT_SECONDS = 10.0
+
+
+class SupportsDelete(Protocol):
+    def delete(self) -> object: ...
+
+
+async def adelete_best_effort(
+    instance: SupportsDelete, *, timeout: float = DEFAULT_TEARDOWN_DELETE_TIMEOUT_SECONDS
+) -> bool:
+    """Delete a model instance during async fixture teardown without letting a hung
+    backend call wedge the test session.
+
+    The delete runs on a daemon thread. If it finishes within ``timeout`` the outcome
+    matches a direct ``instance.delete()`` (success, or a propagated error). If it does
+    not, we abandon the thread and return ``False``: daemon threads do not block
+    interpreter exit, so a leaked one is harmless — unlike asgiref's ``sync_to_async``
+    pool, whose non-daemon workers would still hang the process on exit even after
+    ``asyncio.wait_for`` gave up on the awaiting coroutine.
+
+    Returns ``True`` if the delete completed, ``False`` if it was abandoned.
+    """
+    finished = threading.Event()
+    error: list[Exception] = []
+
+    def _delete() -> None:
+        try:
+            instance.delete()
+        except Exception as exc:
+            error.append(exc)
+        finally:
+            finished.set()
+
+    threading.Thread(target=_delete, name=f"teardown-delete-{type(instance).__name__}", daemon=True).start()
+
+    completed = await asyncio.get_running_loop().run_in_executor(None, finished.wait, timeout)
+    if not completed:
+        sys.stderr.write(
+            f"abandoned hung {type(instance).__name__}.delete() teardown after {timeout}s (uncancellable backend call)\n"
+        )
+        return False
+    if error:
+        raise error[0]
+    return True

--- a/products/batch_exports/backend/tests/teardown.py
+++ b/products/batch_exports/backend/tests/teardown.py
@@ -10,8 +10,9 @@ logger = structlog.get_logger(__name__)
 
 # A fresh test org/team owns no person, cohort, or group rows, so its cascade
 # delete is sub-second. A teardown call that runs longer than this is wedged on
-# an uncancellable backend call — historically a personhog gRPC delete that
-# blocks the worker thread, which asyncio cannot cancel. When that happens the
+# an uncancellable backend call — e.g. delete_batch_exports()'s Temporal schedule
+# delete, or a cascade delete that reaches a gRPC-backed service — that blocks the
+# worker thread, which asyncio cannot cancel. When that happens the
 # product-test shard burns its wall-clock cap and is cancelled, blocking
 # unrelated PRs and the deploy gate. Bounding the call lets the session keep
 # making progress; that one teardown's rows are left behind, which is harmless

--- a/products/batch_exports/backend/tests/teardown.py
+++ b/products/batch_exports/backend/tests/teardown.py
@@ -1,57 +1,63 @@
-import sys
 import asyncio
 import threading
-from typing import Protocol
+from collections.abc import Callable
+
+from django.db import close_old_connections
+
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # A fresh test org/team owns no person, cohort, or group rows, so its cascade
-# delete is sub-second. A teardown delete that runs longer than this is wedged on
-# an uncancellable backend call — historically a personhog gRPC delete that blocks
-# the sync_to_async worker thread, which asyncio cannot cancel. When that happens
-# the product-test shard burns its wall-clock cap and is cancelled, blocking
-# unrelated PRs and the deploy gate. Bounding the call trades a leaked row
-# (harmless: randomized names, reused/rebuilt test DB) for a session that always
-# makes progress.
-DEFAULT_TEARDOWN_DELETE_TIMEOUT_SECONDS = 10.0
+# delete is sub-second. A teardown call that runs longer than this is wedged on
+# an uncancellable backend call — historically a personhog gRPC delete that
+# blocks the worker thread, which asyncio cannot cancel. When that happens the
+# product-test shard burns its wall-clock cap and is cancelled, blocking
+# unrelated PRs and the deploy gate. Bounding the call lets the session keep
+# making progress; that one teardown's rows are left behind, which is harmless
+# because fixture names are randomized so leaked rows never collide with a later
+# test (note: --reuse-db keeps the DB across runs, so they are not auto-cleared).
+DEFAULT_TEARDOWN_TIMEOUT_SECONDS = 10.0
 
 
-class SupportsDelete(Protocol):
-    def delete(self) -> object: ...
-
-
-async def adelete_best_effort(
-    instance: SupportsDelete, *, timeout: float = DEFAULT_TEARDOWN_DELETE_TIMEOUT_SECONDS
+async def arun_best_effort(
+    fn: Callable[[], object], *, label: str, timeout: float = DEFAULT_TEARDOWN_TIMEOUT_SECONDS
 ) -> bool:
-    """Delete a model instance during async fixture teardown without letting a hung
-    backend call wedge the test session.
+    """Run a blocking teardown call on a daemon thread, bounded by ``timeout``.
 
-    The delete runs on a daemon thread. If it finishes within ``timeout`` the outcome
-    matches a direct ``instance.delete()`` (success, or a propagated error). If it does
-    not, we abandon the thread and return ``False``: daemon threads do not block
-    interpreter exit, so a leaked one is harmless — unlike asgiref's ``sync_to_async``
-    pool, whose non-daemon workers would still hang the process on exit even after
+    If ``fn`` finishes within ``timeout`` the outcome matches calling it directly
+    (success, or a propagated exception). If it does not, we abandon the thread
+    and return ``False``: daemon threads do not block interpreter exit, so a
+    leaked one is harmless — unlike asgiref's ``sync_to_async`` pool, whose
+    non-daemon workers would still hang the process on exit even after
     ``asyncio.wait_for`` gave up on the awaiting coroutine.
 
-    Returns ``True`` if the delete completed, ``False`` if it was abandoned.
+    Returns ``True`` if the call completed, ``False`` if it was abandoned.
     """
     finished = threading.Event()
-    error: list[Exception] = []
+    captured: Exception | None = None
 
-    def _delete() -> None:
+    def _run() -> None:
+        nonlocal captured
         try:
-            instance.delete()
+            fn()
         except Exception as exc:
-            error.append(exc)
+            captured = exc
         finally:
+            # This thread opened its own thread-local Django connection; with
+            # CONN_MAX_AGE=0 and no request cycle to reap it, close it here so
+            # teardowns don't leak connections toward Postgres max_connections.
+            # (On the abandoned path the thread is stuck in fn() and never gets
+            # here — that single leaked connection is the cost of the timeout.)
+            close_old_connections()
             finished.set()
 
-    threading.Thread(target=_delete, name=f"teardown-delete-{type(instance).__name__}", daemon=True).start()
+    threading.Thread(target=_run, name=f"teardown-{label}", daemon=True).start()
 
     completed = await asyncio.get_running_loop().run_in_executor(None, finished.wait, timeout)
     if not completed:
-        sys.stderr.write(
-            f"abandoned hung {type(instance).__name__}.delete() teardown after {timeout}s (uncancellable backend call)\n"
-        )
+        logger.warning("teardown_call_abandoned", label=label, timeout_seconds=timeout)
         return False
-    if error:
-        raise error[0]
+    if captured is not None:
+        raise captured
     return True

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -2,6 +2,7 @@ import uuid
 import random
 import asyncio
 import datetime as dt
+import functools
 
 import pytest
 
@@ -26,6 +27,7 @@ from posthog.temporal.tests.utils.events import generate_test_events_in_clickhou
 
 from products.batch_exports.backend.temporal import ACTIVITIES, WORKFLOWS
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
+from products.batch_exports.backend.tests.teardown import arun_best_effort
 from products.batch_exports.backend.tests.temporal.utils.persons import (
     generate_test_person_distinct_id2_in_clickhouse,
     generate_test_persons_in_clickhouse,
@@ -83,7 +85,7 @@ async def aorganization(db):
 
     yield org
 
-    await sync_to_async(org.delete)()
+    await arun_best_effort(org.delete, label="organization")
 
 
 @pytest_asyncio.fixture
@@ -92,8 +94,10 @@ async def ateam(aorganization):
     team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
 
     yield team
-    await sync_to_async(delete_batch_exports)(team_ids=[team.pk])
-    await sync_to_async(team.delete)()
+    # delete_batch_exports() is the uncancellable personhog gRPC path that hangs
+    # teardown; bound it and the cascade delete so a wedge can't burn the shard.
+    await arun_best_effort(functools.partial(delete_batch_exports, team_ids=[team.pk]), label="delete_batch_exports")
+    await arun_best_effort(team.delete, label="team")
 
 
 @pytest_asyncio.fixture
@@ -102,8 +106,8 @@ async def another_ateam(aorganization):
     team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
 
     yield team
-    await sync_to_async(delete_batch_exports)(team_ids=[team.pk])
-    await sync_to_async(team.delete)()
+    await arun_best_effort(functools.partial(delete_batch_exports, team_ids=[team.pk]), label="delete_batch_exports")
+    await arun_best_effort(team.delete, label="team")
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -66,6 +66,13 @@ def organization():
     org.delete()
 
 
+def _delete_team_and_exports(team: Team) -> None:
+    # delete_batch_exports() is the uncancellable personhog gRPC path that can hang
+    # teardown; the async fixtures run this bounded via arun_best_effort.
+    delete_batch_exports(team_ids=[team.pk])
+    team.delete()
+
+
 @pytest.fixture
 def team(organization):
     """A test team."""
@@ -74,8 +81,7 @@ def team(organization):
     team.save()
 
     yield team
-    delete_batch_exports(team_ids=[team.pk])
-    team.delete()
+    _delete_team_and_exports(team)
 
 
 @pytest_asyncio.fixture
@@ -94,10 +100,7 @@ async def ateam(aorganization):
     team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
 
     yield team
-    # delete_batch_exports() is the uncancellable personhog gRPC path that hangs
-    # teardown; bound it and the cascade delete so a wedge can't burn the shard.
-    await arun_best_effort(functools.partial(delete_batch_exports, team_ids=[team.pk]), label="delete_batch_exports")
-    await arun_best_effort(team.delete, label="team")
+    await arun_best_effort(functools.partial(_delete_team_and_exports, team), label="team_cleanup")
 
 
 @pytest_asyncio.fixture
@@ -106,8 +109,7 @@ async def another_ateam(aorganization):
     team = await sync_to_async(Team.objects.create)(organization=aorganization, name=name)
 
     yield team
-    await arun_best_effort(functools.partial(delete_batch_exports, team_ids=[team.pk]), label="delete_batch_exports")
-    await arun_best_effort(team.delete, label="team")
+    await arun_best_effort(functools.partial(_delete_team_and_exports, team), label="team_cleanup")
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -67,8 +67,9 @@ def organization():
 
 
 def _delete_team_and_exports(team: Team) -> None:
-    # delete_batch_exports() is the uncancellable personhog gRPC path that can hang
-    # teardown; the async fixtures run this bounded via arun_best_effort.
+    # delete_batch_exports() makes Temporal client calls (sync_connect + schedule
+    # delete) that can block teardown if Temporal is slow/unreachable; the async
+    # fixtures run this bounded via arun_best_effort so a wedge can't burn the shard.
     delete_batch_exports(team_ids=[team.pk])
     team.delete()
 

--- a/products/batch_exports/backend/tests/test_teardown.py
+++ b/products/batch_exports/backend/tests/test_teardown.py
@@ -1,0 +1,49 @@
+import time
+import threading
+
+import pytest
+
+from products.batch_exports.backend.tests.teardown import adelete_best_effort
+
+
+class _FakeDeletable:
+    def __init__(self, block: threading.Event | None = None, error: Exception | None = None) -> None:
+        self._block = block
+        self._error = error
+        self.deleted = False
+
+    def delete(self) -> None:
+        if self._block is not None:
+            self._block.wait()  # hang until released, simulating a wedged backend call
+        if self._error is not None:
+            raise self._error
+        self.deleted = True
+
+
+async def test_adelete_best_effort_completes_normally():
+    obj = _FakeDeletable()
+
+    assert await adelete_best_effort(obj, timeout=5) is True
+    assert obj.deleted is True
+
+
+async def test_adelete_best_effort_abandons_hung_delete():
+    release = threading.Event()
+    obj = _FakeDeletable(block=release)
+
+    start = time.monotonic()
+    try:
+        completed = await adelete_best_effort(obj, timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        assert completed is False
+        assert elapsed < 2  # returned at the timeout instead of hanging on the blocked delete
+    finally:
+        release.set()  # unblock the daemon thread so it exits cleanly
+
+
+async def test_adelete_best_effort_propagates_real_errors():
+    obj = _FakeDeletable(error=ValueError("boom"))
+
+    with pytest.raises(ValueError, match="boom"):
+        await adelete_best_effort(obj, timeout=5)

--- a/products/batch_exports/backend/tests/test_teardown.py
+++ b/products/batch_exports/backend/tests/test_teardown.py
@@ -1,9 +1,14 @@
 import time
+import random
 import threading
 
 import pytest
 
-from products.batch_exports.backend.tests.teardown import adelete_best_effort
+from asgiref.sync import sync_to_async
+
+from posthog.models import Organization
+
+from products.batch_exports.backend.tests.teardown import arun_best_effort
 
 
 class _FakeDeletable:
@@ -20,30 +25,41 @@ class _FakeDeletable:
         self.deleted = True
 
 
-async def test_adelete_best_effort_completes_normally():
+async def test_arun_best_effort_completes_normally():
     obj = _FakeDeletable()
 
-    assert await adelete_best_effort(obj, timeout=5) is True
+    assert await arun_best_effort(obj.delete, label="fake") is True
     assert obj.deleted is True
 
 
-async def test_adelete_best_effort_abandons_hung_delete():
+async def test_arun_best_effort_abandons_hung_call():
     release = threading.Event()
     obj = _FakeDeletable(block=release)
 
     start = time.monotonic()
     try:
-        completed = await adelete_best_effort(obj, timeout=0.2)
+        completed = await arun_best_effort(obj.delete, label="fake", timeout=0.2)
         elapsed = time.monotonic() - start
 
         assert completed is False
-        assert elapsed < 2  # returned at the timeout instead of hanging on the blocked delete
+        assert 0.2 <= elapsed < 2  # returned at the timeout bound, not before and not hung
     finally:
         release.set()  # unblock the daemon thread so it exits cleanly
 
 
-async def test_adelete_best_effort_propagates_real_errors():
+async def test_arun_best_effort_propagates_real_errors():
     obj = _FakeDeletable(error=ValueError("boom"))
 
     with pytest.raises(ValueError, match="boom"):
-        await adelete_best_effort(obj, timeout=5)
+        await arun_best_effort(obj.delete, label="fake")
+
+
+async def test_arun_best_effort_deletes_a_real_model(db):
+    # Guards the actual change: the delete runs on a different thread/connection
+    # than the create, so prove it still removes a real committed row.
+    org = await sync_to_async(Organization.objects.create)(
+        name=f"TeardownTest-{random.randint(1, 99999)}", is_ai_data_processing_approved=True
+    )
+
+    assert await arun_best_effort(org.delete, label="organization") is True
+    assert await sync_to_async(Organization.objects.filter(pk=org.pk).exists)() is False


### PR DESCRIPTION
## Problem

The `batch-exports` product-test shard intermittently (~1 in 7 runs) hangs in the shared async fixture teardown for `ateam` / `aorganization`. The teardown's cascade `delete()` blocks on an uncancellable backend call — a `sync_to_async` worker thread stuck on a gRPC delete, which asyncio cannot cancel. The shard then burns its full 40-minute wall-clock cap and is cancelled. Because that job is grouped with other products' tests and feeds the deploy gate, the hang blocks unrelated PRs and the `Container Images CD` master gate.

## Changes

- New `adelete_best_effort()` helper: runs the teardown `delete()` on a **daemon** thread and bounds it with a timeout. If the delete wedges, the thread is abandoned and the session continues; if it completes, success and real errors behave exactly like a direct `.delete()`.
- `ateam` / `aorganization` teardowns now call it. A leaked org/team row on the rare abandon is harmless — randomized names, reused/rebuilt test DB.

Why a daemon thread and not `asyncio.wait_for`: `wait_for` unblocks the awaiting coroutine but the underlying non-daemon `sync_to_async` pool thread still joins at interpreter exit, re-hanging the process. Daemon threads don't block exit, which is why this approach actually holds.

This is a **test-infra mitigation**, not the root fix. The underlying product behaviour — a gRPC delete that can block without a deadline — is tracked separately: capture the exact blocking frame, then bound it at source so production gets the same protection.

Out of scope: `conftest_legacy.py`'s sync fixtures (main-thread deletes are signal-interruptible, and the file is currently unused).

## How did you test this code?

I'm an agent (Claude Code); automated checks only:
- Added `test_teardown.py` covering three behaviours: a normal delete completes, a hung delete is abandoned at the timeout (returns promptly without wedging), and real errors propagate.
- Validated the helper logic standalone (asyncio + a fake whose `delete()` blocks): the hung delete returned in 0.21s under a 0.2s timeout; normal and error paths correct.
- `ruff check` / `ruff format` clean; `ty` type-check passed via lint-staged.
- Did not run the full batch-exports suite locally (needs the DB/Temporal stack) — CI covers that.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by the assignee. Investigation traced the recurring `Django Tests Pass` / CD-gate cancellations to this fixture teardown hang — not the shared Django Temporal segment, and not a single slow test. Rejected alternatives: (a) skipping individual tests, since the flake lives in a fixture used by ~35 files so a skip just relocates it; (b) sharding batch-exports into its own job, which shrinks the blast radius but leaves the dedicated shard hanging and still failing the gate. Chose to bound the teardown at the fixture so the session always makes progress while the source fix is handled separately.
