### PR TITLE
feat(max): drive PostHog AI status banner from incident.io

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5482,14 +5482,6 @@ snapshots:
         hash: v1.k794b7964.f92b231b8083680bc33d6c9d2cb13af5a7de2eb7e1f2722f2086c6b4a4ea06c6.cviDFjJA-dUstcAlx2mI0ffr2HRp-VLytWiBxgwBBWM
     scenes-app-persons-modal--with-results--light:
         hash: v1.k794b7964.37b8a4ee1f1cf2aeeca11aee3b3b283008580a928caa0c1d00d2f3cc1eb29492.Iknch3oVJNcVs8fG86RqehgsJj6J-8TmmwysnISdsaE
-    scenes-app-posthog-ai--alerts-only--dark:
-        hash: v1.k794b7964.0e1d6237bd9d280d186f63991b762b73b9d9c008b2f37d73825d3422d4ce6988.lDZMiAw-eYkmnrOviO6lZ4Dr8AAPV9ctSL7uZl0KG6o
-    scenes-app-posthog-ai--alerts-only--light:
-        hash: v1.k794b7964.09d0e274312e73ff80b93c4347e95f764f8566a978699089e683c7b286833675.Sm8decJ6s0FowQccDEr9PJkd8j7WgockW4-LXrtipB4
-    scenes-app-posthog-ai--alerts-with-changelog--dark:
-        hash: v1.k794b7964.56358caa5180cdd83c99a039ccfec98628626edc3fc3ef1269ff4f57b4582853.ZA2QoidhRA7YbP2S-NYATS0yDes_3wMapbFeH1ksEhQ
-    scenes-app-posthog-ai--alerts-with-changelog--light:
-        hash: v1.k794b7964.fdd9c652082327e09a5105d3322588d432e715fa7eb8486f8b8e81d2639ce26c._I2T-IbANg7t613qERE8iMGq8spGQILUcGD4LJkBO5U
     scenes-app-posthog-ai--changelog-only--dark:
         hash: v1.k794b7964.992aae5ce0e0d001b2bc8129ca6411c1da1b78c0ffcdac7c6243a239d38f13b8.wMGah9IabtNwvnVpktHya5m_u0uErsJodGIKHm8rCkc
     scenes-app-posthog-ai--changelog-only--light:
@@ -5530,10 +5522,6 @@ snapshots:
         hash: v1.k794b7964.69ba29ff5ae3e924fc9c0afd2c11362676628eecce218c9dc94632859fc0acc4.7vwX-9bINKddlF5MxNvmGl0t4NBKInr8pzXfgfOxRGQ
     scenes-app-posthog-ai--multi-visualization-in-thread--light:
         hash: v1.k794b7964.ec32f784fb4084e076ca55b320fbbd541620c69d41e12d1d390b409f8ed15f72.lZsJ9fL2DrPJQwh3ZfW1vofBCNvWQ6BEK-NPwSLWf8k
-    scenes-app-posthog-ai--multiple-alerts--dark:
-        hash: v1.k794b7964.53bf90bc41fe4db9d96567e35334dc83e6251ec9304260070aca7b998e87112d.8ngSIIrAjM21HuFDLqQKMZrSXyiRIVd9mysevtVe3gI
-    scenes-app-posthog-ai--multiple-alerts--light:
-        hash: v1.k794b7964.4b813f73f9ea25c2363cb7cb7475372d57a133d028dfeed9b01ac0c486795b1b.tNesXJcIkR_hskmxAxYN8nFHH8N7QXvmrMIGdTseBBw
     scenes-app-posthog-ai--notebook-artifact-markdown-only--dark:
         hash: v1.k794b7964.3bf04c9fd8f9a2654162d001c454676e859951f738d1a3b3f44931ac58d3c1de.1Cyyg8kv0tdZXfY_w8ABNotfhGQfChtz23ioBsYlQTM
     scenes-app-posthog-ai--notebook-artifact-markdown-only--light:
