### PR TITLE
fix(logs): match log attributes by string for equality, not coerced float

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -180,6 +180,22 @@ def _get_property_type(value) -> str:
     return "str"
 
 
+# Operators whose semantics are genuinely numeric and therefore need the `__float` attribute
+# map (string comparison would order `"100" < "99"` lexicographically). Every other operator is
+# equality / substring / regex identity matching and MUST use `__str` — see the comment in
+# `LogsFilterBuilder.__init__` for why routing equality to `__float` is a correctness bug.
+_NUMERIC_COMPARISON_OPERATORS = frozenset(
+    {
+        PropertyOperator.GT,
+        PropertyOperator.GTE,
+        PropertyOperator.LT,
+        PropertyOperator.LTE,
+        PropertyOperator.BETWEEN,
+        PropertyOperator.NOT_BETWEEN,
+    }
+)
+
+
 class LogsFilterBuilder:
     """Builds HogQL WHERE clause AST from LogsQuery filter fields.
 
@@ -219,14 +235,20 @@ class LogsFilterBuilder:
                     [f for f in property_group.values if f.type == LogPropertyFilterType.LOG],
                 )
 
-            # dynamically detect type of the given property values
-            # if they all convert cleanly to float, use the __float property mapping instead
-            # we keep multiple attribute maps for different types:
-            # attribute_map_str
-            # attribute_map_float
-            # attribute_map_datetime
+            # Pick which per-type attribute map to read from. We keep multiple maps:
+            #   attributes_map_str / attributes_map_float / attributes_map_datetime
+            # `attributes_map_float` is MATERIALIZED from `attributes_map_str` via
+            # `toFloat64OrNull`, so every value present in float is also present in str.
             #
-            # for now we'll just check str and float as we need a decent UI for datetime filtering.
+            # The `__float` map is ONLY needed for genuine numeric range comparisons
+            # (`>`, `<`, between) where lexicographic string ordering would be wrong.
+            # For equality / identity matching (Exact, IN, IsNot, contains, regex) we must
+            # stay on `__str`: routing those to `__float` silently coerces values, which is
+            # a correctness bug — distinct_ids "007", "7", and "7.0" all collapse to the
+            # float 7.0 (one person's logs leak onto another), and numeric IDs above 2^53
+            # lose float64 precision. This is the root cause of all-numeric distinct_ids
+            # failing to link logs to a person on the profile Logs tab (the pivot filter
+            # uses Exact, so it was being routed to `__float`).
             for property_filter in self.query.filterGroup.values[0].values:
                 # we only do the type mapping for log attributes
                 if property_filter.type != LogPropertyFilterType.LOG_ATTRIBUTE:
@@ -234,14 +256,15 @@ class LogsFilterBuilder:
 
                 if isinstance(property_filter, LogPropertyFilter) and property_filter.value:
                     property_type = "str"
-                    if isinstance(property_filter.value, list):
-                        property_types = {_get_property_type(v) for v in property_filter.value}
-                        # only use the detected type if all given values have the same type
-                        # e.g. if values are '1', '2', we can use float, if values are '1', 'a', stick to str
-                        if len(property_types) == 1:
-                            property_type = property_types.pop()
-                    else:
-                        property_type = _get_property_type(property_filter.value)
+                    if property_filter.operator in _NUMERIC_COMPARISON_OPERATORS:
+                        if isinstance(property_filter.value, list):
+                            property_types = {_get_property_type(v) for v in property_filter.value}
+                            # only use the detected type if all given values have the same type
+                            # e.g. if values are '1', '2', we can use float, if values are '1', 'a', stick to str
+                            if len(property_types) == 1:
+                                property_type = property_types.pop()
+                        else:
+                            property_type = _get_property_type(property_filter.value)
 
                     # defensive copy as we mutate the filter here and don't want to impact other copies
                     property_filter = property_filter.copy(deep=True)

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -184,7 +184,7 @@ def _get_property_type(value) -> str:
 # map (string comparison would order `"100" < "99"` lexicographically). Every other operator is
 # equality / substring / regex identity matching and MUST use `__str` — see the comment in
 # `LogsFilterBuilder.__init__` for why routing equality to `__float` is a correctness bug.
-_NUMERIC_COMPARISON_OPERATORS = frozenset(
+_NUMERIC_COMPARISON_OPERATORS: frozenset[PropertyOperator] = frozenset(
     {
         PropertyOperator.GT,
         PropertyOperator.GTE,

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -23,6 +23,7 @@ from posthog.hogql.query import HogQLQueryExecutor
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
+from posthog.models.utils import UUIDT
 
 from products.logs.backend.logs_query_runner import LogsQueryRunner
 
@@ -1007,3 +1008,111 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         }
         response = self._make_logs_api_request(query_params)
         self.assertGreater(len(response["results"]), 0)
+
+
+class TestNumericDistinctIdLinking(ClickhouseTestMixin, APIBaseTest):
+    """End-to-end reproduction of the Circleback bug: logs whose person-pivot attribute
+    holds a numeric-looking string (e.g. a customer's own user PK `69339`) must link to
+    that person, and exact matching must not collide across zero-padded / float-equal
+    variants (`"7"` vs `"007"`). Inserts real rows and queries through the API so the
+    `__str` vs `__float` map routing is exercised against stored data, not just asserted
+    on generated SQL."""
+
+    def _insert_logs(self, rows: list[dict]) -> None:
+        full = [
+            {
+                "uuid": str(UUIDT()),
+                "team_id": self.team.id,
+                "body": "",
+                "severity_text": "info",
+                "severity_number": 9,
+                "service_name": "web",
+                "resource_attributes": {},
+                **row,
+            }
+            for row in rows
+        ]
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in full))
+
+    def _query_pivot(self, values: list[str], key: str = "posthogDistinctId") -> list[dict]:
+        query_params = {
+            "dateRange": {"date_from": "2026-01-01T09:00:00Z", "date_to": "2026-01-01T11:00:00Z"},
+            "limit": 50,
+            "filterGroup": {
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [{"key": key, "value": values, "operator": "exact", "type": "log_attribute"}],
+                    }
+                ],
+            },
+        }
+        response = self.client.post(f"/api/projects/{self.team.id}/logs/query", data={"query": query_params})
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        return response.json()["results"]
+
+    def test_all_numeric_distinct_id_links(self):
+        """A person whose only distinct_id is the numeric string `69339` (no anonymous UUID
+        to mask the routing) still matches their logs. Pre-fix this routed to `__float` and
+        silently missed."""
+        self._insert_logs(
+            [
+                {
+                    "timestamp": "2026-01-01 10:00:00.000000",
+                    "body": "numeric-user-log",
+                    "attributes_map_str": {"posthogDistinctId__str": "69339"},
+                }
+            ]
+        )
+        results = self._query_pivot(["69339"])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["body"], "numeric-user-log")
+
+    def test_zero_padded_and_float_equal_values_do_not_collide(self):
+        """`"7"`, `"007"`, and `"7.0"` all coerce to the float 7.0 — under `__float` an exact
+        filter for one would wrongly return all three (cross-person log leakage). Under `__str`
+        each is an exact, distinct string."""
+        self._insert_logs(
+            [
+                {
+                    "timestamp": "2026-01-01 10:00:00.000000",
+                    "body": "user-7",
+                    "attributes_map_str": {"posthogDistinctId__str": "7"},
+                },
+                {
+                    "timestamp": "2026-01-01 10:00:01.000000",
+                    "body": "user-007",
+                    "attributes_map_str": {"posthogDistinctId__str": "007"},
+                },
+                {
+                    "timestamp": "2026-01-01 10:00:02.000000",
+                    "body": "user-7-dot-0",
+                    "attributes_map_str": {"posthogDistinctId__str": "7.0"},
+                },
+            ]
+        )
+        bodies = {r["body"] for r in self._query_pivot(["7"])}
+        self.assertEqual(bodies, {"user-7"}, f"exact match for '7' leaked other people's logs: {bodies}")
+
+    def test_large_numeric_distinct_id_keeps_precision(self):
+        """A numeric distinct_id beyond float64 integer precision (> 2^53) must match exactly.
+        Under `__float` it would round and collide/mismatch; under `__str` it's exact."""
+        big = "9007199254740993"  # 2^53 + 1, not representable exactly as float64
+        neighbor = "9007199254740992"  # 2^53, the value `big` rounds to
+        self._insert_logs(
+            [
+                {
+                    "timestamp": "2026-01-01 10:00:00.000000",
+                    "body": "big-id",
+                    "attributes_map_str": {"posthogDistinctId__str": big},
+                },
+                {
+                    "timestamp": "2026-01-01 10:00:01.000000",
+                    "body": "neighbor-id",
+                    "attributes_map_str": {"posthogDistinctId__str": neighbor},
+                },
+            ]
+        )
+        bodies = {r["body"] for r in self._query_pivot([big])}
+        self.assertEqual(bodies, {"big-id"}, f"large numeric id lost precision / collided: {bodies}")

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -82,6 +82,77 @@ class TestAttributeFilters(APIBaseTest):
         # this optimization was premature and needs more thought, and probably has very little benefit anyway
         self.assertNotIn("in(resource_fingerprint", query_str)
 
+    def _attribute_filter_for(self, *, key, operator, value):
+        """Build a single LogAttribute filter and return the LogsFilterBuilder's processed
+        copy, whose `.key` carries the `__str` / `__float` suffix the routing logic chose."""
+        query = LogsQuery(
+            dateRange=DateRange(date_from="2024-01-10T00:00:00Z", date_to="2024-01-15T23:59:59Z"),
+            serviceNames=[],
+            severityLevels=[],
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    PropertyGroupFilterValue(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            LogPropertyFilter(
+                                key=key,
+                                operator=operator,
+                                type=LogPropertyFilterType.LOG_ATTRIBUTE,
+                                value=value,
+                            )
+                        ],
+                    )
+                ],
+            ),
+            kind="LogsQuery",
+        )
+        af = LogsQueryRunner(query=query, team=self.team)._filter_builder.attribute_filters
+        self.assertEqual(len(af), 1)
+        return af[0]
+
+    @parameterized.expand(
+        [
+            # Equality / identity operators on numeric-looking values MUST route to __str.
+            ("exact_single_numeric", PropertyOperator.EXACT, "69339"),
+            ("exact_numeric_list", PropertyOperator.EXACT, ["5", "8675309"]),
+            ("is_not_numeric", PropertyOperator.IS_NOT, ["5"]),
+            ("icontains_numeric", PropertyOperator.ICONTAINS, "500"),
+        ]
+    )
+    def test_equality_operators_on_numeric_values_route_to_str(self, _name, operator, value):
+        """Regression: numeric distinct_ids (e.g. `69339`) must be matched in the `__str`
+        map, not `__float`. Routing equality to `__float` is the root cause of all-numeric
+        distinct_ids failing to link logs to a person on the profile Logs tab."""
+        f = self._attribute_filter_for(key="posthog.distinct_id", operator=operator, value=value)
+        self.assertTrue(f.key.endswith("__str"), f"expected __str routing, got {f.key!r}")
+        self.assertFalse(f.key.endswith("__float"))
+
+    @parameterized.expand(
+        [
+            ("gt", PropertyOperator.GT),
+            ("gte", PropertyOperator.GTE),
+            ("lt", PropertyOperator.LT),
+            ("lte", PropertyOperator.LTE),
+        ]
+    )
+    def test_numeric_range_operators_still_route_to_float(self, _name, operator):
+        """Numeric range comparisons keep `__float` routing — string ordering would be
+        lexicographically wrong (`"100" < "99"`). This is what the fix deliberately preserves."""
+        f = self._attribute_filter_for(key="duration_ms", operator=operator, value="500")
+        self.assertTrue(f.key.endswith("__float"), f"expected __float routing, got {f.key!r}")
+
+    def test_leading_zero_and_plain_numeric_do_not_collide(self):
+        """`"007"` and `"7"` both parse as float 7.0, so under `__float` they would collide
+        (one person's logs leaking onto another). Under `__str` they stay distinct, exact
+        string values — verify both route to `__str` and keep their literal value."""
+        f_007 = self._attribute_filter_for(key="posthog.distinct_id", operator=PropertyOperator.EXACT, value=["007"])
+        f_7 = self._attribute_filter_for(key="posthog.distinct_id", operator=PropertyOperator.EXACT, value=["7"])
+        self.assertTrue(f_007.key.endswith("__str"))
+        self.assertTrue(f_7.key.endswith("__str"))
+        self.assertEqual(f_007.value, ["007"])
+        self.assertEqual(f_7.value, ["7"])
+
     def test_resource_attribute_filters(self):
         """Test that resource attribute filters are properly handled"""
         query = LogsQuery(
@@ -237,8 +308,10 @@ class TestAttributeFilters(APIBaseTest):
         assert executor.clickhouse_prepared_ast is not None
         query_str = executor.clickhouse_prepared_ast.to_hogql()
 
-        # All filter types should be present
-        self.assertIn("http.status_code__float", query_str)
+        # All filter types should be present. `http.status_code` uses Exact (equality),
+        # so it routes to the `__str` map — equality/identity matching never uses `__float`
+        # (that's reserved for numeric range comparisons). See test_*_routes_to_str/float below.
+        self.assertIn("http.status_code__str", query_str)
         self.assertIn("service.name", query_str)
         self.assertIn("message", query_str)
         self.assertNotIn("service.name__str", query_str)


### PR DESCRIPTION
## Problem

Numeric distinct_ids (e.g. `69339`, `5`) silently fail to link logs to a person on the profile **Logs** tab. The person-tab filter is an `Exact` match on the person's distinct_ids, and the logs query runner detects the value type and routes numeric-looking values to the `attributes_map_float` ClickHouse map.

That routing is wrong for identity matching:

- `attributes_map_float` is `MATERIALIZED` from `attributes_map_str` via `toFloat64OrNull`, so float comparison **coerces**. distinct_ids `"007"`, `"7"`, and `"7.0"` all collapse to the float `7.0` — one person's logs leak onto another — and numeric IDs above 2^53 lose float64 precision.
- Because the pivot uses `Exact`, an **all-numeric** distinct_id list was routed to `__float`; a **mixed** list (numeric + the anonymous SDK UUID) fell back to `__str` and worked. That's why the bug looked intermittent — it only bit people whose distinct_ids are *all* numeric.

This was traced from a real case: a person with distinct_id `69339` (the customer's own numeric user PK) + an anonymous UUID, custom pivot key `posthog.distinct_id`, empty Logs tab. A manual `posthog.distinct_id = 5` filter returned logs (float path, single value) while the same person's tab returned none (str path, mixed list) — the two were querying different ClickHouse maps for the same value.

## Changes

`products/logs/backend/logs_query_runner.py` — route to `__float` **only** for genuine numeric-range operators (`>`, `>=`, `<`, `<=`, `between`, `not_between`), where lexicographic string ordering would be wrong (`"100" < "99"`). Every equality / identity operator (Exact, IN, IsNot, contains, regex, …) now uses `__str`:

- `__str` is the canonical storage for every value (float is derived from it), so equality matching there is complete, exact, and collision-free.
- Range queries (`duration_ms > 500`) keep `__float` routing unchanged.

A new `_NUMERIC_COMPARISON_OPERATORS` frozenset gates the float detection; the detection logic itself is otherwise untouched.

## Scope / blast radius

Deliberately contained:

- `_get_property_type` and the `__str`/`__float` routing are **logs-only** — not shared with spans, metrics, events, feature flags, or cohorts (verified; the 3 other `_get_property_type` symbols in the repo are unrelated name collisions).
- distinct_id matching for events / persons / replay goes through the real `distinct_id` String column, **not** attribute maps — so this has **no implications outside logs-to-person linking**.
- The only behavior delta for *manual* log filtering: an `Exact` match on a numeric-looking attribute value (e.g. `status_code = 200`) now matches the exact string instead of coerce-matching `200.0` / `200`. That's a correctness improvement, not a regression — and range filtering is untouched.

## How did you test this code?

I'm an agent (PostHog Code / Opus 4.8). Added builder-level regression tests in `products/logs/backend/test/test_logs_query_runner.py` that assert the `__str`/`__float` suffix the routing chooses (deterministic — they bypass the full executor/HogQL-parser pipeline, which has a pre-existing local parser-shadow divergence on unrelated SQL):

- equality operators (Exact single, Exact list, IsNot, IContains) on numeric values → `__str`
- range operators (GT/GTE/LT/LTE) → `__float` (preserved)
- `"007"` vs `"7"` both route to `__str` with literal values intact (collision regression)
- updated `test_mixed_attribute_filters`, which previously asserted the buggy `http.status_code__float` for an `Exact` match

**10/10 passing locally.** `ruff` + `ty` clean via pre-commit.

## Notes for reviewers

- Standalone fix off `master`, intended to **ship first**. The in-flight multi-key PR (#61312) has its own type-detection in a separate helper that needs the same equality→str treatment; that will be reconciled in a follow-up once this lands (rebase #61312 on top, or fold the rule into its helper).
- No migration, no schema change, no frontend change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — observable behavior is "numeric distinct_ids now link correctly," which matches what `/docs/logs/link-person` already promises.

## 🤖 Agent context

PostHog Code (Opus 4.8). Root-caused from customer screenshots: confirmed via generated HogQL that a single numeric value routes to `attributes.posthog.distinct_id__float` while a mixed list routes to `__str`, then traced the float map's `toFloat64OrNull` derivation to explain the coercion/collision. Considered fixing in the person-pivot only, but on master there's no per-filter signal to distinguish the pivot from a manual filter without a schema change — so the fix keys off operator semantics instead, which is both sufficient (the pivot uses Exact) and a broader correctness win (kills the collision class for all equality matches) while preserving float for the range operators that genuinely need it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*