### PR TITLE
feat(subscriptions): validate AI prompts at save time

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -9,6 +9,7 @@ from django.db.models import QuerySet
 from django.http import HttpRequest, JsonResponse
 
 import jwt
+import structlog
 import posthoganalytics
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -48,6 +49,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.spec_genera
     PROMPT_MAX_LENGTH as AI_PROMPT_MAX_LENGTH,
     PromptRejectedError,
     sanitize_prompt,
+    validate_prompt_plannable,
 )
 from products.exports.backend.temporal.subscriptions.types import (
     ProcessSubscriptionWorkflowInputs,
@@ -59,8 +61,13 @@ from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, is_tea
 from ee.tasks.subscriptions.auto_disable import validate_re_enable
 from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
 
+logger = structlog.get_logger(__name__)
+
 SUMMARY_QUOTA_CACHE_TTL_SECONDS = 60
 SUMMARY_CAP_HIT_DEDUPE_TTL_SECONDS = 600
+
+AI_PROMPT_VALIDATION_FAILED_EVENT = "ai_subscription_prompt_validation_failed"
+AI_PROMPT_VALIDATION_ERRORED_EVENT = "ai_subscription_prompt_validation_errored"
 
 
 def _summary_quota_cache_key(organization_id) -> str:
@@ -437,7 +444,73 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             organization = self.context["get_organization"]()
             self._validate_summary_enabled_org_limit(organization)
 
+        # Last so an LLM round-trip is never spent on a payload another check already rejects.
+        if resource_type == Subscription.ResourceType.AI_PROMPT:
+            self._validate_ai_prompt_plannable(attrs, existing)
+
         return attrs
+
+    def _validate_ai_prompt_plannable(self, attrs: dict, existing: Optional[Subscription]) -> None:
+        """Run the pipeline's planner-level prompt check at save time so an unusable prompt
+        fails the write immediately instead of auto-disabling at the first scheduled run.
+        Only a genuine rejection blocks the save; transient LLM/infra errors FAIL OPEN —
+        the run-time auto-disable path remains the backstop."""
+        if "prompt" not in attrs:
+            return  # update that doesn't touch the prompt
+        prompt = attrs["prompt"]  # already stripped and length-checked by _validate_ai_content
+        if existing is not None and prompt == (existing.prompt or "").strip():
+            return
+        request = self.context.get("request")
+        user = getattr(request, "user", None) if request else None
+        if not getattr(user, "distinct_id", None):
+            return  # no authenticated user to attribute the LLM call to — leave it to run time
+        subscription_id = existing.id if existing else None
+        try:
+            validate_prompt_plannable(
+                team=self.context["get_team"](),
+                user=user,
+                prompt=prompt,
+                trace_correlation_id=subscription_id,
+            )
+        except PromptRejectedError as exc:
+            self._capture_prompt_validation_event(AI_PROMPT_VALIDATION_FAILED_EVENT, str(exc), subscription_id)
+            raise ValidationError(
+                {
+                    "prompt": [
+                        f"This prompt can't be turned into a report: {exc} "
+                        "Try rephrasing it as a specific question about your product's events or metrics."
+                    ]
+                }
+            )
+        except Exception as exc:
+            logger.warning(
+                "ai_subscription.prompt_validation_errored",
+                team_id=self.context.get("team_id"),
+                subscription_id=subscription_id,
+                exc_info=True,
+            )
+            self._capture_prompt_validation_event(
+                AI_PROMPT_VALIDATION_ERRORED_EVENT, type(exc).__name__, subscription_id
+            )
+
+    def _capture_prompt_validation_event(self, event: str, reason: str, subscription_id: Optional[int]) -> None:
+        organization = self.context["get_organization"]()
+        try:
+            posthoganalytics.capture(
+                distinct_id=self._caller_distinct_id(),
+                event=event,
+                properties={
+                    "team_id": self.context.get("team_id"),
+                    "organization_id": str(organization.id),
+                    "subscription_id": subscription_id,
+                    "reason": reason,
+                    "is_create": self.instance is None,
+                },
+                groups={"organization": str(organization.id)},
+            )
+        except Exception:
+            # Telemetry must never poison the validation path.
+            pass
 
     def _is_becoming_active_summary(self, attrs: dict) -> bool:
         pre_summary_enabled = self.instance.summary_enabled if self.instance else False

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -451,10 +451,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         return attrs
 
     def _validate_ai_prompt_plannable(self, attrs: dict, existing: Optional[Subscription]) -> None:
-        """Run the pipeline's planner-level prompt check at save time so an unusable prompt
-        fails the write immediately instead of auto-disabling at the first scheduled run.
-        Only a genuine rejection blocks the save; transient LLM/infra errors FAIL OPEN —
-        the run-time auto-disable path remains the backstop."""
+        """A genuine prompt rejection blocks the save; transient LLM/infra errors FAIL OPEN — the run-time auto-disable path remains the backstop."""
         if "prompt" not in attrs:
             return  # update that doesn't touch the prompt
         prompt = attrs["prompt"]  # already stripped and length-checked by _validate_ai_content
@@ -465,9 +462,10 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         if not getattr(user, "distinct_id", None):
             return  # no authenticated user to attribute the LLM call to — leave it to run time
         subscription_id = existing.id if existing else None
+        team = self.context["get_team"]()
         try:
             validate_prompt_plannable(
-                team=self.context["get_team"](),
+                team=team,
                 user=user,
                 prompt=prompt,
                 trace_correlation_id=subscription_id,
@@ -485,7 +483,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         except Exception as exc:
             logger.warning(
                 "ai_subscription.prompt_validation_errored",
-                team_id=self.context.get("team_id"),
+                team_id=team.id,
                 subscription_id=subscription_id,
                 exc_info=True,
             )
@@ -494,8 +492,8 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             )
 
     def _capture_prompt_validation_event(self, event: str, reason: str, subscription_id: Optional[int]) -> None:
-        organization = self.context["get_organization"]()
         try:
+            organization = self.context["get_organization"]()
             posthoganalytics.capture(
                 distinct_id=self._caller_distinct_id(),
                 event=event,

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -27,12 +27,14 @@ from products.exports.backend.models.subscription import (
     Subscription,
     SubscriptionDelivery,
 )
+from products.exports.backend.temporal.subscriptions.ai_subscription.spec_generator import PromptRejectedError
 from products.exports.backend.temporal.subscriptions.types import (
     ProcessSubscriptionWorkflowInputs,
     SubscriptionTriggerType,
 )
 from products.product_analytics.backend.models.insight import Insight
 
+from ee.api.subscription import AI_PROMPT_VALIDATION_ERRORED_EVENT, AI_PROMPT_VALIDATION_FAILED_EVENT
 from ee.api.test.base import APILicensedTest
 from ee.models.rbac.access_control import AccessControl
 from ee.tasks.subscriptions.slack_subscriptions import get_slack_integration_for_team
@@ -2103,6 +2105,14 @@ class TestSubscriptionFreeTierAccess(APILicensedTest):
 @patch("ee.api.subscription.posthoganalytics.feature_enabled", return_value=True)
 @patch("ee.api.subscription.is_cloud", return_value=True)
 class TestAISubscriptionAPI(APILicensedTest):
+    def setUp(self):
+        super().setUp()
+        # Patched via setUp (not a class decorator) so existing test signatures stay unchanged;
+        # individual tests steer it through self.mock_validate_prompt.
+        patcher = patch("ee.api.subscription.validate_prompt_plannable")
+        self.mock_validate_prompt = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def _enable_ai(self):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save(update_fields=["is_ai_data_processing_approved"])
@@ -2547,3 +2557,112 @@ class TestAISubscriptionAPI(APILicensedTest):
         )
         assert patch_resp.status_code == status.HTTP_400_BAD_REQUEST, patch_resp.json()
         assert "prompt" in str(patch_resp.json()).lower(), patch_resp.json()
+
+    @parameterized.expand(
+        [
+            ("accepted", None, status.HTTP_201_CREATED, None),
+            (
+                "rejected",
+                PromptRejectedError("Planner returned a malformed plan."),
+                status.HTTP_400_BAD_REQUEST,
+                AI_PROMPT_VALIDATION_FAILED_EVENT,
+            ),
+            (
+                "llm_error_fails_open",
+                RuntimeError("llm down"),
+                status.HTTP_201_CREATED,
+                AI_PROMPT_VALIDATION_ERRORED_EVENT,
+            ),
+            (
+                "llm_timeout_fails_open",
+                TimeoutError("timed out"),
+                status.HTTP_201_CREATED,
+                AI_PROMPT_VALIDATION_ERRORED_EVENT,
+            ),
+        ]
+    )
+    @patch("ee.api.subscription.posthoganalytics.capture")
+    def test_create_prompt_validation_outcomes(
+        self,
+        _name,
+        side_effect,
+        expected_status,
+        expected_event,
+        mock_capture,
+        mock_is_cloud,
+        mock_flag,
+        mock_sync,
+    ):
+        self._enable_ai()
+        self._mock_temporal(mock_sync)
+        self.mock_validate_prompt.side_effect = side_effect
+
+        response = self.client.post(f"/api/projects/{self.team.id}/subscriptions", self._make_ai_payload())
+
+        assert response.status_code == expected_status, response.json()
+        self.mock_validate_prompt.assert_called_once()
+        assert (
+            self.mock_validate_prompt.call_args.kwargs["prompt"] == "What are the biggest event gains week-over-week?"
+        )
+        captured_events = [c.kwargs.get("event") for c in mock_capture.call_args_list]
+        if expected_event is None:
+            assert AI_PROMPT_VALIDATION_FAILED_EVENT not in captured_events
+            assert AI_PROMPT_VALIDATION_ERRORED_EVENT not in captured_events
+        else:
+            assert expected_event in captured_events
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            assert response.json()["attr"] == "prompt"
+            assert "can't be turned into a report" in response.json()["detail"]
+
+    @parameterized.expand(
+        [
+            ("title_only", {"title": "Renamed"}),
+            ("same_prompt_resent", {"prompt": "What are the biggest event gains week-over-week?"}),
+            ("same_prompt_with_whitespace", {"prompt": "  What are the biggest event gains week-over-week?  "}),
+        ]
+    )
+    def test_update_without_prompt_change_skips_validation(
+        self, mock_is_cloud, mock_flag, mock_sync, _name, patch_body
+    ):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+        self.mock_validate_prompt.reset_mock()
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_body)
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        self.mock_validate_prompt.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("accepted", None, status.HTTP_200_OK),
+            ("rejected", PromptRejectedError("Planner returned a malformed plan."), status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_update_with_changed_prompt_revalidates(
+        self, mock_is_cloud, mock_flag, mock_sync, _name, side_effect, expected_status
+    ):
+        self._mock_temporal(mock_sync)
+        sub_id = self._create_subscription_for("ai_prompt")
+        self.mock_validate_prompt.reset_mock()
+        self.mock_validate_prompt.side_effect = side_effect
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
+            {"prompt": "Show me churn by plan"},
+        )
+
+        assert response.status_code == expected_status, response.json()
+        self.mock_validate_prompt.assert_called_once()
+        assert self.mock_validate_prompt.call_args.kwargs["trace_correlation_id"] == sub_id
+        stored_prompt = Subscription.objects.get(pk=sub_id).prompt
+        if expected_status == status.HTTP_200_OK:
+            assert stored_prompt == "Show me churn by plan"
+        else:
+            assert stored_prompt == "What are the biggest event gains week-over-week?"
+
+    def test_non_ai_subscription_never_calls_prompt_validation(self, mock_is_cloud, mock_flag, mock_sync):
+        self._mock_temporal(mock_sync)
+        response = self.client.post(f"/api/projects/{self.team.id}/subscriptions", self._insight_payload())
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        self.mock_validate_prompt.assert_not_called()

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -1,3 +1,4 @@
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import UTC, datetime, timedelta
 from typing import Optional
 from uuid import uuid4
