### PR TITLE
test(oauth): pin OIDC key in oauth admin revoke tests

### DIFF
--- a/ee/api/agentic_provisioning/test/base.py
+++ b/ee/api/agentic_provisioning/test/base.py
@@ -9,28 +9,15 @@ from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
+
+from posthog.test.oauth_test_utils import TEST_RSA_PRIVATE_KEY as _RSA_KEY
 
 from ee.api.agentic_provisioning.signature import compute_signature
 from ee.api.agentic_provisioning.views import AUTH_CODE_CACHE_PREFIX
 
 HMAC_SECRET = "test_hmac_secret"
 TEST_STRIPE_OAUTH_CLIENT_ID = "test_stripe_oauth_client_id"
-
-
-def _generate_rsa_key() -> str:
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return pem.decode("utf-8")
-
-
-_RSA_KEY = _generate_rsa_key()
 
 
 @pytest.mark.requires_secrets

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -13,11 +13,10 @@ from django.conf import settings
 from django.core.cache import cache as real_cache
 from django.test import override_settings
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
 
 from posthog.models.oauth import OAuthApplication
+from posthog.test.oauth_test_utils import TEST_RSA_PRIVATE_KEY as _RSA_KEY
 
 from ee.api.agentic_provisioning.signature import compute_signature
 
@@ -26,24 +25,11 @@ WIZARD_CLIENT_ID = "test-wizard-client"
 TEST_STRIPE_OAUTH_CLIENT_ID = "test_stripe_oauth_client_id"
 
 
-def _generate_rsa_key() -> str:
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return pem.decode("utf-8")
-
-
 def _pkce_pair():
     """Generate a PKCE code_verifier and code_challenge pair."""
     verifier = secrets.token_urlsafe(32)
     challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
     return verifier, challenge
-
-
-_RSA_KEY = _generate_rsa_key()
 
 
 @pytest.mark.requires_secrets

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -9,33 +9,19 @@ from django.contrib.admin import AdminSite
 from django.test import RequestFactory, override_settings
 from django.utils import timezone
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from parameterized import parameterized
 
 from posthog.admin.admins.oauth_admin import OAuthApplicationAdmin, OAuthApplicationForm
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthRefreshToken
-
-
-def _generate_rsa_key() -> str:
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return pem.decode("utf-8")
-
-
-_RSA_KEY = _generate_rsa_key()
+from posthog.test.oauth_test_utils import TEST_RSA_PRIVATE_KEY
 
 
 # Creating an RS256 app requires OIDC_RSA_PRIVATE_KEY, which isn't available on fork/external PR CI and
 # can be cleared by other OAuth tests overriding OAUTH2_PROVIDER (django-oauth-toolkit caches its
 # settings). Pin a test key so these tests pass regardless of environment and ordering.
 @override_settings(
-    OIDC_RSA_PRIVATE_KEY=_RSA_KEY,
-    OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": _RSA_KEY},
+    OIDC_RSA_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY,
+    OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": TEST_RSA_PRIVATE_KEY},
 )
 class TestOAuthApplicationAdmin(BaseTest):
     def setUp(self):

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -4,16 +4,39 @@ from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.admin import AdminSite
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from django.utils import timezone
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from parameterized import parameterized
 
 from posthog.admin.admins.oauth_admin import OAuthApplicationAdmin, OAuthApplicationForm
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthRefreshToken
 
 
+def _generate_rsa_key() -> str:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+_RSA_KEY = _generate_rsa_key()
+
+
+# Creating an RS256 app requires OIDC_RSA_PRIVATE_KEY, which isn't available on fork/external PR CI and
+# can be cleared by other OAuth tests overriding OAUTH2_PROVIDER (django-oauth-toolkit caches its
+# settings). Pin a test key so these tests pass regardless of environment and ordering.
+@override_settings(
+    OIDC_RSA_PRIVATE_KEY=_RSA_KEY,
+    OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": _RSA_KEY},
+)
 class TestOAuthApplicationAdmin(BaseTest):
     def setUp(self):
         super().setUp()

--- a/posthog/test/oauth_test_utils.py
+++ b/posthog/test/oauth_test_utils.py
@@ -1,0 +1,16 @@
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def generate_rsa_private_key_pem() -> str:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+# Generated once so test modules pinning OIDC_RSA_PRIVATE_KEY share a single key.
+TEST_RSA_PRIVATE_KEY = generate_rsa_private_key_pem()


### PR DESCRIPTION
## Problem

`TestOAuthApplicationAdmin.test_revoke_all_sessions_*` create OAuth applications with `algorithm="RS256"`, which requires `OIDC_RSA_PRIVATE_KEY`. That key isn't available to fork or external PR CI, and on internal runs it can be cleared when another OAuth test overrides `OAUTH2_PROVIDER` (django-oauth-toolkit caches its settings). Either way the tests fail with `ValidationError: You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm`.

This is the same failure class previously patched for other test classes in #62276, #55899, #55789, and #50529. `TestOAuthApplicationAdmin` was added in #61711 without a guard, so it's the latest victim. It currently blocks fork PRs that have rebased onto it.

## Changes

Pin a generated test RSA key at the class level via `@override_settings`, mirroring the existing pattern in `ee/api/agentic_provisioning/test/base.py`. Pinning the key keeps these tests running on fork PRs, unlike `@pytest.mark.requires_secrets`, which would skip them there.

## How did you test this code?

Ran the affected tests locally against a fresh test database:

```
pytest --create-db posthog/admin/test_oauth_admin.py::TestOAuthApplicationAdmin
```

All 8 tests pass, including the two `revoke_all_sessions` tests that previously failed.

## Docs update

No docs update needed.