### PR TITLE
fix(cymbal): make apple frame ids stable across aslr slides

### DIFF
--- a/rust/cymbal-resolution/tests/service_tests.rs
+++ b/rust/cymbal-resolution/tests/service_tests.rs
@@ -314,7 +314,7 @@ async fn admitted_items_emit_accepted_before_terminal_outcome() {
 async fn raw_frames_are_resolved_into_done_payload() {
     let raw_frame = sample_raw_frame();
     let mut resolver_frame = sample_resolved_frame(&raw_frame);
-    resolver_frame.frame_id = raw_frame.frame_id(123, 99);
+    resolver_frame.frame_id = raw_frame.frame_id(123, 99, &[]);
     let service = make_service(FakeResolver {
         fail_unhandled: false,
         resolved_frames: vec![resolver_frame],
@@ -525,7 +525,7 @@ fn sample_raw_frame() -> RawFrame {
 
 fn sample_resolved_frame(raw_frame: &RawFrame) -> Frame {
     Frame {
-        frame_id: raw_frame.frame_id(7, 0),
+        frame_id: raw_frame.frame_id(7, 0, &[]),
         mangled_name: "f".to_string(),
         line: Some(42),
         column: Some(7),

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -123,7 +123,7 @@ impl RawFrame {
         let res = res.map(|mut fs| {
             fs.iter_mut()
                 .enumerate()
-                .for_each(|(index, f)| f.frame_id = self.frame_id(team_id, index));
+                .for_each(|(index, f)| f.frame_id = self.frame_id(team_id, index, debug_images));
             fs
         });
 
@@ -170,7 +170,7 @@ impl RawFrame {
         }
     }
 
-    pub fn raw_id(&self, team_id: i32) -> RawFrameId {
+    pub fn raw_id(&self, team_id: i32, debug_images: &[AppleDebugImage]) -> RawFrameId {
         let hash_id = match self {
             RawFrame::JavaScriptWeb(raw) | RawFrame::LegacyJS(raw) => raw.frame_id(),
             RawFrame::JavaScriptNode(raw) => raw.frame_id(),
@@ -183,14 +183,19 @@ impl RawFrame {
             RawFrame::Hermes(raw) => raw.frame_id(),
             RawFrame::Java(raw) => raw.frame_id(),
             RawFrame::Dart(raw) => raw.frame_id(),
-            RawFrame::Apple(raw) => raw.frame_id(),
+            RawFrame::Apple(raw) => raw.frame_id(debug_images),
         };
 
         RawFrameId::new(hash_id, team_id)
     }
 
-    pub fn frame_id(&self, team_id: i32, index: usize) -> FrameId {
-        self.raw_id(team_id).to_full(index as i32)
+    pub fn frame_id(
+        &self,
+        team_id: i32,
+        index: usize,
+        debug_images: &[AppleDebugImage],
+    ) -> FrameId {
+        self.raw_id(team_id, debug_images).to_full(index as i32)
     }
 
     pub fn is_suspicious(&self) -> bool {

--- a/rust/cymbal/src/langs/apple.rs
+++ b/rust/cymbal/src/langs/apple.rs
@@ -410,11 +410,23 @@ impl RawAppleFrame {
         frame
     }
 
-    pub fn frame_id(&self) -> String {
+    pub fn frame_id(&self, debug_images: &[AppleDebugImage]) -> String {
         let mut hasher = Sha512::new();
 
-        if let Some(instruction_addr) = &self.instruction_addr {
-            hasher.update(instruction_addr.as_bytes());
+        // Absolute instruction addresses are ASLR-slid per process launch, so hashing
+        // them directly gives the same logical frame a different id every launch and
+        // the frame record cache never hits. Hash the launch-invariant
+        // (debug image, relative offset) identity instead whenever we can compute it.
+        match self.launch_invariant_addr(debug_images) {
+            Some((debug_id, relative_addr)) => {
+                hasher.update(debug_id.as_bytes());
+                hasher.update(format!("rel:0x{relative_addr:x}").as_bytes());
+            }
+            None => {
+                if let Some(instruction_addr) = &self.instruction_addr {
+                    hasher.update(instruction_addr.as_bytes());
+                }
+            }
         }
 
         if let Some(module) = &self.module {
@@ -430,6 +442,15 @@ impl RawAppleFrame {
         }
 
         format!("{:x}", hasher.finalize())
+    }
+
+    fn launch_invariant_addr(&self, debug_images: &[AppleDebugImage]) -> Option<(String, u64)> {
+        let instruction_addr = parse_hex_address(self.instruction_addr.as_ref()?).ok()?;
+        let debug_image = self.find_debug_image(instruction_addr, debug_images).ok()?;
+        let relative_addr = self
+            .calculate_relative_addr(instruction_addr, debug_image)
+            .ok()?;
+        Some((debug_image.debug_id.clone(), relative_addr))
     }
 }
 
@@ -982,5 +1003,74 @@ mod test {
             all_lines.iter().any(|l| l.contains("volatile int x = 99")),
             "expected 'volatile int x = 99' in inlined_leaf context, got: {all_lines:?}"
         );
+    }
+
+    fn frame_at(instruction_addr: u64, image_addr: u64) -> RawAppleFrame {
+        RawAppleFrame {
+            instruction_addr: Some(format!("0x{instruction_addr:x}")),
+            symbol_addr: None,
+            image_addr: Some(format!("0x{image_addr:x}")),
+            image_uuid: None,
+            module: Some("MyApp".to_string()),
+            function: None,
+            filename: None,
+            lineno: None,
+            colno: None,
+            meta: CommonFrameMetadata::default(),
+        }
+    }
+
+    fn image_at(debug_id: &str, image_addr: u64) -> AppleDebugImage {
+        AppleDebugImage {
+            debug_id: debug_id.to_string(),
+            image_addr: format!("0x{image_addr:x}"),
+            image_vmaddr: None,
+            image_size: Some(0x10000),
+            code_file: None,
+            image_type: None,
+            arch: None,
+        }
+    }
+
+    #[test]
+    fn test_frame_id_stable_across_aslr_slides() {
+        // Same logical frame (same image, same relative offset) from two launches
+        // with different ASLR slides must produce the same frame id.
+        let launch_a = frame_at(0x100004000, 0x100000000);
+        let launch_b = frame_at(0x104f04000, 0x104f00000);
+
+        let id_a = launch_a.frame_id(&[image_at("uuid-build-1", 0x100000000)]);
+        let id_b = launch_b.frame_id(&[image_at("uuid-build-1", 0x104f00000)]);
+
+        assert_eq!(id_a, id_b);
+    }
+
+    #[test]
+    fn test_frame_id_distinguishes_builds() {
+        let launch_a = frame_at(0x100004000, 0x100000000);
+        let launch_b = frame_at(0x100004000, 0x100000000);
+
+        let id_a = launch_a.frame_id(&[image_at("uuid-build-1", 0x100000000)]);
+        let id_b = launch_b.frame_id(&[image_at("uuid-build-2", 0x100000000)]);
+
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn test_frame_id_distinguishes_call_sites_within_image() {
+        let images = [image_at("uuid-build-1", 0x100000000)];
+
+        let id_a = frame_at(0x100004000, 0x100000000).frame_id(&images);
+        let id_b = frame_at(0x100004004, 0x100000000).frame_id(&images);
+
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn test_frame_id_falls_back_to_absolute_addr_without_debug_image() {
+        let launch_a = frame_at(0x100004000, 0x100000000);
+        let launch_b = frame_at(0x104f04000, 0x104f00000);
+
+        assert_ne!(launch_a.frame_id(&[]), launch_b.frame_id(&[]));
     }
 }

--- a/rust/cymbal/src/stages/resolution/frame.rs
+++ b/rust/cymbal/src/stages/resolution/frame.rs
@@ -89,7 +89,7 @@ impl FrameResolver {
             .iter_mut()
             .enumerate()
             .for_each(|(index, resolved_frame)| {
-                resolved_frame.frame_id = frame.frame_id(team_id, index);
+                resolved_frame.frame_id = frame.frame_id(team_id, index, debug_images);
             });
 
         Ok(resolved_frames)

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -109,7 +109,7 @@ impl LocalSymbolResolver {
         if frame.is_suspicious() {
             metrics::counter!(SUSPICIOUS_FRAMES_DETECTED, "frame_type" => "raw").increment(1);
         }
-        let raw_id = frame.raw_id(team_id);
+        let raw_id = frame.raw_id(team_id, debug_images);
         let mut cache_miss = false;
         let frames = self
             .cache
@@ -445,7 +445,7 @@ mod test {
             .unwrap();
 
         // get the frame
-        let frame_id = frame.raw_id(0);
+        let frame_id = frame.raw_id(0, &[]);
         let frame = ErrorTrackingStackFrame::load_all(&pool, &frame_id, resolver.ttl_policy)
             .await
             .unwrap()

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -498,6 +498,7 @@ impl Stacktrace {
         &self,
         team_id: i32,
         lookup_table: &HashMap<RawFrameId, Vec<Frame>>,
+        debug_images: &[AppleDebugImage],
     ) -> Option<Self> {
         let Stacktrace::Raw { frames: raw_frames } = self else {
             return Some(self.clone());
@@ -505,7 +506,7 @@ impl Stacktrace {
 
         let mut resolved_frames = Vec::with_capacity(raw_frames.len() + 10);
         for raw_frame in raw_frames {
-            match lookup_table.get(&raw_frame.raw_id(team_id)) {
+            match lookup_table.get(&raw_frame.raw_id(team_id, debug_images)) {
                 Some(resolved) => resolved_frames.extend(resolved.clone()),
                 None => return None,
             }


### PR DESCRIPTION
## Problem

Cymbal caches resolved stack frames (in-memory and in `posthog_errortrackingstackframe`) keyed by a hash of the raw frame, so each unique frame only pays for symbolication once per TTL.

For Apple frames that hash includes the absolute `instruction_addr`, which is ASLR-slid on every process launch — the same logical frame produces a different frame id every launch. Since a crash ends the process, every crash event arrives from a fresh launch with fresh ids, so for Apple traffic the cache effectively never hits: every frame of every event does the lookup, full resolution, and inserts frame rows under a key that never recurs (write-only rows, since the only read path is by `raw_id`). Symbolication output and issue grouping are correct throughout — this is purely a cache-efficiency and table-growth bug.

## Changes

- Hash the launch-invariant frame identity instead: the matched debug image's `debug_id` plus the relative offset (`instruction_addr - image_addr`) — the same normalization symbolication already uses when resolving the frame.
- Thread the event's `debug_images` into `RawFrame::raw_id` / `RawFrame::frame_id` so the cache key, the saved record ids, and the re-stamped resolved frame ids all derive from the same inputs. Only the Apple arm uses them; the build identity has to come from the event-level debug image list because Apple SDK frames don't carry a per-frame `image_uuid`.
- Fall back to hashing the absolute address when no debug image matches (previous behavior; such frames can't be symbolicated either way).
- Existing cached Apple rows are orphaned by the key change; they were unreachable across launches anyway, and frame ids stored on already-processed events keep working because frontend lookups use the stored id.

## How did you test this code?

I'm an agent — automated tests only:

- New unit tests in `langs/apple.rs`: the same logical frame across two ASLR slides hashes equal; different debug ids (different builds) hash differently; different call sites within one image hash differently; the no-debug-image fallback keeps the old per-launch behavior.
- Full `cymbal` and `cymbal-resolution` suites: 193 passed across 18 suites, including the Postgres-backed frame cache round-trip tests and the gRPC resolution service tests.
- `cargo clippy --all-targets` clean for both crates.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe frame id derivation or the frame cache; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code; reviewed with a structured Codex review pass (no actionable findings) on top of the test suites above.
- Considered deriving the key from per-frame fields only (the frame's own `image_addr`) to avoid threading `debug_images`, but rejected it: without a build identifier in the key, two different app builds could collide on (module, relative offset) and serve a stale cached resolution across builds. Matching against the event's debug images mirrors what resolution does and pins the key to `debug_id`.