@@ -34,7 +35,11 @@ from products.exports.backend.temporal.subscriptions.types import (
 )
 from products.product_analytics.backend.models.insight import Insight
 
-from ee.api.subscription import AI_PROMPT_VALIDATION_ERRORED_EVENT, AI_PROMPT_VALIDATION_FAILED_EVENT
+from ee.api.subscription import (
+    AI_PROMPT_VALIDATION_ERRORED_EVENT,
+    AI_PROMPT_VALIDATION_FAILED_EVENT,
+    SubscriptionSerializer,
+)
 from ee.api.test.base import APILicensedTest
 from ee.models.rbac.access_control import AccessControl
 from ee.tasks.subscriptions.slack_subscriptions import get_slack_integration_for_team
@@ -2579,6 +2584,13 @@ class TestAISubscriptionAPI(APILicensedTest):
                 status.HTTP_201_CREATED,
                 AI_PROMPT_VALIDATION_ERRORED_EVENT,
             ),
+            (
+                # the overall save-validation deadline surfaces as future.result()'s TimeoutError
+                "overall_deadline_fails_open",
+                FuturesTimeoutError("validation deadline exceeded"),
+                status.HTTP_201_CREATED,
+                AI_PROMPT_VALIDATION_ERRORED_EVENT,
+            ),
         ]
     )
     @patch("ee.api.subscription.posthoganalytics.capture")
