### PR TITLE
chore(ci): gate prod build/deploy on CD_DEPLOY_ENABLED variable

### DIFF
--- a/.agents/skills/gating-production-deploys/SKILL.md
+++ b/.agents/skills/gating-production-deploys/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: gating-production-deploys
+description: >
+  Use when adding or editing a GitHub Actions workflow that pushes a container
+  image to a registry (ECR/ghcr/Docker Hub via build-push-action) or dispatches a
+  production deploy (a `commit_state_update` repository_dispatch to PostHog/charts).
+  Those run from a single canonical deploy repo, gated by the CD_DEPLOY_ENABLED
+  variable. Does NOT apply to workflows that publish GitHub releases, npm, crates,
+  or Homebrew — those stay on the public repo.
+---
+
+# Gating production builds and deploys
+
+Container-image pushes and Charts deploy dispatches run from one canonical deploy
+repo, selected by the `CD_DEPLOY_ENABLED` variable. Gate every such step or it
+publishes/deploys from the wrong place.
+
+**Gate** these when they run on `push`-to-`master` / `schedule` / `workflow_dispatch`:
+
+- a prod-tag container image push, and
+- a `commit_state_update` dispatch to `PostHog/charts` (plus its deployer-token step).
+
+**Don't gate:**
+
+- Release/distribution workflows — GitHub release, npm, crate, Homebrew (e.g.
+  `build-phrocs.yml`, `release-cli.yml`). They publish from public; leave them.
+- `pull_request` / `merge_group` validation builds (gating them breaks contributor CI).
+- change-detection / setup jobs (use the org check only, not the variable).
+
+The test is "pushes a prod image or triggers a deploy" — not "builds on master".
+
+## The gate
+
+```yaml
+if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
+```
+
+Use this instead of hardcoding `github.repository == 'PostHog/posthog'`.
+
+## Patterns
+
+```yaml
+# whole job is the deploy/push (no PR builds) — gate the job:
+if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
+
+# deploy job/step already keyed to master — add the gate:
+if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
+
+# build job that also serves PRs — gate only the master arm of its `if`:
+(github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.files == 'true'
+  && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
+
+# push step, master-only:
+push: ${{ github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true' }}
+# push step, `push: true` (also pushes on PR for validation):
+push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
+
+# reusable that pushes — add a `push` boolean input (default true), pass from caller:
+#   with: { push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }} }
+```
+
+Set `CD_DEPLOY_ENABLED` on the repo that should ship **before** merging, or master
+pushes skip the build/deploy. Lint with `actionlint`.
+
+Examples: `container-images-cd.yml` (whole-job); `cd-mcp-image.yml`,
+`livestream-docker-image.yml`, `cd-sandbox-base-image.yml` (mixed PR+master);
+`rust-docker-build.yml` + `_rust-build-images.yml` (reusable `push` input).
+Counter-example, not gated: `build-phrocs.yml`.

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -32,6 +32,10 @@ on:
                 description: 'Comma-separated list of images to build (empty = all)'
                 type: string
                 default: ''
+            push:
+                description: 'Whether to push built images to the registry'
+                type: boolean
+                default: true
         outputs:
             digests:
                 description: 'JSON object mapping image name to digest'
@@ -146,7 +150,7 @@ jobs:
                   context: ./rust/
                   file: ${{ matrix.dockerfile }}
                   target: ${{ matrix.target || '' }}
