### PR TITLE
feat(rbac): honor child resource-level access controls

### DIFF
--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -324,16 +324,16 @@ class TestWarehouseTableAccessControl(BaseTest):
         assert "denied_table" in database._denied_tables
         assert "allowed_table" in database._denied_tables
 
-    def test_parent_objects_deny_is_ceiling_over_child_grant(self):
-        # Parent acts as a ceiling: a warehouse_objects "none" denies everything, and a more
-        # permissive child warehouse_table grant cannot lift it.
+    def test_child_grant_overrides_parent_deny(self):
+        # Most specific wins: an explicit child warehouse_table grant overrides a warehouse_objects
+        # "none" (the allowlist case — share warehouse tables without opening the umbrella).
         self._create_ac(resource="warehouse_objects", access_level="none")
         self._create_ac(resource="warehouse_table", access_level="viewer")
 
         database = Database.create_for(team=self.team, user=self.user)
 
-        assert "denied_table" in database._denied_tables
-        assert "allowed_table" in database._denied_tables
+        assert "denied_table" not in database._denied_tables
+        assert "allowed_table" not in database._denied_tables
 
     def test_org_admin_bypasses_warehouse_acl(self):
         membership = self._membership()

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -314,6 +314,27 @@ class TestWarehouseTableAccessControl(BaseTest):
         assert "allowed_table" not in database._denied_tables
         assert "denied_table" in database._denied_tables
 
+    def test_child_resource_deny_applies_without_parent_rule(self):
+        # A resource-level "none" on the child warehouse_table now denies all warehouse tables,
+        # even with no warehouse_objects rule (child rules apply when the parent doesn't restrict).
+        self._create_ac(resource="warehouse_table", access_level="none")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_table" in database._denied_tables
+        assert "allowed_table" in database._denied_tables
+
+    def test_parent_objects_deny_is_ceiling_over_child_grant(self):
+        # Parent acts as a ceiling: a warehouse_objects "none" denies everything, and a more
+        # permissive child warehouse_table grant cannot lift it.
+        self._create_ac(resource="warehouse_objects", access_level="none")
+        self._create_ac(resource="warehouse_table", access_level="viewer")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_table" in database._denied_tables
+        assert "allowed_table" in database._denied_tables
+
     def test_org_admin_bypasses_warehouse_acl(self):
         membership = self._membership()
         membership.level = OrganizationMembership.Level.ADMIN
@@ -590,6 +611,24 @@ class TestWarehouseViewAccessControl(BaseTest):
 
         assert "denied_view" in database._denied_tables
         assert "allowed_view" in database._denied_tables
+
+    def test_child_resource_deny_applies_without_parent_rule(self):
+        # A resource-level "none" on warehouse_view denies all views, even with no warehouse_objects rule.
+        self._create_ac(resource="warehouse_view", access_level="none")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_view" in database._denied_tables
+        assert "allowed_view" in database._denied_tables
+
+    def test_sibling_child_deny_does_not_affect_views(self):
+        # warehouse_table and warehouse_view are independent children: denying one must not deny the other.
+        self._create_ac(resource="warehouse_table", access_level="none")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "denied_view" not in database._denied_tables
+        assert "allowed_view" not in database._denied_tables
 
     def test_no_user_fails_closed_for_warehouse_views(self):
         database = Database.create_for(team=self.team, user=None)

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -754,48 +754,37 @@ class UserAccessControl:
         Access levels are strings - the order of which is determined at run time.
         We find all relevant access controls and then return the highest value.
 