@@ -2660,6 +2672,16 @@ class TestAISubscriptionAPI(APILicensedTest):
             assert stored_prompt == "Show me churn by plan"
         else:
             assert stored_prompt == "What are the biggest event gains week-over-week?"
+
+    def test_skips_validation_when_request_user_has_no_distinct_id(self, mock_is_cloud, mock_flag, mock_sync):
+        # No authenticated user to attribute the LLM call to — validation is left to run time, not blocked.
+        request = MagicMock()
+        request.user.distinct_id = None
+        serializer = SubscriptionSerializer(context={"request": request})
+
+        serializer._validate_ai_prompt_plannable({"prompt": "Weekly pageviews summary"}, None)
+
+        self.mock_validate_prompt.assert_not_called()
 
     def test_non_ai_subscription_never_calls_prompt_validation(self, mock_is_cloud, mock_flag, mock_sync):
         self._mock_temporal(mock_sync)

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -55,6 +55,12 @@ DEFAULT_PLANNER_MODEL = "gpt-4.1"
 DEFAULT_SYNTHESIS_MODEL = "gpt-4.1"
 _PLANNER_LLM_TIMEOUT_SECONDS = 90.0
 _EVENT_SELECTION_LLM_TIMEOUT_SECONDS = 30.0
+# Save-time validation runs inside an API request, so it gets a much tighter LLM budget than the
+# pipeline's planner call — callers fail open on timeout.
+PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS = 15.0
+# Only sets the "suggested analysis window" context line for the save-time planner call; the real
+# window is derived from the subscription's cadence at run time.
+SAVE_VALIDATION_WINDOW_DAYS = 7
 
 
 class PromptRejectedError(ValueError):
