### PR TITLE
fix(replay-vision): reload bulk-scan scanners on team change

### DIFF
--- a/products/replay_vision/frontend/logics/bulkScanLogic.ts
+++ b/products/replay_vision/frontend/logics/bulkScanLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
@@ -12,6 +12,10 @@ import type { bulkScanLogicType } from './bulkScanLogicType'
 
 export const bulkScanLogic = kea<bulkScanLogicType>([
     path(['products', 'replay_vision', 'frontend', 'logics', 'bulkScanLogic']),
+
+    connect(() => ({
+        actions: [teamLogic, ['loadCurrentTeamSuccess']],
+    })),
 
     actions({
         scanRecordings: (scannerId: string, sessionIds: string[]) => ({ scannerId, sessionIds }),
@@ -53,7 +57,12 @@ export const bulkScanLogic = kea<bulkScanLogicType>([
     listeners(({ actions, values }) => ({
         scanRecordings: async ({ scannerId, sessionIds }) => {
             const teamId = teamLogic.values.currentTeamId
-            if (!teamId || sessionIds.length === 0) {
+            if (sessionIds.length === 0) {
+                lemonToast.error('Select at least one recording to scan')
+                actions.scanRecordingsFailure()
+                return
+            }
+            if (!teamId) {
                 actions.scanRecordingsFailure()
                 return
             }
@@ -82,6 +91,11 @@ export const bulkScanLogic = kea<bulkScanLogicType>([
                 lemonToast.error(`Failed to start scanning ${failed} recording${failed === 1 ? '' : 's'}`)
             }
             actions.scanRecordingsSuccess()
+        },
+        // The logic is global/propless, so reload scanners when the active team changes
+        // to avoid POSTing the previous team's scanner IDs to the new team's endpoint.
+        loadCurrentTeamSuccess: () => {
+            actions.loadScanners()
         },
     })),
 


### PR DESCRIPTION
## Problem

Follow-up to #62282 (bulk "Scan these recordings"). A reviewer flagged that `bulkScanLogic` is global/propless and loaded scanners only once on mount. Switching projects without a full page reload left the bulk-scan menu showing the *previous* team's scanners. Because `scanRecordings` reads `teamLogic.values.currentTeamId` at click time, it would then POST the old team's scanner IDs to the new team's `observe` endpoint and the scan would fail until a remount/refresh.

## Changes

- Reload scanners on team change: `connect` `teamLogic`'s `loadCurrentTeamSuccess` action and reload `scanners` in a listener, following the existing pattern in `experimentsLogic.ts`. This keeps the menu's scanner list aligned with the active team so click-time `currentTeamId` and scanner IDs always belong to the same team.
- Add an error toast to the empty-selection guard in the `scanRecordings` listener (addresses a Greptile P2). The entrypoint button is already disabled on empty selection, so this is a defensive fallback that gives feedback if the path is ever reached.

Single file changed: `products/replay_vision/frontend/logics/bulkScanLogic.ts`.

## How did you test this code?

I'm an agent. Automated checks run locally:
- `pnpm --filter=@posthog/frontend typescript:check` — the changed file type-checks clean (kea-typegen picks up the new `connect`/listener wiring). The only tsc error in the run was a pre-existing, unrelated failure in `packages/quill`.
- `oxlint` on the changed file — 0 warnings, 0 errors.

No manual UI testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). The original PR #62282 was already merged when the review comments came in, so this is a stacked follow-up branched off `master` carrying only the fix. The substantive change (reload on team change) implements the reviewer's suggested approach; the defensive toast addresses a separate low-priority bot comment. The other inline bot suggestions on #62282 (disabled state on empty selection, quota tooltip wiring) were already incorporated into that PR's final commit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*