### PR TITLE
perf(hogql): push joined person filters into the where_optimization prefilter

### DIFF
--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -99,19 +99,22 @@ def select_from_persons_table(
                 version = PersonsArgMaxVersion.V2
                 break
 
-    and_conditions = []
-
-    if filter is not None:
-        and_conditions.append(filter)
-
-    # For now, only do this optimization for directly querying the persons table (without joins or as part of a subquery) to avoid knock-on effects to insight queries
-    if (
+    is_direct_persons_select = (
         node.select_from
         and node.select_from.type
         and hasattr(node.select_from.type, "table")
         and node.select_from.type.table
         and isinstance(node.select_from.type.table, PersonsTable)
-    ):
+    )
+    # The id-prefilter below is correct for any predicate the extractor can rebase onto raw_persons: the
+    # prefilter admits a person when any version row matches, the argMax then resolves the true current
+    # row for those candidates, and the untouched outer predicate re-checks the resolved value. The
+    # explicit `filter` parameter is excluded because its placement carries its own semantics below.
+    use_where_optimization = filter is None and (
+        is_direct_persons_select
+        or (isinstance(join_or_table, LazyJoinToAdd) and context.modifiers.optimizeJoinedFilters)
+    )
+    if use_where_optimization:
         extractor = WhereClauseExtractor(context)
         extractor.add_local_tables(join_or_table)
         where = extractor.get_inner_where(node)
@@ -220,15 +223,6 @@ def select_from_persons_table(
                 select.where = And(exprs=[select.where, filter])
             else:
                 select.where = filter
-
-    if context.modifiers.optimizeJoinedFilters:
-        extractor = WhereClauseExtractor(context)
-        extractor.add_local_tables(join_or_table)
-        where = extractor.get_inner_where(node)
-        if where and select.where:
-            select.where = And(exprs=[select.where, where])
-        elif where:
-            select.where = where
 
     return select
 

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization
+# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization_0_events_join
   '''
   SELECT events.uuid AS uuid
   FROM events
@@ -36,7 +36,7 @@
                      use_hive_partitioning=0
   '''
 # ---
-# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization.1
+# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization_0_events_join.1
   '''
   SELECT events.uuid AS uuid
   FROM events
@@ -73,7 +73,7 @@
                      use_hive_partitioning=0
   '''
 # ---
-# name: TestPersonOptimization.test_joined_person_property_filter_via_person_distinct_ids
+# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization_1_person_distinct_ids_join
   '''
   SELECT person_distinct_ids.distinct_id AS distinct_id
   FROM
@@ -110,7 +110,7 @@
                      use_hive_partitioning=0
   '''
 # ---
-# name: TestPersonOptimization.test_joined_person_property_filter_via_person_distinct_ids.1
+# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization_1_person_distinct_ids_join.1
   '''
   SELECT person_distinct_ids.distinct_id AS distinct_id
   FROM

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons.ambr
@@ -1,4 +1,152 @@
 # serializer version: 1
+# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization
+  '''
+  SELECT events.uuid AS uuid
+  FROM events
+  INNER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS events__pdi___person_id,
+            tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+            person_distinct_id2.distinct_id AS distinct_id
+     FROM person_distinct_id2
+     WHERE equals(person_distinct_id2.team_id, 99999)
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+  INNER JOIN
+    (SELECT person.id AS id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', '') AS `properties___$some_prop`
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(events__pdi__person.`properties___$some_prop`, 'something'), 0))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonOptimization.test_joined_person_property_filter_uses_where_optimization.1
+  '''
+  SELECT events.uuid AS uuid
+  FROM events
+  INNER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS events__pdi___person_id,
+            tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+            person_distinct_id2.distinct_id AS distinct_id
+     FROM person_distinct_id2
+     WHERE equals(person_distinct_id2.team_id, 99999)
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+  INNER JOIN
+    (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', '')), person.version), 1) AS `properties___$some_prop`,
+            person.id AS id
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(id,
+                                                   (SELECT where_optimization.id AS id
+                                                    FROM person AS where_optimization
+                                                    WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0)))))
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(events__pdi__person.`properties___$some_prop`, 'something'), 0))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonOptimization.test_joined_person_property_filter_via_person_distinct_ids
+  '''
+  SELECT person_distinct_ids.distinct_id AS distinct_id
+  FROM
+    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_distinct_ids___person_id,
+            tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+            person_distinct_id2.distinct_id AS distinct_id
+     FROM person_distinct_id2
+     WHERE equals(person_distinct_id2.team_id, 99999)
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS person_distinct_ids
+  INNER JOIN
+    (SELECT person.id AS id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', '') AS `properties___$some_prop`
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS person_distinct_ids__person ON equals(person_distinct_ids.person_distinct_ids___person_id, person_distinct_ids__person.id)
+  WHERE ifNull(equals(person_distinct_ids__person.`properties___$some_prop`, 'something'), 0)
+  ORDER BY person_distinct_ids.distinct_id ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonOptimization.test_joined_person_property_filter_via_person_distinct_ids.1
+  '''
+  SELECT person_distinct_ids.distinct_id AS distinct_id
+  FROM
+    (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_distinct_ids___person_id,
+            tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+            person_distinct_id2.distinct_id AS distinct_id
+     FROM person_distinct_id2
+     WHERE equals(person_distinct_id2.team_id, 99999)
+     GROUP BY person_distinct_id2.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS person_distinct_ids
+  INNER JOIN
+    (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$some_prop'), ''), 'null'), '^"|"$', '')), person.version), 1) AS `properties___$some_prop`,
+            person.id AS id
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(id,
+                                                   (SELECT where_optimization.id AS id
+                                                    FROM person AS where_optimization
+                                                    WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, '$some_prop'), ''), 'null'), '^"|"$', ''), 'something'), 0)))))
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS person_distinct_ids__person ON equals(person_distinct_ids.person_distinct_ids___person_id, person_distinct_ids__person.id)
+  WHERE ifNull(equals(person_distinct_ids__person.`properties___$some_prop`, 'something'), 0)
+  ORDER BY person_distinct_ids.distinct_id ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestPersonOptimization.test_joins_are_left_alone_for_now
   '''
   SELECT events.uuid AS uuid

--- a/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
@@ -344,15 +344,15 @@
      GROUP BY person_distinct_id2.distinct_id
      HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS raw_session_replay_events__pdi ON equals(session_replay_events.distinct_id, raw_session_replay_events__pdi.distinct_id)
   LEFT JOIN
-    (SELECT person.id AS id,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'person_property'), ''), 'null'), '^"|"$', '') AS properties___person_property
+    (SELECT tupleElement(argMax(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'person_property'), ''), 'null'), '^"|"$', '')), person.version), 1) AS properties___person_property,
+            person.id AS id
      FROM person
