### PR TITLE
feat(subscriptions): add report preview for AI prompt subscriptions

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -10,6 +10,7 @@ from django.http import HttpRequest, JsonResponse
 
 import jwt
 import posthoganalytics
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
     OpenApiResponse,
@@ -749,6 +750,51 @@ def _subscription_is_ai_prompt(subscription_id: str | int, team_id: int) -> bool
     )
 
 
+class SubscriptionTestDeliveryRequestSerializer(serializers.Serializer):
+    preview = serializers.BooleanField(
+        default=False,
+        help_text=(
+            "AI subscriptions only: run the report generation pipeline without sending anything. "
+            "Poll the preview_report action with the returned delivery_id to fetch the result."
+        ),
+    )
+
+
+class SubscriptionTestDeliveryResponseSerializer(serializers.Serializer):
+    delivery_id = serializers.UUIDField(
+        allow_null=True,
+        help_text="Delivery row to poll via the preview_report action. Null for non-preview test deliveries.",
+    )
+
+
+class SubscriptionPreviewReportSerializer(serializers.Serializer):
+    status = serializers.ChoiceField(
+        choices=SubscriptionDelivery.Status.choices,
+        help_text="Run status of the preview delivery: starting, completed, failed, or skipped.",
+    )
+    ai_report = serializers.CharField(
+        allow_null=True,
+        help_text="Generated report markdown. Null until the run completes (or when it failed before generating).",
+    )
+    error = serializers.CharField(
+        allow_null=True,
+        help_text="Human-readable failure detail when the run failed, if available.",
+    )
+
+
+def _delivery_error_message(delivery: SubscriptionDelivery) -> str | None:
+    # Auto-disable aborts (consent revoked, prompt rejected) land in recipient_results
+    # with a null top-level error, so fall back to the first recipient error.
+    error = delivery.error
+    if isinstance(error, dict) and error.get("message"):
+        return str(error["message"])
+    for result in delivery.recipient_results or []:
+        recipient_error = result.get("error") if isinstance(result, dict) else None
+        if isinstance(recipient_error, dict) and recipient_error.get("message"):
+            return str(recipient_error["message"])
+    return None
+
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -819,6 +865,10 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
     # for every write — a scope is only a capability flag, not proof of RBAC (personal keys can
     # carry query:read without it), and session auth has no scopes at all.
     def dangerously_get_required_scopes(self, request, view) -> list[str] | None:
+        # preview_report returns the query-derived AI report, so a read isn't enough —
+        # tokens also need query:read (RBAC is enforced separately inside the action).
+        if getattr(view, "action", None) == "preview_report":
+            return [f"{self.scope_object}:read", "query:read"]
         if request.method in ("GET", "HEAD", "OPTIONS"):
             return None
         scopes = [f"{self.scope_object}:write"]
@@ -942,8 +992,13 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
         return Response(payload)
 
     @extend_schema(
-        request=None,
-        responses={202: OpenApiResponse(description="Test delivery workflow started")},
+        request=SubscriptionTestDeliveryRequestSerializer,
+        responses={
+            202: OpenApiResponse(
+                response=SubscriptionTestDeliveryResponseSerializer,
+                description="Test delivery (or preview generation) workflow started.",
+            )
+        },
     )
     @action(
         methods=["POST"],
@@ -964,8 +1019,19 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
                 status=status.HTTP_409_CONFLICT,
             )
 
+        request_serializer = SubscriptionTestDeliveryRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        preview = request_serializer.validated_data["preview"]
+        if preview and not _subscription_is_ai_prompt(subscription.id, self.team_id):
+            raise ValidationError({"preview": ["Preview is only supported for AI subscriptions."]})
+
+        # Preview runs pre-assign the delivery row id so the client can poll it immediately.
+        preview_delivery_id = str(uuid.uuid4()) if preview else None
+
         temporal = sync_connect()
-        workflow_id = f"test-delivery-subscription-{subscription.id}"
+        workflow_id = (
+            f"preview-subscription-{subscription.id}" if preview else f"test-delivery-subscription-{subscription.id}"
+        )
         try:
             asyncio.run(
                 temporal.start_workflow(
@@ -978,8 +1044,9 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
                         else str(subscription.team_id),
                         previous_value=None,
                         invite_message=None,
-                        trigger_type=SubscriptionTriggerType.MANUAL,
+                        trigger_type=SubscriptionTriggerType.PREVIEW if preview else SubscriptionTriggerType.MANUAL,
                         resource_type=subscription.resource_type,
+                        delivery_id=preview_delivery_id,
                     ),
                     id=workflow_id,
                     task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
@@ -1007,11 +1074,63 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
                 "insight_id": subscription.insight_id,
                 "dashboard_id": subscription.dashboard_id,
                 "temporal_workflow_id": workflow_id,
+                "preview": preview,
             },
             groups=groups(None, subscription.team),
         )
 
-        return Response(status=status.HTTP_202_ACCEPTED)
+        return Response({"delivery_id": preview_delivery_id}, status=status.HTTP_202_ACCEPTED)
+
+    @extend_schema(
+        summary="Poll an AI subscription preview report",
+        description=(
+            "Status and result of a preview generation run kicked off via test-delivery with preview=true. "
+            "Poll until status is completed, failed, or skipped."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="delivery_id",
+                type=OpenApiTypes.UUID,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Delivery id returned by the preview kick-off.",
+            ),
+        ],
+        responses={200: SubscriptionPreviewReportSerializer},
+    )
+    @action(
+        methods=["GET"],
+        detail=True,
+        url_path="preview_report",
+        # Scope is resolved dynamically in dangerously_get_required_scopes: the report is
+        # query-derived, so reading it requires query:read on top of subscription:read.
+    )
+    def preview_report(self, request, **kwargs):
+        subscription = self.get_object()
+        # Scopes gate tokens but don't prove RBAC, and session auth has no scopes at all —
+        # enforce actual query access before handing back query-derived report content.
+        if not self.user_access_control.check_access_level_for_resource("query", "viewer"):
+            raise exceptions.PermissionDenied("You need query access to view AI report previews.")
+
+        try:
+            delivery_uuid = uuid.UUID(request.query_params.get("delivery_id", ""))
+        except ValueError:
+            raise ValidationError({"delivery_id": ["A valid delivery_id UUID is required."]}) from None
+
+        delivery = SubscriptionDelivery.objects.filter(
+            pk=delivery_uuid, subscription=subscription, team_id=self.team_id
+        ).first()
+        if delivery is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = SubscriptionPreviewReportSerializer(
+            {
+                "status": delivery.status,
+                "ai_report": delivery.content_snapshot.get("ai_report"),
+                "error": _delivery_error_message(delivery),
+            }
+        )
+        return Response(serializer.data)
 
 
 class SubscriptionDeliverySerializer(serializers.ModelSerializer):

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -750,6 +750,11 @@ def _subscription_is_ai_prompt(subscription_id: str | int, team_id: int) -> bool
     )
 
 
