### PR TITLE
chore(propdefs): add retries + metrics for person calls

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -114,6 +114,15 @@ pub struct Config {
 
     #[envconfig(default = "5000")]
     pub personhog_connect_timeout_ms: u64,
+
+    #[envconfig(default = "2")]
+    pub personhog_max_retries: u32,
+
+    #[envconfig(default = "50")]
+    pub personhog_initial_backoff_ms: u64,
+
+    #[envconfig(default = "1000")]
+    pub personhog_max_backoff_ms: u64,
 }
 
 #[derive(Clone)]

--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -3,22 +3,115 @@ use personhog_proto::personhog::{
     types::v1::{ConsistencyLevel, GetGroupTypeMappingsByTeamIdsRequest, ReadOptions},
 };
 use quick_cache::sync::Cache;
+use rand::Rng;
 use std::collections::HashMap;
+use std::future::Future;
+use std::time::Duration;
+use tokio::time::sleep;
 use tonic::transport::Channel;
+use tonic::{Code, Status};
 use tracing::{info, warn};
 
 use crate::{
     config::Config,
     metrics_consts::{
         GROUP_TYPE_CACHE, PERSONHOG_ERRORS_TOTAL, PERSONHOG_RESOLVE_DURATION,
-        PERSONHOG_RESOLVE_ERRORS,
+        PERSONHOG_RESOLVE_ERRORS, PERSONHOG_RETRIES_TOTAL, PERSONHOG_TERMINAL_ERRORS_TOTAL,
     },
     types::{GroupType, Update},
 };
 
