### PR TITLE
fix(endpoints): skip duplicate select alias when enabling materialization

### DIFF
--- a/products/endpoints/backend/materialization.py
+++ b/products/endpoints/backend/materialization.py
@@ -1262,14 +1262,27 @@ class MaterializationTransformer(CloningVisitor):
 
     def _add_variable_columns(self, node: ast.SelectQuery, vars_for_context: list[MaterializableVariable]) -> None:
         """Add aliased variable columns to SELECT, update GROUP BY, and remove variable WHERE clauses."""
-        select_additions = [self._create_column_field(var) for var in vars_for_context]
-        if node.select:
-            node.select = [*list(node.select), *select_additions]
-        else:
-            node.select = select_additions
+        existing_aliases: dict[str, str] = {
+            expr.alias: expr.expr.to_hogql() for expr in node.select or [] if isinstance(expr, ast.Alias)
+        }
+        vars_to_add: list[MaterializableVariable] = []
+        for var in vars_for_context:
+            existing_expr = existing_aliases.get(var.code_name)
+            if existing_expr is not None:
+                if existing_expr == self._variable_expr(var).to_hogql():
+                    # SELECT already exposes this column under the variable's name
+                    continue
+                raise ValueError(
+                    f"Variable '{var.code_name}' conflicts with an existing SELECT alias for a different expression"
+                )
+            vars_to_add.append(var)
 
-        if node.group_by is not None or self._has_aggregate_functions(node):
-            self._add_group_by(node, vars_for_context)
+        select_additions = [self._create_column_field(var) for var in vars_to_add]
+        if select_additions:
+            node.select = [*list(node.select or []), *select_additions]
+
+        if vars_to_add and (node.group_by is not None or self._has_aggregate_functions(node)):
+            self._add_group_by(node, vars_to_add)
 
         if node.where:
             node.where = self._remove_variable_from_where(node.where)

--- a/products/endpoints/backend/tests/test_variable_materialization.py
+++ b/products/endpoints/backend/tests/test_variable_materialization.py
@@ -990,6 +990,50 @@ class TestQueryTransformation(APIBaseTest):
         assert "GROUP BY" in transformed_query
         assert "event_name" in transformed_query or "event" in transformed_query
 
+    def test_transform_variable_column_already_aliased_in_select(self):
+        # Regression: enabling materialization raised "Cannot redefine an alias" when the
+        # query already selects the variable's column aliased by the variable's code_name.
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "SELECT properties.profile_id AS profile_id, properties.card_id AS card_id, count() AS tap_count "
+                "FROM events "
+                "WHERE event = 'card_tapped' AND properties.profile_id = {variables.profile_id} "
+                "GROUP BY profile_id, card_id"
+            ),
+            "variables": {
+                "var-1": {"variableId": "var-1", "code_name": "profile_id", "value": ""},
+            },
+        }
+
+        can_materialize, reason, var_infos = analyze_variables_for_materialization(query)
+        assert can_materialize is True, reason
+
+        transformed = transform_query_for_materialization(query, var_infos, self.team)
+
+        transformed_query = transformed["query"]
+        assert "{variables" not in transformed_query
+        assert transformed_query.count("AS profile_id") == 1
+
+    def test_transform_variable_alias_collision_with_different_expression(self):
+        query = {
+            "kind": "HogQLQuery",
+            "query": (
+                "SELECT properties.card_id AS profile_id, count() AS tap_count "
+                "FROM events "
+                "WHERE properties.profile_id = {variables.profile_id} "
+                "GROUP BY profile_id"
+            ),
+            "variables": {
+                "var-1": {"variableId": "var-1", "code_name": "profile_id", "value": ""},
+            },
+        }
+
+        _, _, var_infos = analyze_variables_for_materialization(query)
+
+        with pytest.raises(ValueError, match="conflicts with an existing SELECT alias"):
+            transform_query_for_materialization(query, var_infos, self.team)
+
     def test_transform_preserves_order_by(self):
         query = {
             "kind": "HogQLQuery",


### PR DESCRIPTION
## Problem

Enabling materialization on a HogQL endpoint failed with `Cannot redefine an alias with the name: <code_name>` when the query already selects the variable's column aliased by the variable's code name, e.g.:

```sql
SELECT properties.profile_id AS profile_id, count() AS tap_count
FROM events
WHERE properties.profile_id = {variables.profile_id}
GROUP BY profile_id
```

The materialization transformer unconditionally appended its own `<column> AS <code_name>` alias to the SELECT, producing a duplicate alias the HogQL resolver rejects.

## Changes

In `MaterializationTransformer._add_variable_columns`:

- skip the SELECT/GROUP BY additions when the variable's code name is already a select alias for the same expression (compared via `to_hogql()`, so bucket-fn wrapping is matched too)
- raise a clear `ValueError` when the alias name is taken by a *different* expression — silently reusing it would materialize the wrong column; the enable path already converts this to a 400

## How did you test this code?

I'm an agent. Regression tests written first (reproducing the resolver error), then the fix:

- `test_transform_variable_column_already_aliased_in_select`
- `test_transform_variable_alias_collision_with_different_expression`
- full `test_variable_materialization.py` (242 passed) and `test_endpoint_materialization.py` (44 passed)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: traced repeated production `enable` failures via error tracking to the duplicate-alias transform, wrote failing regression tests, then applied the minimal dedupe fix in the transformer.
