### PR TITLE
ci(backend): isolate batch-exports + add test kill switch

### DIFF
--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -12,8 +12,7 @@
 // Products under SMALL_THRESHOLD duration get grouped into one matrix entry
 // to avoid spinning up a full Docker stack for a handful of tests.
 // Durations come from .test_durations (maintained by pytest-split).
-// Products listed in DEDICATED_BUCKET_PRODUCTS opt out of this grouping and
-// always run alone, isolating flaky/hang-prone products from the rest.
+// DEDICATED_BUCKET_PRODUCTS opt out of grouping and always run alone.
 //
 // Input:  LEGACY_CHANGED env var ("true"/"false")
 //         SCHEMA_CHANGED env var ("true"/"false") — when set and LEGACY_CHANGED
@@ -42,24 +41,13 @@ const PRODUCT_SAFETY_FACTOR = 1.3
 // Tests under these paths need special infrastructure (Temporal server, etc.)
 // and are handled by Django CI's dedicated segments — exclude from duration estimates
 const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
-// Products that must never share a bucket — each always gets its own matrix
-// entry (its own runner) instead of being packed with others.
-//
-// Add a product's name (the @posthog/products-<name> suffix, e.g. 'batch-exports')
-// here when it is flaky, slow, or hang-prone enough that sharing a runner risks
-// cancelling unrelated products at the job timeout. batch-exports is isolated
-// because its intermittent async-fixture teardown hang would otherwise take
-// down whatever products were packed alongside it, and isolation lets the shard
-// be tuned independently. The trade-off is a dedicated runner (more CI minutes),
-// so reserve this for products that genuinely need it rather than as a default.
+// Products that always get their own matrix entry instead of being packed with
+// others — isolates a flaky/hang-prone product so it can't cancel bucket-mates
+// at the job timeout. Trade-off: a dedicated runner.
 const DEDICATED_BUCKET_PRODUCTS = new Set(['batch-exports'])
-// Temporary flakiness mitigation for batch-exports' intermittent async-fixture
-// teardown hang (remove once the source fix lands). Its isolated leg runs
-// non-blocking (a failing/flaky run no longer fails the CD gate) and is capped
-// at the 30-min product-test timeout that predated the recent bump to 40. The
-// timeout only bounds a hang's wall-clock — continue-on-error reliably masks a
-// test failure but not a timeout-induced cancellation. Each value's keys are
-// matrix fields the turbo-tests job reads as continue-on-error / timeout-minutes.
+// batch-exports soft-fail for its flaky async-teardown hang (revert once fixed):
+// non-blocking leg, capped at the pre-bump 30-min timeout. continue-on-error
+// masks a failure but not a timeout cancel. Keys → turbo-tests matrix fields.
 const SOFT_FAIL_PRODUCTS = {
     'batch-exports': { continue_on_error: true, timeout_minutes: 30 },
 }

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -53,6 +53,16 @@ const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 // be tuned independently. The trade-off is a dedicated runner (more CI minutes),
 // so reserve this for products that genuinely need it rather than as a default.
 const DEDICATED_BUCKET_PRODUCTS = new Set(['batch-exports'])
+// Temporary flakiness mitigation for batch-exports' intermittent async-fixture
+// teardown hang (remove once the source fix lands). Its isolated leg runs
+// non-blocking (a failing/flaky run no longer fails the CD gate) and is capped
+// at the 30-min product-test timeout that predated the recent bump to 40. The
+// timeout only bounds a hang's wall-clock — continue-on-error reliably masks a
+// test failure but not a timeout-induced cancellation. Each value's keys are
+// matrix fields the turbo-tests job reads as continue-on-error / timeout-minutes.
+const SOFT_FAIL_PRODUCTS = {
+    'batch-exports': { continue_on_error: true, timeout_minutes: 30 },
+}
 
 // --- Django shard auto-sizing (Amdahl's law) ---
 // wall_clock = overhead + (total_from_durations_file / shards)
