### PR TITLE
feat(hogql): ignore minmax skip indexes for negation-only property filters

### DIFF
--- a/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
+++ b/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
@@ -28,6 +28,22 @@ Suggested entry format:
 
 ---
 
+## 2026-06-09: Minmax skip indexes are net-negative for negation-only filters; ignore them per query instead of disabling skip indexes
+
+**Context.** A nightly cache-warming TrendsQuery with an all-time date range ran ~60s per shard on cold replicas while reading only a few MiB. `query_log` showed long wall, low CPU, no CPU-starvation wait (so not cluster load). The 1 Hz production profiler (`system.trace_log`, symbolized in-database with `demangle(addressToSymbol(...))` and `SETTINGS allow_introspection_functions=1` via clusterAllReplicas so symbolization runs on the owning host) attributed the time to `filterMarksUsingIndex` → `MergeTreeIndexReader::read` → `MergeTreeIndexGranuleMinMax::deserializeBinary`, mark loading (`MergeTreeMarksLoader::loadMarksSync`), and a mutex under `CachedCompressedReadBuffer::nextImpl`.
+
+**Question.** PK pruning had already reduced the scan to a few thousand granules across >1k parts, so why did skip-index evaluation cost hundreds of thread-seconds, and what is the safe fix at the HogQL layer?
+
+**What we tried.** Mechanics first: per part and per index, ClickHouse loads the entire index marks file (one entry per granule of the part, regardless of how narrow the candidate ranges are — millions of mark entries for a query that finally selected a few hundred marks), and minmax granules deserialize Field-by-Field through a cache wrapper whose global mutex serializes all index reads on the node (zero-capacity `index_uncompressed_cache` is the default; bypass landed upstream in ClickHouse PR 104063, after 26.3). The query's only applied-but-useless index condition was a bare `notEquals(mat_col, const)`: a minmax condition for `!=` can only exclude granules where min == max == the excluded value (it pruned ~1.5% of granules for ~1/3 of the index-analysis cost). Benchmarked three arms on warm production replicas, host-paired, n=15 per arm, `use_query_condition_cache=0`: A baseline, B `ignore_data_skipping_indices='minmax_<col>'` for the negated column only, C ignore all three applied indexes.
+
+**Numbers.** Medians from `query_log`: B vs A cut `FilteringMarksWithSecondaryKeysMicroseconds` from 1873ms to 811ms (−57%), `CompressedReadBufferBytes` from 689MB to 363MB (−47%), OS IO wait from 1510ms to 720ms (−53%), with identical results. C (no skip indexes at all) read 3.4× more rows and +62% CPU — the positively-used timestamp and equality indexes earn their keep.
+
+**Caveats.** Warm-replica numbers; on cold replicas the same mark/index reads were the bulk of a 60s wall, so the relative win there is larger. `notILike`/`notLike`/regex negations build no usable minmax condition and are already skipped by ClickHouse — the waste is specific to `!=` / `NOT IN`, which build technically-usable conditions.
+
+**Takeaway.** When a minmax-indexed materialized column is referenced only under `!=` / `NOT IN`, evaluating the index costs far more than it prunes; the safe surgical fix is `ignore_data_skipping_indices` (ignoring a skip index can only widen reads, never change results), not `use_skip_indexes=0`. The HogQL printer now does this automatically (modifier `ignoreNegationOnlySkipIndexes`, default on). Also remember: `EXPLAIN indexes=1` granule counts can massively understate skip-index cost — the cost scales with parts × per-part mark-file size, not with candidate granules.
+
+---
+
 ## 2026-05-28: Dropping `FROM person FINAL` via `argMax` is worse than the original; materialization is the actual win
 
 **Context.** `posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py` builds a raw ClickHouse query that does `SELECT id, JSONExtract(properties, '<key>', 'String'), ... FROM person FINAL WHERE team_id = ... AND id BETWEEN ... AND is_deleted = 0 ORDER BY id FORMAT JSONEachRow`. We flagged the `FINAL` as a smell.

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -80,6 +80,10 @@ class MaterializedColumn:
         else:
             return "String"
 
