### PR TITLE
fix(oauth): reject CIMD scope sets that strip to nothing

### DIFF
--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -346,6 +346,13 @@ def _resolve_scopes(metadata: CIMDMetadataDocument) -> list[str] | None:
     """Resolve the allow-listed `com.posthog.scopes` for an app, or None when the field
     is absent so callers leave existing scopes untouched. A present field returns a
     (possibly empty) list, capped to grantable scopes by `filter_to_unprivileged_scopes`.
+
+    Raises CIMDValidationError when the field is present and non-empty but every entry is
+    non-grantable. An empty ceiling falls back to the broad UNPRIVILEGED_SCOPES default
+    (`effective_ceiling`), so silently storing `[]` here would widen a misconfigured app
+    to the full default surface — broader than it asked for. Reject it the way DCR rejects
+    an all-stripped `scope` string, so the partner fixes their metadata. An explicitly empty
+    list is left as the legitimate "use default" signal, same as an absent field.
     """
     com_posthog = metadata.get("com.posthog")
     if not isinstance(com_posthog, dict):
@@ -354,7 +361,13 @@ def _resolve_scopes(metadata: CIMDMetadataDocument) -> list[str] | None:
     raw_scopes: object = com_posthog.get("scopes")
     if not isinstance(raw_scopes, list):
         return None
-    return filter_to_unprivileged_scopes(raw_scopes)
+    filtered = filter_to_unprivileged_scopes(raw_scopes)
+    if raw_scopes and not filtered:
+        raise CIMDValidationError(
+            "None of the declared com.posthog.scopes are available to self-registered clients. "
+            "Remove the field to register with the default scope set."
+        )
+    return filtered
 
 
 def _create_cimd_application(url: str, metadata: CIMDMetadataDocument) -> OAuthApplication:

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -1,6 +1,7 @@
 import json
 import base64
 import hashlib
+from typing import cast
 from urllib.parse import urlencode
 
 import pytest