@@ -315,6 +325,7 @@ function buildMatrix(products, durations) {
                 group: product,
                 filters: `--filter=@posthog/products-${product}`,
                 pytest_args: '',
+                ...SOFT_FAIL_PRODUCTS[product],
             })
         } else {
             packable.push(product)

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -45,12 +45,6 @@ const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 // others — isolates a flaky/hang-prone product so it can't cancel bucket-mates
 // at the job timeout. Trade-off: a dedicated runner.
 const DEDICATED_BUCKET_PRODUCTS = new Set(['batch-exports'])
-// batch-exports soft-fail for its flaky async-teardown hang (revert once fixed):
-// non-blocking leg, capped at the pre-bump 30-min timeout. continue-on-error
-// masks a failure but not a timeout cancel. Keys → turbo-tests matrix fields.
-const SOFT_FAIL_PRODUCTS = {
-    'batch-exports': { continue_on_error: true, timeout_minutes: 30 },
-}
 
 // --- Django shard auto-sizing (Amdahl's law) ---
 // wall_clock = overhead + (total_from_durations_file / shards)
@@ -313,7 +307,6 @@ function buildMatrix(products, durations) {
                 group: product,
                 filters: `--filter=@posthog/products-${product}`,
                 pytest_args: '',
-                ...SOFT_FAIL_PRODUCTS[product],
             })
         } else {
             packable.push(product)
@@ -424,6 +417,16 @@ if (legacyChanged) {
             runLegacy = true
         }
     }
+}
+
+// Kill switch: products named in the SKIP_PRODUCT_TESTS repo variable (comma-
+// separated) are dropped from the matrix without a code change — use it to stop
+// running, and blocking on, a product whose tests are temporarily too flaky.
+const skipProducts = new Set((process.env.SKIP_PRODUCT_TESTS || '').split(',').map((p) => p.trim()).filter(Boolean))
+if (skipProducts.size > 0) {
+    const before = products.length
+    products = products.filter((p) => !skipProducts.has(p))
+    console.error(`SKIP_PRODUCT_TESTS=${[...skipProducts].join(',')} — dropped ${before - products.length} product(s)`)
 }
 
 console.error(`Products to test: ${JSON.stringify(products)}`)

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -12,6 +12,8 @@
 // Products under SMALL_THRESHOLD duration get grouped into one matrix entry
 // to avoid spinning up a full Docker stack for a handful of tests.
 // Durations come from .test_durations (maintained by pytest-split).
+// Products listed in DEDICATED_BUCKET_PRODUCTS opt out of this grouping and
+// always run alone, isolating flaky/hang-prone products from the rest.
 //
 // Input:  LEGACY_CHANGED env var ("true"/"false")
 //         SCHEMA_CHANGED env var ("true"/"false") — when set and LEGACY_CHANGED
@@ -40,6 +42,17 @@ const PRODUCT_SAFETY_FACTOR = 1.3
 // Tests under these paths need special infrastructure (Temporal server, etc.)
 // and are handled by Django CI's dedicated segments — exclude from duration estimates
 const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
+// Products that must never share a bucket — each always gets its own matrix
+// entry (its own runner) instead of being packed with others.
+//
+// Add a product's name (the @posthog/products-<name> suffix, e.g. 'batch-exports')
+// here when it is flaky, slow, or hang-prone enough that sharing a runner risks
+// cancelling unrelated products at the job timeout. batch-exports is isolated
+// because its intermittent async-fixture teardown hang would otherwise take
+// down whatever products were packed alongside it, and isolation lets the shard
+// be tuned independently. The trade-off is a dedicated runner (more CI minutes),
+// so reserve this for products that genuinely need it rather than as a default.
+const DEDICATED_BUCKET_PRODUCTS = new Set(['batch-exports'])
 
 // --- Django shard auto-sizing (Amdahl's law) ---
 // wall_clock = overhead + (total_from_durations_file / shards)
