### PR TITLE
feat(llma): alert on unhandled Max agent run errors

### DIFF
--- a/ee/hogai/core/agent_modes/test/test_toolkit_imports.py
+++ b/ee/hogai/core/agent_modes/test/test_toolkit_imports.py
@@ -1,0 +1,45 @@
+import pkgutil
+import importlib
+
+from posthog.test.base import BaseTest
+
+from langchain_core.runnables import RunnableConfig
+from parameterized import parameterized
+
+import ee.hogai.core.agent_modes.presets as presets_package
+from ee.hogai.context import AssistantContextManager
+from ee.hogai.core.agent_modes.factory import AgentModeDefinition
+from ee.hogai.core.agent_modes.toolkit import AgentToolkit
+
+
+def _discover_toolkit_classes() -> list[tuple[str, type[AgentToolkit]]]:
+    """Every toolkit class reachable from a preset AgentModeDefinition.
+
+    Toolkits load their tools via lazy `from products... import` inside the
+    `tools` property, so a renamed or moved module is invisible until that
+    property runs at runtime. Discovering the classes here lets the test below
+    force those imports — new presets are covered automatically.
+    """
+    toolkit_classes: dict[str, type[AgentToolkit]] = {}
+    for module_info in pkgutil.iter_modules(presets_package.__path__):
+        if module_info.name == "test":
+            continue
+        module = importlib.import_module(f"{presets_package.__name__}.{module_info.name}")
+        for definition in vars(module).values():
+            if isinstance(definition, AgentModeDefinition):
+                toolkit_classes.setdefault(definition.toolkit_class.__name__, definition.toolkit_class)
+    return sorted(toolkit_classes.items())
+
+
+class TestToolkitImports(BaseTest):
+    @parameterized.expand(_discover_toolkit_classes())
+    def test_toolkit_tools_property_imports_resolve(self, _name: str, toolkit_class: type[AgentToolkit]) -> None:
+        context_manager = AssistantContextManager(
+            team=self.team, user=self.user, config=RunnableConfig(configurable={})
+        )
+        toolkit = toolkit_class(team=self.team, user=self.user, context_manager=context_manager)
+        # Accessing `.tools` runs the lazy imports; a stale import raises here.
+        assert isinstance(toolkit.tools, list)
+
+    def test_discovers_toolkits(self) -> None:
+        assert len(_discover_toolkit_classes()) > 0

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -47,6 +47,7 @@ from ee.hogai.core.base import BaseAssistantGraph
 from ee.hogai.core.stream_processor import AssistantStreamProcessorProtocol
 from ee.hogai.tool import ApprovalRequest
 from ee.hogai.utils.exceptions import (
+    AGENT_RUN_UNHANDLED_ERROR_COUNTER,
     HTTPX_TRANSPORT_EXCEPTIONS,
     LLM_API_EXCEPTIONS,
     LLM_CLIENT_ERROR_COUNTER,
@@ -417,6 +418,7 @@ class BaseAgentRunner(ABC):
                     await self._graph.aupdate_state(config, self._partial_state_type.get_reset_state())
 
                 if not isinstance(e, GenerationCanceled):
+                    AGENT_RUN_UNHANDLED_ERROR_COUNTER.labels(error_type=type(e).__name__).inc()
                     logger.exception("Error in assistant stream", error=e)
                     self._capture_exception(e)
 

--- a/ee/hogai/utils/exceptions.py
+++ b/ee/hogai/utils/exceptions.py
@@ -53,6 +53,17 @@ LLM_TRANSPORT_ERROR_COUNTER = Counter(
     ["error_type"],
 )
 
+# Unexpected exceptions that crash an agent run (e.g. a code bug or a stale import),
+# as opposed to the known LLM provider/client/transport errors counted above. These
+# bubble to the catch-all in the runner and return a FailureMessage to the user — an
+# agent generation that never finished. Sits at ~0 in steady state, so a sustained
+# rate signals that a recent change broke an agent path in production.
+AGENT_RUN_UNHANDLED_ERROR_COUNTER = Counter(
+    "posthog_ai_agent_run_unhandled_errors_total",
+    "Total number of agent runs that failed with an unexpected (non-LLM) exception",
+    ["error_type"],
+)
+
 
 def resolve_llm_provider(exc: Exception) -> str:
     """Extract the LLM provider name from an exception.


### PR DESCRIPTION
## Problem

When a code-level bug breaks a Max AI agent path in production — for example a lazy `from products... import` inside an agent toolkit's `tools` property that points at a renamed or moved module (see PostHog/posthog#62577) — the run crashes, the user gets a generic failure message, and nothing pages us. The catch-all in the agent runner captures a `$exception` event but, unlike every known LLM provider/client/transport error branch above it, increments no Prometheus counter. So this whole class of "an agent silently broke after a deploy" has no metric to alert on.

## Changes

- Add `posthog_ai_agent_run_unhandled_errors_total{error_type}` in `ee/hogai/utils/exceptions.py` and increment it in the `except Exception` catch-all in `ee/hogai/core/runner.py` (inside the existing `GenerationCanceled` guard, so user cancellations are excluded). This counts agent runs that failed for an unexpected, non-LLM reason — sits at ~0 in steady state, so a sustained rate signals a real breakage.
- Add a CI guard (`ee/hogai/core/agent_modes/test/test_toolkit_imports.py`) that discovers every toolkit reachable from a preset `AgentModeDefinition` and accesses its `tools` property, forcing the lazy imports to resolve. A renamed/missing import now fails CI instead of only at runtime in prod.

The alert rule + runbook that consume this metric live in a companion PR in `PostHog/charts`.

## How did you test this code?

I'm an agent (PostHog Slack app). I added the parameterized CI guard test and confirmed it discovers the agent toolkits and parameterizes per-toolkit at collection time. I could not execute the suite to green in my sandbox (no test database available), so the full run will happen in CI. Lint/format (`ruff`) pass on all changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with the PostHog Slack app (Claude Code) from a Slack thread. The request was to alert when issues like PostHog/posthog#62577 (a stale lazy import surfacing only in prod) appear. After exploring the signals, we chose to alert on the *symptom* — unexpected agent-run failures at the runner catch-all — rather than the narrow `ImportError` type, since that funnel is exactly where #62577 crashed and where the user-facing failure originates, and it generalizes to any code bug that breaks an agent. Considered and rejected: a dedicated `ImportError` counter (too narrow, would miss non-HTTP paths) and reusing `django_http_exceptions_total_by_type` (HTTP-only, would miss the agent path). Added the CI guard to address the root cause directly, not just detect it.


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B98U9K2P5/p1781071132693389)*
