### PR TITLE
feat(insights): experiment surfacing Subscribe as a prominent header button

### DIFF
--- a/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
+++ b/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
@@ -1,4 +1,4 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
@@ -6,14 +6,34 @@ import { IconBell } from '@posthog/icons'
 import { useFeatureFlagVariantKey } from '@posthog/react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { userLogic } from 'scenes/userLogic'
 
-import { InsightShortId } from '~/types'
+import { AvailableFeature, InsightShortId } from '~/types'
 
+import { subscriptionsLogic } from '../Subscriptions/subscriptionsLogic'
 import { urlForSubscriptions } from '../Subscriptions/utils'
 
 interface InsightSubscribeProminentButtonProps {
     insightShortId: InsightShortId
+}
+
+function SubscribeIcon({ insightShortId }: { insightShortId: InsightShortId }): JSX.Element {
+    const { hasAvailableFeature } = useValues(userLogic)
+    const { subscriptions } = useValues(subscriptionsLogic({ insightShortId }))
+
+    // Mirror the side-panel SceneSubscribeButton: show the active-subscription count badge so
+    // the test arm carries the same "you're already subscribed" signal as the control arm.
+    if (!hasAvailableFeature(AvailableFeature.SUBSCRIPTIONS)) {
+        return <IconBell />
+    }
+
+    return (
+        <IconWithCount count={subscriptions?.length} showZero={false}>
+            <IconBell />
+        </IconWithCount>
+    )
 }
 
 /**
@@ -36,7 +56,7 @@ export function InsightSubscribeProminentButton({
         <LemonButton
             type="secondary"
             size="small"
-            icon={<IconBell />}
+            icon={<SubscribeIcon insightShortId={insightShortId} />}
             data-attr="insight-subscribe-prominent-button"
             onClick={() => {
                 posthog.capture('insight subscribe prominent button clicked', {

--- a/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
+++ b/frontend/src/lib/components/Scenes/InsightSubscribeProminentButton.tsx
@@ -1,0 +1,51 @@
+import { useActions } from 'kea'
+import { router } from 'kea-router'
+import posthog from 'posthog-js'
+
+import { IconBell } from '@posthog/icons'
+import { useFeatureFlagVariantKey } from '@posthog/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
+import { InsightShortId } from '~/types'
+
+import { urlForSubscriptions } from '../Subscriptions/utils'
+
+interface InsightSubscribeProminentButtonProps {
+    insightShortId: InsightShortId
+}
+
+/**
+ * Experiment (insight-subscribe-prominent-button): promotes "Subscribe" from the buried
+ * side-panel action to a visible header button. Reading the flag variant here is the
+ * experiment exposure, so this is mounted only for subscribe-eligible insights to keep the
+ * exposed population aligned with the control arm.
+ */
+export function InsightSubscribeProminentButton({
+    insightShortId,
+}: InsightSubscribeProminentButtonProps): JSX.Element | null {
+    const { push } = useActions(router)
+    const variant = useFeatureFlagVariantKey(FEATURE_FLAGS.INSIGHT_SUBSCRIBE_PROMINENT_BUTTON)
+
+    if (variant !== 'test') {
+        return null
+    }
+
+    return (
+        <LemonButton
+            type="secondary"
+            size="small"
+            icon={<IconBell />}
+            data-attr="insight-subscribe-prominent-button"
+            onClick={() => {
+                posthog.capture('insight subscribe prominent button clicked', {
+                    insight_short_id: insightShortId,
+                })
+                push(urlForSubscriptions({ insightShortId }))
+            }}
+        >
+            Subscribe
+        </LemonButton>
+    )
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -462,6 +462,7 @@ export const FEATURE_FLAGS = {
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection
     SCENE_SUBSCRIBE_LABEL_EXPERIMENT: 'scene-subscribe-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,recurring-updates,scheduled-notifications,scheduled-reports
+    INSIGHT_SUBSCRIBE_PROMINENT_BUTTON: 'insight-subscribe-prominent-button', // owner: @mattp #team-analytics-platform multivariate=control,test
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_ENFORCEMENT_REJECT: 'schema-enforcement-reject', // owner: @aspicer, gates the ability to set schema enforcement mode to "reject"
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -38,8 +38,16 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { insightMode, filtersOverride, variablesOverride, dashboardId } = useValues(insightSceneLogic)
     const { setInsightMode } = useActions(insightSceneLogic)
 
-    const { insightProps, canEditInsight, insight, insightChanged, insightSaving, hasDashboardItemId, insightLoading } =
-        useValues(insightLogic(insightLogicProps))
+    const {
+        insightProps,
+        canEditInsight,
+        insight,
+        insightChanged,
+        insightSaving,
+        // `dashboardItemId` is legacy naming for the insight's own short_id — this is true when the insight is saved, not when it's on a dashboard
+        hasDashboardItemId: isSavedInsight,
+        insightLoading,
+    } = useValues(insightLogic(insightLogicProps))
     const { setInsightMetadata, setInsightMetadataLocal, saveAs, saveInsight } = useActions(
         insightLogic(insightLogicProps)
     )
@@ -61,7 +69,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     const readDataMaxToolProps = useMemo(
         () =>
-            hasDashboardItemId && insight?.short_id
+            isSavedInsight && insight?.short_id
                 ? {
                       identifier: 'read_data' as const,
                       context: {
@@ -74,12 +82,12 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                       },
                   }
                 : undefined,
-        [hasDashboardItemId, insight?.short_id, insight?.id, insightDisplayName, query]
+        [isSavedInsight, insight?.short_id, insight?.id, insightDisplayName, query]
     )
 
     useMaxTool({
         identifier: 'upsert_alert',
-        active: canCreateAlertForInsight && hasDashboardItemId && !!insight.id,
+        active: canCreateAlertForInsight && isSavedInsight && !!insight.id,
         context: useMemo(
             () => ({
                 insight_id: insight.id,
@@ -126,7 +134,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 maxToolProps={readDataMaxToolProps}
                 actions={
                     <>
-                        {insightMode === ItemMode.Edit && hasDashboardItemId && (
+                        {insightMode === ItemMode.Edit && isSavedInsight && (
                             <LemonButton
                                 type="secondary"
                                 onClick={() => {
@@ -140,7 +148,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             </LemonButton>
                         )}
 
-                        {insightMode !== ItemMode.Edit && hasDashboardItemId && insight.short_id && (
+                        {insightMode !== ItemMode.Edit && isSavedInsight && insight.short_id && (
                             <InsightSubscribeProminentButton insightShortId={insight.short_id} />
                         )}
 
@@ -189,7 +197,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                         ? saveInsight(redirectToViewMode)
                                         : saveInsight(redirectToViewMode, getLastNewFolder() ?? 'Unfiled/Insights')
                                 }
-                                isSaved={hasDashboardItemId}
+                                isSaved={isSavedInsight}
                                 addingToDashboard={!!insight.dashboards?.length && !insight.id}
                                 insightSaving={insightSaving}
                                 insightChanged={insightChanged || queryChanged}

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { areAlertsSupportedForInsight } from 'lib/components/Alerts/insightAlertsLogic'
+import { InsightSubscribeProminentButton } from 'lib/components/Scenes/InsightSubscribeProminentButton'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -137,6 +138,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             >
                                 Cancel
                             </LemonButton>
+                        )}
+
+                        {insightMode !== ItemMode.Edit && hasDashboardItemId && insight.short_id && (
+                            <InsightSubscribeProminentButton insightShortId={insight.short_id} />
                         )}
 
                         {insightMode !== ItemMode.Edit ? (


### PR DESCRIPTION
## Problem

Adoption of insight **subscriptions** is bottlenecked at discovery, not at the creation flow. Today the only per-insight entry point is a "Subscribe" item buried in the side-panel Actions menu, among ~10 other actions. Users who would benefit from a recurring email/Slack digest rarely find it.

## Changes

<img width="2574" height="2130" alt="CleanShot 2026-06-10 at 11 17 43@2x" src="https://github.com/user-attachments/assets/781540a9-a948-4170-98ef-8cc174da3819" />


Adds an experiment (`insight-subscribe-prominent-button`) that surfaces "Subscribe" as a visible button in the insight header, next to Edit, instead of only in the side panel.

- New `InsightSubscribeProminentButton` component. Reading the feature-flag variant is the experiment exposure, so the component is mounted **only for subscribe-eligible insights** (saved, view mode). This keeps the exposed population aligned between control and test rather than exposing every page view.
- Wired into `InsightPageHeader` `actions`; renders the button only for the `test` variant.
- New flag constant `INSIGHT_SUBSCRIBE_PROMINENT_BUTTON` (`control`/`test`).

The matching draft experiment is configured in PostHog with:

- **Primary metric:** funnel `exposure → insight subscription created` (the existing server-side event from the subscription `post_save` signal — no new instrumentation needed).
- **Secondary guardrail:** funnel `exposure → insight subscribe prominent button clicked` (test-arm mechanism check).

## How did you test this code?

I'm an agent (Claude Code). I did **not** perform manual UI testing, and this environment had no `node_modules`, so I could not run the frontend typecheck or formatter locally — these should be run before merge (`pnpm --filter=@posthog/frontend typescript:check`, `pnpm --filter=@posthog/frontend format`). The change mirrors the existing `SceneSubscribeButton` flag-reading pattern. I verified against live project data that the `insight subscription created` event is already ingested (emitted server-side), which avoided adding a duplicate frontend capture.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The work began as a brainstorm of A/B-test ideas to drive alerts/subscriptions adoption; this PR implements the highest-leverage discovery experiment (prominent Subscribe button on insights).

Key decision along the way: an initial draft added a frontend `posthog.capture('insight subscription created')`, on the assumption the event wasn't wired up (a source grep only found its type declaration). Querying live project data showed the event is already emitted server-side via the subscription `post_save` signal (`products/exports/backend/models/subscription.py`), so the duplicate frontend capture was reverted to avoid double-counting and the primary metric reuses the existing event.

The draft experiment should not be launched until this ships, otherwise the test arm renders nothing (effectively an A/A test).
