### PR TITLE
fix(data-warehouse): condense SQL editor sync-warning banner

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -985,19 +985,25 @@ function InternalDataTableVisualization(
     )
 }
 
+// The backend `message` is kept self-contained (it also feeds LLM/MCP contexts), so it restates
+// "results may be out of date" — which the banner header already says. Strip that redundant tail
+// for display only, while preserving any "a new sync is in progress" detail.
+const trimRedundantTail = (message: string): string =>
+    message
+        .replace(/\.\s*(A new sync is in progress) but results may be out of date\.?\s*$/i, '. $1.')
+        .replace(/\.\s*Results may be out of date\.?\s*$/i, '.')
+
 const SyncWarningsBanner = ({ warnings }: { warnings?: HogQLQueryResponse['warnings'] }): JSX.Element | null => {
     if (!warnings || warnings.length === 0) {
         return null
     }
     return (
         <LemonBanner type="warning" className="m-2 flex-shrink-0" data-attr="sql-editor-output-pane-sync-warnings">
-            <div className="font-semibold mb-1">
-                Some warehouse sources used by this query are out of date — results may not reflect current data
-            </div>
-            <ul className="list-disc pl-5 space-y-1">
+            Some warehouse sources used by this query are out of date — results may not reflect current data:
+            <ul className="list-disc pl-5">
                 {warnings.map((warning, index) => (
                     <li key={`${warning.table_name}-${warning.schema_name}-${index}`}>
-                        {warning.message}
+                        {trimRedundantTail(warning.message)}
                         {warning.source_id && (
                             <>
                                 {' '}

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -75,6 +75,7 @@ import {
 import { FixErrorButton } from './components/FixErrorButton'
 import { OutputTab, outputPaneLogic } from './outputPaneLogic'
 import { sqlEditorLogic } from './sqlEditorLogic'
+import { trimRedundantTail } from './syncWarnings'
 import TabScroller from './TabScroller'
 
 interface RowDetailsModalProps {
@@ -984,14 +985,6 @@ function InternalDataTableVisualization(
         </div>
     )
 }
-
-// The backend `message` is kept self-contained (it also feeds LLM/MCP contexts), so it restates
-// "results may be out of date" — which the banner header already says. Strip that redundant tail
-// for display only, while preserving any "a new sync is in progress" detail.
-const trimRedundantTail = (message: string): string =>
-    message
-        .replace(/\.\s*(A new sync is in progress) but results may be out of date\.?\s*$/i, '. $1.')
-        .replace(/\.\s*Results may be out of date\.?\s*$/i, '.')
 
 const SyncWarningsBanner = ({ warnings }: { warnings?: HogQLQueryResponse['warnings'] }): JSX.Element | null => {
     if (!warnings || warnings.length === 0) {

--- a/frontend/src/scenes/data-warehouse/editor/syncWarnings.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/syncWarnings.test.ts
@@ -1,0 +1,41 @@
+import { trimRedundantTail } from './syncWarnings'
+
+describe('syncWarnings', () => {
+    describe('trimRedundantTail', () => {
+        // Messages mirror those emitted by products/data_warehouse/backend/sync_status.py.
+        test.each([
+            [
+                'stale completed sync drops the redundant tail',
+                '`postgres_posthog_team` (from Postgres) last synced 2 hours ago, more than twice its configured sync interval. Results may be out of date.',
+                '`postgres_posthog_team` (from Postgres) last synced 2 hours ago, more than twice its configured sync interval.',
+            ],
+            [
+                'running sync keeps the in-progress note but drops the redundant tail',
+                '`postgres_posthog_team` (from Postgres) last completed syncing 2 hours ago, more than twice its configured sync interval. A new sync is in progress but results may be out of date.',
+                '`postgres_posthog_team` (from Postgres) last completed syncing 2 hours ago, more than twice its configured sync interval. A new sync is in progress.',
+            ],
+            [
+                'billing limit reached drops the redundant tail',
+                'Sync of `t` (from Stripe) is paused because the data warehouse billing limit has been reached. Results may be out of date.',
+                'Sync of `t` (from Stripe) is paused because the data warehouse billing limit has been reached.',
+            ],
+            [
+                'billing limit too low drops the redundant tail',
+                'Sync of `t` (from Stripe) is paused because the configured billing limit is too low. Results may be out of date.',
+                'Sync of `t` (from Stripe) is paused because the configured billing limit is too low.',
+            ],
+            [
+                'paused message without the tail is left unchanged',
+                'Sync of `t` (from Stripe) is paused. Results reflect the last successful sync from 2 hours ago.',
+                'Sync of `t` (from Stripe) is paused. Results reflect the last successful sync from 2 hours ago.',
+            ],
+            [
+                'failed message without the tail is left unchanged',
+                'Last sync of `t` (from Stripe) failed. Results reflect data from 2 hours ago. Check the data warehouse source for details.',
+                'Last sync of `t` (from Stripe) failed. Results reflect data from 2 hours ago. Check the data warehouse source for details.',
+            ],
+        ])('%s', (_name, input, expected) => {
+            expect(trimRedundantTail(input)).toEqual(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/data-warehouse/editor/syncWarnings.ts
+++ b/frontend/src/scenes/data-warehouse/editor/syncWarnings.ts
@@ -1,0 +1,8 @@
+// The backend `message` on a DataWarehouseSyncWarning is kept self-contained (it also feeds
+// LLM/MCP contexts), so it restates "results may be out of date" — which the sync-warning banner
+// header already says. Strip that redundant tail for display only, while preserving any
+// "a new sync is in progress" detail. Messages without that tail (failed, paused) are left as-is.
+export const trimRedundantTail = (message: string): string =>
+    message
+        .replace(/\.\s*(A new sync is in progress) but results may be out of date\.?\s*$/i, '. $1.')
+        .replace(/\.\s*Results may be out of date\.?\s*$/i, '.')


### PR DESCRIPTION
## Problem

In the SQL editor, the warehouse "out of date" warning banner feels too big and the copy is redundant. The banner header already says *"results may not reflect current data"*, and then every per-source bullet restates *"Results may be out of date."* again — so the same boilerplate appears once per affected source.

## Changes

- The banner header now reads once and flows into the source list.
- Each per-source bullet drops the redundant trailing "Results may be out of date." sentence (the header conveys it), while preserving genuinely useful detail like "last synced 2 hours ago, more than twice its configured sync interval" and the "a new sync is in progress" note for running syncs.
- Tightened the banner layout (removed the extra bold header block and per-item vertical padding).

The trimming happens **display-only** in the frontend. The backend `message` strings in `products/data_warehouse/backend/sync_status.py` are deliberately kept self-contained because they also feed LLM/MCP/Max contexts, so they are unchanged.

Before (per source):
> `postgres_posthog_team` (from Postgres) last synced 2 hours ago, more than twice its configured sync interval. Results may be out of date. Manage source

After:
> `postgres_posthog_team` (from Postgres) last synced 2 hours ago, more than twice its configured sync interval. Manage source

## How did you test this code?

I'm an agent (PostHog Slack app). I did not run the app manually — the frontend toolchain wasn't available in this environment, so I could not run `format`/`typescript:check` or take screenshots. The change is a small, localized edit to `SyncWarningsBanner` plus a pure `trimRedundantTail` helper; I verified the regex against all message variants produced by `sync_status.py` (stale, running, billing-limit, paused, failed) by hand — only the generic "results may be out of date" tail is stripped, and the failed/paused detail messages are left intact.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at Adam Bowker's request, from a Slack thread. Considered changing the backend message strings to remove the duplication at the source, but rejected that because those messages are intentionally self-contained for LLM/MCP consumption (noted in `sync_status.py`). Chose a display-only trim in the banner instead, implemented as a small pure helper so the redundant tail is removed without losing the per-source detail.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781025387473989?thread_ts=1781025387.473989&cid=C0ACRAMJUAG)*
