### PR TITLE
chore(mcp): remove traffic-sim server registration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,10 +4,6 @@
             "command": "uv",
             "args": ["run", "python", "tools/phrocs/mcp_server.py"]
         },
-        "traffic-sim": {
-            "command": "uv",
-            "args": ["run", "python", "tools/traffic-sim/mcp_server.py"]
-        },
         "posthog-local": {
             "type": "http",
             "url": "http://localhost:8787/mcp"


### PR DESCRIPTION
## Problem

The `traffic-sim` tool is registered as an MCP server in `.mcp.json`, so it loads for everyone working in the repo. It's a niche instrumentation-verification helper that most contributors don't need, and its tools add noise to the MCP surface by default.

## Changes

Remove the `traffic-sim` block from `.mcp.json`. The `tools/traffic-sim/` code (CLI, MCP server, skills, tests) is left untouched — it's simply no longer auto-registered as an MCP server. Anyone who wants it can still run it directly or re-add the entry locally.

## How did you test this code?

I'm an agent. I validated that `.mcp.json` is still well-formed JSON after the edit. No automated tests cover this config file. The remaining `phrocs` and `posthog-local` servers are unchanged.

## 🤖 Agent context

Authored with Claude Code at the user's direction. The user asked to remove the traffic-sim MCP; we scoped it down to just the `.mcp.json` registration (not a full tool deletion) after confirming intent. Branch was cut from master.
