### PR TITLE
fix(ingestion): make event filter conditions deletable

### DIFF
--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
@@ -200,7 +200,7 @@ export function EventFilterScene(): JSX.Element {
                                     Build a filter expression. Drag conditions and groups to reorder or move between
                                     groups. Maximum {EVENT_FILTER_MAX_CONDITIONS} conditions and{' '}
                                     {EVENT_FILTER_MAX_DEPTH} levels of nesting. Empty groups are removed automatically
-                                    on save.
+                                    on save; use the trash icon to remove a condition.
                                 </p>
                             </div>
                             <LemonButton

--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterTreeEditor.test.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterTreeEditor.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom'
+
+import { DndContext } from '@dnd-kit/core'
+import { render, screen } from '@testing-library/react'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { eventFilterLogic, FilterNode, normalizeRootToGroup } from './eventFilterLogic'
+import { NodeEditor } from './EventFilterTreeEditor'
+import { NodeIdMap } from './NodeIdMap'
+import { cond } from './testHelpers'
+
+describe('EventFilterTreeEditor delete affordance', () => {
+    beforeEach(() => {
+        useMocks({ get: { '/api/environments/:team_id/event_filter/': () => [200, null] } })
+        initKeaTests()
+        eventFilterLogic.mount()
+    })
+
+    function renderRoot(node: FilterNode): void {
+        const nodeIds = new NodeIdMap()
+        nodeIds.buildIndex(node)
+        render(
+            <DndContext>
+                <NodeEditor node={node} path={[]} depth={0} nodeIds={nodeIds} />
+            </DndContext>
+        )
+    }
+
+    it('shows no Remove button for a bare condition at the root — reproduces the original bug', () => {
+        // The backend used to collapse a one-condition filter down to a bare condition,
+        // which renders with no delete handler and therefore no way to remove it.
+        renderRoot(cond('event_name', 'exact', 'pageview'))
+        expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
+    })
+
+    it('shows a Remove button once the root is normalized to a group', () => {
+        renderRoot(normalizeRootToGroup(cond('event_name', 'exact', 'pageview')))
+        expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
@@ -2,6 +2,7 @@ import {
     countConditions,
     evaluateFilterTree,
     FilterNode,
+    normalizeRootToGroup,
     treeHasConditions,
     treeHasEmptyValues,
     updateAtPath,
@@ -312,5 +313,24 @@ describe('treeHasEmptyValues', () => {
         ['deeply nested empty value', and(or(cond(), not(cond('event_name', 'exact', '')))), true],
     ])('%s', (_name, tree, expected) => {
         expect(treeHasEmptyValues(tree)).toBe(expected)
+    })
+})
+
+describe('normalizeRootToGroup', () => {
+    it('leaves an AND/OR group untouched', () => {
+        const tree = and(cond())
+        expect(normalizeRootToGroup(tree)).toBe(tree)
+        const orTree = or(cond())
+        expect(normalizeRootToGroup(orTree)).toBe(orTree)
+    })
+
+    it('wraps a bare condition root in an OR so it becomes a deletable group child', () => {
+        const tree = cond('event_name', 'exact', 'pageview')
+        expect(normalizeRootToGroup(tree)).toEqual(or(tree))
+    })
+
+    it('wraps a NOT root in an OR', () => {
+        const tree = not(cond())
+        expect(normalizeRootToGroup(tree)).toEqual(or(tree))
     })
 })

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.ts
@@ -198,6 +198,20 @@ export function treeHasEmptyValues(node: FilterNode): boolean {
     }
 }
 
+/**
+ * Ensure the root is an and/or group. The editor only renders a delete (trash)
+ * button on a group's children, and the backend prunes single-child groups — so a
+ * saved one-condition filter loads back as a bare condition (or NOT) at the root
+ * with no way to remove it. Wrap any non-group root in an OR so every condition is
+ * always a deletable group child.
+ */
+export function normalizeRootToGroup(node: FilterNode): FilterNode {
+    if (node.type === 'and' || node.type === 'or') {
+        return node
+    }
+    return { type: 'or', children: [node] }
+}
+
 // --- Immutable tree updates ---
 
 /**
@@ -260,7 +274,7 @@ export const eventFilterLogic = kea<eventFilterLogicType>([
                         return 'Filter must have at least one condition to be activated'
                     }
                     if (treeHasConditions(filter_tree) && treeHasEmptyValues(filter_tree)) {
-                        return 'All conditions must have a value'
+                        return "All conditions must have a value. Use the trash icon to remove a condition you don't need."
                     }
                     if (mode === 'live' && treeHasConditions(filter_tree) && test_cases.length === 0) {
                         return 'Add at least one test case before going live'
@@ -421,7 +435,7 @@ export const eventFilterLogic = kea<eventFilterLogicType>([
                 actions.setFilterFormValue('id', data.id)
                 actions.setFilterFormValue('mode', data.mode ?? 'disabled')
                 if (data.filter_tree?.type) {
-                    actions.setFilterFormValue('filter_tree', data.filter_tree)
+                    actions.setFilterFormValue('filter_tree', normalizeRootToGroup(data.filter_tree))
                 }
                 const testCases = (data.test_cases ?? []).map((tc: Omit<TestCase, '_key'>) => ({
                     ...tc,

--- a/posthog/api/test/test_event_filter_config.py
+++ b/posthog/api/test/test_event_filter_config.py
@@ -149,11 +149,13 @@ class TestEventFilterConfigAPI(APIBaseTest):
         self.assertEqual(EventFilterConfig.objects.filter(team=self.team).count(), 1)
 
     def test_create_prunes_filter_tree_on_save(self):
-        tree = _and(_cond())
+        # A nested single-child group collapses, but the root stays a group so the
+        # saved one-condition filter remains editable.
+        tree = _and(_or(_cond()))
         response = self.client.post(self._url(), data={"filter_tree": tree}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["filter_tree"], _cond())
+        self.assertEqual(response.json()["filter_tree"], _and(_cond()))
 
     def test_create_timestamps_are_read_only(self):
         response = self.client.post(

--- a/posthog/models/event_filter_config.py
+++ b/posthog/models/event_filter_config.py
@@ -81,28 +81,48 @@ class EventFilterConfig(UUIDTModel):
         super().save(*args, **kwargs)
 
 
-def prune_filter_tree(node: dict) -> dict | None:
-    """Remove empty groups and collapse single-child groups."""
+def prune_filter_tree(node: dict, is_root: bool = True) -> dict | None:
+    """
+    Remove empty groups and collapse single-child groups.
+
+    The root is kept as an and/or group: the tree editor only renders a delete
+    button on a group's children, so collapsing the root down to a bare condition
+    (or NOT) would leave the user with no way to remove it. A bare condition/NOT
+    at the root is wrapped in an OR, which heals already-saved records on next
+    save. Nested single-child groups still collapse as before.
+    """
     node_type = node.get("type")
 
     if node_type == "condition":
-        return node
+        return _ensure_group_root(node, is_root)
 
     if node_type == "not":
-        child = prune_filter_tree(node.get("child", {}))
+        child = prune_filter_tree(node.get("child", {}), is_root=False)
         if child is None:
             return None
-        return {**node, "child": child}
+        return _ensure_group_root({**node, "child": child}, is_root)
 
     if node_type in ("and", "or"):
-        children = [prune_filter_tree(c) for c in node.get("children", [])]
+        children = [prune_filter_tree(c, is_root=False) for c in node.get("children", [])]
         children = [c for c in children if c is not None]
         if len(children) == 0:
             return None
         if len(children) == 1:
-            return children[0]
+            only = children[0]
+            # Collapsing to the lone child is fine unless it would leave a
+            # non-group at the root — keep this group as the wrapper in that case.
+            if is_root and only.get("type") not in ("and", "or"):
+                return {**node, "children": children}
+            return only
         return {**node, "children": children}
 
+    return node
+
+
+def _ensure_group_root(node: dict, is_root: bool) -> dict:
+    """Wrap a non-group node in an OR group when it would otherwise be the root."""
+    if is_root and node.get("type") not in ("and", "or"):
+        return {"type": "or", "children": [node]}
     return node
 
 

--- a/posthog/models/test/test_event_filter_config.py
+++ b/posthog/models/test/test_event_filter_config.py
@@ -155,9 +155,19 @@ class TestPruneFilterTree(SimpleTestCase):
     def test_removes_empty_group(self):
         self.assertIsNone(prune_filter_tree({"type": "and", "children": []}))
 
-    def test_collapses_single_child_group(self):
+    def test_keeps_single_child_group_at_root(self):
+        # The root stays an and/or group so the editor can always render a delete
+        # button on the condition; it is not collapsed down to a bare condition.
         cond = _cond()
-        self.assertEqual(prune_filter_tree(_and(cond)), cond)
+        self.assertEqual(prune_filter_tree(_and(cond)), _and(cond))
+
+    def test_wraps_bare_condition_root_in_or(self):
+        cond = _cond()
+        self.assertEqual(prune_filter_tree(cond), _or(cond))
+
+    def test_wraps_bare_not_root_in_or(self):
+        node = _not(_cond())
+        self.assertEqual(prune_filter_tree(node), _or(node))
 
     def test_removes_not_with_empty_child(self):
         self.assertIsNone(prune_filter_tree(_not({"type": "or", "children": []})))
@@ -167,9 +177,10 @@ class TestPruneFilterTree(SimpleTestCase):
         self.assertEqual(prune_filter_tree(tree), tree)
 
     def test_collapses_nested_single_child_groups(self):
+        # Nested single-child groups still collapse; only the root group is kept.
         cond = _cond()
-        tree = _or(_and(cond))
-        self.assertEqual(prune_filter_tree(tree), cond)
+        tree = _or(_and(_or(cond)), _cond(value="click"))
+        self.assertEqual(prune_filter_tree(tree), _or(cond, _cond(value="click")))
 
 
 class TestEvaluateFilterTree(SimpleTestCase):
@@ -358,14 +369,26 @@ class TestEventFilterConfigModel(BaseTest):
         retrieved = EventFilterConfig.objects.get(pk=config.pk)
         self.assertIsNone(retrieved.filter_tree)
 
-    def test_save_prunes_filter_tree(self):
-        tree = _and(_cond("event_name", "exact", "pageview"))
+    def test_save_prunes_filter_tree_but_keeps_group_at_root(self):
+        # A nested single-child group collapses, but the root stays a group so the
+        # saved one-condition filter remains editable (the condition keeps a delete
+        # button in the editor).
+        tree = _and(_or(_cond("event_name", "exact", "pageview")))
         config = EventFilterConfig.objects.create(
             team=self.team,
             mode=EventFilterMode.LIVE,
             filter_tree=tree,
         )
-        self.assertEqual(config.filter_tree, _cond("event_name", "exact", "pageview"))
+        self.assertEqual(config.filter_tree, _and(_cond("event_name", "exact", "pageview")))
+
+    def test_save_wraps_bare_condition_root_in_group(self):
+        # Heals legacy records that were saved as a bare condition at the root.
+        config = EventFilterConfig.objects.create(
+            team=self.team,
+            mode=EventFilterMode.LIVE,
+            filter_tree=_cond("event_name", "exact", "pageview"),
+        )
+        self.assertEqual(config.filter_tree, _or(_cond("event_name", "exact", "pageview")))
 
     def test_save_rejects_invalid_filter_tree(self):
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
## Problem

On the **Event ingestion filtering** page you build a filter tree of conditions that drop matching events. A one-condition filter could not be deleted: the backend collapsed a single-child group down to a bare `condition` node at the tree root, and the tree editor only renders a delete (trash) button on a group's *children*. On reload, that lone condition rendered with no trash icon at all — there was no way to remove it, and blanking its value just produced `All conditions must have a value`.

## Changes

Keep an and/or group at the root so every condition is always a deletable group child:

- **Backend** `prune_filter_tree` no longer collapses the root below a group, and wraps a bare condition/NOT root in an OR — this heals already-saved one-condition records on their next save. Nested single-child groups still collapse as before.
- **Frontend** `normalizeRootToGroup` re-wraps a non-group root on load, so configs that were already saved in the broken shape become editable (and deletable) again immediately.

Also pointed users at the trash icon: the validation error and the editor hint now explain that a condition is removed with the trash icon rather than by blanking its value.

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual testing. Automated tests I actually ran:

- `EventFilterTreeEditor.test.tsx` (new) — a render test that **reproduces the bug** (a bare-condition root renders with no Remove button) and **proves the fix** (a normalized group root renders the Remove button). Re-run to confirm it isn't flaky.
- `eventFilterLogic.test.ts` — added cases for `normalizeRootToGroup`. Full suite green (76 tests).
- `posthog/models/test/test_event_filter_config.py` / `posthog/api/test/test_event_filter_config.py` — updated/added prune tests (root stays a group, bare-condition records heal to a group, nested single-child groups still collapse). All pure-logic tests pass.

> Note: the DB-backed model/API save tests require a running test database that wasn't available in my environment, so they were not executed locally — I updated their expectations to match the new behavior and they will run in CI.

`ruff check`/`ruff format` clean; TypeScript check shows no errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). The reporter described a real product bug — no way to delete a configured drop-event condition. Initial investigation found two root causes: the backend collapsing a single-condition tree to a bare root node (which leaves the editor with no delete affordance), and an unhelpful validation message. We considered silently pruning blanked conditions on save, but chose instead to **keep the validation and guarantee a usable, discoverable trash icon** — which required keeping an and/or group at the root. An earlier idea to enlarge the trash button was dropped once we confirmed the real issue was that the button wasn't rendered at all, not that it was too small.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
