### PR TITLE
chore(signals): align scout skills with the agent skill spec

### DIFF
--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -100,9 +100,8 @@ agent-enabled team's `LLMSkill` rows by `scout_harness/lazy_seed.py` — see
   dashboard access), curates a durable scratchpad watchlist, and balances
   re-checking known items (exploit) against discovering new ones (explore) across
   runs; scores the latest complete bucket by robust (MAD) deviation from each
-  insight's own seasonality-matched baseline. Unlike the other specialists it
-  bundles its own references (`anomaly-methods.md`, `watchlist-and-memory.md`,
-  `emit-contract.md`).
+  insight's own seasonality-matched baseline. Bundles its own references
+  (`anomaly-methods.md`, `watchlist-and-memory.md`, `emit-contract.md`).
 - `signals-scout-health-checks/` — the judgment layer over PostHog's own health
   checks. Reads the project's active health issues (`health-issues-summary` /
   `-list` / `-get`) rather than re-running detection, and decides which are worth
@@ -167,11 +166,14 @@ fleet also reasons in terms of:
   key-prefix vocabulary, and cross-project noise patterns.
 
 The specialists each carry their own domain discriminator + investigation patterns.
-Most are a single self-contained `SKILL.md`; `signals-scout-anomaly-detection`
-additionally bundles its own references (`anomaly-methods.md`,
-`watchlist-and-memory.md`, `emit-contract.md`). A simplification pass to compress
-them and share the generalist's references is planned; until then, treat the
-generalist as the reference shape.
+Most are a single self-contained `SKILL.md`; a few bundle surface-specific references
+read on demand — `signals-scout-anomaly-detection` (`anomaly-methods.md`,
+`watchlist-and-memory.md`, `emit-contract.md`), `signals-scout-ai-observability`
+(`lenses.md`), and `signals-scout-surveys` (`response-querying.md`). Treat the
+generalist as the reference shape. Note that a scout can only read its own bundled
+files at runtime (each team's `LLMSkill` row carries just that skill's files), so a
+specialist that needs the emit/dedupe conventions in depth bundles its own copy
+rather than pointing at the generalist's.
 
 ## When editing skills in this directory
 

--- a/products/signals/skills/authoring-signals-scouts/SKILL.md
+++ b/products/signals/skills/authoring-signals-scouts/SKILL.md
@@ -46,9 +46,11 @@ only as good as its fit to the data it watches.
 3. **Read the closest canonical scout.** It's your template and your reference shape. Pull
    it with `posthog:llma-skill-get {"skill_name": "signals-scout-<x>"}` (per-team rows) or
    read it from the repo at `products/signals/skills/signals-scout-*/`. The generalist
-   (`signals-scout-general`) is the broad template; pick a specialist
-   (`-error-tracking`, `-ai-observability`, `-logs`, `-revenue-analytics`, `-surveys`,
-   `-csp-violations`, `-observability-gaps`) if your scope is domain-tight.
+   (`signals-scout-general`) is the broad template; if your scope is domain-tight, pick
+   the specialist closest to your surface — list the live roster with
+   `posthog:llma-skill-list {"search": "signals-scout"}` (specialists exist for most
+   product surfaces: error tracking, logs, AI observability, experiments, feature flags,
+   session replay, web analytics, surveys, and more).
 4. **Skim the inbox.** `posthog:inbox-reports-list` shows what findings are actually
    landing — calibrate so your scout adds signal, not noise.
 
@@ -144,8 +146,8 @@ see [`references/lifecycle-and-testing.md`](references/lifecycle-and-testing.md)
 
 To **read** what your scouts are doing rather than change them — surveying the fleet, inspecting
 individual runs, the scratchpad memory, and assessing performance — use the read-only companion
-skill [`exploring-signals-scouts`](../exploring-signals-scouts/SKILL.md). Keep the two in sync when
-the scout config / run / scratchpad surfaces change.
+skill `exploring-signals-scouts`. Keep the two in sync when the scout config / run / scratchpad
+surfaces change.
 
 ## Quality bar for a v1 scout
 

--- a/products/signals/skills/authoring-signals-scouts/references/dedupe-and-memory.md
+++ b/products/signals/skills/authoring-signals-scouts/references/dedupe-and-memory.md
@@ -42,10 +42,11 @@ confirm a quiet observation without duplicating entries).
 | `mcp-gap:`    | Scout-noticed gap in the MCP surface worth raising later.                   |
 
 Format: `<prefix>:<domain>:<entity>` — e.g. `pattern:error_tracking:baseline`,
-`noise:logs:rabbitmq-deploy-window`, `dedupe:csp_violations:a1b2c3d4`. Canonical `<domain>`
-values: `error_tracking`, `warehouse`, `experiments`, `llm_analytics`, `web_analytics`,
-`feature_flags`, `logs`, `surveys`, `revenue_analytics`, `csp_violations`,
-`observability_gaps`. A new scout introduces its own domain label and reuses the prefixes.
+`noise:logs:rabbitmq-deploy-window`, `dedupe:csp_violations:a1b2c3d4`. Each canonical
+specialist has its own `<domain>` label (`error_tracking`, `logs`, `llm_analytics`,
+`experiments`, `feature-flags`, `session-replay`, `web-analytics`, `pipelines`, `health`,
+…) — not a closed set. A new scout introduces its own domain label and reuses the
+prefixes; match the label a surface's existing entries already use.
 
 ## When to write memory vs. emit
 

