### PR TITLE
feat(mcp): search MCP analytics sessions by tool category

### DIFF
--- a/products/mcp_analytics/backend/logic.py
+++ b/products/mcp_analytics/backend/logic.py
@@ -86,7 +86,10 @@ SELECT
     count() AS tool_call_count,
     groupUniqArray(properties.$mcp_tool_name) AS tools_used,
     argMax(distinct_id, timestamp) AS distinct_id,
-    argMax(properties.$mcp_client_name, timestamp) AS mcp_client_name
+    argMax(properties.$mcp_client_name, timestamp) AS mcp_client_name,
+    -- Only consumed by the search HAVING below (not surfaced in the contract);
+    -- mirrors tools_used so category search reuses the same proven aggregate shape.
+    groupUniqArray(properties.$mcp_tool_category) AS categories_used
 FROM events
 WHERE event = {event}
     AND timestamp >= {date_from}
@@ -101,13 +104,16 @@ OFFSET {offset}
 """
 
 # Search is post-aggregation (HAVING) so a match returns the whole session, not
-# just the matching events. tools_used / distinct_id / mcp_client_name are
-# aggregates, so they can only be filtered after GROUP BY.
+# just the matching events. tools_used / categories_used / distinct_id /
+# mcp_client_name are aggregates, so they can only be filtered after GROUP BY. The
+# categories_used clause lets a search like "tracing" surface sessions whose tools
+# (e.g. apm-*) don't contain the term textually but belong to that product category.
 _SESSION_SEARCH_HAVING = (
     "HAVING session_id ILIKE {search} "
     "OR distinct_id ILIKE {search} "
     "OR mcp_client_name ILIKE {search} "
-    "OR arrayExists(t -> t ILIKE {search}, tools_used)"
+    "OR arrayExists(t -> t ILIKE {search}, tools_used) "
+    "OR arrayExists(c -> c ILIKE {search}, categories_used)"
 )
 
 
@@ -148,7 +154,8 @@ def list_mcp_sessions(
     are cached briefly so concurrent dashboard refreshes share a single aggregation.
 
     ``search`` does case-insensitive substring matching across session_id,
-    distinct_id, mcp_client_name, and any element of tools_used. ``order_by`` is a
+    distinct_id, mcp_client_name, any element of tools_used, and any tool
+    category used in the session (e.g. "logs", "tracing"). ``order_by`` is a
     whitelisted column name; prefix with '-' for descending.
 
     Person email/name are resolved from distinct_id via personhog. ``intent`` is

--- a/products/mcp_analytics/backend/tests/test_api.py
+++ b/products/mcp_analytics/backend/tests/test_api.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
 from unittest.mock import patch
@@ -89,6 +90,7 @@ class TestListMCPSessions(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin,
         *,
         client_name: str = "Claude Desktop",
         distinct_id: str = "anon_seed",
+        category: str | None = None,
         session_start: datetime | None = None,
         session_end: datetime | None = None,
     ) -> None:
@@ -96,6 +98,7 @@ class TestListMCPSessions(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin,
 
         tool_call_count == len(tool_sequence); tools_used == its distinct values.
         Events span [session_start, session_end] so min/max timestamps line up.
+        ``category`` stamps $mcp_tool_category on every event when provided.
         """
         now = datetime.now(tz=UTC)
         session_start = session_start or now - timedelta(minutes=5)
