### PR TITLE
chore(ci): resize heavy depot test runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,8 @@ self-hosted-runner:
         - depot-ubuntu-22.04
         - depot-ubuntu-22.04-4
         - depot-ubuntu-24.04-4
+        - depot-macos-latest
         - depot-ubuntu-latest
         - depot-ubuntu-latest-4
         - depot-ubuntu-latest-8
+        - depot-ubuntu-latest-16

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -438,7 +438,7 @@ jobs:
             needs.turbo-discover.result == 'success' &&
             needs.turbo-discover.outputs.matrix != '[]' &&
             needs.turbo-discover.outputs.matrix != ''
-        runs-on: depot-ubuntu-latest
+        runs-on: depot-ubuntu-latest-16
         timeout-minutes: 40
         name: Product tests (${{ matrix.group }})
         strategy:
@@ -1707,7 +1707,7 @@ jobs:
 
         name: Django tests – ${{ matrix.segment }}${{ matrix.compat && ' compat' || '' }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
         # Runner type is performance-critical — consult #team-devex before changing
-        runs-on: depot-ubuntu-latest
+        runs-on: depot-ubuntu-latest-16
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -228,7 +228,7 @@ jobs:
             matrix:
                 include: ${{ fromJson(needs.changes.outputs.matrix_include || '[]') }}
         if: needs.changes.outputs.dagster == 'true'
-        runs-on: depot-ubuntu-latest
+        runs-on: depot-ubuntu-latest-16
         steps:
             - name: 'Checkout repo'
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -221,7 +221,7 @@ jobs:
 
     visual-regression:
         name: Visual regression tests - ${{ matrix.browser }} (${{ matrix.shard }}/${{ matrix.shard_count }})
-        runs-on: ${{ matrix.browser == 'webkit' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
+        runs-on: ${{ matrix.browser == 'webkit' && 'depot-ubuntu-latest-16' || 'ubuntu-latest' }}
         needs: [changes, build-storybook, vr-setup]
         if: >-
             always()


### PR DESCRIPTION
## Problem

Backend, Dagster, and Storybook webkit jobs can run Docker Compose stacks and heavyweight test workloads on the smallest Depot runner class. Recent master CI showed multiple unrelated jobs losing self-hosted runner communication, consistent with resource pressure on undersized runners.

## Changes

- Move backend product test matrix jobs to `depot-ubuntu-latest-16`.
- Move backend Django test matrix jobs to `depot-ubuntu-latest-16`.
- Move Dagster test matrix jobs to `depot-ubuntu-latest-16`.
- Move Storybook webkit visual-regression shards to `depot-ubuntu-latest-16` while leaving Chromium shards on GitHub-hosted runners.
- Reference Depot's runner type labels: https://depot.dev/docs/github-actions/runner-types

## How did you test this code?

- `git diff --check`
- Commit hook ran `bin/hogli format:yaml` on the changed workflow files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed for CI runner sizing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An AI coding assistant made the workflow edits after a human asked to resize Depot runners for heavy CI jobs that were losing runner communication. The change is intentionally limited to the heavy matrices observed failing: backend product tests, Django tests, Dagster tests, and Storybook webkit visual regression.

