### PR TITLE
fix(dashboards): keep tile results when saving returns no cached results

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -353,6 +353,41 @@ describe('dashboardLogic', () => {
             )
         })
 
+        it('saving keeps existing tile results when the PATCH response has no cached results', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const tileBefore = logic.values.dashboard!.tiles.find((t) => t.insight?.short_id === '175')!
+            expect(tileBefore.insight!.result).not.toBeNull()
+
+            const currentLayouts = logic.values.layouts
+            const modifiedLayouts: any = {
+                ...currentLayouts,
+                sm: currentLayouts.sm?.map((layout) =>
+                    layout.i === String(tileBefore.id) ? { ...layout, x: (layout.x ?? 0) + 1 } : layout
+                ),
+            }
+            await expectLogic(logic, () => {
+                logic.actions.updateLayouts(modifiedLayouts)
+            }).toFinishAllListeners()
+
+            // saving never sends `refresh`, so on a backend cache miss the PATCH
+            // response serializes every tile insight with `result: null`
+            jest.spyOn(api, 'update').mockResolvedValueOnce({
+                ...dashboards[5],
+                tiles: logic.values.dashboard!.tiles.map((tile) => ({
+                    ...tile,
+                    ...(tile.insight ? { insight: { ...tile.insight, result: null, last_refresh: null } } : {}),
+                })),
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.saveEditModeChanges()
+            }).toFinishAllListeners()
+
+            const tileAfter = logic.values.dashboard!.tiles.find((t) => t.insight?.short_id === '175')!
+            expect(tileAfter.insight!.result).toEqual(tileBefore.insight!.result)
+        })
+
         it('saving after filter change calls api', async () => {
             await expectLogic(logic).toFinishAllListeners()
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -117,6 +117,7 @@ import {
     layoutsByTile,
     parseURLFilters,
     parseURLVariables,
+    preserveExistingTileResults,
     runWithLimit,
     shouldSharedDashboardAutoForceForStaleTime,
 } from './dashboardUtils'
@@ -547,7 +548,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         if (shouldRefreshTilesAfterSave) {
                             cache.shouldRefreshTilesAfterSave = true
                         }
-                        return getQueryBasedDashboard(updatedDashboard)
+                        return preserveExistingTileResults(getQueryBasedDashboard(updatedDashboard), values.dashboard)
                     } catch (e) {
                         lemonToast.error('Could not update dashboard: ' + String(e))
                         return values.dashboard
@@ -605,7 +606,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                                 tiles: tilesToUpdate.length > 0 ? tilesToUpdate : undefined,
                             }
                         )
-                        return getQueryBasedDashboard(dashboard)
+                        return preserveExistingTileResults(getQueryBasedDashboard(dashboard), values.dashboard)
                     } catch (e) {
                         lemonToast.error('Could not duplicate tile: ' + String(e))
                         return values.dashboard
@@ -626,7 +627,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             to_dashboard: toDashboard,
                         }
                     )