+def _is_ai_prompt_subscription(subscription: Subscription) -> bool:
+    """In-memory mirror of _subscription_is_ai_prompt for an already-loaded row."""
+    return bool(subscription.prompt)
+
+
 class SubscriptionTestDeliveryRequestSerializer(serializers.Serializer):
     preview = serializers.BooleanField(
         default=False,
@@ -1022,7 +1027,7 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
         request_serializer = SubscriptionTestDeliveryRequestSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
         preview = request_serializer.validated_data["preview"]
-        if preview and not _subscription_is_ai_prompt(subscription.id, self.team_id):
+        if preview and not _is_ai_prompt_subscription(subscription):
             raise ValidationError({"preview": ["Preview is only supported for AI subscriptions."]})
 
         # Preview runs pre-assign the delivery row id so the client can poll it immediately.
@@ -1111,6 +1116,9 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
         # enforce actual query access before handing back query-derived report content.
         if not self.user_access_control.check_access_level_for_resource("query", "viewer"):
             raise exceptions.PermissionDenied("You need query access to view AI report previews.")
+        # Previews only exist for AI subscriptions — same gate as the test-delivery kick-off.
+        if not _is_ai_prompt_subscription(subscription):
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         try:
             delivery_uuid = uuid.UUID(request.query_params.get("delivery_id", ""))
@@ -1126,7 +1134,7 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
         serializer = SubscriptionPreviewReportSerializer(
             {
                 "status": delivery.status,
-                "ai_report": delivery.content_snapshot.get("ai_report"),
+                "ai_report": (delivery.content_snapshot or {}).get("ai_report"),
                 "error": _delivery_error_message(delivery),
             }
         )

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -2686,6 +2686,17 @@ class TestAISubscriptionAPI(APILicensedTest):
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_preview_report_for_non_ai_subscription_returns_404(self, mock_is_cloud, mock_flag, mock_sync):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("insight")
+        delivery = self._create_delivery_row(sub_id)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/",
+            {"delivery_id": str(delivery.id)},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     @parameterized.expand(
         [
             ("missing", None),

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -2547,3 +2547,191 @@ class TestAISubscriptionAPI(APILicensedTest):
         )
         assert patch_resp.status_code == status.HTTP_400_BAD_REQUEST, patch_resp.json()
         assert "prompt" in str(patch_resp.json()).lower(), patch_resp.json()
+
+    def _create_delivery_row(self, subscription_id: int, **kwargs) -> SubscriptionDelivery:
+        params = {
+            "subscription_id": subscription_id,
+            "team": self.team,
+            "temporal_workflow_id": f"preview-subscription-{subscription_id}",
+            "idempotency_key": str(uuid4()),
+            "trigger_type": "preview",
+            "target_type": "email",
+            "target_value": "ai@posthog.com",
+            "status": SubscriptionDelivery.Status.COMPLETED,
+        }
+        params.update(kwargs)
+        return SubscriptionDelivery.objects.create(**params)
+
+    @parameterized.expand(
+        [
+            ("preview", True),
+            ("regular", False),
+        ]
+    )
+    def test_test_delivery_kickoff_trigger_and_delivery_id(self, mock_is_cloud, mock_flag, mock_sync, _name, preview):
+        mock_client = self._mock_temporal(mock_sync)
+        cache.clear()  # avoid test-delivery throttle state leaking across parameterized cases
+        sub_id = self._create_subscription_for("ai_prompt")
+        mock_client.start_workflow.reset_mock()
+
+        body = {"preview": True} if preview else {}
+        response = self.client.post(f"/api/projects/{self.team.id}/subscriptions/{sub_id}/test-delivery/", body)
+        assert response.status_code == status.HTTP_202_ACCEPTED, response.json()
+
+        delivery_id = response.json()["delivery_id"]
+        wf_args, wf_kwargs = mock_client.start_workflow.call_args
+        workflow_inputs = wf_args[1]
+        if preview:
+            assert delivery_id is not None
+            assert workflow_inputs.trigger_type == SubscriptionTriggerType.PREVIEW
+            assert workflow_inputs.delivery_id == delivery_id
+            assert wf_kwargs["id"] == f"preview-subscription-{sub_id}"
+        else:
+            assert delivery_id is None
+            assert workflow_inputs.trigger_type == SubscriptionTriggerType.MANUAL
+            assert workflow_inputs.delivery_id is None
+            assert wf_kwargs["id"] == f"test-delivery-subscription-{sub_id}"
+
+    def test_preview_rejected_for_non_ai_subscription(self, mock_is_cloud, mock_flag, mock_sync):
+        mock_client = self._mock_temporal(mock_sync)
+        cache.clear()
+        sub_id = self._create_subscription_for("insight")
+        mock_client.start_workflow.reset_mock()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/test-delivery/", {"preview": True}
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert "AI subscriptions" in str(response.json())
+        mock_client.start_workflow.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                "completed_with_report",
+                {"content_snapshot": {"ai_report": "# Report"}},
+                {"status": "completed", "ai_report": "# Report", "error": None},
+            ),
+            (
+                "still_starting",
+                {"status": SubscriptionDelivery.Status.STARTING},
+                {"status": "starting", "ai_report": None, "error": None},
+            ),
+            (
+                "failed_with_top_level_error",
+                {"status": SubscriptionDelivery.Status.FAILED, "error": {"message": "boom", "type": "RuntimeError"}},
+                {"status": "failed", "ai_report": None, "error": "boom"},
+            ),
+            (
+                # Auto-disable aborts (consent revoked, prompt rejected) leave error null and
+                # carry the detail in recipient_results instead.
+                "failed_with_recipient_error",
+                {
+                    "status": SubscriptionDelivery.Status.FAILED,
+                    "recipient_results": [
+                        {
+                            "recipient": "ai@posthog.com",
+                            "status": "failed",
+                            "error": {"message": "Prompt is empty.", "type": "PromptRejectedError"},
+                        }
+                    ],
+                },
+                {"status": "failed", "ai_report": None, "error": "Prompt is empty."},
+            ),
+        ]
+    )
+    def test_preview_report_returns_status_report_and_error(
+        self, mock_is_cloud, mock_flag, mock_sync, _name, delivery_kwargs, expected
+    ):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+        delivery = self._create_delivery_row(sub_id, **delivery_kwargs)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/",
+            {"delivery_id": str(delivery.id)},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == expected
+
+    def test_preview_report_unknown_delivery_returns_404(self, mock_is_cloud, mock_flag, mock_sync):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/",
+            {"delivery_id": str(uuid4())},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_preview_report_for_another_subscriptions_delivery_returns_404(self, mock_is_cloud, mock_flag, mock_sync):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+        other_sub = Subscription.objects.create(
+            team=self.team,
+            created_by=self.user,
+            prompt="Other recap",
+            target_type="email",
+            target_value="other@posthog.com",
+            frequency="weekly",
+            interval=1,
+            start_date=datetime(2022, 1, 1, tzinfo=UTC),
+            title="Other AI sub",
+        )
+        other_delivery = self._create_delivery_row(other_sub.id, content_snapshot={"ai_report": "# Secret"})
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/",
+            {"delivery_id": str(other_delivery.id)},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @parameterized.expand(
+        [
+            ("missing", None),
+            ("malformed", "not-a-uuid"),
+        ]
+    )
+    def test_preview_report_invalid_delivery_id_returns_400(
+        self, mock_is_cloud, mock_flag, mock_sync, _name, delivery_id
+    ):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+
+        params = {} if delivery_id is None else {"delivery_id": delivery_id}
+        response = self.client.get(f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/", params)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+
+    def test_preview_report_requires_query_access(self, mock_is_cloud, mock_flag, mock_sync):
+        # The preview body is query-derived, so RBAC mirrors the deliveries scrub: a
+        # query-restricted member gets a 403, not the report.
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+        delivery = self._create_delivery_row(sub_id, content_snapshot={"ai_report": "# Secret"})
+        self._restrict_query_access()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/",
+            {"delivery_id": str(delivery.id)},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+
+    @parameterized.expand(
+        [
+            ("read_scope_only", ["subscription:read"], status.HTTP_403_FORBIDDEN),
+            ("read_plus_query_read", ["subscription:read", "query:read"], status.HTTP_200_OK),
+        ]
+    )
+    def test_preview_report_scoped_key_requires_query_read(
+        self, mock_is_cloud, mock_flag, mock_sync, _name, scopes, expected_status
+    ):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+        delivery = self._create_delivery_row(sub_id, content_snapshot={"ai_report": "# Report"})
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}/preview_report/",
+            {"delivery_id": str(delivery.id)},
+            headers=self._scoped_key_headers(scopes),
+        )
+        assert response.status_code == expected_status, response.json()

