### PR TITLE
chore(signals): harden observability-gaps scout with dogfood learnings

### DIFF
--- a/products/signals/skills/signals-scout-observability-gaps/SKILL.md
+++ b/products/signals/skills/signals-scout-observability-gaps/SKILL.md
@@ -49,6 +49,27 @@ in seconds. Re-running with the same key idempotently refreshes the timestamp �
 entry stays until the team grows into meaningful volume, at which point the next run
 rewrites or deletes it.
 
+## Quick close-out: is this team already saturated?
+
+The opposite end has a fast path too. On a mature project (thousands of insights,
+hundreds of alerts), a few runs will establish that whole gap families are
+**saturated** — every high-volume event already has dense coverage, and newly-emerged
+events get covered within days. Record that as durable memory instead of
+rediscovering it every run:
+
+- key: `pattern:observability_gaps:<family>-saturated` (or one `coverage-saturated`
+  entry spanning families)
+- content: what was probed, the coverage counts found, and a **tripwire** — the
+  concrete condition under which the family is worth re-probing (e.g. "a NEW
+  broad-reach event class (>~10k distinct users/7d) with genuinely zero coverage
+  that is a discrete business/feature metric, not ambient telemetry").
+
+Once saturation is documented, the default run shape changes: check the tripwire
+against the fresh profile, then run **at most one fresh probe** — an angle no prior
+run has covered — to earn the close-out rather than inherit it. If the tripwire is
+untriggered and the probe comes back clean, close out empty in minutes. Don't re-run
+coverage SQL a run verified hours ago; that's duplication, not diligence.
+
 ## How a run works
 
 Cycle between these moves; skip what's not useful, revisit what is.
@@ -89,6 +110,16 @@ Direct calls:
 
 Strong signal: event > 1000/day, no insight, `verified=true`. Weak signal: event
 < 100/day, untyped, sporadic.
+
+Volume ranking has a blind spot: a recently-born event with broad reach but low
+per-user frequency may never rank into the count-ranked `top_events`, and a 7-day
+query window clamps `min(timestamp)` so it cannot tell new events from old ones.
+Probe emergence directly with a wide window — events table, last 60 days,
+`event NOT LIKE '$%'`, grouped by event, keeping only groups where
+`min(timestamp) >= now() - 14d` (genuinely new) and distinct users in the last 7
+days clear a reach floor (~500+), ordered by that reach. Each hit is a candidate the
+top-events lens structurally cannot see; run it through the same coverage check and
+disqualifiers as any other candidate.
 
 #### 2. Insight drift — saved insights pointing at zero-volume events
 
@@ -194,10 +225,31 @@ confidence bar trades off:
 
 - **Volume threshold** — gap is structurally interesting only at scale. Below 100/day,
   the recommendation is noise.
-- **Stable-not-spurious** — gap has been present for at least 7 days. Avoid flagging
-  events that just appeared yesterday.
+- **Stable-not-spurious** — gap has been present for at least 7 **complete days in
+  the project timezone**. Avoid flagging events that just appeared yesterday; a
+  partial current day or a deploy-day spike can fake stability.
 - **No prior coverage** — search `popular_insights` and `existing_inbox_reports`
   before emitting. If a previous run already recommended this gap, don't re-emit.
+
+### Park, then emit — the watch lifecycle
+
+Most good recommendations are not emitted the run they're spotted — they're parked
+until the stability bar crosses. The lifecycle:
+
+1. **Park** — write a `watch:observability_gaps:<gap>` entry carrying the
+   discriminating conditions (the exact checks that make this a real gap), the
+   volume evidence so far, and the earliest emit time (when the 7th complete
+   project-timezone day closes). Future runs inherit the candidate instead of
+   re-deriving it.
+2. **Re-verify live, then emit** — the run that crosses the bar must re-check every
+   discriminating condition against live data before emitting (coverage can appear,
+   volume can collapse). Never emit off the watch entry alone.
+3. **Guard** — after emitting, update the watch entry with the finding id and a
+   ~30-day dedupe: no re-emit before then unless a materially new angle appears.
+4. **Retire** — the entry doesn't live forever. When coverage appears, the
+   recommendation was actioned: delete the entry (or convert it to `addressed:`).
+   If ~30 days pass and nobody built coverage, that's "recommended but ignored" —
+   convert it to a `noise:` skip note rather than re-emitting.
 
 ### Close out
 
@@ -218,6 +270,29 @@ a separate "run metadata" scratchpad entry — the run summary already serves th
   disabled or only for a tiny rollout %, the volume is artificially low.
 - **Events on ad-hoc one-off dashboards** — a private dashboard with one viewer doesn't
   count as "covered." Use the `popular_insights` viewer-count threshold.
+- **Ambient app-shell telemetry** — an event whose distinct-user reach is roughly
+  equal to `$pageview`'s fires for nearly every user as part of the app shell, not
+  as a discrete feature metric. Zero saved insights on it is usually intentional;
+  compare reach against `$pageview` before calling it a gap.
+- **Deliberate engineering firehoses** — high-volume internal perf/telemetry events
+  the team consumes via ad-hoc SQL or notebooks rather than saved insights. Before
+  declaring zero coverage, check whether notebooks reference the event — covered by
+  choice is not a gap.
+- **Experiment-exposure events** — events that exist to drive an experiment's
+  metrics are covered by the experiment itself. Don't recommend standalone insights
+  for them while the experiment runs.
+- **One-per-user lifecycle events** — onboarding, wizard, and setup events fire once
+  per user; their volume is just signup flow-through and rarely deserves a
+  standalone insight.
+- **Time-boxed promotion / campaign events** — campaign-shaped events appear, spike,
+  and end by design. Going quiet is not drift, and lacking coverage is not a gap
+  unless the underlying surface (impressions + conversions) persists.
+- **Incident-investigation scaffolding** — short-lived events created during an
+  incident, often with incident-named insights attached. They stop firing when the
+  incident closes; flagging the stoppage as drift is a false positive.
+- **Legacy event-name variants** — insights that deliberately union an old and a new
+  event name for historical continuity are well-maintained, not drifted. Read the
+  insight's query JSON before declaring a dead event "still referenced."
 
 When in doubt, write a scratchpad entry instead of emitting. Recommendations have a
 high panic radius for whoever owns the observability surface — false positives erode


### PR DESCRIPTION
## Problem

The observability-gaps scout has been running on a mature, high-volume project for several days, and the fleet invented several load-bearing behaviors its canonical skill doesn't teach: a fast path for projects whose gap families are already saturated, an emergence probe for newly-born events the count-ranked top-events lens can't see, a park→verify→emit→retire lifecycle for recommendations, and a set of disqualifier classes it learned by almost emitting false positives. Other teams' scouts start from the canonical body, so without folding these back in, every fresh deployment has to relearn them run by run (or worse, emits the false positives this project's scratchpad now suppresses).