-                    return getQueryBasedDashboard(dashboard)
+                    return preserveExistingTileResults(getQueryBasedDashboard(dashboard), values.dashboard)
                 },
                 copyToDashboard: async ({ tile, fromDashboard, toDashboard, toDashboardName }) => {
                     if (!tile?.insight && !tile?.text && !tile?.button_tile && !tile?.widget) {
@@ -927,7 +928,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     return null
                 },
                 [dashboardsModel.actionTypes.updateDashboardSuccess]: (state, { dashboard }) => {
-                    return state && dashboard && state.id === dashboard.id ? dashboard : state
+                    return state && dashboard && state.id === dashboard.id
+                        ? preserveExistingTileResults(dashboard, state)
+                        : state
                 },
                 [insightsModel.actionTypes.renameInsightSuccess]: (
                     state,

--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -1,12 +1,13 @@
 import { dayjs } from 'lib/dayjs'
 
-import { DashboardPlacement, DashboardTile, QueryBasedInsightModel } from '~/types'
+import { DashboardPlacement, DashboardTile, DashboardType, InsightShortId, QueryBasedInsightModel } from '~/types'
 
 import {
     getDashboardTileDisplayName,
     isWidgetTileVisibleOnPlacement,
     parseURLFilters,
     parseURLVariables,
+    preserveExistingTileResults,
     SEARCH_PARAM_FILTERS_KEY,
     SEARCH_PARAM_QUERY_VARIABLES_KEY,
     shouldSharedDashboardAutoForceForStaleTime,
@@ -97,6 +98,98 @@ describe('parseURLFilters', () => {
         }
         expect(parseURLFilters(searchParams)).toEqual({})
         consoleSpy.mockRestore()
+    })
+})
+
+describe('preserveExistingTileResults', () => {
+    const insightTile = (
+        tileId: number,
+        shortId: string,
+        insightOverrides: Partial<QueryBasedInsightModel> = {}
+    ): DashboardTile<QueryBasedInsightModel> =>
+        ({
+            id: tileId,
+            layouts: {},
+            color: null,
+            insight: {
+                id: tileId * 100,
+                short_id: shortId as InsightShortId,
+                result: null,
+                last_refresh: null,
+                ...insightOverrides,
+            } as QueryBasedInsightModel,
+        }) as DashboardTile<QueryBasedInsightModel>
+
+    const dashboardWith = (
+        tiles: DashboardTile<QueryBasedInsightModel>[],
+        id: number = 1
+    ): DashboardType<QueryBasedInsightModel> => ({ id, tiles }) as DashboardType<QueryBasedInsightModel>
+
+    it('copies the previous result into incoming tiles whose result is null', () => {
+        const previous = dashboardWith([
+            insightTile(1, 'abc', { result: [{ count: 42 }], last_refresh: '2026-06-01T00:00:00Z', is_cached: true }),
+        ])
+        const incoming = dashboardWith([insightTile(1, 'abc')])
+
+        const merged = preserveExistingTileResults(incoming, previous)
+
+        expect(merged?.tiles?.[0]?.insight).toMatchObject({
+            result: [{ count: 42 }],
+            last_refresh: '2026-06-01T00:00:00Z',
+            is_cached: true,
+        })
+    })
+
+    it.each([
+        [
+            'the incoming tile already has a result',
+            insightTile(1, 'abc', { result: [{ count: 1 }] }),
+            insightTile(1, 'abc', { result: [{ count: 99 }] }),
+            [{ count: 99 }],
+        ],
+        ['the previous tile has no result either', insightTile(1, 'abc'), insightTile(1, 'abc'), null],
+        [
+            'the tile now holds a different insight',
+            insightTile(1, 'abc', { result: [{ count: 1 }] }),
+            insightTile(1, 'xyz'),
+            null,
+        ],
+        [
+            'the incoming result is an empty array (valid empty result)',
+            insightTile(1, 'abc', { result: [{ count: 1 }] }),
+            insightTile(1, 'abc', { result: [] }),
+            [],
+        ],
+    ])('keeps the incoming result when %s', (_, previousTile, incomingTile, expectedResult) => {
+        const merged = preserveExistingTileResults(dashboardWith([incomingTile]), dashboardWith([previousTile]))
+
+        expect(merged?.tiles?.[0]?.insight?.result).toEqual(expectedResult)
+    })
+
+    it('returns incoming unchanged when dashboards have different ids', () => {
+        const previous = dashboardWith([insightTile(1, 'abc', { result: [{ count: 1 }] })], 1)
+        const incoming = dashboardWith([insightTile(1, 'abc')], 2)
+
+        expect(preserveExistingTileResults(incoming, previous)).toBe(incoming)
+    })
+
+    it('returns incoming unchanged when either dashboard is null', () => {
+        const dashboard = dashboardWith([insightTile(1, 'abc')])
+
+        expect(preserveExistingTileResults(dashboard, null)).toBe(dashboard)
+        expect(preserveExistingTileResults(null, dashboard)).toBe(null)
+    })
+
+    it('leaves non-insight tiles untouched', () => {
+        const textTile = {
+            id: 7,
+            layouts: {},
+            color: null,
+            text: { body: 'hello' },
+        } as unknown as DashboardTile<QueryBasedInsightModel>
+        const merged = preserveExistingTileResults(dashboardWith([textTile]), dashboardWith([textTile]))
+
+        expect(merged?.tiles?.[0]).toBe(textTile)
     })
 })
 

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -110,6 +110,57 @@ export function getDashboardTileDisplayName(tile: DashboardTile<QueryBasedInsigh
     return 'Tile'
 }
 
