### PR TITLE
fix(property-vals): evaluate table-routing flag remotely per request

### DIFF
--- a/posthog/hogql_queries/property_values_query_runner.py
+++ b/posthog/hogql_queries/property_values_query_runner.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, cast
 from django.utils import timezone
 
 import posthoganalytics
+from posthoganalytics.client import Client
 
 from posthog.schema import (
     CachedPropertyValuesQueryResponse,
@@ -34,6 +35,25 @@ from posthog.utils import convert_property_value, flatten, get_instance_region, 
 from products.access_control.backend.property_access_control import get_restricted_property_names
 
 PROPERTY_VALUES_TABLE_FLAG = "property-values-table"
+
+_remote_flags_client: Optional[Client] = None
+
+
+def _flags_client() -> Client:
+    # Dedicated client that never loads flag definitions (no personal_api_key, no
+    # definition provider), so every check evaluates remotely: flag flips must take
+    # effect immediately, and the tight timeout keeps a degraded flags service from
+    # stalling autocomplete. Eval failures return None and the gate fails closed.
+    global _remote_flags_client
+    if _remote_flags_client is None:
+        _remote_flags_client = Client(
+            posthoganalytics.api_key,
+            host=posthoganalytics.host,
+            disabled=posthoganalytics.disabled,
+            enable_local_evaluation=False,
+            feature_flags_request_timeout_seconds=0.3,
+        )
+    return _remote_flags_client
 
 
 class PropertyValuesQueryRunner(AnalyticsQueryRunner[PropertyValuesQueryResponse]):
@@ -87,7 +107,7 @@ class PropertyValuesQueryRunner(AnalyticsQueryRunner[PropertyValuesQueryResponse
         if self.query.is_column or self.query.property_key.startswith("$virt_"):
             return False
         team_id = str(self.team.pk)
-        if not posthoganalytics.feature_enabled(
+        if not _flags_client().feature_enabled(
             PROPERTY_VALUES_TABLE_FLAG,
             team_id,
             person_properties={"region": get_instance_region() or "DEV", "team_id": team_id},

--- a/posthog/hogql_queries/test/test_property_values_query_runner.py
+++ b/posthog/hogql_queries/test/test_property_values_query_runner.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
+from typing import Optional
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
@@ -264,9 +265,11 @@ class TestPropertyValuesQueryRunnerAggregatedTable(ClickhouseTestMixin, APIBaseT
         return runner.calculate().results
 
     def _flag_on(self):
+        client = MagicMock()
+        client.feature_enabled.side_effect = lambda flag, *args, **kwargs: flag == PROPERTY_VALUES_TABLE_FLAG
         return patch(
-            "posthog.hogql_queries.property_values_query_runner.posthoganalytics.feature_enabled",
-            side_effect=lambda flag, *args, **kwargs: flag == PROPERTY_VALUES_TABLE_FLAG,
+            "posthog.hogql_queries.property_values_query_runner._flags_client",
+            return_value=client,
         )
 
     def _insert_rows(self, rows: list[tuple]) -> None:
@@ -394,12 +397,20 @@ class TestPropertyValuesQueryRunnerAggregatedTable(ClickhouseTestMixin, APIBaseT
         with self._flag_on():
             assert runner._use_property_values_table is False
 
-    def test_flag_off_uses_events_scan(self):
+    @parameterized.expand(
+        [
+            ("flag_off", False),
+            ("eval_failed", None),
+        ]
+    )
+    def test_flag_not_enabled_uses_events_scan(self, _name: str, flag_value: Optional[bool]):
         self._insert_rows([(self.team.pk, "event", "browser", "TableOnly", 3, datetime.now())])
 
+        client = MagicMock()
+        client.feature_enabled.return_value = flag_value
         with patch(
-            "posthog.hogql_queries.property_values_query_runner.posthoganalytics.feature_enabled",
-            return_value=False,
+            "posthog.hogql_queries.property_values_query_runner._flags_client",
+            return_value=client,
         ):
             results = self._run(PropertyValuesQuery(property_type=PropertyType.EVENT, property_key="browser"))
         assert results == []


### PR DESCRIPTION
## Problem

The property-value autocomplete runner gates its read path (aggregated `property_values` table vs events scan) on the `property-values-table` flag. The gate evaluated the flag through the app-wide analytics client, which prefers local evaluation from cached flag definitions. Workers that did not have definitions loaded fell back to a remote flags call whose failures were silently treated as "flag off", so a small share of requests from flagged teams randomly routed back to the expensive events scan. The same query from the same team could take either path depending on which worker served it.

## Changes

- The gate now evaluates the flag remotely on every request, through a dedicated SDK client that never loads flag definitions (no personal API key, no definition provider, `enable_local_evaluation=False`). Flag flips take effect immediately, with no definition-cache propagation delay, which also makes the flag usable as a kill switch for the new read path.
- The client uses a tight flags-request timeout (0.3s) so a degraded flags service cannot stall autocomplete, and any evaluation failure fails closed to the events scan.

## How did you test this code?

I'm an agent; no manual testing. Automated tests: `posthog/hogql_queries/test/test_property_values_query_runner.py` (43 passed), including an updated routing test parameterized over flag-off and eval-failure (None) cases, both asserting fallback to the events scan.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed; internal read-path gating only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Investigated why a residual share of autocomplete queries from flag-enabled teams still hit the events scan: per-request flag evaluation returned None when a worker lacked flag definitions and the remote fallback errored, and the gate treated None as "off".
- Considered and rejected: local-only evaluation with a cached last-known value per team (rejected by the maintainer in favor of remote evaluation), and a shared fallback cache (reintroduces propagation delay on flag flips).
- Chosen design per maintainer direction: per-request remote evaluation via a dedicated never-local client, tight timeout, fail closed to the events scan.
