### PR TITLE
feat(dashboards): refresh default signup dashboard from usage data

### DIFF
--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -637,12 +637,13 @@ class TestSignupAPI(APIBaseTest):
 
         dashboard: Dashboard = Dashboard.objects.first()  # type: ignore
         self.assertEqual(dashboard.team, user.team)
-        self.assertEqual(dashboard.tiles.count(), 6)
+        self.assertEqual(dashboard.tiles.count(), 7)
         self.assertEqual(dashboard.name, "My App Dashboard")
         self.assertEqual(
             dashboard.description,
-            "A starter view of how people use your app: how many visit, whether they come back, "
-            "where traffic comes from, and how they move through your pages.",
+            "How people use your app at a glance — reach, retention, top pages, location, and whether "
+            "visitors take action. Built from automatically captured events, so it works on day one. "
+            "Swap in your own events to make it yours.",
         )
         self.assertEqual(Dashboard.objects.filter(team=user.team).count(), 1)
 

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -165,7 +165,7 @@ class TestTeam(BaseTest):
         self.assertIsInstance(team.primary_dashboard, Dashboard)
 
         # Ensure insights are created and linked
-        self.assertEqual(DashboardTile.objects.filter(dashboard=team.primary_dashboard).count(), 6)
+        self.assertEqual(DashboardTile.objects.filter(dashboard=team.primary_dashboard).count(), 7)
 
     @mock.patch("posthoganalytics.feature_enabled", return_value=True)
     def test_team_on_cloud_uses_feature_flag_to_determine_person_on_events(self, mock_feature_enabled):
@@ -272,6 +272,7 @@ class TestTeam(BaseTest):
 
     @parameterized.expand(
         [
+            ("Active users (last 30 days)",),
             ("Daily active users (DAUs)",),
             ("Weekly active users (WAUs)",),
         ]
@@ -294,9 +295,9 @@ class TestTeam(BaseTest):
     @parameterized.expand(
         [
             ("Retention", "RetentionQuery"),
-            ("Growth accounting", "LifecycleQuery"),
-            ("Referring domain (last 14 days)", "TrendsQuery"),
-            ("Pageview funnel, by browser", "FunnelsQuery"),
+            ("Top pages", "TrendsQuery"),
+            ("Users by country", "TrendsQuery"),
+            ("Visit to interaction funnel", "FunnelsQuery"),
         ]
     )
     def test_default_dashboard_pageview_only_tiles(self, tile_name, expected_kind):

--- a/products/dashboards/backend/models/dashboard_templates.py
+++ b/products/dashboards/backend/models/dashboard_templates.py
@@ -69,11 +69,55 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
         return DashboardTemplate(
             template_name="Product analytics",
             dashboard_description=(
-                "A starter view of how people use your app: how many visit, whether they come back, "
-                "where traffic comes from, and how they move through your pages."
+                "How people use your app at a glance — reach, retention, top pages, location, and whether "
+                "visitors take action. Built from automatically captured events, so it works on day one. "
+                "Swap in your own events to make it yours."
             ),
             dashboard_filters={},
             tiles=[
+                {
+                    "name": "Active users (last 30 days)",
+                    "type": "INSIGHT",
+                    "color": "blue",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {
+                                    "kind": "GroupNode",
+                                    "operator": "OR",
+                                    "nodes": [
+                                        {"kind": "EventsNode", "event": "$pageview", "name": "$pageview"},
+                                        {"kind": "EventsNode", "event": "$screen", "name": "$screen"},
+                                    ],
+                                    "math": "dau",
+                                    "name": "Pageview or screen",
+                                }
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-30d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "BoldNumber",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
+                    },
+                    "layouts": {
+                        "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 0, "minH": 5, "minW": 3},
+                    },
+                    "description": "Unique people who used your app in the last 30 days. A quick pulse on your overall reach.",
+                },
                 {
                     "name": "Daily active users (DAUs)",
                     "type": "INSIGHT",
@@ -112,10 +156,10 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         },
                     },
                     "layouts": {
-                        "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
-                        "xs": {"h": 5, "w": 1, "x": 0, "y": 0, "minH": 5, "minW": 3},
+                        "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 5, "minH": 5, "minW": 3},
                     },
-                    "description": "Shows the number of unique users that view a page or screen in your app every day.",
+                    "description": "Unique people who use your app each day. Watch for steady growth or sudden drops.",
                 },
                 {
                     "name": "Weekly active users (WAUs)",
@@ -155,10 +199,78 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         },
                     },
                     "layouts": {
-                        "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},
-                        "xs": {"h": 5, "w": 1, "x": 0, "y": 5, "minH": 5, "minW": 3},
+                        "sm": {"h": 5, "w": 6, "x": 0, "y": 5, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 10, "minH": 5, "minW": 3},
                     },
