### PR TITLE
fix(error-tracking): open Explain in Max side panel with issue context

### DIFF
--- a/products/error_tracking/frontend/components/ExplainIssueTool.tsx
+++ b/products/error_tracking/frontend/components/ExplainIssueTool.tsx
@@ -1,4 +1,9 @@
-import { useOpenAi } from 'scenes/max/useOpenAi'
+import { useActions, useValues } from 'kea'
+
+import { maxContextLogic } from 'scenes/max/maxContextLogic'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { SidePanelTab } from '~/types'
 
 export interface UseErrorTrackingExplainIssueReturn {
     isMaxOpen: boolean
@@ -6,20 +11,24 @@ export interface UseErrorTrackingExplainIssueReturn {
 }
 
 /**
- * Hook to open Max AI side panel with a prompt to explain an error tracking issue.
- * In side panel mode, the issue context is automatically provided via the maxContext selector.
- * In new tab mode, the issue ID is passed for context restoration.
+ * Hook to open the Max AI side panel with a prompt to explain an error tracking issue.
+ * The issue is added to Max's context so the explanation is grounded in the current issue.
  *
  * @param issueId - The error tracking issue ID to explain
  */
 export function useErrorTrackingExplainIssue(issueId: string): UseErrorTrackingExplainIssueReturn {
-    const { isMaxOpen, openAi } = useOpenAi()
+    const { sidePanelOpen, selectedTab } = useValues(sidePanelStateLogic)
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+    const { addOrUpdateContextErrorTrackingIssue } = useActions(maxContextLogic)
+
+    const isMaxOpen = sidePanelOpen && selectedTab === SidePanelTab.Max
 
     return {
         isMaxOpen,
-        openMax: () =>
-            openAi('Explain this issue to me', {
-                errorTrackingIssue: { id: issueId },
-            }),
+        openMax: () => {
+            addOrUpdateContextErrorTrackingIssue({ id: issueId })
+            // Leading "!" auto-runs the prompt once the side panel opens.
+            openSidePanel(SidePanelTab.Max, '!Explain this issue to me')
+        },
     }
 }


### PR DESCRIPTION
## Problem

From a Zendesk ticket: clicking the **🪄 Explain** button on an error tracking issue opened Max (PostHog AI) in a new browser tab, and Max received no context about the issue being viewed.

The button stored the issue context in `sessionStorage` and then opened a new tab. `sessionStorage` is per-tab, so the new tab started with empty storage and the context was never delivered — Max opened with no knowledge of the issue.

## Changes

`useErrorTrackingExplainIssue` now opens the **Max side panel** instead of a new tab, and explicitly adds the issue to Max's context via `maxContextLogic` so the explanation is grounded in the current issue. The prompt auto-runs once the panel opens. This matches the established `openSidePanel(SidePanelTab.Max, '!...')` pattern used elsewhere (e.g. the insight "Explain" action).

## How did you test this code?

I'm an agent. I did not run the app manually. The change is small, reuses imports already present in `useOpenAi.ts`, and follows the existing side-panel + context pattern. Automated checks (typecheck/lint) could not be run locally because frontend dependencies were not installed in the environment; CI will run them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a support thread. The root cause was that `useOpenAi` writes context to per-tab `sessionStorage` before opening a new tab, so the context never reaches the new tab. Rather than fix the cross-tab handoff, the issue scene already exposes the issue via a `maxContext` selector and the codebase has a clean side-panel pattern, so the fix routes Explain to the side panel and adds the issue to context explicitly (deduped against the scene context). `useOpenAi` is left untouched since other features still use it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781033191225319?thread_ts=1781033191.225319&cid=C0ACRAMJUAG)*
