### PR TITLE
feat(signals): add get_team_anomalies facade read

### DIFF
--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -1,7 +1,9 @@
 import enum
+import json
 import dataclasses
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import get_args
+from typing import Any, get_args
 
 from django.conf import settings
 
@@ -409,3 +411,95 @@ async def emit_signal(
             source_type=source_type,
             source_id=source_id,
         )
+
+
+# ---------------------------------------------------------------------------
+# get_team_anomalies — read path for Pulse v2 cross-product consumption
+# ---------------------------------------------------------------------------
+
+ANOMALY_DETECTION_SKILL = "signals-scout-anomaly-detection"
+
+# The scout's emit contract puts the flagged insight's short_id in the evidence entry tagged with this
+# source_product. It is LLM-authored convention (not a SourceProduct enum member), so anchor it here as
+# the single consumer-side reference rather than scattering the literal.
+EVIDENCE_SOURCE_PRODUCT_QUERY_RUNS = "query_runs"
+
+
+@dataclass(frozen=True)
+class AnomalyFinding:
+    """A single anomaly the scout surfaced, flattened for cross-product (Pulse) consumption.
+
+    insight_short_id is best-effort: the scout puts it in the evidence entry whose source_product is
+    EVIDENCE_SOURCE_PRODUCT_QUERY_RUNS, but the field is LLM-authored and optional, so it can be None
+    (the consumer counts + skips those). The descriptive fields (hypothesis/severity/confidence/time_range)
+    aren't all consumed yet — they're forward-looking for narrative enrichment.
+    """
+
+    insight_short_id: str | None
+    weight: float
+    confidence: float
+    hypothesis: str | None
+    severity: str | None
+    description: str
+    time_range: tuple[str, str] | None
+    finding_id: str
+    scout_run_id: str
+
+
+def _short_id_from_evidence(evidence: list[Any]) -> str | None:
+    for entry in evidence:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("source_product") == EVIDENCE_SOURCE_PRODUCT_QUERY_RUNS and entry.get("entity_id"):
+            return str(entry["entity_id"])
+    return None
+
+
+async def get_team_anomalies(team: Team, period_start: str, period_end: str) -> list[AnomalyFinding]:
+    """The team's anomaly-detection scout findings in [period_start, period_end].
+
+    Reads raw signals from ClickHouse (NOT grouped reports), scopes to the anomaly-detection scout, and
+    flattens each into an AnomalyFinding. Returns [] when the org hasn't approved AI data processing
+    (mirrors emit_signal's gate).
+    """
+    organization = await database_sync_to_async(lambda: team.organization)()
+    if not organization.is_ai_data_processing_approved:
+        # Distinguish a gated team from a genuinely quiet one — both return [], but only this logs why.
+        logger.info("get_team_anomalies_ai_gate_off", team_id=team.id)
+        return []
+
+    # Deferred import: signal_queries pulls in the temporal graph, which imports back from this
+    # facade (drop_telemetry → _telemetry_props_from_extra). A module-level import would cycle.
+    from products.signals.backend.temporal.signal_queries import (  # noqa: PLC0415 — breaks a circular import
+        fetch_team_anomaly_signal_rows,
+    )
+
+    rows = await fetch_team_anomaly_signal_rows(team, period_start, period_end)
+    out: list[AnomalyFinding] = []
+    for _document_id, content, metadata_json, _timestamp in rows:
+        # metadata + extra are LLM-authored; isolate per row so one malformed emit can't abort the batch.
+        try:
+            metadata = json.loads(metadata_json)
+            extra = metadata.get("extra") or {}
+            if extra.get("skill_name") != ANOMALY_DETECTION_SKILL:
+                continue
+            tr = extra.get("time_range")
+            time_range: tuple[str, str] | None = None
+            if isinstance(tr, dict) and tr.get("date_from") and tr.get("date_to"):
+                time_range = (str(tr["date_from"]), str(tr["date_to"]))
+            out.append(
+                AnomalyFinding(
+                    insight_short_id=_short_id_from_evidence(extra.get("evidence") or []),
+                    weight=float(metadata.get("weight") or 0.0),
+                    confidence=float(extra.get("confidence") or 0.0),
+                    hypothesis=extra.get("hypothesis"),
+                    severity=extra.get("severity"),
+                    description=content or "",
+                    time_range=time_range,
+                    finding_id=extra.get("finding_id") or "",
+                    scout_run_id=extra.get("scout_run_id") or "",
+                )
+            )
+        except Exception:
+            logger.warning("get_team_anomalies_skipped_malformed_row", team_id=team.id, exc_info=True)
+    return out

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -540,6 +540,49 @@ def fetch_signals_for_report_sync(team: Team, report_id: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
+async def fetch_team_anomaly_signal_rows(team: Team, date_from: str, date_to: str) -> list[tuple]:
+    """Raw scout signals for a team in [date_from, date_to], deduped, not deleted.
+
+    Scopes to source_product=signals_scout and source_type=cross_source_issue at the query level.
+    Skill-level narrowing (anomaly-detection only) is left to the caller via extra.skill_name.
+    Returns (document_id, content, metadata_json, timestamp) rows.
+    """
+    from products.signals.backend.models import (
+        SignalSourceConfig,  # noqa: PLC0415 — avoids circular import at module level
+    )
+
+    # Build the dedup subquery FIRST as a plain string so its placeholders stay single-brace
+    # ({team_id} etc.) — putting this call inside the outer f-string would double the braces.
+    deduped = _deduped_signals_subquery(
+        extra_where="team_id = {team_id} AND timestamp >= {date_from} AND timestamp <= {date_to}"
+    )
+    # Defensive bound matching the sibling reads in this file (the caller trims further by weight). Order
+    # newest-first so the rows kept under the cap are the most recent.
+    query = f"""
+        SELECT document_id, content, metadata, timestamp
+        FROM ({deduped})
+        WHERE JSONExtractString(metadata, 'source_product') = {{source_product}}
+          AND JSONExtractString(metadata, 'source_type') = {{source_type}}
+          AND NOT JSONExtractBool(metadata, 'deleted')
+        ORDER BY timestamp DESC
+        LIMIT 500
+    """
+    result = await execute_hogql_query_with_retry(
+        query_type="SignalsFetchTeamAnomalies",
+        query=query,
+        team=team,
+        placeholders={
+            "team_id": ast.Constant(value=team.id),
+            "date_from": ast.Constant(value=date_from),
+            "date_to": ast.Constant(value=date_to),
+            "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+            "source_product": ast.Constant(value=SignalSourceConfig.SourceProduct.SIGNALS_SCOUT.value),
+            "source_type": ast.Constant(value=SignalSourceConfig.SourceType.CROSS_SOURCE_ISSUE.value),
+        },
+    )
+    return list(result.results or [])
+
+
 def fetch_report_ids_for_source_products(team: Team, source_products: list[str]) -> set[str]:
     """Return the set of report IDs that have at least one non-deleted signal from the given source products.
 

--- a/products/signals/backend/test/test_get_team_anomalies.py
+++ b/products/signals/backend/test/test_get_team_anomalies.py
@@ -1,0 +1,137 @@
+import json
+
+from posthog.test.base import BaseTest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from parameterized import parameterized
+
+from products.signals.backend.facade.api import (
+    ANOMALY_DETECTION_SKILL,
+    EVIDENCE_SOURCE_PRODUCT_QUERY_RUNS,
+    AnomalyFinding,
+    get_team_anomalies,
+)
+
+
+def _signal_row(skill_name=ANOMALY_DETECTION_SKILL, short_id="abc123", with_short_id=True):
+    evidence = [
+        {
+            "source_product": EVIDENCE_SOURCE_PRODUCT_QUERY_RUNS,
+            "summary": "spike",
+            **({"entity_id": short_id} if with_short_id else {}),
+        }
+    ]
+    metadata = {
+        "source_product": "signals_scout",
+        "source_type": "cross_source_issue",
+        "weight": 0.86,
+        "deleted": False,
+        "extra": {
+            "skill_name": skill_name,
+            "skill_version": 1.0,
+            "confidence": 0.9,
+            "finding_id": "f1",
+            "scout_run_id": "r1",
+            "task_run_id": "t1",
+            "evidence": evidence,
+            "hypothesis": "Likely a deploy regression.",
+            "severity": "P1",
+            "time_range": {"date_from": "2026-06-01T00:00:00Z", "date_to": "2026-06-08T00:00:00Z"},
+        },
+    }
+    return ("doc-1", "Signups dropped 60%.", json.dumps(metadata), "2026-06-07T00:00:00Z")
+
+
+class TestGetTeamAnomalies(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows", new_callable=AsyncMock)
+    def test_parses_and_scopes_to_anomaly_scout(self, mock_rows):
+        mock_rows.return_value = [_signal_row(), _signal_row(skill_name="signals-scout-logs")]
+        out = async_to_sync(get_team_anomalies)(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert len(out) == 1
+        a = out[0]
+        assert isinstance(a, AnomalyFinding)
+        assert a.insight_short_id == "abc123"
+        assert a.weight == 0.86
+        assert a.hypothesis == "Likely a deploy regression."
+        assert a.severity == "P1"
+        assert a.time_range == ("2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows", new_callable=AsyncMock)
+    def test_short_id_none_when_no_query_runs_evidence(self, mock_rows):
+        mock_rows.return_value = [_signal_row(with_short_id=False)]
+        out = async_to_sync(get_team_anomalies)(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert len(out) == 1
+        assert out[0].insight_short_id is None
+
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows", new_callable=AsyncMock)
+    def test_empty_when_ai_not_approved(self, mock_rows):
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+        mock_rows.return_value = [_signal_row()]
+        out = async_to_sync(get_team_anomalies)(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert out == []
+
+    @parameterized.expand(
+        [
+            ("bare_string", "date_from..date_to"),  # substring trap: must not match via `in` on a str
+            ("null_bound", {"date_from": None, "date_to": "2026-06-08T00:00:00Z"}),
+            ("missing_date_to", {"date_from": "2026-06-01T00:00:00Z"}),
+        ]
+    )
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows", new_callable=AsyncMock)
+    def test_malformed_time_range_degrades_to_none(self, _name, time_range, mock_rows):
+        # time_range is LLM-authored: anything but a dict with both truthy bounds must degrade to None.
+        metadata = {
+            "source_product": "signals_scout",
+            "source_type": "cross_source_issue",
+            "weight": 0.5,
+            "deleted": False,
+            "extra": {"skill_name": ANOMALY_DETECTION_SKILL, "time_range": time_range, "evidence": []},
+        }
+        mock_rows.return_value = [("doc", "content", json.dumps(metadata), "2026-06-07T00:00:00Z")]
+        out = async_to_sync(get_team_anomalies)(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert len(out) == 1
+        assert out[0].time_range is None
+
+    @patch("products.signals.backend.facade.api.fetch_team_anomaly_signal_rows", new_callable=AsyncMock)
+    def test_malformed_row_is_skipped_not_fatal(self, mock_rows):
+        mock_rows.return_value = [("bad", "content", "{not valid json", "2026-06-07T00:00:00Z"), _signal_row()]
+        out = async_to_sync(get_team_anomalies)(self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z")
+        assert len(out) == 1  # the malformed row is skipped, the valid one survives
+        assert out[0].insight_short_id == "abc123"
+
+
+class TestFetchTeamAnomalySignalRows(BaseTest):
+    def test_query_uses_single_brace_placeholders(self):
+        from products.signals.backend.temporal import signal_queries
+
+        captured = {}
+
+        async def _fake(**kwargs):
+            captured.update(kwargs)
+            return MagicMock(results=[])
+
+        with patch.object(signal_queries, "execute_hogql_query_with_retry", side_effect=_fake):
+            async_to_sync(signal_queries.fetch_team_anomaly_signal_rows)(
+                self.team, "2026-06-01T00:00:00Z", "2026-06-08T00:00:00Z"
+            )
+
+        query = captured["query"]
+        assert "{{" not in query and "}}" not in query, f"double braces leaked into query: {query}"
+        for ph in ("{team_id}", "{date_from}", "{date_to}", "{model_name}", "{source_product}", "{source_type}"):
+            assert ph in query, f"missing placeholder {ph} in query: {query}"
+        # placeholders dict must carry every placeholder the query references
+        assert set(captured["placeholders"].keys()) >= {
+            "team_id",
+            "date_from",
+            "date_to",
+            "model_name",
+            "source_product",
+            "source_type",
+        }


### PR DESCRIPTION
## Problem

Pulse (the proactive analytics digest product, stacked above this PR) needs to consume the anomalies that the Signals anomaly-detection scout surfaces. The scout is an LLM agent that emits its findings as raw signals into ClickHouse — there was no read path for another product to consume them, only write-side facade methods (`emit_signal`, `dismiss_report_from_slack`).

## Changes

Adds one read method to the signals facade: `get_team_anomalies(team, period_start, period_end) -> list[AnomalyFinding]`.

```mermaid
flowchart LR
    scout["Anomaly-detection scout<br/>(LLM agent)"] -->|emit_signal| ch[("ClickHouse<br/>document_embeddings<br/>source_product=signals_scout")]
    ch --> q["fetch_team_anomaly_signal_rows<br/>deduped · team-scoped ·<br/>ORDER BY timestamp DESC LIMIT 500"]
    q --> f["facade/api.py :: get_team_anomalies<br/>org AI-gate · skill_name filter ·<br/>defensive per-row parsing"]
    f --> dto["AnomalyFinding (frozen DTO)<br/>best-effort insight short_id, weight,<br/>hypothesis, severity, time_range"]
    dto -->|consumed by| pulse["products/pulse<br/>(stacked PRs above)"]
```

Design notes:

- **Raw signals, not grouped reports.** A `SignalReport` groups cross-source evidence — too fuzzy for a 1:1 "this insight is anomalous" mapping. The read scopes to `source_product=signals_scout` / `source_type=cross_source_issue` in ClickHouse, then narrows to the anomaly-detection skill in Python.
- **The metadata is LLM-authored, so parsing is defensive**: a per-row try/except (one malformed emit can't abort the batch), `isinstance`/truthiness guards on `time_range`, and the insight `short_id` is extracted best-effort from the `query_runs` evidence entry (anchored as a named constant). The consumer counts and skips unresolvable rows.
- **Mirrors `emit_signal`'s gates**: returns `[]` (with a log line) when the org hasn't approved AI data processing.
- The read is bounded (`LIMIT 500`) to match the sibling reads in `signal_queries.py`.

No new REST surface, no scout emit-contract change, no schema change.

## How did you test this code?

I'm an agent; no manual testing claimed. Automated coverage in `products/signals/backend/test/test_get_team_anomalies.py`: parsing + skill scoping, missing/short-id-less evidence, AI-gate-off, malformed-row isolation, non-dict and null-valued `time_range` degradation, and a query-construction test guarding the HogQL single-brace placeholders. Full pulse+signals suite (275 tests), ruff, and `tach check` green locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @vdekrijger. This is the cross-product base of the Pulse stack (#62116–#62120): Pulse consumes scout anomalies strictly through this facade method (tach-enforced). Reviewed via a local multi-reviewer swarm pass plus targeted hardening rounds (defensive parsing and the bounded read came out of those reviews).
