### PR TITLE
fix(hogql): raise QueryError for unsubstituted filters/variables placeholders

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -1,3 +1,4 @@
+import re
 import dataclasses
 from datetime import date, datetime
 from typing import ClassVar, Literal, Optional, TypedDict, Union, cast
@@ -60,6 +61,8 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
+
+from common.hogvm.python.utils import HogVMException
 
 tracer = trace.get_tracer(__name__)
 DIRECT_POSTGRES_CONNECT_TIMEOUT_SECONDS = 15
@@ -334,7 +337,28 @@ class HogQLQueryExecutor:
                 )
 
             if finder.placeholder_fields or finder.placeholder_expressions:
-                self.select_query = cast(ast.SelectQuery, replace_placeholders(self.select_query, self.placeholders))
+                try:
+                    self.select_query = cast(
+                        ast.SelectQuery, replace_placeholders(self.select_query, self.placeholders)
+                    )
+                except HogVMException as e:
+                    # A {filters.*}/{variables.*} placeholder that escaped substitution is a
+                    # malformed query, not an internal error — surface it as a user-facing one.
+                    match = re.fullmatch(r"Global variable not found: (filters|variables)", str(e))
+                    if not match:
+                        raise
+                    name = match.group(1)
+                    provided = self.filters is not None if name == "filters" else bool(self.variables)
+                    if provided:
+                        # Substitution only handles direct fields; a complex expression like
+                        # {toDateTime(filters.dateRange.from)} skips it and lands here.
+                        message = (
+                            f"'{name}' can only be used as a direct placeholder field "
+                            f"(e.g. {{{name}.foo}}), not inside a placeholder expression."
+                        )
+                    else:
+                        message = f"Query uses '{name}' in a placeholder, but no {name} were provided with the query."
+                    raise QueryError(message) from e
 
     @tracer.start_as_current_span("HogQLQueryExecutor._apply_limit")
     def _apply_limit(self):

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -344,6 +344,8 @@ class HogQLQueryExecutor:
                 except HogVMException as e:
                     # A {filters.*}/{variables.*} placeholder that escaped substitution is a
                     # malformed query, not an internal error — surface it as a user-facing one.
+                    # The matched text is pinned by common/hogvm/python/test/test_execute.py; if
+                    # it ever drifts, this fails open to re-raising the original exception.
                     match = re.fullmatch(r"Global variable not found: (filters|variables)", str(e))
                     if not match:
                         raise

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1649,17 +1649,31 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             f"Query uses '{name}' in a placeholder, but no {name} were provided with the query.",
         )
 