-                    "description": "Shows the number of unique users that view a page or screen in your app every week.",
+                    "description": "Unique people who use your app each week. Smooths out daily noise to show the underlying trend.",
+                },
+                {
+                    "name": "Top pages",
+                    "type": "INSIGHT",
+                    "color": "purple",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "total", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-7d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "ActionsBarValue",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown": "$pathname", "breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
+                    },
+                    "layouts": {
+                        "sm": {"h": 5, "w": 6, "x": 6, "y": 5, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 15, "minH": 5, "minW": 3},
+                    },
+                    "description": "Your most visited pages over the last 7 days. Shows where people spend their attention.",
+                },
+                {
+                    "name": "Users by country",
+                    "type": "INSIGHT",
+                    "color": "green",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-30d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "WorldMap",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown": "$geoip_country_code", "breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
+                    },
+                    "layouts": {
+                        "sm": {"h": 5, "w": 6, "x": 0, "y": 10, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 20, "minH": 5, "minW": 3},
+                    },
+                    "description": "Where your users are, based on their IP address. Hover a country to see its user count.",
                 },
                 {
                     "name": "Retention",
@@ -181,71 +293,15 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                         },
                     },
                     "layouts": {
-                        "sm": {"h": 5, "w": 6, "x": 6, "y": 5, "minH": 5, "minW": 3},
-                        "xs": {"h": 5, "w": 1, "x": 0, "y": 10, "minH": 5, "minW": 3},
+                        "sm": {"h": 5, "w": 6, "x": 6, "y": 10, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 25, "minH": 5, "minW": 3},
                     },
-                    "description": "Weekly retention of your users based on pageviews.",
+                    "description": "How many people come back week after week after their first visit. The clearest signal of whether your product is sticky.",
                 },
                 {
-                    "name": "Growth accounting",
-                    "type": "INSIGHT",
-                    "color": "purple",
-                    "query": {
-                        "kind": "InsightVizNode",
-                        "source": {
-                            "kind": "LifecycleQuery",
-                            "series": [{"kind": "EventsNode", "name": "$pageview", "event": "$pageview"}],
-                            "interval": "week",
-                            "dateRange": {"date_from": "-30d", "explicitDate": False},
-                            "properties": [],
-                            "lifecycleFilter": {"showLegend": False},
-                            "filterTestAccounts": False,
-                        },
-                    },
-                    "layouts": {
-                        "sm": {"h": 5, "w": 6, "x": 0, "y": 5, "minH": 5, "minW": 3},
-                        "xs": {"h": 5, "w": 1, "x": 0, "y": 15, "minH": 5, "minW": 3},
-                    },
-                    "description": "How many of your users are new, returning, resurrecting, or dormant each week based on pageviews.",
-                },
-                {
-                    "name": "Referring domain (last 14 days)",
+                    "name": "Visit to interaction funnel",
                     "type": "INSIGHT",
                     "color": "black",
-                    "query": {
-                        "kind": "InsightVizNode",
-                        "source": {
-                            "kind": "TrendsQuery",
-                            "series": [
-                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
-                            ],
-                            "interval": "day",
-                            "dateRange": {"date_from": "-14d", "explicitDate": False},
-                            "properties": [],
-                            "trendsFilter": {
-                                "display": "ActionsBarValue",
-                                "showLegend": False,
-                                "yAxisScaleType": "linear",
-                                "showValuesOnSeries": False,
-                                "smoothingIntervals": 1,
-                                "showPercentStackView": False,
-                                "aggregationAxisFormat": "numeric",
-                                "showAlertThresholdLines": False,
-                            },
-                            "breakdownFilter": {"breakdown": "$referring_domain", "breakdown_type": "event"},
-                            "filterTestAccounts": False,
-                        },
-                    },
-                    "layouts": {
-                        "sm": {"h": 5, "w": 6, "x": 0, "y": 10, "minH": 5, "minW": 3},
-                        "xs": {"h": 5, "w": 1, "x": 0, "y": 20, "minH": 5, "minW": 3},
-                    },
-                    "description": "Shows the most common referring domains for your users over the past 14 days. Pageviews only.",
-                },
-                {
-                    "name": "Pageview funnel, by browser",
-                    "type": "INSIGHT",
-                    "color": "green",
                     "query": {
                         "kind": "InsightVizNode",
                         "source": {
@@ -255,19 +311,13 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                                     "kind": "EventsNode",
                                     "name": "$pageview",
                                     "event": "$pageview",
-                                    "custom_name": "First page view",
+                                    "custom_name": "Viewed a page",
                                 },
                                 {
                                     "kind": "EventsNode",
-                                    "name": "$pageview",
-                                    "event": "$pageview",
-                                    "custom_name": "Second page view",
-                                },
-                                {
-                                    "kind": "EventsNode",
-                                    "name": "$pageview",
-                                    "event": "$pageview",
-                                    "custom_name": "Third page view",
+                                    "name": "$autocapture",
+                                    "event": "$autocapture",
+                                    "custom_name": "Clicked something",
                                 },
                             ],
                             "interval": "day",
@@ -283,15 +333,15 @@ class DashboardTemplate(UUIDTModel, RootTeamMixin):
                                 "breakdownAttributionType": "first_touch",
                                 "funnelWindowIntervalUnit": "day",
                             },
