### PR TITLE
feat(dashboards): expose dashboard template discovery via MCP

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1036,7 +1036,10 @@ class DashboardSerializer(DashboardMetadataSerializer):
         write_only=True,
         allow_blank=True,
         required=False,
-        help_text="Template key to create the dashboard from a predefined template.",
+        help_text=(
+            "Template key to create the dashboard from a predefined template — this is the `template_name` of an "
+            "available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard."
+        ),
     )
     use_dashboard = serializers.IntegerField(
         write_only=True,

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -333,7 +333,7 @@ export interface DashboardApi {
     quick_filter_ids?: string[] | null
     /** @nullable */
     readonly tiles: readonly DashboardApiTilesItem[] | null
-    /** Template key to create the dashboard from a predefined template. */
+    /** Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard. */
     use_template?: string
     /**
      * ID of an existing dashboard to duplicate.
@@ -429,7 +429,7 @@ export interface PatchedDashboardApi {
     quick_filter_ids?: string[] | null
     /** @nullable */
     readonly tiles?: readonly PatchedDashboardApiTilesItem[] | null
-    /** Template key to create the dashboard from a predefined template. */
+    /** Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard. */
     use_template?: string
     /**
      * ID of an existing dashboard to duplicate.

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -151,7 +151,9 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()
@@ -198,7 +200,9 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()
@@ -236,7 +240,9 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()
@@ -802,7 +808,9 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()
@@ -845,7 +853,9 @@ export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -22,8 +22,16 @@ tools:
         title: Create dashboard
         description: >
             Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
-            from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
-            — use dashboard-insights-run to fetch the actual data for each insight.
+            from a template (pass use_template) or duplicate an existing dashboard (pass use_dashboard). The returned
+            tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each
+            insight.
+        param_overrides:
+            use_template:
+                description: >
+                    Optional template key to pre-populate the dashboard with tiles. This is the `template_name` of an
+                    existing dashboard template — call dashboard-templates-list to discover valid keys (and
+                    dashboard-templates-retrieve to inspect a candidate's tiles). Do not guess a key; an unknown key
+                    returns an error. Omit to create an empty dashboard.
         exclude_params:
             - creation_mode
             - effective_restriction_level
@@ -240,12 +248,57 @@ tools:
         enabled: false
     dashboard-templates-list:
         operation: dashboard_templates_list
-        enabled: false
-    dashboard-templates-partial-update:
-        operation: dashboard_templates_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - dashboard:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List dashboard templates
+        description: >
+            List dashboard templates available to this project — the keys you can pass to dashboard-create's
+            use_template (use each template's `template_name`). Returns lightweight metadata per template (template_name,
+            description, tags, scope, whether it's featured) so you can pick one by intent; tile contents are omitted to
+            keep this light — once you've narrowed to a candidate, use dashboard-templates-retrieve to see that one
+            template's tile-by-tile summary. By default both the official global templates and this project's own
+            templates are returned — pass `scope=global` to restrict to the official set, or `scope=team` for just this
+            project's. `is_featured` narrows further.
+        response:
+            exclude:
+                - tiles
+                - variables
+                - dashboard_filters
+                - deleted
+                - created_by
     dashboard-templates-retrieve:
         operation: dashboard_templates_retrieve
+        enabled: true
+        scopes:
+            - dashboard:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get dashboard template
+        description: >
+            Get a single dashboard template by ID to see what it builds before creating a dashboard from it. Returns a
+            tile-by-tile summary — each tile's name, description, and type — so you can confirm a candidate's contents.
+            The underlying query definitions, layout, and colors are omitted to save context; create the dashboard
+            (dashboard-create with use_template = the template's `template_name`, not its id) and use dashboard-get /
+            dashboard-insights-run to see the actual queries and data. Discover template IDs with
+            dashboard-templates-list.
+        response:
+            exclude:
+                - created_by
+                - deleted
+                - dashboard_filters
+                - tiles.*.query
+                - tiles.*.layouts
+                - tiles.*.color
+    dashboard-templates-partial-update:
+        operation: dashboard_templates_partial_update
         enabled: false
     dashboard-templates-update:
         operation: dashboard_templates_update

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -272,6 +272,7 @@ tools:
                 - dashboard_filters
                 - deleted
                 - created_by
+                - availability_contexts
     dashboard-templates-partial-update:
         operation: dashboard_templates_partial_update
         enabled: false
@@ -295,8 +296,8 @@ tools:
         response:
             exclude:
                 - created_by
-                - deleted
                 - dashboard_filters
+                - availability_contexts
                 - tiles.*.query
                 - tiles.*.layouts
                 - tiles.*.color

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -25,13 +25,6 @@ tools:
             from a template (pass use_template) or duplicate an existing dashboard (pass use_dashboard). The returned
             tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each
             insight.
-        param_overrides:
-            use_template:
-                description: >
-                    Optional template key to pre-populate the dashboard with tiles. This is the `template_name` of an
-                    existing dashboard template — call dashboard-templates-list to discover valid keys (and
-                    dashboard-templates-retrieve to inspect a candidate's tiles). Do not guess a key; an unknown key
-                    returns an error. Omit to create an empty dashboard.
         exclude_params:
             - creation_mode
             - effective_restriction_level
@@ -44,6 +37,13 @@ tools:
             - persisted_filters
             - persisted_variables
             - _create_in_folder
+        param_overrides:
+            use_template:
+                description: >
+                    Optional template key to pre-populate the dashboard with tiles. This is the `template_name` of an
+                    existing dashboard template — call dashboard-templates-list to discover valid keys (and
+                    dashboard-templates-retrieve to inspect a candidate's tiles). Do not guess a key; an unknown key
+                    returns an error. Omit to create an empty dashboard.
         response:
             exclude:
                 - effective_restriction_level
@@ -259,12 +259,12 @@ tools:
         title: List dashboard templates
         description: >
             List dashboard templates available to this project — the keys you can pass to dashboard-create's
-            use_template (use each template's `template_name`). Returns lightweight metadata per template (template_name,
-            description, tags, scope, whether it's featured) so you can pick one by intent; tile contents are omitted to
-            keep this light — once you've narrowed to a candidate, use dashboard-templates-retrieve to see that one
-            template's tile-by-tile summary. By default both the official global templates and this project's own
-            templates are returned — pass `scope=global` to restrict to the official set, or `scope=team` for just this
-            project's. `is_featured` narrows further.
+            use_template (use each template's `template_name`). Returns lightweight metadata per template
+            (template_name, description, tags, scope, whether it's featured) so you can pick one by intent; tile
+            contents are omitted to keep this light — once you've narrowed to a candidate, use
+            dashboard-templates-retrieve to see that one template's tile-by-tile summary. By default both the official
+            global templates and this project's own templates are returned — pass `scope=global` to restrict to the
+            official set, or `scope=team` for just this project's. `is_featured` narrows further.
         response:
             exclude:
                 - tiles
@@ -272,6 +272,9 @@ tools:
                 - dashboard_filters
                 - deleted
                 - created_by
+    dashboard-templates-partial-update:
+        operation: dashboard_templates_partial_update
+        enabled: false
     dashboard-templates-retrieve:
         operation: dashboard_templates_retrieve
         enabled: true
@@ -297,9 +300,6 @@ tools:
                 - tiles.*.query
                 - tiles.*.layouts
                 - tiles.*.color
-    dashboard-templates-partial-update:
-        operation: dashboard_templates_partial_update
-        enabled: false
     dashboard-templates-update:
         operation: dashboard_templates_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -982,7 +982,7 @@
         }
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template (pass use_template) or duplicate an existing dashboard (pass use_dashboard). The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -1077,6 +1077,34 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "dashboard-templates-list": {
+        "description": "List dashboard templates available to this project — the keys you can pass to dashboard-create's use_template (use each template's `template_name`). Returns lightweight metadata per template (template_name, description, tags, scope, whether it's featured) so you can pick one by intent; tile contents are omitted to keep this light — once you've narrowed to a candidate, use dashboard-templates-retrieve to see that one template's tile-by-tile summary. By default both the official global templates and this project's own templates are returned — pass `scope=global` to restrict to the official set, or `scope=team` for just this project's. `is_featured` narrows further.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "List dashboard templates",
+        "title": "List dashboard templates",
+        "required_scopes": ["dashboard:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "dashboard-templates-retrieve": {
+        "description": "Get a single dashboard template by ID to see what it builds before creating a dashboard from it. Returns a tile-by-tile summary — each tile's name, description, and type — so you can confirm a candidate's contents. The underlying query definitions, layout, and colors are omitted to save context; create the dashboard (dashboard-create with use_template = the template's `template_name`, not its id) and use dashboard-get / dashboard-insights-run to see the actual queries and data. Discover template IDs with dashboard-templates-list.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Get dashboard template",
+        "title": "Get dashboard template",
+        "required_scopes": ["dashboard:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "dashboard-tile-copy": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -998,7 +998,7 @@
         }
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template (pass use_template) or duplicate an existing dashboard (pass use_dashboard). The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -1093,6 +1093,34 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "dashboard-templates-list": {
+        "description": "List dashboard templates available to this project — the keys you can pass to dashboard-create's use_template (use each template's `template_name`). Returns lightweight metadata per template (template_name, description, tags, scope, whether it's featured) so you can pick one by intent; tile contents are omitted to keep this light — once you've narrowed to a candidate, use dashboard-templates-retrieve to see that one template's tile-by-tile summary. By default both the official global templates and this project's own templates are returned — pass `scope=global` to restrict to the official set, or `scope=team` for just this project's. `is_featured` narrows further.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "List dashboard templates",
+        "title": "List dashboard templates",
+        "required_scopes": ["dashboard:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "dashboard-templates-retrieve": {
+        "description": "Get a single dashboard template by ID to see what it builds before creating a dashboard from it. Returns a tile-by-tile summary — each tile's name, description, and type — so you can confirm a candidate's contents. The underlying query definitions, layout, and colors are omitted to save context; create the dashboard (dashboard-create with use_template = the template's `template_name`, not its id) and use dashboard-get / dashboard-insights-run to see the actual queries and data. Discover template IDs with dashboard-templates-list.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Get dashboard template",
+        "title": "Get dashboard template",
+        "required_scopes": ["dashboard:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "dashboard-tile-copy": {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12468,7 +12468,7 @@ export namespace Schemas {
       quick_filter_ids?: string[] | null;
       /** @nullable */
       readonly tiles: readonly DashboardTilesItem[] | null;
-      /** Template key to create the dashboard from a predefined template. */
+      /** Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard. */
       use_template?: string;
       /**
          * ID of an existing dashboard to duplicate.
@@ -28768,7 +28768,7 @@ export namespace Schemas {
       quick_filter_ids?: string[] | null;
       /** @nullable */
       readonly tiles?: readonly PatchedDashboardTilesItem[] | null;
-      /** Template key to create the dashboard from a predefined template. */
+      /** Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard. */
       use_template?: string;
       /**
          * ID of an existing dashboard to duplicate.

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -3,10 +3,50 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 15 enabled ops
+ * PostHog API - MCP 17 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+export const DashboardTemplatesListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const DashboardTemplatesListQueryParams = /* @__PURE__ */ zod.object({
+    is_featured: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Omit for all templates. When set, filter by featured flag; parsed with str_to_bool (same as other API query booleans).'
+        ),
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    ordering: zod
+        .string()
+        .optional()
+        .describe(
+            'Optional. When not using `search`, results are sorted with featured templates first (`is_featured=true`), then by `template_name` (case-insensitive A–Z; `-template_name` for Z–A) or by `created_at` (`-created_at` for newest first). When `search` is set, order is featured first, then relevance rank, then case-insensitive name for ties.'
+        ),
+    scope: zod
+        .enum(['feature_flag', 'global', 'team'])
+        .optional()
+        .describe(
+            "Optional. `global`: official templates only. `team`: this project's saved templates only (`scope=team` rows for the current project). `feature_flag`: feature-flag dashboard templates only. Omit for both official and this project's templates (default dashboard template picker behavior)."
+        ),
+})
+
+export const DashboardTemplatesRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this dashboard template.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
 
 export const DashboardsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -65,7 +105,9 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()
@@ -135,7 +177,9 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
         use_template: zod
             .string()
             .optional()
-            .describe('Template key to create the dashboard from a predefined template.'),
+            .describe(
+                'Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.'
+            ),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
         delete_insights: zod
             .boolean()

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    DashboardTemplatesListQueryParams,
+    DashboardTemplatesRetrieveParams,
     DashboardsCopyTileCreateBody,
     DashboardsCopyTileCreateParams,
     DashboardsCreateBody,
@@ -33,7 +35,11 @@ import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
-const DashboardCreateSchema = DashboardsCreateBody
+const DashboardCreateSchema = DashboardsCreateBody.extend({
+    use_template: DashboardsCreateBody.shape['use_template'].describe(
+        "Optional template key to pre-populate the dashboard with tiles. This is the `template_name` of an existing dashboard template — call dashboard-templates-list to discover valid keys (and dashboard-templates-retrieve to inspect a candidate's tiles). Do not guess a key; an unknown key returns an error. Omit to create an empty dashboard."
+    ),
+})
 
 const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUrl<Schemas.Dashboard>> => ({
     name: 'dashboard-create',
@@ -330,6 +336,63 @@ const dashboardReorderTiles = (): ToolBase<typeof DashboardReorderTilesSchema, W
     },
 })
 
