### PR TITLE
fix(funnels): correlation unmatched-row guard and join build side

### DIFF
--- a/docker/clickhouse/users-dev.xml
+++ b/docker/clickhouse/users-dev.xml
@@ -24,8 +24,8 @@
 
             <compatibility>26.3</compatibility>
             <!-- Keep inserts synchronous. Production configures async inserts explicitly
-                 (currently off), and tests rely on per-row inserts being visible as soon
-                 as the insert returns; the 26.3 compatibility default would turn them on. -->
+                 (currently off); the 26.3 compatibility default turns them on, which makes
+                 every single-row test insert wait for the async flush and slows the suite. -->
             <async_insert>0</async_insert>
             <!-- 26.3 enables rewriting `col = ''` / `col != ''` into emptiness checks that
                  skip DEFAULT-expression evaluation on parts written before the column was

--- a/docker/clickhouse/users-dev.xml
+++ b/docker/clickhouse/users-dev.xml
@@ -23,6 +23,16 @@
             <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
 
             <compatibility>26.3</compatibility>
+            <!-- Keep inserts synchronous. Production configures async inserts explicitly
+                 (currently off), and tests rely on per-row inserts being visible as soon
+                 as the insert returns; the 26.3 compatibility default would turn them on. -->
+            <async_insert>0</async_insert>
+            <!-- 26.3 enables rewriting `col = ''` / `col != ''` into emptiness checks that
+                 skip DEFAULT-expression evaluation on parts written before the column was
+                 added. Materialized property columns rely on that evaluation for
+                 is_set / is_not_set filters on rows older than their backfill window, so
+                 pin the rewrite off until ClickHouse honors DEFAULTs there. -->
+            <optimize_empty_string_comparisons>0</optimize_empty_string_comparisons>
             <distributed_product_mode>global</distributed_product_mode>
             <enable_parallel_replicas>0</enable_parallel_replicas>
             <max_parallel_replicas>1</max_parallel_replicas>

--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -25,8 +25,8 @@
 
             <compatibility>26.3</compatibility>
             <!-- Keep inserts synchronous. Production configures async inserts explicitly
-                 (currently off), and tests rely on per-row inserts being visible as soon
-                 as the insert returns; the 26.3 compatibility default would turn them on. -->
+                 (currently off); the 26.3 compatibility default turns them on, which makes
+                 every single-row test insert wait for the async flush and slows the suite. -->
             <async_insert>0</async_insert>
             <!-- 26.3 enables rewriting `col = ''` / `col != ''` into emptiness checks that
                  skip DEFAULT-expression evaluation on parts written before the column was

--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -24,6 +24,16 @@
             <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
 
             <compatibility>26.3</compatibility>
+            <!-- Keep inserts synchronous. Production configures async inserts explicitly
+                 (currently off), and tests rely on per-row inserts being visible as soon
+                 as the insert returns; the 26.3 compatibility default would turn them on. -->
+            <async_insert>0</async_insert>
+            <!-- 26.3 enables rewriting `col = ''` / `col != ''` into emptiness checks that
+                 skip DEFAULT-expression evaluation on parts written before the column was
+                 added. Materialized property columns rely on that evaluation for
+                 is_set / is_not_set filters on rows older than their backfill window, so
+                 pin the rewrite off until ClickHouse honors DEFAULTs there. -->
+            <optimize_empty_string_comparisons>0</optimize_empty_string_comparisons>
             <distributed_product_mode>global</distributed_product_mode>
             <enable_parallel_replicas>0</enable_parallel_replicas>
             <max_parallel_replicas>1</max_parallel_replicas>

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Literal, Union, cast
 from uuid import UUID
 
@@ -36,7 +36,7 @@ from posthog.queries.person_query import PersonQuery
 from posthog.queries.property_optimizer import PropertyOptimizer
 from posthog.queries.util import PersonPropertiesMode
 
-from ee.clickhouse.materialized_columns.columns import backfill_materialized_columns, materialize
+from ee.clickhouse.materialized_columns.columns import materialize
 
 
 class TestPropFormat(ClickhouseTestMixin, BaseTest):
@@ -1770,8 +1770,7 @@ def test_prop_filter_json_extract(test_events, clean_up_materialised_columns, pr
 def test_prop_filter_json_extract_materialized(
     test_events, clean_up_materialised_columns, property, expected_event_indexes, team
 ):
-    column = materialize("events", property.key)
-    backfill_materialized_columns("events", [column], timedelta(days=50), test_settings={"mutations_sync": "2"})
+    materialize("events", property.key)
 
     query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=True)
 

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from datetime import timedelta
 from typing import Any, Literal, Optional, Union, cast
 
 from freezegun import freeze_time
