### PR TITLE
chore(ci): report required checks on merge_group events

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -5,6 +5,11 @@ on:
         branches:
             - master
     pull_request:
+    # Required so `Dagster Tests Pass` (a required status check) reports on merge
+    # queue entries — without it the queue would wait for the check until timeout.
+    # The jobs themselves skip on merge_group (the suite already runs in full on
+    # every PR) and the aggregator treats skipped as success.
+    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -45,6 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Validate dagster path filter coverage
+        if: github.event_name != 'merge_group'
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -60,6 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         name: Determine need to run dagster checks
+        if: github.event_name != 'merge_group'
         # Set job outputs to values from filter step
         outputs:
             dagster: ${{ steps.filter.outputs.dagster || 'true' }}

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -16,6 +16,11 @@ on:
     push:
         branches:
             - master
+    # Required so `Playwright tests pass` (a required status check) reports on
+    # merge queue entries — without it the queue would wait for the check until
+    # timeout. The jobs themselves skip on merge_group (the suite already runs
+    # in full on every PR) and the aggregator treats skipped as success.
+    merge_group:
 
 permissions:
     contents: read
@@ -72,10 +77,13 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         # Run on master push, manual dispatch, and on internal-repo PRs.
+        # Skipped on merge_group (explicitly, though the allowlist below would
+        # also skip it implicitly) — see the trigger comment above.
         if: |
+            github.event_name != 'merge_group' && (
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch' ||
-            github.event.pull_request.head.repo.full_name == github.repository
+            github.event.pull_request.head.repo.full_name == github.repository)
         name: Determine need to run E2E checks
         outputs:
             shouldRun: ${{ steps.decide.outputs.shouldRun }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -4,6 +4,11 @@ on:
     push:
         branches: [master]
     pull_request:
+    # Required so `MCP Tests Pass` (a required status check) reports on merge
+    # queue entries — without it the queue would wait for the check until timeout.
+    # The jobs themselves skip on merge_group (the suite already runs in full on
+    # every PR) and the aggregator treats skipped as success.
+    merge_group:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -22,6 +27,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run MCP checks
+        if: github.event_name != 'merge_group'
         outputs:
             mcp: ${{ steps.filter.outputs.mcp || 'true' }}
         steps:


### PR DESCRIPTION
## Problem

Three required status checks on `master` — `Dagster Tests Pass`, `Playwright tests pass`, and `MCP Tests Pass` — come from workflows that don't trigger on `merge_group`. With the GitHub merge queue enabled (planned as the safety net for #58053), every queue entry would wait for these checks until the response timeout evicts it, so nothing would merge.

This is a prerequisite for enabling the queue: it must land on master first, because merge queue entries run workflow files from master merged with each PR.

## Changes

Adds the `merge_group` trigger to `ci-dagster.yml`, `ci-mcp.yml`, and `ci-e2e-playwright.yml`, and gates their root jobs on `github.event_name != 'merge_group'` — the same pattern `ci-storybook.yml` already uses.

These three suites are not narrowed on PRs (they already run in full on every PR), so re-running them in the queue adds cost without adding safety. The root `changes` job skips on `merge_group`, downstream jobs skip via `needs`, and the existing `if: always()` aggregator jobs treat skipped as success — so the required checks report green on queue entries with no test jobs run.

If a later change narrows any of these suites on `pull_request`, the corresponding merge_group gate must flip from skip to run at that point.

## How did you test this code?

Agent-authored, no manual testing. Validated YAML parses for all three files; verified each downstream job's `if` condition resolves to skipped when `changes` skips (implicit `success()` on `needs`, or explicit output checks against empty strings), and that each aggregator's outcome script accepts `skipped` results. CI's actionlint job covers expression linting.

## Publish to changelog?

no

## Docs update

no

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by @gantoine as a prerequisite for enabling the merge queue ahead of #58053.

Decisions worth flagging:

- **Skip rather than run on merge_group.** These suites run unnarrowed on every PR, so the PR run is already the full safety check; running them again per queue entry would only burn runners. Mirrors how storybook handles `merge_group` today.
- **Playwright's `changes` gate was already implicitly merge_group-safe** (its event allowlist doesn't match `merge_group`), but the exclusion is now explicit so a future condition edit can't silently start running it in the queue.
- **`validate-paths` in the Dagster workflow is also gated** — it's not a required check, just avoids a wasted job per queue entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