@@ -104,16 +107,19 @@ class TestListMCPSessions(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin,
         span = session_end - session_start
         for i, tool in enumerate(tool_sequence):
             timestamp = session_end if n == 1 else session_start + span * (i / (n - 1))
+            properties: dict[str, Any] = {
+                "$mcp_session_id": session_id,
+                "$mcp_tool_name": tool,
+                "$mcp_client_name": client_name,
+            }
+            if category is not None:
+                properties["$mcp_tool_category"] = category
             _create_event(
                 team=self.team,
                 event="mcp_tool_call",
                 distinct_id=distinct_id,
                 timestamp=timestamp,
-                properties={
-                    "$mcp_session_id": session_id,
-                    "$mcp_tool_name": tool,
-                    "$mcp_client_name": client_name,
-                },
+                properties=properties,
             )
 
     def test_lists_sessions_in_newest_first_order(self) -> None:
@@ -215,6 +221,28 @@ class TestListMCPSessions(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin,
         assert {alice_id, bob_id, misc_id}.issubset(search(""))
         # no match
         assert search("zzzz") == set()
+
+    def test_search_matches_tool_category(self) -> None:
+        # A category search surfaces sessions whose tool names don't contain the term
+        # but whose tools belong to that product category — e.g. "tracing" matching
+        # apm-* tools stamped with $mcp_tool_category = "Tracing".
+        tracing_id = str(uuid7())
+        logs_id = str(uuid7())
+        other_id = str(uuid7())
+
+        self._seed_session(tracing_id, ["apm-trace-get", "apm-services-list"], category="Tracing")
+        self._seed_session(logs_id, ["query-logs"], category="Logs")
+        self._seed_session(other_id, ["dashboard_get"], category="Dashboards")
+
+        def search(term: str) -> set[str]:
+            return {s.session_id for s in api.list_mcp_sessions(self.team, limit=50, offset=0, search=term).results}
+
+        # "tracing" matches only via category — the apm-* tool names don't contain it
+        assert search("tracing") == {tracing_id}
+        # case-insensitive category match
+        assert search("LOGS") == {logs_id}
+        # unrelated category isn't matched
+        assert search("tracing") & {logs_id, other_id} == set()
 
     def test_order_by_whitelist(self) -> None:
         # new_id and big_id share a session_end below, so the

--- a/products/mcp_analytics/frontend/sessions/MCPSessionsTable.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionsTable.tsx
@@ -70,7 +70,7 @@ export function MCPSessionsTable(): JSX.Element {
                 <LemonInput
                     type="search"
                     className="w-96 !max-w-none"
-                    placeholder="Search by session id, client, or tool"
+                    placeholder="Search by session id, client, tool, or category"
                     onChange={(value) => setFilters({ search: value })}
                     value={filters.search}
                 />


### PR DESCRIPTION
## Problem

In MCP analytics → **Sessions**, search matches session id, client, and tool name — but not *category*. As the owner of the Logs and Tracing tools, I want to type "logs" or "tracing" and see every session that used a tool in that category. Tool-name search alone misses this: our tracing tools are named `apm-*` / `query-apm-spans`, so "tracing" matches none of them despite all being category `Tracing`.

## Changes

Builds on `$mcp_tool_category` (stamped on `mcp_tool_call`, already in master).

- Extend the server-side session search to also match the **tool categories used in a session**. The match stays post-aggregation (`HAVING`), so a hit returns the whole session (and all its tools), not just the matching calls — preserving the "what else did they use" view.
- Categories are aggregated via a `categories_used` alias that mirrors the existing, proven `tools_used` pattern (only consumed by the search `HAVING`, not surfaced in the response contract).
- Reuses the existing `search` query param — **no new API parameter, no serializer/OpenAPI/generated-type changes**. The only frontend change is the search placeholder copy ("…client, tool, or category").

So "tracing" surfaces sessions using `apm-*` tools, "logs" surfaces `query-logs`/`logs-*` sessions, etc. — driven entirely by the stamped category, case-insensitively.

## How did you test this code?

I'm an agent (PostHog Code). Added `test_search_matches_tool_category` (and extended the `_seed_session` helper with a `category` arg) asserting "tracing" matches a session of `apm-*` tools purely via category (the names don't contain the term), and that the match is case-insensitive. Ran the session search suite with a fresh test DB — the new test and the pre-existing `test_search_filters_across_multiple_columns` both pass. `ruff` and `oxlint` clean. No manual UI testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code, directed by Daniel. Design note: extended the existing free-text `search` (matching the ask to "just search 'logs'/'traces'") rather than adding a dedicated category param — keeping it backend-only with no schema/type churn. First cut used an inline `groupUniqArray(...)` in `HAVING`; switched to a `categories_used` SELECT alias mirroring the proven `tools_used` shape after confirming with a fresh-DB test run (the local test DB was in a poisoned-transaction state that masked passing tests until recreated).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
