### PR TITLE
fix(error-tracking): handle deleted teams in recommendation refresh

### DIFF
--- a/products/error_tracking/backend/temporal/recommendations_refresh/activities.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/activities.py
@@ -36,8 +36,7 @@ def get_teams_with_recent_exceptions_activity(inputs: RecommendationsRefreshInpu
     # ClickHouse retains events for teams that have since been deleted in Postgres.
     # Drop those here so the per-team refresh never tries to scope to a missing team
     # (which raises and pollutes error tracking).
-    existing_team_ids = set(Team.objects.filter(id__in=candidate_team_ids).values_list("id", flat=True))
-    team_ids = [team_id for team_id in candidate_team_ids if team_id in existing_team_ids]
+    team_ids = list(Team.objects.filter(id__in=candidate_team_ids).values_list("id", flat=True))
 
     logger.info(
         "error_tracking.recommendations_refresh.teams_enumerated",

--- a/products/error_tracking/backend/temporal/recommendations_refresh/activities.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/activities.py
@@ -3,6 +3,7 @@ from temporalio import activity
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.workload import Workload
+from posthog.models.team import Team
 
 from products.error_tracking.backend.recommendations.refresh import refresh_team_recommendations_inline
 from products.error_tracking.backend.temporal.recommendations_refresh.types import (
@@ -30,10 +31,18 @@ def get_teams_with_recent_exceptions_activity(inputs: RecommendationsRefreshInpu
         {"lookback_days": inputs.lookback_days},
         workload=Workload.OFFLINE,
     )
-    team_ids = [int(row[0]) for row in rows]
+    candidate_team_ids = [int(row[0]) for row in rows]
+
+    # ClickHouse retains events for teams that have since been deleted in Postgres.
+    # Drop those here so the per-team refresh never tries to scope to a missing team
+    # (which raises and pollutes error tracking).
+    existing_team_ids = set(Team.objects.filter(id__in=candidate_team_ids).values_list("id", flat=True))
+    team_ids = [team_id for team_id in candidate_team_ids if team_id in existing_team_ids]
+
     logger.info(
         "error_tracking.recommendations_refresh.teams_enumerated",
         team_count=len(team_ids),
+        deleted_team_count=len(candidate_team_ids) - len(team_ids),
         lookback_days=inputs.lookback_days,
     )
     return team_ids

--- a/products/error_tracking/backend/temporal/recommendations_refresh/test/test_recommendations_refresh.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/test/test_recommendations_refresh.py
@@ -71,6 +71,22 @@ class TestGetTeamsWithRecentExceptionsActivity(ClickhouseTestMixin, APIBaseTest)
         assert team_pageview_only.id not in team_ids
         assert team_old_exception.id not in team_ids
 
+    def test_drops_teams_deleted_from_postgres(self):
+        # ClickHouse keeps events for deleted teams; their team_id must not survive enumeration.
+        deleted_team = Team.objects.create(organization=self.organization, name="Deleted")
+        deleted_team_id = deleted_team.id
+
+        _create_event(distinct_id="u1", event="$exception", team=self.team, timestamp=timezone.now().isoformat())
+        _create_event(distinct_id="u2", event="$exception", team=deleted_team, timestamp=timezone.now().isoformat())
+        flush_persons_and_events()
+
+        deleted_team.delete()
+
+        team_ids = get_teams_with_recent_exceptions_activity(RecommendationsRefreshInputs(lookback_days=7))
+
+        assert self.team.id in team_ids
+        assert deleted_team_id not in team_ids
+
 
 class TestRefreshRecommendationsBatchActivity(NonAtomicBaseTest):
     # Inline compute fans out over the shared thread pool, each thread with its own DB


### PR DESCRIPTION
## Problem

The error-tracking recommendations refresh sweep enumerates team IDs from ClickHouse `$exception` events. ClickHouse retains events for teams that have since been deleted in Postgres, so those stale team IDs flowed into the per-team refresh and raised a `TeamScopeError` when scoping to a non-existent team. The result was a fresh, recurring backend exception that polluted error tracking.

## Changes

Filter the ClickHouse-derived team IDs against Postgres in `get_teams_with_recent_exceptions_activity`, dropping any IDs that no longer have a corresponding `Team` before any per-team work runs. This is the natural boundary where raw ClickHouse IDs enter the pipeline. The enumeration log now also reports how many deleted teams were dropped.

## How did you test this code?

I'm an agent (PostHog Slack app). I added an automated test (`test_drops_teams_deleted_from_postgres`) asserting that a team with recent `$exception` events but deleted from Postgres is excluded from enumeration. I could not run the suite in this environment — no database was reachable — but `ruff check` and `ruff format --check` pass on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) at Aleks's direction from a Slack thread. Investigated the recommendations refresh call chain and traced the recurring exception to `resolve_effective_team_id` raising `TeamScopeError` for team IDs that exist in ClickHouse but were deleted in Postgres. Chose to fix at enumeration (filtering IDs against Postgres) rather than swallowing the error downstream, so deleted teams never trigger per-team work or exception capture in the first place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1781024626406529?thread_ts=1781024626.406529&cid=C0B8ZE81ZT7)*
