### PR TITLE
fix(docker): bump
  libssl3 pin to 3.0.20-1~deb12u2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -289,7 +289,7 @@ RUN apt-get update && \
     "libxmlsec1=1.2.37-2" \
     "libxmlsec1-openssl=1.2.37-2" \
     "libxml2" \
-    "libssl3=3.0.19-1~deb12u2" \
+    "libssl3=3.0.20-1~deb12u2" \
     "libjemalloc2" \
     && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

Debian rotated `libssl3` in bookworm-security from `3.0.19-1~deb12u2` to `3.0.20-1~deb12u2`, so the version pinned in the runtime-deps stage of `Dockerfile` no longer exists in the archive. Any build that does not have this layer cached now fails:

```
E: Version '3.0.19-1~deb12u2' for 'libssl3' was not found
```

Builds with a warm layer cache still pass, which masks the breakage until the layer is invalidated (e.g. the next PR that touches the runtime-deps stage, or any cold builder).

## Changes

Bump the pin to the current bookworm-security version `3.0.20-1~deb12u2`. The `libxmlsec1`/`libxmlsec1-openssl` pins target bookworm main and are unaffected.

## How did you test this code?

I'm an agent; no manual end-to-end image build was run. Verification done:

- Reproduced the failure in external CI builds of this Dockerfile at the current master pin (uncached builds fail with the apt error above; cached builds pass).
- Confirmed `3.0.20-1~deb12u2` is the version currently served by `deb.debian.org/debian-security bookworm-security/main` (apt fetch logs from the same builds).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Anthropic CLI agent) while diagnosing external CI failures that build this repo's Dockerfile; the human driver is the PR author.
- Considered waiting for an upstream fix or carrying a local Dockerfile patch in our CI; rejected both in favor of fixing the pin at the source, matching the existing pin-maintenance pattern in this Dockerfile.
