### PR TITLE
feat(symbol-data): add ElfDebugInfo container type

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-symbol-data"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/rust/common/symbol_data/Cargo.toml
+++ b/rust/common/symbol_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-symbol-data"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/rust/common/symbol_data/src/data_types/elf.rs
+++ b/rust/common/symbol_data/src/data_types/elf.rs
@@ -1,0 +1,23 @@
+use crate::symbol_data::{SymbolData, SymbolDataType};
+
+/// Debug information for a native ELF binary, packaged as a ZIP with the
+/// DWARF-bearing binary stored as `dwarf` at the root plus an optional
+/// `__source/` bundle — the same layout as `AppleDsym`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElfDebugInfo {
+    pub data: Vec<u8>,
+}
+
+impl SymbolData for ElfDebugInfo {
+    fn from_bytes(data: Vec<u8>) -> Result<Self, crate::SymbolDataError> {
+        Ok(Self { data })
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.data
+    }
+
+    fn data_type() -> SymbolDataType {
+        SymbolDataType::ElfDebugInfo
+    }
+}

--- a/rust/common/symbol_data/src/data_types/mod.rs
+++ b/rust/common/symbol_data/src/data_types/mod.rs
@@ -1,4 +1,5 @@
 pub mod dsym;
+pub mod elf;
 pub mod hermesmap;
 pub mod proguard;
 pub mod sourcemap;

--- a/rust/common/symbol_data/src/lib.rs
+++ b/rust/common/symbol_data/src/lib.rs
@@ -23,3 +23,6 @@ pub use data_types::proguard::ProguardMapping;
 
 // Apple dSYM
 pub use data_types::dsym::AppleDsym;
+
+// Native (ELF) debug info
+pub use data_types::elf::ElfDebugInfo;

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -12,6 +12,7 @@ pub enum SymbolDataType {
     HermesMap = 3,
     ProguardMapping = 4,
     AppleDsym = 5,
+    ElfDebugInfo = 6,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -97,15 +97,21 @@ roundtrip_test!(
 );
 
 #[test]
-fn test_reading_elf_debug_info_as_apple_dsym_fails() {
-    let input = ElfDebugInfo {
-        data: b"\x7fELF fake debug payload".to_vec(),
-    };
-
-    let bytes = write_symbol_data(input).unwrap();
+fn test_cross_type_reads_fail() {
     // Consumers that accept multiple container types dispatch on the type tag,
-    // so a type mismatch must be an error rather than a silent reinterpretation.
-    assert!(read_symbol_data::<AppleDsym>(&bytes).is_err());
+    // so a type mismatch must be an error rather than a silent
+    // reinterpretation — in both directions.
+    let elf_bytes = write_symbol_data(ElfDebugInfo {
+        data: b"\x7fELF fake debug payload".to_vec(),
+    })
+    .unwrap();
+    assert!(read_symbol_data::<AppleDsym>(&elf_bytes).is_err());
+
+    let dsym_bytes = write_symbol_data(AppleDsym {
+        data: b"fake dsym zip payload".to_vec(),
+    })
+    .unwrap();
+    assert!(read_symbol_data::<ElfDebugInfo>(&dsym_bytes).is_err());
 }
 
 #[test]

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -1,6 +1,6 @@
 use posthog_symbol_data::{
-    read_symbol_data, write_symbol_data, write_symbol_data_uncompressed, HermesMap,
-    ProguardMapping, SourceAndMap,
+    read_symbol_data, write_symbol_data, write_symbol_data_uncompressed, AppleDsym, ElfDebugInfo,
+    HermesMap, ProguardMapping, SourceAndMap,
 };
 
 const MAGIC_LEN: usize = b"posthog_error_tracking".len();
@@ -88,6 +88,25 @@ roundtrip_test!(
         content: "proguard mapping data".to_string(),
     }
 );
+roundtrip_test!(
+    test_v2_roundtrip_elf_debug_info,
+    ElfDebugInfo,
+    ElfDebugInfo {
+        data: b"\x7fELF fake debug payload".to_vec(),
+    }
+);
+
+#[test]
+fn test_reading_elf_debug_info_as_apple_dsym_fails() {
+    let input = ElfDebugInfo {
+        data: b"\x7fELF fake debug payload".to_vec(),
+    };
+
+    let bytes = write_symbol_data(input).unwrap();
+    // Consumers that accept multiple container types dispatch on the type tag,
+    // so a type mismatch must be an error rather than a silent reinterpretation.
+    assert!(read_symbol_data::<AppleDsym>(&bytes).is_err());
+}
 
 #[test]
 fn test_v2_compressed_large_payload() {


### PR DESCRIPTION
## Problem

Uploaded symbol artifacts are wrapped in the versioned `posthog_error_tracking` container with a type tag (`SourceAndMap`, `HermesMap`, `ProguardMapping`, `AppleDsym`). Rust server-side symbolication needs a container type for ELF debug-info bundles (stacked PR train for Rust error tracking symbolication, step 3).

## Changes

- `SymbolDataType::ElfDebugInfo = 6` and the `ElfDebugInfo { data: Vec<u8> }` wrapper — a ZIP with the DWARF-bearing ELF stored as `dwarf` at the root plus optional `__source/` bundle, mirroring the `AppleDsym` layout.
- Version bump to 0.5.0 (publish itself is intentionally not part of this PR) + workspace lockfile update.
- Round-trip test and a cross-type rejection test (reading `ElfDebugInfo` bytes as `AppleDsym` must fail on the type tag — the native provider in the next PR dispatches on exactly this).

Note on sequencing: the second-model review flagged that nothing consumes the new tag yet. That's the stacking, by design — the cymbal native provider that reads both `AppleDsym` and `ElfDebugInfo` is the next PR in this train, and the first producer (`posthog-cli debug-symbols upload`) is stacked after that, so there is no window where a producer exists without the consumer.

## How did you test this code?

Agent-authored; automated tests only:

- `cargo test -p posthog-symbol-data` — 9 passed (round-trip incl. zstd, cross-type rejection, v1 back-compat).
- `cargo check -p cymbal --locked` to confirm the lockfile is consistent.
- `cargo clippy --all-targets` / `cargo fmt` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Fable 5) as part of the Rust error tracking symbolication plan
- crates.io publish (tag `posthog-symbol-data/v0.5.0`) is deliberately left out; the CLI PR later in the train depends on the published crate and is gated on that release.