+const DashboardTemplatesListSchema = DashboardTemplatesListQueryParams
+
+const dashboardTemplatesList = (): ToolBase<
+    typeof DashboardTemplatesListSchema,
+    WithPostHogUrl<Schemas.PaginatedDashboardTemplateList>
+> => ({
+    name: 'dashboard-templates-list',
+    schema: DashboardTemplatesListSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardTemplatesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedDashboardTemplateList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboard_templates/`,
+            query: {
+                is_featured: params.is_featured,
+                limit: params.limit,
+                offset: params.offset,
+                ordering: params.ordering,
+                scope: params.scope,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                omitResponseFields(item, ['tiles', 'variables', 'dashboard_filters', 'deleted', 'created_by'])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/dashboard')
+    },
+})
+
+const DashboardTemplatesRetrieveSchema = DashboardTemplatesRetrieveParams.omit({ project_id: true })
+
+const dashboardTemplatesRetrieve = (): ToolBase<
+    typeof DashboardTemplatesRetrieveSchema,
+    Schemas.DashboardTemplate
+> => ({
+    name: 'dashboard-templates-retrieve',
+    schema: DashboardTemplatesRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardTemplatesRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.DashboardTemplate>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboard_templates/${encodeURIComponent(String(params.id))}/`,
+        })
+        const filtered = omitResponseFields(result, [
+            'created_by',
+            'deleted',
+            'dashboard_filters',
+            'tiles.*.query',
+            'tiles.*.layouts',
+            'tiles.*.color',
+        ]) as typeof result
+        return filtered
+    },
+})
+
 const DashboardTileCopySchema = DashboardsCopyTileCreateParams.omit({ project_id: true })
     .extend(DashboardsCopyTileCreateBody.shape)
     .extend({ id: z.preprocess(castStringToInt, DashboardsCopyTileCreateParams.shape['id']) })