@@ -5550,14 +5538,6 @@ snapshots:
         hash: v1.k794b7964.9e7820bda555416bbcf484382400e54f3aa6f3fbea8288704b4777c39bdb7a3c.JAd9YaS-X_bDF7UJKQFX7ZTf2FyW0kYaS4bMzzuQxy4
     scenes-app-posthog-ai--notebook-artifact-with-visualizations--light:
         hash: v1.k794b7964.070e07dbcacdd4321e3ce4dd5c8a5af6b389aedb95c4cd5dadabb76c85491d92.-kuX5SNZTG6QNl5g2QChrmqPiy9FE-wrp6omHy24JAE
-    scenes-app-posthog-ai--outage-alert--dark:
-        hash: v1.k794b7964.bef0e01423fd4b64ec1381ae557dbf3ea9af00372878b8acbf13ed30dc5e7617.yUz6uiD5KR9GLe0PUCb7OCM_OJW6Q1EKE6EzHdGFfJ0
-    scenes-app-posthog-ai--outage-alert--light:
-        hash: v1.k794b7964.a01c6f2cdbe900be72a59a8fc02b3544dcf8603857dc66e48597f877f3891f9c.Nw4hoRkggORMkq9zcixDnWaktspUIuNZhtLIIi4QBRQ
-    scenes-app-posthog-ai--outage-with-changelog--dark:
-        hash: v1.k794b7964.8bd0556638f4ce56836e0efc6a4a59ca3366704a822517a1ec41c7046a010287.FuWdW8L83xluAnENSaeJOF7qL1WXxN1GiOvF5whcr-M
-    scenes-app-posthog-ai--outage-with-changelog--light:
-        hash: v1.k794b7964.a8f937e8e61a53e43815ab28208380b289013ec54bb1468aa2ec24b69edfc29f.GNAdJCG0pSXc74tps6mJTyYD5LV9eti3-j7X-2cPWng
     scenes-app-posthog-ai--planning-component--dark:
         hash: v1.k794b7964.4c07c035fddc6cae9bc415a4d9493a5d2f17da120b9cdf1dfa56343b17530d3d.BK0bbVuaJWBhFAc24hbNYGSdk0Z3CoasK9jADu697NA
     scenes-app-posthog-ai--planning-component--light:

--- a/frontend/src/lib/components/HelpMenu/incidentStatusLogic.tsx
+++ b/frontend/src/lib/components/HelpMenu/incidentStatusLogic.tsx
@@ -4,6 +4,9 @@ import posthog from 'posthog-js'
 
 // eslint-disable-next-line import/no-cycle
 import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+import { Region } from '~/types'
 
 import type { incidentStatusLogicType } from './incidentStatusLogicType'
 
@@ -56,6 +59,13 @@ export interface Summary {
     scheduled_maintenances: Maintenance[]
 }
 
+// A user-facing warning derived from an ongoing incident that affects a specific component.
+export interface ComponentIncidentAlert {
+    title: string
+    description: string
+    severity: 'warning' | 'error'
+}
+
 export const STATUS_PAGE_BASE = 'https://www.posthogstatus.com'
 const REFRESH_INTERVAL = 60 * 1000 * 5 // 5 minutes
 
@@ -80,12 +90,27 @@ export function getIncidentStatus(): NormalizedStatus {
     return currentStatus
 }
 
