### PR TITLE
fix(dashboards): use text cursor on editable scene title

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -552,7 +552,7 @@ export function SceneName({
                         <ButtonPrimitive
                             className={cn(
                                 buttonPrimitiveVariants({ size: 'fit', className: textClasses }),
-                                'flex text-left [&_.LemonIcon]:size-4 focus-visible:z-50'
+                                'flex text-left [&_.LemonIcon]:size-4 focus-visible:z-50 cursor-text'
                             )}
                             onClick={() => {
                                 if (!isGeneratingMetadata) {


### PR DESCRIPTION
## Problem

Editable scene titles use `ButtonPrimitive`, which inherits `cursor: pointer`. A text cursor is a better affordance for inline rename.

## Changes

Add `cursor-text` to the editable title button in `SceneTitleSection`.

## How did you test this code?

Not run locally — CSS-only one-liner. Sanity-check the cursor on a dashboard title in edit mode.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt asked to simplify the PR to a single CSS change: `cursor-text` instead of the default pointer on the editable title, dropping the earlier textarea/description approach and the long investigation write-up.