### PR TITLE
feat(signals): default auto-start threshold to P2

### DIFF
--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -155,7 +155,7 @@ async def maybe_autostart_implementation_task(
 
     team = await Team.objects.select_related("organization").aget(id=team_id)
     team_config = await SignalTeamConfig.objects.filter(team_id=team_id).afirst()
-    team_default_priority = Priority(team_config.default_autostart_priority) if team_config else Priority.P0
+    team_default_priority = Priority(team_config.default_autostart_priority) if team_config else Priority.P2
 
     task_user = await database_sync_to_async(_resolve_autostart_assignee, thread_sensitive=False)(
         team_id, priority.priority, reviewers_content, team_default_priority

--- a/products/signals/backend/migrations/0035_signalteamconfig_default_autostart_priority_p2.py
+++ b/products/signals/backend/migrations/0035_signalteamconfig_default_autostart_priority_p2.py
@@ -1,17 +1,6 @@
 from django.db import migrations, models
 
 
-def bump_default_p0_to_p2(apps, schema_editor):
-    """Raise teams still on the old P0 default up to the new P2 default.
-
-    P0 was only ever the auto-created default (there's no UI to pick it), so a row at
-    P0 reflects the old default rather than a deliberate choice. Rows set to any other
-    priority are left untouched.
-    """
-    SignalTeamConfig = apps.get_model("signals", "SignalTeamConfig")
-    SignalTeamConfig.objects.filter(default_autostart_priority="P0").update(default_autostart_priority="P2")
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("signals", "0034_signalscoutemission"),
@@ -27,5 +16,4 @@ class Migration(migrations.Migration):
                 max_length=2,
             ),
         ),
-        migrations.RunPython(bump_default_p0_to_p2, migrations.RunPython.noop),
     ]

--- a/products/signals/backend/migrations/0035_signalteamconfig_default_autostart_priority_p2.py
+++ b/products/signals/backend/migrations/0035_signalteamconfig_default_autostart_priority_p2.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+def bump_default_p0_to_p2(apps, schema_editor):
+    """Raise teams still on the old P0 default up to the new P2 default.
+
+    P0 was only ever the auto-created default (there's no UI to pick it), so a row at
+    P0 reflects the old default rather than a deliberate choice. Rows set to any other
+    priority are left untouched.
+    """
+    SignalTeamConfig = apps.get_model("signals", "SignalTeamConfig")
+    SignalTeamConfig.objects.filter(default_autostart_priority="P0").update(default_autostart_priority="P2")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("signals", "0034_signalscoutemission"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="signalteamconfig",
+            name="default_autostart_priority",
+            field=models.CharField(
+                choices=[("P0", "P0"), ("P1", "P1"), ("P2", "P2"), ("P3", "P3"), ("P4", "P4")],
+                default="P2",
+                max_length=2,
+            ),
+        ),
+        migrations.RunPython(bump_default_p0_to_p2, migrations.RunPython.noop),
+    ]

--- a/products/signals/backend/migrations/0036_signalteamconfig_backfill_default_autostart_p2.py
+++ b/products/signals/backend/migrations/0036_signalteamconfig_backfill_default_autostart_p2.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def bump_default_p0_to_p2(apps, schema_editor):
+    """Raise teams still on the old P0 default up to the new P2 default.
+
+    P0 was only ever the auto-created default (there's no UI to pick it), so a row at
+    P0 reflects the old default rather than a deliberate choice. Rows set to any other
+    priority are left untouched. SignalTeamConfig has one row per team, so a single
+    filtered UPDATE is cheap.
+    """
+    SignalTeamConfig = apps.get_model("signals", "SignalTeamConfig")
+    SignalTeamConfig.objects.filter(default_autostart_priority="P0").update(default_autostart_priority="P2")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("signals", "0035_signalteamconfig_default_autostart_priority_p2"),
+    ]
+
+    operations = [
+        migrations.RunPython(bump_default_p0_to_p2, migrations.RunPython.noop),
+    ]

--- a/products/signals/backend/migrations/max_migration.txt
+++ b/products/signals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0034_signalscoutemission
+0035_signalteamconfig_default_autostart_priority_p2

--- a/products/signals/backend/migrations/max_migration.txt
+++ b/products/signals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0035_signalteamconfig_default_autostart_priority_p2
+0036_signalteamconfig_backfill_default_autostart_p2

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -93,7 +93,7 @@ class SignalTeamConfig(UUIDModel):
         on_delete=models.CASCADE,
         related_name="signal_team_config",
     )
-    default_autostart_priority = models.CharField(max_length=2, choices=AutonomyPriority, default=AutonomyPriority.P0)
+    default_autostart_priority = models.CharField(max_length=2, choices=AutonomyPriority, default=AutonomyPriority.P2)
     default_slack_notification_channel = models.CharField(max_length=255, null=True, blank=True)
     autostart_base_branches = models.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/products/signals/backend/test/test_signal_team_config_api.py
+++ b/products/signals/backend/test/test_signal_team_config_api.py
@@ -20,7 +20,7 @@ class TestSignalTeamConfigAPI(APIBaseTest):
         data = response.json()
         assert response.status_code == status.HTTP_200_OK, data
         assert data["default_slack_notification_channel"] is None
-        assert data["default_autostart_priority"] == "P0"
+        assert data["default_autostart_priority"] == "P2"
 
     def test_get_config_lazily_creates_when_no_config_exists(self):
         self.config.delete()
@@ -28,7 +28,7 @@ class TestSignalTeamConfigAPI(APIBaseTest):
         response = self.client.get(self._url())
         data = response.json()
         assert response.status_code == status.HTTP_200_OK, data
-        assert data["default_autostart_priority"] == "P0"
+        assert data["default_autostart_priority"] == "P2"
         assert data["default_slack_notification_channel"] is None
         assert SignalTeamConfig.objects.filter(team=self.team).exists()
 


### PR DESCRIPTION
## Problem

In Signals, the team-level `default_autostart_priority` is the threshold every user falls back to when they haven't set a personal override (the per-user `autostart_priority` is `null` = "use the team default"). It defaulted to `P0`, so only `P0` reports auto-started an implementation task — in practice almost nothing did.

**Why:** we want auto-start to be useful by default — reports at `P2` or more urgent (`P0`, `P1`, `P2`) should kick off a task automatically, rather than effectively nothing.

## Changes

- `default_autostart_priority` model default `P0` → `P2`, plus the matching no-config fallback in `auto_start.py`.
- Migration `0035` alters the field default and backfills existing teams **still on the old `P0` default** up to `P2`. There's no UI to pick `P0`, so an existing `P0` row is the leftover auto-created default rather than a deliberate choice; rows set to any other priority are left untouched.

This is a backend-only default — there's no frontend UI for this setting yet, and the field isn't exposed in the generated TS/MCP clients.

## How did you test this code?

I'm an agent (PostHog Slack app). I updated the two `test_signal_team_config_api.py` assertions that pinned the old `P0` default to `P2`. I did not run the suite or manual testing in this environment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack: make `P2` the default auto-start threshold for users in Signals rather than nothing. Traced the default to `SignalTeamConfig.default_autostart_priority` (the per-user fallback) plus the hardcoded `Priority.P0` no-config fallback in `auto_start.py`. Chose to backfill existing teams still on the old `P0` default so the change takes effect for the current fleet, while leaving any explicitly-set priorities alone.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1781030673686219)*
