### PR TITLE
feat(signals): emit signal_dropped event when grouping drops a signal

### DIFF
--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -268,6 +268,7 @@ class TestSignalsProductModuleIntegrity:
             "emit_backfill_signal_activity",
             "fetch_error_tracking_issues_activity",
             "assign_and_emit_signal_activity",
+            "capture_signal_dropped_activity",
             "delete_report_activity",
             "emit_eval_signal_activity",
             "fetch_report_contexts_activity",

--- a/products/signals/backend/temporal/__init__.py
+++ b/products/signals/backend/temporal/__init__.py
@@ -22,6 +22,7 @@ from products.signals.backend.temporal.buffer import (
 )
 from products.signals.backend.temporal.custom_agent import CustomSignalAgentWorkflow, run_custom_signal_agent_activity
 from products.signals.backend.temporal.deletion import SignalReportDeletionWorkflow
+from products.signals.backend.temporal.drop_telemetry import capture_signal_dropped_activity
 from products.signals.backend.temporal.emit_eval_signal import EmitEvalSignalWorkflow, emit_eval_signal_activity
 from products.signals.backend.temporal.emitter import SignalEmitterWorkflow
 from products.signals.backend.temporal.grouping import (
@@ -96,6 +97,7 @@ ACTIVITIES = [
     fetch_enabled_signals_scout_runs_activity,
     stamp_dispatched_signals_scout_runs_activity,
     assign_and_emit_signal_activity,
+    capture_signal_dropped_activity,
     delete_report_activity,
     emit_eval_signal_activity,
     fetch_report_contexts_activity,

--- a/products/signals/backend/temporal/drop_telemetry.py
+++ b/products/signals/backend/temporal/drop_telemetry.py
@@ -11,6 +11,7 @@ from posthog.models import Team
 from posthog.temporal.common.scoped import scoped_temporal
 from posthog.temporal.common.utils import close_db_connections
 
+from products.signals.backend.facade.api import _telemetry_props_from_extra
 from products.signals.backend.temporal.types import EmitSignalInputs
 
 logger = structlog.get_logger(__name__)
@@ -57,6 +58,10 @@ async def capture_signal_dropped_activity(input: CaptureSignalDroppedInput) -> N
             event="signal_dropped",
             distinct_id=str(team.uuid),
             properties={
+                # Flattened scalars only (truncated, nested lists/dicts dropped) — `extra`
+                # nests customer-derived content that must not leak into product analytics.
+                # Core keys win on conflict, same as signal_emitted / signal_emission_started.
+                **_telemetry_props_from_extra(input.extra),
                 "reason": "grouping_processing_error",
                 "stage": input.stage,
                 "error_type": input.error_type,
@@ -65,7 +70,6 @@ async def capture_signal_dropped_activity(input: CaptureSignalDroppedInput) -> N
                 "source_type": input.source_type,
                 "source_id": input.source_id,
                 "weight": input.weight,
-                "extra": input.extra,
             },
             groups=groups(team.organization, team),
         )

--- a/products/signals/backend/temporal/drop_telemetry.py
+++ b/products/signals/backend/temporal/drop_telemetry.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+import structlog
+import posthoganalytics
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+
+from posthog.event_usage import groups
+from posthog.models import Team
+from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
+
+from products.signals.backend.temporal.types import EmitSignalInputs
+
+logger = structlog.get_logger(__name__)
+
+# Gate so workflows replaying history recorded before this event existed don't
+# schedule a command their history doesn't have (Temporal nondeterminism).
+_PATCH_SIGNAL_DROPPED = "signal-dropped-telemetry-v1"
+
+_MAX_ERROR_LENGTH = 500
+
+
+@dataclass
+class CaptureSignalDroppedInput:
+    team_id: int
+    source_product: str
+    source_type: str
+    source_id: str
+    weight: float
+    stage: str
+    error_type: str
+    error: str
+    extra: dict = field(default_factory=dict)
+
+
+def _summarize_drop_error(error: BaseException) -> tuple[str, str]:
+    """Extract the most specific (type, message) from a (possibly wrapped) activity error.
+
+    Temporal wraps the real failure: an ActivityError's `cause` is an ApplicationError
+    whose `type` carries the original exception class name (e.g. "OperationalError").
+    """
+    cause = getattr(error, "cause", None) or error.__cause__ or error
+    error_type = getattr(cause, "type", None) or type(cause).__name__
+    return error_type, str(cause)[:_MAX_ERROR_LENGTH]
+
+
+@activity.defn
+@scoped_temporal()
+@close_db_connections
+async def capture_signal_dropped_activity(input: CaptureSignalDroppedInput) -> None:
+    """Emit a lifecycle event when the pipeline drops a signal, so drops are trackable per signal."""
+    try:
+        team = await Team.objects.select_related("organization").aget(pk=input.team_id)
+        posthoganalytics.capture(
+            event="signal_dropped",
+            distinct_id=str(team.uuid),
+            properties={
+                "reason": "grouping_processing_error",
+                "stage": input.stage,
+                "error_type": input.error_type,
+                "error": input.error,
+                "source_product": input.source_product,
+                "source_type": input.source_type,
+                "source_id": input.source_id,
+                "weight": input.weight,
+                "extra": input.extra,
+            },
+            groups=groups(team.organization, team),
+        )
+    except Exception as e:
+        # Swallow the exception, to avoid breaking the flow over a failed analytics event
+        posthoganalytics.capture_exception(e)
+        logger.exception(
+            "Failed to capture signal_dropped event",
+            team_id=input.team_id,
+            source_id=input.source_id,
+        )
+
+
+async def capture_signal_dropped(signal: EmitSignalInputs, error: BaseException, stage: str) -> None:
+    """Best-effort signal_dropped telemetry from workflow code; never raises into the grouping flow."""
+    if not workflow.patched(_PATCH_SIGNAL_DROPPED):
+        return
+    error_type, error_message = _summarize_drop_error(error)
+    try:
+        await workflow.execute_activity(
+            capture_signal_dropped_activity,
+            CaptureSignalDroppedInput(
+                team_id=signal.team_id,
+                source_product=signal.source_product,
+                source_type=signal.source_type,
+                source_id=signal.source_id,
+                weight=signal.weight,
+                stage=stage,
+                error_type=error_type,
+                error=error_message,
+                extra=signal.extra,
+            ),
+            start_to_close_timeout=timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to schedule signal_dropped capture",
+            team_id=signal.team_id,
+            source_id=signal.source_id,
+        )

--- a/products/signals/backend/temporal/drop_telemetry.py
+++ b/products/signals/backend/temporal/drop_telemetry.py
@@ -44,7 +44,11 @@ def _summarize_drop_error(error: BaseException) -> tuple[str, str]:
     """
     cause = getattr(error, "cause", None) or error.__cause__ or error
     error_type = getattr(cause, "type", None) or type(cause).__name__
-    return error_type, str(cause)[:_MAX_ERROR_LENGTH]
+    # First line only: multi-line messages (pydantic validation errors, LLM response
+    # dumps) carry customer-derived values on continuation lines that must not reach
+    # product analytics. Infra failures (DB, timeout) are single-line and unaffected.
+    message = str(cause).partition("\n")[0][:_MAX_ERROR_LENGTH]
+    return error_type, message
 
 
 @activity.defn
@@ -100,7 +104,9 @@ async def capture_signal_dropped(signal: EmitSignalInputs, error: BaseException,
                 stage=stage,
                 error_type=error_type,
                 error=error_message,
-                extra=signal.extra,
+                # Flatten before scheduling: the raw `extra` can nest large customer-derived
+                # payloads, and the activity input is recorded verbatim in workflow history.
+                extra=_telemetry_props_from_extra(signal.extra),
             ),
             start_to_close_timeout=timedelta(minutes=1),
             retry_policy=RetryPolicy(maximum_attempts=2),

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -934,111 +934,123 @@ async def _process_signal_batch(
 
     # === PARALLEL PHASE (steps 1-4) ===
 
-    # Step 1a: Fetch type examples if not cached (needed by query gen)
-    if cached_type_examples is not None:
-        type_examples_result = cached_type_examples
-    else:
-        type_examples_result = await workflow.execute_activity(
-            fetch_signal_type_examples_activity,
-            FetchSignalTypeExamplesInput(team_id=team_id),
-            start_to_close_timeout=timedelta(minutes=5),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
-
-    # Step 1b: Embed all signals + generate search queries in parallel
-    # (query gen needs type examples but NOT the signal embeddings)
-    step1b_results = await asyncio.gather(
-        *[
-            workflow.execute_activity(
-                get_embedding_activity,
-                GenerateEmbeddingInput(team_id=team_id, content=s.description),
+    try:
+        # Step 1a: Fetch type examples if not cached (needed by query gen)
+        if cached_type_examples is not None:
+            type_examples_result = cached_type_examples
+        else:
+            type_examples_result = await workflow.execute_activity(
+                fetch_signal_type_examples_activity,
+                FetchSignalTypeExamplesInput(team_id=team_id),
                 start_to_close_timeout=timedelta(minutes=5),
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
-            for s in batch
-        ],
-        *[
-            workflow.execute_activity(
-                generate_search_queries_activity,
-                GenerateSearchQueriesInput(
-                    team_id=team_id,
-                    description=s.description,
-                    source_product=s.source_product,
-                    source_type=s.source_type,
-                    signal_type_examples=type_examples_result.examples,
-                ),
-                start_to_close_timeout=timedelta(minutes=10),
-                retry_policy=RetryPolicy(maximum_attempts=5),
-            )
-            for s in batch
-        ],
-    )
-    signal_embeddings = cast(list[GenerateEmbeddingOutput], step1b_results[: len(batch)])
-    query_gen_results = cast(list[GenerateSearchQueriesOutput], step1b_results[len(batch) :])
 
-    # Step 3: Embed all queries across all signals (flatten → parallel embed)
-    all_queries_flat: list[tuple[int, str]] = []
-    for sig_idx, qr in enumerate(query_gen_results):
-        for q in qr.queries:
-            all_queries_flat.append((sig_idx, q))
-
-    all_query_embeddings: list[GenerateEmbeddingOutput] = list(
-        await asyncio.gather(
+        # Step 1b: Embed all signals + generate search queries in parallel
+        # (query gen needs type examples but NOT the signal embeddings)
+        step1b_results = await asyncio.gather(
             *[
                 workflow.execute_activity(
                     get_embedding_activity,
-                    GenerateEmbeddingInput(team_id=team_id, content=q_text),
+                    GenerateEmbeddingInput(team_id=team_id, content=s.description),
                     start_to_close_timeout=timedelta(minutes=5),
                     retry_policy=RetryPolicy(maximum_attempts=3),
                 )
-                for _, q_text in all_queries_flat
-            ]
-        )
-    )
-
-    # Step 4: Semantic search for all queries (all parallel)
-    all_search_results: list[RunSignalSemanticSearchOutput] = list(
-        await asyncio.gather(
+                for s in batch
+            ],
             *[
                 workflow.execute_activity(
-                    run_signal_semantic_search_activity,
-                    RunSignalSemanticSearchInput(team_id=team_id, embedding=emb.embedding, limit=10),
-                    start_to_close_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(maximum_attempts=3),
+                    generate_search_queries_activity,
+                    GenerateSearchQueriesInput(
+                        team_id=team_id,
+                        description=s.description,
+                        source_product=s.source_product,
+                        source_type=s.source_type,
+                        signal_type_examples=type_examples_result.examples,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=10),
+                    retry_policy=RetryPolicy(maximum_attempts=5),
                 )
-                for emb in all_query_embeddings
-            ]
+                for s in batch
+            ],
         )
-    )
+        signal_embeddings = cast(list[GenerateEmbeddingOutput], step1b_results[: len(batch)])
+        query_gen_results = cast(list[GenerateSearchQueriesOutput], step1b_results[len(batch) :])
 
-    # Regroup flat results back to per-signal
-    # Each query becomes an embedding vector for lookup
-    type EmbeddingVector = list[float]
-    # For each new signal, we generate a number N of query strings
-    type SignalQueries = list[str]
-    # For each new signal, we generate an embedding for each query (so N embeddings)
-    type SignalQueryEmbeddings = list[EmbeddingVector]
-    # For each new signal, for each query, we get a list of M candidates back (10 at time of writing)
-    type SignalQueryResults = list[SignalCandidate]
-    # For each new signal, we run each query, so we get N * M total candidates for matching (although we fold down overlap across queries)
-    type SignalMatchCandidates = list[SignalQueryResults]
-    per_signal_queries: list[SignalQueries] = [[] for _ in batch]
-    per_signal_query_embeddings: list[SignalQueryEmbeddings] = [[] for _ in batch]
-    per_signal_ch_results: list[SignalMatchCandidates] = [[] for _ in batch]
-    for flat_idx, (sig_idx, q_text) in enumerate(all_queries_flat):
-        per_signal_queries[sig_idx].append(q_text)
-        per_signal_query_embeddings[sig_idx].append(all_query_embeddings[flat_idx].embedding)
-        per_signal_ch_results[sig_idx].append(all_search_results[flat_idx].candidates)
+        # Step 3: Embed all queries across all signals (flatten → parallel embed)
+        all_queries_flat: list[tuple[int, str]] = []
+        for sig_idx, qr in enumerate(query_gen_results):
+            for q in qr.queries:
+                all_queries_flat.append((sig_idx, q))
 
-    # Step 4.5: Fetch report contexts for all CH candidates (group-aware matching)
-    all_candidate_report_ids = list({c.report_id for results in all_search_results for c in results.candidates})
-    report_contexts_result: FetchReportContextsOutput = await workflow.execute_activity(
-        fetch_report_contexts_activity,
-        FetchReportContextsInput(team_id=team_id, report_ids=all_candidate_report_ids),
-        start_to_close_timeout=timedelta(minutes=5),
-        retry_policy=RetryPolicy(maximum_attempts=3),
-    )
-    report_contexts: dict[str, ReportContext] = report_contexts_result.contexts
+        all_query_embeddings: list[GenerateEmbeddingOutput] = list(
+            await asyncio.gather(
+                *[
+                    workflow.execute_activity(
+                        get_embedding_activity,
+                        GenerateEmbeddingInput(team_id=team_id, content=q_text),
+                        start_to_close_timeout=timedelta(minutes=5),
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                    )
+                    for _, q_text in all_queries_flat
+                ]
+            )
+        )
+
+        # Step 4: Semantic search for all queries (all parallel)
+        all_search_results: list[RunSignalSemanticSearchOutput] = list(
+            await asyncio.gather(
+                *[
+                    workflow.execute_activity(
+                        run_signal_semantic_search_activity,
+                        RunSignalSemanticSearchInput(team_id=team_id, embedding=emb.embedding, limit=10),
+                        start_to_close_timeout=timedelta(minutes=5),
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                    )
+                    for emb in all_query_embeddings
+                ]
+            )
+        )
+
+        # Regroup flat results back to per-signal
+        # Each query becomes an embedding vector for lookup
+        type EmbeddingVector = list[float]
+        # For each new signal, we generate a number N of query strings
+        type SignalQueries = list[str]
+        # For each new signal, we generate an embedding for each query (so N embeddings)
+        type SignalQueryEmbeddings = list[EmbeddingVector]
+        # For each new signal, for each query, we get a list of M candidates back (10 at time of writing)
+        type SignalQueryResults = list[SignalCandidate]
+        # For each new signal, we run each query, so we get N * M total candidates for matching (although we fold down overlap across queries)
+        type SignalMatchCandidates = list[SignalQueryResults]
+        per_signal_queries: list[SignalQueries] = [[] for _ in batch]
+        per_signal_query_embeddings: list[SignalQueryEmbeddings] = [[] for _ in batch]
+        per_signal_ch_results: list[SignalMatchCandidates] = [[] for _ in batch]
+        for flat_idx, (sig_idx, q_text) in enumerate(all_queries_flat):
+            per_signal_queries[sig_idx].append(q_text)
+            per_signal_query_embeddings[sig_idx].append(all_query_embeddings[flat_idx].embedding)
+            per_signal_ch_results[sig_idx].append(all_search_results[flat_idx].candidates)
+
+        # Step 4.5: Fetch report contexts for all CH candidates (group-aware matching)
+        all_candidate_report_ids = list({c.report_id for results in all_search_results for c in results.candidates})
+        report_contexts_result: FetchReportContextsOutput = await workflow.execute_activity(
+            fetch_report_contexts_activity,
+            FetchReportContextsInput(team_id=team_id, report_ids=all_candidate_report_ids),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+        report_contexts: dict[str, ReportContext] = report_contexts_result.contexts
+    except Exception as e:
+        # Nothing has been emitted yet, so the whole batch is explainable as dropped.
+        # The outer workflow handler can't emit these: it also catches post-emission
+        # failures (the CH wait in step 7), where signals were successfully assigned.
+        logger.exception(
+            "Failed to prepare signal batch",
+            team_id=team_id,
+            batch_size=len(batch),
+        )
+        await asyncio.gather(*(capture_signal_dropped(signal, e, stage="grouping_prep") for signal in batch))
+        raise
 
     # === SEQUENTIAL PHASE (steps 5-7) ===
     _PATCH_PARALLEL_SEQUENTIAL = "parallel-sequential-phase-v1"

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -29,6 +29,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.scoped import scoped_temporal
 
 from products.signals.backend.models import SignalReport
+from products.signals.backend.temporal.drop_telemetry import capture_signal_dropped
 from products.signals.backend.temporal.llm import MAX_QUERY_TOKENS, call_llm, truncate_query_to_token_limit
 from products.signals.backend.temporal.signal_queries import (
     EMBEDDING_MODEL,
@@ -1192,7 +1193,7 @@ async def _process_signal_batch(
                     assign_result.run_count,
                 )
 
-        except Exception:
+        except Exception as e:
             dropped += 1
             logger.exception(
                 "Failed to process signal in batch",
@@ -1201,6 +1202,7 @@ async def _process_signal_batch(
                 source_type=signal.source_type,
                 source_id=signal.source_id,
             )
+            await capture_signal_dropped(signal, e, stage="grouping_sequential")
 
     # Step 7: Wait for all emitted signals to land in CH so the next batch can find them
     if emitted_signals:

--- a/products/signals/backend/temporal/parallel_grouping.py
+++ b/products/signals/backend/temporal/parallel_grouping.py
@@ -8,6 +8,7 @@ import structlog
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
+from products.signals.backend.temporal.drop_telemetry import capture_signal_dropped
 from products.signals.backend.temporal.grouping import (
     AssignAndEmitSignalInput,
     AssignAndEmitSignalOutput,
@@ -277,7 +278,7 @@ async def _process_signal_safe(
             augmented_results=augmented_results,
             report_contexts=report_contexts,
         )
-    except Exception:
+    except Exception as e:
         logger.exception(
             "Failed to process signal in parallel batch",
             team_id=team_id,
@@ -285,6 +286,7 @@ async def _process_signal_safe(
             source_type=signal.source_type,
             source_id=signal.source_id,
         )
+        await capture_signal_dropped(signal, e, stage="grouping_parallel")
         return None
 
 

--- a/products/signals/backend/temporal/safety_filter.py
+++ b/products/signals/backend/temporal/safety_filter.py
@@ -11,6 +11,7 @@ from posthog.event_usage import groups
 from posthog.models import Team
 from posthog.temporal.common.scoped import scoped_temporal
 
+from products.signals.backend.facade.api import _telemetry_props_from_extra
 from products.signals.backend.temporal.llm import EmptyLLMResponseError, call_llm
 
 logger = structlog.get_logger(__name__)
@@ -156,13 +157,16 @@ async def _capture_signal_blocked_event(input: SafetyFilterInput, result: Safety
             event="signal_blocked_by_safety_filter",
             distinct_id=str(team.uuid),
             properties={
+                # Flattened scalars only (truncated, nested lists/dicts dropped) — `extra`
+                # nests customer-derived content that must not leak into product analytics.
+                # Core keys win on conflict, same as signal_emitted / signal_emission_started.
+                **_telemetry_props_from_extra(input.extra),
                 "threat_type": result.threat_type,
                 "explanation": result.explanation,
                 "source_product": input.source_product,
                 "source_type": input.source_type,
                 "source_id": input.source_id,
                 "weight": input.weight,
-                "extra": input.extra,
             },
             groups=groups(team.organization, team),
         )

--- a/products/signals/backend/test/test_drop_telemetry.py
+++ b/products/signals/backend/test/test_drop_telemetry.py
@@ -22,7 +22,7 @@ def _make_signal(team_id: int = 1) -> EmitSignalInputs:
         source_id="run:abc:finding:def",
         description="a finding",
         weight=0.7,
-        extra={"skill_name": "error-tracking"},
+        extra={"skill_name": "error-tracking", "evidence": [{"nested": "customer content"}]},
     )
 
 
@@ -130,6 +130,9 @@ async def test_helper_schedules_capture_activity():
     assert activity_input.stage == "grouping_parallel"
     assert activity_input.error_type == "ValueError"
     assert activity_input.error == "boom"
+    # extra is flattened before scheduling so nested customer-derived payloads
+    # never enter workflow history via the activity input
+    assert activity_input.extra == {"skill_name": "error-tracking"}
 
 
 @pytest.mark.asyncio
@@ -160,9 +163,22 @@ async def test_helper_swallows_activity_failure():
             "untyped failure",
         ),
         (ValueError("x" * 2000), "ValueError", "x" * 500),
+        (
+            # Pydantic-style multi-line validation error: continuation lines carry
+            # customer-derived input values and must not be forwarded
+            _make_activity_error(
+                ApplicationError(
+                    "1 validation error for SignalMatchResult\nreport_id\n  Input should be a valid string [input_value={'customer': 'secret'}]",
+                    type="ValidationError",
+                )
+            ),
+            "ValidationError",
+            "1 validation error for SignalMatchResult",
+        ),
     ],
 )
 def test_summarize_drop_error(error, expected_type, expected_message):
     error_type, message = _summarize_drop_error(error)
     assert error_type == expected_type
     assert expected_message in message
+    assert "\n" not in message

--- a/products/signals/backend/test/test_drop_telemetry.py
+++ b/products/signals/backend/test/test_drop_telemetry.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import patch
+
+from temporalio.exceptions import ActivityError, ApplicationError
+
+from products.signals.backend.temporal.drop_telemetry import (
+    CaptureSignalDroppedInput,
+    _summarize_drop_error,
+    capture_signal_dropped_activity,
+)
+
+PIPELINE_MODULE_PATH = "products.signals.backend.temporal.drop_telemetry"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_capture_signal_dropped_activity_emits_event(ateam):
+    with patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture:
+        await capture_signal_dropped_activity(
+            CaptureSignalDroppedInput(
+                team_id=ateam.id,
+                source_product="signals_scout",
+                source_type="cross_source_issue",
+                source_id="run:abc:finding:def",
+                weight=0.7,
+                stage="grouping_parallel",
+                error_type="OperationalError",
+                error="the connection is closed",
+                extra={"skill_name": "error-tracking", "task_run_id": "task-run-1"},
+            )
+        )
+
+    capture.assert_called_once()
+    kwargs = capture.call_args.kwargs
+    assert kwargs["event"] == "signal_dropped"
+    assert kwargs["distinct_id"] == str(ateam.uuid)
+    assert kwargs["properties"]["reason"] == "grouping_processing_error"
+    assert kwargs["properties"]["stage"] == "grouping_parallel"
+    assert kwargs["properties"]["error_type"] == "OperationalError"
+    assert kwargs["properties"]["error"] == "the connection is closed"
+    assert kwargs["properties"]["source_product"] == "signals_scout"
+    assert kwargs["properties"]["source_type"] == "cross_source_issue"
+    assert kwargs["properties"]["source_id"] == "run:abc:finding:def"
+    assert kwargs["properties"]["weight"] == 0.7
+    assert kwargs["properties"]["extra"]["skill_name"] == "error-tracking"
+    assert kwargs["properties"]["extra"]["task_run_id"] == "task-run-1"
+    assert "project" in kwargs["groups"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_capture_failure_is_swallowed(ateam):
+    with (
+        patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture", side_effect=RuntimeError("capture down")),
+        patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture_exception") as capture_exception,
+    ):
+        await capture_signal_dropped_activity(
+            CaptureSignalDroppedInput(
+                team_id=ateam.id,
+                source_product="error_tracking",
+                source_type="issue_created",
+                source_id="issue-1",
+                weight=0.5,
+                stage="grouping_sequential",
+                error_type="TimeoutError",
+                error="LLM match timed out",
+            )
+        )
+
+    capture_exception.assert_called_once()
+
+
+def _make_activity_error(cause: BaseException) -> ActivityError:
+    error = ActivityError(
+        "Activity task failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="worker",
+        activity_type="get_embedding_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    error.__cause__ = cause
+    return error
+
+
+class TestSummarizeDropError:
+    def test_plain_exception(self):
+        error_type, message = _summarize_drop_error(ValueError("bad input"))
+        assert error_type == "ValueError"
+        assert message == "bad input"
+
+    def test_activity_error_unwraps_application_error_type(self):
+        cause = ApplicationError("the connection is closed", type="OperationalError")
+        error_type, message = _summarize_drop_error(_make_activity_error(cause))
+        assert error_type == "OperationalError"
+        assert "the connection is closed" in message
+
+    def test_message_truncated(self):
+        _, message = _summarize_drop_error(ValueError("x" * 2000))
+        assert len(message) == 500

--- a/products/signals/backend/test/test_drop_telemetry.py
+++ b/products/signals/backend/test/test_drop_telemetry.py
@@ -1,15 +1,43 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from temporalio.exceptions import ActivityError, ApplicationError
 
 from products.signals.backend.temporal.drop_telemetry import (
     CaptureSignalDroppedInput,
     _summarize_drop_error,
+    capture_signal_dropped,
     capture_signal_dropped_activity,
 )
+from products.signals.backend.temporal.types import EmitSignalInputs
 
 PIPELINE_MODULE_PATH = "products.signals.backend.temporal.drop_telemetry"
+
+
+def _make_signal(team_id: int = 1) -> EmitSignalInputs:
+    return EmitSignalInputs(
+        team_id=team_id,
+        source_product="signals_scout",
+        source_type="cross_source_issue",
+        source_id="run:abc:finding:def",
+        description="a finding",
+        weight=0.7,
+        extra={"skill_name": "error-tracking"},
+    )
+
+
+def _make_activity_error(cause: BaseException) -> ActivityError:
+    error = ActivityError(
+        "Activity task failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="worker",
+        activity_type="get_embedding_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    error.__cause__ = cause
+    return error
 
 
 @pytest.mark.asyncio
@@ -26,7 +54,11 @@ async def test_capture_signal_dropped_activity_emits_event(ateam):
                 stage="grouping_parallel",
                 error_type="OperationalError",
                 error="the connection is closed",
-                extra={"skill_name": "error-tracking", "task_run_id": "task-run-1"},
+                extra={
+                    "skill_name": "error-tracking",
+                    "task_run_id": "task-run-1",
+                    "evidence": [{"nested": "customer content"}],
+                },
             )
         )
 
@@ -42,8 +74,11 @@ async def test_capture_signal_dropped_activity_emits_event(ateam):
     assert kwargs["properties"]["source_type"] == "cross_source_issue"
     assert kwargs["properties"]["source_id"] == "run:abc:finding:def"
     assert kwargs["properties"]["weight"] == 0.7
-    assert kwargs["properties"]["extra"]["skill_name"] == "error-tracking"
-    assert kwargs["properties"]["extra"]["task_run_id"] == "task-run-1"
+    # extra is flattened to top-level scalars; nested customer-derived content is dropped
+    assert kwargs["properties"]["skill_name"] == "error-tracking"
+    assert kwargs["properties"]["task_run_id"] == "task-run-1"
+    assert "evidence" not in kwargs["properties"]
+    assert "extra" not in kwargs["properties"]
     assert "project" in kwargs["groups"]
 
 
@@ -70,32 +105,64 @@ async def test_capture_failure_is_swallowed(ateam):
     capture_exception.assert_called_once()
 
 
-def _make_activity_error(cause: BaseException) -> ActivityError:
-    error = ActivityError(
-        "Activity task failed",
-        scheduled_event_id=1,
-        started_event_id=2,
-        identity="worker",
-        activity_type="get_embedding_activity",
-        activity_id="1",
-        retry_state=None,
-    )
-    error.__cause__ = cause
-    return error
+@pytest.mark.asyncio
+async def test_helper_noops_when_patch_not_applied():
+    with (
+        patch(f"{PIPELINE_MODULE_PATH}.workflow.patched", return_value=False),
+        patch(f"{PIPELINE_MODULE_PATH}.workflow.execute_activity", new_callable=AsyncMock) as execute_activity,
+    ):
+        await capture_signal_dropped(_make_signal(), ValueError("boom"), stage="grouping_sequential")
+
+    execute_activity.assert_not_called()
 
 
-class TestSummarizeDropError:
-    def test_plain_exception(self):
-        error_type, message = _summarize_drop_error(ValueError("bad input"))
-        assert error_type == "ValueError"
-        assert message == "bad input"
+@pytest.mark.asyncio
+async def test_helper_schedules_capture_activity():
+    with (
+        patch(f"{PIPELINE_MODULE_PATH}.workflow.patched", return_value=True),
+        patch(f"{PIPELINE_MODULE_PATH}.workflow.execute_activity", new_callable=AsyncMock) as execute_activity,
+    ):
+        await capture_signal_dropped(_make_signal(team_id=42), ValueError("boom"), stage="grouping_parallel")
 
-    def test_activity_error_unwraps_application_error_type(self):
-        cause = ApplicationError("the connection is closed", type="OperationalError")
-        error_type, message = _summarize_drop_error(_make_activity_error(cause))
-        assert error_type == "OperationalError"
-        assert "the connection is closed" in message
+    execute_activity.assert_called_once()
+    activity_input = execute_activity.call_args.args[1]
+    assert activity_input.team_id == 42
+    assert activity_input.stage == "grouping_parallel"
+    assert activity_input.error_type == "ValueError"
+    assert activity_input.error == "boom"
 
-    def test_message_truncated(self):
-        _, message = _summarize_drop_error(ValueError("x" * 2000))
-        assert len(message) == 500
+
+@pytest.mark.asyncio
+async def test_helper_swallows_activity_failure():
+    with (
+        patch(f"{PIPELINE_MODULE_PATH}.workflow.patched", return_value=True),
+        patch(
+            f"{PIPELINE_MODULE_PATH}.workflow.execute_activity",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("activity failed"),
+        ),
+    ):
+        await capture_signal_dropped(_make_signal(), ValueError("boom"), stage="grouping_sequential")
+
+
+@pytest.mark.parametrize(
+    "error,expected_type,expected_message",
+    [
+        (ValueError("bad input"), "ValueError", "bad input"),
+        (
+            _make_activity_error(ApplicationError("the connection is closed", type="OperationalError")),
+            "OperationalError",
+            "the connection is closed",
+        ),
+        (
+            _make_activity_error(ApplicationError("untyped failure")),
+            "ApplicationError",
+            "untyped failure",
+        ),
+        (ValueError("x" * 2000), "ValueError", "x" * 500),
+    ],
+)
+def test_summarize_drop_error(error, expected_type, expected_message):
+    error_type, message = _summarize_drop_error(error)
+    assert error_type == expected_type
+    assert expected_message in message

--- a/products/signals/backend/test/test_safety_filter_telemetry.py
+++ b/products/signals/backend/test/test_safety_filter_telemetry.py
@@ -50,8 +50,10 @@ async def test_capture_fires_only_when_blocked(ateam, safe, expect_capture):
     assert kwargs["properties"]["source_type"] == "cross_source_issue"
     assert kwargs["properties"]["source_id"] == "run:abc:finding:def"
     assert kwargs["properties"]["weight"] == 0.7
-    assert kwargs["properties"]["extra"]["skill_name"] == "error-tracking"
-    assert kwargs["properties"]["extra"]["task_run_id"] == "task-run-1"
+    # extra is flattened to top-level scalars, never forwarded as a nested dict
+    assert kwargs["properties"]["skill_name"] == "error-tracking"
+    assert kwargs["properties"]["task_run_id"] == "task-run-1"
+    assert "extra" not in kwargs["properties"]
     assert "project" in kwargs["groups"]
 
 


### PR DESCRIPTION
## Problem

When the grouping pipeline drops a signal after `signal_emitted` — an LLM match failure, embedding error, or DB error that exhausts activity retries — the only traces are a worker log line and an aggregate Temporal counter. There is no per-signal record, so dropped signals are indistinguishable from signals still in flight: they show up as emitted-but-never-assigned with no way to tell why, which signal, or from which source. Every other terminal outcome in the signal lifecycle already has an event (`signal_emitted`, `signal_assigned_to_report`, `signal_blocked_by_safety_filter`); the drop path is the one silent branch.

## Changes

- New `signal_dropped` analytics event, following the `signal_blocked_by_safety_filter` pattern: captured from a small dedicated activity (`capture_signal_dropped_activity` in a new `drop_telemetry.py`), with the team's UUID as distinct_id, group attribution, and source identity (`source_product` / `source_type` / `source_id` / `weight` / `extra`) so per-source drop rates are queryable and scout signals keep their run attribution.
- Event carries `stage` (`grouping_sequential` / `grouping_parallel`), `error_type`, and a truncated `error` message — unwrapping Temporal's `ActivityError` → `ApplicationError` chain so the original exception class (e.g. `OperationalError`) is what lands on the event.
- Wired into both per-signal drop sites: the sequential batch loop in `grouping.py` and `_process_signal_safe` in `parallel_grouping.py`.
- Replay-safe: the capture is gated behind `workflow.patched("signal-dropped-telemetry-v1")` so in-flight workflows replaying pre-deploy history don't schedule a command their history doesn't contain. Best-effort: a failed capture is logged and swallowed at both the activity and workflow layers, never failing the batch further.
- Activity registered in the worker's `ACTIVITIES` list.

The whole-batch failure path in grouping v2's collect loop is intentionally not instrumented — it re-stashes the batch keys and retries, so those signals are in flight rather than dropped.

## How did you test this code?

I'm an agent — no manual testing claimed. Automated: new `test_drop_telemetry.py` (event payload, capture-failure swallowing, `ActivityError`/`ApplicationError` unwrapping, message truncation) plus the existing grouping suites — 59 tests pass across `test_drop_telemetry.py`, `test_parallel_grouping.py`, `test_assign_and_emit_signal.py`. `ruff check`/`format` clean; `ty check` ran via lint-staged on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session auditing where emitted signals end up: a large emitted-but-never-assigned bucket traced to silent drops in grouping (companion fix: #62634 addresses the dominant root cause, stale DB connections). This PR makes the remaining drops observable per signal.
- Chose a workflow-called capture activity over capturing inside the failing activities (an activity can't know it's on its final retry; the drop decision happens at the workflow layer) and over a metric-only approach (the aggregate counter already exists but has no signal identity).
- `workflow.patched()` gating follows the existing convention in this file (`parallel-sequential-phase-v1`, `collect-batch-signals-v1`).
