### PR TITLE
test: validate SKIP_PRODUCT_TESTS kill switch (do not merge)

### DIFF
--- a/products/batch_exports/__init__.py
+++ b/products/batch_exports/__init__.py
@@ -1,1 +1,3 @@
 """Batch exports product for PostHog."""
+
+# no-op touch to exercise CI product-test discovery (SKIP_PRODUCT_TESTS kill switch validation)


### PR DESCRIPTION
## Throwaway validation PR — do not merge

Touches a `batch-exports` source file so the CI product-test discovery puts batch-exports into the matrix, to confirm the `SKIP_PRODUCT_TESTS=batch-exports` repo variable actually drops it on a real PR run.

Expected in the "Discover product tests" job:
- `SKIP_PRODUCT_TESTS=batch-exports — dropped 1 product(s)`
- no `batch-exports` entry in the product matrix / no `Product tests (batch-exports)` job

Will be closed once validated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — verifying PR (#62479) kill switch behaves on a live PR run.