-     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                   (SELECT person.id AS id, max(person.version) AS version
-                                                    FROM person
-                                                    WHERE equals(person.team_id, 99999)
-                                                    GROUP BY person.id
-                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'person_property'), ''), 'null'), '^"|"$', ''), 'true'), 0)) SETTINGS optimize_aggregation_in_order=1) AS raw_session_replay_events__pdi__person ON equals(raw_session_replay_events__pdi.raw_session_replay_events__pdi___person_id, raw_session_replay_events__pdi__person.id)
+     WHERE and(equals(person.team_id, 99999), in(id,
+                                                   (SELECT where_optimization.id AS id
+                                                    FROM person AS where_optimization
+                                                    WHERE and(equals(where_optimization.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties, 'person_property'), ''), 'null'), '^"|"$', ''), 'true'), 0)))))
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS raw_session_replay_events__pdi__person ON equals(raw_session_replay_events__pdi.raw_session_replay_events__pdi___person_id, raw_session_replay_events__pdi__person.id)
   WHERE and(equals(session_replay_events.team_id, 99999), ifNull(equals(raw_session_replay_events__pdi__person.properties___person_property, 'true'), 0))
   GROUP BY session_replay_events.session_id
   ORDER BY session_replay_events.session_id ASC

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -127,9 +127,17 @@ class TestPersonOptimization(ClickhouseTestMixin, APIBaseTest):
         modifiers.optimizeJoinedFilters = True
         return modifiers
 
+    @parameterized.expand(
+        [
+            ("events_join", "select uuid from events where person.properties.$some_prop = 'something'"),
+            (
+                "person_distinct_ids_join",
+                "select distinct_id from person_distinct_ids where person.properties.$some_prop = 'something' order by distinct_id",
+            ),
+        ]
+    )
     @snapshot_clickhouse_queries
-    def test_joined_person_property_filter_uses_where_optimization(self):
-        query = "select uuid from events where person.properties.$some_prop = 'something'"
+    def test_joined_person_property_filter_uses_where_optimization(self, _name: str, query: str):
         baseline = execute_hogql_query(parse_select(query), self.team, modifiers=self.modifiers)
         response = execute_hogql_query(parse_select(query), self.team, modifiers=self._modifiers_with_joined_filters())
         assert response.clickhouse
@@ -137,15 +145,6 @@ class TestPersonOptimization(ClickhouseTestMixin, APIBaseTest):
         self.assertNotIn("in(tuple(person.id, person.version)", response.clickhouse)
         assert sorted(response.results) == sorted(baseline.results)
         assert len(response.results) == 2