+const hasRenderableResult = (insight: QueryBasedInsightModel | null | undefined): boolean =>
+    insight?.result !== null && insight?.result !== undefined
+
+/**
+ * Dashboard PATCH responses (saving layouts, renaming, duplicating a tile, …) never request a refresh,
+ * so the backend serializes tiles in cache-only mode and returns `result: null` on a cache miss.
+ * Swapping such a response into state as-is wipes results that are already rendered, making tiles
+ * show "Chart data didn't load". Keep the previously loaded result for tiles whose incoming payload
+ * has none.
+ */
+export function preserveExistingTileResults(
+    incoming: DashboardType<QueryBasedInsightModel> | null,
+    previous: DashboardType<QueryBasedInsightModel> | null
+): DashboardType<QueryBasedInsightModel> | null {
+    if (!incoming?.tiles || !previous?.tiles || incoming.id !== previous.id) {
+        return incoming
+    }
+
+    const previousTilesById = new Map(previous.tiles.map((tile) => [tile.id, tile]))
+
+    return {
+        ...incoming,
+        tiles: incoming.tiles.map((tile) => {
+            if (!tile.insight || hasRenderableResult(tile.insight)) {
+                return tile
+            }
+            const previousInsight = previousTilesById.get(tile.id)?.insight
+            if (
+                !previousInsight ||
+                previousInsight.short_id !== tile.insight.short_id ||
+                !hasRenderableResult(previousInsight)
+            ) {
+                return tile
+            }
+            return {
+                ...tile,
+                insight: {
+                    ...tile.insight,
+                    result: previousInsight.result,
+                    // The carried-over result was computed for the previous refresh metadata
+                    last_refresh: tile.insight.last_refresh ?? previousInsight.last_refresh,
+                    cache_target_age: tile.insight.cache_target_age ?? previousInsight.cache_target_age,
+                    next_allowed_client_refresh:
+                        tile.insight.next_allowed_client_refresh ?? previousInsight.next_allowed_client_refresh,
+                    is_cached: previousInsight.is_cached,
+                },
+            }
+        }),
+    }
+}
+
 /** Which widget payload is set on a dashboard tile row. Add a branch per `DashboardWidgetType` when new tile kinds ship. */
 export function getDashboardWidgetType(
     tile: Pick<DashboardTile<InsightModel | QueryBasedInsightModel>, 'insight' | 'text' | 'button_tile' | 'widget'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Rearranging or saving a dashboard randomly makes tiles show "Chart data didn't load" even though the charts were rendered fine a moment earlier.

Root cause: dashboard PATCH requests (saving layouts, renaming, duplicating a tile, moving a tile) never send a `refresh` param, so the backend serializes tiles in `CACHE_ONLY_NEVER_CALCULATE` mode and returns `result: null` for any insight whose query cache has expired. The frontend then swaps that response into `dashboardLogic` state wholesale, wiping the results that were already loaded and rendered. With nothing left to render and no refresh queued, tiles fall through to the "Chart data didn't load" empty state. It looks random because it depends on which tiles happen to be cache misses on the backend at save time.

## Changes

- New `preserveExistingTileResults` helper in `dashboardUtils.ts`: when merging a dashboard PATCH response into state, tiles whose incoming insight payload has `result: null` keep the previously loaded result (matched by tile id + insight short_id), along with the refresh metadata that result was computed with. Tiles with a real incoming result (including a valid empty `[]`) are untouched.
- Applied at the spots where a PATCH response replaces the whole dashboard in `dashboardLogic`: `saveEditModeChanges`, `duplicateTile`, `moveToDashboard`, and the `updateDashboardSuccess` reducer (covers renames/saves broadcast via `dashboardsModel`).

The existing post-save refresh behavior is unchanged: when filters or variables changed, tiles still reload to match the saved settings — they now show the previous data with a loading state instead of an error in the meantime.

## How did you test this code?

I'm an agent; automated tests only (the cloud VM cannot run the Docker dev stack, so no manual browser testing was performed):

- New regression test in `dashboardLogic.test.ts` simulating a layout change + save where the PATCH response contains `result: null` insights — fails without the fix, passes with it.
- New unit tests for `preserveExistingTileResults` in `dashboardUtils.test.ts` (preserve on null, keep incoming result, valid empty results, insight swapped on a tile, different dashboard ids, non-insight tiles).
- Full `dashboardLogic.test.ts` and `dashboardUtils.test.ts` suites pass (88 passed, 1 pre-existing skip).
- `tsc --noEmit` clean; `oxlint`/`oxfmt` clean on touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Cursor cloud agent. Traced the "Chart data didn't load" empty state (`InsightRefreshDataHint`) back through `shouldShowDashboardInsightRefreshHint` → `dashboardLogic` state replacement → the dashboard PATCH path, and confirmed in `posthog/hogql_queries/query_runner.py` that requests without `refresh` serialize insights in `CACHE_ONLY_NEVER_CALCULATE` mode (null result on cache miss). Chose a frontend merge over changing the backend PATCH serialization so shared callers of the dashboard PATCH response keep their current contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ebe1a2f-d052-4130-bcba-ab014fdf6198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ebe1a2f-d052-4130-bcba-ab014fdf6198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