## Changes

All in `products/signals/skills/signals-scout-observability-gaps/SKILL.md`:

- **Saturated-project quick close-out** — a mirror of the existing too-quiet close-out: document per-family saturation in `pattern:` entries with an explicit re-probe tripwire, then each run checks the tripwire plus at most one fresh probe to "earn" the empty close-out rather than inherit it.
- **New-event emergence probe in family 1** — the count-ranked `top_events` can't surface a recently-born broad-reach but low-frequency event, and a 7-day query window clamps `min(timestamp)` so it can't detect emergence at all. Adds the wide-window recipe (60d window, `min(timestamp)` within 14d, 7d distinct-user reach floor).
- **Seven new disqualifier classes** observed in practice: ambient app-shell telemetry (reach ≈ `$pageview`), engineering firehoses consumed via notebooks/ad-hoc SQL, experiment-exposure events, one-per-user lifecycle events, time-boxed campaign events, incident-investigation scaffolding, and legacy event-name variants unioned into existing insights (not drift).
- **Watch lifecycle for recommendations** — park candidates in a `watch:` entry with discriminating conditions and an earliest emit time, re-verify live before emitting, guard with a ~30-day dedupe, and retire the entry (actioned → delete/`addressed:`, ignored → `noise:`). Also tightens the stability bar from "7 days" to "7 complete days in the project timezone".

No harness or coordinator changes; `lazy_seed` picks the new body up on the next sync for non-diverged teams.

## How did you test this code?

I'm an agent. `hogli build:skills` passes with the edited skill. The guidance itself is distilled from observed scout runs and scratchpad memory on a live project (~40 runs: healthy cadence, 1 well-evidenced emit that became an inbox report, zero false positives — with the behaviors above doing the suppression work).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: dogfooded the scout's recent runs, scratchpad, and emitted findings via the PostHog MCP (`signals-scout-runs-list` / `-scratchpad-search` / `inbox-reports-list`), then folded the fleet-invented behaviors back into the canonical skill body.
- Deliberately scoped to skill-body tweaks only: a separate harness issue (dropped run close-outs being mislabeled as timeouts) was observed during the same session and is intentionally **not** addressed here.
- Kept everything in the single self-contained `SKILL.md` (no new references) to match the current shape of this scout; wrote the emergence probe as prose rather than literal SQL so the scout adapts it to HogQL at run time.
