### PR TITLE
chore(deps): bump posthog-js to 1.384.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^0.35.0
       version: 0.35.0
     posthog-js:
-      specifier: ^1.383.3
-      version: 1.383.3
+      specifier: ^1.384.1
+      version: 1.384.1
     ts-pattern:
       specifier: '4.3'
       version: 4.3.0
@@ -336,7 +336,7 @@ importers:
         version: 3.1.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
     devDependencies:
       '@swc/core':
         specifier: ^1.11.29
@@ -349,7 +349,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -364,7 +364,7 @@ importers:
         version: 1.5.15
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
     devDependencies:
       '@swc/core':
         specifier: ^1.11.29
@@ -759,7 +759,7 @@ importers:
         version: link:../packages/quill/packages/charts
       '@posthog/react':
         specifier: 'catalog:'
-        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.383.3)(react@18.3.1)
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.384.1)(react@18.3.1)
       '@posthog/replay-shared':
         specifier: workspace:*
         version: link:../common/replay-shared
@@ -1086,7 +1086,7 @@ importers:
         version: 2.11.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       query-selector-shadow-dom:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2250,7 +2250,7 @@ importers:
         version: 0.1.7
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2290,7 +2290,7 @@ importers:
         version: 3.2.0(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2336,7 +2336,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2435,7 +2435,7 @@ importers:
         version: 3.3.0
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2500,7 +2500,7 @@ importers:
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2536,7 +2536,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2620,7 +2620,7 @@ importers:
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2768,7 +2768,7 @@ importers:
         version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2849,7 +2849,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2951,7 +2951,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3104,7 +3104,7 @@ importers:
         version: 5.4.1
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3232,7 +3232,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3328,7 +3328,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3602,7 +3602,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3642,7 +3642,7 @@ importers:
         version: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -3657,7 +3657,7 @@ importers:
         version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/react':
         specifier: '*'
-        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.383.3)(react@18.3.1)
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.384.1)(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3757,7 +3757,7 @@ importers:
         version: 3.0.1(kea@4.0.0-pre.5(react@18.3.1))
       posthog-js:
         specifier: 'catalog:'
-        version: 1.383.3
+        version: 1.384.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -9128,8 +9128,8 @@ packages:
   '@posthog/core@1.28.3':
     resolution: {integrity: sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw==}
 
-  '@posthog/core@1.30.14':
-    resolution: {integrity: sha512-cC0che/17kP6qMIMgdmxsoz3h8Jar8knQfDM8WqQwVacSeWXkrwkemoV7S5tCGmgTuRTTsdigirs9HiBXHQ/dA==}
+  '@posthog/core@1.31.1':
+    resolution: {integrity: sha512-ZV7qk1lSLpJR7n5HZ/au0iA1H/5TaZjwAF3pVVhQYwCALOSIF5jvnI2X9mvByQIS+wSUckPkZQ+33YaIT6SZJQ==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -9187,8 +9187,8 @@ packages:
   '@posthog/types@1.372.9':
     resolution: {integrity: sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA==}
 
-  '@posthog/types@1.383.3':
-    resolution: {integrity: sha512-N4jtmLaJxzjQ/C0UHnF0igQPSwUqwScPDv9ePGjKCfDomIEUcO3+c6pBrjTp7woxuMQ49BmyM/pV4/SOBPpe0Q==}
+  '@posthog/types@1.384.1':
+    resolution: {integrity: sha512-tzObc/AIunXrKGX3lsPGQ1vs915L0KEChBDmPvgs9PMkCc7sH9eMn8/XKPbZ/BxJALRN8fsWCeSkR2fyoADWvA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -19287,8 +19287,8 @@ packages:
   posthog-js-lite@4.2.2:
     resolution: {integrity: sha512-fFCoGtMICWwoW0tsEdyFS7OFFgwe7bTTha/SKEtUdyJ56UyJ8wi6VghxyPkO2GVWpco5Za/edT1z1ovGYPCyLQ==}
 
-  posthog-js@1.383.3:
-    resolution: {integrity: sha512-caH+lSELdgqaS2uxmBiJT22/cr3epuMKSqBsO8QYQgORehokwdWB/Q4LIh3Dgyjy26B2yhprcAAqmuKMf4s3Nw==}
+  posthog-js@1.384.1:
+    resolution: {integrity: sha512-PDgxuNz2A8UsrglsSAhxYUuOx598PomxidDKuifydmz2LeMvLNvXg+6Iil8+MIHjVJjaPal0kdUhomsaeWiDOQ==}
 
   posthog-node@5.25.0:
     resolution: {integrity: sha512-DFE5lZAoD6hk7RATuT8qVQ7KFgFP5YlFTJciMbU2qq6NX0A8eJxiJcmEsMnB3g30jJJ9suiwGIq4I8ESwf9bZg==}
@@ -30035,9 +30035,9 @@ snapshots:
     dependencies:
       '@posthog/types': 1.372.9
 
-  '@posthog/core@1.30.14':
+  '@posthog/core@1.31.1':
     dependencies:
-      '@posthog/types': 1.383.3
+      '@posthog/types': 1.384.1
 
   '@posthog/core@1.7.1':
     dependencies:
@@ -30083,9 +30083,9 @@ snapshots:
     transitivePeerDependencies:
       - rxjs
 
-  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.383.3)(react@18.3.1)':
+  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.384.1)(react@18.3.1)':
     dependencies:
-      posthog-js: 1.383.3
+      posthog-js: 1.384.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
@@ -30094,7 +30094,7 @@ snapshots:
 
   '@posthog/types@1.372.9': {}
 
-  '@posthog/types@1.383.3': {}
+  '@posthog/types@1.384.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -31899,7 +31899,7 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.37(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -38939,25 +38939,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0:
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
@@ -39600,7 +39581,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -40035,7 +40016,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -40106,18 +40087,6 @@ snapshots:
       - supports-color
       - ts-node
       - utf-8-validate
-
-  jest@29.7.0:
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
@@ -43107,10 +43076,10 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
-  posthog-js@1.383.3:
+  posthog-js@1.384.1:
     dependencies:
-      '@posthog/core': 1.30.14
-      '@posthog/types': 1.383.3
+      '@posthog/core': 1.31.1
+      '@posthog/types': 1.384.1
       core-js: 3.40.0
       dompurify: 3.4.0
       fflate: 0.4.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
     kea-window-values: ^3.0.1
     # PostHog packages
     '@posthog/react': ^1.9.0
-    posthog-js: ^1.383.3
+    posthog-js: ^1.384.1
     # Build tools
     '@parcel/packager-ts': 2.16.4
     '@parcel/transformer-typescript-types': 2.16.4


### PR DESCRIPTION
## Problem

The session replay player can render duplicated, stacked DOM content (e.g. a title repeated 10–20×), and JSON exports of affected recordings show mutation events with emptied `removes` arrays even though the stored recording data is correct.

Root cause is in the rrweb replayer consumed from `posthog-js` (via the `posthog-js/rrweb` subpath): `Replayer.addEvent()` applied events older than the playback baseline synchronously onto the current DOM. The player feeds snapshot blocks to the replayer as they load, so seeking ahead before loading finished (timeline click, `?t=` link, skip-to-first-matching-event) force-applied late-arriving past mutations onto a DOM at the wrong position. Their `removes` failed mirror lookups and `applyMutation` then stripped the failed entries from the event objects in place, permanently corrupting the in-memory recording — every later seek rebuilt accumulated stale nodes, and exports serialized the stripped events.

## Changes

Bumps the `posthog-js` catalog entry to `1.384.1`, which includes the fix (PostHog/posthog-js#3787): past events are only applied synchronously in live mode, and `applyMutation` no longer mutates event data.

## How did you test this code?

I'm an agent. `pnpm install --lockfile-only` regenerated the lockfile; the diff is scoped to `posthog-js`/`@posthog/core`/`@posthog/types` plus pnpm peer-resolution normalization. The underlying replayer fix was verified in PostHog/posthog-js#3787 with unit tests and a puppeteer reproduction against a real affected recording (corruption present before the fix, absent after).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session driven by @tuehaulund, continuing the session replay player corruption investigation that produced PostHog/posthog-js#3787.
- This PR is the final step of that fix: getting the patched replayer into the app's player by bumping the pinned `posthog-js` version (excluded from automated dependency updates by design).