@@ -44,7 +43,7 @@ from products.event_definitions.backend.models.property_definition import Proper
 from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 
-from ee.clickhouse.materialized_columns.columns import backfill_materialized_columns, materialize
+from ee.clickhouse.materialized_columns.columns import materialize
 
 elements_chain_match = lambda x: parse_expr("elements_chain =~ {regex}", {"regex": ast.Constant(value=str(x))})
 elements_chain_imatch = lambda x: parse_expr("elements_chain =~* {regex}", {"regex": ast.Constant(value=str(x))})
@@ -1828,15 +1827,12 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
     def _expected_is_not_set_values(self, is_materialized: bool) -> dict[str, int]:
         return {k: 1 - v for k, v in self._expected_is_set_values(is_materialized).items()}
 
-    def _materialize_test_case_properties(self) -> None:
-        columns = [materialize("events", prop_name) for prop_name, _, _, _ in self.test_cases]
-        backfill_materialized_columns("events", columns, timedelta(days=50), test_settings={"mutations_sync": "2"})
-
     @parameterized.expand([("not_materialized", False), ("materialized", True)])
     def test_is_set_operator(self, _name: str, is_materialized: bool):
         if is_materialized:
             self.addCleanup(cleanup_materialized_columns)
-            self._materialize_test_case_properties()
+            for prop_name, _, _, _ in self.test_cases:
+                materialize("events", prop_name)
 
         select_exprs: list[ast.Expr] = [
             ast.Alias(
@@ -1872,7 +1868,8 @@ class TestPropertyIsSetIsNotSetWithData(APIBaseTest):
     def test_is_not_set_operator(self, _name: str, is_materialized: bool):
         if is_materialized:
             self.addCleanup(cleanup_materialized_columns)
-            self._materialize_test_case_properties()
+            for prop_name, _, _, _ in self.test_cases:
+                materialize("events", prop_name)
 
         select_exprs: list[ast.Expr] = [
             ast.Alias(

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -556,7 +556,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
             raise ValidationError("Event Property Correlation expects atleast one event name to run correlation on")
 
         funnel_persons_query = self.get_funnel_actors_cte()
-        event_left_join_query = self._get_events_left_join_query("AND event_table.event IN {event_names}")
+        event_right_join_query = self._get_events_right_join_query("AND event_table.event IN {event_names}")
         target_step = self.context.max_steps
         funnel_step_names = self._get_funnel_step_names()
         date_from = self._date_range().date_from_as_hogql()
@@ -619,8 +619,8 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                         [tuple({{total_identifier}}, '', '')],
                         {event_property_array_query}
                     )) as prop
-                FROM funnel_actors
-                    {event_left_join_query}
+                FROM events AS event_table
+                    {event_right_join_query}
             )
             GROUP BY name, prop
             -- Discard high cardinality / low hits properties
@@ -785,7 +785,14 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                 AND event.event NOT IN funnel_step_names
         """
 
-    def _get_events_left_join_query(self, extra_event_conditions: str = "") -> str:
+    def _get_events_right_join_query(self, extra_event_conditions: str = "") -> str:
+        """Join filtered events onto funnel_actors, preserving actors without events.
+
+        Written as `FROM events RIGHT JOIN funnel_actors` rather than
+        `FROM funnel_actors LEFT JOIN events`: the semantics are identical, but the
+        right table is ClickHouse's hash-build side, and that must be the small
+        funnel_actors set — not events — or memory scales with the event count.
+        """
         windowInterval = self.context.funnelWindowInterval
         windowIntervalUnit = funnel_window_interval_unit_to_sql(self.context.funnelWindowIntervalUnit)
 
@@ -799,7 +806,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
             join_condition = "event_table.person_id = funnel_actors.actor_id"
 
         return f"""
-            LEFT JOIN events AS event_table
+            RIGHT JOIN funnel_actors
                 ON {join_condition}
                 AND toTimeZone(toDateTime(event_table.timestamp), 'UTC') >= {{date_from}}
                 AND toTimeZone(toDateTime(event_table.timestamp), 'UTC') < {{date_to}}

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -573,9 +573,11 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                 allow_denormalized_props=False,
                 table_alias="event_table",
             )
