### PR TITLE
chore(signals): fix scout test fixture leaking committed rows into reused test db

### DIFF
--- a/products/signals/backend/test/test_management_sync_signals_scout_skills.py
+++ b/products/signals/backend/test/test_management_sync_signals_scout_skills.py
@@ -68,6 +68,11 @@ class TestSyncSignalsScoutSkillsCommand(BaseTest):
         # Two teams; only one has enabled config.
         from posthog.models import Team
 
+        # `--all-enabled` scans configs across all teams, so residue committed by async
+        # tests (which bypass transaction rollback) in a --reuse-db database would leak in.
+        # Clear it here; this delete rolls back with the test transaction.
+        SignalScoutConfig.objects.unscoped().all().delete()
+
         other_team = Team.objects.create(organization=self.organization, name="OtherTeam")
         SignalScoutConfig.objects.create(team=self.team, enabled=True)
         SignalScoutConfig.objects.create(team=other_team, enabled=False)

--- a/products/signals/backend/test/test_scout_harness_tools.py
+++ b/products/signals/backend/test/test_scout_harness_tools.py
@@ -467,7 +467,11 @@ async def aorganization_emit():
     org = await database_sync_to_async(Organization.objects.create)(
         name="signals-scout-emit", is_ai_data_processing_approved=True
     )
-    return org
+    # These async tests commit (no transaction rollback across the worker thread), so
+    # delete explicitly — otherwise every run leaks an org/team with an enabled
+    # SignalScoutConfig into the reused test DB, breaking cross-team scans elsewhere.
+    yield org
+    await database_sync_to_async(org.delete)()
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Problem

`test_management_sync_signals_scout_skills.py::test_all_enabled_iterates_only_enabled_configs` fails on local checkouts and can flake in CI.

The `emit_finding` fixtures in `test_scout_harness_tools.py` (`aorganization_emit` / `ateam_emit`) create an organization, team, and an enabled `SignalScoutConfig` via `database_sync_to_async`. Async tests run DB work on a worker thread, so those writes commit for real instead of rolling back — and the fixtures never deleted them. With `--reuse-db` on by default in `pytest.ini`, every local run of that file leaks one more team with an enabled config into the persistent test database.

The `--all-enabled` management command test then does an (intentionally) unscoped cross-team scan of enabled configs, picks up all the stale teams, and reports `Synced N team(s)` instead of `Synced 1 team`. The same leak can hit CI within a single pytest session when the emit tests run before the management command test on the same shard.

## Changes

Test-only, no production code:

- `test_scout_harness_tools.py`: `aorganization_emit` now yields and deletes the organization afterward, cascading away the leaked team, configs, and runs — same pattern `test_scout_coordinator.py` already uses.
- `test_management_sync_signals_scout_skills.py`: the `--all-enabled` test clears all `SignalScoutConfig` rows at the start (inside its rolled-back test transaction), so it is hermetic against committed residue regardless of source.

## How did you test this code?

Agent-run automated tests only:

- `hogli test products/signals/backend/test/test_management_sync_signals_scout_skills.py` — 7 passed (the target test failed before the fix on a residue-polluted reused DB)
- `hogli test products/signals/backend/test/test_scout_harness_tools.py` — 55 passed, and verified no new `emit-team` rows remain in the test database afterward

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at Andy Maguire's direction after he hit the failure locally on clean master. Diagnosed by running the failing test, inspecting the reused test database (25 stale enabled configs across leaked `emit-team` teams), and tracing the leak to the commit-mode async fixtures. Considered only making the management command test hermetic, but fixed the fixture leak too so residue stops accumulating for other cross-team scans.