-
-    @snapshot_clickhouse_queries
-    def test_joined_person_property_filter_via_person_distinct_ids(self):
-        query = "select distinct_id from person_distinct_ids where person.properties.$some_prop = 'something' order by distinct_id"
-        baseline = execute_hogql_query(parse_select(query), self.team, modifiers=self.modifiers)
-        response = execute_hogql_query(parse_select(query), self.team, modifiers=self._modifiers_with_joined_filters())
-        assert response.clickhouse
-        self.assertIn("where_optimization", response.clickhouse)
-        assert response.results == baseline.results == [("1",), ("2",)]
 
     def test_joined_filters_do_not_match_stale_person_property_versions(self):
         changed = _create_person(

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -121,6 +121,60 @@ class TestPersonOptimization(ClickhouseTestMixin, APIBaseTest):
         self.assertIn("in(tuple(person.id, person.version)", response.clickhouse)
         self.assertNotIn("where_optimization", response.clickhouse)
 
+    def _modifiers_with_joined_filters(self) -> HogQLQueryModifiers:
+        modifiers = create_default_modifiers_for_team(self.team)
+        modifiers.personsOnEventsMode = PersonsOnEventsMode.DISABLED
+        modifiers.optimizeJoinedFilters = True
+        return modifiers
+
+    @snapshot_clickhouse_queries
+    def test_joined_person_property_filter_uses_where_optimization(self):
+        query = "select uuid from events where person.properties.$some_prop = 'something'"
+        baseline = execute_hogql_query(parse_select(query), self.team, modifiers=self.modifiers)
+        response = execute_hogql_query(parse_select(query), self.team, modifiers=self._modifiers_with_joined_filters())
+        assert response.clickhouse
+        self.assertIn("where_optimization", response.clickhouse)
+        self.assertNotIn("in(tuple(person.id, person.version)", response.clickhouse)
+        assert sorted(response.results) == sorted(baseline.results)
+        assert len(response.results) == 2
+
+    @snapshot_clickhouse_queries
+    def test_joined_person_property_filter_via_person_distinct_ids(self):
+        query = "select distinct_id from person_distinct_ids where person.properties.$some_prop = 'something' order by distinct_id"
+        baseline = execute_hogql_query(parse_select(query), self.team, modifiers=self.modifiers)
+        response = execute_hogql_query(parse_select(query), self.team, modifiers=self._modifiers_with_joined_filters())
+        assert response.clickhouse
+        self.assertIn("where_optimization", response.clickhouse)
+        assert response.results == baseline.results == [("1",), ("2",)]
+
+    def test_joined_filters_do_not_match_stale_person_property_versions(self):
+        changed = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["changed"],
+            properties={"$some_prop": "old_value"},
+            version=1,
+        )
+        create_person(
+            team_id=self.team.pk,
+            uuid=str(changed.uuid),
+            properties={"$some_prop": "new_value"},
+            version=2,
+        )
+        _create_event(event="$pageview", distinct_id="changed", team=self.team)
+        flush_persons_and_events()
+
+        query = "select uuid from events where person.properties.$some_prop = 'old_value'"
+        baseline = execute_hogql_query(parse_select(query), self.team, modifiers=self.modifiers)
+        response = execute_hogql_query(parse_select(query), self.team, modifiers=self._modifiers_with_joined_filters())
+        assert baseline.results == []
+        assert response.results == []
+
+        query_new = "select uuid from events where person.properties.$some_prop = 'new_value'"
+        response_new = execute_hogql_query(
+            parse_select(query_new), self.team, modifiers=self._modifiers_with_joined_filters()
+        )
+        assert len(response_new.results) == 1
+
     def test_person_modal_not_optimized_yet(self):
         source_query = TrendsQuery(
             series=[EventsNode(event="$pageview")],

--- a/posthog/hogql/database/schema/util/test/test_person_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_person_where_clause_extractor.py
@@ -76,9 +76,17 @@ class TestPersonWhereClauseExtractor(ClickhouseTestMixin, APIBaseTest):
         if where is None:
             return None
 
-        where = RemoveHiddenAliases().visit(where)
-        assert isinstance(where, ast.Expr)
-        return clone_expr(where, clear_types=True, clear_locations=True)
+        # Extracted filters land inside the where_optimization id-prefilter subquery:
+        # `id IN (SELECT id FROM raw_persons AS where_optimization WHERE <extracted>)`.
+        assert isinstance(where, ast.CompareOperation)
+        assert where.op == ast.CompareOperationOp.In
+        assert isinstance(where.right, ast.SelectQuery)
+        inner_where = where.right.where
+        assert inner_where is not None
+
+        inner_where = RemoveHiddenAliases().visit(inner_where)
+        assert isinstance(inner_where, ast.Expr)
+        return clone_expr(inner_where, clear_types=True, clear_locations=True)
 
     def print_query(self, query: str):
         context = self.prep_context()
@@ -191,7 +199,7 @@ class TestPersonWhereClauseExtractor(ClickhouseTestMixin, APIBaseTest):
         actual = self.print_query(
             "SELECT * FROM events WHERE person.id IN (select person_id from person_distinct_ids where distinct_id = '1')"
         )
-        assert "in(id, (SELECT person_distinct_ids.person_id" in actual
+        assert "in(where_optimization.id, (SELECT person_distinct_ids.person_id" in actual
 
     def test_boolean(self):
         PropertyDefinition.objects.get_or_create(
@@ -202,6 +210,6 @@ class TestPersonWhereClauseExtractor(ClickhouseTestMixin, APIBaseTest):
         )
         actual = self.print_query("SELECT * FROM events WHERE person.properties.person_boolean = false")
         assert (
-            f"ifNull(equals(toBool(transform(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties"
+            f"ifNull(equals(toBool(transform(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(where_optimization.properties"
             in actual
         )


### PR DESCRIPTION
## Problem

User-written HogQL that filters a joined persons table, for example `SELECT DISTINCT distinct_id FROM person_distinct_ids WHERE person.properties.email = 'x'`, compiles into a join against a persons subquery that builds the whole-team `(id, version) IN (SELECT id, max(version) ... GROUP BY id)` version-dedup set before any filtering happens. For one customer's recurring person-by-email lookup this means reading roughly 76M rows and peaking around 14 GiB of memory to return a handful of distinct ids, dozens of times per day.

The `optimizeJoinedFilters` modifier was supposed to help here, but its current placement ANDs the extracted filter onto the outer person scan, after the dedup set is already built. Measured on production with interleaved runs, that placement changes nothing: duration, memory, rows read and CPU are all within noise of the baseline.

Direct `FROM persons` selects already avoid this through the `where_optimization` id-prefilter added in #25824. The joined path was deliberately left out back then ("only for simple selects... to avoid knock-on effects"), and the modifier has sat default-off since the #25715 / #25731 reverts.

## Changes

When `optimizeJoinedFilters` is enabled and the persons table is reached through a lazy join, route the extracted filter into the same `where_optimization` id-prefilter shape that direct selects use, instead of ANDing it onto the outer scan:

- candidate person ids are admitted when any version row matches the extracted filter,
- the untouched argMax then resolves the true current row for those candidates,
- the outer predicate stays in place as the final check.

This ordering matters for correctness: filtering inside the version-dedup subquery instead (the obvious placement) can resolve a stale version as current for persons whose old property value matched but whose current one does not. A test covers exactly that scenario. The old outer-AND placement is removed since the new branch supersedes it whenever extraction succeeds, and extraction failing means neither placement had anything to do.

Production measurements on the customer query above (4 interleaved runs per arm, `use_query_condition_cache=0`, medians from `system.query_log`):

| Arm | Duration | Memory | Rows read | CPU |
|---|---|---|---|---|
| Baseline (modifier off, prod today) | 6.3 to 8.0s | 14 to 15.3 GiB | 75.9M | ~77s |
| Old placement (modifier on, before this PR) | no measurable change | no change | no change | no change |
| New id-prefilter placement | ~1.1s | 12.6 GiB | 50.4M | ~57s |

About 6x faster with a third less CPU and reads. The remaining memory is the `person_distinct_id2` aggregation on the left side of the join, which this layer cannot reduce.

The modifier default stays off. The 2024 reverts in this area came from a broader filter-first rewrite; this change is scoped to queries that opt in, and can be rolled out per team via `team.modifiers` (the customer above being the obvious first candidate) before any default flip is considered.

## How did you test this code?

I am an agent; automated tests plus the production measurements above:

- New tests in `posthog/hogql/database/schema/test/test_persons.py`: joined filter through events and through `person_distinct_ids` produces the `where_optimization` shape with results identical to the unoptimized baseline, and a stale-version test proving old property values do not match (person with `$some_prop` changed between versions: old value returns nothing, new value returns the row).
- `test_person_where_clause_extractor.py` updated for the new placement (the helper unwraps the id-prefilter subquery; the per-shape extraction assertions are unchanged in meaning). Two full-SQL assertions updated for the `where_optimization` alias.
- Session replay join-optimization snapshot regenerated; its results assertion passes unchanged.
- Full `posthog/hogql` tree: 5263 passed, 0 failed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session continuing a slow-query investigation: swept `query_log_archive` for slow user-written HogQL, picked the recurring person-lookup pattern (high memory, low result count), and confirmed via the compiled SQL that the predicate never reaches the persons subquery.
- Benchmarked four placements on production before writing code: baseline, the existing outer-AND placement (no effect), a filter inside the version-dedup subquery (fast but subtly wrong for persons whose old property versions matched), and the id-prefilter shape (fast and correct). Only then implemented the winning shape.
- Considered flipping the modifier default on in this PR and decided against it: the 2024 revert history in this area argues for per-team rollout first.
