### PR TITLE
refactor(auth): rename legacy secret-token auth to TeamSecretToken*

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -38,8 +38,8 @@ from posthog.api.oauth.test_dcr import generate_rsa_key
 from posthog.auth import (
     InternalAPIUser,
     OAuthAccessTokenAuthentication,
-    ProjectSecretAPIKeyAuthentication,
-    ProjectSecretAPIKeyUser,
+    TeamSecretTokenAuthentication,
+    TeamSecretTokenUser,
 )
 from posthog.helpers.user_devices import (
     KNOWN_DEVICE_COOKIE,
@@ -1912,7 +1912,7 @@ class TestTimeSensitivePermissions(APIBaseTest):
             assert res.status_code == 200
 
 
-class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
+class TestTeamSecretTokenAuthentication(APIBaseTest):
     def setUp(self):
         super().setUp()  # Call the setup from APIBaseTest
         self.team.secret_api_token = "phs_JVRb8fNi0XyIKGgUCyi29ZJUOXEr6NF2dKBy5Ws8XVeF11C"
@@ -1920,7 +1920,7 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         self.factory = APIRequestFactory()  # Use APIRequestFactory instead of RequestFactory
 
     def test_authenticate_with_valid_secret_api_key_in_header(self):
-        # Simulate a request with a valid secret API key
+        # Simulate a request with a valid team secret token
         wsgi_request = self.factory.get(
             "/",
             data=None,
@@ -1929,17 +1929,17 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         )
         request = Request(wsgi_request)  # Wrap the WSGIRequest in a DRF Request
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
         assert result is not None
         user, _ = result
 
         self.assertIsNotNone(user)
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, TeamSecretTokenUser)
         self.assertEqual(user.team, self.team)
 
     def test_authenticate_with_valid_secret_api_key_in_body(self):
-        # Simulate a request with a valid secret API key
+        # Simulate a request with a valid team secret token
         wsgi_request = self.factory.post(
             "/",
             data=f'{{"secret_api_key": "{self.team.secret_api_token}"}}',
@@ -1948,13 +1948,13 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         request = Request(wsgi_request)  # Wrap the WSGIRequest in a DRF Request
         request.parsers = [JSONParser()]  # Explicitly set JSONParser
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
         assert result is not None
         user, _ = result
 
         self.assertIsNotNone(user)
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, TeamSecretTokenUser)
         self.assertEqual(user.team, self.team)
 
     def test_authenticate_with_secret_api_key_in_query_string_not_supported(self):
@@ -1962,27 +1962,27 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         wsgi_request = self.factory.get(f"/?secret_api_key={self.team.secret_api_token}")
         request = Request(wsgi_request)  # Wrap the WSGIRequest in a DRF Request
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
 
         self.assertIsNone(result)
 
     def test_authenticate_with_invalid_secret_api_key(self):
-        # Simulate a request with an invalid secret API key
+        # Simulate a request with an invalid team secret token
         wsgi_request = self.factory.get("/", HTTP_AUTHORIZATION="Bearer phs_NOT_A_VALID_KEY")
         request = Request(wsgi_request)  # Wrap the WSGIRequest in a DRF Request
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
 
         self.assertIsNone(result)
 
     def test_authenticate_without_secret_api_key(self):
-        # Simulate a request without a secret API key
+        # Simulate a request without a team secret token
         wsgi_request = self.factory.get("/")
         request = Request(wsgi_request)  # Wrap the WSGIRequest in a DRF Request
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
 
         self.assertIsNone(result)
@@ -1998,12 +1998,12 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         request = Request(wsgi_request)
         request.parsers = [JSONParser()]
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
 
         assert result is not None
         user, _ = result
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, TeamSecretTokenUser)
         self.assertEqual(user.team, self.team)
 
     def test_authenticate_with_no_project_api_key_in_body_passes(self):
@@ -2017,12 +2017,12 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         request = Request(wsgi_request)
         request.parsers = [JSONParser()]
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
 
         assert result is not None
         user, _ = result