-// Map hostname to the group_name used in incident.io
-const RELEVANT_GROUP_NAME_MAP: Record<string, string> = {
-    'us.posthog.com': 'US Cloud 🇺🇸',
-    'eu.posthog.com': 'EU Cloud 🇪🇺',
-    localhost: 'US Cloud 🇺🇸', // Default to US for local dev
-    '127.0.0.1': 'US Cloud 🇺🇸', // Storybook CI runs at 127.0.0.1:6006
+// incident.io component name for the PostHog AI service. An incident is treated as affecting AI only
+// when it tags a component with this exact name under the current region's group (see getRelevantGroupName).
+export const AI_COMPONENT_NAME = 'PostHog AI'
+
+// incident.io component group name (text only — the status page suffixes a region flag emoji we strip
+// on the API side via normalizeGroupName) for each cloud region.
+const GROUP_NAME_BY_REGION: Record<Region, string> = {
+    [Region.US]: 'US Cloud',
+    [Region.EU]: 'EU Cloud',
+}
+
+// Resolve the incident.io component group from preflight. US and EU cloud each see their own region's
+// incidents; everything else (local dev, self-hosted, Storybook, unknown deployments) sees nothing.
+function getRelevantGroupName(region: Region | null | undefined): string | null {
+    if (region === Region.US) {
+        return GROUP_NAME_BY_REGION[Region.US]
+    }
+    if (region === Region.EU) {
+        return GROUP_NAME_BY_REGION[Region.EU]
+    }
+    return null
 }
 
 // Map hostname to the region-specific status page path (incident.io sub-pages)
@@ -96,8 +121,10 @@ const REGION_PATH_MAP: Record<string, string> = {
     '127.0.0.1': '/us', // Storybook CI runs at 127.0.0.1:6006
 }
 
-function getRelevantGroupName(): string | null {
-    return RELEVANT_GROUP_NAME_MAP[window.location.hostname] || null
+// Reduce an incident.io group_name to its text, dropping the region flag emoji and surrounding
+// whitespace, so it can be compared against the emoji-free names in GROUP_NAME_BY_REGION.
+function normalizeGroupName(name: string): string {
+    return name.replace(/[^\p{L}\p{N}\s]/gu, '').trim()
 }
 
 // Region-specific status page URL, falling back to the root page for unknown (self-hosted) hosts
@@ -105,26 +132,25 @@ export function getStatusPageUrl(): string {
     return `${STATUS_PAGE_BASE}${REGION_PATH_MAP[window.location.hostname] ?? ''}`
 }
 
-function hasRelevantComponents(affectedComponents: AffectedComponent[]): boolean {
-    const relevantGroupName = getRelevantGroupName()
+function hasRelevantComponents(affectedComponents: AffectedComponent[], relevantGroupName: string | null): boolean {
     if (!relevantGroupName) {
-        // Unknown hostname (self-hosted) — cloud incidents aren't relevant
+        // No region (local dev, self-hosted, unknown) — cloud incidents aren't relevant
         return false
     }
     // If no affected components, show the incident (it's global)
     if (affectedComponents.length === 0) {
         return true
     }
-    return affectedComponents.some((component) => component.group_name === relevantGroupName)
+    return affectedComponents.some((component) => normalizeGroupName(component.group_name ?? '') === relevantGroupName)
 }
 
-function getWorstStatusForRegion(summary: Summary): NormalizedStatus {
+function getWorstStatusForRegion(summary: Summary, relevantGroupName: string | null): NormalizedStatus {
     // Filter incidents to only those affecting the current region
     const relevantIncidents = summary.ongoing_incidents.filter((incident) =>
-        hasRelevantComponents(incident.affected_components)
+        hasRelevantComponents(incident.affected_components, relevantGroupName)
     )
     const relevantMaintenances = summary.in_progress_maintenances.filter((maintenance) =>
-        hasRelevantComponents(maintenance.affected_components)
+        hasRelevantComponents(maintenance.affected_components, relevantGroupName)
     )
 
     const hasOngoingIncidents = relevantIncidents.length > 0
@@ -161,11 +187,44 @@ function getWorstStatusForRegion(summary: Summary): NormalizedStatus {
     return 'operational'
 }
 
+// The AI component tagged on this incident for the current region, if any.
+function matchedAiComponent(incident: Incident, relevantGroupName: string | null): AffectedComponent | undefined {
+    if (!relevantGroupName) {
+        // No region (local dev, self-hosted, unknown) — cloud AI incidents aren't relevant.
+        return undefined
+    }
+    return incident.affected_components.find(
+        (component) =>
+            component.name === AI_COMPONENT_NAME && normalizeGroupName(component.group_name ?? '') === relevantGroupName
+    )
+}
+
+function componentStatusToSeverity(status: ComponentStatus): ComponentIncidentAlert['severity'] {
+    return status === 'partial_outage' || status === 'full_outage' ? 'error' : 'warning'
+}
+
+function getAiIncidentAlerts(summary: Summary | null, relevantGroupName: string | null): ComponentIncidentAlert[] {
+    if (!summary) {
+        return []
+    }
+    return summary.ongoing_incidents.reduce<ComponentIncidentAlert[]>((alerts, incident) => {
+        const component = matchedAiComponent(incident, relevantGroupName)
+        if (component) {
+            alerts.push({
+                title: incident.name,
+                description: incident.last_update_message,
+                severity: componentStatusToSeverity(component.current_status),
+            })
+        }
+        return alerts
+    }, [])
+}
+
 export const incidentStatusLogic = kea<incidentStatusLogicType>([
     path(['lib', 'components', 'HelpMenu', 'incidentStatusLogic']),
 
     connect(() => ({
-        values: [superpowersLogic, ['fakeStatusOverride', 'superpowersEnabled']],
+        values: [superpowersLogic, ['fakeStatusOverride', 'superpowersEnabled'], preflightLogic, ['preflight']],
     })),
 
     actions({
@@ -207,13 +266,17 @@ export const incidentStatusLogic = kea<incidentStatusLogicType>([
 
     selectors({
         statusPageUrl: [() => [], (): string => getStatusPageUrl()],
+        relevantGroupName: [
+            (s) => [s.preflight],
+            (preflight): string | null => getRelevantGroupName(preflight?.region),
+        ],
         rawStatus: [
-            (s) => [s.summary],
-            (summary: Summary | null): NormalizedStatus => {
+            (s) => [s.summary, s.relevantGroupName],
+            (summary: Summary | null, relevantGroupName): NormalizedStatus => {
                 if (!summary) {
                     return 'operational'
                 }
-                return getWorstStatusForRegion(summary)
+                return getWorstStatusForRegion(summary, relevantGroupName)
             },
         ],
         status: [
@@ -225,9 +288,14 @@ export const incidentStatusLogic = kea<incidentStatusLogicType>([
                 return rawStatus
             },
         ],
+        aiIncidentAlerts: [
+            (s) => [s.summary, s.relevantGroupName],
+            (summary: Summary | null, relevantGroupName): ComponentIncidentAlert[] =>
+                getAiIncidentAlerts(summary, relevantGroupName),
+        ],
         statusDescription: [
-            (s) => [s.summary, s.status],
-            (summary, status): string | null => {
+            (s) => [s.summary, s.status, s.relevantGroupName],
+            (summary, status, relevantGroupName): string | null => {
                 if (!summary) {
                     return null
                 }
@@ -236,10 +304,10 @@ export const incidentStatusLogic = kea<incidentStatusLogicType>([
                 }
                 // Filter to only count incidents/maintenances relevant to this region
                 const incidentCount = summary.ongoing_incidents.filter((incident: Incident) =>
-                    hasRelevantComponents(incident.affected_components)
+                    hasRelevantComponents(incident.affected_components, relevantGroupName)
                 ).length
                 const maintenanceCount = summary.in_progress_maintenances.filter((maintenance: Maintenance) =>
-                    hasRelevantComponents(maintenance.affected_components)
+                    hasRelevantComponents(maintenance.affected_components, relevantGroupName)
                 ).length
                 if (incidentCount > 0) {
                     return `${incidentCount} ongoing incident${incidentCount > 1 ? 's' : ''}`

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -408,7 +408,6 @@ export const FEATURE_FLAGS = {
     PINTEREST_ADS_SOURCE: 'pinterest-ads-source', // owner: @jabahamondes #team-web-analytics
     PIPELINE_STATUS_PAGE: 'pipeline-status-page', // owner: @clr182 #team-support
     POST_ONBOARDING_MODAL_EXPERIMENT: 'post-onboarding-modal-experiment', // owner: @fercgomes #team-growth multivariate=control,test
-    POSTHOG_AI_ALERTS: 'posthog-ai-alerts', // owner: #team-posthog-ai
     POSTHOG_AI_BILLING_DISPLAY: 'posthog-ai-billing-display', // owner: #team-posthog-ai
     POSTHOG_AI_CHANGELOG: 'posthog-ai-changelog', // owner: #team-posthog-ai
     POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG: 'posthog-ai-conversation-feedback-config', // owner: #team-posthog-ai

--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -35,7 +35,7 @@ import { FilterLogicalOperator, InsightShortId, PendingApproval, PropertyFilterT
 
 import conversationList from './__mocks__/conversationList.json'
 import { MaxInstance, MaxInstanceProps } from './Max'
-import { AlertEntry, ChangelogEntry, maxChangelogLogic } from './maxChangelogLogic'
+import { ChangelogEntry, maxChangelogLogic } from './maxChangelogLogic'
 import { maxContextLogic } from './maxContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
 import { QUESTION_SUGGESTIONS_DATA, maxLogic } from './maxLogic'
@@ -3150,18 +3150,6 @@ const SAMPLE_CHANGELOG_ENTRIES: ChangelogEntry[] = [
     },
 ]
 
-const SAMPLE_WARNING_ALERT: AlertEntry = {
-    title: 'Service degraded',
-    description: 'Some AI features may be slower than usual',
-    severity: 'warning',
-}
-
-const SAMPLE_OUTAGE_ALERT: AlertEntry = {
-    title: 'Service outage',
-    description: 'AI features are temporarily unavailable. We are working on a fix.',
-    severity: 'error',
-}
-
 export const ChangelogOnly: Story = {
     render: () => {
         const { setEntries, openChangelog } = useActions(maxChangelogLogic)
@@ -3175,104 +3163,6 @@ export const ChangelogOnly: Story = {
     },
     parameters: {
         featureFlags: ['posthog-ai-changelog'],
-        testOptions: {
-            waitForLoadersToDisappear: false,
-        },
-    },
-}
-
-export const AlertsOnly: Story = {
-    render: () => {
-        const { setAlerts, openChangelog } = useActions(maxChangelogLogic)
-
-        useEffect(() => {
-            setAlerts([SAMPLE_WARNING_ALERT])
-            setTimeout(() => openChangelog(), 100)
-        }, [setAlerts, openChangelog])
-
-        return <Template />
-    },
-    parameters: {
-        featureFlags: ['posthog-ai-alerts'],
-        testOptions: {
-            waitForLoadersToDisappear: false,
-        },
-    },
-}
-
-export const OutageAlert: Story = {
-    render: () => {
-        const { setAlerts, openChangelog } = useActions(maxChangelogLogic)
-
-        useEffect(() => {
-            setAlerts([SAMPLE_OUTAGE_ALERT])
-            setTimeout(() => openChangelog(), 100)
-        }, [setAlerts, openChangelog])
-
-        return <Template />
-    },
-    parameters: {
-        featureFlags: ['posthog-ai-alerts'],
-        testOptions: {
-            waitForLoadersToDisappear: false,
-        },
-    },
-}
-
-export const AlertsWithChangelog: Story = {
-    render: () => {
-        const { setEntries, setAlerts, openChangelog } = useActions(maxChangelogLogic)
-
-        useEffect(() => {
-            setEntries(SAMPLE_CHANGELOG_ENTRIES)
-            setAlerts([SAMPLE_WARNING_ALERT])
-            setTimeout(() => openChangelog(), 100)
-        }, [setEntries, setAlerts, openChangelog])
-
-        return <Template />
-    },
-    parameters: {
-        featureFlags: ['posthog-ai-changelog', 'posthog-ai-alerts'],
-        testOptions: {
-            waitForLoadersToDisappear: false,
-        },
-    },
-}
-
-export const OutageWithChangelog: Story = {
-    render: () => {
-        const { setEntries, setAlerts, openChangelog } = useActions(maxChangelogLogic)
-
-        useEffect(() => {
-            setEntries(SAMPLE_CHANGELOG_ENTRIES)
-            setAlerts([SAMPLE_OUTAGE_ALERT])
-            setTimeout(() => openChangelog(), 100)
-        }, [setEntries, setAlerts, openChangelog])
-
-        return <Template />
-    },
-    parameters: {
-        featureFlags: ['posthog-ai-changelog', 'posthog-ai-alerts'],
-        testOptions: {
-            waitForLoadersToDisappear: false,
-        },
-    },
-}
-
-export const MultipleAlerts: Story = {
-    render: () => {
-        const { setEntries, setAlerts, openChangelog } = useActions(maxChangelogLogic)
-
-        useEffect(() => {
-            setEntries(SAMPLE_CHANGELOG_ENTRIES)
-            setAlerts([SAMPLE_WARNING_ALERT, SAMPLE_OUTAGE_ALERT])
-            setTimeout(() => openChangelog(), 100)
-        }, [setEntries, setAlerts, openChangelog])
-
-        return <Template />
-    },
-    parameters: {
-        featureFlags: ['posthog-ai-changelog', 'posthog-ai-alerts'],
         testOptions: {
             waitForLoadersToDisappear: false,
         },

--- a/frontend/src/scenes/max/components/MaxChangelog.tsx
+++ b/frontend/src/scenes/max/components/MaxChangelog.tsx
@@ -41,16 +41,14 @@ export function getAlertTagProps(severity: AlertEntry['severity']): {
 
 export function MaxChangelog(): JSX.Element | null {
     const changelogFlagEnabled = useFeatureFlag('POSTHOG_AI_CHANGELOG')
-    const alertsFlagEnabled = useFeatureFlag('POSTHOG_AI_ALERTS')
     const { entries, alerts, isOpen, hasUnread, hasAlerts, isVisible } = useValues(maxChangelogLogic)
     const { openChangelog, closeChangelog, dismissChangelog } = useActions(maxChangelogLogic)
     const displayedEntries = useMemo(() => entries.slice(0, 4), [entries])
     const hasMoreEntries = entries.length > 4
 
-    const showAlerts = alertsFlagEnabled && hasAlerts
     const showChangelog = changelogFlagEnabled && entries.length > 0
 
-    if (!isVisible || (!showAlerts && !showChangelog)) {
+    if (!isVisible || (!hasAlerts && !showChangelog)) {
         return null
     }
 
@@ -64,11 +62,11 @@ export function MaxChangelog(): JSX.Element | null {
                 <div className="p-3 min-w-[280px] max-w-[320px]">
                     <div className="flex items-center justify-between mb-3">
                         <h3 className="font-semibold text-sm m-0">
-                            {showAlerts ? 'PostHog AI status' : "What's new in PostHog AI"}
+                            {hasAlerts ? 'PostHog AI status' : "What's new in PostHog AI"}
                         </h3>
                         <LemonButton size="xsmall" icon={<IconX />} onClick={closeChangelog} />
                     </div>
-                    {showAlerts && (
+                    {hasAlerts && (
                         <ul className="space-y-2 mb-3">
                             {alerts.map((alert, index) => (
                                 <li
@@ -88,7 +86,7 @@ export function MaxChangelog(): JSX.Element | null {
                     )}
                     {showChangelog && (
                         <>
-                            {showAlerts && <h4 className="font-semibold text-xs text-muted m-0 mb-2">What's new</h4>}
+                            {hasAlerts && <h4 className="font-semibold text-xs text-muted m-0 mb-2">What's new</h4>}
                             <ul className="space-y-3 mb-3">
                                 {displayedEntries.map((entry, index) => (
                                     <li key={index} className="flex gap-2 text-sm">
@@ -127,15 +125,15 @@ export function MaxChangelog(): JSX.Element | null {
             <LemonButton
                 size="xsmall"
                 type="tertiary"
-                icon={showAlerts ? <IconWarning /> : <IconSparkles />}
+                icon={hasAlerts ? <IconWarning /> : <IconSparkles />}
                 onClick={isOpen ? closeChangelog : openChangelog}
                 className="relative"
             >
-                {showAlerts ? 'Status' : "What's new"}
-                {(hasUnread || showAlerts) && (
+                {hasAlerts ? 'Status' : "What's new"}
+                {(hasUnread || hasAlerts) && (
                     <span
                         className={`absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full ${
-                            showAlerts ? 'bg-warning' : 'bg-danger'
+                            hasAlerts ? 'bg-warning' : 'bg-danger'
                         }`}
                     />
                 )}

--- a/frontend/src/scenes/max/maxChangelogLogic.ts
+++ b/frontend/src/scenes/max/maxChangelogLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 
+import { incidentStatusLogic } from 'lib/components/HelpMenu/incidentStatusLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic, getFeatureFlagPayload } from 'lib/logic/featureFlagLogic'
 
@@ -19,10 +20,6 @@ export interface AlertEntry {
 
 interface ChangelogPayload {
     entries: ChangelogEntry[]
-}
-
-interface AlertsPayload {
-    alerts: AlertEntry[]
 }
 
 const CHANGELOG_STORAGE_KEY = 'posthog_ai_changelog_last_seen'
@@ -53,24 +50,6 @@ function parseChangelogPayload(payload: unknown): ChangelogEntry[] {
             entry !== null &&
             typeof entry.title === 'string' &&
             typeof entry.description === 'string'
-    )
-}
-
-function parseAlertsPayload(payload: unknown): AlertEntry[] {
-    if (!payload || typeof payload !== 'object') {
-        return []
-    }
-    const typedPayload = payload as AlertsPayload
-    if (!Array.isArray(typedPayload.alerts)) {
-        return []
-    }
-    return typedPayload.alerts.filter(
-        (alert): alert is AlertEntry =>
-            typeof alert === 'object' &&
-            alert !== null &&
-            typeof alert.title === 'string' &&
-            typeof alert.description === 'string' &&
-            (alert.severity === 'warning' || alert.severity === 'error')
     )
 }
 
@@ -119,7 +98,7 @@ export const maxChangelogLogic = kea<maxChangelogLogicType>([
     path(['scenes', 'max', 'maxChangelogLogic']),
 
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], incidentStatusLogic, ['aiIncidentAlerts']],
     })),
 
     actions({
@@ -131,21 +110,14 @@ export const maxChangelogLogic = kea<maxChangelogLogicType>([
         setIsDismissed: (isDismissed: boolean) => ({ isDismissed }),
         // For testing/storybook only
         setEntries: (entries: ChangelogEntry[]) => ({ entries }),
-        setAlerts: (alerts: AlertEntry[]) => ({ alerts }),
     }),
 
     reducers({
-        // Override entries/alerts for testing - null means use feature flag payload
+        // Override entries for testing - null means use feature flag payload
         entriesOverride: [
             null as ChangelogEntry[] | null,
             {
                 setEntries: (_, { entries }) => entries,
-            },
-        ],
-        alertsOverride: [
-            null as AlertEntry[] | null,
-            {
-                setAlerts: (_, { alerts }) => alerts,
             },
         ],
         isOpen: [
@@ -188,21 +160,8 @@ export const maxChangelogLogic = kea<maxChangelogLogicType>([
                 return parseChangelogPayload(payload)
             },
         ],
-        // Derive alerts from feature flag payload, with override for testing
-        alerts: [
-            (s) => [s.alertsOverride, s.featureFlags],
-            (alertsOverride, featureFlags): AlertEntry[] => {
-                if (alertsOverride !== null) {
-                    return alertsOverride
-                }
-                // featureFlags dependency ensures this re-runs when flags load
-                if (!featureFlags) {
-                    return []
-                }
-                const payload = getFeatureFlagPayload(FEATURE_FLAGS.POSTHOG_AI_ALERTS)
-                return parseAlertsPayload(payload)
-            },
-        ],
+        // Derive alerts from ongoing incident.io incidents tagged to PostHog AI
+        alerts: [(s) => [s.aiIncidentAlerts], (aiIncidentAlerts): AlertEntry[] => aiIncidentAlerts],
         entriesHash: [
             (s) => [s.entries],
             (entries): string | null => (entries.length > 0 ? generateEntriesHash(entries) : null),


### PR DESCRIPTION
## Problem

The PostHog AI status banner (the "Status" warning shown on the Max AI page) was gated on the manual `POSTHOG_AI_ALERTS` feature flag. Surfacing a warning during an AI incident meant a person had to hand-edit the flag's JSON payload, and clearing it meant remembering to edit it back. That's slow during an incident and easy to leave stale afterwards.

We already poll the incident.io status page (`posthogstatus.com`) for the help-menu status badge, so the data needed to drive the banner automatically was already in the app.

## Changes

- **Derive the banner from incidents, not a flag.** `incidentStatusLogic` gains an `aiIncidentAlerts` selector: an ongoing incident that tags a component named `PostHog AI` under the current region's group becomes an alert automatically. `maxChangelogLogic.alerts` now reads that selector instead of the flag payload, and the `POSTHOG_AI_ALERTS` flag and its gate are removed. This also drops the test-only alerts override (`setAlerts`/`alertsOverride`) and the Storybook stories that existed solely to render the flag-driven banner (`AlertsOnly`, `OutageAlert`, `AlertsWithChangelog`, `OutageWithChangelog`, `MultipleAlerts`); the changelog stories are untouched.
- **Resolve region from preflight, not the hostname.** Region detection no longer parses `window.location.hostname`. It reads `preflight.region`: US and EU cloud each see their own region's incidents; everything else (local dev, self-hosted, unknown deployments) resolves to no region and surfaces nothing.
- **Match region group on text, ignoring the flag emoji.** The status page suffixes group names with a region flag emoji (e.g. `US Cloud 🇺🇸`); matching now strips it and compares on `US Cloud` / `EU Cloud`, so it won't silently break if the emoji changes.
- **Severity from the matched component's status.** `partial_outage`/`full_outage` → error, otherwise warning — which sidesteps the incident-level `operational` impact edge case where a real AI incident would otherwise read as "all clear".

No backend or schema changes. The banner UI (`MaxChangelog.tsx`) is unchanged beyond dropping the flag gate.

**Tagging requirement for incident response:** for the banner to fire, an incident must tag a component named exactly `PostHog AI` under the relevant region group (`US Cloud` / `EU Cloud`). An untagged incident will not surface the banner.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual UI testing. Automated checks I ran locally, all passing:

- `kea-typegen write` (regenerated logic types)
- `pnpm --filter=@posthog/frontend typescript:check`
- `oxlint` and `oxfmt` on the changed files

I also verified the matching logic against the live `posthogstatus.com/api/v1/summary` response for a real ongoing "PostHog AI" incident: the component is tagged under both `US Cloud 🇺🇸` and `EU Cloud 🇪🇺`, and traced that it produces a warning-severity alert for the matching region.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @rafaeelaudibert.

Started from a debugging question — why the help-menu status badge stayed green during a live AI incident — which surfaced two real issues: the badge defaults to `operational` when an incident carries `operational` impact, and the region-group match was emoji-sensitive (the repo even hardcoded an invalid EU flag, so EU matching would have silently failed). Those informed the design here.

Key decisions:
- **Component-tag detection over keyword matching.** Considered matching incident name/text (works without any incident.io process change) but chose tagging a dedicated `PostHog AI` component — robust and no false positives — accepting that incident response must tag it.
- **Replaced the flag entirely** rather than merging flag + incident sources, per the directive to keep one source of truth.
- **Region scoping narrowed twice during review:** first to a US default for non-EU, then to the final "US/EU see their own, everything else sees nothing" so self-hosted/local don't surface cloud incidents.