--- a/frontend/src/lib/components/Subscriptions/runSubscriptionTestDelivery.ts
+++ b/frontend/src/lib/components/Subscriptions/runSubscriptionTestDelivery.ts
@@ -12,7 +12,7 @@ export type SubscriptionTestDeliveryResult = 'success' | 'failure'
 
 /** Toast + HTTP error mapping for subscription manual test delivery (scene list + insight/admin modal). */
 export async function runSubscriptionTestDelivery(
-    execute: () => Promise<void>
+    execute: () => Promise<unknown>
 ): Promise<SubscriptionTestDeliveryResult> {
     try {
         await execute()

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
@@ -1,6 +1,11 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import {
+    subscriptionsPreviewReportRetrieve,
+    subscriptionsTestDeliveryCreate,
+} from '@posthog/products-subscriptions/frontend/generated/api'
+
 import { ApiError } from 'lib/api'
 import { getRecentSlackChannelIds } from 'lib/integrations/slackChannel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -9,13 +14,19 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import { InsightShortId, SubscriptionType } from '~/types'
 
-import { subscriptionLogic } from './subscriptionLogic'
+import { AI_PREVIEW_TIMEOUT_MS, subscriptionLogic } from './subscriptionLogic'
 
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: {
         success: jest.fn(),
         error: jest.fn(),
     },
+}))
+
+jest.mock('@posthog/products-subscriptions/frontend/generated/api', () => ({
+    ...jest.requireActual('@posthog/products-subscriptions/frontend/generated/api'),
+    subscriptionsTestDeliveryCreate: jest.fn(),
+    subscriptionsPreviewReportRetrieve: jest.fn(),
 }))
 
 const Insight1 = '1' as InsightShortId
@@ -249,5 +260,101 @@ describe('subscriptionLogic', () => {
         newLogic.actions.submitSubscription()
         await expectLogic(newLogic).toFinishListeners().toDispatchActions(['submitSubscriptionSuccess'])
         expect(capturedBody?.prompt).toBeUndefined()
+    })
+
+    describe('AI preview', () => {
+        const mockKickoff = subscriptionsTestDeliveryCreate as jest.Mock
+        const mockPoll = subscriptionsPreviewReportRetrieve as jest.Mock
+
+        it('does not kick off a preview for an unsaved subscription', async () => {
+            newLogic.actions.generateAiPreview()
+            await expectLogic(newLogic).toFinishListeners()
+            expect(mockKickoff).not.toHaveBeenCalled()
+            expect(newLogic.values.aiPreviewLoading).toBe(false)
+        })
+
+        it('kicks off a preview run and starts polling with the returned delivery id', async () => {
+            mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
+            existingLogic.actions.generateAiPreview()
+            await expectLogic(existingLogic)
+                .toDispatchActions([existingLogic.actionCreators.startAiPreviewPolling('delivery-1')])
+                .toFinishListeners()
+            expect(mockKickoff).toHaveBeenCalledWith(expect.any(String), 1, { preview: true })
+            expect(existingLogic.values.aiPreviewLoading).toBe(true)
+            expect(existingLogic.values.aiPreviewError).toBeNull()
+        })
+
+        it('surfaces a kick-off failure and stops loading', async () => {
+            mockKickoff.mockRejectedValue(
+                new ApiError('Delivery already in progress', 409, undefined, {
+                    type: 'throttled_error',
+                    detail: 'Delivery already in progress',
+                })
+            )
+            existingLogic.actions.generateAiPreview()
+            await expectLogic(existingLogic).toFinishListeners()
+            expect(existingLogic.values.aiPreviewLoading).toBe(false)
+            expect(existingLogic.values.aiPreviewError).toBe('Delivery already in progress')
+        })
+
+        it.each<
+            [string, { status: string; ai_report: string | null; error: string | null }, string | null, string | null]
+        >([
+            ['completed run', { status: 'completed', ai_report: '# Report', error: null }, '# Report', null],
+            [
+                'failed run',
+                { status: 'failed', ai_report: null, error: 'Query planning failed' },
+                null,
+                'Query planning failed',
+            ],
+            [
+                'skipped run without error detail',
+                { status: 'skipped', ai_report: null, error: null },
+                null,
+                'Preview generation did not produce a report. Please try again.',
+            ],
+        ])('stops polling and renders the outcome of a %s', async (_name, report, expectedMarkdown, expectedError) => {
+            mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
+            mockPoll.mockResolvedValue(report)
+            existingLogic.actions.generateAiPreview()
+            await expectLogic(existingLogic).toDispatchActions(['startAiPreviewPolling']).toFinishListeners()
+
+            existingLogic.actions.loadAiPreviewReport('delivery-1')
+            await expectLogic(existingLogic).toDispatchActions(['stopAiPreviewPolling']).toFinishListeners()
+            expect(existingLogic.values.aiPreviewLoading).toBe(false)
+            expect(existingLogic.values.aiPreviewMarkdown).toBe(expectedMarkdown)
+            expect(existingLogic.values.aiPreviewError).toBe(expectedError)
+        })
+
+        it.each<[string, () => void]>([
+            [
+                'a still-starting run',
+                () => mockPoll.mockResolvedValue({ status: 'starting', ai_report: null, error: null }),
+            ],
+            ['a transient poll failure', () => mockPoll.mockRejectedValue(new ApiError('Not found', 404))],
+        ])('keeps polling through %s', async (_name, setupPoll) => {
+            mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
+            setupPoll()
+            existingLogic.actions.generateAiPreview()
+            await expectLogic(existingLogic).toDispatchActions(['startAiPreviewPolling']).toFinishListeners()
+
+            existingLogic.actions.loadAiPreviewReport('delivery-1')
+            await expectLogic(existingLogic).toFinishListeners().toNotHaveDispatchedActions(['stopAiPreviewPolling'])
+            expect(existingLogic.values.aiPreviewLoading).toBe(true)
+            expect(existingLogic.values.aiPreviewError).toBeNull()
+        })
+
+        it('gives up with an error once the polling window elapses', async () => {
+            mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
+            mockPoll.mockResolvedValue({ status: 'starting', ai_report: null, error: null })
+            existingLogic.actions.generateAiPreview()
+            await expectLogic(existingLogic).toDispatchActions(['startAiPreviewPolling']).toFinishListeners()
+
+            existingLogic.cache.aiPreviewStartedAt = Date.now() - AI_PREVIEW_TIMEOUT_MS - 1
+            existingLogic.actions.loadAiPreviewReport('delivery-1')
+            await expectLogic(existingLogic).toDispatchActions(['stopAiPreviewPolling']).toFinishListeners()
+            expect(existingLogic.values.aiPreviewLoading).toBe(false)
+            expect(existingLogic.values.aiPreviewError).toContain('taking longer than expected')
+        })
     })
 })

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.test.ts
@@ -273,13 +273,18 @@ describe('subscriptionLogic', () => {
             expect(newLogic.values.aiPreviewLoading).toBe(false)
         })
 