@@ -289,15 +295,17 @@ def generate_query_plan(
     team: Team,
     user: User,
     trace_correlation_id: Optional[Union[int, str]] = None,
+    llm_timeout: float = _PLANNER_LLM_TIMEOUT_SECONDS,
+    stage: str = "plan",
 ) -> QueryPlan:
-    # `user is None` is enforced at the public entry point (`generate_ai_report`)
-    # which is the only caller path into here. Don't repeat the check.
-    posthog_properties: dict[str, Union[str, int]] = {"feature": "ai_subscription", "stage": "plan"}
+    # `user is None` is enforced at the public entry points (`generate_ai_report` raises;
+    # `validate_prompt_plannable` requires it by type). Don't repeat the check.
+    posthog_properties: dict[str, Union[str, int]] = {"feature": "ai_subscription", "stage": stage}
     if trace_correlation_id is not None:
         posthog_properties["subscription_id"] = trace_correlation_id
     llm = MaxChatOpenAI(
         model=DEFAULT_PLANNER_MODEL,
-        timeout=_PLANNER_LLM_TIMEOUT_SECONDS,
+        timeout=llm_timeout,
         user=user,
         team=team,
         billable=True,
@@ -313,6 +321,30 @@ def generate_query_plan(
     if not isinstance(result, QueryPlan):
         raise PromptRejectedError("Planner returned a malformed plan.")
     return result
+
+
+def validate_prompt_plannable(
+    *,
+    team: Team,
+    user: User,
+    prompt: Optional[str],
+    trace_correlation_id: Optional[Union[int, str]] = None,
+) -> None:
+    # Save-time mirror of the pipeline's planner stage (sanitize + plan), minus the event-selection
+    # pass and any query execution, so save-time acceptance and run-time rejection can't drift.
+    # Raises PromptRejectedError on a genuine rejection; any other exception (LLM timeout, infra
+    # failure) is transient and callers are expected to fail open.
+    cleaned = sanitize_prompt(prompt)
+    context_blob = build_context_blob(team, SAVE_VALIDATION_WINDOW_DAYS)
+    generate_query_plan(
+        cleaned_prompt=cleaned,
+        context_blob=context_blob,
+        team=team,
+        user=user,
+        trace_correlation_id=trace_correlation_id,
+        llm_timeout=PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS,
+        stage="save_validation",
+    )
 
 
 def build_enriched_prompt(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from django.db.models import F, Q
 
@@ -53,14 +54,20 @@ EVENT_PROPERTIES_PER_EVENT_LIMIT = 15
 
 DEFAULT_PLANNER_MODEL = "gpt-4.1"
 DEFAULT_SYNTHESIS_MODEL = "gpt-4.1"
-_PLANNER_LLM_TIMEOUT_SECONDS = 90.0
+PLANNER_LLM_TIMEOUT_SECONDS = 90.0
 _EVENT_SELECTION_LLM_TIMEOUT_SECONDS = 30.0
 # Save-time validation runs inside an API request, so it gets a much tighter LLM budget than the
 # pipeline's planner call — callers fail open on timeout.
 PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS = 15.0
+# Single LLM attempt at save time — the client's default retries would multiply the budget per attempt.
+PROMPT_SAVE_VALIDATION_LLM_MAX_RETRIES = 0
+# Bounds the whole save-time check (context build + one LLM attempt), not just the LLM call.
+PROMPT_SAVE_VALIDATION_OVERALL_TIMEOUT_SECONDS = 25.0
 # Only sets the "suggested analysis window" context line for the save-time planner call; the real
 # window is derived from the subscription's cadence at run time.
 SAVE_VALIDATION_WINDOW_DAYS = 7
+
+_SAVE_VALIDATION_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="ai-sub-save-validation")
 
 
 class PromptRejectedError(ValueError):
@@ -295,8 +302,9 @@ def generate_query_plan(
     team: Team,
     user: User,
     trace_correlation_id: Optional[Union[int, str]] = None,
-    llm_timeout: float = _PLANNER_LLM_TIMEOUT_SECONDS,
-    stage: str = "plan",
+    llm_timeout: float = PLANNER_LLM_TIMEOUT_SECONDS,
+    llm_max_retries: Optional[int] = None,
+    stage: Literal["plan", "save_validation"] = "plan",
 ) -> QueryPlan:
     # `user is None` is enforced at the public entry points (`generate_ai_report` raises;
     # `validate_prompt_plannable` requires it by type). Don't repeat the check.
@@ -306,6 +314,8 @@ def generate_query_plan(
     llm = MaxChatOpenAI(
         model=DEFAULT_PLANNER_MODEL,
         timeout=llm_timeout,
+        # None resolves to the client's default retry count (MaxChatMixin.model_post_init).
+        max_retries=llm_max_retries,
         user=user,
         team=team,
         billable=True,
@@ -332,19 +342,26 @@ def validate_prompt_plannable(
 ) -> None:
     # Save-time mirror of the pipeline's planner stage (sanitize + plan), minus the event-selection
     # pass and any query execution, so save-time acceptance and run-time rejection can't drift.
-    # Raises PromptRejectedError on a genuine rejection; any other exception (LLM timeout, infra
+    # Raises PromptRejectedError on a genuine rejection; any other exception (timeout, infra
     # failure) is transient and callers are expected to fail open.
     cleaned = sanitize_prompt(prompt)
-    context_blob = build_context_blob(team, SAVE_VALIDATION_WINDOW_DAYS)
-    generate_query_plan(
-        cleaned_prompt=cleaned,
-        context_blob=context_blob,
-        team=team,
-        user=user,
-        trace_correlation_id=trace_correlation_id,
-        llm_timeout=PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS,
-        stage="save_validation",
-    )
+
+    def _build_and_plan() -> None:
+        context_blob = build_context_blob(team, SAVE_VALIDATION_WINDOW_DAYS)
+        generate_query_plan(
+            cleaned_prompt=cleaned,
+            context_blob=context_blob,
+            team=team,
+            user=user,
+            trace_correlation_id=trace_correlation_id,
+            llm_timeout=PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS,
+            llm_max_retries=PROMPT_SAVE_VALIDATION_LLM_MAX_RETRIES,
+            stage="save_validation",
+        )
+
+    # On timeout the orphaned worker keeps running, but it's bounded by the LLM/ClickHouse server-side timeouts.
+    future = _SAVE_VALIDATION_EXECUTOR.submit(_build_and_plan)
+    future.result(timeout=PROMPT_SAVE_VALIDATION_OVERALL_TIMEOUT_SECONDS)
 
 
 def build_enriched_prompt(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -14,7 +14,9 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.schemas imp
     RelevantEvents,
 )
 from products.exports.backend.temporal.subscriptions.ai_subscription.spec_generator import (
+    _PLANNER_LLM_TIMEOUT_SECONDS,
     PROMPT_MAX_LENGTH,
+    PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS,
     PromptRejectedError,
     _event_property_names,
     _group_type_labels,
@@ -24,6 +26,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.spec_genera
     build_context_blob,
     generate_query_plan,
     sanitize_prompt,
+    validate_prompt_plannable,
 )
 
 _SG = "products.exports.backend.temporal.subscriptions.ai_subscription.spec_generator"
@@ -280,3 +283,74 @@ class TestGenerateQueryPlanSubstitution(APIBaseTest):
 
         with pytest.raises(PromptRejectedError, match="malformed"):
             generate_query_plan(cleaned_prompt="p", context_blob="c", team=self.team, user=self.user)
+
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_defaults_to_runtime_timeout_and_plan_stage(self, mock_chat: MagicMock) -> None:
+        structured = mock_chat.return_value.with_structured_output.return_value
+        structured.invoke.return_value = QueryPlan(
+            overall_intent="intent",
+            steps=[QueryPlanStep(description="d", hogql="SELECT 1")],
+        )
+
+        generate_query_plan(cleaned_prompt="p", context_blob="c", team=self.team, user=self.user)
+
+        assert mock_chat.call_args.kwargs["timeout"] == _PLANNER_LLM_TIMEOUT_SECONDS
+        assert mock_chat.call_args.kwargs["posthog_properties"]["stage"] == "plan"
+
+
+class TestValidatePromptPlannable(APIBaseTest):
+    _VALID_PLAN = QueryPlan(overall_intent="intent", steps=[QueryPlanStep(description="d", hogql="SELECT 1")])
+
+    @patch(f"{_SG}._top_event_names", return_value=[])
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_accepts_plannable_prompt_with_save_time_timeout(self, mock_chat: MagicMock, _mock_top: object) -> None:
+        structured = mock_chat.return_value.with_structured_output.return_value
+        structured.invoke.return_value = self._VALID_PLAN
+
+        validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")
+
+        assert mock_chat.call_args.kwargs["timeout"] == PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS
+        assert mock_chat.call_args.kwargs["posthog_properties"]["stage"] == "save_validation"
+
+    @parameterized.expand(
+        [
+            ("empty", "   "),
+            ("over_max_length", "x" * (PROMPT_MAX_LENGTH + 1)),
+            ("only_framing_tags", "<system></system>"),
+        ]
+    )
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_rejects_unsanitizable_prompt_without_llm_call(self, _name: str, raw: str, mock_chat: MagicMock) -> None:
+        with pytest.raises(PromptRejectedError):
+            validate_prompt_plannable(team=self.team, user=self.user, prompt=raw)
+        mock_chat.assert_not_called()
+
+    @patch(f"{_SG}._top_event_names", return_value=[])
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_rejects_when_planner_returns_malformed_plan(self, mock_chat: MagicMock, _mock_top: object) -> None:
+        mock_chat.return_value.with_structured_output.return_value.invoke.return_value = "not a QueryPlan"
+
+        with pytest.raises(PromptRejectedError, match="malformed"):
+            validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")
+
+    @patch(f"{_SG}._top_event_names", return_value=[])
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_propagates_transient_llm_errors_for_caller_to_fail_open(
+        self, mock_chat: MagicMock, _mock_top: object
+    ) -> None:
+        mock_chat.return_value.with_structured_output.return_value.invoke.side_effect = TimeoutError("llm timed out")
+
+        with pytest.raises(TimeoutError):
+            validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")
+
+    @patch(f"{_SG}._select_relevant_events")
+    @patch(f"{_SG}._top_event_names", return_value=[])
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_skips_the_event_selection_pass(
+        self, mock_chat: MagicMock, _mock_top: object, mock_select: MagicMock
+    ) -> None:
+        mock_chat.return_value.with_structured_output.return_value.invoke.return_value = self._VALID_PLAN
+
+        validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")
+
+        mock_select.assert_not_called()

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -1,3 +1,4 @@
+import time
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -14,8 +15,9 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.schemas imp
     RelevantEvents,
 )
 from products.exports.backend.temporal.subscriptions.ai_subscription.spec_generator import (
-    _PLANNER_LLM_TIMEOUT_SECONDS,
+    PLANNER_LLM_TIMEOUT_SECONDS,
     PROMPT_MAX_LENGTH,
+    PROMPT_SAVE_VALIDATION_LLM_MAX_RETRIES,
     PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS,
     PromptRejectedError,
     _event_property_names,
@@ -294,7 +296,9 @@ class TestGenerateQueryPlanSubstitution(APIBaseTest):
 
         generate_query_plan(cleaned_prompt="p", context_blob="c", team=self.team, user=self.user)
 
-        assert mock_chat.call_args.kwargs["timeout"] == _PLANNER_LLM_TIMEOUT_SECONDS
+        assert mock_chat.call_args.kwargs["timeout"] == PLANNER_LLM_TIMEOUT_SECONDS
+        # None resolves to the client's default retry count in MaxChatMixin.model_post_init.
+        assert mock_chat.call_args.kwargs["max_retries"] is None
         assert mock_chat.call_args.kwargs["posthog_properties"]["stage"] == "plan"
 
 
@@ -310,6 +314,7 @@ class TestValidatePromptPlannable(APIBaseTest):
         validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")
 
         assert mock_chat.call_args.kwargs["timeout"] == PROMPT_SAVE_VALIDATION_LLM_TIMEOUT_SECONDS
+        assert mock_chat.call_args.kwargs["max_retries"] == PROMPT_SAVE_VALIDATION_LLM_MAX_RETRIES
         assert mock_chat.call_args.kwargs["posthog_properties"]["stage"] == "save_validation"
 
     @parameterized.expand(
@@ -339,6 +344,18 @@ class TestValidatePromptPlannable(APIBaseTest):
         self, mock_chat: MagicMock, _mock_top: object
     ) -> None:
         mock_chat.return_value.with_structured_output.return_value.invoke.side_effect = TimeoutError("llm timed out")
+
+        with pytest.raises(TimeoutError):
+            validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")
+
+    @patch(f"{_SG}.PROMPT_SAVE_VALIDATION_OVERALL_TIMEOUT_SECONDS", 0.01)
+    @patch(f"{_SG}.build_context_blob")
+    @patch(f"{_SG}.MaxChatOpenAI")
+    def test_times_out_when_validation_exceeds_overall_deadline(
+        self, mock_chat: MagicMock, mock_build: MagicMock
+    ) -> None:
+        mock_chat.return_value.with_structured_output.return_value.invoke.return_value = self._VALID_PLAN
+        mock_build.side_effect = lambda *args, **kwargs: time.sleep(0.2) or "context"
 
         with pytest.raises(TimeoutError):
             validate_prompt_plannable(team=self.team, user=self.user, prompt="Weekly pageviews summary")


### PR DESCRIPTION
## Problem

An unusable prompt on a prompt-based subscription is only detected at the first scheduled run: the pipeline raises `PromptRejectedError`, the subscription auto-disables, and the creator finds out from a "your subscription was disabled" email — potentially a week after writing the prompt. The feedback should arrive while they're still in the form.

## Changes

- New `validate_prompt_plannable` in `spec_generator.py`: the save-time mirror of the pipeline's planner stage (sanitize + plan) with no event-selection pass or query execution. It deliberately reuses the exact run-time code path so save-time acceptance and run-time rejection cannot drift apart.
- The whole check is latency-bounded for the request worker: a single LLM attempt (`max_retries=0`, 15s timeout) plus a 25s **overall** deadline that also covers the context build (which can hit a cold ClickHouse taxonomy cache) — run on a small bounded thread pool; breaching the deadline fails open.
- `SubscriptionSerializer` runs it on create, and on update only when the prompt actually changed — ordered last in `validate` so an LLM round-trip is never spent on a payload another check already rejects.
- A genuine rejection → 400 on the `prompt` field with the reason and a rephrasing hint. Anything transient (timeout, LLM infra error) **fails open**: the save proceeds and the run-time auto-disable path remains the backstop.
- Analytics: `ai_subscription_prompt_validation_failed` (rejection) and `ai_subscription_prompt_validation_errored` (fail-open), following the existing capture patterns in the viewset.

```mermaid
flowchart TD
    SAVE["create / update with changed prompt<br/>(resource_type = ai_prompt)"] --> V["validate_prompt_plannable<br/>sanitize + planner LLM · single attempt, 15s · 25s overall deadline incl. context build<br/>same code path the pipeline runs at delivery time"]
    V -->|plannable| OK["save proceeds"]
    V -->|PromptRejectedError| R["400 on 'prompt' field with reason<br/>+ ai_subscription_prompt_validation_failed"]
    V -->|"deadline / infra error"| FO["fail open: save proceeds<br/>+ ai_subscription_prompt_validation_errored<br/>(run-time auto-disable remains the backstop)"]
    classDef bad fill:#2d1417,stroke:#cf222e,color:#e8e8e8;
    class R bad;
```

## How did you test this code?

Agent-authored; automated tests only:

- Backend (isolated test DB): 202 passed — `ee/api/test/test_subscription.py` + `test_spec_generator.py`, including parameterized cases: valid prompt accepted; rejected prompt → 400 with field error; LLM error / overall-deadline timeout → save succeeds and the errored event is captured; update without prompt change → no LLM call; non-AI subscription → no LLM call; request user without `distinct_id` → validation skipped; unit tests for `validate_prompt_plannable` including the deadline path and `max_retries=0` plumbing.
- ruff check and format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — early-access feature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code as part of a four-branch early-access hardening pass on prompt-based subscriptions.
- Key decisions: reuse the pipeline's planner call (with a tighter timeout, single attempt, and a `save_validation` stage tag) instead of writing a separate validation prompt, so the two judgments can't diverge; strict fail-open on anything that isn't a genuine rejection, because an LLM outage must never block subscription saves. A local multi-reviewer pass flagged that the original version's 15s timeout was per-attempt (client default of 3 retries) and didn't bound the context build — both fixed in the follow-up commit with a single-attempt budget and an overall deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