-        Inheriting children (e.g. warehouse_table -> warehouse_objects) combine the parent's
-        level with their own resource-level rows: the parent acts as a ceiling (most restrictive
-        wins), so a parent "none" always denies, while a child rule applies when the parent allows.
-        A child with no rules of its own inherits the parent's level unchanged.
+        Inheriting children (e.g. warehouse_table -> warehouse_objects) resolve as "most specific wins"
+        an explicit child rule (allow or deny) overrides the parent umbrella, and a child
+        with no rule of its own inherits the parent's level.
         """
 
         parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
         if parent_resource:
-            org_membership = self._organization_membership
-            if not org_membership:
+            if self._organization_membership is None:
                 return None
             # Org admins always have resource level access
-            if org_membership.level >= OrganizationMembership.Level.ADMIN:
+            if self.is_organization_admin:
                 return highest_access_level(resource)
 
-            parent_level = self.access_level_for_resource(parent_resource)
             if not self.access_controls_supported:
-                return parent_level
+                return self.access_level_for_resource(parent_resource)
 
             child_level = self._own_resource_access_level(resource)
-            if child_level is None:
-                # No child-specific rule: inherit the parent's level unchanged.
-                return parent_level
-            if parent_level is None:
+            if child_level is not None:
                 return child_level
-
-            # Parent acts as a ceiling: the most restrictive of (parent, child) wins.
-            levels = ordered_access_levels(resource)
-            return min((parent_level, child_level), key=levels.index)
+            return self.access_level_for_resource(parent_resource)
 
         # These are resources which we don't have resource level access controls for
         if resource == "organization" or resource == "project" or resource == "plugin":
             return default_access_level(resource)
 
-        org_membership = self._organization_membership
-
-        if not resource or not org_membership:
+        if not resource or self._organization_membership is None:
             # In any of these cases, we can't determine the access level
             return None
 
         # Org admins always have resource level access
-        if org_membership.level >= OrganizationMembership.Level.ADMIN:
+        if self.is_organization_admin:
             return highest_access_level(resource)
 
         if not self.access_controls_supported:

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -737,17 +737,52 @@ class UserAccessControl:
     # Resource level - checking conditions for the resource type
     # ------------------------------------------------------------
 
+    def _own_resource_access_level(self, resource: APIScopeObject) -> Optional[AccessControlLevel]:
+        """Resource-level access from this resource's OWN rows only (no parent inheritance).
+        Returns None when the resource has no resource-level rows of its own."""
+        filters = self._access_controls_filters_for_resource(resource)
+        access_controls = self._get_access_controls(filters)
+        if not access_controls:
+            return None
+        return max(
+            access_controls,
+            key=lambda access_control: ordered_access_levels(resource).index(access_control.access_level),
+        ).access_level
+
     def access_level_for_resource(self, resource: APIScopeObject) -> Optional[AccessControlLevel]:
         """
         Access levels are strings - the order of which is determined at run time.
-        We find all relevant access controls and then return the highest value
+        We find all relevant access controls and then return the highest value.
+
+        Inheriting children (e.g. warehouse_table -> warehouse_objects) combine the parent's
+        level with their own resource-level rows: the parent acts as a ceiling (most restrictive
+        wins), so a parent "none" always denies, while a child rule applies when the parent allows.
+        A child with no rules of its own inherits the parent's level unchanged.
         """
 
-        # Check if this resource inherits access from a parent resource
         parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
         if parent_resource:
-            # Use parent resource for access control checks
-            return self.access_level_for_resource(parent_resource)
+            org_membership = self._organization_membership
+            if not org_membership:
+                return None
+            # Org admins always have resource level access
+            if org_membership.level >= OrganizationMembership.Level.ADMIN:
+                return highest_access_level(resource)
+
+            parent_level = self.access_level_for_resource(parent_resource)
+            if not self.access_controls_supported:
+                return parent_level
+
+            child_level = self._own_resource_access_level(resource)
+            if child_level is None:
+                # No child-specific rule: inherit the parent's level unchanged.
+                return parent_level
+            if parent_level is None:
+                return child_level
+
+            # Parent acts as a ceiling: the most restrictive of (parent, child) wins.
+            levels = ordered_access_levels(resource)
+            return min((parent_level, child_level), key=levels.index)
 
         # These are resources which we don't have resource level access controls for
         if resource == "organization" or resource == "project" or resource == "plugin":
@@ -767,31 +802,24 @@ class UserAccessControl:
             # If access controls aren't supported, then return the default access level
             return default_access_level(resource)
 
-        filters = self._access_controls_filters_for_resource(resource)
-        access_controls = self._get_access_controls(filters)
-
-        if not access_controls:
+        own_level = self._own_resource_access_level(resource)
+        if own_level is None:
             return default_access_level(resource)
-
-        return max(
-            access_controls,
-            key=lambda access_control: ordered_access_levels(resource).index(access_control.access_level),
-        ).access_level
+        return own_level
 
     def has_access_levels_for_resource(self, resource: APIScopeObject) -> bool:
         if not self._team:
             # If there is no team, then there can't be any access controls on this resource
             return False
 
-        # Inheriting children (e.g. warehouse_view -> warehouse_objects) intentionally
-        # bypass their own resource-level rows: only the parent (umbrella) is consulted.
-        # This keeps the AC picker simple — admins configure one umbrella scope instead
-        # of N child scopes — at the cost of ignoring any standalone resource-level row
-        # written against a child. Object-level rows on the child are still honored via
-        # specific_access_level_for_object, which queries the child resource directly.
+        # Inheriting children (e.g. warehouse_table -> warehouse_objects) consult both the parent
+        # umbrella and their own resource-level rows. Object-level rows on the child are handled
+        # separately via specific_access_level_for_object.
         parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
         if parent_resource:
-            return self.has_access_levels_for_resource(parent_resource)
+            return self.has_access_levels_for_resource(parent_resource) or (
+                self._own_resource_access_level(resource) is not None
+            )
 
         filters = self._access_controls_filters_for_resource(resource)
         access_controls = self._get_access_controls(filters)

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -737,18 +737,6 @@ class UserAccessControl:
     # Resource level - checking conditions for the resource type
     # ------------------------------------------------------------
 
-    def _own_resource_access_level(self, resource: APIScopeObject) -> Optional[AccessControlLevel]:
-        """Resource-level access from this resource's OWN rows only (no parent inheritance).
-        Returns None when the resource has no resource-level rows of its own."""
-        filters = self._access_controls_filters_for_resource(resource)
-        access_controls = self._get_access_controls(filters)
-        if not access_controls:
-            return None
-        return max(
-            access_controls,
-            key=lambda access_control: ordered_access_levels(resource).index(access_control.access_level),
-        ).access_level
-
     def access_level_for_resource(self, resource: APIScopeObject) -> Optional[AccessControlLevel]:
         """
         Access levels are strings - the order of which is determined at run time.
