### PR TITLE
fix(api): serialize non-utf8 bytes as hex in orjson fallback

### DIFF
--- a/posthog/cache_utils.py
+++ b/posthog/cache_utils.py
@@ -8,8 +8,8 @@ from django.utils.timezone import now
 
 import orjson
 from django_redis.serializers.base import BaseSerializer
-from rest_framework.utils.encoders import JSONEncoder
 
+from posthog.renderers import orjson_default
 from posthog.settings import TEST
 
 P = ParamSpec("P")
@@ -89,7 +89,7 @@ def instance_memoize(callback):
 class OrjsonJsonSerializer(BaseSerializer):
     def dumps(self, value: Any) -> bytes:
         option = orjson.OPT_UTC_Z
-        return orjson.dumps(value, default=JSONEncoder().default, option=option)
+        return orjson.dumps(value, default=orjson_default, option=option)
 
     def loads(self, value: bytes) -> Any:
         return orjson.loads(value)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -1,8 +1,23 @@
+from typing import Any
+
 import orjson
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.utils.encoders import JSONEncoder
 
 CleaningMarker = bool | dict[int, "CleaningMarker"]
+
+_DRF_ENCODER = JSONEncoder()
+
+
+def orjson_default(obj: Any) -> Any:
+    # ClickHouse can return non-UTF-8 binary (FixedString, aggregate states); DRF's
+    # encoder does a bare .decode() that blows up on those — fall back to hex.
+    if isinstance(obj, bytes):
+        try:
+            return obj.decode()
+        except UnicodeDecodeError:
+            return obj.hex()
+    return _DRF_ENCODER.default(obj)
 
 
 class SafeJSONRenderer(JSONRenderer):
@@ -15,7 +30,7 @@ class SafeJSONRenderer(JSONRenderer):
         if renderer_context and renderer_context.get("indent"):
             option |= orjson.OPT_INDENT_2
 
-        return orjson.dumps(data, default=JSONEncoder().default, option=option)
+        return orjson.dumps(data, default=orjson_default, option=option)
 
 
 class ServerSentEventRenderer(BaseRenderer):

--- a/posthog/test/test_cache_utils.py
+++ b/posthog/test/test_cache_utils.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from time import sleep
 from typing import Optional
@@ -5,7 +6,9 @@ from typing import Optional
 from posthog.test.base import APIBaseTest
 from unittest.mock import Mock
 
-from posthog.cache_utils import cache_for
+from parameterized import parameterized
+
+from posthog.cache_utils import OrjsonJsonSerializer, cache_for
 
 mocked_dependency = Mock()
 mocked_dependency.return_value = 1
@@ -34,6 +37,17 @@ class TestCacheUtils(APIBaseTest):
         mocked_dependency.reset_mock()
         mocked_dependency.return_value = 1
         order_of_events.reset_mock()
+
+    @parameterized.expand(
+        [
+            ("utf8_bytes", b"hello", "hello"),
+            ("non_utf8_bytes", b"\x80\x81\xff", "8081ff"),
+        ]
+    )
+    def test_orjson_serializer_dumps_bytes(self, _name, value, expected) -> None:
+        serializer = OrjsonJsonSerializer({})
+
+        assert json.loads(serializer.dumps({"value": value})) == {"value": expected}
 
     def test_cache_for_with_different_passed_arguments_styles_when_skipping_cache(self) -> None:
         assert 1 == fn(use_cache=False)

--- a/posthog/test/test_renderers.py
+++ b/posthog/test/test_renderers.py
@@ -2,6 +2,8 @@ import json
 
 from django.test import TestCase
 
+from parameterized import parameterized
+
 from posthog.renderers import SafeJSONRenderer
 
 
@@ -72,6 +74,17 @@ class TestCleanDataForJSON(TestCase):
                 "test": [None, [None, None, 1.0], None, 5.0],
             },
         )
+
+    @parameterized.expand(
+        [
+            ("utf8_bytes", b"hello", "hello"),
+            ("non_utf8_bytes", b"\x80\x81\xff", "8081ff"),
+        ]
+    )
+    def test_renders_bytes(self, _name, value, expected):
+        data = SafeJSONRenderer().render({"value": value})
+
+        self.assertEqual(json.loads(data), {"value": expected})
 
     def test_cleans_dict_with_nan_nested_dict(self):
         response = {


### PR DESCRIPTION
## Problem

When a query result contains non-UTF-8 binary (ClickHouse `FixedString` columns, aggregate function states), the query itself succeeds but the JSON render of the response fails with `Type is not JSON serializable: bytes`. Both orjson serialization sites in the query path — the API response renderer and the query cache serializer — fall back to DRF's `JSONEncoder.default`, which decodes bytes with a bare `.decode()`; the resulting `UnicodeDecodeError` surfaces through orjson as a `TypeError`.

## Changes

- `posthog/renderers.py`: shared `orjson_default` hook — UTF-8 bytes decode to a string exactly as before; non-UTF-8 bytes (which previously always raised) hex-encode; everything else delegates to a module-level DRF encoder instance. `SafeJSONRenderer` uses it.
- `posthog/cache_utils.py`: `OrjsonJsonSerializer` uses the same hook (import direction is cycle-free: `renderers.py` imports nothing from `posthog.*`).

**Suggested reading order:** the parameterized tests at both sites (UTF-8 round-trips unchanged — regression guard; `b"\x80\x81\xff"` renders as `"8081ff"`), then the hook. The call-site changes are mechanical.

Deliberately out of scope: `posthog/utils.py to_json` has the same fallback but serializes pydantic-derived query dicts for cache keys, where bytes cannot appear; left untouched to keep blast radius minimal.

## How did you test this code?

Agent-authored, TDD: the non-UTF-8 cases failed on HEAD (`TypeError` at the renderer) and pass after the fix. Full containing files (`posthog/test/test_renderers.py`, `posthog/test/test_cache_utils.py`) pass. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a production SLO triage session; the root cause (DRF's bare `.decode()` swallowed by orjson) was confirmed with a live repro before writing the fix.
- Decisions: hex over base64 for the non-decodable representation (compact, greppable, and strictly new surface — that input previously always raised, so no existing consumer can change behavior); shared hook lives in `renderers.py` because it imports nothing from `posthog.*`. Independent review agent graded A−.
