### PR TITLE
chore(llma): add Claude Fable 5 to LLM costs

### DIFF
--- a/nodejs/src/ingestion/ai/costs/providers/llm-costs.json
+++ b/nodejs/src/ingestion/ai/costs/providers/llm-costs.json
@@ -313,6 +313,32 @@
         }
     },
     {
+        "model": "anthropic/claude-fable-5",
+        "cost": {
+            "default": {
+                "prompt_token": 0.00001,
+                "completion_token": 0.00005,
+                "cache_read_token": 0.000001,
+                "cache_write_token": 0.0000125,
+                "web_search": 0.01
+            },
+            "anthropic": {
+                "prompt_token": 0.00001,
+                "completion_token": 0.00005,
+                "cache_read_token": 0.000001,
+                "cache_write_token": 0.0000125,
+                "web_search": 0.01
+            },
+            "anthropic-claude-on-aws": {
+                "prompt_token": 0.00001,
+                "completion_token": 0.00005,
+                "cache_read_token": 0.000001,
+                "cache_write_token": 0.0000125,
+                "web_search": 0.01
+            }
+        }
+    },
+    {
         "model": "anthropic/claude-haiku-4.5",
         "cost": {
             "default": {


### PR DESCRIPTION
## Summary

- Adds `anthropic/claude-fable-5` to `llm-costs.json`
- Bridges the gap until the next auto-update job runs (litellm's source data does not have Fable yet either).
- Pricing verified against OpenRouter's per-endpoint API for both providers it exposes (Anthropic, Amazon Bedrock); identical values:
  - prompt $10/M
  - completion $50/M
  - cache_read $1/M
  - cache_write $12.50/M
  - web_search $0.01

## Test plan

- [ ] CI passes (JSON validity, lint).
- [ ] Spot-check: emit an event with `\$ai_model: claude-fable-5` and confirm `\$ai_total_cost_usd` populates with the expected value.
- [ ] Next auto-update run regenerates without removing the entry.