@@ -616,6 +679,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-get': dashboardGet,
     'dashboard-insights-run': dashboardInsightsRun,
     'dashboard-reorder-tiles': dashboardReorderTiles,
+    'dashboard-templates-list': dashboardTemplatesList,
+    'dashboard-templates-retrieve': dashboardTemplatesRetrieve,
     'dashboard-tile-copy': dashboardTileCopy,
     'dashboard-update': dashboardUpdate,
     'dashboard-update-text-tile': dashboardUpdateTextTile,

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -360,7 +360,14 @@ const dashboardTemplatesList = (): ToolBase<
         const filtered = {
             ...result,
             results: (result.results ?? []).map((item: any) =>
-                omitResponseFields(item, ['tiles', 'variables', 'dashboard_filters', 'deleted', 'created_by'])
+                omitResponseFields(item, [
+                    'tiles',
+                    'variables',
+                    'dashboard_filters',
+                    'deleted',
+                    'created_by',
+                    'availability_contexts',
+                ])
             ),
         } as typeof result
         return await withPostHogUrl(context, filtered, '/dashboard')
@@ -383,8 +390,8 @@ const dashboardTemplatesRetrieve = (): ToolBase<
         })
         const filtered = omitResponseFields(result, [
             'created_by',
-            'deleted',
             'dashboard_filters',
+            'availability_contexts',
             'tiles.*.query',
             'tiles.*.layouts',
             'tiles.*.color',

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Serializer mixin that handles tags for objects.",
     "properties": {
         "breakdown_colors": {
             "description": "Custom color mapping for breakdown values."
@@ -81,7 +80,7 @@
             "description": "ID of an existing dashboard to duplicate."
         },
         "use_template": {
-            "description": "Template key to create the dashboard from a predefined template.",
+            "description": "Optional template key to pre-populate the dashboard with tiles. This is the `template_name` of an existing dashboard template — call dashboard-templates-list to discover valid keys (and dashboard-templates-retrieve to inspect a candidate's tiles). Do not guess a key; an unknown key returns an error. Omit to create an empty dashboard.",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-templates-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-templates-list.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "is_featured": {
+            "description": "Omit for all templates. When set, filter by featured flag; parsed with str_to_bool (same as other API query booleans).",
+            "type": "boolean"
+        },
+        "limit": {
+            "description": "Number of results to return per page.",
+            "type": "number"
+        },
+        "offset": {
+            "description": "The initial index from which to return the results.",
+            "type": "number"
+        },
+        "ordering": {
+            "description": "Optional. When not using `search`, results are sorted with featured templates first (`is_featured=true`), then by `template_name` (case-insensitive A–Z; `-template_name` for Z–A) or by `created_at` (`-created_at` for newest first). When `search` is set, order is featured first, then relevance rank, then case-insensitive name for ties.",
+            "type": "string"
+        },
+        "scope": {
+            "description": "Optional. `global`: official templates only. `team`: this project's saved templates only (`scope=team` rows for the current project). `feature_flag`: feature-flag dashboard templates only. Omit for both official and this project's templates (default dashboard template picker behavior).",
+            "enum": ["feature_flag", "global", "team"],
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-templates-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-templates-retrieve.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this dashboard template.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -83,7 +83,7 @@
             "description": "ID of an existing dashboard to duplicate."
         },
         "use_template": {
-            "description": "Template key to create the dashboard from a predefined template.",
+            "description": "Template key to create the dashboard from a predefined template — this is the `template_name` of an available dashboard template (list them via the dashboard templates endpoint). Omit for an empty dashboard.",
             "type": "string"
         }
     },


### PR DESCRIPTION
## Problem

Agents creating dashboards through the PostHog MCP could already pass `use_template` to `dashboard-create`, but had no way to **discover** valid template keys or understand **what a template builds**. The key space is dynamic — the built-in globals plus per-team `DashboardTemplate` rows — so a static enum can't represent it, and the field description named no valid values. In practice agents either ignored templates or guessed a key and hit `Invalid template provided`. The feature was reachable but effectively undiscoverable.

## Changes

Enable two read-only template tools and add a discovery hint, sized for the common case (~30 global templates):

| Tool | Returns | Why |
|------|---------|-----|
| `dashboard-templates-list` | Lightweight index per template — `template_name` (the key), description, tags, scope, featured. Tiles stripped. | One ~2.5K-token call lets an agent pick by intent across all globals. |
| `dashboard-templates-retrieve` | Tile-by-tile summary (name, type, description) for a single template; `query`/`layout`/`color` stripped. | On-demand confirmation of a candidate's contents without inlining heavy query JSON (~88K for 30 templates if kept). |

- `dashboard-create`'s `use_template` parameter now carries an MCP hint pointing at `dashboard-templates-list` (discover keys) and `dashboard-templates-retrieve` (inspect tiles), and warns against guessing. The serializer `help_text` is expanded to match — it flows to frontend API types and OpenAPI docs for non-MCP consumers too.
- Template **write/management** tools (create/update/destroy/copy) stay disabled — only discovery is exposed.

The typical flow is two calls: `dashboard-templates-list` → `dashboard-create` (with `retrieve` opt-in when an agent wants to verify tiles first).

Tracking was already in place: the existing `"dashboard created"` event records `from_template` and `template_key`, and because it's reported with the request, `source="mcp"` (plus `mcp_client_name`) is auto-stamped — so template-via-MCP usage is queryable without any change here.

## How did you test this code?

I'm an agent (Claude Code, via the PostHog MCP code tools). Automated checks I actually ran:

- Validated `tools.yaml` parses and the two tools have the expected `enabled`/`scopes`/`annotations`/`response.exclude` config (Python `yaml` load).
- Simulated the `response.exclude` paths against real seed templates (`posthog/demo/dashboard_template_seeds/`) using the same `removeAtPath` semantics as `services/mcp/src/tools/tool-utils.ts`, confirming `list` returns index-only metadata and `retrieve` returns the tile table of contents with query blobs stripped.

I did **not** run the full type/codegen pipeline (see below) or any manual end-to-end MCP call.

> [!IMPORTANT]
> **Generated artifacts still need regeneration.** This environment had no database, so `hogli build:openapi` (Django `spectacular` step) could not run. The generated MCP handler (`services/mcp/src/tools/generated/dashboards.ts`), Orval/Zod schemas, tool-schema snapshots, and frontend `api.schemas.ts` for the `help_text` change are **not** included in this commit. Run `hogli build:openapi` in a DB-connected env (or let the CI in-sync check flag it) and commit the result before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code via PostHog MCP code tools.
- The requester asked how dashboard creation via MCP relates to templates; investigation showed `use_template` existed but was undiscoverable (no enum-able key space, the listing tool disabled). We rejected a static enum (template names are dynamic/per-team) and a verbosity toggle on `retrieve` (the MCP framework applies `response.include`/`exclude` statically — no per-call shape switching). We also evaluated folding the tile table-of-contents into `list` to save a round trip, then rejected it: it front-loads ~5–10K tokens of detail for all ~30 templates when the agent typically picks one by description, so a lean index `list` + on-demand `retrieve` is more token-efficient. `search` exists in the backend but isn't a documented OpenAPI parameter, so it isn't exposed; deferred as a small follow-up if team-template volume ever warrants it.
- Agent-authored — requires human review; do not self-merge.