+    @property
+    def minmax_index_name(self) -> str | None:
+        return get_minmax_index_name(self.name) if self.has_minmax_index else None
+
     def get_expression_and_parameters(self) -> tuple[str, dict[str, Any]]:
         if self.is_nullable:
             return (

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -22686,6 +22686,10 @@
                 "formatCsvAllowDoubleQuotes": {
                     "type": "boolean"
                 },
+                "ignoreNegationOnlySkipIndexes": {
+                    "description": "Ignore minmax skip indexes on materialized columns that the query only compares with negated operators (`!=` / `NOT IN`), where evaluating the index costs more than it prunes",
+                    "type": "boolean"
+                },
                 "inCohortVia": {
                     "enum": ["auto", "leftjoin", "subquery", "leftjoin_conjoined"],
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -452,6 +452,8 @@ export interface HogQLQueryModifiers {
     pushDownPredicates?: boolean
     /** If these are provided, the query will fail if these skip indexes are not used */
     forceClickhouseDataSkippingIndexes?: string[]
+    /** Ignore minmax skip indexes on materialized columns that the query only compares with negated operators (`!=` / `NOT IN`), where evaluating the index costs more than it prunes */
+    ignoreNegationOnlySkipIndexes?: boolean
     inlineCohortCalculation?: 'off' | 'auto' | 'always'
     /** HogQL parser backend; absent → `rust_py_with_cpp_shadow` (rust-py is primary, cpp runs as a sampled shadow). `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
     parserMode?:

--- a/posthog/clickhouse/materialized_columns.py
+++ b/posthog/clickhouse/materialized_columns.py
@@ -17,6 +17,9 @@ class MaterializedColumn(Protocol):
     has_ngram_lower_index: bool
     has_bloom_filter_lower_index: bool
 
+    @property
+    def minmax_index_name(self) -> str | None: ...
+
 
 if EE_AVAILABLE:
     from ee.clickhouse.materialized_columns.columns import get_enabled_materialized_columns

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -119,6 +119,9 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
     if modifiers.sessionPropertyPreAggregation is None:
         modifiers.sessionPropertyPreAggregation = False
 
+    if modifiers.ignoreNegationOnlySkipIndexes is None:
+        modifiers.ignoreNegationOnlySkipIndexes = True
+
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:
     if modifiers.inCohortVia is None or modifiers.inCohortVia == InCohortVia.AUTO:

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1317,6 +1317,7 @@ class BasePrinter(Visitor[str]):
                     has_ngram_lower_index=materialized_column.has_ngram_lower_index,
                     has_bloom_filter_index=materialized_column.has_bloom_filter_index,
                     has_bloom_filter_lower_index=materialized_column.has_bloom_filter_lower_index,
+                    minmax_index_name=materialized_column.minmax_index_name,
                 )
 
             # Check for dmat (dynamic materialized) columns
@@ -1349,6 +1350,7 @@ class BasePrinter(Visitor[str]):
                     has_ngram_lower_index=materialized_column.has_ngram_lower_index,
                     has_bloom_filter_index=materialized_column.has_bloom_filter_index,
                     has_bloom_filter_lower_index=materialized_column.has_bloom_filter_lower_index,
+                    minmax_index_name=materialized_column.minmax_index_name,
                 )
 
     def visit_property_type(self, type: ast.PropertyType):

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date, datetime
-from typing import ClassVar, Literal, Union, cast
+from typing import Any, ClassVar, Literal, Union, cast
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -65,6 +65,22 @@ COLUMNS_WITH_HACKY_OPTIMIZED_NULL_HANDLING = {
 
 class ClickHousePrinter(BasePrinter):
     DIALECT_NAME: ClassVar[HogQLDialect] = "clickhouse"
+
+    # Comparison operators whose minmax skip-index conditions can only prune granules where min == max == the
+    # excluded value, so evaluating the index (reading its marks and granules across every part) almost never
+    # pays for itself. Columns referenced exclusively under these operators get their minmax index ignored via
+    # the ignore_data_skipping_indices setting; skipping an index can only widen the read, never change results.
+    NEGATED_COMPARE_OPS = (
+        ast.CompareOperationOp.NotEq,
+        ast.CompareOperationOp.NotIn,
+        ast.CompareOperationOp.GlobalNotIn,
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._negated_compare_depth = 0
+        self._minmax_skip_indexes_negated: set[str] = set()
+        self._minmax_skip_indexes_positive: set[str] = set()
 
     def _render_set_query_limit_percent(self, limit: ast.Expr, limit_str: str) -> str:
         return str(self._limit_percent_constant_value(limit))
@@ -292,11 +308,24 @@ class ClickHousePrinter(BasePrinter):
             if not isinstance(node, ast.SelectQuery) and not isinstance(node, ast.SelectSetQuery):
                 raise QueryError("Settings can only be applied to SELECT queries")
             merged = self._merge_table_top_level_settings(self.settings)
+            if ignored_indexes := self._negation_only_skip_indexes_to_ignore(merged):
+                merged["ignore_data_skipping_indices"] = ignored_indexes
             printed = self._print_settings(merged)
             if printed is not None:
                 response += " " + printed
 
         return response
+
+    def _negation_only_skip_indexes_to_ignore(self, merged_settings: dict[str, Any]) -> list[str] | None:
+        if self.context.modifiers.ignoreNegationOnlySkipIndexes is False:
+            return None
+        candidates = self._minmax_skip_indexes_negated - self._minmax_skip_indexes_positive
+        if not candidates:
+            return None
+        forced = set(merged_settings.get("force_data_skipping_indices") or [])
+        existing = set(merged_settings.get("ignore_data_skipping_indices") or [])
+        result = sorted((candidates | existing) - forced)
+        return result or None
 
     def visit_select_query(self, node: ast.SelectQuery):
         if not self.context.enable_select_queries:
@@ -426,7 +455,16 @@ class ClickHousePrinter(BasePrinter):
         # value collapses to an empty string instead of leaking the materialized value.
         if self._is_property_type_restricted(type):
             return None
-        return super()._get_materialized_property_source_for_property_type(type)
+        source = super()._get_materialized_property_source_for_property_type(type)
+        # Track which minmax-indexed materialized columns the query references, and whether the reference sits
+        # under a negated comparison. Columns referenced only under negations get their index ignored at the
+        # top-level SETTINGS clause (see _negation_only_skip_indexes_to_ignore).
+        if isinstance(source, PrintableMaterializedColumn) and source.minmax_index_name is not None:
+            if self._negated_compare_depth > 0:
+                self._minmax_skip_indexes_negated.add(source.minmax_index_name)
+            else:
+                self._minmax_skip_indexes_positive.add(source.minmax_index_name)
+        return source
 
     def _is_property_type_restricted(self, type: ast.PropertyType) -> bool:
         if not self.context.restricted_properties or len(type.chain) == 0:
@@ -1211,6 +1249,15 @@ class ClickHousePrinter(BasePrinter):
         return False
 
     def visit_compare_operation(self, node: ast.CompareOperation):
+        if node.op in self.NEGATED_COMPARE_OPS:
+            self._negated_compare_depth += 1
+            try:
+                return self._visit_compare_operation_inner(node)
+            finally:
+                self._negated_compare_depth -= 1
+        return self._visit_compare_operation_inner(node)
+
+    def _visit_compare_operation_inner(self, node: ast.CompareOperation):
         # If either side of the operation is a property that is part of a property group, special optimizations may
         # apply here to ensure that data skipping indexes can be used when possible.
         if optimized_session_id := self._get_optimized_session_id_compare_operation(node):

--- a/posthog/hogql/printer/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/printer/test/__snapshots__/test_printer.ambr
@@ -3026,7 +3026,8 @@
                      optimize_rewrite_aggregate_function_with_if=0,
                      optimize_min_inequality_conjunction_chain_length=4294967295,
                      allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+                     use_hive_partitioning=0,
+                     ignore_data_skipping_indices='minmax_mat_test_prop'
   '''
 # ---
 # name: TestMaterializedColumnOptimization.test_materialized_column_optimization_returns_correct_results_1_not_nullable
@@ -3066,7 +3067,8 @@
                      optimize_rewrite_aggregate_function_with_if=0,
                      optimize_min_inequality_conjunction_chain_length=4294967295,
                      allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+                     use_hive_partitioning=0,
+                     ignore_data_skipping_indices='minmax_mat_test_prop'
   '''
 # ---
 # name: TestMaterializedColumnOptimization.test_materialized_column_range_optimization_returns_correct_results_0_nullable

--- a/posthog/hogql/printer/types.py
+++ b/posthog/hogql/printer/types.py
@@ -18,6 +18,8 @@ class PrintableMaterializedColumn:
     has_bloom_filter_index: bool
     has_ngram_lower_index: bool
     has_bloom_filter_lower_index: bool
+    # ClickHouse name of the column's minmax skip index, when one exists (e.g. "minmax_mat_foo")
+    minmax_index_name: str | None = None
 
     def __str__(self) -> str:
         if self.table is None:

--- a/posthog/hogql/test/__snapshots__/test_property_skip_indexes.ambr
+++ b/posthog/hogql/test/__snapshots__/test_property_skip_indexes.ambr
@@ -508,6 +508,66 @@
   LIMIT 50000
   '''
 # ---
+# name: TestNegationOnlyMinmaxIndexIgnore.test_neq_only_ignores_minmax_index_0_non_nullable
+  '''
+  SELECT count() AS `count()`
+  FROM events
+  WHERE and(equals(events.team_id, 99999), notEquals(events.mat_test_prop, '5'))
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       optimize_rewrite_aggregate_function_with_if=0,
+                       optimize_min_inequality_conjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0,
+                       ignore_data_skipping_indices='minmax_mat_test_prop'
+  '''
+# ---
+# name: TestNegationOnlyMinmaxIndexIgnore.test_neq_only_ignores_minmax_index_1_nullable
+  '''
+  SELECT count() AS `count()`
+  FROM events
+  WHERE and(equals(events.team_id, 99999), ifNull(notEquals(events.mat_test_prop, '5'), 1))
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       optimize_rewrite_aggregate_function_with_if=0,
+                       optimize_min_inequality_conjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0,
+                       ignore_data_skipping_indices='minmax_mat_test_prop'
+  '''
+# ---
+# name: TestNegationOnlyMinmaxIndexIgnore.test_not_in_multi_value_ignores_minmax_index
+  '''
+  SELECT count() AS `count()`
+  FROM events
+  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('2', '5')))
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       optimize_rewrite_aggregate_function_with_if=0,
+                       optimize_min_inequality_conjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0,
+                       ignore_data_skipping_indices='minmax_mat_test_prop'
+  '''
+# ---
 # name: TestPersonOnEventsPropertySkipIndexes.test_mat_col_nullable_bloom_filter_0_eq
   '''
   SELECT count() AS `count()`

--- a/posthog/hogql/test/test_property_skip_indexes.py
+++ b/posthog/hogql/test/test_property_skip_indexes.py
@@ -644,6 +644,150 @@ class TestEventPropertySkipIndexes(_PropertySkipIndexTestBase):
 
 
 # ============================================================================
+# Negation-only minmax index ignore (ignore_data_skipping_indices)
+# ============================================================================
+# A minmax condition for `!=` / `NOT IN` can only prune granules where min == max == the excluded value, so
+# evaluating the index reads its marks and granules across every part for ~no pruning. When a minmax-indexed
+# materialized column is referenced only under those operators, the printer ignores the index via the
+# top-level `SETTINGS ignore_data_skipping_indices=...`. Ignoring a skip index never changes results.
+
+
+@snapshot_clickhouse_queries
+class TestNegationOnlyMinmaxIndexIgnore(_PropertySkipIndexTestBase):
+    SCOPE = "event"
+    PROPERTY_TO_EXPR_SCOPE = "event"
+    FILTER_TYPE = "event"
+
+    def _print_select(
+        self,
+        where: ast.Expr,
+        order_by: list[ast.OrderExpr] | None = None,
+        modifiers: HogQLQueryModifiers | None = None,
+        settings: HogQLGlobalSettings | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        select_query = ast.SelectQuery(
+            select=[ast.Call(name="count", args=[])],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=where,
+            order_by=order_by,
+        )
+        context = HogQLContext(
+            team_id=self.team.pk,
+            team=self.team,
+            enable_select_queries=True,
+            modifiers=modifiers
+            or HogQLQueryModifiers(
+                materializationMode=MaterializationMode.AUTO,
+                propertyGroupsMode=PropertyGroupsMode.OPTIMIZED,
+                personsOnEventsMode=self.POE_MODE,
+            ),
+        )
+        query, _ = prepare_and_print_ast(
+            select_query, context, "clickhouse", settings=settings or HogQLGlobalSettings()
+        )
+        return query, context.values
+
+    def _property_expr(self, operator: PropertyOperator, value: Any) -> ast.Expr:
+        return property_to_expr(self._filter(operator, value), team=self.team, scope=self.PROPERTY_TO_EXPR_SCOPE)
+
+    @parameterized.expand([("non_nullable", False), ("nullable", True)])
+    def test_neq_only_ignores_minmax_index(self, _name: str, is_nullable: bool) -> None:
+        self._seed()
+        mat_col = self._materialize_with(is_nullable=is_nullable, create_minmax_index=True)
+        index = get_minmax_index_name(mat_col.name)
+        query, values = self._print_select(self._property_expr(PropertyOperator.IS_NOT, "5"))
+        assert f"ignore_data_skipping_indices='{index}'" in query, f"Expected {index} ignored in SQL: {query}"
+        sync_execute(query, values)
+        assert index not in _run_explain_and_get_skip_indexes(query, values)
+
+    def test_not_in_multi_value_ignores_minmax_index(self) -> None:
+        self._seed()
+        mat_col = self._materialize_with(is_nullable=False, create_minmax_index=True)
+        index = get_minmax_index_name(mat_col.name)
+        query, values = self._print_select(self._property_expr(PropertyOperator.IS_NOT, ["2", "5"]))
+        assert f"ignore_data_skipping_indices='{index}'" in query, f"Expected {index} ignored in SQL: {query}"
+        sync_execute(query, values)
+        assert index not in _run_explain_and_get_skip_indexes(query, values)
+
+    def test_eq_does_not_ignore_minmax_index(self) -> None:
+        self._seed()
+        self._materialize_with(is_nullable=False, create_minmax_index=True)
+        query, _ = self._print_select(self._property_expr(PropertyOperator.EXACT, "5"))
+        assert "ignore_data_skipping_indices" not in query, f"Unexpected ignore in SQL: {query}"
+
+    def test_mixed_eq_and_neq_does_not_ignore_minmax_index(self) -> None:
+        self._seed()
+        self._materialize_with(is_nullable=False, create_minmax_index=True)
+        where = ast.And(
+            exprs=[
+                self._property_expr(PropertyOperator.IS_NOT, "5"),
+                self._property_expr(PropertyOperator.EXACT, "3"),
+            ]
+        )
+        query, _ = self._print_select(where)
+        assert "ignore_data_skipping_indices" not in query, f"Unexpected ignore in SQL: {query}"
+
+    def test_order_by_reference_does_not_ignore_minmax_index(self) -> None:
+        self._seed()
+        self._materialize_with(is_nullable=False, create_minmax_index=True)
+        query, _ = self._print_select(
+            self._property_expr(PropertyOperator.IS_NOT, "5"),
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["properties", self._mat_property_key]), order="ASC")],
+        )
+        assert "ignore_data_skipping_indices" not in query, f"Unexpected ignore in SQL: {query}"
+
+    def test_modifier_disabled_does_not_ignore_minmax_index(self) -> None:
+        self._seed()
+        self._materialize_with(is_nullable=False, create_minmax_index=True)
+        query, _ = self._print_select(
+            self._property_expr(PropertyOperator.IS_NOT, "5"),
+            modifiers=HogQLQueryModifiers(
+                materializationMode=MaterializationMode.AUTO,
+                propertyGroupsMode=PropertyGroupsMode.OPTIMIZED,
+                personsOnEventsMode=self.POE_MODE,
+                ignoreNegationOnlySkipIndexes=False,
+            ),
+        )
+        assert "ignore_data_skipping_indices" not in query, f"Unexpected ignore in SQL: {query}"
+
+    def test_no_minmax_index_nothing_to_ignore(self) -> None:
+        self._seed()
+        self._materialize_with(is_nullable=False, create_minmax_index=False)
+        query, _ = self._print_select(self._property_expr(PropertyOperator.IS_NOT, "5"))
+        assert "ignore_data_skipping_indices" not in query, f"Unexpected ignore in SQL: {query}"
+
+    def test_forced_index_is_never_ignored(self) -> None:
+        self._seed()
+        mat_col = self._materialize_with(is_nullable=False, create_minmax_index=True)
+        index = get_minmax_index_name(mat_col.name)
+        settings = HogQLGlobalSettings(force_data_skipping_indices=[index])
+        query, _ = self._print_select(self._property_expr(PropertyOperator.IS_NOT, "5"), settings=settings)
+        assert "ignore_data_skipping_indices" not in query, f"Unexpected ignore in SQL: {query}"
+
+    def test_no_settings_object_prints_no_settings_clause(self) -> None:
+        self._seed()
+        self._materialize_with(is_nullable=False, create_minmax_index=True)
+        expr = self._property_expr(PropertyOperator.IS_NOT, "5")
+        select_query = ast.SelectQuery(
+            select=[ast.Call(name="count", args=[])],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=expr,
+        )
+        context = HogQLContext(
+            team_id=self.team.pk,
+            team=self.team,
+            enable_select_queries=True,
+            modifiers=HogQLQueryModifiers(
+                materializationMode=MaterializationMode.AUTO,
+                propertyGroupsMode=PropertyGroupsMode.OPTIMIZED,
+                personsOnEventsMode=self.POE_MODE,
+            ),
+        )
+        query, _ = prepare_and_print_ast(select_query, context, "clickhouse")
+        assert "ignore_data_skipping_indices" not in query
+
+
+# ============================================================================
 # Person-on-Events (events.person_properties)
 # ============================================================================
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7626,6 +7626,14 @@ class HogQLQueryModifiers(BaseModel):
         description=("If these are provided, the query will fail if these skip indexes are not used"),
     )
     formatCsvAllowDoubleQuotes: bool | None = None
+    ignoreNegationOnlySkipIndexes: bool | None = Field(
+        default=None,
+        description=(
+            "Ignore minmax skip indexes on materialized columns that the query only"
+            " compares with negated operators (`!=` / `NOT IN`), where evaluating the"
+            " index costs more than it prunes"
+        ),
+    )
     inCohortVia: InCohortVia | None = None
     inlineCohortCalculation: InlineCohortCalculation | None = None
     materializationMode: MaterializationMode | None = None

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -733,6 +733,8 @@ export interface HogQLQueryModifiersApi {
     /** If these are provided, the query will fail if these skip indexes are not used */
     forceClickhouseDataSkippingIndexes?: string[] | null
     formatCsvAllowDoubleQuotes?: boolean | null
+    /** Ignore minmax skip indexes on materialized columns that the query only compares with negated operators (`!=` / `NOT IN`), where evaluating the index costs more than it prunes */
+    ignoreNegationOnlySkipIndexes?: boolean | null
     inCohortVia?: InCohortViaApi | null
     inlineCohortCalculation?: InlineCohortCalculationApi | null
     materializationMode?: MaterializationModeApi | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -426,6 +426,8 @@ export interface HogQLQueryModifiersApi {
     /** If these are provided, the query will fail if these skip indexes are not used */
     forceClickhouseDataSkippingIndexes?: string[] | null
     formatCsvAllowDoubleQuotes?: boolean | null
+    /** Ignore minmax skip indexes on materialized columns that the query only compares with negated operators (`!=` / `NOT IN`), where evaluating the index costs more than it prunes */
+    ignoreNegationOnlySkipIndexes?: boolean | null
     inCohortVia?: InCohortViaApi | null
     inlineCohortCalculation?: InlineCohortCalculationApi | null
     materializationMode?: MaterializationModeApi | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -383,6 +383,8 @@ export namespace Schemas {
       /** If these are provided, the query will fail if these skip indexes are not used */
       forceClickhouseDataSkippingIndexes?: string[] | null;
       formatCsvAllowDoubleQuotes?: boolean | null;
+      /** Ignore minmax skip indexes on materialized columns that the query only compares with negated operators (`!=` / `NOT IN`), where evaluating the index costs more than it prunes */
+      ignoreNegationOnlySkipIndexes?: boolean | null;
       inCohortVia?: InCohortVia | null;
       inlineCohortCalculation?: InlineCohortCalculation | null;
       materializationMode?: MaterializationMode | null;


### PR DESCRIPTION
## Problem

The printer's recent materialized-column comparison rewrites emit bare `notEquals(mat_col, const)` / `notIn(mat_col, ...)` so that skip indexes stay visible to ClickHouse. That is right for equality and ranges, but a minmax index condition for `!=` / `NOT IN` can only prune granules where `min == max ==` the excluded value, which essentially never happens on real data. ClickHouse still pays the full evaluation cost for such an index: per part and per index it loads the entire index marks file (one entry per granule of the part, regardless of how narrow the candidate ranges are) and deserializes index granules value by value.

Profiling a recurring slow production query (long wall time, low CPU, no CPU-starvation wait) with the always-on query profiler put the time squarely in `filterMarksUsingIndex` / `MergeTreeIndexGranuleMinMax::deserializeBinary` / `MergeTreeMarksLoader::loadMarksSync`. The only negation-only index in that query pruned about 1.5% of the granule set while accounting for roughly a third of the index-analysis cost; on cold replicas the equivalent mark and index reads were the bulk of a ~60s wall time. This shape is common: "exclude internal users/org" filters (`!=` / `NOT IN` on a materialized property) appear in many insights.

Exclude-style filters become pure overhead once the column's minmax index gets evaluated, and the cost scales with the table's part count rather than with the data the query actually reads, so all-time queries on large teams hurt most.

## Changes

- The ClickHouse printer tracks every minmax-indexed materialized column reference and whether it sits under a negated comparison (`!=`, `NOT IN`, `GLOBAL NOT IN`).
- Columns referenced only under negated comparisons get their minmax index listed in `ignore_data_skipping_indices` in the top-level SETTINGS clause. Ignoring a skip index is correctness-safe by construction: it can only widen the read, never change results.
- Any positive reference anywhere in the query (equality, range, IN, ORDER BY, plain projection) keeps the index. Indexes in `force_data_skipping_indices` are never ignored.
- New `ignoreNegationOnlySkipIndexes` modifier (default on) as a kill switch.
- `MaterializedColumn` now exposes `minmax_index_name`, and `PrintableMaterializedColumn` carries it through the printer.
- Operators that build no usable minmax condition at all (`NOT LIKE`, `NOT ILIKE`, regex negations) are unaffected: ClickHouse already skips the index for those.

Measured on production replicas (host-paired, 15 runs per arm, median of `system.query_log`): ignoring just the negation-only index cut skip-index filtering thread-time by 57%, compressed buffer reads by 47%, and IO wait by 53%, with identical results. Ignoring all skip indexes instead regressed rows read by 3.4x, which is why this targets only negation-only columns rather than disabling skip indexes.

For context, the underlying ClickHouse-side costs are known upstream: the zero-capacity index uncompressed cache contention was fixed in https://github.com/ClickHouse/ClickHouse/pull/104063 (after the version we run), and vectorized minmax evaluation is in flight in https://github.com/ClickHouse/ClickHouse/pull/103526. This change is the query-layer mitigation that removes the pointless index reads regardless of server version.

## How did you test this code?

I am an agent; no manual QA beyond the production measurements described above. Automated tests:

- New `TestNegationOnlyMinmaxIndexIgnore` suite (10 tests) in `posthog/hogql/test/test_property_skip_indexes.py`: emits the setting for `!=` and multi-value `NOT IN` (nullable and non-nullable columns) and verifies via `EXPLAIN indexes=1` that the index is no longer considered; verifies no setting is emitted for equality, mixed positive+negative usage, ORDER BY references, missing minmax index, the modifier kill switch, and forced indexes; verifies queries printed without a settings object are unchanged.
- Full `posthog/hogql/test/` directory: 3027 passed. `posthog/hogql/printer/test/test_printer.py`: 648 passed with two snapshots updated (the end-to-end `!=` queries now carry the setting; their result assertions pass unchanged).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: swept `query_log_archive` via Metabase for queries with long wall time but low CPU and no CPU-starvation wait (to exclude cluster-load cases), drilled into shard-level ProfileEvents, and built a flame graph from `system.trace_log` (1 Hz production profiler, symbolized in-database) to attribute the time to skip-index mark loading and minmax granule deserialization rather than HogQL SQL shape.
- Considered and rejected: disabling skip indexes wholesale (measured 3.4x read regression), an upstream ClickHouse patch (the two relevant fixes are already merged or in flight upstream, linked above), and dropping the minmax indexes themselves (positively-used conditions on the same indexes prune well).
- Benchmarked baseline vs surgical ignore vs ignore-all on production replicas before implementing; the printer-level `ignore_data_skipping_indices` emission was chosen because it is correctness-safe, version-independent, and scoped to provably useless index evaluations.
