### PR TITLE
feat(cymbal): carry debug images under a generic grpc metadata key

### DIFF
--- a/rust/cymbal-resolution/src/service/resolve.rs
+++ b/rust/cymbal-resolution/src/service/resolve.rs
@@ -230,6 +230,7 @@ fn record_item_metrics(started_at: Instant, outcome: &'static str, kind: &'stati
         .record(started_at.elapsed().as_secs_f64() * 1000.0);
 }
 
+#[derive(Debug)]
 enum ItemFailure {
     InvalidPayload(String),
     Overloaded(String),
@@ -262,12 +263,18 @@ fn debug_images_from_metadata(metadata: &[u8]) -> Result<Vec<DebugImage>, ItemFa
 
     let metadata: serde_json::Value = serde_json::from_slice(metadata)
         .map_err(|e| ItemFailure::InvalidPayload(format!("invalid metadata: {e}")))?;
-    let Some(debug_images) = metadata.get("apple_debug_images_json") else {
-        return Ok(Vec::new());
+    // Prefer the generic key; fall back to the legacy apple-specific key sent
+    // by older cymbal deployments.
+    // TODO(2026-09-01): drop the legacy key once the dual-write release is fully rolled out.
+    let (key, debug_images) = match metadata.get("debug_images_json") {
+        Some(images) => ("debug_images_json", images),
+        None => match metadata.get("apple_debug_images_json") {
+            Some(images) => ("apple_debug_images_json", images),
+            None => return Ok(Vec::new()),
+        },
     };
-    serde_json::from_value(debug_images.clone()).map_err(|e| {
-        ItemFailure::InvalidPayload(format!("invalid metadata.apple_debug_images_json: {e}"))
-    })
+    serde_json::from_value(debug_images.clone())
+        .map_err(|e| ItemFailure::InvalidPayload(format!("invalid metadata.{key}: {e}")))
 }
 
 enum ResolveOneError {
@@ -315,4 +322,64 @@ async fn acquire_permit(
 
 fn to_unhandled(err: UnhandledError) -> ResolveOneError {
     ResolveOneError::Unhandled(err.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn images_json(debug_id: &str) -> serde_json::Value {
+        serde_json::json!([{
+            "debug_id": debug_id,
+            "image_addr": "0x100000000",
+            "image_size": 4096,
+            "type": "macho",
+        }])
+    }
+
+    #[test]
+    fn metadata_prefers_generic_debug_images_key() {
+        let metadata = serde_json::to_vec(&serde_json::json!({
+            "debug_images_json": images_json("generic"),
+            "apple_debug_images_json": images_json("legacy"),
+        }))
+        .unwrap();
+
+        let images = debug_images_from_metadata(&metadata).unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].debug_id, "generic");
+    }
+
+    #[test]
+    fn metadata_falls_back_to_legacy_apple_key() {
+        let metadata = serde_json::to_vec(&serde_json::json!({
+            "apple_debug_images_json": images_json("legacy"),
+        }))
+        .unwrap();
+
+        let images = debug_images_from_metadata(&metadata).unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].debug_id, "legacy");
+    }
+
+    #[test]
+    fn metadata_without_debug_images_keys_is_empty() {
+        let metadata = serde_json::to_vec(&serde_json::json!({"other": 1})).unwrap();
+        assert!(debug_images_from_metadata(&metadata).unwrap().is_empty());
+        assert!(debug_images_from_metadata(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn invalid_generic_key_errors_even_when_legacy_is_valid() {
+        let metadata = serde_json::to_vec(&serde_json::json!({
+            "debug_images_json": "not-a-list",
+            "apple_debug_images_json": images_json("legacy"),
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            debug_images_from_metadata(&metadata),
+            Err(ItemFailure::InvalidPayload(msg)) if msg.contains("debug_images_json")
+        ));
+    }
 }

--- a/rust/cymbal-resolution/tests/service_tests.rs
+++ b/rust/cymbal-resolution/tests/service_tests.rs
@@ -402,11 +402,12 @@ async fn invalid_payload_and_metadata_formats_are_invalid_payload_errors() {
                 &exc,
                 br#"{"apple_debug_images_json":"not-a-list"}"#.to_vec(),
             ),
+            make_item_with_metadata(4, &exc, br#"{"debug_images_json":"not-a-list"}"#.to_vec()),
         ],
     )
     .await;
 
-    assert_eq!(outcomes.len(), 3);
+    assert_eq!(outcomes.len(), 4);
     for outcome in outcomes {
         assert_eq!(error_kind(&outcome), ErrorKind::InvalidPayload);
     }

--- a/rust/cymbal/src/stages/resolution/remote/resolver/partition.rs
+++ b/rust/cymbal/src/stages/resolution/remote/resolver/partition.rs
@@ -70,6 +70,9 @@ fn prepare_remote_event(
         Vec::new()
     } else {
         serde_json::to_vec(&serde_json::json!({
+            "debug_images_json": evt.debug_images,
+            // Legacy key still read by older cymbal-resolution deployments.
+            // TODO(2026-09-01): drop once the dual-read release is fully rolled out.
             "apple_debug_images_json": evt.debug_images,
         }))
         .map_err(UnhandledError::from)?

--- a/rust/cymbal/tests/remote_resolution.rs
+++ b/rust/cymbal/tests/remote_resolution.rs
@@ -377,7 +377,7 @@ async fn accepted_outcomes_release_routing_slots_before_terminal_completion() {
 }
 
 #[tokio::test]
-async fn metadata_encodes_apple_debug_images_as_json_field() {
+async fn metadata_encodes_debug_images_under_both_keys() {
     let (addr, _streams, items) = spawn_recording_stub_server(ServerBehavior::Happy).await;
     let ctx = make_ctx(&[addr], 0, Duration::from_secs(5)).await;
     let mut evt = build_event(1);
@@ -401,6 +401,11 @@ async fn metadata_encodes_apple_debug_images_as_json_field() {
     assert_eq!(items.len(), 1);
     let metadata: serde_json::Value =
         serde_json::from_slice(&items[0].metadata).expect("metadata is json");
+    assert_eq!(
+        metadata["debug_images_json"][0]["debug_id"],
+        serde_json::Value::String("ABCDEF".to_string())
+    );
+    // Legacy key still written for older cymbal-resolution readers during rollout.
     assert_eq!(
         metadata["apple_debug_images_json"][0]["debug_id"],
         serde_json::Value::String("ABCDEF".to_string())


### PR DESCRIPTION
## Problem

The cymbal → cymbal-resolution gRPC stream carries `$debug_images` in an opaque metadata blob keyed `apple_debug_images_json`. Debug images are about to be used for Rust/ELF native frames too (stacked PR train for Rust error tracking symbolication, step 2), so the key name needs to stop being apple-specific — without breaking the deploy-skew window, since the two services deploy separately.

## Changes

- Writer (cymbal remote resolver) now emits the images under both `debug_images_json` (new, generic) and `apple_debug_images_json` (legacy) for one release cycle.
- Reader (cymbal-resolution) prefers the generic key and falls back to the legacy key, so both skew directions keep working: new writer + old reader reads legacy, old writer + new reader falls back.
- `TODO(2026-09-01)` markers on both sides to drop the legacy key after the dual-read release is fully rolled out.
- Unit tests for the reader: key preference, legacy fallback, absent keys, and invalid payloads under either key.

## How did you test this code?

Agent-authored; automated tests only:

- `cargo test -p cymbal -p cymbal-resolution` — 199 passed, including the updated metadata round-trip integration test asserting both keys are written.
- `cargo clippy --all-targets` / `cargo fmt` clean.
- Structured second-model review (codex) reported no actionable findings.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal wire metadata.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Fable 5) as part of the Rust error tracking symbolication plan.
- Dual-write/dual-read chosen over a hard key rename because cymbal and cymbal-resolution deploy independently; a one-shot rename would drop debug images (and thus apple symbolication) for in-flight items during rollout.