+const METHOD: &str = "GetGroupTypeMappingsByTeamIds";
+const CLIENT: &str = "property-defs-rs";
+
+fn is_retryable(code: Code) -> bool {
+    matches!(
+        code,
+        Code::Unavailable
+            | Code::DeadlineExceeded
+            | Code::ResourceExhausted
+            | Code::Aborted
+            | Code::Internal
+            | Code::Unknown
+    )
+}
+
+/// Retry a gRPC call with exponential backoff and jitter on transient errors.
+///
+/// Emits `personhog_errors_total` on every failed attempt, `personhog_retries_total`
+/// on each retry, and `personhog_terminal_errors_total` when giving up.
+async fn with_retry<F, Fut, T>(
+    max_retries: u32,
+    initial_backoff_ms: u64,
+    max_backoff_ms: u64,
+    method: &'static str,
+    client: &'static str,
+    mut make_call: F,
+) -> Result<T, Status>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, Status>>,
+{
+    let mut attempt = 0;
+    let mut delay_ms = initial_backoff_ms;
+
+    loop {
+        match make_call().await {
+            Ok(value) => return Ok(value),
+            Err(status) => {
+                let error_type = format!("{:?}", status.code());
+
+                metrics::counter!(
+                    PERSONHOG_ERRORS_TOTAL,
+                    "method" => method,
+                    "client" => client,
+                    "error_type" => error_type.clone(),
+                )
+                .increment(1);
+
+                if !is_retryable(status.code()) || attempt == max_retries {
+                    metrics::counter!(
+                        PERSONHOG_TERMINAL_ERRORS_TOTAL,
+                        "method" => method,
+                        "client" => client,
+                        "error_type" => error_type,
+                    )
+                    .increment(1);
+                    return Err(status);
+                }
+
+                metrics::counter!(
+                    PERSONHOG_RETRIES_TOTAL,
+                    "method" => method,
+                    "client" => client,
+                    "error_type" => error_type,
+                )
+                .increment(1);
+
+                warn!(
+                    method = method,
+                    attempt = attempt + 1,
+                    max_retries = max_retries,
+                    error = %status,
+                    "Retrying after transient personhog error"
+                );
+
+                let base = delay_ms / 2;
+                let jittered_ms = base + rand::thread_rng().gen_range(0..=base);
+                sleep(Duration::from_millis(jittered_ms)).await;
+                delay_ms = (delay_ms * 2).min(max_backoff_ms);
+                attempt += 1;
+            }
+        }
+    }
+}
+
 pub struct GroupTypeResolver {
     cache: Cache<String, i32>,
     personhog_client: Option<PersonHogServiceClient<Channel>>,
+    max_retries: u32,
+    initial_backoff_ms: u64,
+    max_backoff_ms: u64,
 }
 
 impl GroupTypeResolver {
@@ -39,6 +132,7 @@ impl GroupTypeResolver {
                         addr = %config.personhog_addr,
                         timeout_ms = config.personhog_timeout_ms,
                         connect_timeout_ms = config.personhog_connect_timeout_ms,
+                        max_retries = config.personhog_max_retries,
                         "Created personhog gRPC client"
                     );
                     Some(PersonHogServiceClient::new(channel))
@@ -59,6 +153,9 @@ impl GroupTypeResolver {
         Self {
             cache,
             personhog_client,
+            max_retries: config.personhog_max_retries,
+            initial_backoff_ms: config.personhog_initial_backoff_ms,
+            max_backoff_ms: config.personhog_max_backoff_ms,
         }
     }
 
@@ -92,18 +189,11 @@ impl GroupTypeResolver {
                 Ok(map) => map,
                 Err(e) => {
                     let error_type = e
-                        .downcast_ref::<tonic::Status>()
+                        .downcast_ref::<Status>()
                         .map(|s| format!("{:?}", s.code()))
                         .unwrap_or_else(|| "unknown".to_string());
                     warn!(error = %e, error_type = %error_type, "personhog group type resolution failed");
                     metrics::counter!(PERSONHOG_RESOLVE_ERRORS).increment(1);
-                    metrics::counter!(
-                        PERSONHOG_ERRORS_TOTAL,
-                        "method" => "GetGroupTypeMappingsByTeamIds",
-                        "client" => "property-defs-rs",
-                        "error_type" => error_type,
-                    )
-                    .increment(1);
                     return Err(e);
                 }
             };
@@ -142,7 +232,7 @@ impl GroupTypeResolver {
     ) -> Result<HashMap<(String, i32), i32>, anyhow::Error> {
         let start = std::time::Instant::now();
 
-        let mut client = self
+        let client = self
             .personhog_client
             .clone()
             .ok_or_else(|| anyhow::anyhow!("personhog client not configured"))?;
@@ -154,31 +244,46 @@ impl GroupTypeResolver {
             ids.into_iter().map(|id| id as i64).collect()
         };
 
-        let consistency = ConsistencyLevel::Eventual;
-        let mut request = tonic::Request::new(GetGroupTypeMappingsByTeamIdsRequest {
-            team_ids: unique_team_ids,
-            read_options: Some(ReadOptions {
-                consistency: consistency.into(),
-                ..Default::default()
-            }),
-        });
-        let metadata = request.metadata_mut();
-        metadata.insert("x-client-name", "property-defs-rs".parse().unwrap());
-        metadata.insert(
-            "x-caller-tag",
-            "property-defs/group-type-resolution".parse().unwrap(),
-        );
-        metadata.insert(
-            "x-read-consistency",
-            match consistency {
-                ConsistencyLevel::Strong => "strong",
-                _ => "eventual",
-            }
-            .parse()
-            .unwrap(),
-        );
+        let build_request = || {
+            let consistency = ConsistencyLevel::Eventual;
+            let mut request = tonic::Request::new(GetGroupTypeMappingsByTeamIdsRequest {
+                team_ids: unique_team_ids.clone(),
+                read_options: Some(ReadOptions {
+                    consistency: consistency.into(),
+                    ..Default::default()
+                }),
+            });
+            let metadata = request.metadata_mut();
+            metadata.insert("x-client-name", CLIENT.parse().unwrap());
+            metadata.insert(
+                "x-caller-tag",
+                "property-defs/group-type-resolution".parse().unwrap(),
+            );
+            metadata.insert(
+                "x-read-consistency",
+                match consistency {
+                    ConsistencyLevel::Strong => "strong",
+                    _ => "eventual",
+                }
+                .parse()
+                .unwrap(),
+            );
+            request
+        };
 
-        let response = client.get_group_type_mappings_by_team_ids(request).await?;
+        let response = with_retry(
+            self.max_retries,
+            self.initial_backoff_ms,
+            self.max_backoff_ms,
+            METHOD,
+            CLIENT,
+            || {
+                let request = build_request();
+                let mut c = client.clone();
+                async move { c.get_group_type_mappings_by_team_ids(request).await }
+            },
+        )
+        .await?;
 
         let elapsed_ms = start.elapsed().as_millis() as f64;
         metrics::histogram!(PERSONHOG_RESOLVE_DURATION).record(elapsed_ms);

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -37,6 +37,8 @@ pub const ISOLATED_PROPDEFS_DB_SELECTED: &str = "isolated_propdefs_db_selected";
 pub const PERSONHOG_RESOLVE_ERRORS: &str = "prop_defs_personhog_resolve_errors";
 pub const PERSONHOG_RESOLVE_DURATION: &str = "prop_defs_personhog_resolve_duration_ms";
 pub const PERSONHOG_ERRORS_TOTAL: &str = "personhog_errors_total";
+pub const PERSONHOG_RETRIES_TOTAL: &str = "personhog_retries_total";
+pub const PERSONHOG_TERMINAL_ERRORS_TOTAL: &str = "personhog_terminal_errors_total";
 
 //
 // property-defs-rs "v2" batch write path metric keys below

--- a/rust/property-defs-rs/tests/group_type_resolver.rs
+++ b/rust/property-defs-rs/tests/group_type_resolver.rs
@@ -7,7 +7,7 @@ use personhog_proto::personhog::{
     types::v1::*,
 };
 use tokio::net::TcpListener;
-use tonic::{Request, Response, Status};
+use tonic::{Code, Request, Response, Status};
 
 use property_defs_rs::{
     group_type_resolver::GroupTypeResolver,
@@ -18,7 +18,9 @@ use property_defs_rs::{
 
 struct MockPersonHogService {
     mappings_by_team: Vec<GroupTypeMappingsByKey>,
-    fail: bool,
+    /// Number of calls that should fail before succeeding. usize::MAX = always fail.
+    fail_remaining: AtomicUsize,
+    fail_code: Code,
     call_count: Arc<AtomicUsize>,
 }
 
@@ -26,7 +28,8 @@ impl MockPersonHogService {
     fn with_mappings(mappings_by_team: Vec<GroupTypeMappingsByKey>) -> Self {
         Self {
             mappings_by_team,
-            fail: false,
+            fail_remaining: AtomicUsize::new(0),
+            fail_code: Code::Internal,
             call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -37,7 +40,8 @@ impl MockPersonHogService {
     ) -> Self {
         Self {
             mappings_by_team,
-            fail: false,
+            fail_remaining: AtomicUsize::new(0),
+            fail_code: Code::Internal,
             call_count,
         }
     }
@@ -45,8 +49,32 @@ impl MockPersonHogService {
     fn failing() -> Self {
         Self {
             mappings_by_team: vec![],
-            fail: true,
+            fail_remaining: AtomicUsize::new(usize::MAX),
+            fail_code: Code::InvalidArgument,
             call_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn transient_then_ok(
+        mappings_by_team: Vec<GroupTypeMappingsByKey>,
+        fail_count: usize,
+        fail_code: Code,
+        call_count: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            mappings_by_team,
+            fail_remaining: AtomicUsize::new(fail_count),
+            fail_code,
+            call_count,
+        }
+    }
+
+    fn always_failing(fail_code: Code, call_count: Arc<AtomicUsize>) -> Self {
+        Self {
+            mappings_by_team: vec![],
+            fail_remaining: AtomicUsize::new(usize::MAX),
+            fail_code,
+            call_count,
         }
     }
 }
@@ -58,9 +86,19 @@ impl PersonHogService for MockPersonHogService {
         _req: Request<GetGroupTypeMappingsByTeamIdsRequest>,
     ) -> Result<Response<GroupTypeMappingsBatchResponse>, Status> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
-        if self.fail {
-            return Err(Status::internal("mock failure"));
+
+        // Decrement fail_remaining; if it was > 0 before the decrement, fail this call.
+        // Uses saturating to avoid wrapping usize::MAX (always-fail case).
+        let prev = self
+            .fail_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                Some(n.saturating_sub(1))
+            })
+            .unwrap();
+        if prev > 0 {
+            return Err(Status::new(self.fail_code, "mock failure"));
         }
+
         Ok(Response::new(GroupTypeMappingsBatchResponse {
             results: self.mappings_by_team.clone(),
         }))
@@ -313,6 +351,9 @@ fn make_config(addr: &str) -> property_defs_rs::config::Config {
     let mut config = property_defs_rs::config::Config::init_with_defaults().unwrap();
     config.personhog_addr = addr.to_string();
     config.personhog_timeout_ms = 5000;
+    config.personhog_max_retries = 2;
+    config.personhog_initial_backoff_ms = 1;
+    config.personhog_max_backoff_ms = 10;
     config.skip_writes = true;
     config.skip_reads = false;
     config
@@ -525,4 +566,118 @@ async fn test_no_personhog_client_returns_error() {
     let result = resolver.resolve(&mut updates).await;
 
     assert!(result.is_err());
+}
+
+// -- retry tests --------------------------------------------------------
+
+fn org_mapping() -> Vec<GroupTypeMappingsByKey> {
+    vec![GroupTypeMappingsByKey {
+        key: 1,
+        mappings: vec![GroupTypeMapping {
+            id: 1,
+            team_id: 1,
+            project_id: 1,
+            group_type: "organization".to_string(),
+            group_type_index: 0,
+            name_singular: None,
+            name_plural: None,
+            default_columns: None,
+            detail_dashboard_id: None,
+            created_at: None,
+        }],
+    }]
+}
+
+#[tokio::test]
+async fn test_retries_transient_error_then_succeeds() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let mock = MockPersonHogService::transient_then_ok(
+        org_mapping(),
+        2,
+        Code::Unavailable,
+        call_count.clone(),
+    );
+
+    let addr = start_mock_server(mock).await;
+    let config = make_config(&format!("http://{addr}"));
+    let resolver = GroupTypeResolver::new(&config);
+
+    let mut updates = vec![make_group_update(1, "organization")];
+    resolver.resolve(&mut updates).await.unwrap();
+
+    assert_eq!(get_resolved_index(&updates[0]), Some(0));
+    // 2 transient failures + 1 success = 3 total calls
+    assert_eq!(call_count.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn test_retries_deadline_exceeded_then_succeeds() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let mock = MockPersonHogService::transient_then_ok(
+        org_mapping(),
+        1,
+        Code::DeadlineExceeded,
+        call_count.clone(),
+    );
+
+    let addr = start_mock_server(mock).await;
+    let config = make_config(&format!("http://{addr}"));
+    let resolver = GroupTypeResolver::new(&config);
+
+    let mut updates = vec![make_group_update(1, "organization")];
+    resolver.resolve(&mut updates).await.unwrap();
+
+    assert_eq!(get_resolved_index(&updates[0]), Some(0));
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn test_does_not_retry_non_retryable_error() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let mock = MockPersonHogService::always_failing(Code::InvalidArgument, call_count.clone());
+
+    let addr = start_mock_server(mock).await;
+    let config = make_config(&format!("http://{addr}"));
+    let resolver = GroupTypeResolver::new(&config);
+
+    let mut updates = vec![make_group_update(1, "organization")];
+    let result = resolver.resolve(&mut updates).await;
+
+    assert!(result.is_err());
+    // Non-retryable error: only 1 attempt, no retries
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_exhausts_retries_on_persistent_transient_error() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let mock = MockPersonHogService::always_failing(Code::Unavailable, call_count.clone());
+
+    let addr = start_mock_server(mock).await;
+    let config = make_config(&format!("http://{addr}"));
+    let resolver = GroupTypeResolver::new(&config);
+
+    let mut updates = vec![make_group_update(1, "organization")];
+    let result = resolver.resolve(&mut updates).await;
+
+    assert!(result.is_err());
+    // 1 initial + 2 retries = 3 total attempts (max_retries=2)
+    assert_eq!(call_count.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn test_no_retries_when_max_retries_is_zero() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let mock = MockPersonHogService::always_failing(Code::Unavailable, call_count.clone());
+
+    let addr = start_mock_server(mock).await;
+    let mut config = make_config(&format!("http://{addr}"));
+    config.personhog_max_retries = 0;
+    let resolver = GroupTypeResolver::new(&config);
+
+    let mut updates = vec![make_group_update(1, "organization")];
+    let result = resolver.resolve(&mut updates).await;
+
+    assert!(result.is_err());
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
## Problem

we want personhog client behavior and metrics to be consistent across all client surfaces.

## Changes

- add retry to personhog calls to propdefs
- add standard retry metrics (all errors, retried errors, terminal errors)