@@ -21,6 +22,7 @@ from posthog.api.oauth.cimd import (
     CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
     CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
     CIMDFetchError,
+    CIMDMetadataDocument,
     CIMDValidationError,
     _fetch_lock_key,
     _resolve_scopes,
@@ -1096,7 +1098,8 @@ class TestResolveScopes(SimpleTestCase):
     def test_absent_or_malformed_field_returns_none(self) -> None:
         self.assertIsNone(_resolve_scopes({}))
         self.assertIsNone(_resolve_scopes({"com.posthog": {}}))
-        self.assertIsNone(_resolve_scopes({"com.posthog": {"scopes": "not-a-list"}}))
+        # Malformed partner JSON: a non-list scopes value hits the runtime guard and returns None.
+        self.assertIsNone(_resolve_scopes(cast(CIMDMetadataDocument, {"com.posthog": {"scopes": "not-a-list"}})))
 
     def test_explicit_empty_list_is_use_default(self) -> None:
         # Distinct from all-stripped: an explicitly empty array is the legitimate "use default" signal.

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.core.cache import cache as real_cache
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 import requests
 from cryptography.hazmat.primitives import serialization
@@ -23,6 +23,7 @@ from posthog.api.oauth.cimd import (
     CIMDFetchError,
     CIMDValidationError,
     _fetch_lock_key,
+    _resolve_scopes,
     fetch_and_upsert_cimd_application,
     fetch_cimd_metadata,
     get_application_by_client_id,
@@ -1056,3 +1057,55 @@ class TestCIMDComPostHogNamespace(APIBaseTest):
 
         assert app is not None
         self.assertEqual(app.scopes, [])
+
+    # A present, non-empty com.posthog.scopes that strips to nothing is rejected, not
+    # stored as [] (which would widen the app to the broad UNPRIVILEGED default via the
+    # empty-ceiling fallback). Mirrors DCR's all-stripped rejection; no app is created.
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_all_non_grantable_scopes_on_creation_rejected(self, mock_get, _url_mock):
+        only_non_grantable = [*sorted(PRIVILEGED_SCOPES), "not_a_real_scope:write"]
+        mock_get.return_value = _mock_response(_make_metadata(com_posthog={"scopes": only_non_grantable}), headers={})
+
+        with self.assertRaises(CIMDValidationError):
+            fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+
+        self.assertFalse(OAuthApplication.objects.filter(cimd_metadata_url=VALID_CIMD_URL).exists())
+
+    # On refresh, a doc whose scopes all strip out is rejected and the existing ceiling is
+    # left untouched (fail-closed) rather than widened to the default.
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_all_non_grantable_scopes_on_refresh_leaves_existing_untouched(self, mock_get, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(com_posthog={"scopes": ["insight:read"]}), headers={})
+        created = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+        assert created is not None
+
+        real_cache.delete(_fetch_lock_key(VALID_CIMD_URL))
+        only_non_grantable = [*sorted(PRIVILEGED_SCOPES), "not_a_real_scope:write"]
+        mock_get.return_value = _mock_response(_make_metadata(com_posthog={"scopes": only_non_grantable}), headers={})
+
+        with self.assertRaises(CIMDValidationError):
+            fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+
+        created.refresh_from_db()
+        self.assertEqual(created.scopes, ["insight:read"])
+
+
+class TestResolveScopes(SimpleTestCase):
+    """`_resolve_scopes` parsing in isolation — no DB, so it runs without local services."""
+
+    def test_absent_or_malformed_field_returns_none(self) -> None:
+        self.assertIsNone(_resolve_scopes({}))
+        self.assertIsNone(_resolve_scopes({"com.posthog": {}}))
+        self.assertIsNone(_resolve_scopes({"com.posthog": {"scopes": "not-a-list"}}))
+
+    def test_explicit_empty_list_is_use_default(self) -> None:
+        # Distinct from all-stripped: an explicitly empty array is the legitimate "use default" signal.
+        self.assertEqual(_resolve_scopes({"com.posthog": {"scopes": []}}), [])
+
+    def test_partial_strip_keeps_grantable(self) -> None:
+        resolved = _resolve_scopes({"com.posthog": {"scopes": ["insight:read", "llm_gateway:read"]}})
+        self.assertEqual(resolved, ["insight:read"])
+
+    def test_all_non_grantable_raises(self) -> None:
+        with self.assertRaises(CIMDValidationError):
+            _resolve_scopes({"com.posthog": {"scopes": ["llm_gateway:read", "not_a_real_scope:write"]}})


### PR DESCRIPTION
## Problem

Follow-up to #62180 (which consolidated DCR + CIMD scope filtering into one helper). While reviewing that consolidation, I found a pre-existing asymmetry between the two self-registration paths in how they handle a declared scope set that filters down to nothing:

- **DCR** rejects a present `scope` string that strips to empty with `400 invalid_client_metadata`.
- **CIMD** stored the empty result as `[]`. An empty ceiling falls back to the broad `UNPRIVILEGED_SCOPES` default (`effective_ceiling`), so a CIMD client that declared only non-grantable scopes (e.g. `llm_gateway:read` plus junk) silently ended up with the **full unprivileged surface** as its ceiling — broader than it asked for, and the opposite of fail-closed.

Part of #60327.

## Changes

`_resolve_scopes` (`posthog/api/oauth/cimd.py`) now raises `CIMDValidationError` when `com.posthog.scopes` is present and non-empty but every entry is non-grantable, mirroring DCR's rejection instead of widening to the default.

- New-client registration: the synchronous fetch surfaces the error, so `validate_client_id` rejects the client (no app created with a too-broad ceiling).
- Refresh of an existing client: the background task already catches `CIMDValidationError`, so the refresh fails closed and the existing ceiling is left untouched rather than widened.
- An **explicitly empty** `scopes: []` is unchanged — it remains the legitimate "use the default scope set" signal, same as an absent field.

No behavior change for the common cases (partial strip keeps the grantable subset; absent field leaves scopes untouched).

## How did you test this code?

I'm an agent (Claude Code, agent-assisted). Automated tests only — no manual testing:

- Added `TestResolveScopes` (a no-DB `SimpleTestCase`) covering: absent/malformed field → `None`, explicit empty list → `[]`, partial strip keeps grantable, all-non-grantable raises. **Ran locally: 4 passed.**
- Added two DB-backed integration tests to `TestCIMDComPostHogNamespace`: all-non-grantable scopes on creation are rejected and no app is created; on refresh the existing ceiling is left untouched. These need Postgres, so they run in CI.
- `ruff check` / `ruff format` clean; pre-commit `ty` type check passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Matt directed this while reviewing #62180.

Authored with Claude Code. The asymmetry surfaced during a DCR-vs-CIMD scope-handling review of #62180. Considered two options: (a) make CIMD treat present-but-all-stripped like an absent field, or (b) reject it like DCR. Chose (b) because (a) doesn't fix the creation-time widening (absent → `[]` → broad default is the same problem), whereas rejecting is symmetric with DCR and fail-closed on both the create and refresh paths. The fix is contained to `_resolve_scopes`; the existing error-handling in the synchronous view and the background refresh task already route `CIMDValidationError` correctly.