-                            "breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event"},
+                            "breakdownFilter": {"breakdown_type": "event"},
                             "filterTestAccounts": False,
                         },
                     },
                     "layouts": {
-                        "sm": {"h": 5, "w": 6, "x": 6, "y": 10, "minH": 5, "minW": 3},
-                        "xs": {"h": 5, "w": 1, "x": 0, "y": 25, "minH": 5, "minW": 3},
+                        "sm": {"h": 5, "w": 12, "x": 0, "y": 15, "minH": 5, "minW": 3},
+                        "xs": {"h": 5, "w": 1, "x": 0, "y": 30, "minH": 5, "minW": 3},
                     },
-                    "description": "This example funnel shows how many of your users have completed 3 page views, broken down by browser. Pageviews only.",
+                    "description": "Of people who land on a page, how many go on to interact. Replace these steps with your own events to track real conversions.",
                 },
             ],
             tags=[],


### PR DESCRIPTION
## Problem

New users get a sample dashboard ("My App Dashboard") on signup, but it hasn't been revisited in a long time. Some tiles don't reflect how people actually use PostHog, and one is actively misleading: the "Pageview funnel, by browser" tile is three identical `$pageview` steps, which doesn't demonstrate what funnels are for. The goal is to get new users to an "aha" moment faster with insights that are useful immediately and need no custom event setup.

## Changes

I looked at what PostHog users actually build (saved-insight telemetry over the last 90 days) and rebuilt the starter template around it. Key signals:

- **Trends and Funnels dominate** adoption — together ~90% of all saved insights.
- The **bold single-number** display is the 2nd most-built visualization, yet the old dashboard had none.
- Typical insights are **simple** (avg ~1.9 series for trends, ~12% use a formula), so the defaults should stay simple.

The template goes from 6 → 7 tiles. Everything still uses only autocapture events (`$pageview` / `$screen` / `$autocapture`) so the dashboard is meaningful on day one.

| Tile | Change |
|---|---|
| **Active users (last 30 days)** — bold number | new |
| Daily active users — line | kept |
| Weekly active users — line | kept |
| **Top pages** — bar value, breakdown `$pathname` | replaces "Referring domain" |
| **Users by country** — world map | new |
| Retention | kept |
| **Visit to interaction funnel** (`$pageview → $autocapture`) | replaces the 3x-pageview "by browser" funnel |

Dropped **Growth accounting** (Lifecycle): low adoption and hard to interpret on a brand-new project.

I also rewrote the dashboard description and every tile description to plainly say what the tile is and why it's useful — one tight line each, no padding.

The separate DB-seeded global "Product analytics" template (migration `0310` / `demo/dashboard_template_seeds/07_product_analytics.json`) shown in the template chooser is intentionally left untouched; happy to align it in a follow-up.

## How did you test this code?

I'm an agent. I ran the automated checks available in this environment:

- `ruff format` and `ruff check` on all three changed files — clean.
- An AST-level structural validation of `original_template()` confirming 7 tiles, a valid grid layout, and a non-empty description on every tile.

The DB-backed tests (`posthog/test/test_team.py`, `posthog/api/test/test_signup.py`) were updated to match (tile count 6→7, new tile names, new dashboard description) and **collect** correctly, but I could **not execute** them here — this sandbox has no Postgres. They should be run in CI / a real env:

```
hogli test posthog/test/test_team.py posthog/api/test/test_signup.py -k default_dashboard
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt directed this work: analyze how PostHog users build insights and apply the patterns to the default signup dashboard, favoring insights that are quick to set up to speed activation.

- Used Claude Code with the PostHog MCP tools (`execute-sql`, `read-data-schema`) to analyze saved-insight telemetry, and the codebase tools to find and edit the template.
- Decisions: kept the two trends lines and retention (well-justified by adoption); added a bold-number hero metric and a world map as low-effort/high-payoff "quick wins"; swapped the fake by-browser pageview funnel for a real visit→interaction funnel; dropped Lifecycle/Growth accounting as low-adoption and hard to read early. Constrained every tile to autocapture events because a brand-new project has no custom events.
