### PR TITLE
chore(ci): register depot-macos-latest actionlint runner label

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,3 +6,4 @@ self-hosted-runner:
         - depot-ubuntu-latest
         - depot-ubuntu-latest-4
         - depot-ubuntu-latest-8
+        - depot-macos-latest


### PR DESCRIPTION
## Problem

actionlint went blocking in #62207, then the dev filesystem-sandbox PR (#61789) merged a new workflow (`dev-sandbox-selftest.yml`) using `runs-on: depot-macos-latest` — a real Depot runner label that isn't registered in `.github/actionlint.yaml`. actionlint flags it as an unknown runner label (1 finding → exit 1).

Because the gate runs against *PR-merged-with-master*, this poisons every PR that touches any `.github/` file, not just #61789. #61789 slipped through because its last actionlint run predated the blocking change and it merged without rebasing.

## Changes

Add `depot-macos-latest` to the `self-hosted-runner.labels` allowlist. The workflow is correct; the config just didn't know the label.

## How did you test this code?

Agent-authored. Ran the pinned actionlint (1.7.12, `SHELLCHECK_OPTS=--severity=error`) locally against the full `.github/` tree:
- before: 1 finding (`runner-label` on `dev-sandbox-selftest.yml:30`), exit 1
- after: 0 findings, exit 0

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Diagnosed the master-wide actionlint failure to the unregistered `depot-macos-latest` label introduced by #61789 after actionlint became blocking, confirmed via local reproduction with the pinned actionlint version, and registered the label. Considered changing the workflow's runner instead but the label is a legitimate Depot macOS runner — the config allowlist was the gap.