@@ -296,6 +309,13 @@ function buildMatrix(products, durations) {
                     pytest_args: `-- --splits ${shards} --group ${i} --splitting-algorithm duration_based_chunks`,
                 })
             }
+        } else if (DEDICATED_BUCKET_PRODUCTS.has(product)) {
+            console.error(`  ${product}: ${(raw / 60).toFixed(1)} min raw → dedicated bucket (never packed)`)
+            matrix.push({
+                group: product,
+                filters: `--filter=@posthog/products-${product}`,
+                pytest_args: '',
+            })
         } else {
             packable.push(product)
         }

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -424,6 +424,16 @@ if (legacyChanged) {
 // running, and blocking on, a product whose tests are temporarily too flaky.
 const skipProducts = new Set((process.env.SKIP_PRODUCT_TESTS || '').split(',').map((p) => p.trim()).filter(Boolean))
 if (skipProducts.size > 0) {
+    // Warn loudly on a name that matches no real product (checked against the
+    // full product list, not just the affected ones) — catches the dash/
+    // underscore mixup where the dir is batch_exports but the product is
+    // batch-exports, which would otherwise silently skip nothing.
+    const allProductSet = new Set(allProducts)
+    for (const name of skipProducts) {
+        if (!allProductSet.has(name)) {
+            console.error(`::warning::SKIP_PRODUCT_TESTS: unknown product '${name}' — use the dashed name (e.g. 'batch-exports'), not the directory form`)
+        }
+    }
     const before = products.length
     products = products.filter((p) => !skipProducts.has(p))
     console.error(`SKIP_PRODUCT_TESTS=${[...skipProducts].join(',')} — dropped ${before - products.length} product(s)`)

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -416,6 +416,10 @@ jobs:
                   SCHEMA_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.schema }}
                   TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
                   TURBO_SCM_HEAD: ${{ github.sha }}
+                  # Kill switch: comma-separated product names to drop from the matrix.
+                  # Set the SKIP_PRODUCT_TESTS repo variable to stop running (and blocking
+                  # on) a product whose tests are temporarily too flaky; empty = run all.
+                  SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS }}
               run: |
                   # turbo-discover.js uses Turbo's Git affectedness to detect
                   # changed products. Non-isolated product changes trigger the
@@ -439,10 +443,7 @@ jobs:
             needs.turbo-discover.outputs.matrix != '[]' &&
             needs.turbo-discover.outputs.matrix != ''
         runs-on: depot-ubuntu-latest
-        # Per-leg overrides from the turbo-discover matrix (defaults for unset legs);
-        # batch-exports runs non-blocking with a tighter cap — see SOFT_FAIL_PRODUCTS.
-        timeout-minutes: ${{ matrix.timeout_minutes || 40 }}
-        continue-on-error: ${{ matrix.continue_on_error || false }}
+        timeout-minutes: 40
         name: Product tests (${{ matrix.group }})
         strategy:
             fail-fast: false

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -416,10 +416,8 @@ jobs:
                   SCHEMA_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.schema }}
                   TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
                   TURBO_SCM_HEAD: ${{ github.sha }}
-                  # Kill switch: comma-separated product names to drop from the matrix.
-                  # Set the SKIP_PRODUCT_TESTS repo variable to stop running (and blocking
-                  # on) a product whose tests are temporarily too flaky; empty = run all.
-                  SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS }}
+                  # Kill switch — drop comma-separated products from the matrix; empty = run all.
+                  SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS || '' }}
               run: |
                   # turbo-discover.js uses Turbo's Git affectedness to detect
                   # changed products. Non-isolated product changes trigger the

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -439,10 +439,8 @@ jobs:
             needs.turbo-discover.outputs.matrix != '[]' &&
             needs.turbo-discover.outputs.matrix != ''
         runs-on: depot-ubuntu-latest
