### PR TITLE
feat(llma): add daily AI observability digest agent

### DIFF
--- a/.semgrep/rules/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/idor-team-scoped-models.yaml
@@ -55,6 +55,7 @@ rules:
                       regex: |
                           (?x)(
                               AccessControl
+                              |AIObservabilityReportConfig
                               |Account
                               |Action
                               |AgentArtifact
@@ -298,6 +299,7 @@ rules:
                 regex: |
                     (?x)(
                         AccessControl
+                        |AIObservabilityReportConfig
                         |Account
                         |Action
                         |AgentArtifact

--- a/posthog/temporal/ai_observability/__init__.py
+++ b/posthog/temporal/ai_observability/__init__.py
@@ -1,3 +1,7 @@
+from posthog.temporal.ai_observability.ai_observability_reports import (
+    ACTIVITIES as AI_OBSERVABILITY_REPORT_ACTIVITIES,
+    WORKFLOWS as AI_OBSERVABILITY_REPORT_WORKFLOWS,
+)
 from posthog.temporal.ai_observability.eval_reports.activities import (
     deliver_report_activity,
     fetch_count_triggered_eval_reports_activity,
@@ -127,6 +131,8 @@ WORKFLOWS = [
     AIObservabilityEvaluationSamplerWorkflow,
     AIObservabilityEvaluationClusteringCoordinatorWorkflow,
     AIObservabilityEvaluationClusteringWorkflow,
+    # Daily AI observability digest (Slack-only, never files a Signals report)
+    *AI_OBSERVABILITY_REPORT_WORKFLOWS,
     # Keep sentiment workflow registered here temporarily so orphaned workflows on general-purpose queue can complete
     ClassifySentimentWorkflow,
     # Keep eval workflow registered here temporarily so orphaned workflows on general-purpose queue can complete
@@ -164,6 +170,8 @@ ACTIVITIES = [
     generate_evaluation_cluster_labels_activity,
     compute_evaluation_cluster_aggregates_activity,
     emit_evaluation_cluster_events_activity,
+    # Daily AI observability digest
+    *AI_OBSERVABILITY_REPORT_ACTIVITIES,
     # Keep sentiment activity registered here temporarily so orphaned workflows on general-purpose queue can complete
     classify_sentiment_activity,
     # Keep eval activities registered here temporarily so orphaned workflows on general-purpose queue can complete

--- a/posthog/temporal/ai_observability/ai_observability_reports/__init__.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/__init__.py
@@ -1,0 +1,27 @@
+from posthog.temporal.ai_observability.ai_observability_reports.activities import (
+    fetch_enabled_ai_observability_report_configs_activity,
+    run_ai_observability_report_agent_activity,
+)
+from posthog.temporal.ai_observability.ai_observability_reports.coordinator import (
+    AIObservabilityReportCoordinatorWorkflow,
+)
+from posthog.temporal.ai_observability.ai_observability_reports.workflow import GenerateAIObservabilityReportWorkflow
+
+WORKFLOWS = [
+    AIObservabilityReportCoordinatorWorkflow,
+    GenerateAIObservabilityReportWorkflow,
+]
+
+ACTIVITIES = [
+    fetch_enabled_ai_observability_report_configs_activity,
+    run_ai_observability_report_agent_activity,
+]
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "AIObservabilityReportCoordinatorWorkflow",
+    "GenerateAIObservabilityReportWorkflow",
+    "fetch_enabled_ai_observability_report_configs_activity",
+    "run_ai_observability_report_agent_activity",
+]

--- a/posthog/temporal/ai_observability/ai_observability_reports/activities.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/activities.py
@@ -149,7 +149,8 @@ async def run_ai_observability_report_agent_activity(
     inputs: RunAIObservabilityReportAgentInput,
 ) -> RunAIObservabilityReportAgentOutput:
     """Run the digest agent for one config: load skill, execute in sandbox, post to Slack."""
-    from products.ai_observability.backend.ai_observability_digest import AIObservabilityDigestAgent
+    from posthog.temporal.ai_observability.ai_observability_reports.agent import AIObservabilityDigestAgent
+
     from products.signals.backend.custom_agent.base import NO_REPO
 
     log = logger.bind(config_id=inputs.config_id)

--- a/posthog/temporal/ai_observability/ai_observability_reports/activities.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/activities.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import dataclasses
+
+import structlog
+import temporalio.activity
+
+from posthog.models import Team
+from posthog.models.organization import OrganizationMembership
+from posthog.sync import database_sync_to_async
+from posthog.temporal.ai_observability.ai_observability_reports.types import (
+    FetchEnabledConfigsOutput,
+    RunAIObservabilityReportAgentInput,
+    RunAIObservabilityReportAgentOutput,
+)
+from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.common.scoped import scoped_temporal
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass
+class _DigestContext:
+    team: Team
+    initial_prompt: str
+    slack_integration_id: int | str | None
+    slack_channel: str
+    user_id: int
+    skill_name: str
+
+
+def _resolve_digest_user_id(team: Team, created_by_id: int | None) -> int:
+    """Pick a PostHog user to attribute the sandbox run to.
+
+    Unlike repo-backed agents, the digest does no GitHub work, so we don't require a GitHub
+    integration: prefer the config's creator (if still an active org member), else any active
+    member. Raises if the org has no active users.
+    """
+    if created_by_id is not None:
+        is_active = OrganizationMembership.objects.filter(
+            organization=team.organization,
+            user_id=created_by_id,
+            user__is_active=True,
+        ).exists()
+        if is_active:
+            return created_by_id
+    membership = (
+        OrganizationMembership.objects.select_related("user")
+        .filter(organization=team.organization, user__is_active=True)
+        .order_by("id")
+        .first()
+    )
+    if not membership:
+        raise RuntimeError(f"No active users in organization for team {team.id}; cannot run AI observability digest")
+    return membership.user_id
+
+
+def _build_initial_prompt(skill_body: str, additional_instructions: str) -> str:
+    parts = [
+        "You are running the daily AI observability digest for this team.",
+        "## Skill instructions",
+        skill_body.strip(),
+    ]
+    if additional_instructions.strip():
+        parts.extend(["## Additional instructions", additional_instructions.strip()])
+    return "\n\n".join(parts)
+
+
+def _load_digest_context(config_id: str) -> _DigestContext | None:
+    """Resolve everything the agent needs from a config row. Returns None to skip the run."""
+    from products.ai_observability.backend.models import AIObservabilityReportConfig
+    from products.signals.backend.scout_harness.skill_loader import load_skill_for_run
+
+    config = (
+        AIObservabilityReportConfig.all_teams.select_related("team", "team__organization").filter(id=config_id).first()
+    )
+    if config is None or not config.enabled:
+        logger.info("ai_observability_digest_skip_disabled", config_id=config_id)
+        return None
+    if not config.slack_integration_id or not config.slack_channel:
+        logger.warning("ai_observability_digest_skip_no_slack", config_id=config_id, team_id=config.team_id)
+        return None
+
+    team = config.team
+    # Mirror the consent gate enforced by emit_signal / arun_agent — the digest sends team
+    # data through an LLM + sandbox.
+    if not team.organization.is_ai_data_processing_approved:
+        logger.warning("ai_observability_digest_skip_no_consent", config_id=config_id, team_id=team.id)
+        return None
+
+    skill = load_skill_for_run(team, config.skill_name)
+    user_id = _resolve_digest_user_id(team, config.created_by_id)
+    return _DigestContext(
+        team=team,
+        initial_prompt=_build_initial_prompt(skill.body, config.additional_instructions),
+        slack_integration_id=config.slack_integration_id,
+        slack_channel=config.slack_channel,
+        user_id=user_id,
+        skill_name=skill.name,
+    )
+
+
+def _stamp_last_run_at(config_id: str) -> None:
+    from django.utils import timezone
+
+    from products.ai_observability.backend.models import AIObservabilityReportConfig
+
+    AIObservabilityReportConfig.all_teams.filter(id=config_id).update(last_run_at=timezone.now())
+
+
+@temporalio.activity.defn
+@scoped_temporal()
+async def fetch_enabled_ai_observability_report_configs_activity() -> FetchEnabledConfigsOutput:
+    """Return the IDs of every enabled config wired to a Slack integration."""
+
+    def _fetch() -> list[str]:
+        from products.ai_observability.backend.models import AIObservabilityReportConfig
+
+        ids = (
+            AIObservabilityReportConfig.all_teams.filter(enabled=True, slack_integration__isnull=False)
+            .order_by("created_at", "id")
+            .values_list("id", flat=True)
+        )
+        return [str(i) for i in ids]
+
+    config_ids = await database_sync_to_async(_fetch, thread_sensitive=False)()
+    logger.info("ai_observability_digest_configs_discovered", count=len(config_ids))
+    return FetchEnabledConfigsOutput(config_ids=config_ids)
+
+
+@temporalio.activity.defn
+@scoped_temporal()
+async def run_ai_observability_report_agent_activity(
+    inputs: RunAIObservabilityReportAgentInput,
+) -> RunAIObservabilityReportAgentOutput:
+    """Run the digest agent for one config: load skill, execute in sandbox, post to Slack."""
+    from products.ai_observability.backend.ai_observability_digest import AIObservabilityDigestAgent
+    from products.signals.backend.custom_agent.base import NO_REPO
+
+    log = logger.bind(config_id=inputs.config_id)
+    async with Heartbeater():
+        context = await database_sync_to_async(_load_digest_context, thread_sensitive=False)(inputs.config_id)
+        if context is None:
+            return RunAIObservabilityReportAgentOutput(delivered=False, skill_name="")
+
+        agent = AIObservabilityDigestAgent(
+            team=context.team,
+            initial_prompt=context.initial_prompt,
+            repository=NO_REPO,
+            slack_integration_id=context.slack_integration_id,
+            slack_channel=context.slack_channel,
+            user_id=context.user_id,
+        )
+        try:
+            await agent.start()
+        finally:
+            await database_sync_to_async(_stamp_last_run_at, thread_sensitive=False)(inputs.config_id)
+
+        log.info("ai_observability_digest_agent_completed", skill_name=context.skill_name)
+        return RunAIObservabilityReportAgentOutput(delivered=True, skill_name=context.skill_name)

--- a/posthog/temporal/ai_observability/ai_observability_reports/activities.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/activities.py
@@ -45,8 +45,7 @@ def _resolve_digest_user_id(team: Team, created_by_id: int | None) -> int:
         if is_active:
             return created_by_id
     membership = (
-        OrganizationMembership.objects.select_related("user")
-        .filter(organization=team.organization, user__is_active=True)
+        OrganizationMembership.objects.filter(organization=team.organization, user__is_active=True)
         .order_by("id")
         .first()
     )
@@ -69,7 +68,7 @@ def _build_initial_prompt(skill_body: str, additional_instructions: str) -> str:
 def _load_digest_context(config_id: str) -> _DigestContext | None:
     """Resolve everything the agent needs from a config row. Returns None to skip the run."""
     from products.ai_observability.backend.models import AIObservabilityReportConfig
-    from products.signals.backend.scout_harness.skill_loader import load_skill_for_run
+    from products.signals.backend.scout_harness.skill_loader import SkillNotFoundError, load_skill_for_run
 
     config = (
         AIObservabilityReportConfig.all_teams.select_related("team", "team__organization").filter(id=config_id).first()
@@ -88,7 +87,18 @@ def _load_digest_context(config_id: str) -> _DigestContext | None:
         logger.warning("ai_observability_digest_skip_no_consent", config_id=config_id, team_id=team.id)
         return None
 
-    skill = load_skill_for_run(team, config.skill_name)
+    # A stale config pointing at a deleted/renamed skill should skip quietly, not fail the
+    # child workflow — one team's bad config shouldn't generate noisy daily failures.
+    try:
+        skill = load_skill_for_run(team, config.skill_name)
+    except SkillNotFoundError:
+        logger.warning(
+            "ai_observability_digest_skip_missing_skill",
+            config_id=config_id,
+            team_id=team.id,
+            skill_name=config.skill_name,
+        )
+        return None
     user_id = _resolve_digest_user_id(team, config.created_by_id)
     return _DigestContext(
         team=team,
@@ -117,7 +127,12 @@ async def fetch_enabled_ai_observability_report_configs_activity() -> FetchEnabl
         from products.ai_observability.backend.models import AIObservabilityReportConfig
 
         ids = (
-            AIObservabilityReportConfig.all_teams.filter(enabled=True, slack_integration__isnull=False)
+            AIObservabilityReportConfig.all_teams.filter(
+                enabled=True,
+                slack_integration__isnull=False,
+                slack_integration__kind="slack",
+            )
+            .exclude(slack_channel="")
             .order_by("created_at", "id")
             .values_list("id", flat=True)
         )
@@ -151,10 +166,10 @@ async def run_ai_observability_report_agent_activity(
             slack_channel=context.slack_channel,
             user_id=context.user_id,
         )
-        try:
-            await agent.start()
-        finally:
-            await database_sync_to_async(_stamp_last_run_at, thread_sensitive=False)(inputs.config_id)
+        await agent.start()
+        # Stamp only after a successful run so `last_run_at` stays a reliable signal of the
+        # last good digest (a failed run leaves it untouched).
+        await database_sync_to_async(_stamp_last_run_at, thread_sensitive=False)(inputs.config_id)
 
         log.info("ai_observability_digest_agent_completed", skill_name=context.skill_name)
         return RunAIObservabilityReportAgentOutput(delivered=True, skill_name=context.skill_name)

--- a/posthog/temporal/ai_observability/ai_observability_reports/agent.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/agent.py
@@ -11,6 +11,11 @@ from products.signals.backend.custom_agent import CustomSignalAgent
 
 logger = structlog.get_logger(__name__)
 
+# Lives in the posthog temporal layer (not products.ai_observability) because it subclasses
+# the Signals custom-agent framework: products.ai_observability is not allowed to depend on
+# products.signals (tach), but the posthog layer may depend on both. The digest's schema and
+# Slack delivery (no signals dependency) stay in the product.
+
 _OVERVIEW_DIRECTIVE = (
     "Now execute the skill instructions above against this team's AI observability data, using the "
     "available read-only PostHog MCP tools to gather the numbers (errors, costliest users, tool usage "

--- a/posthog/temporal/ai_observability/ai_observability_reports/constants.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/constants.py
@@ -1,0 +1,25 @@
+from datetime import timedelta
+
+from temporalio.common import RetryPolicy
+
+# Workflow + schedule identifiers.
+COORDINATOR_WORKFLOW_NAME = "ai-observability-report-coordinator"
+COORDINATOR_SCHEDULE_ID = "ai-observability-report-coordinator-schedule"
+GENERATE_WORKFLOW_NAME = "generate-ai-observability-report"
+
+# The coordinator just reads config rows and fans out — keep it short.
+COORDINATOR_EXECUTION_TIMEOUT = timedelta(minutes=15)
+FETCH_ACTIVITY_TIMEOUT = timedelta(seconds=60)
+FETCH_RETRY_POLICY = RetryPolicy(maximum_attempts=3)
+
+# The agent runs a full sandbox session (skill execution + MCP calls + Slack post), so the
+# per-config workflow and its single activity get a generous budget — mirrors the signals
+# custom-agent timeouts. maximum_attempts=1 so a missed heartbeat fails the run rather than
+# spawning a duplicate sandbox session / double Slack post.
+GENERATE_WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=90)
+AGENT_ACTIVITY_TIMEOUT = timedelta(minutes=85)
+AGENT_HEARTBEAT_TIMEOUT = timedelta(minutes=2)
+AGENT_RETRY_POLICY = RetryPolicy(maximum_attempts=1)
+
+# Bound how many configs one coordinator tick will dispatch concurrently.
+DEFAULT_MAX_CONCURRENT_CONFIGS = 10

--- a/posthog/temporal/ai_observability/ai_observability_reports/coordinator.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/coordinator.py
@@ -1,0 +1,77 @@
+"""Daily coordinator: scan enabled AI observability report configs and fan out per config."""
+
+import asyncio
+
+import temporalio.workflow
+from structlog import get_logger
+
+from posthog.temporal.ai_observability.ai_observability_reports.constants import (
+    COORDINATOR_WORKFLOW_NAME,
+    FETCH_ACTIVITY_TIMEOUT,
+    FETCH_RETRY_POLICY,
+    GENERATE_WORKFLOW_EXECUTION_TIMEOUT,
+)
+from posthog.temporal.ai_observability.ai_observability_reports.types import (
+    AIObservabilityReportCoordinatorInputs,
+    GenerateAIObservabilityReportInput,
+)
+from posthog.temporal.ai_observability.ai_observability_reports.workflow import GenerateAIObservabilityReportWorkflow
+from posthog.temporal.common.base import PostHogWorkflow
+
+with temporalio.workflow.unsafe.imports_passed_through():
+    from posthog.temporal.ai_observability.ai_observability_reports.activities import (
+        fetch_enabled_ai_observability_report_configs_activity,
+    )
+
+logger = get_logger(__name__)
+
+
+@temporalio.workflow.defn(name=COORDINATOR_WORKFLOW_NAME)
+class AIObservabilityReportCoordinatorWorkflow(PostHogWorkflow):
+    """Daily fan-out: one child `GenerateAIObservabilityReportWorkflow` per enabled config.
+
+    Child failures are isolated (a broken skill or disconnected Slack on one team must not
+    block the others) and logged for observability.
+    """
+
+    inputs_cls = AIObservabilityReportCoordinatorInputs
+    inputs_optional = True
+
+    @temporalio.workflow.run
+    async def run(self, inputs: AIObservabilityReportCoordinatorInputs) -> None:
+        result = await temporalio.workflow.execute_activity(
+            fetch_enabled_ai_observability_report_configs_activity,
+            start_to_close_timeout=FETCH_ACTIVITY_TIMEOUT,
+            retry_policy=FETCH_RETRY_POLICY,
+        )
+        if not result.config_ids:
+            return
+
+        run_stamp = temporalio.workflow.now().isoformat()
+        max_concurrent = max(1, inputs.max_concurrent_configs)
+        for batch_start in range(0, len(result.config_ids), max_concurrent):
+            batch = result.config_ids[batch_start : batch_start + max_concurrent]
+            tasks = [
+                temporalio.workflow.execute_child_workflow(
+                    GenerateAIObservabilityReportWorkflow.run,
+                    GenerateAIObservabilityReportInput(config_id=config_id),
+                    id=f"ai-observability-report-{config_id}-{run_stamp}",
+                    execution_timeout=GENERATE_WORKFLOW_EXECUTION_TIMEOUT,
+                )
+                for config_id in batch
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            _log_fan_out_failures(batch, results)
+
+
+def _log_fan_out_failures(config_ids: list[str], results: list) -> None:
+    failed = [
+        (config_id, f"{type(result).__name__}: {result}")
+        for config_id, result in zip(config_ids, results)
+        if isinstance(result, BaseException)
+    ]
+    if failed:
+        temporalio.workflow.logger.warning(
+            "ai_observability_report_coordinator.child_workflow_errors",
+            extra={"failed_count": len(failed), "failures": failed},
+        )

--- a/posthog/temporal/ai_observability/ai_observability_reports/schedule.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/schedule.py
@@ -1,0 +1,52 @@
+"""Daily schedule for the AI observability report coordinator."""
+
+from datetime import timedelta
+
+from django.conf import settings
+
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+
+from posthog.temporal.ai_observability.ai_observability_reports.constants import (
+    COORDINATOR_EXECUTION_TIMEOUT,
+    COORDINATOR_SCHEDULE_ID,
+    COORDINATOR_WORKFLOW_NAME,
+)
+from posthog.temporal.ai_observability.ai_observability_reports.types import AIObservabilityReportCoordinatorInputs
+from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
+
+
+async def create_ai_observability_report_coordinator_schedule(client: Client):
+    """Create or update the daily schedule for the AI observability report coordinator."""
+    coordinator_schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            COORDINATOR_WORKFLOW_NAME,
+            AIObservabilityReportCoordinatorInputs(),
+            id=COORDINATOR_SCHEDULE_ID,
+            task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=COORDINATOR_EXECUTION_TIMEOUT,
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, COORDINATOR_SCHEDULE_ID):
+        await a_update_schedule(client, COORDINATOR_SCHEDULE_ID, coordinator_schedule)
+    else:
+        await a_create_schedule(
+            client,
+            COORDINATOR_SCHEDULE_ID,
+            coordinator_schedule,
+            trigger_immediately=False,
+        )
+
+
+async def delete_ai_observability_report_coordinator_schedule(client: Client):
+    await a_delete_schedule(client, COORDINATOR_SCHEDULE_ID)

--- a/posthog/temporal/ai_observability/ai_observability_reports/types.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/types.py
@@ -1,0 +1,33 @@
+import dataclasses
+
+from posthog.temporal.ai_observability.ai_observability_reports.constants import DEFAULT_MAX_CONCURRENT_CONFIGS
+
+
+@dataclasses.dataclass
+class AIObservabilityReportCoordinatorInputs:
+    """Inputs for the daily coordinator. `config_ids` carries continuation state."""
+
+    max_concurrent_configs: int = DEFAULT_MAX_CONCURRENT_CONFIGS
+
+
+@dataclasses.dataclass
+class FetchEnabledConfigsOutput:
+    config_ids: list[str]
+
+
+@dataclasses.dataclass
+class GenerateAIObservabilityReportInput:
+    config_id: str
+
+
+@dataclasses.dataclass
+class RunAIObservabilityReportAgentInput:
+    config_id: str
+
+
+@dataclasses.dataclass
+class RunAIObservabilityReportAgentOutput:
+    # Empty when the agent ran but produced no report (the expected path — this agent never
+    # files a Signals report). `delivered` reflects whether a Slack message was posted.
+    delivered: bool
+    skill_name: str

--- a/posthog/temporal/ai_observability/ai_observability_reports/types.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/types.py
@@ -5,7 +5,7 @@ from posthog.temporal.ai_observability.ai_observability_reports.constants import
 
 @dataclasses.dataclass
 class AIObservabilityReportCoordinatorInputs:
-    """Inputs for the daily coordinator. `config_ids` carries continuation state."""
+    """Inputs for the daily coordinator. It fetches all enabled configs fresh each tick."""
 
     max_concurrent_configs: int = DEFAULT_MAX_CONCURRENT_CONFIGS
 

--- a/posthog/temporal/ai_observability/ai_observability_reports/workflow.py
+++ b/posthog/temporal/ai_observability/ai_observability_reports/workflow.py
@@ -1,0 +1,40 @@
+"""Per-config workflow: run the digest agent for one team's AI observability report config."""
+
+import temporalio.workflow
+from structlog import get_logger
+
+from posthog.temporal.ai_observability.ai_observability_reports.constants import (
+    AGENT_ACTIVITY_TIMEOUT,
+    AGENT_HEARTBEAT_TIMEOUT,
+    AGENT_RETRY_POLICY,
+    GENERATE_WORKFLOW_NAME,
+)
+from posthog.temporal.ai_observability.ai_observability_reports.types import (
+    GenerateAIObservabilityReportInput,
+    RunAIObservabilityReportAgentInput,
+)
+from posthog.temporal.common.base import PostHogWorkflow
+
+with temporalio.workflow.unsafe.imports_passed_through():
+    from posthog.temporal.ai_observability.ai_observability_reports.activities import (
+        run_ai_observability_report_agent_activity,
+    )
+
+logger = get_logger(__name__)
+
+
+@temporalio.workflow.defn(name=GENERATE_WORKFLOW_NAME)
+class GenerateAIObservabilityReportWorkflow(PostHogWorkflow):
+    """Runs the digest agent for a single config. The agent posts to Slack and files no report."""
+
+    inputs_cls = GenerateAIObservabilityReportInput
+
+    @temporalio.workflow.run
+    async def run(self, inputs: GenerateAIObservabilityReportInput) -> None:
+        await temporalio.workflow.execute_activity(
+            run_ai_observability_report_agent_activity,
+            RunAIObservabilityReportAgentInput(config_id=inputs.config_id),
+            start_to_close_timeout=AGENT_ACTIVITY_TIMEOUT,
+            heartbeat_timeout=AGENT_HEARTBEAT_TIMEOUT,
+            retry_policy=AGENT_RETRY_POLICY,
+        )

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -23,6 +23,9 @@ from temporalio.client import (
 from posthog.hogql_queries.ai.vector_search_query_runner import LATEST_ACTIONS_EMBEDDING_VERSION
 from posthog.temporal.ai import SyncVectorsInputs
 from posthog.temporal.ai.sync_vectors import EmbeddingVersion
+from posthog.temporal.ai_observability.ai_observability_reports.schedule import (
+    create_ai_observability_report_coordinator_schedule,
+)
 from posthog.temporal.ai_observability.eval_reports.schedule import (
     create_count_trigger_schedule,
     create_eval_reports_schedule,
@@ -639,6 +642,7 @@ schedules = [
     create_intent_clustering_coordinator_schedule,
     create_eval_reports_schedule,
     create_count_trigger_schedule,
+    create_ai_observability_report_coordinator_schedule,
     create_evaluation_sampler_schedule,
     create_evaluation_clustering_schedule,
     cleanup_legacy_session_summarization_schedules,

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -332,6 +332,8 @@ class TestAIObservabilityModuleIntegrity:
             "AIObservabilityEvaluationSamplerWorkflow",
             "AIObservabilityEvaluationClusteringCoordinatorWorkflow",
             "AIObservabilityEvaluationClusteringWorkflow",
+            "AIObservabilityReportCoordinatorWorkflow",
+            "GenerateAIObservabilityReportWorkflow",
             "ClassifySentimentWorkflow",
             "RunEvaluationWorkflow",
         ]
@@ -370,6 +372,8 @@ class TestAIObservabilityModuleIntegrity:
             "generate_evaluation_cluster_labels_activity",
             "compute_evaluation_cluster_aggregates_activity",
             "emit_evaluation_cluster_events_activity",
+            "fetch_enabled_ai_observability_report_configs_activity",
+            "run_ai_observability_report_agent_activity",
             "classify_sentiment_activity",
             "fetch_evaluation_activity",
             "increment_trial_eval_count_activity",

--- a/products/ai_observability/backend/ai_observability_digest/__init__.py
+++ b/products/ai_observability/backend/ai_observability_digest/__init__.py
@@ -1,8 +1,6 @@
-from products.ai_observability.backend.ai_observability_digest.agent import AIObservabilityDigestAgent
 from products.ai_observability.backend.ai_observability_digest.schema import AIObservabilityOverview, OverviewSection
 
 __all__ = [
-    "AIObservabilityDigestAgent",
     "AIObservabilityOverview",
     "OverviewSection",
 ]

--- a/products/ai_observability/backend/ai_observability_digest/__init__.py
+++ b/products/ai_observability/backend/ai_observability_digest/__init__.py
@@ -1,0 +1,8 @@
+from products.ai_observability.backend.ai_observability_digest.agent import AIObservabilityDigestAgent
+from products.ai_observability.backend.ai_observability_digest.schema import AIObservabilityOverview, OverviewSection
+
+__all__ = [
+    "AIObservabilityDigestAgent",
+    "AIObservabilityOverview",
+    "OverviewSection",
+]

--- a/products/ai_observability/backend/ai_observability_digest/agent.py
+++ b/products/ai_observability/backend/ai_observability_digest/agent.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import structlog
+
+from posthog.models import Team
+from posthog.sync import database_sync_to_async
+
+from products.ai_observability.backend.ai_observability_digest.delivery import deliver_overview_to_slack
+from products.ai_observability.backend.ai_observability_digest.schema import AIObservabilityOverview
+from products.signals.backend.custom_agent import CustomSignalAgent
+
+logger = structlog.get_logger(__name__)
+
+_OVERVIEW_DIRECTIVE = (
+    "Now execute the skill instructions above against this team's AI observability data, using the "
+    "available read-only PostHog MCP tools to gather the numbers (errors, costliest users, tool usage "
+    "and errors, evaluation pass rates, cluster results, LLM latencies, and anything else the skill "
+    "asks for). Summarize the current status into the structured overview below. Ground every section "
+    "in data you actually retrieved and include concrete numbers; omit any section you have no data for."
+)
+
+
+class AIObservabilityDigestAgent(CustomSignalAgent):
+    """Daily AI observability digest agent.
+
+    Runs a team-authored skill (loaded into ``initial_prompt`` by the caller) against the
+    team's AI observability data via read-only MCP, then posts the resulting structured
+    overview to a Slack channel. It never files a Signals report — ``run`` returns ``False``
+    so the base class skips report finalization entirely; Slack is the only output.
+    """
+
+    def __init__(
+        self,
+        *,
+        team: Team,
+        initial_prompt: str,
+        repository: str | None,
+        slack_integration_id: int | str | None,
+        slack_channel: str,
+        user_id: int | None = None,
+        model: str | None = None,
+    ) -> None:
+        super().__init__(
+            team=team,
+            initial_prompt=initial_prompt,
+            repository=repository,
+            user_id=user_id,
+            model=model,
+        )
+        self.slack_integration_id = slack_integration_id
+        self.slack_channel = slack_channel
+
+    @classmethod
+    def identifier(cls) -> tuple[str, str]:
+        return "llma", "ai_observability_digest"
+
+    async def run(self) -> bool:
+        overview = await self.send(
+            _OVERVIEW_DIRECTIVE,
+            AIObservabilityOverview,
+            label="ai_observability_overview",
+        )
+        await database_sync_to_async(deliver_overview_to_slack, thread_sensitive=False)(
+            team_id=self.team_id,
+            integration_id=self.slack_integration_id,
+            channel=self.slack_channel,
+            overview=overview,
+        )
+        logger.info(
+            "ai_observability_digest_completed",
+            team_id=self.team_id,
+            channel=self.slack_channel,
+            section_count=len(overview.sections),
+        )
+        # Slack-only digest: never create a Signals report.
+        return False

--- a/products/ai_observability/backend/ai_observability_digest/delivery.py
+++ b/products/ai_observability/backend/ai_observability_digest/delivery.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import structlog
+from markdown_to_mrkdwn import SlackMarkdownConverter
+
+from posthog.models.integration import Integration, SlackIntegration
+
+from products.ai_observability.backend.ai_observability_digest.schema import AIObservabilityOverview
+
+logger = structlog.get_logger(__name__)
+
+# Slack `section` blocks and message text cap out at 3000 characters.
+_SLACK_TEXT_LIMIT = 3000
+# Slack `header` blocks cap out at 150 characters.
+_SLACK_HEADER_LIMIT = 150
+
+_slack_converter = SlackMarkdownConverter()
+
+
+class SlackDeliveryError(RuntimeError):
+    """Raised when the digest cannot be delivered to Slack."""
+
+
+def _section_mrkdwn(title: str, body: str) -> str:
+    return f"*{title}*\n{_slack_converter.convert(body)}"[:_SLACK_TEXT_LIMIT]
+
+
+def deliver_overview_to_slack(
+    *,
+    team_id: int,
+    integration_id: int | str | None,
+    channel: str,
+    overview: AIObservabilityOverview,
+) -> str:
+    """Post the overview to a Slack channel via the team's connected Slack integration.
+
+    Main message = headline (header) + summary + first section. Remaining sections are
+    posted as thread replies. Returns the Slack message timestamp (`ts`).
+    """
+    if not integration_id or not channel:
+        raise SlackDeliveryError(f"Missing Slack integration or channel for team {team_id}")
+
+    # Scoped by team_id so a config can't deliver through another team's integration.
+    integration = Integration.objects.get(id=integration_id, team_id=team_id, kind="slack")
+    client = SlackIntegration(integration).client
+
+    header_text = overview.headline[:_SLACK_HEADER_LIMIT]
+    blocks: list[dict] = [
+        {"type": "header", "text": {"type": "plain_text", "text": header_text}},
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": _slack_converter.convert(overview.summary)[:_SLACK_TEXT_LIMIT]},
+        },
+    ]
+    if overview.sections:
+        blocks.append({"type": "divider"})
+        first = overview.sections[0]
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": _section_mrkdwn(first.title, first.body)}})
+
+    result = client.chat_postMessage(channel=channel, blocks=blocks, text=header_text)
+    thread_ts = result.get("ts")
+
+    if thread_ts and len(overview.sections) > 1:
+        for section in overview.sections[1:]:
+            client.chat_postMessage(
+                channel=channel,
+                thread_ts=thread_ts,
+                text=_section_mrkdwn(section.title, section.body),
+            )
+
+    logger.info(
+        "ai_observability_digest_delivered",
+        team_id=team_id,
+        channel=channel,
+        section_count=len(overview.sections),
+        ts=thread_ts,
+    )
+    return thread_ts or ""

--- a/products/ai_observability/backend/ai_observability_digest/delivery.py
+++ b/products/ai_observability/backend/ai_observability_digest/delivery.py
@@ -41,7 +41,12 @@ def deliver_overview_to_slack(
         raise SlackDeliveryError(f"Missing Slack integration or channel for team {team_id}")
 
     # Scoped by team_id so a config can't deliver through another team's integration.
-    integration = Integration.objects.get(id=integration_id, team_id=team_id, kind="slack")
+    try:
+        integration = Integration.objects.get(id=integration_id, team_id=team_id, kind="slack")
+    except Integration.DoesNotExist as e:
+        raise SlackDeliveryError(
+            f"No Slack integration {integration_id} for team {team_id} (deleted or wrong kind)"
+        ) from e
     client = SlackIntegration(integration).client
 
     header_text = overview.headline[:_SLACK_HEADER_LIMIT]

--- a/products/ai_observability/backend/ai_observability_digest/schema.py
+++ b/products/ai_observability/backend/ai_observability_digest/schema.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class OverviewSection(BaseModel):
+    """One topic of the AI observability overview (errors, costly users, evals, …)."""
+
+    title: str = Field(
+        max_length=120,
+        description="Short section title, e.g. 'Errors', 'Costliest users', 'Evaluation pass rates', 'LLM latency'.",
+    )
+    body: str = Field(
+        description="Markdown summary of this section, grounded in retrieved data. Include concrete numbers.",
+    )
+
+
+class AIObservabilityOverview(BaseModel):
+    """Structured status of a team's AI observability, produced by the digest agent."""
+
+    headline: str = Field(
+        max_length=150,
+        description="One-line headline summarizing overall AI observability health for the day.",
+    )
+    summary: str = Field(
+        description="A short (2-4 sentence) executive summary of the team's AI observability status.",
+    )
+    sections: list[OverviewSection] = Field(
+        default_factory=list,
+        description=(
+            "Per-topic sections (errors, costliest users, tool usage/errors, evaluation pass rates, "
+            "cluster results, LLM latencies, …). Include only sections you actually have data for."
+        ),
+    )

--- a/products/ai_observability/backend/ai_observability_digest/test_delivery.py
+++ b/products/ai_observability/backend/ai_observability_digest/test_delivery.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from products.ai_observability.backend.ai_observability_digest.delivery import (
+    SlackDeliveryError,
+    deliver_overview_to_slack,
+)
+from products.ai_observability.backend.ai_observability_digest.schema import AIObservabilityOverview, OverviewSection
+
+
+def _overview(section_count: int) -> AIObservabilityOverview:
+    return AIObservabilityOverview(
+        headline="AI observability digest",
+        summary="All systems nominal.",
+        sections=[OverviewSection(title=f"Section {i}", body=f"Body {i}") for i in range(section_count)],
+    )
+
+
+class TestDeliverOverviewToSlack(SimpleTestCase):
+    def _patch_slack(self):
+        integration = MagicMock()
+        integration_objects = MagicMock()
+        integration_objects.get.return_value = MagicMock()
+        integration.objects = integration_objects
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ts": "1234.5678"}
+        slack_integration = MagicMock()
+        slack_integration.return_value.client = client
+        return integration, client, slack_integration
+
+    def test_raises_when_no_integration_or_channel(self):
+        with self.assertRaises(SlackDeliveryError):
+            deliver_overview_to_slack(team_id=1, integration_id=None, channel="#x", overview=_overview(1))
+        with self.assertRaises(SlackDeliveryError):
+            deliver_overview_to_slack(team_id=1, integration_id=7, channel="", overview=_overview(1))
+
+    def test_scopes_lookup_by_team_and_posts_single_message_for_one_section(self):
+        integration, client, slack_integration = self._patch_slack()
+        with (
+            patch("products.ai_observability.backend.ai_observability_digest.delivery.Integration", integration),
+            patch(
+                "products.ai_observability.backend.ai_observability_digest.delivery.SlackIntegration", slack_integration
+            ),
+        ):
+            ts = deliver_overview_to_slack(team_id=42, integration_id=7, channel="#aio", overview=_overview(1))
+
+        self.assertEqual(ts, "1234.5678")
+        # Integration lookup is scoped to the team and the slack kind.
+        integration.objects.get.assert_called_once_with(id=7, team_id=42, kind="slack")
+        # One main message, no thread replies (only one section).
+        self.assertEqual(client.chat_postMessage.call_count, 1)
+        main_call = client.chat_postMessage.call_args
+        self.assertEqual(main_call.kwargs["channel"], "#aio")
+        block_types = [b["type"] for b in main_call.kwargs["blocks"]]
+        self.assertEqual(block_types[0], "header")
+        self.assertIn("section", block_types)
+
+    def test_threads_remaining_sections(self):
+        integration, client, slack_integration = self._patch_slack()
+        with (
+            patch("products.ai_observability.backend.ai_observability_digest.delivery.Integration", integration),
+            patch(
+                "products.ai_observability.backend.ai_observability_digest.delivery.SlackIntegration", slack_integration
+            ),
+        ):
+            deliver_overview_to_slack(team_id=1, integration_id=7, channel="#aio", overview=_overview(3))
+
+        # 1 main message + 2 thread replies for sections[1:].
+        self.assertEqual(client.chat_postMessage.call_count, 3)
+        thread_calls = client.chat_postMessage.call_args_list[1:]
+        for call in thread_calls:
+            self.assertEqual(call.kwargs["thread_ts"], "1234.5678")
+
+    def test_raises_slack_delivery_error_when_integration_missing(self):
+        integration, _client, slack_integration = self._patch_slack()
+
+        class _DoesNotExist(Exception):
+            pass
+
+        integration.DoesNotExist = _DoesNotExist
+        integration.objects.get.side_effect = _DoesNotExist()
+
+        with (
+            patch("products.ai_observability.backend.ai_observability_digest.delivery.Integration", integration),
+            patch(
+                "products.ai_observability.backend.ai_observability_digest.delivery.SlackIntegration", slack_integration
+            ),
+        ):
+            with self.assertRaises(SlackDeliveryError):
+                deliver_overview_to_slack(team_id=1, integration_id=7, channel="#aio", overview=_overview(1))

--- a/products/ai_observability/backend/migrations/0005_aiobservabilityreportconfig.py
+++ b/products/ai_observability/backend/migrations/0005_aiobservabilityreportconfig.py
@@ -1,0 +1,77 @@
+import django.db.models.manager
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ai_observability", "0004_parserrecipe"),
+        ("posthog", "1207_migrate_ai_observability_models"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AIObservabilityReportConfig",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("enabled", models.BooleanField(db_default=True, default=True)),
+                ("skill_name", models.CharField(max_length=200)),
+                ("slack_channel", models.CharField(max_length=255)),
+                ("additional_instructions", models.TextField(blank=True, default="")),
+                ("last_run_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "slack_integration",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="posthog.integration",
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="ai_observability_report_configs",
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "AI observability report config",
+                "verbose_name_plural": "AI observability report configs",
+                "default_manager_name": "all_teams",
+            },
+            managers=[
+                ("all_teams", django.db.models.manager.Manager()),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="aiobservabilityreportconfig",
+            constraint=models.UniqueConstraint(fields=("team",), name="unique_ai_observability_report_config_per_team"),
+        ),
+    ]

--- a/products/ai_observability/backend/migrations/max_migration.txt
+++ b/products/ai_observability/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0004_parserrecipe
+0005_aiobservabilityreportconfig

--- a/products/ai_observability/backend/models/__init__.py
+++ b/products/ai_observability/backend/models/__init__.py
@@ -1,3 +1,4 @@
+from .ai_observability_report_config import AIObservabilityReportConfig
 from .clustering_config import ClusteringConfig
 from .clustering_job import ClusteringJob
 from .datasets import Dataset, DatasetItem
@@ -16,6 +17,7 @@ from .taggers import Tagger
 from .trace_reviews import TraceReview, TraceReviewScore
 
 __all__ = [
+    "AIObservabilityReportConfig",
     "ClusteringConfig",
     "ClusteringJob",
     "Evaluation",

--- a/products/ai_observability/backend/models/ai_observability_report_config.py
+++ b/products/ai_observability/backend/models/ai_observability_report_config.py
@@ -1,0 +1,59 @@
+from django.db import models
+
+from posthog.models.scoping.root_mixin import TeamScopedRootMixin
+from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDModel
+
+
+class AIObservabilityReportConfig(TeamScopedRootMixin, UUIDModel, CreatedMetaFields, UpdatedMetaFields):
+    """Per-team opt-in for the daily AI observability digest.
+
+    When `enabled`, a daily coordinator on the LLMA worker runs the
+    `AIObservabilityDigestAgent` for this team: it loads `skill_name` from the
+    team's skill store, executes it in a sandbox (gathering the AI observability
+    overview via read-only MCP), and posts the result to `slack_channel` on the
+    connected `slack_integration`. The agent never files a Signals report — Slack
+    is the only output.
+    """
+
+    # `objects` (TeamScopedManager) inherited from TeamScopedRootMixin stays fail-closed for
+    # explicit user code. `all_teams` is the unscoped sibling the daily coordinator uses to
+    # scan every team's config, plus Django framework internals (admin changelist, related
+    # access, prefetch) that must not filter by team. Same pattern as SignalScoutConfig.
+    all_teams = models.Manager()  # noqa: DJ012
+
+    team = models.ForeignKey(
+        "posthog.Team",
+        on_delete=models.CASCADE,
+        related_name="ai_observability_report_configs",
+    )
+    enabled = models.BooleanField(default=True, db_default=True)
+    # The `LLMSkill` (by name) the digest agent loads and executes. Resolved against the
+    # team's skill store at run time — follows-latest, so re-versioning the skill takes
+    # effect on the next daily run.
+    skill_name = models.CharField(max_length=200)
+    # The team's connected Slack OAuth integration the digest is posted through. SET_NULL so
+    # disconnecting Slack doesn't cascade-delete the config; the coordinator skips configs
+    # whose integration is missing.
+    slack_integration = models.ForeignKey(
+        "posthog.Integration",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+    )
+    # Slack channel ID (or name) the digest is delivered to.
+    slack_channel = models.CharField(max_length=255)
+    # Optional free-text steering appended to the skill instructions (e.g. "skip tool
+    # insights"). Mirrors the eval-report `report_prompt_guidance` escape hatch.
+    additional_instructions = models.TextField(blank=True, default="")
+    # Stamped by the coordinator after each dispatch; lets a future change add a due-check
+    # without a schema migration.
+    last_run_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "AI observability report config"
+        verbose_name_plural = "AI observability report configs"
+        default_manager_name = "all_teams"
+        constraints = [
+            models.UniqueConstraint(fields=["team"], name="unique_ai_observability_report_config_per_team"),
+        ]


### PR DESCRIPTION
## Problem

AI observability users want a recurring, at-a-glance read on the health of their AI features — errors, costliest users, tool usage/errors, evaluation pass rates, cluster results, LLM latencies — delivered where they already are (Slack), without digging through the product. The building blocks exist (custom agents, the skill store, MCP read access, Temporal schedules, Slack integrations); this PR glues them together into a daily digest.

This is backend-only scaffolding — no UI yet.

## Changes

Built on the Signals custom-agent framework (`CustomSignalAgent`), reused for an `llma`-owned agent type.

- **`AIObservabilityReportConfig` model** (`products/ai_observability/backend`) — per-team opt-in storing the three things that drive a digest: whether it's `enabled`, the `skill_name` to run, and the Slack destination (`slack_integration` + `slack_channel`), plus optional free-text `additional_instructions` and a `last_run_at` stamp. Fail-closed `TeamScopedRootMixin` (with an unscoped `all_teams` manager the coordinator uses), one row per team.
- **`AIObservabilityDigestAgent`** — a custom agent type identified as `("llma", "ai_observability_digest")`. It runs the configured skill (loaded from the skill store at run time) against the team's AI observability data via read-only MCP, returns a structured `AIObservabilityOverview` (headline + summary + per-topic sections), and posts it to the configured Slack channel. It **never files a Signals report** — `run()` returns `False`, so the base framework skips report finalization entirely; Slack is the only output. Runs with no subject repository, so no GitHub integration is required.
- **Daily Temporal coordinator on the AIO worker** (`posthog/temporal/ai_observability/ai_observability_reports/`) — a once-a-day schedule on `LLMA_TASK_QUEUE` (`SKIP` overlap) that scans enabled configs and fans out one child workflow per team. The per-config activity loads the skill, resolves an attributable active org member, enforces the AI-data-processing consent gate, runs the agent under a heartbeat, and stamps `last_run_at`. `maximum_attempts=1` avoids duplicate Slack posts on retry.

Registered the workflows/activities on the LLMA worker, added the schedule to the schedule hub, and added the model to the IDOR semgrep rules.

## How did you test this code?

I'm an agent (Claude Code). No manual/end-to-end run — there was no database or dev stack available in the session, so this is automated/static verification only:

- `TestAIObservabilityModuleIntegrity` updated and passing (workflows + activities registered on the LLMA worker).
- Migration ↔ model checked for state drift via Django's migration autodetector — **no drift** (migration was hand-authored since `makemigrations` couldn't reach a DB).
- IDOR / fail-closed coverage script (`.github/scripts/check-idor-model-coverage.py`) passes: the model's `objects` resolves to `TeamScopedManager`, and it's listed in the semgrep IDOR rules.
- Worker-boot and schedule-hub imports load cleanly; agent identifier and output schema validated.
- `ruff check` and `ruff format --check` clean across all touched files.

Not yet exercised at runtime: the live sandbox session, MCP data gathering, and the actual Slack delivery. There's no API or admin to create a config yet (intentionally — no UI in this PR), so a config must be created directly via the ORM to try it.

## Docs update

No user-facing docs (backend scaffolding, no UI).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of the AI observability team. The ask was to wire existing primitives into a daily Slack digest: a custom agent type that runs a skill-store skill, emits a structured overview, and posts to Slack instead of creating a Signals report, plus a daily AIO-worker cron over per-team configs.

Key decisions:
- **Reused the Signals `CustomSignalAgent` framework** rather than building a new agent runtime. The "never file a report" requirement falls out naturally: the base class only finalizes a report when `run()` returns truthy, so returning `False` after the Slack post is all that's needed.
- **Ran the coordinator/agent on the AIO worker (`LLMA_TASK_QUEUE`)** per the request, mirroring the trace-clustering and eval-reports coordinator/fan-out patterns already on that worker, rather than reusing the Signals worker's `signals-custom-agent` workflow.
- **No `ModelActivityMixin`** on the config model (unlike `SignalScoutConfig`): wiring real activity logging needs a typed `ActivityScope` entry, a signal receiver, and field exclusions — out of scope for "just the backend support." Easy to add later.
- **Skill is passed by injecting its body into the agent's initial prompt** at run time (resolved via the skill store by name), keeping the agent generic.