@@ -758,22 +746,6 @@ class UserAccessControl:
         an explicit child rule (allow or deny) overrides the parent umbrella, and a child
         with no rule of its own inherits the parent's level.
         """
-
-        parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
-        if parent_resource:
-            if self._organization_membership is None:
-                return None
-            # Org admins always have resource level access
-            if self.is_organization_admin:
-                return highest_access_level(resource)
-
-            if not self.access_controls_supported:
-                return self.access_level_for_resource(parent_resource)
-
-            child_level = self._own_resource_access_level(resource)
-            if child_level is not None:
-                return child_level
-            return self.access_level_for_resource(parent_resource)
 
         # These are resources which we don't have resource level access controls for
         if resource == "organization" or resource == "project" or resource == "plugin":
@@ -791,10 +763,23 @@ class UserAccessControl:
             # If access controls aren't supported, then return the default access level
             return default_access_level(resource)
 
-        own_level = self._own_resource_access_level(resource)
-        if own_level is None:
-            return default_access_level(resource)
-        return own_level
+        filters = self._access_controls_filters_for_resource(resource)
+        access_controls = self._get_access_controls(filters)
+
+        if access_controls:
+            return max(
+                access_controls,
+                key=lambda access_control: ordered_access_levels(resource).index(access_control.access_level),
+            ).access_level
+
+        # No resource-level rules of its own, using the parent resource's rules
+        # (e.g. warehouse_table -> warehouse_objects)
+        parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
+        if parent_resource:
+            return self.access_level_for_resource(parent_resource)
+
+        # Fall back to the default if there are no access controls for either the child or parent resource
+        return default_access_level(resource)
 
     def has_access_levels_for_resource(self, resource: APIScopeObject) -> bool:
         if not self._team:
@@ -806,9 +791,9 @@ class UserAccessControl:
         # separately via specific_access_level_for_object.
         parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
         if parent_resource:
-            return self.has_access_levels_for_resource(parent_resource) or (
-                self._own_resource_access_level(resource) is not None
-            )
+            filters = self._access_controls_filters_for_resource(resource)
+            access_controls = self._get_access_controls(filters)
+            return self.has_access_levels_for_resource(parent_resource) or bool(access_controls)
 
         filters = self._access_controls_filters_for_resource(resource)
         access_controls = self._get_access_controls(filters)

--- a/products/data_warehouse/backend/api/test/test_saved_query_access_control.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query_access_control.py
@@ -151,15 +151,11 @@ class TestDataWarehouseSavedQueryAccessControl(WarehouseAccessControlTestMixin):
         self.saved_query.refresh_from_db()
         self.assertEqual(self.saved_query.query, {"kind": "HogQLQuery", "query": "select 1"})
 
-    def test_resource_level_row_on_child_alone_has_no_effect(self):
-        # Contract: warehouse_view inherits from warehouse_objects, so resource-level rows
-        # keyed on warehouse_view (without resource_id) are intentionally bypassed — only
-        # the umbrella warehouse_objects scope counts. The distinguishing assertion is that
-        # creator bypass (resolved via access_level_for_object) still returns "manager" on
-        # the user's own query, even with a child-only `none` row that would otherwise
-        # short-circuit resource access. If has_access_levels_for_resource ever started
-        # honoring child rows it would route through access_level_for_resource and lose
-        # creator bypass, returning the default ("editor") instead.
+    def test_child_resource_none_denies_resource_access(self):
+        # A resource-level "none" on the child warehouse_view is now honored (it used to be
+        # ignored in favor of the warehouse_objects umbrella). It denies at the resource gate just
+        # like a warehouse_objects "none" would — even for the creator, who has no explicit
+        # object-level grant to fall back on (has_any_specific_access_for_resource).
         own_query = DataWarehouseSavedQuery.objects.create(
             team=self.team,
             name="own_view",
@@ -171,9 +167,7 @@ class TestDataWarehouseSavedQueryAccessControl(WarehouseAccessControlTestMixin):
 
         url = f"/api/environments/{self.team.pk}/warehouse_saved_queries/{own_query.id}/"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Creator bypass: highest level for warehouse_view is "manager".
-        self.assertEqual(response.json().get("user_access_level"), "manager")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_object_level_access_grants_through_resource_default_none(self):
         # When the project default is 'none' (no resource access), an object-level grant on a

--- a/products/data_warehouse/backend/api/test/test_saved_query_access_control.py
+++ b/products/data_warehouse/backend/api/test/test_saved_query_access_control.py
@@ -152,10 +152,9 @@ class TestDataWarehouseSavedQueryAccessControl(WarehouseAccessControlTestMixin):
         self.assertEqual(self.saved_query.query, {"kind": "HogQLQuery", "query": "select 1"})
 
     def test_child_resource_none_denies_resource_access(self):
-        # A resource-level "none" on the child warehouse_view is now honored (it used to be
-        # ignored in favor of the warehouse_objects umbrella). It denies at the resource gate just
-        # like a warehouse_objects "none" would — even for the creator, who has no explicit
-        # object-level grant to fall back on (has_any_specific_access_for_resource).
+        # Setting warehouse_view to "none" blocks access at the resource gate, which runs before any
+        # object-level checks — so the creator bypass (full access to objects you created) never gets
+        # a chance to apply, and the creator is denied too.
         own_query = DataWarehouseSavedQuery.objects.create(
             team=self.team,
             name="own_view",


### PR DESCRIPTION
## Problem

Warehouse tables and views are access-controlled through an **inheritance map**: `warehouse_table` and `warehouse_view` are children of the `warehouse_objects` umbrella resource. Until now, the resolver (`access_level_for_resource` / `has_access_levels_for_resource`) **fully delegated children to the parent** — a resource-level rule written against a child resource was ignored. 

That means you can't restrict (or grant) a child resource independently of the umbrella. Setting `warehouse_view` or `warehouse_table` to `none` had no effect. 

Building on top of #61686

## Changes

Resolve inheriting child resources as **most-specific wins** instead of always deferring to the parent:

- An explicit child rule (allow or deny) overrides the parent umbrella
- A child with no rule of its own inherits the parent's level (unchanged behavior)
- `access_level_for_resource` and `has_access_levels_for_resource` now consult the child's own resource-level rows. 

- Also collapsed the duplicated org-admin / membership handling onto the existing `is_organization_admin` cached property.

**Not in this PR (follow-ups):**
- No UI yet to configure a child resource (`warehouse_table` / `warehouse_view`) separately from the `warehouse_objects` umbrella. The resolver now supports it, surfacing it in the access-control picker makes sense as a future addition.
- The broader "most-specific wins everywhere" / explicit-grant-pierces-project-`none` work ([RFC](https://github.com/PostHog/requests-for-comments-public/pull/557)) is out of scope here.

## How did you test this code?

Unit tests (added + updated), run with:

```
pytest posthog/rbac/test/test_user_access_control.py posthog/hogql/printer/test/test_hogql_access_control.py products/data_warehouse/backend/api/test/test_saved_query_access_control.py products/data_warehouse/backend/api/test/test_external_data_source_access_control.py products/data_warehouse/backend/api/test/test_table_access_control.py products/data_warehouse/backend/api/test/test_view_link_access_control.py products/ai_observability/backend/api/test/test_ai_observability_access_control.py
```

Coverage of the new behavior:
- Child grant overrides parent deny (`warehouse_objects=none` + `warehouse_table=viewer` → tables visible) — the allowlist case.
- Child deny applies with no parent rule (`warehouse_view=none` → views denied) — the denylist case.
- Sibling isolation: denying `warehouse_table` doesn't affect `warehouse_view`.
- REST contract: a `warehouse_view=none` denies at the resource gate even for the object's creator (no object-level grant to fall back on).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

The main design decision was the precedence rule for combining a parent umbrella with a child resource rule. First implementation used a **most-restrictive ceiling** (`min(parent, child)`), so a parent `none` would always win. That was rejected in favor of **most-specific wins** to support both the allowlist (child grant over a restrictive parent) and denylist (child deny under a permissive parent) cases, matching the direction of the RBAC v2 RFC. If the team prefers a ceiling model, it's a small change localized to `access_level_for_resource`.
