### PR TITLE
fix(exports): retry render timeouts in export asset activity

### DIFF
--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -12,9 +12,13 @@ from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
 
 from products.exports.backend.models.exported_asset import ExportedAsset
-from products.exports.backend.tasks.failure_handler import SYSTEM_ERROR_NAMES
+from products.exports.backend.tasks.failure_handler import SYSTEM_ERROR_NAMES, TIMEOUT_ERROR_NAMES, ExportCancelled
 
 logger = structlog.get_logger(__name__)
+
+# Render/query timeouts are transient and must stay retryable; an explicit
+# cancellation is terminal even though it lives in TIMEOUT_ERROR_NAMES.
+RETRYABLE_ERROR_NAMES = SYSTEM_ERROR_NAMES | (TIMEOUT_ERROR_NAMES - {ExportCancelled.__name__})
 
 
 @temporalio.activity.defn
@@ -59,7 +63,7 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
                 truncate_for_temporal_payload(str(e), MAX_ERROR_MESSAGE_CHARS),
                 truncate_for_temporal_payload(error_trace, MAX_ERROR_TRACE_CHARS),
                 type=exception_class,
-                non_retryable=exception_class not in SYSTEM_ERROR_NAMES,
+                non_retryable=exception_class not in RETRYABLE_ERROR_NAMES,
             ) from e
 
         await database_sync_to_async(asset.refresh_from_db, thread_sensitive=False)()

--- a/posthog/temporal/tests/test_export_activities.py
+++ b/posthog/temporal/tests/test_export_activities.py
@@ -10,8 +10,10 @@ from django.conf import settings
 
 import temporalio.workflow
 from asgiref.sync import sync_to_async
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from selenium.common import TimeoutException
 from temporalio.client import Client, WorkflowFailureError
-from temporalio.exceptions import ActivityError
+from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -21,7 +23,7 @@ from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
 
 from products.exports.backend.models.exported_asset import ExportedAsset
-from products.exports.backend.tasks.failure_handler import ExcelColumnLimitExceeded
+from products.exports.backend.tasks.failure_handler import ExcelColumnLimitExceeded, ExportCancelled
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
 
@@ -115,3 +117,33 @@ async def test_export_asset_activity_propagates_user_errors(mock_exporter: Magic
     app_error = activity_error.cause
     assert app_error is not None
     assert "ExcelColumnLimitExceeded" in str(app_error) or "18,278 columns" in str(app_error)
+
+
+@pytest.mark.parametrize(
+    "exception,expected_non_retryable",
+    [
+        (TimeoutError("Timeout while waiting for the page to load"), False),
+        (PlaywrightTimeoutError("Timeout 30000ms exceeded"), False),
+        (TimeoutException("renderer timed out"), False),
+        (ExportCancelled("export canceled"), True),
+        (ValueError("bad input"), True),
+    ],
+)
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_export_asset_activity_timeout_errors_are_retryable(
+    mock_exporter: MagicMock, activity_environment, team, exception, expected_non_retryable
+):
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format=ExportedAsset.ExportFormat.PNG,
+    )
+
+    def fake_export(asset_obj, **kwargs):
+        raise exception
+
+    mock_exporter.export_asset_direct = fake_export
+
+    with pytest.raises(ApplicationError) as exc_info:
+        await activity_environment.run(export_asset_activity, ExportAssetActivityInputs(exported_asset_id=asset.id))
+
+    assert exc_info.value.non_retryable is expected_non_retryable


### PR DESCRIPTION
## Problem

Image and screenshot export render timeouts (the headless browser never finishing page load) fail the export permanently on the first attempt. `export_asset_activity` wraps every exception in an `ApplicationError` whose `non_retryable` flag is set unless the exception class is in `SYSTEM_ERROR_NAMES` — and timeout classes live only in `TIMEOUT_ERROR_NAMES`, so `EXPORT_RETRY_POLICY`'s retry budget never gets a chance. Transient render slowness becomes a permanent failure.

Subscription deliveries fan out the same activity per asset, so one transient render timeout also degrades a scheduled delivery (`PartialExportFailure`): this one-line change covers both paths.

## Changes

- `posthog/temporal/exports/activities.py`: introduce `RETRYABLE_ERROR_NAMES = SYSTEM_ERROR_NAMES | (TIMEOUT_ERROR_NAMES - {ExportCancelled.__name__})` and use it for the `non_retryable` flag. Explicit cancellation stays terminal; render/query timeouts become retryable and defer to `EXPORT_RETRY_POLICY` (which already excludes user query errors).

**Suggested reading order:** the parameterized test first (it is the retryability oracle — timeout classes retryable, `ExportCancelled`/`ValueError` terminal), then the one-line production change. The import change is mechanical.

## How did you test this code?

Agent-authored, TDD: the new parameterized test failed on HEAD for the three timeout cases (`non_retryable` was `True`) and passes after the fix. Full containing file (`posthog/temporal/tests/test_export_activities.py`) passes. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a production SLO triage session (`slo_operation_completed` failure analysis) that traced export timeout failures and subscription partial-delivery failures to the same non-retryable wrapping.
- Asked: make export render timeouts retryable. Built: exactly that, with `ExportCancelled` deliberately excluded from the retryable set (it is defined as a terminal cancellation; currently never raised in production code, excluded for semantic correctness).
- TDD loop (failing test approved before fix), then an independent review agent graded the branch A−.