+            # With join_use_nulls=0 (our default), unmatched LEFT JOIN rows yield '' for
+            # event_table.event rather than NULL, so guard with empty() instead of isNull().
             event_property_array_query = f"""
                 if(
-                    isNull(event_table.event),
+                    empty(event_table.event),
                     [],
                     [tuple(event_table.event, 'elements_chain', concat({event_type_expression}, '{self.ELEMENTS_DIVIDER}', event_table.elements_chain))]
                 )
@@ -583,7 +585,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
         else:
             event_property_array_query = """
                 if(
-                    isNull(event_table.event),
+                    empty(event_table.event),
                     [],
                     arrayMap(prop -> tuple(event_table.event, prop.1, prop.2), JSONExtractKeysAndValues(event_table.properties, 'String'))
                 )

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -490,7 +490,12 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
         event_correlation_query = parse_select(
             f"""
             WITH
-                funnel_actors AS MATERIALIZED (
+                -- Defined once and shared by both branches of the UNION ALL below.
+                -- Deliberately not AS MATERIALIZED: materialized CTEs are an experimental
+                -- ClickHouse 26.3 feature behind enable_materialized_cte, which is off in
+                -- every environment we run, so the keyword would be inert today and would
+                -- silently change execution whenever that setting is turned on.
+                funnel_actors AS (
                     {{funnel_persons_query}}
                 ),
                 {{date_from}} AS date_from,
@@ -602,10 +607,7 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
                 funnel_actors AS (
                     {{funnel_persons_query}}
                 ),
-                {{date_from}} AS date_from,
-                {{date_to}} AS date_to,
-                {target_step} AS target_step,
-                {funnel_step_names} AS funnel_step_names
+                {target_step} AS target_step
 
             SELECT
                    if(prop.1 = {{total_identifier}}, {{total_identifier}}, concat(prop.1, '::', prop.2, '::', prop.3)) as name,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -1246,7 +1246,7 @@
   FROM
     (SELECT funnel_actors.actor_id AS actor_id,
             funnel_actors.steps AS steps,
-            arrayJoin(arrayConcat([tuple('Total_Values_In_Query', '', '')], if(isNull(event_table.event), [], arrayMap(prop -> tuple(event_table.event, prop.1, prop.2), JSONExtractKeysAndValues(event_table.properties, 'String'))))) AS prop
+            arrayJoin(arrayConcat([tuple('Total_Values_In_Query', '', '')], if(empty(event_table.event), [], arrayMap(prop -> tuple(event_table.event, prop.1, prop.2), JSONExtractKeysAndValues(event_table.properties, 'String'))))) AS prop
      FROM funnel_actors
      LEFT JOIN events AS event_table ON and(equals(event_table.team_id, 99999), and(equals(funnel_actors.actor_id, event_table.`$group_1`), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event_table.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event_table.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime('2020-01-14 23:59:59', 'UTC'))), equals(event_table.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event_table.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event_table.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime('2020-01-14 23:59:59', 'UTC')))), notIn(event_table.event, tuple('paid', 'user signed up')), in(event_table.event, tuple('positively_related', 'negatively_related')))))
   GROUP BY name,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -2107,6 +2107,70 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         #     6,
         # )
 
+    def test_funnel_correlation_with_event_properties_autocapture_no_rows_for_actors_without_events(self):
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
+            ],
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
+
+        for i in range(6):
+            _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id=f"user_{i}",
+                timestamp="2020-01-02T14:00:00Z",
+            )
+            _create_event(
+                team=self.team,
+                event="$autocapture",
+                distinct_id=f"user_{i}",
+                elements=[Element(nth_of_type=1, nth_child=0, tag_name="a", href="/movie")],
+                timestamp="2020-01-03T14:00:00Z",
+                properties={"$event_type": "click"},
+            )
+            _create_event(
+                team=self.team,
+                event="paid",
+                distinct_id=f"user_{i}",
+                timestamp="2020-01-04T14:00:00Z",
+            )
+
+        # Enough non-converting users without any $autocapture events to pass the
+        # significance filters, so a synthesized correlation row for them would show up
+        for i in range(3):
+            _create_person(distinct_ids=[f"user_fail_{i}"], team_id=self.team.pk)
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id=f"user_fail_{i}",
+                timestamp="2020-01-02T14:00:00Z",
+            )
+
+        result, _ = self._get_events_for_query(
+            query,
+            funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
+            funnelCorrelationEventNames=["$autocapture"],
+        )
+
+        # Actors with no matching events must only contribute to the totals — the LEFT
+        # JOIN's unmatched rows must not produce a correlation entry of their own
+        self.assertEqual(
+            result,
+            [
+                {
+                    "event": '$autocapture::elements_chain::click__~~__a:href="/movie"nth-child="0"nth-of-type="1"',
+                    "success_count": 6,
+                    "failure_count": 0,
+                    "odds_ratio": 28.0,
+                    "correlation_type": "success",
+                },
+            ],
+        )
+
 
 class TestCorrelationFunctions(unittest.TestCase):
     def test_are_results_insignificant(self):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -124,7 +124,7 @@ from posthog.models.person.sql import (
     TRUNCATE_PERSON_DISTINCT_ID_TABLE_SQL,
     TRUNCATE_PERSON_STATIC_COHORT_TABLE_SQL,
 )
-from posthog.models.person.util import bulk_create_persons, create_person
+from posthog.models.person.util import bulk_create_persons
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.precalculated_events.sql import (
     DROP_PRECALCULATED_EVENTS_KAFKA_TABLE_SQL,
@@ -1557,14 +1557,7 @@ def _create_person(*args, **kwargs):
     if kwargs.get("immediate") or (
         hasattr(dt.datetime.now(), "__module__") and dt.datetime.now().__module__ == "freezegun.api"
     ):
-        if kwargs.get("immediate"):
-            del kwargs["immediate"]
-        create_person(
-            team_id=kwargs.get("team_id") or kwargs["team"].pk,
-            properties=kwargs.get("properties"),
-            uuid=kwargs["uuid"],
-            version=kwargs.get("version", 0),
-        )
+        kwargs.pop("immediate", None)
         return Person.objects.create(**kwargs)
     if len(args) > 0:
         kwargs["distinct_ids"] = [args[0]]  # allow calling _create_person("distinct_id")

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -124,7 +124,7 @@ from posthog.models.person.sql import (
     TRUNCATE_PERSON_DISTINCT_ID_TABLE_SQL,
     TRUNCATE_PERSON_STATIC_COHORT_TABLE_SQL,
 )
-from posthog.models.person.util import bulk_create_persons
+from posthog.models.person.util import bulk_create_persons, create_person
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.precalculated_events.sql import (
     DROP_PRECALCULATED_EVENTS_KAFKA_TABLE_SQL,
@@ -1557,7 +1557,14 @@ def _create_person(*args, **kwargs):
     if kwargs.get("immediate") or (
         hasattr(dt.datetime.now(), "__module__") and dt.datetime.now().__module__ == "freezegun.api"
     ):
-        kwargs.pop("immediate", None)
+        if kwargs.get("immediate"):
+            del kwargs["immediate"]
+        create_person(
+            team_id=kwargs.get("team_id") or kwargs["team"].pk,
+            properties=kwargs.get("properties"),
+            uuid=kwargs["uuid"],
+            version=kwargs.get("version", 0),
+        )
         return Person.objects.create(**kwargs)
     if len(args) > 0:
         kwargs["distinct_ids"] = [args[0]]  # allow calling _create_person("distinct_id")


### PR DESCRIPTION
## Problem

Review findings from #60421 (the ClickHouse 26.3 compatibility bump). This PR targets that branch so the diff shows only the fixes. Four issues, each explained by a comment at the relevant spot in the code:

1. **The "actor had no events" guard never fires.** The rewritten event-property correlation query detects actors with no matching events using `isNull(event_table.event)`. We run ClickHouse with `join_use_nulls = 0`, so unmatched join rows produce an empty string, not NULL — the check is always false. For autocapture correlation this fabricates a result row counting every funnel actor who had **no** autocapture events; with 3 or more such actors the garbage row appears in the insight. The existing test had only one such actor, below the "more than 2 people" cutoff, so it couldn't catch this.

2. **The join holds the events table in memory.** ClickHouse builds the in-memory hash table from the right-hand table of a join, and the rewrite put `events` there (`FROM funnel_actors LEFT JOIN events`). Comparing query plans on a production-scale cluster: the date/event/team filters do prune the events scan, but the planner does not swap the join sides, so memory grows with the number of matching events — `properties` blobs included. For a popular event over a wide date range this hits memory limits where the old query streamed. Rewritten as the equivalent `FROM events RIGHT JOIN funnel_actors`: same results, small side in memory, pruning intact (verified with `EXPLAIN indexes=1` under both compatibility settings).

3. **The MATERIALIZED keyword does nothing and is a latent behavior change.** Materialized CTEs are an experimental 26.3 feature behind `enable_materialized_cte`, which is off in CI, dev, and production — verified by running the exact query shape on a 26.3 server with the setting off: it executes fine, unmaterialized. The real fix in #60421 is defining the CTE once and sharing it across the UNION branches, which needs no keyword. Removed the keyword so behavior doesn't silently change the day someone enables the setting; the HogQL printer support for it stays.

4. **Two 26.3 compatibility regressions are better pinned in config than worked around in tests.**
   - `optimize_empty_string_comparisons` (off → on under 26.3): the failing run that motivated the materialized-column test changes in #60421 shows plain value comparisons passing but `is_set` matching nothing and `is_not_set` matching everything, on rows written before the column existed. Those filters compile to `mat_col != ''` / `mat_col = ''`, and this setting rewrites exactly those comparisons into emptiness checks that skip DEFAULT-expression evaluation on parts that predate the column. Left unpinned, every is-set/is-not-set filter on a materialized property would silently go wrong for rows older than that column's backfill window once production compatibility is bumped. Pinned off in both users.xml files, and the explicit-backfill test workarounds are reverted — green CI on this PR confirms the diagnosis.
   - `async_insert` (off → on under 26.3): production configures async inserts explicitly (currently off), and under the 26.3 default every single-row test insert waits for the async flush, slowing the suite. Pinned off for prod parity and test speed.

Two #60421 changes reviewed and deliberately **kept**:

- The `_create_person` change is correct: a test-only `post_save` receiver on `Person` (`posthog/models/person/util.py`) already writes the person to ClickHouse on `Person.objects.create`, so the explicit `create_person()` call in the immediate path was a duplicate insert. (An earlier revision of this PR restored it on the mistaken belief it was the only ClickHouse write — corrected.)
- Person-property correlation totals are now computed after the join to `persons`, so actors whose person row was deleted drop out of the denominators. A small results change, but it makes the totals consistent with the per-property counts (which always required a person row), so I'm accepting it as the queries owner.

## Changes

- `empty()` instead of `isNull()` for unmatched-row detection, plus a regression test (3 non-converting users with no autocapture events must not produce a correlation row).
- `FROM events RIGHT JOIN funnel_actors` instead of `FROM funnel_actors LEFT JOIN events`, with a docstring explaining the build-side reasoning.
- Drop `AS MATERIALIZED` from the events correlation CTE; remove WITH aliases the event-property query no longer references.
- Pin `optimize_empty_string_comparisons=0` and `async_insert=0` in `docker/clickhouse/users.xml` and `users-dev.xml` (comments inline); revert the explicit-backfill workarounds in `ee/clickhouse/models/test/test_property.py` and `posthog/hogql/test/test_property.py` to their master state.

Query snapshots are stale on this branch — CI will regenerate them.

## How did you test this code?

Authored by an agent (Claude Code) during Sandy's review, so no manual testing claimed. Verification done:

- Confirmed empty-string (not NULL) behavior of unmatched join rows empirically on production ClickHouse.
- Compared `EXPLAIN indexes=1` plans for both join shapes on a production-scale cluster under `compatibility='25.8'` and `'26.3'`.
- Ran the shared-CTE-across-UNION shape (with and without `MATERIALIZED`) on a 26.3 production server with `enable_materialized_cte` off.
- Diffed the effective settings between `compatibility='25.8'` and `'26.3'` (72 changes) to identify the two pinned settings, and pulled the original failing CI run from #60421 to match the failure signature.
- The reverted property tests now double as the experiment: if CI is green here, the `optimize_empty_string_comparisons` diagnosis is confirmed; if the materialized-column tests fail, the pin is wrong and the backfill workarounds should return.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

Authored by Claude Code during Sandy Spicer's review of #60421, using repo inspection, read-only HogQL probes and `EXPLAIN` comparisons against production ClickHouse, a settings diff between the two compatibility values, and the original failing CI logs from #60421. Decisions: `empty()` over null-wrapping to match codebase convention; RIGHT JOIN over join hints because it needs no settings and was verified at plan level; config pins over test workarounds because the workarounds masked behavior production still depends on. One self-correction during review: an earlier revision restored the explicit ClickHouse person insert in `_create_person`, on the mistaken belief #60421 had removed the only ClickHouse write — the test-only `post_save` signal covers it, so the base PR's deduplication stands. Agent-authored; requires human review.
