### PR TITLE
chore(replay-vision): align summarizer prompt template with new UI framing

### DIFF
--- a/products/replay_vision/backend/temporal/scanners/prompts/summarizer.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/summarizer.jinja
@@ -1,6 +1,9 @@
 {% extends "base.jinja" %}
 {% from "_macros.jinja" import cite_in %}
-{% block task %}Summarize this session per these instructions: {{ user_prompt }}
+{% block task %}Summarize this session.{% if user_prompt %}
+
+Additional context from the team operating the product being recorded:
+{{ user_prompt }}{% endif %}
 
 `title` is at most ~80 characters and contains no event citations. `summary` should be {{ length_guidance }}.
 

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTypeConfigEditor.tsx
@@ -95,7 +95,7 @@ export function ScannerTypeConfigEditor({ scannerId }: { scannerId: string }): J
                 <ScannerPromptField
                     scannerId={scannerId}
                     label="Additional context"
-                    caption="We maintain the core summary prompt. Use this to give context about your product or steer summaries in a direction — for example, the ideal user flow."
+                    caption="The core summarizer prompt is built in. Use this field to add product context or steer summaries — for example, what the ideal user flow looks like."
                     placeholder="e.g. This is a B2B analytics tool. Users usually come to build a dashboard — call out where they get stuck in that flow."
                 />
                 <LemonField name="scanner_config.length" label="Summary length">


### PR DESCRIPTION
## Problem

#62588 relabeled the summarizer's prompt field from **Prompt** to **Additional context**, framing the user's text as product context rather than a directive. But `summarizer.jinja` still wraps that text as

> Summarize this session per these instructions: {{ user_prompt }}

so the user's now-context-shaped input arrives at Gemini as if it were the instructions. With the new placeholder ("e.g. This is a B2B analytics tool. Users usually come to build a dashboard — call out where they get stuck in that flow."), the model sees:

> Summarize this session per these instructions: This is a B2B analytics tool…

Functional but semantically off. And an empty user_prompt renders the dangling "per these instructions:" with nothing after.

## Changes

- **`summarizer.jinja`** — restructure the task block so the user's text is presented as additional context from the team operating the recorded product, and gate it on `{% if user_prompt %}` so empty input degrades cleanly to "Summarize this session." plus the rest of the built-in structure.
- **`ScannerTypeConfigEditor.tsx`** — reword the field caption from "We maintain the core summary prompt…" to "The core summarizer prompt is built in. Use this field to add product context or steer summaries — for example, what the ideal user flow looks like."

## How did you test this code?

Agent, automated only — `hogli test products/replay_vision/backend/tests/test_temporal.py::TestResolveCitations` passes (the only summarizer-touching test in temporal). No prompt-content snapshots to break.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Drafted with Claude Code. Caught while reviewing #62588 — UI change shipped without the corresponding template update.