-    def test_placeholder_expression_with_filters_provided_raises_query_error(self):
-        with self.assertRaises(QueryError) as e:
-            execute_hogql_query(
-                "SELECT event FROM events WHERE {toDateTime(filters.dateRange.from)} < now()",
+    @parameterized.expand(["filters", "variables"])
+    def test_placeholder_expression_with_globals_provided_raises_query_error(self, name: str):
+        if name == "filters":
+            query = "SELECT event FROM events WHERE {toDateTime(filters.dateRange.from)} < now()"
+            kwargs: dict = {"filters": HogQLFilters(dateRange=DateRange(date_from="-7d"))}
+        else:
+            insight_variable = InsightVariable.objects.create(
                 team=self.team,
-                filters=HogQLFilters(dateRange=DateRange(date_from="-7d")),
+                name="Test var",
+                code_name="test_var",
+                type=InsightVariable.Type.STRING,
             )
+            query = "SELECT {toString(variables.test_var)}"
+            kwargs = {
+                "variables": {
+                    "test_var": HogQLVariable(code_name="test_var", value="x", variableId=str(insight_variable.id))
+                }
+            }
+
+        with self.assertRaises(QueryError) as e:
+            execute_hogql_query(query, team=self.team, **kwargs)
         self.assertEqual(
             str(e.exception),
-            "'filters' can only be used as a direct placeholder field "
-            "(e.g. {filters.foo}), not inside a placeholder expression.",
+            f"'{name}' can only be used as a direct placeholder field "
+            f"(e.g. {{{name}.foo}}), not inside a placeholder expression.",
         )
 
     def test_placeholder_with_unknown_global_reraises_hogvm_exception(self):

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -47,6 +47,8 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 from products.product_analytics.backend.models.insight_variable import InsightVariable
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
+from common.hogvm.python.utils import HogVMException
+
 
 class TestQuery(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
@@ -1632,6 +1634,37 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             str(e.exception),
             "Variable variable_two is missing from query. Did you mean: variable_one?",
         )
+
+    @parameterized.expand(
+        [
+            ("variables", "SELECT {variables.test_var}"),
+            ("filters", "SELECT event FROM events WHERE {toDateTime(filters.dateRange.from)} < now()"),
+        ]
+    )
+    def test_placeholder_without_globals_raises_query_error(self, name: str, query: str):
+        with self.assertRaises(QueryError) as e:
+            execute_hogql_query(query, team=self.team)
+        self.assertEqual(
+            str(e.exception),
+            f"Query uses '{name}' in a placeholder, but no {name} were provided with the query.",
+        )
+
+    def test_placeholder_expression_with_filters_provided_raises_query_error(self):
+        with self.assertRaises(QueryError) as e:
+            execute_hogql_query(
+                "SELECT event FROM events WHERE {toDateTime(filters.dateRange.from)} < now()",
+                team=self.team,
+                filters=HogQLFilters(dateRange=DateRange(date_from="-7d")),
+            )
+        self.assertEqual(
+            str(e.exception),
+            "'filters' can only be used as a direct placeholder field "
+            "(e.g. {filters.foo}), not inside a placeholder expression.",
+        )
+
+    def test_placeholder_with_unknown_global_reraises_hogvm_exception(self):
+        with self.assertRaises(HogVMException):
+            execute_hogql_query("SELECT {nonexistent.x}", team=self.team)
 
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_hogql_query_filters(self):


### PR DESCRIPTION
## Problem

A HogQL query referencing `{filters.*}` or `{variables.*}` placeholders that escape substitution is evaluated in the HogVM with empty globals and fails with an internal `HogVMException` ("Global variable not found: filters"). This leaks an internal error to the user for what is really a malformed query, and counts as a service failure in SLO metrics. Two ways to get there:

- a `{variables.x}` placeholder with no variables map supplied, and
- a complex placeholder expression like `{toDateTime(filters.dateRange.from)}` — `FindPlaceholders` only recognizes direct field chains, so `replace_filters` is skipped *even when filters were provided*.

## Changes

- `posthog/hogql/query.py` (`_process_placeholders`): wrap `replace_placeholders` in a narrow `except HogVMException` that matches exactly "Global variable not found: (filters|variables)" and re-raises as a user-facing `QueryError` (an `ExposedHogQLError`, so it is classified as a user error downstream). Any other `HogVMException` re-raises unchanged.
- The message depends on whether the globals were provided: "no filters were provided with the query" vs. "'filters' can only be used as a direct placeholder field (e.g. {filters.foo}), not inside a placeholder expression" — the second case exists because substitution genuinely cannot resolve expression-embedded references.

**Suggested reading order:** the three tests (parameterized not-provided cases for both globals; provided-filters complex-expression case asserting the second message; unknown-global case asserting unrelated HogVM errors still re-raise), then the except block. The `re`/`HogVMException` imports are mechanical.

## How did you test this code?

Agent-authored, TDD: the parameterized test failed on HEAD with `HogVMException` for both globals and passes after the fix. Full containing file (`posthog/hogql/test/test_query.py`) passes including snapshots. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a production SLO triage session that surfaced recurring `HogVMException` query-service failures with sub-20ms durations (compile-time, pre-ClickHouse).
- Decisions: catch-and-translate at the executor chokepoint rather than a typed exception in the shared HogVM package (proportionate to a focused fix; the regex fails open — message drift reverts to the old behavior rather than mistranslating). An independent review agent flagged the original single message as misleading for the provided-filters case; the two-message split and the re-raise test came from that round (regraded A−).
- Known residual, deliberately out of scope: `HogQLQueryRunner.to_query` calls `replace_placeholders` directly when variables are present; the no-variables production cases flow through this chokepoint and are covered.
