### PR TITLE
fix(alerts): cap activity retry budgets inside workflow execution timeout

### DIFF
--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -145,6 +145,7 @@ class CheckAlertWorkflow(PostHogWorkflow):
                 prepare_alert,
                 PrepareAlertActivityInputs(alert_id=inputs.alert_id),
                 start_to_close_timeout=dt.timedelta(minutes=2),
+                schedule_to_close_timeout=ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
                 retry_policy=ALERT_PREPARE_RETRY_POLICY,
             )
 

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -37,6 +37,14 @@ with temporalio.workflow.unsafe.imports_passed_through():
 
     from posthog.temporal.ai.anomaly_investigation import AnomalyInvestigationWorkflowInputs
 
+# Each activity's retry budget must exhaust inside the child workflow's execution
+# timeout: a server-side workflow timeout skips workflow code entirely, so the SLO
+# completion would never be emitted and the alert's next_check_at would never advance.
+# Compound worst cases (e.g. a slow prepare pushing evaluate past the envelope) can
+# still hit the server-side timeout; the cap guarantees no single activity does.
+CHECK_ALERT_EXECUTION_TIMEOUT = dt.timedelta(minutes=15)
+ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT = dt.timedelta(minutes=12)
+
 
 @temporalio.workflow.defn(name="schedule-due-alert-checks")
 class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
@@ -88,7 +96,7 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
                 ),
                 id=f"check-alert-{alert.alert_id}",
                 parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
-                execution_timeout=dt.timedelta(minutes=15),
+                execution_timeout=CHECK_ALERT_EXECUTION_TIMEOUT,
             )
             tasks.append(task)
 
@@ -149,6 +157,7 @@ class CheckAlertWorkflow(PostHogWorkflow):
                 evaluate_alert,
                 EvaluateAlertActivityInputs(alert_id=inputs.alert_id),
                 start_to_close_timeout=dt.timedelta(minutes=10),
+                schedule_to_close_timeout=ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
                 heartbeat_timeout=dt.timedelta(minutes=2),
                 retry_policy=ALERT_EVALUATE_RETRY_POLICY,
             )
@@ -167,6 +176,7 @@ class CheckAlertWorkflow(PostHogWorkflow):
                         breaches=evaluation.breaches,
                     ),
                     start_to_close_timeout=dt.timedelta(minutes=5),
+                    schedule_to_close_timeout=ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
                     retry_policy=ALERT_NOTIFY_RETRY_POLICY,
                 )
 

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -352,6 +352,7 @@ async def test_alert_activity_retry_budgets_capped_inside_execution_timeout():
         if activity is notify_alert:
             captured["notify"] = kwargs
             return None
+        captured["prepare"] = kwargs
         return MagicMock(action=PrepareAction.EVALUATE)
 
     with patch("temporalio.workflow.execute_activity", side_effect=fake_execute_activity):
@@ -366,7 +367,7 @@ async def test_alert_activity_retry_budgets_capped_inside_execution_timeout():
             )
         )
 
-    assert captured.keys() == {"evaluate", "notify"}
+    assert captured.keys() == {"prepare", "evaluate", "notify"}
     for kwargs in captured.values():
         assert kwargs["schedule_to_close_timeout"] == ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT
         assert kwargs["schedule_to_close_timeout"] < CHECK_ALERT_EXECUTION_TIMEOUT

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -27,12 +27,8 @@ from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.tasks.alerts.utils import AlertEvaluationResult
 from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
 from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