-        # Per-leg overrides (matrix entries from turbo-discover; default for unset legs):
-        # batch-exports runs non-blocking with a tighter cap to keep its async-teardown
-        # flakiness off the CD gate. continue-on-error masks a failing run but not a
-        # timeout-induced cancellation — the tighter timeout only bounds a hang's wall-clock.
+        # Per-leg overrides from the turbo-discover matrix (defaults for unset legs);
+        # batch-exports runs non-blocking with a tighter cap — see SOFT_FAIL_PRODUCTS.
         timeout-minutes: ${{ matrix.timeout_minutes || 40 }}
         continue-on-error: ${{ matrix.continue_on_error || false }}
         name: Product tests (${{ matrix.group }})

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -439,7 +439,12 @@ jobs:
             needs.turbo-discover.outputs.matrix != '[]' &&
             needs.turbo-discover.outputs.matrix != ''
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 40
+        # Per-leg overrides (matrix entries from turbo-discover; default for unset legs):
+        # batch-exports runs non-blocking with a tighter cap to keep its async-teardown
+        # flakiness off the CD gate. continue-on-error masks a failing run but not a
+        # timeout-induced cancellation — the tighter timeout only bounds a hang's wall-clock.
+        timeout-minutes: ${{ matrix.timeout_minutes || 40 }}
+        continue-on-error: ${{ matrix.continue_on_error || false }}
         name: Product tests (${{ matrix.group }})
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Problem

batch-exports' product tests share CI runners with other small products (turbo-discover bin-packs sub-target products into one "Product tests" bucket), and the suite has an intermittent async-fixture teardown hang. A hang cancels the whole shared bucket at the job timeout — taking unrelated products down with it and blocking the `Django Tests Pass` gate that CD waits on.

## Changes

1. **Isolate** (`turbo-discover.js`): a `DEDICATED_BUCKET_PRODUCTS` set — listed products (currently `batch-exports`) always get their own matrix entry instead of being packed with others, so a hang/flake can't cancel unrelated products. Reusable extension point.
2. **Kill switch** (`turbo-discover.js` + `ci-backend.yml`): products named in the `SKIP_PRODUCT_TESTS` repository variable (comma-separated) are dropped from the matrix. Toggle it in the GitHub UI — no code change, no deploy — to stop running, and blocking on, a product whose tests are temporarily too flaky. Unset/empty (the default) runs everything.

### Why a skip toggle, not `continue-on-error`?

`continue-on-error` only reliably masks a test *failure*, not a *hang* — a hang hits `timeout-minutes`, GitHub records it as `cancelled`, and the gate blocks on `cancelled`. Whether `continue-on-error` covers a timeout is undocumented and tested community reports contradict each other, so it's not a guarantee. Skipping needs no such guarantee: a product absent from the matrix can't contribute a failure or cancel to `needs.turbo-tests.result`. Certain, and reverts by clearing one variable.

## How to use

To stop batch-exports blocking CI (e.g. while the teardown hang is unfixed):
- GitHub → Settings → Secrets and variables → Actions → Variables → New repository variable
- Name `SKIP_PRODUCT_TESTS`, value `batch-exports`
- Clear it (or set empty) to re-enable.

## How did you test this code?

Agent-authored. Automated checks run locally:
- `node --check` on `turbo-discover.js`; YAML parse + `actionlint` (CI-faithful, shellcheck error-only) on `ci-backend.yml` — clean.
- Sandbox-ran the skip filter: unset/empty → run all; `batch-exports` → dropped; whitespace trimmed; unknown name → no-op. And `buildMatrix`: batch-exports gets its own bucket, others packed, large/split path unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Iterated through approaches: bucket isolation (the original ask), then a `continue-on-error` + per-leg `timeout` soft-fail — dropped after confirming `continue-on-error` can't be relied on to mask a job-`timeout` `cancellation` (docs silent; tested community reports contradict each other). Landed on a repo-variable kill switch as the certain, simplest, reusable way to make a product non-blocking, plus the permanent isolation. `SKIP_PRODUCT_TESTS` must be created in repo settings to take effect; absent, it's a no-op.