-        it('kicks off a preview run and starts polling with the returned delivery id', async () => {
+        it('kicks off a preview run and immediately polls with the returned delivery id', async () => {
             mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
+            mockPoll.mockResolvedValue({ status: 'starting', ai_report: null, error: null })
             existingLogic.actions.generateAiPreview()
             await expectLogic(existingLogic)
-                .toDispatchActions([existingLogic.actionCreators.startAiPreviewPolling('delivery-1')])
+                .toDispatchActions([
+                    existingLogic.actionCreators.startAiPreviewPolling('delivery-1'),
+                    existingLogic.actionCreators.loadAiPreviewReport('delivery-1'),
+                ])
                 .toFinishListeners()
             expect(mockKickoff).toHaveBeenCalledWith(expect.any(String), 1, { preview: true })
+            expect(mockPoll).toHaveBeenCalledWith(expect.any(String), 1, { delivery_id: 'delivery-1' })
             expect(existingLogic.values.aiPreviewLoading).toBe(true)
             expect(existingLogic.values.aiPreviewError).toBeNull()
         })
@@ -311,6 +316,12 @@ describe('subscriptionLogic', () => {
                 'skipped run without error detail',
                 { status: 'skipped', ai_report: null, error: null },
                 null,
+                "Preview generation was skipped — this can happen when your organization is over its AI credit budget. Check the subscription owner's inbox for details.",
+            ],
+            [
+                'failed run without error detail',
+                { status: 'failed', ai_report: null, error: null },
+                null,
                 'Preview generation did not produce a report. Please try again.',
             ],
         ])('stops polling and renders the outcome of a %s', async (_name, report, expectedMarkdown, expectedError) => {
@@ -331,7 +342,12 @@ describe('subscriptionLogic', () => {
                 'a still-starting run',
                 () => mockPoll.mockResolvedValue({ status: 'starting', ai_report: null, error: null }),
             ],
-            ['a transient poll failure', () => mockPoll.mockRejectedValue(new ApiError('Not found', 404))],
+            [
+                'a 404 before the workflow creates the delivery row',
+                () => mockPoll.mockRejectedValue(new ApiError('Not found', 404)),
+            ],
+            ['a transient server error', () => mockPoll.mockRejectedValue(new ApiError('Bad gateway', 502))],
+            ['a network failure', () => mockPoll.mockRejectedValue(new Error('NetworkError'))],
         ])('keeps polling through %s', async (_name, setupPoll) => {
             mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
             setupPoll()
@@ -342,6 +358,22 @@ describe('subscriptionLogic', () => {
             await expectLogic(existingLogic).toFinishListeners().toNotHaveDispatchedActions(['stopAiPreviewPolling'])
             expect(existingLogic.values.aiPreviewLoading).toBe(true)
             expect(existingLogic.values.aiPreviewError).toBeNull()
+        })
+
+        it('stops polling and surfaces the error when the poll endpoint returns a 403', async () => {
+            mockKickoff.mockResolvedValue({ delivery_id: 'delivery-1' })
+            mockPoll.mockRejectedValue(
+                new ApiError('You need query access to view AI report previews.', 403, undefined, {
+                    type: 'permission_denied',
+                    detail: 'You need query access to view AI report previews.',
+                })
+            )
+            existingLogic.actions.generateAiPreview()
+            await expectLogic(existingLogic)
+                .toDispatchActions(['startAiPreviewPolling', 'loadAiPreviewReport', 'stopAiPreviewPolling'])
+                .toFinishListeners()
+            expect(existingLogic.values.aiPreviewLoading).toBe(false)
+            expect(existingLogic.values.aiPreviewError).toBe('You need query access to view AI report previews.')
         })
 
         it('gives up with an error once the polling window elapses', async () => {

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -4,11 +4,18 @@ import { loaders } from 'kea-loaders'
 import { beforeUnload, router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
+import {
+    subscriptionsPreviewReportRetrieve,
+    subscriptionsTestDeliveryCreate,
+} from '@posthog/products-subscriptions/frontend/generated/api'
+import { SubscriptionDeliveryStatusEnumApi } from '@posthog/products-subscriptions/frontend/generated/api.schemas'
+
 import api, { ApiError } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { recordRecentSlackChannel, slackChannelId } from 'lib/integrations/slackChannel'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isEmail } from 'lib/utils'
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { getInsightId } from 'scenes/insights/utils'
 
 import { ExportedAssetType, ExporterFormat, SubscriptionResourceTypes, SubscriptionType } from '~/types'
@@ -45,6 +52,19 @@ function subscriptionSaveErrorMessage(error: unknown): string {
     return 'Could not save subscription. Please try again.'
 }
 
+export const AI_PREVIEW_POLL_INTERVAL_MS = 5000
+export const AI_PREVIEW_TIMEOUT_MS = 5 * 60 * 1000
+
+function aiPreviewKickoffErrorMessage(error: unknown): string {
+    if (error instanceof ApiError) {
+        const msg = (error.detail || error.message || '').trim()
+        if (msg) {
+            return msg
+        }
+    }
+    return 'Could not start preview generation. Please try again.'
+}
+
 const NEW_SUBSCRIPTION: Partial<SubscriptionType> = {
     resource_type: SubscriptionResourceTypes.Insight,
     frequency: 'weekly',
@@ -75,6 +95,13 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
         setPreviewError: (error: string | null) => ({ error }),
         setPreviewImageUrl: (url: string | null) => ({ url }),
         selectAiExamplePrompt: (prompt: string, label: string) => ({ prompt, label }),
+        generateAiPreview: true,
+        startAiPreviewPolling: (deliveryId: string) => ({ deliveryId }),
+        stopAiPreviewPolling: true,
+        loadAiPreviewReport: (deliveryId: string) => ({ deliveryId }),
+        setAiPreviewLoading: (loading: boolean) => ({ loading }),
+        setAiPreviewMarkdown: (markdown: string | null) => ({ markdown }),
+        setAiPreviewError: (error: string | null) => ({ error }),
     }),
 
     reducers({
@@ -100,6 +127,24 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             null as string | null,
             {
                 setPreviewImageUrl: (_, { url }) => url,
+            },
+        ],
+        aiPreviewLoading: [
+            false,
+            {
+                setAiPreviewLoading: (_, { loading }) => loading,
+            },
+        ],
+        aiPreviewMarkdown: [
+            null as string | null,
+            {
+                setAiPreviewMarkdown: (_, { markdown }) => markdown,
+            },
+        ],
+        aiPreviewError: [
+            null as string | null,
+            {
+                setAiPreviewError: (_, { error }) => error,
             },
         ],
     }),
@@ -205,7 +250,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
         },
     })),
 
