### PR TITLE
fix(docker): widen libssl pin to 3.0.*, fix hobby installer apt-key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -289,7 +289,9 @@ RUN apt-get update && \
     "libxmlsec1=1.2.37-2" \
     "libxmlsec1-openssl=1.2.37-2" \
     "libxml2" \
-    "libssl3=3.0.19-1~deb12u2" \
+    # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
+    # point releases out of the security archive, which breaks exact pins on uncached builds.
+    "libssl3=3.0.*" \
     "libjemalloc2" \
     && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -29,8 +29,10 @@ RUN apt-get update && \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
     "librdkafka-dev=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.19-1~deb12u2" \
-    "libssl3=3.0.19-1~deb12u2" \
+    # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
+    # point releases out of the security archive, which breaks exact pins on uncached builds.
+    "libssl-dev=3.0.*" \
+    "libssl3=3.0.*" \
     "zlib1g-dev" \
     && \
     rm -rf /var/lib/apt/lists/*
@@ -100,7 +102,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "libssl3=3.0.19-1~deb12u2" \
+    # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
+    # point releases out of the security archive, which breaks exact pins on uncached builds.
+    "libssl3=3.0.*" \
     "curl" \
     "gettext-base" \
     "libjemalloc2" \

--- a/Dockerfile.recording-rasterizer
+++ b/Dockerfile.recording-rasterizer
@@ -27,8 +27,10 @@ RUN apt-get update && \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
     "librdkafka-dev=2.10.1-1.cflt~deb12" \
-    "libssl-dev=3.0.19-1~deb12u2" \
-    "libssl3=3.0.19-1~deb12u2" \
+    # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
+    # point releases out of the security archive, which breaks exact pins on uncached builds.
+    "libssl-dev=3.0.*" \
+    "libssl3=3.0.*" \
     "zlib1g-dev" \
     && \
     rm -rf /var/lib/apt/lists/*
@@ -106,7 +108,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends --allow-downgrades \
     "librdkafka1=2.10.1-1.cflt~deb12" \
     "librdkafka++1=2.10.1-1.cflt~deb12" \
-    "libssl3=3.0.19-1~deb12u2" \
+    # libssl pinned to the 3.0 series (ABI-stable), not an exact version: Debian rotates
+    # point releases out of the security archive, which breaks exact pins on uncached builds.
+    "libssl3=3.0.*" \
     # ffmpeg intentionally unpinned: tracks the latest bookworm candidate so security point-updates flow in on rebuild
     "ffmpeg" \
     # Shared libraries required by chrome-headless-shell

--- a/bin/hobby-installer/core/docker.go
+++ b/bin/hobby-installer/core/docker.go
@@ -74,11 +74,15 @@ func InstallDocker() error {
 
 	logger.WriteString("Installing Docker...\n")
 
+	// apt-key was removed in Ubuntu 25.10; use the modern signed-by keyring approach instead.
+	// See https://docs.docker.com/engine/install/ubuntu/ and issue #54406.
 	commands := [][]string{
 		{"apt", "update"},
-		{"apt", "install", "-y", "apt-transport-https", "ca-certificates", "curl", "software-properties-common"},
-		{"sh", "-c", "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -"},
-		{"add-apt-repository", "-y", "deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"},
+		{"apt", "install", "-y", "apt-transport-https", "ca-certificates", "curl", "gnupg"},
+		{"install", "-d", "-m", "0755", "/etc/apt/keyrings"},
+		{"sh", "-c", "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg"},
+		{"chmod", "a+r", "/etc/apt/keyrings/docker.gpg"},
+		{"sh", "-c", "echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu jammy stable' > /etc/apt/sources.list.d/docker.list"},
 		{"apt", "update"},
 		{"apt", "install", "-y", "docker-ce"},
 	}


### PR DESCRIPTION
## Problem

Two independently reported apt breakages, both verified locally:

**Stale libssl pin.** Debian rotated `libssl3` in bookworm-security from `3.0.19-1~deb12u2` to `3.0.20-1~deb12u2`, so the exact pin in `Dockerfile`, `Dockerfile.node`, and `Dockerfile.recording-rasterizer` no longer resolves. Any build without a warm layer cache fails with `E: Version '3.0.19-1~deb12u2' for 'libssl3' was not found`. Reported in #62621 (thanks @gauravtiwari), which only covers `Dockerfile` — the other two Dockerfiles have the same pin.

**apt-key removal.** The hobby installer still pipes the Docker GPG key into `apt-key add`, which no longer exists on modern Ubuntu (apt 3.x / 25.10), so Docker installation fails there. Reported and fixed in #54620 (thanks @SAY-5).

## Changes

- Pin libssl to the `3.0.*` series instead of an exact version, in all three Dockerfiles. The exact pin came from #38156 as a companion to the librdkafka pin (SSL handshake drift between node-rdkafka and system libssl). The series glob keeps that guarantee — OpenSSL is ABI-stable within the series and bookworm only ever ships 3.0.x — without breaking every time Debian rotates a point release out of the security archive (this would have been the third bump: 3.0.17 → 3.0.19 → 3.0.20). The librdkafka pins are the load-bearing ones and stay exact.
- Cherry-pick the apt-key → signed-by keyring fix from #54620, preserving the original author. Same hardcoded jammy repo as before, just the modern keyring mechanism per Docker's install docs.

Closes #62621
Closes #54620
Closes #54406

## How did you test this code?

I'm an agent; verification done:

- Reproduced the libssl failure in a container on the `unit:1.34.2-python3.13` runtime base: installing `libssl3=3.0.19-1~deb12u2` fails with the apt error above.
- Verified `libssl3=3.0.*` and `libssl-dev=3.0.*` resolve and install `3.0.20-1~deb12u2` on both the `unit` and `node:24.13.0-bookworm-slim` base images.
- `go build ./...` passes for the hobby installer.
- `hadolint` output unchanged at the touched lines (glob still counts as a pinned version).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code; the assignee directed the work after triaging two external contributor PRs (#62621, #54620) that we adopt here for safety, with independent local verification.
- For the libssl pin, considered bumping the exact pin to 3.0.20 (as #62621 does) but chose the series glob after git-blame showed the pin's only purpose (build/runtime consistency for node-rdkafka, #38156) survives a series pin, while exact pins keep breaking on Debian security rotations.
- The #54620 commit is cherry-picked unmodified to preserve attribution.