-        self.assertIsInstance(user, ProjectSecretAPIKeyUser)
+        self.assertIsInstance(user, TeamSecretTokenUser)
         self.assertEqual(user.team, self.team)
 
     @parameterized.expand(
@@ -2039,7 +2039,7 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         request = Request(wsgi_request)
         request.parsers = [JSONParser()]
 
-        authenticator = ProjectSecretAPIKeyAuthentication()
+        authenticator = TeamSecretTokenAuthentication()
         result = authenticator.authenticate(request)
 
         self.assertIsNone(result)
@@ -2492,7 +2492,7 @@ async def test_known_device_cookie_async_chain_with_project_secret_api_key():
             set_known_device_cookie(response, request.user)
         File "posthog/helpers/user_devices.py", in set_known_device_cookie
             KNOWN_DEVICE_COOKIE.format(user_id=user.id),
-        AttributeError: 'ProjectSecretAPIKeyUser' object has no attribute 'id'
+        AttributeError: 'TeamSecretTokenUser' object has no attribute 'id'
 
     Drives the real ASGI middleware chain via httpx + ASGITransport (patterned after
     posthog-python's integration_tests/django5). Sync `Client` skips the ASGI app and so

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -68,7 +68,7 @@ _SECRET_API_KEY_RE = re.compile(r"^phs_[a-zA-Z0-9]+$")
 
 SECRET_API_KEY_BODY_COUNTER = Counter(
     "api_auth_secret_api_key_body",
-    "Requests where the secret API key is provided in the request body instead of the Authorization header",
+    "Requests where the team secret token is provided in the request body instead of the Authorization header",
 )
 
 PERSONAL_API_KEY_QUERY_PARAM_COUNTER = Counter(
@@ -327,12 +327,12 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         return cls.keyword
 
 
-class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
+class TeamSecretTokenAuthentication(authentication.BaseAuthentication):
     """
-    Authenticates using a project secret API key. Unlike a personal API key, this is not associated with a
+    Authenticates using a team secret token. Unlike a personal API key, this is not associated with a
     user and should only be used for local_evaluation and flags remote_config (not to be confused with the
     other remote_config endpoint) requests. When authenticated, this returns a "synthetic"
-    ProjectSecretAPIKeyUser object that has the team set. This allows us to use the existing permissioning
+    TeamSecretTokenUser object that has the team set. This allows us to use the existing permissioning
     system for local_evaluation and flags remote_config requests.
 
     Only the first key candidate found in the request is tried, and the order is:
@@ -347,7 +347,7 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         cls,
         request: Union[HttpRequest, Request],
     ) -> Optional[str]:
-        """Try to find project secret API key in request and return it"""
+        """Try to find team secret token in request and return it"""
         if "authorization" in request.headers:
             authorization_match = re.match(rf"^{cls.keyword}\s+(.+)$", request.headers["authorization"])
             if authorization_match:
@@ -375,7 +375,7 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         if not secret_api_token:
             return None
 
-        # get the team from the secret api key
+        # get the team from the team secret token
         try:
             Team = apps.get_model(app_label="posthog", model_name="Team")
             team = Team.objects.get_team_from_cache_or_secret_api_token(secret_api_token)
@@ -383,9 +383,9 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
             if team is None:
                 return None
 
-            # Secret api keys are not associated with a user, so we create a ProjectSecretAPIKeyUser
+            # The team secret token is not associated with a user, so we create a TeamSecretTokenUser
             # and attach the team. The team is the important part here.
-            return (ProjectSecretAPIKeyUser(team), None)
+            return (TeamSecretTokenUser(team), None)
         except Team.DoesNotExist:
             return None
 
@@ -394,9 +394,9 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         return cls.keyword
 
 
-class ProjectSecretAPIKeyUser:
+class TeamSecretTokenUser:
     """
-    A "synthetic" user object returned by the ProjectSecretAPIKeyAuthentication when authenticating with a project secret API key.
+    A "synthetic" user object returned by the TeamSecretTokenAuthentication when authenticating with a team secret token.
     """
 
     def __init__(self, team):

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -18,10 +18,10 @@ from posthog.auth import (
     IDJagAccessTokenAuthentication,
     OAuthAccessTokenAuthentication,
     PersonalAPIKeyAuthentication,
-    ProjectSecretAPIKeyAuthentication,
     SessionAuthentication,
     SharingAccessTokenAuthentication,
     SharingPasswordProtectedAuthentication,
+    TeamSecretTokenAuthentication,
 )
 from posthog.cloud_utils import is_cloud
 from posthog.constants import AvailableFeature
@@ -214,8 +214,8 @@ class TeamMemberAccessPermission(BasePermission):
     message = "You don't have access to the project."
 
     def has_permission(self, request, view) -> bool:
-        if is_authenticated_via_project_secret_api_token(request):
-            # Ignore the team check for project secret API keys. It's handled by the ProjectSecretAPITokenPermission
+        if is_authenticated_via_team_secret_token(request):
+            # Ignore the team check for team secret tokens. It's handled by the TeamSecretTokenPermission
             return True
 
         try:
@@ -229,11 +229,11 @@ class TeamMemberAccessPermission(BasePermission):
         return requesting_level is not None
 
 
-def is_authenticated_via_project_secret_api_token(request: Request) -> bool:
-    return isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication)
+def is_authenticated_via_team_secret_token(request: Request) -> bool:
+    return isinstance(request.successful_authenticator, TeamSecretTokenAuthentication)
 
 
-def _is_request_for_project_secret_api_token_secured_endpoint(request: Request) -> bool:
+def _is_request_for_team_secret_token_secured_endpoint(request: Request) -> bool:
     return bool(
         request.resolver_match
         and request.resolver_match.view_name
@@ -731,8 +731,8 @@ class AccessControlPermission(ScopeBasePermission):
         # Primarily we are checking the user's access to the parent resource type (i.e. project, organization)
         # as well as enforcing any global restrictions (e.g. generically only editing of a flag is allowed)
 
-        if is_authenticated_via_project_secret_api_token(request):
-            # Ignore the team check for project secret API keys. It's handled by the ProjectSecretAPITokenPermission
+        if is_authenticated_via_team_secret_token(request):
+            # Ignore the team check for team secret tokens. It's handled by the TeamSecretTokenPermission
             return True
 
         # Check if the endpoint requires a current team to be set on the user
@@ -851,23 +851,23 @@ class PostHogFeatureFlagPermission(BasePermission):
         return True
 
 
-class ProjectSecretAPITokenPermission(BasePermission):
+class TeamSecretTokenPermission(BasePermission):
     """
-    Controls access to the local_evaluation and remote_config endpoints when authenticated via a project secret API token.
+    Controls access to the local_evaluation and remote_config endpoints when authenticated via a team secret token.
     Also validates that the authenticated team matches the resolved team (analogous to TeamMemberAccessPermission for personal keys).
     """
 
     def has_permission(self, request, view) -> bool:
-        if not isinstance(request.successful_authenticator, ProjectSecretAPIKeyAuthentication):
+        if not isinstance(request.successful_authenticator, TeamSecretTokenAuthentication):
             return True
 
-        # Check that the endpoint is allowed for secret API keys
-        if not _is_request_for_project_secret_api_token_secured_endpoint(request):
+        # Check that the endpoint is allowed for team secret tokens
+        if not _is_request_for_team_secret_token_secured_endpoint(request):
             return False
 
         # Check team consistency: authenticated team must match resolved team
         # This prevents cross-team access when project_api_key is provided in request body
-        authenticated_team = request.user.team  # From ProjectSecretAPIKeyUser
+        authenticated_team = request.user.team  # From TeamSecretTokenUser
         try:
             resolved_team = view.team  # From routing logic (may use project_api_key override)
         except (AttributeError, Team.DoesNotExist):

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -210,26 +210,26 @@ class TestAccessControlPermission(BaseTest):
         # Should have permission to create
         assert self.permission.has_permission(request, view) is True
 
-    def test_has_permission_with_project_secret_api_token_authentication(self):
-        """Test that has_permission returns True when authenticated via project secret API token"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+    def test_has_permission_with_team_secret_token_authentication(self):
+        """Test that has_permission returns True when authenticated via team secret token"""
+        from posthog.auth import TeamSecretTokenAuthentication
 
         request = self._create_mock_request()
-        request.successful_authenticator = ProjectSecretAPIKeyAuthentication()
+        request.successful_authenticator = TeamSecretTokenAuthentication()
         view = self._create_real_view(action="list")
 
-        # Should have permission when authenticated via project secret API token
+        # Should have permission when authenticated via team secret token
         assert self.permission.has_permission(request, view) is True
 
 
-class TestProjectSecretAPITokenPermission(BaseTest):
-    """Direct unit tests for ProjectSecretAPITokenPermission.has_permission method"""
+class TestTeamSecretTokenPermission(BaseTest):
+    """Direct unit tests for TeamSecretTokenPermission.has_permission method"""
 
     def setUp(self):
         super().setUp()
-        from posthog.permissions import ProjectSecretAPITokenPermission
+        from posthog.permissions import TeamSecretTokenPermission
 
-        self.permission = ProjectSecretAPITokenPermission()
+        self.permission = TeamSecretTokenPermission()
 
     def _create_mock_request(self, authenticator_class=None, view_name="featureflag-local-evaluation", user=None):
         """Helper to create a mock request with specified authenticator and view name"""
@@ -275,8 +275,8 @@ class TestProjectSecretAPITokenPermission(BaseTest):
         user.team = team
         return user
 
-    def test_has_permission_with_non_project_secret_authenticator(self):
-        """Should return True when not using ProjectSecretAPIKeyAuthentication"""
+    def test_has_permission_with_non_team_secret_token_authenticator(self):
+        """Should return True when not using TeamSecretTokenAuthentication"""
         from posthog.auth import PersonalAPIKeyAuthentication
 
         request = self._create_mock_request(authenticator_class=PersonalAPIKeyAuthentication)
@@ -286,12 +286,12 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
         self.assertTrue(result)
 
-    def test_has_permission_with_project_secret_authenticator_disallowed_endpoint(self):
+    def test_has_permission_with_team_secret_token_authenticator_disallowed_endpoint(self):
         """Should return False for disallowed endpoints"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         request = self._create_mock_request(
-            authenticator_class=ProjectSecretAPIKeyAuthentication, view_name="some-other-endpoint"
+            authenticator_class=TeamSecretTokenAuthentication, view_name="some-other-endpoint"
         )
         view = self._create_mock_view()
 
@@ -306,15 +306,15 @@ class TestProjectSecretAPITokenPermission(BaseTest):
             ("project_feature_flags-local-evaluation",),
         ]
     )
-    def test_has_permission_to_secret_api_token_secured_endpoints(self, endpoint_name):
+    def test_has_permission_to_team_secret_token_secured_endpoints(self, endpoint_name):
         """Should allow project_feature_flags endpoints with matching teams"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         team = self._create_mock_team(team_id=1)
         user = self._create_mock_user(team)
 
         request = self._create_mock_request(
-            authenticator_class=ProjectSecretAPIKeyAuthentication,
+            authenticator_class=TeamSecretTokenAuthentication,
             view_name=endpoint_name,
             user=user,
         )
@@ -326,10 +326,10 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
     def test_has_permission_unknown_endpoint(self):
         """Should reject unknown endpoints"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         request = self._create_mock_request(
-            authenticator_class=ProjectSecretAPIKeyAuthentication, view_name="unknown-endpoint"
+            authenticator_class=TeamSecretTokenAuthentication, view_name="unknown-endpoint"
         )
         view = self._create_mock_view()
 
@@ -339,12 +339,12 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
     def test_has_permission_matching_teams(self):
         """Should return True when authenticated team matches resolved team"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         team = self._create_mock_team(team_id=1)
         user = self._create_mock_user(team)
 
-        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+        request = self._create_mock_request(authenticator_class=TeamSecretTokenAuthentication, user=user)
         view = self._create_mock_view(team=team)
 
         result = self.permission.has_permission(request, view)
@@ -353,13 +353,13 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
     def test_has_permission_mismatched_teams(self):
         """Should return False when authenticated team doesn't match resolved team"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         team1 = self._create_mock_team(team_id=1)
         team2 = self._create_mock_team(team_id=2)
         user = self._create_mock_user(team1)
 
-        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+        request = self._create_mock_request(authenticator_class=TeamSecretTokenAuthentication, user=user)
         view = self._create_mock_view(team=team2)
 
         result = self.permission.has_permission(request, view)
@@ -368,12 +368,12 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
     def test_has_permission_view_team_resolution_fails_with_team_does_not_exist(self):
         """Should return True when view.team raises Team.DoesNotExist"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         team = self._create_mock_team(team_id=1)
         user = self._create_mock_user(team)
 
-        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+        request = self._create_mock_request(authenticator_class=TeamSecretTokenAuthentication, user=user)
 
         # Create a view class that raises Team.DoesNotExist when team is accessed
         class MockView:
@@ -388,12 +388,12 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
     def test_has_permission_view_missing_team_attribute(self):
         """Should return True when view.team raises AttributeError"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
         team = self._create_mock_team(team_id=1)
         user = self._create_mock_user(team)
 
-        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, user=user)
+        request = self._create_mock_request(authenticator_class=TeamSecretTokenAuthentication, user=user)
 
         # Create a view class that raises AttributeError when team is accessed
         class MockView:
@@ -408,9 +408,9 @@ class TestProjectSecretAPITokenPermission(BaseTest):
 
     def test_has_permission_no_view_name(self):
         """Should handle missing view_name gracefully"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+        from posthog.auth import TeamSecretTokenAuthentication
 
-        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication, view_name=None)
+        request = self._create_mock_request(authenticator_class=TeamSecretTokenAuthentication, view_name=None)
         view = self._create_mock_view()
 
         result = self.permission.has_permission(request, view)
@@ -474,18 +474,18 @@ class TestTeamMemberAccessPermission(BaseTest):
         user_permissions.current_team = current_team
         return user_permissions
 
-    def test_has_permission_with_project_secret_api_token_authenticator(self):
-        """Should return True when using ProjectSecretAPIKeyAuthentication"""
-        from posthog.auth import ProjectSecretAPIKeyAuthentication
+    def test_has_permission_with_team_secret_token_authenticator(self):
+        """Should return True when using TeamSecretTokenAuthentication"""
+        from posthog.auth import TeamSecretTokenAuthentication
 
-        request = self._create_mock_request(authenticator_class=ProjectSecretAPIKeyAuthentication)
+        request = self._create_mock_request(authenticator_class=TeamSecretTokenAuthentication)
         view = self._create_mock_view()
 
         result = self.permission.has_permission(request, view)
 
         self.assertTrue(result)
 
-    def test_has_permission_with_non_project_secret_authenticator_and_valid_membership(self):
+    def test_has_permission_with_non_team_secret_token_authenticator_and_valid_membership(self):
         """Should return True when not using project secret auth and user has valid membership"""
         from posthog.auth import PersonalAPIKeyAuthentication
         from posthog.models.organization import OrganizationMembership
@@ -502,7 +502,7 @@ class TestTeamMemberAccessPermission(BaseTest):
 
         self.assertTrue(result)
 
-    def test_has_permission_with_non_project_secret_authenticator_and_no_membership(self):
+    def test_has_permission_with_non_team_secret_token_authenticator_and_no_membership(self):
         """Should return False when not using project secret auth and user has no membership"""
         from posthog.auth import PersonalAPIKeyAuthentication
 

--- a/posthog/test/test_two_factor_enforcement.py
+++ b/posthog/test/test_two_factor_enforcement.py
@@ -13,7 +13,7 @@ from django.test import RequestFactory, TestCase
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.test import APIClient, APIRequestFactory
 
-from posthog.auth import PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication, SessionAuthentication
+from posthog.auth import PersonalAPIKeyAuthentication, SessionAuthentication, TeamSecretTokenAuthentication
 from posthog.helpers.two_factor_session import (
     TWO_FACTOR_ENFORCEMENT_FROM_DATE,
     clear_two_factor_session_flags,
@@ -439,7 +439,7 @@ class TestAPIAuthenticationTwoFactorBypass(TestCase):
         self.assertIsNone(result)
 
     def test_project_secret_api_key_authentication_bypasses_two_factor(self):
-        auth = ProjectSecretAPIKeyAuthentication()
+        auth = TeamSecretTokenAuthentication()
         request = self.factory.get("/api/users/@me/")
 
         result = auth.authenticate(request)

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -37,7 +37,7 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSet
 from posthog.api.utils import ClassicBehaviorBooleanFieldSerializer, ErrorResponseSerializer, action
 from posthog.approvals.decorators import approval_gate
 from posthog.approvals.mixins import ApprovalHandlingMixin
-from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, ProjectSecretAPIKeyAuthentication
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, TeamSecretTokenAuthentication
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.constants import FlagRequestType
 from posthog.date_util import thirty_days_ago
@@ -55,7 +55,7 @@ from posthog.models.person.point_in_time_properties import (
 )
 from posthog.models.property import Property
 from posthog.models.signals import model_activity_signal, mutable_receiver
-from posthog.permissions import ProjectSecretAPITokenPermission
+from posthog.permissions import TeamSecretTokenPermission
 from posthog.queries.base import determine_parsed_date_for_property_matching
 from posthog.rate_limit import BurstRateThrottle, ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -3784,9 +3784,9 @@ class FeatureFlagViewSet(
         detail=True,
         required_scopes=["feature_flag:read"],
         authentication_classes=[
-            ProjectSecretAPIKeyAuthentication,
+            TeamSecretTokenAuthentication,
         ],
-        permission_classes=[ProjectSecretAPITokenPermission],
+        permission_classes=[TeamSecretTokenPermission],
         throttle_classes=[RemoteConfigThrottle],
     )
     def remote_config(self, request: request.Request, **kwargs):

--- a/products/live_debugger/backend/api.py
+++ b/products/live_debugger/backend/api.py
@@ -9,8 +9,8 @@ from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.auth import ProjectSecretAPIKeyAuthentication, SessionAuthentication
-from posthog.permissions import ProjectSecretAPITokenPermission
+from posthog.auth import SessionAuthentication, TeamSecretTokenAuthentication
+from posthog.permissions import TeamSecretTokenPermission
 
 from products.live_debugger.backend.models import LiveDebuggerBreakpoint
 
@@ -245,11 +245,11 @@ class LiveDebuggerBreakpointViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
         methods=["GET"],
         detail=False,
         authentication_classes=[
-            ProjectSecretAPIKeyAuthentication,
+            TeamSecretTokenAuthentication,
             SessionAuthentication,
         ],
         required_scopes=["live_debugger:read"],
-        permission_classes=[ProjectSecretAPITokenPermission],
+        permission_classes=[TeamSecretTokenPermission],
         url_path="active",
     )
     def active_breakpoints(self, request: Request, *args, **kwargs) -> Response:


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

1 / 3 in Project Secret API Keys - team secret tokens are untruthfully named

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- rename all occurrences to team secret token so we release the namespace for project secret APi keys

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

tests ran -should have no behaviour changes

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

brakdown of #56190 

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->