-    listeners(({ actions, values, props }) => ({
+    listeners(({ actions, values, props, cache }) => ({
         submitSubscriptionSuccess: ({ subscription }) => {
             if (subscription?.target_type === 'slack' && subscription.target_value && subscription.integration_id) {
                 recordRecentSlackChannel(subscription.integration_id, slackChannelId(subscription.target_value))
@@ -311,6 +356,77 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 actions.setPreviewError(e instanceof Error ? e.message : 'Failed to generate preview')
             } finally {
                 actions.setPreviewLoading(false)
+            }
+        },
+
+        generateAiPreview: async () => {
+            // Previews run against the saved subscription, so an unsaved one has nothing to preview
+            // (the button is also disabled in that state).
+            if (props.id === 'new' || values.aiPreviewLoading) {
+                return
+            }
+            actions.setAiPreviewLoading(true)
+            actions.setAiPreviewError(null)
+            actions.setAiPreviewMarkdown(null)
+            try {
+                const response = await subscriptionsTestDeliveryCreate(String(getCurrentTeamId()), props.id, {
+                    preview: true,
+                })
+                if (!response.delivery_id) {
+                    throw new Error('Preview generation did not return a delivery to poll.')
+                }
+                actions.startAiPreviewPolling(response.delivery_id)
+            } catch (e) {
+                actions.setAiPreviewLoading(false)
+                actions.setAiPreviewError(aiPreviewKickoffErrorMessage(e))
+            }
+        },
+
+        startAiPreviewPolling: ({ deliveryId }) => {
+            cache.aiPreviewStartedAt = Date.now()
+            cache.disposables.add(() => {
+                const id = setInterval(() => actions.loadAiPreviewReport(deliveryId), AI_PREVIEW_POLL_INTERVAL_MS)
+                return () => clearInterval(id)
+            }, 'aiPreviewPoll')
+        },
+
+        stopAiPreviewPolling: () => {
+            cache.disposables.dispose('aiPreviewPoll')
+        },
+
+        loadAiPreviewReport: async ({ deliveryId }) => {
+            if (props.id === 'new') {
+                return
+            }
+            // The timeout is checked per tick (not via setTimeout) so a hidden tab — which pauses
+            // the poll interval — can't fire a premature "timed out" while nothing was polling.
+            if (Date.now() - (cache.aiPreviewStartedAt ?? 0) > AI_PREVIEW_TIMEOUT_MS) {
+                actions.stopAiPreviewPolling()
+                actions.setAiPreviewLoading(false)
+                actions.setAiPreviewError(
+                    'Preview generation is taking longer than expected. Check the delivery history for the result, or try again.'
+                )
+                return
+            }
+            try {
+                const report = await subscriptionsPreviewReportRetrieve(String(getCurrentTeamId()), props.id, {
+                    delivery_id: deliveryId,
+                })
+                if (report.status === SubscriptionDeliveryStatusEnumApi.Starting) {
+                    return // still generating — keep polling
+                }
+                actions.stopAiPreviewPolling()
+                actions.setAiPreviewLoading(false)
+                if (report.status === SubscriptionDeliveryStatusEnumApi.Completed && report.ai_report) {
+                    actions.setAiPreviewMarkdown(report.ai_report)
+                } else {
+                    actions.setAiPreviewError(
+                        report.error || 'Preview generation did not produce a report. Please try again.'
+                    )
+                }
+            } catch {
+                // Transient poll failure, or the workflow hasn't created the delivery row yet (404)
+                // — keep polling until the timeout above gives up.
             }
         },
     })),

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -360,8 +360,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
         },
 
         generateAiPreview: async () => {
-            // Previews run against the saved subscription, so an unsaved one has nothing to preview
-            // (the button is also disabled in that state).
+            // Previews run against the saved subscription, so an unsaved one has nothing to preview.
             if (props.id === 'new' || values.aiPreviewLoading) {
                 return
             }
@@ -388,6 +387,8 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 const id = setInterval(() => actions.loadAiPreviewReport(deliveryId), AI_PREVIEW_POLL_INTERVAL_MS)
                 return () => clearInterval(id)
             }, 'aiPreviewPoll')
+            // Fast runs render without waiting out the first interval.
+            actions.loadAiPreviewReport(deliveryId)
         },
 
         stopAiPreviewPolling: () => {
@@ -419,14 +420,33 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 actions.setAiPreviewLoading(false)
                 if (report.status === SubscriptionDeliveryStatusEnumApi.Completed && report.ai_report) {
                     actions.setAiPreviewMarkdown(report.ai_report)
+                } else if (report.status === SubscriptionDeliveryStatusEnumApi.Skipped) {
+                    actions.setAiPreviewError(
+                        report.error ||
+                            "Preview generation was skipped — this can happen when your organization is over its AI credit budget. Check the subscription owner's inbox for details."
+                    )
                 } else {
                     actions.setAiPreviewError(
                         report.error || 'Preview generation did not produce a report. Please try again.'
                     )
                 }
-            } catch {
-                // Transient poll failure, or the workflow hasn't created the delivery row yet (404)
-                // — keep polling until the timeout above gives up.
+            } catch (e) {
+                // 404 means the workflow hasn't created the delivery row yet, and 5xx/network failures
+                // are transient — keep polling until the timeout above gives up. Other 4xx (auth,
+                // permission) won't heal on retry, so stop and surface them.
+                if (
+                    e instanceof ApiError &&
+                    e.status !== undefined &&
+                    e.status >= 400 &&
+                    e.status < 500 &&
+                    e.status !== 404
+                ) {
+                    actions.stopAiPreviewPolling()
+                    actions.setAiPreviewLoading(false)
+                    actions.setAiPreviewError(
+                        (e.detail || e.message || '').trim() || 'Could not load the preview report. Please try again.'
+                    )
+                }
             }
         },
     })),

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -722,19 +722,22 @@ function EditSubscriptionForm({
                                         onClick={generateAiPreview}
                                         loading={aiPreviewLoading}
                                         disabledReason={
-                                            !isEditing
-                                                ? 'Save the subscription first to generate a preview'
-                                                : aiPreviewLoading
-                                                  ? 'Preview generation is already running'
-                                                  : undefined
+                                            !isEditing ? 'Save the subscription first to generate a preview' : undefined
                                         }
                                     >
                                         Generate preview
                                     </LemonButton>
 
+                                    {!aiPreviewLoading && !aiPreviewError && !aiPreviewMarkdown && (
+                                        <div className="mt-2 text-sm text-secondary">
+                                            Generate a sample report to see what subscribers will receive.
+                                        </div>
+                                    )}
+
                                     {aiPreviewLoading && (
                                         <div className="mt-2 text-sm text-secondary">
-                                            Generating preview… this can take a few minutes. Nothing will be sent.
+                                            Generating preview… this can take a few minutes. Nothing is delivered to
+                                            recipients.
                                         </div>
                                     )}
 
@@ -745,7 +748,7 @@ function EditSubscriptionForm({
                                     )}
 
                                     {aiPreviewMarkdown && (
-                                        <div className="mt-2 border rounded p-3">
+                                        <div className="mt-2 border rounded p-3 max-h-96 overflow-y-auto">
                                             <LemonMarkdown>{aiPreviewMarkdown}</LemonMarkdown>
                                         </div>
                                     )}

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -19,6 +19,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
@@ -263,7 +264,8 @@ function EditSubscriptionForm({
     const { subscription, subscriptionLoading, isSubscriptionSubmitting, subscriptionChanged, summaryQuota } =
         useValues(logic)
     const { previewLoading, previewError, previewImageUrl } = useValues(logic)
-    const { resetSubscription, generatePreview } = useActions(logic)
+    const { aiPreviewLoading, aiPreviewMarkdown, aiPreviewError } = useValues(logic)
+    const { resetSubscription, generatePreview, generateAiPreview } = useActions(logic)
     const { preflight, siteUrlMisconfigured } = useValues(preflightLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { deleteSubscription } = useActions(subscriptionslogic)
@@ -708,6 +710,47 @@ function EditSubscriptionForm({
                                     </FlaggedFeature>
                                 )}
                             </FlaggedFeature>
+                        )}
+
+                        {isAiPrompt && (
+                            <div>
+                                <LemonLabel className="mb-2">Preview</LemonLabel>
+                                <div className="border rounded p-2">
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={generateAiPreview}
+                                        loading={aiPreviewLoading}
+                                        disabledReason={
+                                            !isEditing
+                                                ? 'Save the subscription first to generate a preview'
+                                                : aiPreviewLoading
+                                                  ? 'Preview generation is already running'
+                                                  : undefined
+                                        }
+                                    >
+                                        Generate preview
+                                    </LemonButton>
+
+                                    {aiPreviewLoading && (
+                                        <div className="mt-2 text-sm text-secondary">
+                                            Generating preview… this can take a few minutes. Nothing will be sent.
+                                        </div>
+                                    )}
+
+                                    {aiPreviewError && (
+                                        <LemonBanner type="error" className="mt-2">
+                                            {aiPreviewError}
+                                        </LemonBanner>
+                                    )}
+
+                                    {aiPreviewMarkdown && (
+                                        <div className="mt-2 border rounded p-3">
+                                            <LemonMarkdown>{aiPreviewMarkdown}</LemonMarkdown>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
                         )}
 
                         {insightShortId && !isAiPrompt && (

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -484,6 +484,7 @@ SPECTACULAR_SETTINGS = {
         "AutonomyPriorityEnum": "products.signals.backend.models.AutonomyPriority",
         "UserInterviewSearchDocumentTypeEnum": "products.user_interviews.backend.facade.enums.SEARCH_DOCUMENT_TYPES",
         "BatchExportRunStatusEnum": "products.batch_exports.backend.models.batch_export.BatchExportRun.Status",
+        "SubscriptionDeliveryStatusEnum": "products.exports.backend.models.subscription.SubscriptionDelivery.Status",
         "HeatmapType": "products.web_analytics.backend.models.heatmap_saved.SavedHeatmap.Type",
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "PropertyGroupOperator": ["AND", "OR"],

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -1024,6 +1024,34 @@ async def test_create_delivery_record_persists_row_and_idempotency_key_dedupes(t
     assert row_after.temporal_workflow_id == "wf-delivery-1"
 
 
+async def test_create_delivery_record_uses_preassigned_id_and_dedupes_on_it(team, user):
+    sub = await _create_ai_subscription(team, user)
+    preassigned_id = str(uuid.uuid4())
+
+    env = ActivityEnvironment()
+
+    def _inputs(idempotency_key: str) -> CreateDeliveryRecordInputs:
+        return CreateDeliveryRecordInputs(
+            subscription_id=sub.id,
+            team_id=team.id,
+            trigger_type=SubscriptionTriggerType.PREVIEW,
+            temporal_workflow_id="wf-preview-1",
+            idempotency_key=idempotency_key,
+            delivery_id=preassigned_id,
+        )
+
+    delivery_id = await env.run(create_delivery_record, _inputs("idem-preview-1"))
+    assert str(delivery_id) == preassigned_id
+
+    # A redispatch with a different idempotency key must not mint a second row for the same id.
+    delivery_id_again = await env.run(create_delivery_record, _inputs("idem-preview-2"))
+    assert delivery_id_again == delivery_id
+    assert await sync_to_async(SubscriptionDelivery.objects.filter(pk=preassigned_id).count)() == 1
+    row = await sync_to_async(SubscriptionDelivery.objects.get)(pk=preassigned_id)
+    assert row.trigger_type == SubscriptionTriggerType.PREVIEW
+    assert row.idempotency_key == "idem-preview-1"
+
+
 @freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
 async def test_update_delivery_record_patches_status_and_results_without_touching_content(team, user):
@@ -2472,6 +2500,68 @@ async def test_schedule_routes_ai_subscription_through_full_workflow(
     assert mock_send_email.call_args.kwargs["markdown"] == "# AI Report"
     delivery = await sync_to_async(SubscriptionDelivery.objects.filter(subscription=sub).latest)("created_at")
     assert delivery.status == SubscriptionDelivery.Status.COMPLETED
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("products.exports.backend.temporal.subscriptions.ai_subscription.activities.send_email_ai_subscription_report")
+@patch(_GENERATE_MARKDOWN, return_value="# Preview report")
+@pytest.mark.asyncio
+async def test_preview_ai_subscription_generates_without_delivering_or_advancing_schedule(
+    mock_generate: MagicMock,
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_analytics: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    # Preview runs the full validate + generate pipeline onto the pre-assigned delivery
+    # row, then stops: nothing is sent and the subscription's schedule stays untouched.
+    await _set_ai_consent(team, True)
+    sub = await _create_ai_subscription(team, user)
+    next_delivery_before = await sync_to_async(lambda: Subscription.objects.get(pk=sub.id).next_delivery_date)()
+    preview_delivery_id = str(uuid.uuid4())
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[
+                HandleSubscriptionValueChangeWorkflow,
+                ProcessSubscriptionWorkflow,
+                ProcessAISubscriptionWorkflow,
+            ],
+            activities=SUBSCRIPTION_PROCESS_ACTIVITIES,
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=50),
+            debug_mode=True,
+        ):
+            await env.client.execute_workflow(
+                HandleSubscriptionValueChangeWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=sub.id,
+                    team_id=sub.team_id,
+                    distinct_id=str(user.distinct_id),
+                    trigger_type=SubscriptionTriggerType.PREVIEW,
+                    resource_type="ai_prompt",
+                    delivery_id=preview_delivery_id,
+                ),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    mock_generate.assert_called_once()
+    mock_send_email.assert_not_called()
+    delivery = await sync_to_async(SubscriptionDelivery.objects.get)(pk=preview_delivery_id)
+    assert delivery.subscription_id == sub.id
+    assert delivery.trigger_type == SubscriptionTriggerType.PREVIEW
+    assert delivery.status == SubscriptionDelivery.Status.COMPLETED
+    assert delivery.content_snapshot["ai_report"] == "# Preview report"
+    assert delivery.finished_at is not None
+    await sync_to_async(sub.refresh_from_db)()
+    assert sub.next_delivery_date == next_delivery_before
 
 
 async def test_fetch_due_subscriptions_includes_ai_with_resource_type(team, user):

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -2505,7 +2505,7 @@ async def test_schedule_routes_ai_subscription_through_full_workflow(
 @patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("products.exports.backend.temporal.subscriptions.ai_subscription.activities.send_email_ai_subscription_report")
-@patch(_GENERATE_MARKDOWN, return_value="# Preview report")
+@patch(_GENERATE_REPORT, return_value=AiReportResult(markdown="# Preview report", diagnostics=()))
 @pytest.mark.asyncio
 async def test_preview_ai_subscription_generates_without_delivering_or_advancing_schedule(
     mock_generate: MagicMock,

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -426,20 +426,29 @@ async def create_delivery_record(inputs: CreateDeliveryRecordInputs) -> uuid.UUI
 
         content_snapshot = build_initial_content_snapshot(subscription)
 
-        delivery, _created = SubscriptionDelivery.objects.get_or_create(
-            idempotency_key=inputs.idempotency_key,
-            defaults={
-                "subscription": subscription,
-                "team_id": inputs.team_id,
-                "temporal_workflow_id": inputs.temporal_workflow_id,
-                "trigger_type": inputs.trigger_type,
-                "scheduled_at": scheduled_at,
-                "target_type": subscription.target_type,
-                "target_value": subscription.target_value,
-                "content_snapshot": content_snapshot,
-                "status": SubscriptionDelivery.Status.STARTING,
-            },
-        )
+        defaults: dict[str, typing.Any] = {
+            "subscription": subscription,
+            "team_id": inputs.team_id,
+            "temporal_workflow_id": inputs.temporal_workflow_id,
+            "trigger_type": inputs.trigger_type,
+            "scheduled_at": scheduled_at,
+            "target_type": subscription.target_type,
+            "target_value": subscription.target_value,
+            "content_snapshot": content_snapshot,
+            "status": SubscriptionDelivery.Status.STARTING,
+        }
+        if inputs.delivery_id:
+            # Preview runs pre-assign the row id so the API can hand it to the polling
+            # client up front; keying get_or_create on the id keeps retries idempotent.
+            delivery, _created = SubscriptionDelivery.objects.get_or_create(
+                id=uuid.UUID(inputs.delivery_id),
+                defaults={**defaults, "idempotency_key": inputs.idempotency_key},
+            )
+        else:
+            delivery, _created = SubscriptionDelivery.objects.get_or_create(
+                idempotency_key=inputs.idempotency_key,
+                defaults=defaults,
+            )
         return delivery.id
 
     delivery_id = await _create()

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -35,6 +35,7 @@ class SubscriptionTriggerType:
     SCHEDULED = "scheduled"  # Regular cron-based delivery
     TARGET_CHANGE = "target_change"  # Target changed (previous_value is the old target)
     MANUAL = "manual"  # User clicked "Test delivery"
+    PREVIEW = "preview"  # User clicked "Generate preview" — generate only, skip delivery
 
 
 @dataclasses.dataclass
@@ -114,6 +115,9 @@ class ProcessSubscriptionWorkflowInputs:
     # Lets HandleSubscriptionValueChangeWorkflow route AI-prompt subs to
     # ProcessAISubscriptionWorkflow. Passed by the API from the loaded instance.
     resource_type: str = ""
+    # Pre-assigned delivery row id for preview runs — the API hands it to the client
+    # for polling before the workflow has created the row.
+    delivery_id: typing.Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -135,6 +139,8 @@ class TrackedSubscriptionInputs:
     trigger_type: str = SubscriptionTriggerType.TARGET_CHANGE
     scheduled_at: typing.Optional[str] = None
     resource_type: str = ""
+    # Pre-assigned delivery row id for preview runs (see ProcessSubscriptionWorkflowInputs).
+    delivery_id: typing.Optional[str] = None
 
 
 RecipientResultStatus = typing.Literal["success", "failed", "partial"]
@@ -191,6 +197,9 @@ class CreateDeliveryRecordInputs:
     temporal_workflow_id: str
     idempotency_key: str
     scheduled_at: typing.Optional[str] = None
+    # When set (preview runs), the row is created with this id so the API can return
+    # it to the polling client before the workflow has run.
+    delivery_id: typing.Optional[str] = None
 
 
 @dataclasses.dataclass

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -197,8 +197,7 @@ class CreateDeliveryRecordInputs:
     temporal_workflow_id: str
     idempotency_key: str
     scheduled_at: typing.Optional[str] = None
-    # When set (preview runs), the row is created with this id so the API can return
-    # it to the polling client before the workflow has run.
+    # Pre-assigned id for preview runs (see ProcessSubscriptionWorkflowInputs.delivery_id).
     delivery_id: typing.Optional[str] = None
 
 

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -462,6 +462,7 @@ class ProcessAISubscriptionWorkflow(PostHogWorkflow):
                     scheduled_at=inputs.scheduled_at,
                     temporal_workflow_id=temporalio.workflow.info().workflow_id,
                     idempotency_key=str(temporalio.workflow.uuid4()),
+                    delivery_id=inputs.delivery_id,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=2),
                 retry_policy=SUBSCRIPTION_RECORD_LIFECYCLE_RETRY_POLICY,
@@ -508,6 +509,13 @@ class ProcessAISubscriptionWorkflow(PostHogWorkflow):
                 # notified the owner. SKIPPED (not FAILED): the sub isn't broken, it resumes when
                 # credits reset; advance_next_delivery_date (finally) recomputes from the reschedule.
                 final_status = DeliveryStatus.SKIPPED
+                return
+
+            if inputs.trigger_type == SubscriptionTriggerType.PREVIEW:
+                # Preview runs stop after generation: the report sits on the delivery row
+                # for the API to poll, nothing is sent, and the schedule doesn't advance
+                # (the finally-block advance only fires for SCHEDULED triggers).
+                final_status = DeliveryStatus.COMPLETED
                 return
 
             # Phase 2: ship the persisted report. is_new only for target-change triggers.
@@ -608,6 +616,7 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
             invite_message=inputs.invite_message,
             trigger_type=inputs.trigger_type,
             resource_type=inputs.resource_type,
+            delivery_id=inputs.delivery_id,
             slo=SloConfig(
                 operation=SloOperation.SUBSCRIPTION_DELIVERY,
                 area=SloArea.ANALYTIC_PLATFORM,

--- a/products/subscriptions/frontend/generated/api.schemas.ts
+++ b/products/subscriptions/frontend/generated/api.schemas.ts
@@ -460,6 +460,39 @@ export interface PatchedSubscriptionApi {
     summary_prompt_guide?: string
 }
 
+export interface SubscriptionPreviewReportApi {
+    /** Run status of the preview delivery: starting, completed, failed, or skipped.
+     *
+     * * `starting` - Starting
+     * * `completed` - Completed
+     * * `failed` - Failed
+     * * `skipped` - Skipped */
+    status: SubscriptionDeliveryStatusEnumApi
+    /**
+     * Generated report markdown. Null until the run completes (or when it failed before generating).
+     * @nullable
+     */
+    ai_report: string | null
+    /**
+     * Human-readable failure detail when the run failed, if available.
+     * @nullable
+     */
+    error: string | null
+}
+
+export interface SubscriptionTestDeliveryRequestApi {
+    /** AI subscriptions only: run the report generation pipeline without sending anything. Poll the preview_report action with the returned delivery_id to fetch the result. */
+    preview?: boolean
+}
+
+export interface SubscriptionTestDeliveryResponseApi {
+    /**
+     * Delivery row to poll via the preview_report action. Null for non-preview test deliveries.
+     * @nullable
+     */
+    delivery_id: string | null
+}
+
 export type SubscriptionsDeliveriesListParams = {
     /**
      * The pagination cursor value.
@@ -535,6 +568,13 @@ export const SubscriptionsListTargetType = {
     Email: 'email',
     Slack: 'slack',
 } as const
+
+export type SubscriptionsPreviewReportRetrieveParams = {
+    /**
+     * Delivery id returned by the preview kick-off.
+     */
+    delivery_id: string
+}
 
 export type SubscriptionsSummaryQuotaRetrieve200 = {
     active_count: number

--- a/products/subscriptions/frontend/generated/api.ts
+++ b/products/subscriptions/frontend/generated/api.ts
@@ -14,8 +14,12 @@ import type {
     PatchedSubscriptionApi,
     SubscriptionApi,
     SubscriptionDeliveryApi,
+    SubscriptionPreviewReportApi,
+    SubscriptionTestDeliveryRequestApi,
+    SubscriptionTestDeliveryResponseApi,
     SubscriptionsDeliveriesListParams,
     SubscriptionsListParams,
+    SubscriptionsPreviewReportRetrieveParams,
     SubscriptionsSummaryQuotaRetrieve200,
 } from './api.schemas'
 
@@ -204,6 +208,42 @@ export const subscriptionsDestroy = async (projectId: string, id: number, option
     })
 }
 
+export const getSubscriptionsPreviewReportRetrieveUrl = (
+    projectId: string,
+    id: number,
+    params: SubscriptionsPreviewReportRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/subscriptions/${id}/preview_report/?${stringifiedParams}`
+        : `/api/projects/${projectId}/subscriptions/${id}/preview_report/`
+}
+
+/**
+ * Status and result of a preview generation run kicked off via test-delivery with preview=true. Poll until status is completed, failed, or skipped.
+ * @summary Poll an AI subscription preview report
+ */
+export const subscriptionsPreviewReportRetrieve = async (
+    projectId: string,
+    id: number,
+    params: SubscriptionsPreviewReportRetrieveParams,
+    options?: RequestInit
+): Promise<SubscriptionPreviewReportApi> => {
+    return apiMutator<SubscriptionPreviewReportApi>(getSubscriptionsPreviewReportRetrieveUrl(projectId, id, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getSubscriptionsTestDeliveryCreateUrl = (projectId: string, id: number) => {
     return `/api/projects/${projectId}/subscriptions/${id}/test-delivery/`
 }
@@ -211,11 +251,14 @@ export const getSubscriptionsTestDeliveryCreateUrl = (projectId: string, id: num
 export const subscriptionsTestDeliveryCreate = async (
     projectId: string,
     id: number,
+    subscriptionTestDeliveryRequestApi?: SubscriptionTestDeliveryRequestApi,
     options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getSubscriptionsTestDeliveryCreateUrl(projectId, id), {
+): Promise<SubscriptionTestDeliveryResponseApi> => {
+    return apiMutator<SubscriptionTestDeliveryResponseApi>(getSubscriptionsTestDeliveryCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(subscriptionTestDeliveryRequestApi),
     })
 }
 

--- a/products/subscriptions/frontend/generated/api.zod.ts
+++ b/products/subscriptions/frontend/generated/api.zod.ts
@@ -372,3 +372,14 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
             ),
     })
     .describe('Standard Subscription serializer.')
+
+export const subscriptionsTestDeliveryCreateBodyPreviewDefault = false
+
+export const SubscriptionsTestDeliveryCreateBody = /* @__PURE__ */ zod.object({
+    preview: zod
+        .boolean()
+        .default(subscriptionsTestDeliveryCreateBodyPreviewDefault)
+        .describe(
+            'AI subscriptions only: run the report generation pipeline without sending anything. Poll the preview_report action with the returned delivery_id to fetch the result.'
+        ),
+})

--- a/products/subscriptions/mcp/tools.yaml
+++ b/products/subscriptions/mcp/tools.yaml
@@ -160,6 +160,9 @@ tools:
             - resource_name
             - insight_short_id
             - invite_message
+    subscriptions-preview-report-retrieve:
+        operation: subscriptions_preview_report_retrieve
+        enabled: false
     subscriptions-retrieve:
         operation: subscriptions_retrieve
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -40096,6 +40096,39 @@ export namespace Schemas {
       interesting_notes: InterestingNote[];
     }
 
+    export interface SubscriptionPreviewReport {
+      /** Run status of the preview delivery: starting, completed, failed, or skipped.
+       *
+       * * `starting` - Starting
+       * * `completed` - Completed
+       * * `failed` - Failed
+       * * `skipped` - Skipped */
+      status: SubscriptionDeliveryStatusEnum;
+      /**
+         * Generated report markdown. Null until the run completes (or when it failed before generating).
+         * @nullable
+         */
+      ai_report: string | null;
+      /**
+         * Human-readable failure detail when the run failed, if available.
+         * @nullable
+         */
+      error: string | null;
+    }
+
+    export interface SubscriptionTestDeliveryRequest {
+      /** AI subscriptions only: run the report generation pipeline without sending anything. Poll the preview_report action with the returned delivery_id to fetch the result. */
+      preview?: boolean;
+    }
+
+    export interface SubscriptionTestDeliveryResponse {
+      /**
+         * Delivery row to poll via the preview_report action. Null for non-preview test deliveries.
+         * @nullable
+         */
+      delivery_id: string | null;
+    }
+
     export interface SuggestReplyError {
       detail: string;
       error_type?: string;
@@ -46729,6 +46762,13 @@ export namespace Schemas {
       Slack: 'slack',
     } as const;
 
+    export type EnvironmentsSubscriptionsPreviewReportRetrieveParams = {
+    /**
+     * Delivery id returned by the preview kick-off.
+     */
+    delivery_id: string;
+    };
+
     export type EnvironmentsSubscriptionsSummaryQuotaRetrieve200 = {
       active_count: number;
       /** @nullable */
@@ -53036,6 +53076,13 @@ export namespace Schemas {
       Email: 'email',
       Slack: 'slack',
     } as const;
+
+    export type SubscriptionsPreviewReportRetrieveParams = {
+    /**
+     * Delivery id returned by the preview kick-off.
+     */
+    delivery_id: string;
+    };
 
     export type SubscriptionsSummaryQuotaRetrieve200 = {
       active_count: number;

--- a/services/mcp/src/generated/subscriptions/api.ts
+++ b/services/mcp/src/generated/subscriptions/api.ts
@@ -347,3 +347,14 @@ export const SubscriptionsTestDeliveryCreateParams = /* @__PURE__ */ zod.object(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
 })
+
+export const subscriptionsTestDeliveryCreateBodyPreviewDefault = false
+
+export const SubscriptionsTestDeliveryCreateBody = /* @__PURE__ */ zod.object({
+    preview: zod
+        .boolean()
+        .default(subscriptionsTestDeliveryCreateBodyPreviewDefault)
+        .describe(
+            'AI subscriptions only: run the report generation pipeline without sending anything. Poll the preview_report action with the returned delivery_id to fetch the result.'
+        ),
+})

--- a/services/mcp/src/tools/generated/subscriptions.ts
+++ b/services/mcp/src/tools/generated/subscriptions.ts
@@ -12,6 +12,7 @@ import {
     SubscriptionsPartialUpdateBody,
     SubscriptionsPartialUpdateParams,
     SubscriptionsRetrieveParams,
+    SubscriptionsTestDeliveryCreateBody,
     SubscriptionsTestDeliveryCreateParams,
 } from '@/generated/subscriptions/api'
 import { castStringToInt } from '@/tools/cast-helpers'
@@ -279,16 +280,23 @@ const subscriptionsRetrieve = (): ToolBase<typeof SubscriptionsRetrieveSchema, S
     },
 })
 
-const SubscriptionsTestDeliveryCreateSchema = SubscriptionsTestDeliveryCreateParams.omit({ project_id: true })
+const SubscriptionsTestDeliveryCreateSchema = SubscriptionsTestDeliveryCreateParams.omit({ project_id: true }).extend(
+    SubscriptionsTestDeliveryCreateBody.shape
+)
 
 const subscriptionsTestDeliveryCreate = (): ToolBase<typeof SubscriptionsTestDeliveryCreateSchema, unknown> => ({
     name: 'subscriptions-test-delivery-create',
     schema: SubscriptionsTestDeliveryCreateSchema,
     handler: async (context: Context, params: z.infer<typeof SubscriptionsTestDeliveryCreateSchema>) => {
         const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.preview !== undefined) {
+            body['preview'] = params.preview
+        }
         const result = await context.api.request<unknown>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/subscriptions/${encodeURIComponent(String(params.id))}/test-delivery/`,
+            body,
         })
         return result
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-test-delivery-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-test-delivery-create.json
@@ -4,6 +4,11 @@
         "id": {
             "description": "A unique integer value identifying this subscription.",
             "type": "number"
+        },
+        "preview": {
+            "default": false,
+            "description": "AI subscriptions only: run the report generation pipeline without sending anything. Poll the preview_report action with the returned delivery_id to fetch the result.",
+            "type": "boolean"
         }
     },
     "required": ["id"],


### PR DESCRIPTION
## Problem

The only way to see what a prompt-based subscription will actually produce is to save it, send a test delivery to the real destination, and check your inbox. For a feature whose value depends entirely on prompt quality, that iteration loop is far too slow — users are flying blind until the first delivery lands.

## Changes

- New `SubscriptionTriggerType.PREVIEW`: the existing `test_delivery` action accepts `{preview: true}` (AI subscriptions only, 400 otherwise; existing throttle kept) and responds 202 with the pre-assigned delivery id.
- `ProcessAISubscriptionWorkflow` runs the create-record → validate → generate phases completely unchanged (consent gate, credit budget, idempotency all apply), persists the report to `content_snapshot` as it already does, then skips the deliver phase for preview runs. The schedule never advances.
- New poll action `GET /subscriptions/{id}/preview_report/?delivery_id=…` returning `{status, ai_report, error}`, with the same query-access RBAC as the deliveries endpoint; 404 for non-AI subscriptions.
- Frontend: a "Generate preview" section in the AI subscription form — disabled with a reason until the subscription is saved, an immediate first poll then every 5s (kea + `cache.disposables`, 5-minute cap), markdown rendered inline in a scrollable panel or an error banner. Permission errors (non-404 4xx) stop polling and surface immediately; 404s (the row may not exist yet) and transient 5xx keep polling. Skipped runs get a specific message (over-budget) instead of a generic failure. Button guards double-submission.
- OpenAPI types regenerated; one `ENUM_NAME_OVERRIDES` entry to resolve a `status` enum collision.

```mermaid
flowchart TD
    B["'Generate preview' (saved AI subscription)"] --> K["POST …/test_delivery {preview: true}<br/>202 {delivery_id} · throttled"]
    K --> W["ProcessAISubscriptionWorkflow<br/>trigger = preview"]
    W --> G["validate → generate<br/>consent gate, credit budget, idempotency unchanged"]
    G --> CS[("SubscriptionDelivery.content_snapshot.ai_report")]
    W -. "deliver phase skipped<br/>schedule not advanced" .-> X(("∅"))
    P["GET …/preview_report?delivery_id=…<br/>immediate poll, then every 5s · 5 min cap<br/>404/5xx → keep polling · other 4xx → stop + surface"] --> CS
    CS --> R["inline markdown render / error banner"]
```

Known rough edges (intentional v1 scope): preview on an over-credit-budget org still triggers the existing skip side effects (the UI copy says "Nothing is delivered to recipients" and the skipped state explains the budget case); preview requires the subscription to be saved first; a disabled subscription returns the same 409 as test delivery.

## How did you test this code?

Agent-authored; automated tests only:

- Backend (isolated test DB): 235 passed initially, 165 on the follow-up run — `ee/api/test/test_subscription.py` + `posthog/temporal/tests/test_subscriptions_workflows.py`, including: preview skips delivery and leaves `next_delivery_date` untouched, pre-assigned-id idempotency, parameterized kickoff (preview vs regular), 400 for non-AI subscriptions, poll happy/starting/failed paths, 404 unknown / cross-subscription / non-AI-subscription cases, 400 invalid uuid, RBAC 403, scoped-key matrix.
- Frontend: `subscriptionLogic.test.ts` — 25 passed, covering kick-off with immediate first poll, terminal states, 403-stops / 404-and-502-keep-polling, timeout cap, skipped-specific messaging, double-submission guard. `typescript:check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — early-access feature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code as part of a four-branch early-access hardening pass on prompt-based subscriptions.
- Key decisions: reuse the test-delivery path with a trigger-type discriminator instead of a parallel preview pipeline, so all run-time guardrails apply to previews automatically; a dedicated poll action instead of widening the deliveries list serializer, to stay conflict-free with a sibling branch exposing `ai_report` there. A local multi-reviewer pass drove the follow-up commit: status-aware poll error handling, AI-only gating on the poll action, immediate first poll, and copy fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
