### PR TITLE
fix(signals): evict stale db connections in grouping activities

### DIFF
--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -27,6 +27,7 @@ from posthog.event_usage import groups
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
 
 from products.signals.backend.models import SignalReport
 from products.signals.backend.temporal.llm import MAX_QUERY_TOKENS, call_llm, truncate_query_to_token_limit
@@ -82,6 +83,7 @@ class GenerateEmbeddingOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def get_embedding_activity(input: GenerateEmbeddingInput) -> GenerateEmbeddingOutput:
     """Generate embedding for signal content using the embedding worker API."""
     try:
@@ -194,6 +196,7 @@ class GenerateSearchQueriesOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def generate_search_queries_activity(input: GenerateSearchQueriesInput) -> GenerateSearchQueriesOutput:
     """Use LLM to generate 1-3 search queries for finding related signals."""
     try:
@@ -487,6 +490,7 @@ class MatchSignalToReportInput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def match_signal_to_report_activity(input: MatchSignalToReportInput) -> MatchResult:
     """Determine if a new signal matches an existing report or needs a new one."""
     try:
@@ -528,6 +532,7 @@ class FetchReportContextsOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def fetch_report_contexts_activity(input: FetchReportContextsInput) -> FetchReportContextsOutput:
     """Fetch lightweight context (title, signal count) for reports from Postgres."""
     if not input.report_ids:
@@ -609,6 +614,7 @@ async def verify_match_specificity(
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def verify_match_specificity_activity(input: VerifyMatchSpecificityInput) -> VerifyMatchSpecificityOutput:
     """Verify that adding a signal to a group produces a specific-enough PR title."""
     try:
@@ -667,6 +673,7 @@ class AssignAndEmitSignalOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def assign_and_emit_signal_activity(input: AssignAndEmitSignalInput) -> AssignAndEmitSignalOutput:
     match_result = input.match_result
 

--- a/products/signals/backend/temporal/safety_filter.py
+++ b/products/signals/backend/temporal/safety_filter.py
@@ -10,6 +10,7 @@ from temporalio import activity
 from posthog.event_usage import groups
 from posthog.models import Team
 from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
 
 from products.signals.backend.temporal.llm import EmptyLLMResponseError, call_llm
 
@@ -174,6 +175,7 @@ async def _capture_signal_blocked_event(input: SafetyFilterInput, result: Safety
 
 @activity.defn
 @scoped_temporal()
+@close_db_connections
 async def safety_filter_activity(input: SafetyFilterInput) -> SafetyFilterOutput:
     """Filter out unsafe signals before passing them through the pipeline."""
     try:

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -16,6 +16,7 @@ from posthog.api.embedding_worker import emit_embedding_request
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Team
 from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
 
 from products.signals.backend.temporal.clickhouse import execute_hogql_query_with_retry
 from products.signals.backend.temporal.types import SignalCandidate, SignalData, SignalTypeExample
@@ -176,6 +177,7 @@ class FetchSignalTypeExamplesOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def fetch_signal_type_examples_activity(input: FetchSignalTypeExamplesInput) -> FetchSignalTypeExamplesOutput:
     """Fetch one example signal per unique (source_product, source_type) pair from ClickHouse."""
     try:
@@ -259,6 +261,7 @@ class RunSignalSemanticSearchOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def run_signal_semantic_search_activity(input: RunSignalSemanticSearchInput) -> RunSignalSemanticSearchOutput:
     """Run a nearest neighbor query against the signal embeddings in ClickHouse."""
     try:
@@ -339,6 +342,7 @@ class WaitForClickHouseInput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) -> None:
     """Poll ClickHouse until all emitted signals appear, or give up after max_wait_time_seconds.
 
@@ -442,6 +446,7 @@ class FetchSignalsForReportOutput:
 
 @temporalio.activity.defn
 @scoped_temporal()
+@close_db_connections
 async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -> FetchSignalsForReportOutput:
     try:
         team = await Team.objects.aget(pk=input.team_id)


### PR DESCRIPTION
## Problem

Signals that fire `signal_emitted` can silently never reach a report. Production worker logs show the per-team grouping workflow (`team-signal-grouping-v2`) retry-looping whole batches because activities like `get_embedding_activity` fail with psycopg `OperationalError: the connection is closed` — and every Temporal retry hits the same dead connection, so the retry policy can't save the batch. Per-signal failures in the matching phase take the silent `dropped += 1` path, so the affected signals end up emitted-but-never-assigned: invisible in the inbox and in semantic search.

The root cause is a known one for long-running Temporal workers: they never go through Django's request cycle, so the `close_old_connections()` housekeeping that normally evicts dead/expired connections never runs. Connections killed by the database (or past `CONN_MAX_AGE`) sit in the per-thread pool until a query fails on them. `posthog.temporal.common.utils.close_db_connections` exists precisely for this and is already used by other temporal activities (e.g. the Slack mention workflows), but none of the signals activities use it.

## Changes

Apply `@close_db_connections` to the 11 ORM-touching activities on the signal-processing path:

- `grouping.py`: `get_embedding_activity`, `generate_search_queries_activity`, `match_signal_to_report_activity`, `fetch_report_contexts_activity`, `verify_match_specificity_activity`, `assign_and_emit_signal_activity`
- `signal_queries.py`: `fetch_signal_type_examples_activity`, `run_signal_semantic_search_activity`, `wait_for_signal_in_clickhouse_activity`, `fetch_signals_for_report_activity`
- `safety_filter.py`: `safety_filter_activity`

With the eviction in place, a connection killed between activity runs is discarded before the activity queries, and a retry after a connection-level failure gets a fresh connection instead of the same dead one. The decorator is a no-op under `settings.TEST`, so test DB fixtures are unaffected.

## How did you test this code?

I'm an agent — no manual testing claimed. Automated: `pytest products/signals/backend/test/test_assign_and_emit_signal.py test_parallel_grouping.py test_safety_filter_telemetry.py` — 57 passed. `ruff check` / `ruff format` clean; `ty check` ran via lint-staged on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session tracing where scout-emitted signals go: ~40% of scout signals were emitted-but-never-assigned. Loki showed `team-signal-grouping-v2-2` retry-looping a batch on `get_embedding_activity` psycopg `OperationalError: the connection is closed` (plus unrelated embedding-api 500s, not addressed here).
- Chose the existing `close_db_connections` decorator over ad-hoc connection handling — it's the codebase-blessed fix for exactly this worker pattern and is a test-mode no-op.
- Scoped to the buffer → grouping → assign path; downstream summary/reingestion activities have the same latent exposure but failures there don't drop signals (reports re-promote), so they're left for a follow-up if needed.
