### PR TITLE
feat(mcp): stamp $mcp_tool_category on mcp_tool_call events

### DIFF
--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -6,6 +6,7 @@ import {
     MCP_ANALYTICS_VERSION,
     type MCPAnalyticsContext,
 } from '@/lib/posthog/analytics'
+import { getToolCategory } from '@/tools/toolDefinitions'
 
 import { buildMCPSessionAnalyticsProperties } from './mcp-context'
 import type { ResolvedState } from './request-state-resolver'
@@ -102,6 +103,15 @@ export async function trackToolCall(
 
         const { properties, groups } = buildBaseProperties(state, analyticsContext)
 
+        // `$mcp_tool_category` is the dashboard's grouping dimension (e.g. "Logs",
+        // "Tracing"). The contract is: the producer stamps the category onto every
+        // tool-call event; the MCP analytics dashboard reads it back verbatim and
+        // never maps tool names to categories itself. PostHog's server derives it
+        // from its own catalog here; external servers using the SDK declare it per
+        // tool. Omitted when unknown (e.g. the `exec` wrapper) so the dashboard
+        // buckets those as "Uncategorized".
+        const toolCategory = getToolCategory(toolName)
+
         getPostHogClient().capture({
             distinctId: state.distinctId,
             event: 'mcp_tool_call',
@@ -112,6 +122,7 @@ export async function trackToolCall(
                 $mcp_duration_ms: durationMs,
                 $mcp_is_error: isError,
                 tool_name: toolName,
+                ...(toolCategory ? { $mcp_tool_category: toolCategory } : {}),
                 ...(sessionUuid ? { $session_id: sessionUuid } : {}),
                 ...extraProperties,
             },

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/errors'
 import { AnalyticsEvent } from '@/lib/posthog/analytics'
 import { createExecTool, type ExecInnerCallTracker } from '@/tools/exec'
+import { getToolCategory } from '@/tools/toolDefinitions'
 import type { Context, ZodObjectAny } from '@/tools/types'
 
 import { trackToolCall } from './analytics'
@@ -209,11 +210,19 @@ export class ToolExecutor {
             toolCallsTotal.inc({ tool: toolName, status })
             toolCallDurationSeconds.observe({ tool: toolName, status }, properties.duration_ms / 1000)
 
+            // Mirror the native path: stamp the inner tool's category so exec-routed
+            // calls share the dashboard's `$mcp_tool_category` grouping dimension.
+            const toolCategory = getToolCategory(toolName)
+
             void (async () => {
                 const freshContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
                 await state.reqCtx.trackEvent(
                     AnalyticsEvent.MCP_TOOL_CALL,
-                    { tool_name: toolName, ...properties },
+                    {
+                        tool_name: toolName,
+                        ...(toolCategory ? { $mcp_tool_category: toolCategory } : {}),
+                        ...properties,
+                    },
                     freshContext,
                     undefined,
                     state.distinctId

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -104,6 +104,16 @@ export function getToolDefinition(toolName: string): ToolDefinition {
     return definition
 }
 
+/**
+ * The product category a tool belongs to (e.g. "Logs", "Tracing"), or undefined
+ * for tools without a catalogued definition (e.g. the `exec` wrapper). Unlike
+ * {@link getToolDefinition} this never throws, so it is safe to call from the
+ * analytics hot path where a missing definition must not break the request.
+ */
+export function getToolCategory(toolName: string): string | undefined {
+    return getToolDefinitions()[toolName]?.category
+}
+
 export interface ToolFilterOptions {
     features?: string[] | undefined
     tools?: string[] | undefined

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -96,4 +96,16 @@ describe('Hono MCP analytics contexts', () => {
         expect(properties.mcp_session_client_name).toBeUndefined()
         expect(properties.mcp_session_vendor_client).toBeUndefined()
     })
+
+    it('stamps $mcp_tool_category from the catalogued tool definition', async () => {
+        await trackToolCall('query-logs', 5, false, makeState())
+
+        expect(mockCapture.mock.calls[0]![0].properties.$mcp_tool_category).toBe('Logs')
+    })
+
+    it('omits $mcp_tool_category for tools without a catalogued definition', async () => {
+        await trackToolCall('exec', 5, false, makeState())
+
+        expect(mockCapture.mock.calls[0]![0].properties).not.toHaveProperty('$mcp_tool_category')
+    })
 })


### PR DESCRIPTION
## Problem

MCP analytics has no way to group or filter tool usage by the product a tool belongs to (e.g. Logs, Tracing). The `mcp_tool_call` event carries the tool name but not its category, so any per-team or per-product view has to map tool names to categories at query time — brittle, and impossible for external customers whose tool catalogs PostHog doesn't know.

This is the first step toward an ownership/category dimension: stamp the category onto the event at capture, so the dashboard can read it back verbatim.

## Changes

- Add `getToolCategory(toolName)` to `toolDefinitions.ts` — a non-throwing lookup over the in-process tool catalog (covers hand-written tools too, since the catalog merges `tool-definitions.json` + the generated definitions).
- Stamp `$mcp_tool_category` onto `mcp_tool_call` on both emit paths: the native path (`hono/analytics.ts`) and the exec inner-call path (`tool-executor.ts`).
- Omit the property for tools without a catalogued definition (e.g. the `exec` wrapper), which the dashboard buckets as "Uncategorized".

This establishes the event contract: the producer stamps the category; the dashboard reads it back and never maps tool names itself. PostHog's server derives it from its own catalog here; external servers using the `@posthog/mcp` SDK will declare it per tool (separate repo, follow-up).

Forward-only: events emitted before this deploys won't carry the property.

## How did you test this code?

I'm an agent (PostHog Code). I added and ran automated unit tests in `tests/hono/analytics.test.ts` (via `vitest --config vitest.hono.config.mts`): asserting `$mcp_tool_category` is stamped from the catalogued definition (`query-logs` → `Logs`) and omitted for uncatalogued tools (`exec`). Existing `analytics` and `tool-executor` hono suites still pass. Lint (oxlint) clean on changed files. I did not perform manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). Daniel directed the design across several iterations; key decision was to stamp at capture in the in-repo server emitter rather than via the `@posthog/mcp` npm SDK, because production traffic runs on the Hono runtime which emits events directly (the SDK's `eventProperties`/`eventTags` callbacks never fire there). The catalog-derived lookup avoids introducing a separate generated map. First of a stacked pair; PR 2 adds the dashboard scope that consumes this property.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