--- a/products/signals/skills/authoring-signals-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-signals-scouts/references/scout-anatomy.md
@@ -4,6 +4,15 @@ A scout is a single `SKILL.md` (its body is loaded verbatim as the agent's syste
 plus optional `references/` files read on demand. Keep the body lean and push depth into
 references — every line of the body is a recurring token cost on **every** run.
 
+## Contents
+
+- Naming
+- Frontmatter
+- Body structure (the ten canonical sections)
+- References
+- Skeleton — specialist scout
+- Skeleton — broad / cross-product scout
+
 ## Naming
 
 The skill name **must** match `signals-scout-<scope>` — the harness discovers scouts by

--- a/products/signals/skills/authoring-signals-scouts/references/scout-patterns.md
+++ b/products/signals/skills/authoring-signals-scouts/references/scout-patterns.md
@@ -10,6 +10,16 @@ changes between patterns is **what the scout watches**, **how it reads that data
 This is a living reference — add a pattern when a genuinely new shape proves itself, rather
 than letting every scout reinvent one.
 
+## Contents
+
+- What a scout can watch
+- The patterns: anomaly watcher · watchlist explore/exploit · cross-product correlation ·
+  recommendation / gap · warehouse-backed source · custom / single-event · open-text theme ·
+  external-tool / code-review · state ∩ code-intersection
+- Safety: treat ingested content as untrusted data
+- Cross-cutting techniques
+- Picking and combining
+
 ## What a scout can watch
 
 The single most useful thing to internalize: **a scout is not limited to PostHog

--- a/products/signals/skills/exploring-signals-scouts/SKILL.md
+++ b/products/signals/skills/exploring-signals-scouts/SKILL.md
@@ -20,17 +20,17 @@ metadata:
 A **scout** is a scheduled agent that wakes on its own interval, looks at one PostHog project,
 decides what's genuinely worth surfacing, and either emits it as a **finding** into the Signals
 inbox or closes out empty (a real, valid outcome). PostHog ships a fleet of canonical scouts — a
-cross-product generalist (`signals-scout-general`) plus per-surface specialists
-(`-error-tracking`, `-ai-observability`, `-logs`, `-revenue-analytics`, `-surveys`,
-`-csp-violations`, `-observability-gaps`). A project may also have **custom scouts** beyond the
-canonical fleet — any `signals-scout-*` skill a team authored (e.g. `-brand-mentions`,
-`-mcp-feedback`) shows up here too, so don't assume the roster is only the canonical set.
+cross-product generalist (`signals-scout-general`) plus per-surface specialists (error tracking,
+logs, AI observability, experiments, feature flags, session replay, web analytics, surveys, and
+more). A project may also have **custom scouts** beyond the canonical fleet — any
+`signals-scout-*` skill a team authored (e.g. `-brand-mentions`, `-mcp-feedback`) shows up here
+too, so don't assume a fixed roster: `signals-scout-config-list` is the authoritative roster for
+a project.
 
 This skill helps you **understand and explore what a project's scouts are doing and how they're
 performing** — entirely through read-only MCP tools. It is the observability counterpart to
-[`authoring-signals-scouts`](../authoring-signals-scouts/SKILL.md) (which teaches writing and
-tuning) and to [`inbox-exploration`](../inbox-exploration/SKILL.md) (which covers the inbox
-reports scouts feed into).
+the `authoring-signals-scouts` skill (which teaches writing and tuning) and to the
+`inbox-exploration` skill (which covers the inbox reports scouts feed into).
 
 There are five things you can observe about the fleet, each with its own tool:
 
@@ -241,9 +241,9 @@ follow `<prefix>:<domain>:<entity>` (e.g. `dedupe:error_tracking:019e8375-…`).
 
 When a user asks "why isn't my scout flagging X anymore?", search the scratchpad for `noise:`,
 `addressed:`, `dedupe:`, and `allowlist:` entries — the fleet may have deliberately learned to
-suppress it. The canonical prefix vocabulary and the four-state dedupe classifier the fleet reasons
-in terms of are documented in
-[`../authoring-signals-scouts/references/dedupe-and-memory.md`](../authoring-signals-scouts/references/dedupe-and-memory.md).
+suppress it. The canonical prefix vocabulary and the four-state dedupe classifier the fleet
+reasons in terms of are documented in the `authoring-signals-scouts` skill
+(`references/dedupe-and-memory.md`).
 
 ## Workflow: list what scouts have actually emitted
 
@@ -269,10 +269,9 @@ side matters when explaining a gap: a scout can narrate "EMITTED ..." in its `su
 the emit **silently dropped** by a preflight gate (dry-run at the time, the org hasn't approved
 AI processing, or the `signals_scout` source is disabled), or the emit failed. Those never reach
 this table, so a claimed-but-absent finding is itself a diagnostic, not a script bug. The emit
-contract behind each row (weight vs. confidence rubrics, severity, dedupe) is documented in
-[`../authoring-signals-scouts/references/emit-contract.md`](../authoring-signals-scouts/references/emit-contract.md);
-the run → finding link and its limits are in
-[`references/scout-data-model.md`](references/scout-data-model.md).
+contract behind each row (weight vs. confidence rubrics, severity, dedupe) is documented in the
+`authoring-signals-scouts` skill (`references/emit-contract.md`); the run → finding link and its
+limits are in [`references/scout-data-model.md`](references/scout-data-model.md).
 
 ## Workflow: see what scouts have surfaced
 
@@ -294,10 +293,10 @@ scout-backed reports is the normal, expected state. For the per-run view of what
 the runs instead: `signals-scout-runs-list?emitted=true` lists every emitting run, and each run's
 `emitted_count` / `emitted_finding_ids` tell you how many and which findings it produced (each
 `finding_id` maps to a `Signal` with `source_id = run:<run_id>:finding:<finding_id>`). To browse the
-inbox more broadly, use the [`inbox-exploration`](../inbox-exploration/SKILL.md) skill (statuses,
-suggested reviewers, drilling into a report's underlying signals). The emit contract behind each
-finding — weight, confidence, severity, the description prose — is documented in
-[`../authoring-signals-scouts/references/emit-contract.md`](../authoring-signals-scouts/references/emit-contract.md).
+inbox more broadly, use the `inbox-exploration` skill (statuses, suggested reviewers, drilling
+into a report's underlying signals). The emit contract behind each finding — weight, confidence,
+severity, the description prose — is documented in the `authoring-signals-scouts` skill
+(`references/emit-contract.md`).
 
 ## Workflow: assess health and performance
 
@@ -450,5 +449,5 @@ disabled) or failed.
   shows whether the surface it watches is even in use — a logs scout on a project with no logs has
   nothing to do.
 - **This skill is read-only.** To change a scout's schedule, posture, or body, hand off to
-  [`authoring-signals-scouts`](../authoring-signals-scouts/SKILL.md) — it covers
-  `signals-scout-config-update` and the skills-store edit path.
+  the `authoring-signals-scouts` skill — it covers `signals-scout-config-update` and the
+  skills-store edit path.

--- a/products/signals/skills/exploring-signals-scouts/references/assessing-performance.md
+++ b/products/signals/skills/exploring-signals-scouts/references/assessing-performance.md
@@ -102,6 +102,6 @@ emits most of which get suppressed (too noisy — retune), dead silence on a sur
 is active (too strict — retune), or no memory growth despite many runs (not learning).
 
 When the diagnosis points at the scout's instructions — discriminator, thresholds, disqualifiers,
-save-memory, schedule, or posture — that's where exploration ends and authoring begins. Hand off to
-[`../../authoring-signals-scouts/SKILL.md`](../../authoring-signals-scouts/SKILL.md), which covers
-the dry-run-first test loop and `signals-scout-config-update`.
+save-memory, schedule, or posture — that's where exploration ends and authoring begins. Hand off
+to the `authoring-signals-scouts` skill, which covers the dry-run-first test loop and
+`signals-scout-config-update`.

--- a/products/signals/skills/exploring-signals-scouts/references/scout-data-model.md
+++ b/products/signals/skills/exploring-signals-scouts/references/scout-data-model.md
@@ -110,8 +110,7 @@ tracked but still below the emit bar), `noise:` (ignore), `addressed:` (fixed/mo
 (tooling gap). This vocabulary is open — scouts coin their own prefixes and `<domain>` labels, so
 treat an unfamiliar prefix as just another category. Entries link to each other with `[[key]]`
 wikilinks. The canonical prefix set and the four-state dedupe classifier the fleet reasons in terms
-of live in
-[`../../authoring-signals-scouts/references/dedupe-and-memory.md`](../../authoring-signals-scouts/references/dedupe-and-memory.md).
+of live in the `authoring-signals-scouts` skill (`references/dedupe-and-memory.md`).
 
 ## SignalProjectProfile — orientation snapshot
 

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -7,18 +7,12 @@ description: >
   it discovers over time. Leans on the sandbox's bundled `exploring-llm-*` deep-dive skills
   for the actual queries. Emits findings only when they clear the confidence bar; otherwise
   writes durable memory and closes out empty. Self-contained peer in the signals-scout-*
-  fleet — no dependencies on other scouts. Picked uniformly at random by the coordinator
-  alongside `signals-scout-general` and other specialists.
+  fleet — no dependencies on other scouts.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family is available (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal), the analytics + LLM
-  tools (query-llm-traces-list, query-llm-trace, execute-sql, get-llm-total-costs-for-project,
-  llma-evaluation-list, llma-evaluation-get, llma-evaluation-test-hog,
-  llma-evaluation-summary-create, llma-tagger-list, llma-score-definition-list,
-  llma-clustering-job-list, llma-prompt-list, llma-prompt-get, read-data-schema),
-  and the bundled deep-dive skills (exploring-llm-costs / -traces / -evaluations / -clusters,
-  querying-posthog-data).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family, the LLM analytics tools listed in the body's MCP
+  tools section, and the bundled exploring-llm-* deep-dive skills.
 metadata:
   owner_team: signals
   scope: llm_analytics

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -11,16 +11,11 @@ description: >
   clears the confidence bar, otherwise it updates the baseline memory and closes out
   empty. Self-contained peer in the signals-scout-* fleet.
 compatibility: >
-  Runs as the PostHog Signals scout in a Claude sandbox with read-only analytics scopes plus
-  signal_scout_internal:write (scratchpad + emit) and notebook:write (write-up artifact).
-  Uses the signals-scout MCP family
-  (project-profile-get, runs-list, runs-retrieve, scratchpad-search/-remember/-forget,
-  emit-signal) plus dashboard/insight tools (insights-trending-retrieve, insight-get,
-  insight-query, dashboards-get-all, dashboard-get, dashboard-insights-run, insights-list),
-  alert-simulate (the anomaly-detection simulator — primary scorer for saved insights),
-  notebooks-create / notebooks-destroy (the durable write-up that backs each emitted
-  finding, removed if the emit is preflight-skipped),
-  execute-sql, read-data-schema, inbox-reports-list.
+  Runs as the PostHog Signals scout in a Claude sandbox with read-only analytics scopes
+  plus signal_scout_internal:write (scratchpad + emit) and notebook:write (the notebook
+  write-up behind each finding). Assumes the signals-scout MCP tool family plus the
+  dashboard/insight, alert-simulate, and notebook tools listed in the body's MCP tools
+  section.
 metadata:
   owner_team: signals
   scope: anomaly_detection

--- a/products/signals/skills/signals-scout-csp-violations/SKILL.md
+++ b/products/signals/skills/signals-scout-csp-violations/SKILL.md
@@ -7,14 +7,12 @@ description: >
   third-party domains that may indicate a compromised script. Emits aggregated
   findings only when a cluster clears the confidence bar; otherwise writes durable
   memory and closes out empty. Self-contained peer in the signals-scout-* fleet — no
-  dependencies on other skills. Picked uniformly at random by the coordinator
-  alongside `signals-scout-general` and other specialists.
+  dependencies on other skills.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  standard analytics tools (execute-sql, read-data-schema, activity-log-list,
-  inbox-reports-list).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the analytics tools listed in the body's MCP
+  tools section.
 metadata:
   owner_team: signals
   scope: csp_violations
@@ -83,8 +81,8 @@ Three cheap reads cold-start a run:
 ### Explore
 
 Patterns to watch — starting points, not a checklist. Group violations along four
-dimensions and look for clusters worth a finding. The team's existing push-based
-emission (PR #58596) already deduplicates _individual_ violations at
+dimensions and look for clusters worth a finding. PostHog's push-based CSP
+emission already deduplicates _individual_ violations at
 `sha1(violated_directive | blocked_url | document_url | source_file)` granularity with a
 24h Redis TTL; your job is to _aggregate_ across that grain into higher-confidence
 findings the inbox wouldn't surface on its own.
@@ -115,8 +113,7 @@ ORDER BY occurrences DESC
 LIMIT 20
 ```
 
-Three lenses for triage — copy these directly from PR #58596's `_build_description`,
-they're the prompt the team needs:
+Three lenses for triage — every blocked-URL finding should name which one fits:
 
 1. **Legitimate — CSP policy needs widening.** New CDN, new analytics provider, new
    marketing tag the team rolled out and forgot to add to the allowlist.
@@ -276,7 +273,7 @@ Harness-level:
 
 "Looked but found nothing meaningful" is a real outcome.
 
-## How this relates to the push-based source (PR #58596)
+## How this relates to the push-based CSP source
 
 The companion push path (`posthog/tasks/csp_signal.py`, behind per-team
 `SignalSourceConfig` opt-in) emits **one raw signal per unique violation fingerprint**

--- a/products/signals/skills/signals-scout-data-pipelines/SKILL.md
+++ b/products/signals/skills/signals-scout-data-pipelines/SKILL.md
@@ -12,14 +12,9 @@ description: >
   on other skills.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (mostly read-only, plus signal_scout_internal:write for scratchpad-remember/forget and
-  emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus the
-  pipeline MCP tools (cdp-functions-list, cdp-functions-retrieve,
-  cdp-functions-metrics-retrieve, cdp-functions-logs-retrieve, batch-exports-list,
-  batch-export-get, workflows-list, workflows-global-stats, workflows-stats,
-  workflows-list-invocations, workflows-logs) and standard analytics tools
-  (execute-sql, activity-log-list, inbox-reports-list).
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the CDP function, batch export, workflow, and
+  analytics tools listed in the body's MCP tools section.
 metadata:
   owner_team: signals
   scope: data_pipelines

--- a/products/signals/skills/signals-scout-error-tracking/SKILL.md
+++ b/products/signals/skills/signals-scout-error-tracking/SKILL.md
@@ -5,14 +5,12 @@ description: >
   bursts, stuck loops, multi-fingerprint clusters, status regressions, and stack-trace
   activity-name patterns. Emits findings only when they clear the confidence bar;
   otherwise writes durable memory and closes out empty. Self-contained peer in the
-  signals-scout-* fleet — no dependencies on other skills. Picked uniformly at random
-  by the coordinator alongside `signals-scout-general` and other specialists.
+  signals-scout-* fleet — no dependencies on other skills.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  error-tracking + analytics tools (query-error-tracking-issues-list, query-error-tracking-issue,
-  execute-sql, activity-log-list, inbox-reports-list).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the error-tracking and analytics tools listed in
+  the body's MCP tools section.
 metadata:
   owner_team: signals
   scope: error_tracking

--- a/products/signals/skills/signals-scout-experiments/SKILL.md
+++ b/products/signals/skills/signals-scout-experiments/SKILL.md
@@ -10,13 +10,9 @@ description: >
   peer in the signals-scout-* fleet — no dependencies on other skills.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (mostly read-only, plus signal_scout_internal:write for scratchpad-remember/forget and
-  emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus the
-  experiments MCP tools (experiment-list, experiment-get, experiment-results-get,
-  experiment-stats, experiment-timeseries-results), feature flag tools (feature-flag-get-definition,
-  feature-flags-activity-retrieve), and standard analytics tools (execute-sql,
-  read-data-schema, activity-log-list, inbox-reports-list).
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the experiments, feature flag, and analytics
+  tools listed in the body's MCP tools section.
 metadata:
   owner_team: signals
   scope: experiments

--- a/products/signals/skills/signals-scout-feature-flags/SKILL.md
+++ b/products/signals/skills/signals-scout-feature-flags/SKILL.md
@@ -11,13 +11,9 @@ description: >
   fleet — no dependencies on other skills.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (mostly read-only, plus signal_scout_internal:write for scratchpad-remember/forget and
-  emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus the
-  feature flag MCP tools (feature-flag-get-all, feature-flag-get-definition,
-  feature-flags-status-retrieve, feature-flags-activity-retrieve,
-  feature-flags-dependent-flags-retrieve) and standard analytics tools (execute-sql,
-  read-data-schema, activity-log-list, inbox-reports-list).
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the feature flag and analytics tools listed in
+  the body's MCP tools section.
 metadata:
   owner_team: signals
   scope: feature_flags

--- a/products/signals/skills/signals-scout-general/SKILL.md
+++ b/products/signals/skills/signals-scout-general/SKILL.md
@@ -2,13 +2,11 @@
 name: signals-scout-general
 description: >
   General Signals scout for PostHog projects. Cross-product explorer that scans a
-  team's project and emits findings into the Signals inbox. Sibling specialists
-  (signals-scout-ai-observability, -logs, -error-tracking, -revenue-analytics, -surveys,
-  -observability-gaps, -csp-violations, -anomaly-detection) cover individual product
-  surfaces; this
-  scout looks for cross-product correlations and explores what specialists don't
-  cover. Each scout runs on its own schedule (default hourly), so general fires
-  independently of the specialists over time.
+  team's project and emits findings into the Signals inbox. Sibling signals-scout-*
+  specialists each watch a single product surface in depth; this scout looks for
+  cross-product correlations and explores the surfaces no specialist covers. Each
+  scout runs on its own schedule (default hourly), so general fires independently
+  of the specialists over time.
 compatibility: >
   Runs as the PostHog Signals scout in a Claude sandbox with PostHog MCP scopes: signal_scout:read + signal_scout_internal:write (for
   scratchpad-remember/forget and emit-signal), llm_skill:read, plus standard analytics reads. Uses the
@@ -45,10 +43,12 @@ already covered. Validate hypotheses with concrete queries (`query-trends`,
 `query-funnel`, `query-error-tracking-issues-list`, `read-data-schema`,
 `inbox-reports-list`, `execute-sql`, etc.) before emitting.
 
-If a sibling specialist already covers a surface in depth (AI observability, logs,
-error tracking, revenue, surveys, observability gaps, CSP, or dashboard/insight
-anomalies), leave the deep dive to it on a future tick. Spend your time on
-**cross-product correlations** or on **surfaces no specialist covers**.
+If a sibling specialist already covers a surface in depth, leave the deep dive to it
+on a future tick — the `skill_name`s on recent runs in `signals-scout-runs-list` show
+the live roster (specialists exist for most product surfaces: error tracking, logs, AI
+observability, experiments, feature flags, session replay, web analytics, surveys, and
+more). Spend your time on **cross-product correlations** or on **surfaces no
+specialist covers**.
 
 ## Decide
 

--- a/products/signals/skills/signals-scout-general/references/conventions.md
+++ b/products/signals/skills/signals-scout-general/references/conventions.md
@@ -46,9 +46,12 @@ runs can find an entry with a single `text=` search:
 Format: `<prefix>:<domain>:<entity>` (e.g. `pattern:error_tracking:baseline`,
 `noise:logs:rabbitmq-deploy-window`, `dedupe:csp_violations:a1b2c3d4`).
 
-Canonical `<domain>` values: `error_tracking`, `warehouse`, `experiments`,
-`llm_analytics`, `web_analytics`, `feature_flags`, `logs`, `surveys`,
-`revenue_analytics`, `csp_violations`, `observability_gaps`.
+Common `<domain>` values in fleet use: `error_tracking`, `warehouse`, `experiments`,
+`llm_analytics`, `web-analytics`, `feature-flags`, `logs`, `surveys`,
+`revenue_analytics`, `csp_violations`, `observability_gaps`, `session-replay`,
+`pipelines`, `health`, `anomaly_detection`. Not a closed set — a specialist (or a
+custom scout) coins its own label and reuses the prefixes; match the label a
+surface's existing entries already use rather than inventing a variant.
 
 Re-using a key updates the entry in place and refreshes `updated_at` — that's
 the idempotent refresh pattern. Use it to confirm a quiet observation without

--- a/products/signals/skills/signals-scout-health-checks/SKILL.md
+++ b/products/signals/skills/signals-scout-health-checks/SKILL.md
@@ -9,15 +9,12 @@ description: >
   weights by real blast radius (cross-referencing actual event volume and reach), and
   prioritizes issues an agent can resolve via the MCP. Emits only above the confidence
   bar; otherwise writes durable memory and closes out empty. Self-contained peer in the
-  signals-scout-* fleet — picked uniformly at random by the coordinator alongside
-  `signals-scout-general` and other specialists.
+  signals-scout-* fleet — no dependencies on other skills.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
-  the signals-scout MCP family (project-profile-get, runs-list, runs-retrieve,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus the health
-  issues read tools (health-issues-summary, health-issues-list, health-issues-get) and
-  standard analytics tools (read-data-schema, query-trends, execute-sql, inbox-reports-list).
+  the signals-scout MCP tool family plus the health-issues read tools and analytics tools
+  listed in the body's MCP tools section.
 metadata:
   owner_team: signals
   scope: health_checks

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -6,15 +6,11 @@ description: >
   trace-correlated bursts via the logs ingestion pipeline. Emits findings only when
   they clear the confidence bar; otherwise writes durable memory and closes out empty.
   Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
-  Picked uniformly at random by the coordinator alongside `signals-scout-general` and
-  other specialists.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family is available (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  the logs tool family (logs-count, logs-count-ranges, logs-sparkline-query, query-logs,
-  logs-services-create, logs-attributes-list, logs-attribute-values-list, logs-alerts-list,
-  logs-alerts-events-list).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the logs tool family listed in the body's MCP
+  tools section.
 metadata:
   owner_team: signals
   scope: logs

--- a/products/signals/skills/signals-scout-observability-gaps/SKILL.md
+++ b/products/signals/skills/signals-scout-observability-gaps/SKILL.md
@@ -7,14 +7,12 @@ description: >
   related context, critical events with no alerts. Watches the event-stream-vs-saved-
   inventory delta as the team's product evolves and emits findings recommending new
   insights, dashboard additions, or alerts when gaps clear the confidence bar.
-  Self-contained peer in the signals-scout-* fleet — picked uniformly at random by the
-  coordinator alongside `signals-scout-general` and other specialists.
+  Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family is available (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  standard analytics + entity tools (read-data-schema, query-trends, insights-list,
-  dashboards-get-all, event-definitions-list, alerts-list, execute-sql).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the analytics and entity tools listed in the
+  body's MCP tools section.
 metadata:
   owner_team: signals
   scope: observability_gaps

--- a/products/signals/skills/signals-scout-revenue-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-revenue-analytics/SKILL.md
@@ -7,15 +7,12 @@ description: >
   broken Stripe↔person joins, deferred-revenue gaps), and goal-miss escalations.
   Emits findings only when they clear the confidence bar; otherwise writes durable
   memory and closes out empty. Self-contained peer in the signals-scout-* fleet —
-  no dependencies on other skills. Picked uniformly at random by the coordinator
-  alongside `signals-scout-general` and other specialists.
+  no dependencies on other skills.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  warehouse + analytics tools (external-data-sources-list, external-data-sync-logs,
-  query-trends, execute-sql, read-data-schema, dashboards-get-all,
-  data-warehouse-data-health-issues-retrieve).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the warehouse and analytics tools listed in the
+  body's MCP tools section.
 metadata:
   owner_team: signals
   scope: revenue_analytics

--- a/products/signals/skills/signals-scout-surveys/SKILL.md
+++ b/products/signals/skills/signals-scout-surveys/SKILL.md
@@ -7,15 +7,12 @@ description: >
   the team should know about (clusters of complaints, praise, feature requests). Emits
   findings only when a theme or anomaly clears the confidence bar; otherwise writes
   durable memory and closes out empty. Self-contained peer in the signals-scout-* fleet
-  — no dependencies on other skills. Picked uniformly at random by the coordinator
-  alongside `signals-scout-general` and other specialists.
+  — no dependencies on other skills.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes (mostly read-only, plus
-  signal_scout_internal:write for scratchpad-remember/forget and emit-signal). Assumes the signals-scout MCP family (project-profile-get, runs-list,
-  scratchpad-search, scratchpad-remember, scratchpad-forget, emit-signal) plus
-  the surveys MCP tools (surveys-get-all, survey-get, survey-stats, surveys-global-stats)
-  and standard analytics tools (execute-sql, query-trends, read-data-schema,
-  activity-log-list).
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
+  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
+  the signals-scout MCP tool family plus the surveys and analytics tools listed in the
+  body's MCP tools section.
 metadata:
   owner_team: signals
   scope: surveys
@@ -126,56 +123,14 @@ Surveys with rating questions (NPS 0–10, CSAT 1–5, single rating) are the cl
 quantitative signal. For each rating-style active survey, pull the last 30 days of
 `survey sent` events and compute the score trend.
 
-**Resolving the response value — coalesce both key schemes.** PostHog writes each
-answer under two property keys and the product reads them with a `coalesce`
-(`getSurveyResponse()` in `frontend/src/scenes/surveys/utils.ts`). Query the same way
-or you will miss responses. Read `survey-get` for the question's `id` **and** its
-position in the `questions` array:
-
-- **id-based** (modern posthog-js): `$survey_response_<question_id>` — the question's UUID.
-- **index-based** (legacy, still emitted): bare `$survey_response` for the first
-  question (index 0), `$survey_response_<n>` (numeric) for question index _n_.
-
-A survey whose responses are only index-based — common when the rating is the first
-question, so the key is bare `$survey_response` — returns all-NULL under the id-based
-key alone, which reads as "no responses." Always coalesce id-based over the
-index-based fallback:
-
-```sql
-SELECT
-    toDate(timestamp) AS day,
-    avg(toFloat64OrNull(coalesce(
-        nullIf(JSONExtractString(properties, '$survey_response_<question_id>'), ''),  -- id-based (modern)
-        nullIf(JSONExtractString(properties, '<index_based_key>'), '')                -- '$survey_response' (index 0) or '$survey_response_<n>'
-    ))) AS avg_score,
-    count() AS responses
-FROM events
-WHERE event = 'survey sent'
-  AND JSONExtractString(properties, '$survey_id') = '<survey_id>'
-  AND timestamp > now() - INTERVAL 30 DAY
-GROUP BY day
-ORDER BY day
-```
-
-Always dedupe by `$survey_submission_id` for surveys collected after that property
-shipped — the legacy path is one row per submission, but newer client versions can
-emit multiple `survey sent` events per submission and you'll over-count rating
-responses. Pattern (from `products/surveys/backend/util.py`):
-
-```sql
--- Inside the WHERE clause
-AND uuid IN (
-    SELECT argMax(uuid, timestamp) FROM events
-    WHERE event = 'survey sent'
-      AND JSONExtractString(properties, '$survey_id') = '<survey_id>'
-      AND timestamp > now() - INTERVAL 30 DAY
-    GROUP BY CASE
-        WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = ''
-        THEN toString(uuid)
-        ELSE JSONExtractString(properties, '$survey_submission_id')
-    END
-)
-```
+**Two mechanical traps make response SQL non-obvious — read
+[`references/response-querying.md`](references/response-querying.md) before writing
+any.** Answers land under two property key schemes (id-based
+`$survey_response_<question_id>` and legacy index-based `$survey_response` /
+`$survey_response_<n>`) that must be coalesced — querying the id-based key alone reads
+as "no responses" on legacy surveys — and newer clients can emit multiple `survey sent`
+events per submission, so every count needs the `$survey_submission_id` dedupe. The
+reference has the copy-ready rating-trend SQL with both handled.
 
 What counts as "enough responses" depends on the survey's normal volume. Flagship
 NPS surveys can hit 100+/week; a feature-specific widget survey running at 15–25
@@ -255,29 +210,10 @@ naturally has high dismiss); don't re-flag every run.
 #### Recurring theme in open-text responses
 
 This is the highest-value pattern — and the one with the highest false-positive risk.
-For each survey with at least one open-text question, pull recent responses and look
-for clustering.
-
-```sql
-SELECT
-    coalesce(
-        nullIf(JSONExtractString(properties, '$survey_response_<question_id>'), ''),  -- id-based (modern)
-        nullIf(JSONExtractString(properties, '<index_based_key>'), '')                -- '$survey_response' (index 0) or '$survey_response_<n>'
-    ) AS response,
-    person_id,
-    timestamp
-FROM events
-WHERE event = 'survey sent'
-  AND JSONExtractString(properties, '$survey_id') = '<survey_id>'
-  AND timestamp > now() - INTERVAL 14 DAY
-  AND coalesce(
-        nullIf(JSONExtractString(properties, '$survey_response_<question_id>'), ''),
-        nullIf(JSONExtractString(properties, '<index_based_key>'), '')
-      ) != ''
-  -- dedupe by submission as above
-ORDER BY timestamp DESC
-LIMIT 200
-```
+For each survey with at least one open-text question, pull recent responses (the
+open-text pull SQL — key coalesce and submission dedupe included — is in
+[`references/response-querying.md`](references/response-querying.md)) and look for
+clustering.
 
 Read the responses. Look for:
 
@@ -469,16 +405,9 @@ Direct calls (read-only):
   `survey-get` per id. Use `surveys-get-all {"search": "..."}` if you need to
   resolve a name from a memory entry.
 - `execute-sql` against `events` — for raw response analysis (rating trends, theme
-  aggregation, dedupe by `$survey_submission_id`). The properties to extract:
-  - `$survey_id` — which survey
-  - `$survey_iteration` — which iteration of a recurring survey
-  - `$survey_submission_id` — dedupe key (newer events; older events lack this)
-  - `$survey_response` — first question's response, index-based legacy key (index 0)
-  - `$survey_response_<n>` — index-based key for question index _n_ > 0 (numeric suffix)
-  - `$survey_response_<question_id>` — id-based per-question key (question UUID; preferred,
-    but coalesce over the index-based keys above — see "Resolving the response value")
-  - `$survey_completed`, `$survey_partially_completed`, `$survey_dismissed` — status
-  - `$survey_responded` — whether the user responded at all
+  aggregation). The property reference, the dual response-key coalesce, and the
+  `$survey_submission_id` dedupe SQL are all in
+  [`references/response-querying.md`](references/response-querying.md).
 - `read-data-schema event_property_values` — sample response values to confirm
   property keys exist and have the shape you expect before running heavy aggregations.
 - `query-trends` — confirm `survey shown` / `survey sent` volume trends with weekly

--- a/products/signals/skills/signals-scout-surveys/references/response-querying.md
+++ b/products/signals/skills/signals-scout-surveys/references/response-querying.md
@@ -1,0 +1,111 @@
+# Querying survey responses — keys, dedupe, and the exact SQL
+
+The two mechanical traps in `survey sent` data — the dual response-key schemes and
+multi-event submissions — plus the copy-ready SQL for rating trends and open-text pulls.
+Read this before writing any response query: getting either trap wrong silently returns
+"no responses" or over-counts.
+
+## Resolving the response value — coalesce both key schemes
+
+PostHog writes each answer under two property keys and the product reads them with a
+`coalesce` (`getSurveyResponse()` in `frontend/src/scenes/surveys/utils.ts`). Query the
+same way or you will miss responses. Read `survey-get` for the question's `id` **and**
+its position in the `questions` array:
+
+- **id-based** (modern posthog-js): `$survey_response_<question_id>` — the question's UUID.
+- **index-based** (legacy, still emitted): bare `$survey_response` for the first
+  question (index 0), `$survey_response_<n>` (numeric) for question index _n_.
+
+A survey whose responses are only index-based — common when the rating is the first
+question, so the key is bare `$survey_response` — returns all-NULL under the id-based
+key alone, which reads as "no responses." Always coalesce id-based over the
+index-based fallback.
+
+## Dedupe by submission
+
+Always dedupe by `$survey_submission_id` for surveys collected after that property
+shipped — the legacy path is one row per submission, but newer client versions can
+emit multiple `survey sent` events per submission and you'll over-count rating
+responses. Pattern (from `products/surveys/backend/util.py`):
+
+```sql
+-- Inside the WHERE clause
+AND uuid IN (
+    SELECT argMax(uuid, timestamp) FROM events
+    WHERE event = 'survey sent'
+      AND JSONExtractString(properties, '$survey_id') = '<survey_id>'
+      AND timestamp > now() - INTERVAL 30 DAY
+    GROUP BY CASE
+        WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = ''
+        THEN toString(uuid)
+        ELSE JSONExtractString(properties, '$survey_submission_id')
+    END
+)
+```
+
+## Rating trend (score regression)
+
+Daily average score for one rating question, both key schemes coalesced:
+
+```sql
+SELECT
+    toDate(timestamp) AS day,
+    avg(toFloat64OrNull(coalesce(
+        nullIf(JSONExtractString(properties, '$survey_response_<question_id>'), ''),  -- id-based (modern)
+        nullIf(JSONExtractString(properties, '<index_based_key>'), '')                -- '$survey_response' (index 0) or '$survey_response_<n>'
+    ))) AS avg_score,
+    count() AS responses
+FROM events
+WHERE event = 'survey sent'
+  AND JSONExtractString(properties, '$survey_id') = '<survey_id>'
+  AND timestamp > now() - INTERVAL 30 DAY
+  -- plus the submission-dedupe clause above
+GROUP BY day
+ORDER BY day
+```
+
+## Open-text pull (theme aggregation)
+
+Recent non-empty open-text responses for one question, ready to read for clustering:
+
+```sql
+SELECT
+    coalesce(
+        nullIf(JSONExtractString(properties, '$survey_response_<question_id>'), ''),  -- id-based (modern)
+        nullIf(JSONExtractString(properties, '<index_based_key>'), '')                -- '$survey_response' (index 0) or '$survey_response_<n>'
+    ) AS response,
+    person_id,
+    timestamp
+FROM events
+WHERE event = 'survey sent'
+  AND JSONExtractString(properties, '$survey_id') = '<survey_id>'
+  AND timestamp > now() - INTERVAL 14 DAY
+  AND coalesce(
+        nullIf(JSONExtractString(properties, '$survey_response_<question_id>'), ''),
+        nullIf(JSONExtractString(properties, '<index_based_key>'), '')
+      ) != ''
+  -- plus the submission-dedupe clause above
+ORDER BY timestamp DESC
+LIMIT 200
+```
+
+## Iteration filter
+
+Recurring surveys tag each iteration's responses with `$survey_iteration`. To compare
+iterations cleanly, add:
+
+```sql
+AND JSONExtractString(properties, '$survey_iteration') = '<n>'
+```
+
+## Property reference (`survey sent` events)
+
+- `$survey_id` — which survey
+- `$survey_iteration` — which iteration of a recurring survey
+- `$survey_submission_id` — dedupe key (newer events; older events lack this)
+- `$survey_response` — first question's response, index-based legacy key (index 0)
+- `$survey_response_<n>` — index-based key for question index _n_ > 0 (numeric suffix)
+- `$survey_response_<question_id>` — id-based per-question key (question UUID; preferred,
+  but always coalesce over the index-based keys)
+- `$survey_completed`, `$survey_partially_completed`, `$survey_dismissed` — status
+- `$survey_responded` — whether the user responded at all


### PR DESCRIPTION
- trim compatibility frontmatter to the spec's 500-char limit across the
  fleet (tool enumerations already live in each body's MCP tools section)
- drop the stale 'picked uniformly at random' claim from eight scout
  descriptions — the coordinator dispatches per-scout schedules
- make the generalist and both meta skills roster-agnostic instead of
  enumerating a specialist list that drifts as the fleet grows
- replace cross-skill ../ links with skill-name references so links
  survive standalone distribution
- split surveys response-querying SQL into a reference, bringing its
  body under the 500-line guidance
- add tables of contents to the two longest authoring references
- update the shared domain-label vocabulary to match live fleet usage
- update AGENTS.md fleet-shape notes (bundled references, runtime
  file-visibility constraint)

https://claude.ai/code/session_01VVMrfR36EmB7SbBBevERxH