-                  push: true
+                  push: ${{ inputs.push }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/arm64,linux/amd64

--- a/.github/workflows/cd-llm-analytics-image.yml
+++ b/.github/workflows/cd-llm-analytics-image.yml
@@ -30,7 +30,7 @@ jobs:
     posthog_llm_analytics_build:
         name: Build and push container image
         if: |
-            github.repository == 'PostHog/posthog' && (
+            github.repository_owner == 'PostHog' && (
                 github.event_name == 'push' ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-llm-analytics-image')
@@ -73,13 +73,13 @@ jobs:
                   project: c1f2m5s6zd
                   file: ./Dockerfile.llm-analytics
                   buildx-fallback: false
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ github.ref == 'refs/heads/master' && format('{0}/posthog-llm-analytics:master,{0}/posthog-llm-analytics:{1}', steps.aws-ecr.outputs.registry, github.sha) || format('{0}/posthog-llm-analytics:{1}', steps.aws-ecr.outputs.registry, github.sha) }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 
             - name: Get deployer token
-              if: github.ref == 'refs/heads/master'
+              if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
               id: deployer
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               with:
@@ -89,14 +89,14 @@ jobs:
                   repositories: charts
 
             - name: Get PR labels
-              if: github.ref == 'refs/heads/master'
+              if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
               id: labels
               uses: ./.github/actions/get-pr-labels
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Trigger LLM Analytics Temporal Worker deployment
-              if: github.ref == 'refs/heads/master'
+              if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -21,7 +21,7 @@ jobs:
     build:
         name: Build and push container image
         if: |
-            github.repository == 'PostHog/posthog' && (
+            github.repository_owner == 'PostHog' && (
                 github.event_name == 'push' ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-mcp-image')
@@ -63,7 +63,7 @@ jobs:
                   project: c1f2m5s6zd
                   file: ./services/mcp/Dockerfile
                   buildx-fallback: false
-                  push: ${{ github.ref == 'refs/heads/master' }}
+                  push: ${{ github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
                   platforms: linux/arm64,linux/amd64
@@ -74,7 +74,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         needs: build
-        if: github.ref == 'refs/heads/master'
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
         permissions: {}
 
         steps:

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -11,7 +11,7 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog'
+        if: github.repository_owner == 'PostHog'
         name: Determine if sandbox image needs to be built
         permissions:
             contents: read
@@ -42,7 +42,7 @@ jobs:
         needs: changes
         name: Build agent skills from source
         if: |
-            github.repository == 'PostHog/posthog' && (
+            github.repository_owner == 'PostHog' && (
                 needs.changes.outputs.sandbox_image == 'true' ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
@@ -156,7 +156,7 @@ jobs:
         needs: [changes, build_skills]
         name: Build and push Tasks Sandbox container image
         if: |
-            github.repository == 'PostHog/posthog' && (
+            github.repository_owner == 'PostHog' && (
                 needs.changes.outputs.sandbox_image == 'true' ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
@@ -204,7 +204,7 @@ jobs:
                   context: . # use local checkout (includes downloaded artifact)
                   file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
                   buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-base:master,ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
@@ -216,7 +216,7 @@ jobs:
                   context: . # use local checkout (includes downloaded artifact)
                   file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook
                   buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-notebook:master,ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
@@ -228,7 +228,7 @@ jobs:
                   context: . # use local checkout (includes downloaded artifact)
                   file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
                   buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-pi:master,ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) }}
                   platforms: linux/arm64,linux/amd64
                   build-args: |

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -19,7 +19,7 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog' && github.event_name != 'merge_group'
+        if: github.repository_owner == 'PostHog' && github.event_name != 'merge_group'
         name: Determine need to run node Docker build
         outputs:
             node_files: ${{ steps.filter.outputs.node_files }}
@@ -59,7 +59,7 @@ jobs:
         if: |
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.node_files == 'true') ||
             github.event_name == 'merge_group' ||
-            (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.node_files == 'true')
+            (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.node_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
         timeout-minutes: 30
         permissions:
@@ -97,7 +97,7 @@ jobs:
                   context: .
                   buildx-fallback: false
                   project: '00mrvlsdvh'
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: Dockerfile.node
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
@@ -138,7 +138,7 @@ jobs:
                   properties: '{"status": "failure", "commit_hash": "${{ github.sha }}"}'
 
             - name: Get deployer token
-              if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+              if: github.ref == 'refs/heads/master' && github.event_name == 'push' && vars.CD_DEPLOY_ENABLED == 'true'
               id: deployer
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               with:
@@ -148,14 +148,14 @@ jobs:
                   repositories: charts
 
             - name: Get PR labels
-              if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+              if: github.ref == 'refs/heads/master' && github.event_name == 'push' && vars.CD_DEPLOY_ENABLED == 'true'
               id: labels
               uses: ./.github/actions/get-pr-labels
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Trigger node deployment
-              if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+              if: github.ref == 'refs/heads/master' && github.event_name == 'push' && vars.CD_DEPLOY_ENABLED == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -23,7 +23,7 @@ jobs:
             contents: read
             pull-requests: read
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog' && github.event_name != 'merge_group'
+        if: github.repository_owner == 'PostHog' && github.event_name != 'merge_group'
         name: Determine need to run recording-rasterizer Docker build
         outputs:
             rasterizer_files: ${{ steps.filter.outputs.rasterizer_files }}
@@ -67,9 +67,9 @@ jobs:
         if: |
             (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.rasterizer_files == 'true') ||
             github.event_name == 'merge_group' ||
-            github.event_name == 'workflow_dispatch' ||
-            github.event_name == 'schedule' ||
-            (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.rasterizer_files == 'true')
+            (github.event_name == 'workflow_dispatch' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
+            (github.event_name == 'schedule' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true') ||
+            (github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.changes.outputs.rasterizer_files == 'true' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true')
         runs-on: depot-ubuntu-latest
         timeout-minutes: 30
         permissions:
@@ -110,7 +110,7 @@ jobs:
                   context: .
                   buildx-fallback: false
                   project: '00mrvlsdvh'
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   file: Dockerfile.recording-rasterizer
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
@@ -157,7 +157,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         needs: build
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule'
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule')
         permissions:
             contents: read
         steps:

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -21,7 +21,8 @@ on:
 jobs:
     posthog_build:
         name: Build and push PostHog
-        if: github.repository == 'PostHog/posthog'
+        # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
         runs-on: depot-ubuntu-latest
         # Bumped from 30: the deploy dispatch now waits for backend CI on this commit
         # before firing, so the job stays alive through the build + the wait window.

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -23,6 +23,8 @@ jobs:
         runs-on: depot-ubuntu-latest
         timeout-minutes: 10
 
+        if: github.repository_owner == 'PostHog'
+
         permissions:
             contents: read
             packages: write
@@ -63,7 +65,7 @@ jobs:
               with:
                   context: ./livestream/
                   file: livestream/Dockerfile
-                  push: true
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
@@ -73,7 +75,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         needs: build
-        if: github.ref == 'refs/heads/master'
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
         steps:
             - name: get deployer token
               id: deployer

--- a/.github/workflows/llm-gateway-cd.yml
+++ b/.github/workflows/llm-gateway-cd.yml
@@ -13,6 +13,7 @@ jobs:
     build:
         runs-on: depot-ubuntu-latest
         timeout-minutes: 10
+        if: github.repository_owner == 'PostHog'
 
         permissions:
             contents: read
@@ -48,7 +49,7 @@ jobs:
 
             - name: Build and push Docker image
               id: push
-              if: github.ref == 'refs/heads/master'
+              if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
                   context: ./services/llm-gateway/
@@ -63,6 +64,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         needs: build
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
         permissions: {}
         steps:
             - name: get deployer token

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -81,6 +81,8 @@ jobs:
             needs.affected.outputs.image-filter != 'none'
         uses: ./.github/workflows/_rust-build-images.yml
         with:
+            # Only the canonical deploy repo pushes prod images on master; PRs still push for validation.
+            push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
             image-filter: ${{ needs.affected.outputs.image-filter || '' }}
             tag-rules: |
                 type=ref,event=pr
@@ -100,7 +102,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         needs: build-images
-        if: github.ref == 'refs/heads/master'
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == 'refs/heads/master'
         strategy:
             # fail-fast false so one missing digest doesn't cancel other deploys
             fail-fast: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,4 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/modifying-taxonomic-filter` — any TaxonomicFilter change
 - `/sending-notifications` — adding notification support
 - `/writing-skills` — creating or updating skills in `.agents/skills/`
+- `/gating-production-deploys` — any workflow that builds and pushes a production image or dispatches a deploy


### PR DESCRIPTION
### Problem

Production container builds and Charts deploy dispatches are hardcoded to run only when `github.repository == 'PostHog/posthog'`. That couples "which repository ships production artifacts" to a literal repository name, so the deploy source can't be selected operationally — it requires editing every workflow to change it.

### Changes

Gate every production build/deploy job behind an org check **plus** a `CD_DEPLOY_ENABLED` repository variable:

```yaml
if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
```

This replaces the hardcoded github.repository == 'PostHog/posthog' guards. The org check keeps forks/other orgs out; the variable selects which repository actually ships.

Applied to 11 production builders/deployers:
- container-images-cd
- cd-mcp-image
- cd-llm-analytics-image
- cd-sandbox-base-image
- llm-gateway-cd
- livestream-docker-image
- rust-docker-build (+ the reusable _rust-build-images)
- ci-nodejs-container
- ci-recording-rasterizer-container

Scope of the gate:
- pull_request / merge_group CI builds are unchanged — they still build and push their validation tags exactly as before.
- Only master / schedule / workflow_dispatch production side effects are gated: prod-tag registry pushes (push: on those events) and commit_state_update deploy dispatches.
- _rust-build-images gains a push boolean input (default true) so the same gating reaches the rust images without affecting the smoke-test build path that also calls it.

> [!WARNING]
> Before merging, set CD_DEPLOY_ENABLED=true on this repository. Otherwise the next push to master will skip all production builds and deploys.

How did you test this code?

I'm an agent (Claude Code) — I did not execute these workflows. Validation performed:

- YAML parse (yaml.safe_load) on all 11 files — pass.
- actionlint (via the rhysd/actionlint Docker image) on all 11 files — zero findings related to this change. The only output was pre-existing shellcheck SC2086 warnings inside untouched run: blocks.