### PR TITLE
feat(logs): pro-rate billing for rows removed by drop rules

### DIFF
--- a/nodejs/src/logs-ingestion/config.ts
+++ b/nodejs/src/logs-ingestion/config.ts
@@ -49,6 +49,13 @@ export type LogsIngestionConsumerConfig = {
     LOGS_SAMPLING_ENABLED_TEAMS: string
     /** When `true`, sampling always keeps every record (metrics path may still run). */
     LOGS_SAMPLING_KILLSWITCH: boolean
+    /**
+     * When `true`, rows removed by drop rules are credited back to the billed usage metrics
+     * (`bytes_ingested` / `records_ingested`). When `false` (default), the credit is only
+     * computed and observable via the `logs_ingestion_billing_*_credited_total` counters
+     * (shadow mode) — billing is unchanged.
+     */
+    LOGS_BILLING_PRORATE_ENABLED: boolean
     REDIS_URL: string
     REDIS_POOL_MIN_SIZE: number
     REDIS_POOL_MAX_SIZE: number
@@ -75,6 +82,7 @@ export function getDefaultLogsIngestionConsumerConfig(): LogsIngestionConsumerCo
         LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND: '',
         LOGS_SAMPLING_ENABLED_TEAMS: '*',
         LOGS_SAMPLING_KILLSWITCH: false,
+        LOGS_BILLING_PRORATE_ENABLED: false,
         // Overlapping fields with CommonConfig, included for standalone usage
         // ok to connect to localhost over plaintext
         // nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport

--- a/nodejs/src/logs-ingestion/logs-billing.test.ts
+++ b/nodejs/src/logs-ingestion/logs-billing.test.ts
@@ -1,31 +1,17 @@
 import { billingByteReductionForDrops } from './logs-ingestion-consumer'
 
 describe('billingByteReductionForDrops', () => {
-    it('credits the dropped content fraction of the header', () => {
-        // 60% of content dropped → credit 60% of the 1000-byte header.
-        expect(billingByteReductionForDrops(1000, 600, 1000)).toBe(600)
-    })
-
-    it('credits nothing when no rows were dropped', () => {
-        expect(billingByteReductionForDrops(1000, 0, 1000)).toBe(0)
-    })
-
-    it('credits the full header when every row is dropped', () => {
-        expect(billingByteReductionForDrops(1000, 1000, 1000)).toBe(1000)
-    })
-
-    it('credits nothing when we cannot measure (no per-row bytes / no header)', () => {
-        expect(billingByteReductionForDrops(1000, 50, 0)).toBe(0)
-        expect(billingByteReductionForDrops(0, 50, 100)).toBe(0)
-    })
-
-    it('caps the dropped fraction at 1 (defensive)', () => {
-        expect(billingByteReductionForDrops(1000, 1500, 1000)).toBe(1000)
-    })
-
-    it('rounds to whole bytes', () => {
-        // 1000 × 1/3 = 333.33 → 333
-        expect(billingByteReductionForDrops(1000, 1, 3)).toBe(333)
+    it.each<[string, number, number, number, number]>([
+        // label, headerBytes, bytesDropped, bytesTotal, expected
+        ['credits the dropped content fraction of the header', 1000, 600, 1000, 600],
+        ['credits nothing when no rows were dropped', 1000, 0, 1000, 0],
+        ['credits the full header when every row is dropped', 1000, 1000, 1000, 1000],
+        ['credits nothing when bytesTotal is zero (unmeasurable)', 1000, 50, 0, 0],
+        ['credits nothing when headerBytes is zero (unmeasurable)', 0, 50, 100, 0],
+        ['caps the dropped fraction at 1 (defensive)', 1000, 1500, 1000, 1000],
+        ['rounds to whole bytes (1000 × 1/3 = 333.33 → 333)', 1000, 1, 3, 333],
+    ])('%s', (_label, headerBytes, bytesDropped, bytesTotal, expected) => {
+        expect(billingByteReductionForDrops(headerBytes, bytesDropped, bytesTotal)).toBe(expected)
     })
 
     it('content- and record-weighted credits diverge on size-skewed drops (Tier 2 confidence signal)', () => {

--- a/nodejs/src/logs-ingestion/logs-billing.test.ts
+++ b/nodejs/src/logs-ingestion/logs-billing.test.ts
@@ -1,0 +1,30 @@
+import { billingByteReductionForDrops } from './logs-ingestion-consumer'
+
+describe('billingByteReductionForDrops', () => {
+    it('credits the dropped content fraction of the header', () => {
+        // 60% of content dropped → credit 60% of the 1000-byte header.
+        expect(billingByteReductionForDrops(1000, 600, 1000)).toBe(600)
+    })
+
+    it('credits nothing when no rows were dropped', () => {
+        expect(billingByteReductionForDrops(1000, 0, 1000)).toBe(0)
+    })
+
+    it('credits the full header when every row is dropped', () => {
+        expect(billingByteReductionForDrops(1000, 1000, 1000)).toBe(1000)
+    })
+
+    it('credits nothing when we cannot measure (no per-row bytes / no header)', () => {
+        expect(billingByteReductionForDrops(1000, 50, 0)).toBe(0)
+        expect(billingByteReductionForDrops(0, 50, 100)).toBe(0)
+    })
+
+    it('caps the dropped fraction at 1 (defensive)', () => {
+        expect(billingByteReductionForDrops(1000, 1500, 1000)).toBe(1000)
+    })
+
+    it('rounds to whole bytes', () => {
+        // 1000 × 1/3 = 333.33 → 333
+        expect(billingByteReductionForDrops(1000, 1, 3)).toBe(333)
+    })
+})

--- a/nodejs/src/logs-ingestion/logs-billing.test.ts
+++ b/nodejs/src/logs-ingestion/logs-billing.test.ts
@@ -27,4 +27,19 @@ describe('billingByteReductionForDrops', () => {
         // 1000 × 1/3 = 333.33 → 333
         expect(billingByteReductionForDrops(1000, 1, 3)).toBe(333)
     })
+
+    it('content- and record-weighted credits diverge on size-skewed drops (Tier 2 confidence signal)', () => {
+        // header 10000; the dropped rows are 90% of content but only 10% of records (big rows dropped).
+        const header = 10000
+        const contentCredit = billingByteReductionForDrops(header, 9000, 10000) // 9000
+        const recordCredit = billingByteReductionForDrops(header, 1, 10) // 1000
+        // Large divergence ⇒ skewed batch ⇒ the content-weighted pro-rate is low-confidence.
+        expect(Math.abs(contentCredit - recordCredit) / header).toBeGreaterThan(0.5)
+    })
+
+    it('content- and record-weighted credits agree on uniform drops (high confidence)', () => {
+        const header = 10000
+        // Uniform rows: dropping half the content == dropping half the records.
+        expect(billingByteReductionForDrops(header, 5000, 10000)).toBe(billingByteReductionForDrops(header, 5, 10))
+    })
 })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -23,6 +23,7 @@ import {
     type LogsIngestionConsumerDeps,
     logMessageDlqCounter,
     logMessageDroppedCounter,
+    logsBillingBytesCreditedCounter,
     logsBytesAllowedCounter,
     logsBytesDroppedCounter,
     logsBytesReceivedCounter,
@@ -1573,9 +1574,11 @@ describe('LogsIngestionConsumer', () => {
         })
 
         describe('sampling usage to app_metrics2', () => {
+            let mockSamplingCache: Pick<SamplingRulesCache, 'getCompiledRuleSet'>
+
             beforeEach(async () => {
                 await consumer.stop()
-                const mockSamplingCache: Pick<SamplingRulesCache, 'getCompiledRuleSet'> = {
+                mockSamplingCache = {
                     getCompiledRuleSet: (teamId: number) =>
                         Promise.resolve(
                             teamId === team.id
@@ -1625,6 +1628,60 @@ describe('LogsIngestionConsumer', () => {
                 })
                 expect(byRule).toBeDefined()
                 expect(parseMetricValue(byRule!.value).count).toBe(1)
+            })
+
+            const sendDroppedAndKeptMessages = async () => {
+                // Two single-record messages: the info one is fully dropped by the rule
+                // (credit = its whole 400-byte header), the error one is kept (600 bytes).
+                const messages = [
+                    ...(await createKafkaMessages([createLogMessage({ level: 'info' })], {
+                        token: team.api_token,
+                        bytes_uncompressed: '400',
+                        record_count: '1',
+                    })),
+                    ...(await createKafkaMessages([createLogMessage({ level: 'error' })], {
+                        token: team.api_token,
+                        bytes_uncompressed: '600',
+                        record_count: '1',
+                    })),
+                ]
+                await waitForBackgroundTasks(consumer.processKafkaBatch(messages))
+            }
+
+            const teamBytesIngested = (): number | undefined => {
+                const m = getProducedKafkaMessages()
+                    .filter((m) => m.topic === KAFKA_APP_METRICS_2)
+                    .find((m) => {
+                        const value = parseMetricValue(m.value)
+                        return value.metric_name === 'bytes_ingested' && value.team_id === team.id
+                    })
+                return m ? parseMetricValue(m.value).count : undefined
+            }
+
+            it('shadow mode (default): computes the drop credit but bills the full gross bytes', async () => {
+                const creditSpy = jest.spyOn(logsBillingBytesCreditedCounter, 'inc')
+
+                await sendDroppedAndKeptMessages()
+
+                // The would-be credit is computed and observable...
+                expect(creditSpy).toHaveBeenCalledWith({ team_id: team.id.toString() }, 400)
+                // ...but billed usage is untouched: full gross of both messages.
+                expect(teamBytesIngested()).toBe(1000)
+            })
+
+            it('credits dropped rows off bytes_ingested when LOGS_BILLING_PRORATE_ENABLED', async () => {
+                await consumer.stop()
+                consumer = await createLogsIngestionConsumer(
+                    hub,
+                    { LOGS_BILLING_PRORATE_ENABLED: true },
+                    { samplingRulesCache: mockSamplingCache as SamplingRulesCache }
+                )
+                await deleteKeysWithPrefix(consumer['redis'], BASE_REDIS_KEY)
+
+                await sendDroppedAndKeptMessages()
+
+                // The fully-dropped message's 400-byte header is credited; only the kept one bills.
+                expect(teamBytesIngested()).toBe(600)
             })
         })
     })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -1,7 +1,7 @@
 import { trace } from '@opentelemetry/api'
 import { Message } from 'node-rdkafka'
 import pLimit from 'p-limit'
-import { Counter } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
 import { AppMetricsAggregator } from '~/common/services/app-metrics-aggregator'
@@ -147,18 +147,50 @@ export const logsBytesDroppedByRuleCounter = new Counter({
     labelNames: ['team_id'],
 })
 
+// --- Billing impact of drop rules (Tier 1) ---
+export const logsBillingBytesCreditedCounter = new Counter({
+    name: 'logs_ingestion_billing_bytes_credited_total',
+    help: 'Uncompressed header bytes credited back to billing for rows removed by drop rules (pro-rated).',
+    labelNames: ['team_id'],
+})
+
+export const logsBillingRecordsCreditedCounter = new Counter({
+    name: 'logs_ingestion_billing_records_credited_total',
+    help: 'Records removed by drop rules and credited back to billing.',
+    labelNames: ['team_id'],
+})
+
+// --- Pro-rate accuracy-confidence signals (Tier 2). No team_id label — kept low-cardinality. ---
+export const logsBillingProrateDivergenceHistogram = new Histogram({
+    name: 'logs_ingestion_billing_prorate_divergence',
+    help: 'Per-message |content-weighted − record-weighted credit| / header. High = size-skewed batch = pro-rate less trustworthy.',
+    buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1],
+})
+
+export const logsDropBatchRowsHistogram = new Histogram({
+    name: 'logs_ingestion_drop_batch_rows',
+    help: 'Rows per batch for messages that had drop-rule drops; small batches carry larger pro-rate error.',
+    buckets: [1, 2, 5, 10, 50, 100, 500, 1000, 5000],
+})
+
+export const logsDropFractionHistogram = new Histogram({
+    name: 'logs_ingestion_drop_fraction',
+    help: 'Fraction of a message content dropped by drop rules; extreme fractions carry larger pro-rate error.',
+    buckets: [0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1],
+})
+
 /**
  * Pro-rate a message's billable uncompressed bytes by the fraction of its content that drop
  * rules removed. Billing is on the per-message header (whole-batch wire size), but drops are
  * decided per row (content bytes), so we scale the header down by the dropped content fraction
  * to bill only what survived.
  *
- * This is an approximation: the shared envelope (resource/scope/serialization framing) is spread
- * across rows by content weight rather than kept as a fixed residual, so a batch with a large
- * shared resource that is mostly dropped is credited slightly too much. It only ever credits
- * (never over-charges) and is within ~1% for typical multi-row batches; the error grows only for
- * small, resource-heavy, heavily-dropped batches. Returns 0 when we can't measure (no header or
- * no per-row bytes), i.e. no credit rather than a wrong one.
+ * This is an approximation: it weights by per-row content, which only equals each row's true wire
+ * share when rows are uniform. The result is always ≤ the gross header (keptFraction ≤ 1), so a
+ * message is never billed above today's gross. But vs the exact net the credit can be off in
+ * either direction — within ~1% for uniform multi-row batches, but it under-credits (bills above
+ * the exact net) for size-skewed drops or tiny / resource-heavy batches. Returns 0 when we can't
+ * measure (no header or no per-row bytes), i.e. no credit rather than a wrong one.
  */
 export function billingByteReductionForDrops(headerBytes: number, bytesDropped: number, bytesTotal: number): number {
     if (headerBytes <= 0 || bytesDropped <= 0 || bytesTotal <= 0) {
@@ -542,18 +574,49 @@ export class LogsIngestionConsumer {
                         // Drop rules removed rows from this message — credit billing by the dropped
                         // content fraction. `bytesReceived` stays gross (what was sent); `bytesAllowed`
                         // (→ bytes_ingested) and `recordsAllowed` reflect only what survived the drops.
-                        const billingRow = usageStats.get(message.teamId)
-                        if (billingRow) {
-                            billingRow.bytesAllowed = Math.max(
-                                0,
-                                billingRow.bytesAllowed -
-                                    billingByteReductionForDrops(
-                                        message.bytesUncompressed,
-                                        resolved.bytesDropped,
-                                        resolved.bytesTotal
-                                    )
+                        if (resolved.recordsDropped > 0) {
+                            const header = message.bytesUncompressed
+                            const contentCredit = billingByteReductionForDrops(
+                                header,
+                                resolved.bytesDropped,
+                                resolved.bytesTotal
                             )
-                            billingRow.recordsAllowed = Math.max(0, billingRow.recordsAllowed - resolved.recordsDropped)
+                            // Second estimator (record-weighted) for the accuracy-confidence signal:
+                            // when content- and record-weighted credits diverge, the batch is size-skewed
+                            // and the content-weighted pro-rate we bill on is less trustworthy.
+                            const recordCredit = billingByteReductionForDrops(
+                                header,
+                                resolved.recordsDropped,
+                                message.recordCount
+                            )
+
+                            const teamIdLabel = message.teamId.toString()
+                            if (contentCredit > 0) {
+                                logsBillingBytesCreditedCounter.inc({ team_id: teamIdLabel }, contentCredit)
+                            }
+                            logsBillingRecordsCreditedCounter.inc({ team_id: teamIdLabel }, resolved.recordsDropped)
+                            if (message.recordCount > 0) {
+                                logsDropBatchRowsHistogram.observe(message.recordCount)
+                            }
+                            if (resolved.bytesTotal > 0) {
+                                logsDropFractionHistogram.observe(
+                                    Math.min(1, resolved.bytesDropped / resolved.bytesTotal)
+                                )
+                            }
+                            if (header > 0) {
+                                logsBillingProrateDivergenceHistogram.observe(
+                                    Math.abs(contentCredit - recordCredit) / header
+                                )
+                            }
+
+                            const billingRow = usageStats.get(message.teamId)
+                            if (billingRow) {
+                                billingRow.bytesAllowed = Math.max(0, billingRow.bytesAllowed - contentCredit)
+                                billingRow.recordsAllowed = Math.max(
+                                    0,
+                                    billingRow.recordsAllowed - resolved.recordsDropped
+                                )
+                            }
                         }
 
                         if (resolved.outcome === 'sampling_all_dropped') {

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -213,6 +213,7 @@ export class LogsIngestionConsumer {
     private samplingService: LogsSamplingService
     private readonly samplingEnabledTeamsRaw: string
     private readonly samplingKillswitch: boolean
+    private readonly billingProrateEnabled: boolean
 
     protected groupId: string
     protected topic: string
@@ -255,6 +256,7 @@ export class LogsIngestionConsumer {
         this.samplingService = new LogsSamplingService(this.redis, mergedConfig.LOGS_LIMITER_TTL_SECONDS)
         this.samplingEnabledTeamsRaw = mergedConfig.LOGS_SAMPLING_ENABLED_TEAMS
         this.samplingKillswitch = mergedConfig.LOGS_SAMPLING_KILLSWITCH
+        this.billingProrateEnabled = mergedConfig.LOGS_BILLING_PRORATE_ENABLED
     }
 
     private isSamplingEvalEnabledForTeam(teamId: number): boolean {
@@ -611,13 +613,17 @@ export class LogsIngestionConsumer {
                                 )
                             }
 
-                            const billingRow = usageStats.get(message.teamId)
-                            if (billingRow) {
-                                billingRow.bytesAllowed = Math.max(0, billingRow.bytesAllowed - contentCredit)
-                                billingRow.recordsAllowed = Math.max(
-                                    0,
-                                    billingRow.recordsAllowed - resolved.recordsDropped
-                                )
+                            // Shadow mode unless LOGS_BILLING_PRORATE_ENABLED: the credit above is
+                            // computed and counted (observability) but billed usage is untouched.
+                            if (this.billingProrateEnabled) {
+                                const billingRow = usageStats.get(message.teamId)
+                                if (billingRow) {
+                                    billingRow.bytesAllowed = Math.max(0, billingRow.bytesAllowed - contentCredit)
+                                    billingRow.recordsAllowed = Math.max(
+                                        0,
+                                        billingRow.recordsAllowed - resolved.recordsDropped
+                                    )
+                                }
                             }
                         }
 

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -147,6 +147,27 @@ export const logsBytesDroppedByRuleCounter = new Counter({
     labelNames: ['team_id'],
 })
 
+/**
+ * Pro-rate a message's billable uncompressed bytes by the fraction of its content that drop
+ * rules removed. Billing is on the per-message header (whole-batch wire size), but drops are
+ * decided per row (content bytes), so we scale the header down by the dropped content fraction
+ * to bill only what survived.
+ *
+ * This is an approximation: the shared envelope (resource/scope/serialization framing) is spread
+ * across rows by content weight rather than kept as a fixed residual, so a batch with a large
+ * shared resource that is mostly dropped is credited slightly too much. It only ever credits
+ * (never over-charges) and is within ~1% for typical multi-row batches; the error grows only for
+ * small, resource-heavy, heavily-dropped batches. Returns 0 when we can't measure (no header or
+ * no per-row bytes), i.e. no credit rather than a wrong one.
+ */
+export function billingByteReductionForDrops(headerBytes: number, bytesDropped: number, bytesTotal: number): number {
+    if (headerBytes <= 0 || bytesDropped <= 0 || bytesTotal <= 0) {
+        return 0
+    }
+    const droppedFraction = Math.min(1, bytesDropped / bytesTotal)
+    return Math.round(headerBytes * droppedFraction)
+}
+
 export class LogsIngestionConsumer {
     protected name = 'LogsIngestionConsumer'
     // Billing identity for quota enforcement and usage metering; overridden by subclasses (e.g. traces).
@@ -236,6 +257,8 @@ export class LogsIngestionConsumer {
               recordsDropped: number
               recordsDroppedByRuleId: Map<string, number>
               bytesDroppedByRuleId: Map<string, number>
+              bytesDropped: number
+              bytesTotal: number
           }
         | {
               outcome: 'sampling_all_dropped'
@@ -243,6 +266,8 @@ export class LogsIngestionConsumer {
               recordsDropped: number
               recordsDroppedByRuleId: Map<string, number>
               bytesDroppedByRuleId: Map<string, number>
+              bytesDropped: number
+              bytesTotal: number
           }
     > {
         const samplingCache = this.deps.samplingRulesCache
@@ -285,6 +310,8 @@ export class LogsIngestionConsumer {
                     recordsDropped: sampled.recordsDropped,
                     recordsDroppedByRuleId: sampled.recordsDroppedByRuleId,
                     bytesDroppedByRuleId: sampled.bytesDroppedByRuleId,
+                    bytesDropped: sampled.bytesDropped,
+                    bytesTotal: sampled.bytesTotal,
                 }
             }
             return {
@@ -294,9 +321,12 @@ export class LogsIngestionConsumer {
                 recordsDropped: sampled.recordsDropped,
                 recordsDroppedByRuleId: sampled.recordsDroppedByRuleId,
                 bytesDroppedByRuleId: sampled.bytesDroppedByRuleId,
+                bytesDropped: sampled.bytesDropped,
+                bytesTotal: sampled.bytesTotal,
             }
         }
 
+        // Passthrough (sampling disabled / no rules): nothing dropped, so nothing to credit.
         const res = await processLogMessageBuffer(message.message.value!, logsSettings)
         return {
             outcome: 'produce',
@@ -305,6 +335,8 @@ export class LogsIngestionConsumer {
             recordsDropped: 0,
             recordsDroppedByRuleId: new Map(),
             bytesDroppedByRuleId: new Map(),
+            bytesDropped: 0,
+            bytesTotal: 0,
         }
     }
 
@@ -506,6 +538,24 @@ export class LogsIngestionConsumer {
                             },
                             async () => this.resolveLogMessageBufferWithOptionalSampling(message, logsSettings)
                         )
+
+                        // Drop rules removed rows from this message — credit billing by the dropped
+                        // content fraction. `bytesReceived` stays gross (what was sent); `bytesAllowed`
+                        // (→ bytes_ingested) and `recordsAllowed` reflect only what survived the drops.
+                        const billingRow = usageStats.get(message.teamId)
+                        if (billingRow) {
+                            billingRow.bytesAllowed = Math.max(
+                                0,
+                                billingRow.bytesAllowed -
+                                    billingByteReductionForDrops(
+                                        message.bytesUncompressed,
+                                        resolved.bytesDropped,
+                                        resolved.bytesTotal
+                                    )
+                            )
+                            billingRow.recordsAllowed = Math.max(0, billingRow.recordsAllowed - resolved.recordsDropped)
+                        }
+
                         if (resolved.outcome === 'sampling_all_dropped') {
                             logMessageDroppedCounter.inc(
                                 { reason: 'sampling_all_dropped', team_id: message.teamId.toString() },

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -99,7 +99,7 @@ export const logsBytesReceivedCounter = new Counter({
 
 export const logsBytesAllowedCounter = new Counter({
     name: 'logs_ingestion_bytes_allowed_total',
-    help: 'Total uncompressed bytes allowed through quota and rate limiting',
+    help: 'Total uncompressed bytes allowed through quota and rate limiting. Gross of the drop-rule billing credit: billed bytes_ingested = this − logs_ingestion_billing_bytes_credited_total.',
 })
 
 export const logsBytesAllowedRecordsCounter = new Counter({
@@ -126,7 +126,7 @@ export const logsRecordsReceivedCounter = new Counter({
 
 export const logsRecordsAllowedCounter = new Counter({
     name: 'logs_ingestion_records_allowed_total',
-    help: 'Total log records allowed through quota and rate limiting',
+    help: 'Total log records allowed through quota and rate limiting. Gross of the drop-rule billing credit: billed records_ingested = this − logs_ingestion_billing_records_credited_total.',
 })
 
 export const logsRecordsDroppedCounter = new Counter({
@@ -443,6 +443,7 @@ export class LogsIngestionConsumer {
         }
 
         logsBytesAllowedRecordsCounter.inc(totalBytesAllowedRecords)
+        // Gross, before the drop-rule billing credit applied in processAndProduceLogMessages (see counter help).
         logsBytesAllowedCounter.inc(totalBytesAllowed)
         logsRecordsAllowedCounter.inc(totalRecordsAllowed)
 

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -185,12 +185,13 @@ export const logsDropFractionHistogram = new Histogram({
  * decided per row (content bytes), so we scale the header down by the dropped content fraction
  * to bill only what survived.
  *
- * This is an approximation: it weights by per-row content, which only equals each row's true wire
- * share when rows are uniform. The result is always ≤ the gross header (keptFraction ≤ 1), so a
- * message is never billed above today's gross. But vs the exact net the credit can be off in
- * either direction — within ~1% for uniform multi-row batches, but it under-credits (bills above
- * the exact net) for size-skewed drops or tiny / resource-heavy batches. Returns 0 when we can't
- * measure (no header or no per-row bytes), i.e. no credit rather than a wrong one.
+ * Weights are customer-content bytes per row (body + attributes + event_name) — NOT the per-row
+ * `bytes_uncompressed` field, whose near-constant denormalization overhead (duplicated resource
+ * attributes, server uuid) would skew the ratio toward record-count weighting. Content weights
+ * track "share of what the customer sent"; residual error vs true wire share (protobuf framing,
+ * per-batch resource blocks) is small and direction-neutral. The result is always ≤ the gross
+ * header (droppedFraction ≤ 1), so a message is never billed above today's gross. Returns 0 when
+ * we can't measure (no header or no content bytes), i.e. no credit rather than a wrong one.
  */
 export function billingByteReductionForDrops(headerBytes: number, bytesDropped: number, bytesTotal: number): number {
     if (headerBytes <= 0 || bytesDropped <= 0 || bytesTotal <= 0) {
@@ -289,8 +290,8 @@ export class LogsIngestionConsumer {
               recordsDropped: number
               recordsDroppedByRuleId: Map<string, number>
               bytesDroppedByRuleId: Map<string, number>
-              bytesDropped: number
-              bytesTotal: number
+              contentBytesDropped: number
+              contentBytesTotal: number
           }
         | {
               outcome: 'sampling_all_dropped'
@@ -298,8 +299,8 @@ export class LogsIngestionConsumer {
               recordsDropped: number
               recordsDroppedByRuleId: Map<string, number>
               bytesDroppedByRuleId: Map<string, number>
-              bytesDropped: number
-              bytesTotal: number
+              contentBytesDropped: number
+              contentBytesTotal: number
           }
     > {
         const samplingCache = this.deps.samplingRulesCache
@@ -342,8 +343,8 @@ export class LogsIngestionConsumer {
                     recordsDropped: sampled.recordsDropped,
                     recordsDroppedByRuleId: sampled.recordsDroppedByRuleId,
                     bytesDroppedByRuleId: sampled.bytesDroppedByRuleId,
-                    bytesDropped: sampled.bytesDropped,
-                    bytesTotal: sampled.bytesTotal,
+                    contentBytesDropped: sampled.contentBytesDropped,
+                    contentBytesTotal: sampled.contentBytesTotal,
                 }
             }
             return {
@@ -353,8 +354,8 @@ export class LogsIngestionConsumer {
                 recordsDropped: sampled.recordsDropped,
                 recordsDroppedByRuleId: sampled.recordsDroppedByRuleId,
                 bytesDroppedByRuleId: sampled.bytesDroppedByRuleId,
-                bytesDropped: sampled.bytesDropped,
-                bytesTotal: sampled.bytesTotal,
+                contentBytesDropped: sampled.contentBytesDropped,
+                contentBytesTotal: sampled.contentBytesTotal,
             }
         }
 
@@ -367,8 +368,8 @@ export class LogsIngestionConsumer {
             recordsDropped: 0,
             recordsDroppedByRuleId: new Map(),
             bytesDroppedByRuleId: new Map(),
-            bytesDropped: 0,
-            bytesTotal: 0,
+            contentBytesDropped: 0,
+            contentBytesTotal: 0,
         }
     }
 
@@ -579,8 +580,8 @@ export class LogsIngestionConsumer {
                             const header = message.bytesUncompressed
                             const contentCredit = billingByteReductionForDrops(
                                 header,
-                                resolved.bytesDropped,
-                                resolved.bytesTotal
+                                resolved.contentBytesDropped,
+                                resolved.contentBytesTotal
                             )
                             // Second estimator (record-weighted) for the accuracy-confidence signal:
                             // when content- and record-weighted credits diverge, the batch is size-skewed
@@ -599,9 +600,9 @@ export class LogsIngestionConsumer {
                             if (message.recordCount > 0) {
                                 logsDropBatchRowsHistogram.observe(message.recordCount)
                             }
-                            if (resolved.bytesTotal > 0) {
+                            if (resolved.contentBytesTotal > 0) {
                                 logsDropFractionHistogram.observe(
-                                    Math.min(1, resolved.bytesDropped / resolved.bytesTotal)
+                                    Math.min(1, resolved.contentBytesDropped / resolved.contentBytesTotal)
                                 )
                             }
                             if (header > 0) {

--- a/nodejs/src/logs-ingestion/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/logs-sampling.service.test.ts
@@ -168,6 +168,8 @@ describe('LogsSamplingService', () => {
         expect(result.recordsDroppedByRuleId.get('rl-kb')).toBe(1)
         expect(result.bytesDropped).toBe(500)
         expect(result.bytesDroppedByRuleId.get('rl-kb')).toBe(500)
+        // Sum of all rows' per-row bytes (300+400+500) — used to pro-rate billing by the dropped fraction.
+        expect(result.bytesTotal).toBe(1200)
 
         const [, , kept] = await decodeLogRecords(result.value)
         expect(kept).toHaveLength(2)
@@ -208,6 +210,8 @@ describe('LogsSamplingService', () => {
         expect(result.recordsDropped).toBe(1)
         expect(result.bytesDropped).toBe(1000)
         expect(result.bytesDroppedByRuleId.get('rl-kb')).toBe(1000)
+        // null row contributes 0; total = 200 + 0 + 1000.
+        expect(result.bytesTotal).toBe(1200)
 
         const [, , kept] = await decodeLogRecords(result.value)
         expect(kept).toHaveLength(2)

--- a/nodejs/src/logs-ingestion/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/logs-sampling.service.test.ts
@@ -148,7 +148,7 @@ describe('LogsSamplingService', () => {
         const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', [
             baseLog('a', 'api', 300),
             baseLog('b', 'api', 400),
-            baseLog('c', 'api', 500),
+            { ...baseLog('c', 'api', 500), attributes: { k: 'vv' }, event_name: 'evt' },
         ])
 
         const mockRedis: RedisV2 = {
@@ -168,8 +168,11 @@ describe('LogsSamplingService', () => {
         expect(result.recordsDroppedByRuleId.get('rl-kb')).toBe(1)
         expect(result.bytesDropped).toBe(500)
         expect(result.bytesDroppedByRuleId.get('rl-kb')).toBe(500)
-        // Sum of all rows' per-row bytes (300+400+500) — used to pro-rate billing by the dropped fraction.
-        expect(result.bytesTotal).toBe(1200)
+        // Billing pro-rate weights are customer-content bytes (body + attributes + event_name),
+        // independent of the per-row bytes_uncompressed field used for rate limiting:
+        // rows a,b = body 'x' (1 each); dropped row c = body(1) + attrs 'k'+'vv'(3) + 'evt'(3) = 7.
+        expect(result.contentBytesTotal).toBe(9)
+        expect(result.contentBytesDropped).toBe(7)
 
         const [, , kept] = await decodeLogRecords(result.value)
         expect(kept).toHaveLength(2)
@@ -210,8 +213,10 @@ describe('LogsSamplingService', () => {
         expect(result.recordsDropped).toBe(1)
         expect(result.bytesDropped).toBe(1000)
         expect(result.bytesDroppedByRuleId.get('rl-kb')).toBe(1000)
-        // null row contributes 0; total = 200 + 0 + 1000.
-        expect(result.bytesTotal).toBe(1200)
+        // Content weights don't depend on the per-row bytes_uncompressed field at all:
+        // the null-field row still weighs its body bytes (1 each, 3 rows, 1 dropped).
+        expect(result.contentBytesTotal).toBe(3)
+        expect(result.contentBytesDropped).toBe(1)
 
         const [, , kept] = await decodeLogRecords(result.value)
         expect(kept).toHaveLength(2)

--- a/nodejs/src/logs-ingestion/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs-ingestion/sampling/logs-sampling.service.ts
@@ -68,6 +68,8 @@ export type ProcessBufferWithSamplingResult = {
     bytesDropped: number
     /** Sum of per-row `bytes_uncompressed` for dropped lines, attributed to the first matching rule UUID. */
     bytesDroppedByRuleId: Map<string, number>
+    /** Sum of per-row `bytes_uncompressed` across ALL decoded rows (kept + dropped); 0 when rows lack the field. Used to pro-rate billing by the dropped fraction. */
+    bytesTotal: number
     /** When true, the caller must not produce this message to downstream Kafka (all lines sampled out). */
     allDropped: boolean
 }
@@ -102,6 +104,7 @@ export class LogsSamplingService {
         const recordsDroppedByRuleId = new Map<string, number>()
         let bytesDropped = 0
         const bytesDroppedByRuleId = new Map<string, number>()
+        const bytesTotal = records.reduce((sum, r) => sum + recordBytes(r), 0)
 
         const useRate = Boolean(ruleSet.hasRateLimitRules && teamId != null)
 
@@ -179,6 +182,7 @@ export class LogsSamplingService {
                 recordsDroppedByRuleId,
                 bytesDropped,
                 bytesDroppedByRuleId,
+                bytesTotal,
                 allDropped: true,
             }
         }
@@ -190,6 +194,7 @@ export class LogsSamplingService {
             recordsDroppedByRuleId,
             bytesDropped,
             bytesDroppedByRuleId,
+            bytesTotal,
             allDropped: false,
         }
     }

--- a/nodejs/src/logs-ingestion/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs-ingestion/sampling/logs-sampling.service.ts
@@ -68,13 +68,31 @@ export type ProcessBufferWithSamplingResult = {
     bytesDropped: number
     /** Sum of per-row `bytes_uncompressed` for dropped lines, attributed to the first matching rule UUID. */
     bytesDroppedByRuleId: Map<string, number>
-    /** Sum of per-row `bytes_uncompressed` across ALL decoded rows (kept + dropped); 0 when rows lack the field. Used to pro-rate billing by the dropped fraction. */
-    bytesTotal: number
+    /** Sum of customer-content bytes (body + attributes + event_name) for dropped lines. Billing pro-rate numerator. */
+    contentBytesDropped: number
+    /** Sum of customer-content bytes across ALL decoded rows (kept + dropped). Billing pro-rate denominator. */
+    contentBytesTotal: number
     /** When true, the caller must not produce this message to downstream Kafka (all lines sampled out). */
     allDropped: boolean
 }
 
 const recordBytes = (r: LogRecord): number => r.bytes_uncompressed ?? 0
+
+/**
+ * Customer-sent content bytes of a row: body + attributes + event_name. The billing
+ * pro-rate weight — deliberately NOT `bytes_uncompressed`, which includes per-row
+ * denormalization overhead (resource attributes duplicated onto every row, server
+ * uuid, id placeholders). That overhead is near-constant per row, so as a ratio
+ * weight it would skew the pro-rate toward record-count weighting instead of
+ * "share of what the customer sent".
+ */
+const contentBytes = (r: LogRecord): number => {
+    let total = Buffer.byteLength(r.body ?? '') + Buffer.byteLength(r.event_name ?? '')
+    for (const [k, v] of Object.entries(r.attributes ?? {})) {
+        total += Buffer.byteLength(k) + Buffer.byteLength(v ?? '')
+    }
+    return total
+}
 
 export class LogsSamplingService {
     private rateLimiter: KeyedRateLimiterService
@@ -104,7 +122,8 @@ export class LogsSamplingService {
         const recordsDroppedByRuleId = new Map<string, number>()
         let bytesDropped = 0
         const bytesDroppedByRuleId = new Map<string, number>()
-        const bytesTotal = records.reduce((sum, r) => sum + recordBytes(r), 0)
+        let contentBytesDropped = 0
+        const contentBytesTotal = records.reduce((sum, r) => sum + contentBytes(r), 0)
 
         const useRate = Boolean(ruleSet.hasRateLimitRules && teamId != null)
 
@@ -129,6 +148,7 @@ export class LogsSamplingService {
                         const rb = recordBytes(record)
                         recordsDropped++
                         bytesDropped += rb
+                        contentBytesDropped += contentBytes(record)
                         recordsDroppedByRuleId.set(c.ruleId, (recordsDroppedByRuleId.get(c.ruleId) ?? 0) + 1)
                         bytesDroppedByRuleId.set(c.ruleId, (bytesDroppedByRuleId.get(c.ruleId) ?? 0) + rb)
                         continue
@@ -140,6 +160,7 @@ export class LogsSamplingService {
                     const rb = recordBytes(record)
                     recordsDropped++
                     bytesDropped += rb
+                    contentBytesDropped += contentBytes(record)
                     if (c.ruleId != null) {
                         recordsDroppedByRuleId.set(c.ruleId, (recordsDroppedByRuleId.get(c.ruleId) ?? 0) + 1)
                         bytesDroppedByRuleId.set(c.ruleId, (bytesDroppedByRuleId.get(c.ruleId) ?? 0) + rb)
@@ -155,6 +176,7 @@ export class LogsSamplingService {
                     const rb = recordBytes(record)
                     recordsDropped++
                     bytesDropped += rb
+                    contentBytesDropped += contentBytes(record)
                     if (ruleId != null) {
                         recordsDroppedByRuleId.set(ruleId, (recordsDroppedByRuleId.get(ruleId) ?? 0) + 1)
                         bytesDroppedByRuleId.set(ruleId, (bytesDroppedByRuleId.get(ruleId) ?? 0) + rb)
@@ -182,7 +204,8 @@ export class LogsSamplingService {
                 recordsDroppedByRuleId,
                 bytesDropped,
                 bytesDroppedByRuleId,
-                bytesTotal,
+                contentBytesDropped,
+                contentBytesTotal,
                 allDropped: true,
             }
         }
@@ -194,7 +217,8 @@ export class LogsSamplingService {
             recordsDroppedByRuleId,
             bytesDropped,
             bytesDroppedByRuleId,
-            bytesTotal,
+            contentBytesDropped,
+            contentBytesTotal,
             allDropped: false,
         }
     }


### PR DESCRIPTION
## Problem

Logs/traces are billed on the per-message **uncompressed header** (`bytes_uncompressed` = the whole-batch wire size, set at capture). Drop rules and rate limits remove rows *after* that header is set, in ingestion — so **dropped volume is still billed**. A customer's drop rule reduces storage/query load but not their bill.

The two byte numbers we have aren't directly subtractable: the header is the whole-message wire size; the per-row `bytes_uncompressed` field is the row's denormalized content — it carries near-constant per-row overhead (resource attributes duplicated onto every row, server-generated uuid, trace/span-id placeholders). Used as a ratio weight, that overhead skews the pro-rate toward record-count weighting: dropping a few large rows under-credits, dropping many small rows over-credits.

## Changes

- **Pro-rate, don't subtract**: bill `bytes_uncompressed × (1 − dropped_content / total_content)` per message. Batches no rule touches keep the fast path (never unwrapped, billed exactly as today). The billing **basis stays the payload header** — matching how Datadog/Axiom/Sentry/Grafana bill (uncompressed customer-sent bytes); drop rules just credit back the removed share.
- **Ships in shadow mode**: the credit only adjusts billed usage (`bytes_ingested` / `records_ingested` in app_metrics2 — the source invoicing reads) when **`LOGS_BILLING_PRORATE_ENABLED`** is set; it defaults to `false`. Until the flag is flipped per environment, merging and deploying this changes **nothing** about what customers are charged — the credit is computed and emitted on `logs_ingestion_billing_bytes_credited_total` / `logs_ingestion_billing_records_credited_total` (per team) so the would-be impact can be validated on production traffic first.
- **Weights are customer-content bytes computed inline at drop time** (`body + attributes + event_name` per row, in the sampling service where the records are already decoded) — *not* the per-row `bytes_uncompressed` field, for the skew reason above. The per-row field keeps its existing roles unchanged (rate-limit cost, `bytes_dropped_by_rule`).
- Credit is capped at the header (a message can never bill above today's gross); unmeasurable cases (no header / no content bytes) credit nothing rather than something wrong.
- Observability: per-team credited bytes/records counters, plus confidence histograms (content-vs-record-weighted divergence, batch size, drop fraction).
- `bytes_received` stays gross (what was sent) in both modes.

### Rollout

1. Merge + deploy (note: the `logs-ingestion` ArgoCD app has auto-sync disabled — manual sync required). No billing change.
2. Watch `logs_ingestion_billing_bytes_credited_total` per team — the exact credit that would apply.
3. When validated, set `LOGS_BILLING_PRORATE_ENABLED=true` on the logs-ingestion deployment.

## How did you test this code?

Agent-assisted rework. Automated tests only: `logs-billing.test.ts` (pure pro-rate function: fraction, caps, unmeasurable cases, rounding), sampling service tests for content-weight accounting (attribute/event_name handling, independence from the per-row `bytes_uncompressed` field), and consumer end-to-end tests for **both modes** — shadow (credit counted, `bytes_ingested` unchanged at gross) and enabled (`bytes_ingested` reduced by the dropped share). 65 consumer tests + 12 sampling/billing tests pass. Additionally validated live on a local stack in both modes — see “Local end-to-end validation” below.


### Local end-to-end validation

Validated on a live local stack (real capture → kafka → consumer → app_metrics2), credits **applied** (`LOGS_BILLING_PRORATE_ENABLED=true`), one scenario per OTLP request (one billing header each):

| # | Scenario | Drop rule (filter) | Charge basis (header) | Rule-reported drop | Credit | Billed | Credit % (predicted) | Stored in logs |
|---|---|---|---|---|---|---|---|---|
| S1 | No rule matches (control) | — | 17,011 B | — | 0 B | 17,011 B | 0% (0%) | 4/4 |
| S2 | Partial drop, equal sizes (2 of 4) | `service AND severity=info` | 17,190 B | 4 recs / 16,692 B | 8,228 B | 8,962 B | 47.9% (~50%) | 2/4 |
| S3 | Drop 1 big (12 KB), keep 3×1 KB | same shape | 16,191 B | 1 rec / 12,196 B | 12,247 B | 3,944 B | 75.6% (~80%) | 3/4 |
| S4 | Drop 3 small (1 KB ea), keep 1×12 KB | same shape | 16,189 B | 3 recs / 3,519 B | 3,209 B | 12,980 B | 19.8% (~20%) | 1/4 |
| S5 | Everything dropped | `service` (unconditional) | 17,011 B | 4 recs / 16,692 B | ~17,011 B | 0 B | 100% (100%) | 0/4 |
| S6 | Rate-limit burst (1 KB/s + 4 KB burst, 6×2 KB sent) | rate limit | 13,419 B | 5 recs / 10,865 B | ~11,183 B | ~2,236 B | ~83% (~83%) | 1/6 |

Key observations:

- **S3/S4 (mirrored size skew)** demonstrate content weighting: record-count weighting would have credited 25%/75% — backwards. Content weighting credits ~76%/~20%, i.e. customers are credited for the bytes their rules remove, not the line count.
- **Shadow mode** validated separately: with the flag off, the same drops produced `bytes_ingested == bytes_received` exactly while the `logs_ingestion_billing_bytes_credited_total` counters recorded the would-be credit.
- Stored-row counts matched billed shares in all six scenarios; fully-dropped batches bill zero and store nothing; rate-limit drops credit identically to filter drops.
- Retention-tier metrics mirror the credited `bytes_ingested`; `bytes_received` and the `bytes_ingested_records` comparison metric stay gross in both modes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reworked with PostHog Code (Claude). Decisions: (1) keep billing on customer-sent payload bytes — the records-vs-payload comparison (#63116/#63115) measured records-basis ~18% above payload fleet-wide, so the basis does not change; (2) pro-rate with content-only weights computed at unwrap time, because the per-row byte field's denormalization overhead skews ratio weighting; (3) default to shadow mode behind `LOGS_BILLING_PRORATE_ENABLED` so merging cannot affect invoices — `bytes_ingested` in app_metrics2 is the exact quantity usage reports bill on, so the live credit is opt-in per environment after validating the shadow counters.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
