### PR TITLE
fix(data-warehouse): stop sync history link pushing a stale tab

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
@@ -224,6 +224,13 @@ function ManagedSourceTabs({
     const showMetricsTab = !!featureFlags[FEATURE_FLAGS.DWH_SOURCE_METRICS]
 
     useEffect(() => {
+        // Wait until the source has loaded before deciding a tab is unavailable.
+        // While `source` is null, showSyncsTab/showWebhookTab are false, so a tab
+        // selected via URL (e.g. "syncs") would get bounced to "schemas" and push
+        // a bogus history entry over the URL the user actually navigated to.
+        if (!source) {
+            return
+        }
         if (!showSyncsTab && currentTab === 'syncs') {
             setCurrentTab('schemas')
         }
@@ -233,7 +240,7 @@ function ManagedSourceTabs({
         if (!showMetricsTab && currentTab === 'metrics') {
             setCurrentTab('schemas')
         }
-    }, [showSyncsTab, showWebhookTab, showMetricsTab, currentTab, setCurrentTab])
+    }, [source, showSyncsTab, showWebhookTab, showMetricsTab, currentTab, setCurrentTab])
 
     if (sourceLoading && !source) {
         return <LemonSkeleton className="w-full h-12" />


### PR DESCRIPTION
## Problem

The "View sync history" button on a data warehouse schema (table) page navigates to the wrong tab. Clicking it lands you on the **Schemas** tab instead of **Syncs**, and only hitting the browser Back button gets you to the syncs page you actually asked for.

## Changes

Root cause is a render-time race in `ManagedSourceTabs` (`SourceScene.tsx`). Clicking the button pushes `/data-management/sources/:id/syncs`, and `urlToAction` correctly sets `currentTab = 'syncs'`. But on (re)mount the source data is still loading, so `source` is `null` and `shouldShowManagedSourceSyncsTab(null)` returns `false`. A `useEffect` then concludes the syncs tab is unavailable and calls `setCurrentTab('schemas')` — the URL-pushing action — stacking a `/schemas` entry on top of the `/syncs` one. That's why you land on schemas and Back returns to the correct syncs page. The loading guard below the effect can't prevent this because hooks always run.

The fix gates the redirect logic on the source having actually loaded: while `source` is `null` we can't yet know whether a tab should be hidden, so we don't redirect. Once the source loads, a managed source reports `showSyncsTab = true` and `currentTab` stays on `syncs` with no extra history entry.

## How did you test this code?

I'm an agent (Claude Code, agent-assisted). No automated tests were added for this — it's a render-timing fix in a scene component. The reasoning was validated against the existing code paths (`shouldShowManagedSourceSyncsTab`, the `urlToAction`/`actionToUrl` wiring, and the redirect `useEffect`). Manual verification of the navigation flow in the running app is recommended before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marcus reported the navigation bug while working on an unrelated branch. I traced the "View sync history" button (`SchemaScene.tsx`) → push to the source `syncs` tab → `sourceSceneLogic` routing → the `ManagedSourceTabs` redirect effect, and identified the loading-time race that pushes a stale tab onto history. Fix was kept minimal: gate the redirect on `source` being loaded and add it to the effect deps. A pre-existing, separate edge case (a genuinely tab-less direct-access source visited at `/syncs` still uses a push-style redirect, a mild back-button trap) was deliberately left out of scope.