-from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, PrepareAction, SkipReason
-from posthog.temporal.alerts.workflows import (
-    ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
-    CHECK_ALERT_EXECUTION_TIMEOUT,
-    CheckAlertWorkflow,
-)
+from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, SkipReason
+from posthog.temporal.alerts.workflows import CheckAlertWorkflow
 from posthog.temporal.common.slo_interceptor import SloInterceptor
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, Threshold
@@ -335,39 +331,3 @@ async def test_check_alert_workflow_auto_disables_alert_with_invalid_config(
     assert completed_props["outcome"] == SloOutcome.SUCCESS
     assert completed_props.get("skip_reason") is not None
     assert "alert_state" not in completed_props
-
-
-@pytest.mark.asyncio
-async def test_alert_activity_retry_budgets_capped_inside_execution_timeout():
-    captured: dict[str, dict[str, Any]] = {}
-
-    async def fake_execute_activity(activity: Any, *args: Any, **kwargs: Any) -> Any:
-        if activity is evaluate_alert:
-            captured["evaluate"] = kwargs
-            return MagicMock(
-                should_notify=True,
-                should_gate_notification=False,
-                should_start_investigation=False,
-            )
-        if activity is notify_alert:
-            captured["notify"] = kwargs
-            return None
-        captured["prepare"] = kwargs
-        return MagicMock(action=PrepareAction.EVALUATE)
-
-    with patch("temporalio.workflow.execute_activity", side_effect=fake_execute_activity):
-        await CheckAlertWorkflow().run(
-            CheckAlertWorkflowInputs(
-                alert_id=str(uuid.uuid4()),
-                team_id=1,
-                distinct_id="d",
-                calculation_interval="daily",
-                insight_id=1,
-                slo=None,
-            )
-        )
-
-    assert captured.keys() == {"prepare", "evaluate", "notify"}
-    for kwargs in captured.values():
-        assert kwargs["schedule_to_close_timeout"] == ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT
-        assert kwargs["schedule_to_close_timeout"] < CHECK_ALERT_EXECUTION_TIMEOUT

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -27,8 +27,12 @@ from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.tasks.alerts.utils import AlertEvaluationResult
 from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
 from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
-from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, SkipReason
-from posthog.temporal.alerts.workflows import CheckAlertWorkflow
+from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, PrepareAction, SkipReason
+from posthog.temporal.alerts.workflows import (
+    ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT,
+    CHECK_ALERT_EXECUTION_TIMEOUT,
+    CheckAlertWorkflow,
+)
 from posthog.temporal.common.slo_interceptor import SloInterceptor
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, Threshold
@@ -331,3 +335,38 @@ async def test_check_alert_workflow_auto_disables_alert_with_invalid_config(
     assert completed_props["outcome"] == SloOutcome.SUCCESS
     assert completed_props.get("skip_reason") is not None
     assert "alert_state" not in completed_props
+
+
+@pytest.mark.asyncio
+async def test_alert_activity_retry_budgets_capped_inside_execution_timeout():
+    captured: dict[str, dict[str, Any]] = {}
+
+    async def fake_execute_activity(activity: Any, *args: Any, **kwargs: Any) -> Any:
+        if activity is evaluate_alert:
+            captured["evaluate"] = kwargs
+            return MagicMock(
+                should_notify=True,
+                should_gate_notification=False,
+                should_start_investigation=False,
+            )
+        if activity is notify_alert:
+            captured["notify"] = kwargs
+            return None
+        return MagicMock(action=PrepareAction.EVALUATE)
+
+    with patch("temporalio.workflow.execute_activity", side_effect=fake_execute_activity):
+        await CheckAlertWorkflow().run(
+            CheckAlertWorkflowInputs(
+                alert_id=str(uuid.uuid4()),
+                team_id=1,
+                distinct_id="d",
+                calculation_interval="daily",
+                insight_id=1,
+                slo=None,
+            )
+        )
+
+    assert captured.keys() == {"evaluate", "notify"}
+    for kwargs in captured.values():
+        assert kwargs["schedule_to_close_timeout"] == ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT
+        assert kwargs["schedule_to_close_timeout"] < CHECK_ALERT_EXECUTION_TIMEOUT


### PR DESCRIPTION
## Problem

When an alert's evaluation query hangs, `evaluate_alert`'s retry budget (10-minute start-to-close × up to 5 attempts) can exceed the check-alert child workflow's 15-minute `execution_timeout`. Temporal then closes the workflow **server-side** (TimedOut) — no workflow code runs, so:

- the SLO interceptor's `finally` never emits `slo_operation_completed` (a silent SLO loss, invisible to failure-rate alerting), and
- the alert's `next_check_at` never advances, so the scheduler re-dispatches the same check on the next run, indefinitely — each loop consuming a full 15-minute evaluation slot.

```mermaid
sequenceDiagram
    participant S as Scheduler workflow
    participant W as CheckAlertWorkflow (15m execution_timeout)
    participant A as evaluate_alert activity
    S->>W: start child (SLO started emitted)
    W->>A: attempt 1 (hangs, heartbeating)
    A--xW: start_to_close 10m
    W->>A: attempt 2
    Note over W: t=15m: server closes workflow TimedOut<br/>no workflow code runs, no SLO completion,<br/>next_check_at never advances
    S->>W: next schedule run starts the same check again
```

## Changes

- `posthog/temporal/alerts/workflows.py`: new constants `CHECK_ALERT_EXECUTION_TIMEOUT` (15m) and `ALERT_ACTIVITY_SCHEDULE_TO_CLOSE_TIMEOUT` (12m); the cap is applied to **both** `evaluate_alert` and `notify_alert` (notify's uncapped budget of 5 × 5m alone exceeded the execution timeout — same mechanism, caught in review). Retries now exhaust inside the workflow, so the failure surfaces through workflow code: SLO completion is emitted and the check is recorded as errored.
- Compound worst cases (slow prepare pushing evaluate near the envelope) are acknowledged in the constants comment; the invariant guaranteed here is that no *single* activity's budget exceeds the envelope.

**Suggested reading order:** the test (drives the workflow through evaluate + notify with a patched `execute_activity` and asserts both receive the cap, and that the cap is below the execution timeout), then the constants block, then the two call sites.

## How did you test this code?

Agent-authored, TDD: the wiring test failed on HEAD (`schedule_to_close_timeout` kwarg absent) and passes after the fix. Full containing file (`posthog/temporal/tests/test_alerts_workflows.py`) passes. The server-side-timeout behavior itself is Temporal-internal and not unit-testable; the test pins the configuration invariant. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a production SLO triage session: orphaned `slo_operation_started` events (start with no completion) concentrated on a small number of alerts re-checking on a tight loop led to the execution-timeout arithmetic above.
- Asked: cap evaluate's retry budget below the workflow execution timeout. Built: that, plus the same cap on `notify_alert` after an independent review agent flagged its budget alone exceeds the envelope (review round 2 regraded A−).
- Follow-up worth considering separately: why the affected alerts' queries hang at all (likely candidates for the query-timeout class).
