### PR TITLE
refactor(alerts): converge anomaly-detector path onto the evaluation contract

### DIFF
--- a/posthog/tasks/alerts/detector.py
+++ b/posthog/tasks/alerts/detector.py
@@ -1,27 +1,12 @@
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 
-from posthog.schema import DetectorType, IntervalType, TrendsAlertConfig, TrendsQuery
+from posthog.schema import DetectorType, IntervalType, TrendsQuery
 
-from posthog.api.services.query import ExecutionMode
-from posthog.caching.calculate_results import calculate_for_query_based_insight
-from posthog.schema_migrations.upgrade_manager import upgrade_query
-from posthog.tasks.alerts.detectors import get_detector
 from posthog.tasks.alerts.detectors.base import DetectionResult
-from posthog.tasks.alerts.trends import (
-    TrendResult,
-    _drop_incomplete_current_interval,
-    _has_breakdown,
-    _is_non_time_series_trend,
-    _pick_series_result,
-)
-from posthog.tasks.alerts.utils import WRAPPER_NODE_KINDS, AlertEvaluationResult
-from posthog.utils import get_from_dict_or_attr
-
-from products.alerts.backend.models.alert import AlertConfiguration
-from products.product_analytics.backend.models.insight import Insight
+from posthog.tasks.alerts.trends import TrendResult, _drop_incomplete_current_interval
 
 # Minimum samples required for each detector type
 DETECTOR_MIN_SAMPLES: dict[DetectorType, int] = {
@@ -46,11 +31,6 @@ DETECTOR_DEFAULT_WINDOW = 30
 # Maximum number of breakdown values to evaluate with a detector.
 # Matches the default breakdown_limit in the query layer (25).
 MAX_DETECTOR_BREAKDOWN_VALUES = 25
-
-
-# ---------------------------------------------------------------------------
-# Shared data-prep and detection helpers
-# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -81,13 +61,6 @@ def _prepare_series(series: TrendResult, is_non_time_series: bool) -> PreparedSe
     return PreparedSeries(data=data, dates=dates, label=series.get("label", "Series"))
 
 
-def _map_triggered_dates(result: DetectionResult, dates: list[str]) -> list[str]:
-    """Map triggered indices to their corresponding date strings."""
-    if not result.triggered_indices or not dates:
-        return []
-    return [dates[i] for i in result.triggered_indices if i < len(dates)]
-
-
 def _extract_sub_detector_scores(detector_type_str: str, result: DetectionResult) -> list[dict[str, Any]] | None:
     """Extract per-sub-detector scores for ensemble detectors."""
     if detector_type_str != "ensemble" or not result.metadata:
@@ -99,11 +72,6 @@ def _extract_sub_detector_scores(detector_type_str: str, result: DetectionResult
         if sr.get("all_scores")
     ]
     return scores or None
-
-
-# ---------------------------------------------------------------------------
-# Min-samples and date-range helpers
-# ---------------------------------------------------------------------------
 
 
 def _compute_min_samples_for_detector(detector_config: dict[str, Any]) -> int:
@@ -157,272 +125,3 @@ def _date_range_override_for_detector(query: TrendsQuery, min_samples: int) -> d
             date_from = f"-{min_samples}h"
 
     return {"date_from": date_from}
-
-
-# ---------------------------------------------------------------------------
-# Alert check
-# ---------------------------------------------------------------------------
-
-
-def check_trends_alert_with_detector(
-    alert: AlertConfiguration, insight: Insight, query: TrendsQuery, detector_config: dict[str, Any]
-) -> AlertEvaluationResult:
-    """Check a trends alert using detector-based anomaly detection."""
-    config = (
-        TrendsAlertConfig.model_validate(alert.config)
-        if alert.config
-        else TrendsAlertConfig(type="TrendsAlertConfig", series_index=0)
-    )
-    detector_type_str = detector_config.get("type", "zscore")
-
-    # Request one extra sample because we drop the current (incomplete) interval.
-    min_samples = _compute_min_samples_for_detector(detector_config) + 1
-    filters_override = _date_range_override_for_detector(query, min_samples)
-
-    is_non_time_series = _is_non_time_series_trend(query)
-    if is_non_time_series:
-        filters_override = None
-
-    execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
-    if query.interval == IntervalType.HOUR:
-        execution_mode = ExecutionMode.CALCULATE_BLOCKING_ALWAYS
-
-    calculation_result = calculate_for_query_based_insight(
-        insight,
-        team=alert.team,
-        execution_mode=execution_mode,
-        user=None,
-        filters_override=filters_override,
-    )
-
-    if calculation_result.result is None:
-        raise RuntimeError(f"No results found for insight with alert id = {alert.id}")
-
-    if not calculation_result.result:
-        return AlertEvaluationResult(
-            value=0,
-            breaches=[],
-            interval=query.interval.value if query.interval else None,
-        )
-
-    interval_value = query.interval.value if query.interval else None
-
-    if _has_breakdown(query):
-        breakdown_results = cast(list[TrendResult], calculation_result.result)[:MAX_DETECTOR_BREAKDOWN_VALUES]
-
-        for bd_index, breakdown_result in enumerate(breakdown_results):
-            prepared = _prepare_series(breakdown_result, is_non_time_series)
-            if prepared is None:
-                continue
-
-            detector = get_detector(detector_config)
-            result = detector.detect(prepared.data)
-
-            if result.is_anomaly:
-                current_value = float(prepared.data[-1])
-                score_str = f" (anomaly probability: {result.score:.0%})" if result.score is not None else ""
-                return AlertEvaluationResult(
-                    value=current_value,
-                    breaches=[
-                        f"Anomaly detected in {prepared.label}: value {current_value:.2f}{score_str} using {detector_type_str} detector"
-                    ],
-                    anomaly_scores=result.all_scores or None,
-                    triggered_points=result.triggered_indices if result.triggered_indices else None,
-                    triggered_dates=_map_triggered_dates(result, prepared.dates) or None,
-                    interval=interval_value,
-                    triggered_metadata={"series_index": bd_index},
-                )
-
-        return AlertEvaluationResult(value=None, breaches=[], interval=interval_value)
-
-    # Non-breakdown: pick a single series by index
-    selected = _pick_series_result(config, calculation_result)
-    prepared = _prepare_series(selected, is_non_time_series)
-    if prepared is None:
-        return AlertEvaluationResult(value=None, breaches=[], interval=interval_value)
-
-    detector = get_detector(detector_config)
-    result = detector.detect(prepared.data)
-
-    triggered_dates = _map_triggered_dates(result, prepared.dates) or None
-
-    breaches: list[str] = []
-    if result.is_anomaly:
-        current_value = float(prepared.data[-1])
-        score_str = f" (anomaly probability: {result.score:.0%})" if result.score is not None else ""
-
-        sub_scores_str = ""
-        if detector_type_str == "ensemble" and result.metadata:
-            sub_results = result.metadata.get("sub_results", [])
-            if sub_results:
-                parts = []
-                for sr in sub_results:
-                    sr_type = sr.get("type", "unknown")
-                    sr_score = sr.get("score")
-                    sr_fired = sr.get("is_anomaly", False)
-                    score_pct = f"{sr_score:.0%}" if sr_score is not None else "n/a"
-                    parts.append(f"{sr_type}: {score_pct}{' [fired]' if sr_fired else ''}")
-                sub_scores_str = f" | sub-detectors: {', '.join(parts)}"
-
-        breaches.append(
-            f"Anomaly detected in {prepared.label}: value {current_value:.2f}{score_str} using {detector_type_str} detector{sub_scores_str}"
-        )
-
-    return AlertEvaluationResult(
-        value=float(prepared.data[-1]) if len(prepared.data) > 0 else None,
-        breaches=breaches if breaches else [],
-        anomaly_scores=result.all_scores or None,
-        triggered_points=result.triggered_indices if result.triggered_indices else None,
-        triggered_dates=triggered_dates,
-        interval=interval_value,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Simulation (read-only, no AlertCheck records)
-# ---------------------------------------------------------------------------
-
-
-def _build_series_sim_result(
-    prepared: PreparedSeries,
-    detector_config: dict[str, Any],
-    detector_type_str: str,
-) -> dict[str, Any]:
-    """Run detect_batch on a single prepared series and return a simulation result dict."""
-    detector = get_detector(detector_config)
-    result = detector.detect_batch(prepared.data)
-
-    triggered_dates = _map_triggered_dates(result, prepared.dates)
-    scores = result.all_scores if result.all_scores else [None] * len(prepared.data)
-
-    sim: dict[str, Any] = {
-        "label": prepared.label,
-        "data": prepared.data.tolist(),
-        "dates": prepared.dates,
-        "scores": scores,
-        "triggered_indices": result.triggered_indices or [],
-        "triggered_dates": triggered_dates,
-        "total_points": len(prepared.data),
-        "anomaly_count": len(result.triggered_indices) if result.triggered_indices else 0,
-    }
-
-    sub_scores = _extract_sub_detector_scores(detector_type_str, result)
-    if sub_scores:
-        sim["sub_detector_scores"] = sub_scores
-
-    return sim
-
-
-def simulate_detector_on_insight(
-    insight: Insight,
-    team: Any,
-    detector_config: dict[str, Any],
-    series_index: int = 0,
-    date_from: str | None = None,
-) -> dict[str, Any]:
-    """Run a detector over historical insight data for chart visualization.
-
-    No AlertCheck records are created — this is read-only.
-    """
-    if insight.query is None:
-        raise ValueError("Insight has no valid query.")
-
-    with upgrade_query(insight):
-        query = insight.query
-
-    kind = get_from_dict_or_attr(query, "kind")
-    if kind in WRAPPER_NODE_KINDS:
-        query = get_from_dict_or_attr(query, "source")
-        kind = get_from_dict_or_attr(query, "kind")
-
-    if kind != "TrendsQuery":
-        raise ValueError("Only TrendsQuery insights are supported for simulation.")
-
-    trends_query = TrendsQuery.model_validate(query)
-    detector_type_str = detector_config.get("type", "zscore")
-    min_samples = _compute_min_samples_for_detector(detector_config)
-
-    # +1 because _drop_incomplete_current_interval removes the last point
-    min_samples_with_padding = min_samples + 1
-    min_date_from = _date_range_override_for_detector(trends_query, min_samples_with_padding)
-
-    is_non_time_series = _is_non_time_series_trend(trends_query)
-    if is_non_time_series:
-        filters_override = None
-    elif date_from:
-        # Use whichever goes further back: the user's range or the detector minimum.
-        # We parse both to absolute datetimes and pick the earlier one.
-        from zoneinfo import ZoneInfo
-
-        from posthog.utils import relative_date_parse
-
-        utc = ZoneInfo("UTC")
-        user_dt = relative_date_parse(date_from, utc)
-        min_dt = relative_date_parse(min_date_from["date_from"], utc) if min_date_from else None
-        if min_dt and min_dt < user_dt:
-            filters_override = min_date_from
-        else:
-            filters_override = {"date_from": date_from}
-    else:
-        filters_override = min_date_from
-
-    execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
-    if trends_query.interval == IntervalType.HOUR:
-        execution_mode = ExecutionMode.CALCULATE_BLOCKING_ALWAYS
-
-    calculation_result = calculate_for_query_based_insight(
-        insight,
-        team=team,
-        execution_mode=execution_mode,
-        user=None,
-        filters_override=filters_override,
-    )
-
-    if calculation_result.result is None or not calculation_result.result:
-        raise ValueError("No results found for insight.")
-
-    interval_value = trends_query.interval.value if trends_query.interval else None
-
-    if _has_breakdown(trends_query):
-        all_results = cast(list[TrendResult], calculation_result.result)[:MAX_DETECTOR_BREAKDOWN_VALUES]
-        breakdown_sims: list[dict[str, Any]] = []
-        total_points = 0
-        total_anomalies = 0
-
-        for br in all_results:
-            prepared = _prepare_series(br, is_non_time_series)
-            if prepared is None:
-                continue
-
-            sim = _build_series_sim_result(prepared, detector_config, detector_type_str)
-            breakdown_sims.append(sim)
-            total_points += sim["total_points"]
-            total_anomalies += sim["anomaly_count"]
-
-        if not breakdown_sims:
-            raise ValueError("No breakdown values had enough data points for simulation.")
-
-        return {
-            "data": [],
-            "dates": [],
-            "scores": [],
-            "triggered_indices": [],
-            "triggered_dates": [],
-            "interval": interval_value,
-            "total_points": total_points,
-            "anomaly_count": total_anomalies,
-            "breakdown_results": breakdown_sims,
-        }
-
-    # Non-breakdown
-    config = TrendsAlertConfig(type="TrendsAlertConfig", series_index=series_index)
-    selected = _pick_series_result(config, calculation_result)
-    prepared = _prepare_series(selected, is_non_time_series)
-    if prepared is None:
-        raise ValueError("No data points found for the selected series.")
-
-    sim = _build_series_sim_result(prepared, detector_config, detector_type_str)
-
-    # For non-breakdown, promote fields to top level (no "label" key)
-    sim.pop("label", None)
-    return {**sim, "interval": interval_value}

--- a/posthog/tasks/alerts/test/test_detector_breakdowns.py
+++ b/posthog/tasks/alerts/test/test_detector_breakdowns.py
@@ -18,24 +18,15 @@ from posthog.schema import (
 
 from posthog.caching.fetch_from_cache import InsightResult
 from posthog.tasks.alerts.detector import MAX_DETECTOR_BREAKDOWN_VALUES
-from posthog.tasks.alerts.utils import AlertEvaluationResult
 
 from products.alerts.backend.evaluation.detector import (
     evaluate_with_detector,
     extract_detector_series,
     simulate_detector_on_insight,
 )
+from products.alerts.backend.evaluation.dispatcher import check_detector_alert
 from products.alerts.backend.models.alert import AlertConfiguration
 from products.product_analytics.backend.models.insight import Insight
-
-
-def check_trends_alert_with_detector(
-    alert: Any, insight: Any, query: TrendsQuery, detector_config: dict[str, Any]
-) -> AlertEvaluationResult:
-    """Evaluate a detector alert through the extractor + detector scorer (test convenience)."""
-    series_index = (alert.config or {}).get("series_index", 0)
-    result = extract_detector_series(insight, alert.team, query, detector_config, series_index=series_index)
-    return evaluate_with_detector(result, detector_config)
 
 
 def _make_trend_result(label: str, data: list[float], breakdown_value: str = "") -> dict[str, Any]:
@@ -115,7 +106,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         insight = MagicMock(spec=Insight)
         query = _make_query_with_breakdown()
 
-        result = check_trends_alert_with_detector(alert, insight, query, ZSCORE_DETECTOR_CONFIG)
+        result = check_detector_alert(alert, insight, query)
 
         assert result.breaches is not None and len(result.breaches) > 0
         assert "staking" in result.breaches[0]
@@ -143,7 +134,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         insight = MagicMock(spec=Insight)
         query = _make_query_with_breakdown()
 
-        result = check_trends_alert_with_detector(alert, insight, query, ZSCORE_DETECTOR_CONFIG)
+        result = check_detector_alert(alert, insight, query)
 
         assert result.breaches == []
         assert result.value is None
@@ -175,7 +166,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         insight = MagicMock(spec=Insight)
         query = _make_query_with_breakdown()
 
-        result = check_trends_alert_with_detector(alert, insight, query, ZSCORE_DETECTOR_CONFIG)
+        result = check_detector_alert(alert, insight, query)
 
         # The anomalous breakdown is beyond the cap, so it should NOT fire
         assert result.breaches == []
@@ -199,7 +190,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         insight = MagicMock(spec=Insight)
         query = _make_query_with_breakdown()
 
-        result = check_trends_alert_with_detector(alert, insight, query, ZSCORE_DETECTOR_CONFIG)
+        result = check_detector_alert(alert, insight, query)
 
         # Should not error, and should not fire (stable data only)
         assert result.breaches == []
@@ -222,7 +213,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         insight = MagicMock(spec=Insight)
         query = _make_query_without_breakdown()
 
-        result = check_trends_alert_with_detector(alert, insight, query, ZSCORE_DETECTOR_CONFIG)
+        result = check_detector_alert(alert, insight, query)
 
         assert result.breaches is not None and len(result.breaches) > 0
         assert "Anomaly detected" in result.breaches[0]
@@ -247,7 +238,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         insight = MagicMock(spec=Insight)
         query = _make_query_with_breakdown()
 
-        result = check_trends_alert_with_detector(alert, insight, query, ZSCORE_DETECTOR_CONFIG)
+        result = check_detector_alert(alert, insight, query)
 
         assert result.anomaly_scores is not None
         assert result.triggered_points is not None

--- a/posthog/tasks/alerts/test/test_detector_breakdowns.py
+++ b/posthog/tasks/alerts/test/test_detector_breakdowns.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from unittest.mock import MagicMock, patch
 
+from parameterized import parameterized
+
 from posthog.schema import (
     AlertCalculationInterval,
     BaseMathType,
@@ -15,14 +17,22 @@ from posthog.schema import (
 )
 
 from posthog.caching.fetch_from_cache import InsightResult
-from posthog.tasks.alerts.detector import (
-    MAX_DETECTOR_BREAKDOWN_VALUES,
-    check_trends_alert_with_detector,
+from posthog.tasks.alerts.detector import MAX_DETECTOR_BREAKDOWN_VALUES
+
+from products.alerts.backend.evaluation.detector import (
+    evaluate_with_detector,
+    extract_detector_series,
     simulate_detector_on_insight,
 )
-
 from products.alerts.backend.models.alert import AlertConfiguration
 from products.product_analytics.backend.models.insight import Insight
+
+
+def check_trends_alert_with_detector(alert, insight, query, detector_config):
+    """Evaluate a detector alert through the extractor + detector scorer (test convenience)."""
+    series_index = (alert.config or {}).get("series_index", 0)
+    result = extract_detector_series(insight, alert.team, query, detector_config, series_index=series_index)
+    return evaluate_with_detector(result, detector_config)
 
 
 def _make_trend_result(label: str, data: list[float], breakdown_value: str = "") -> dict[str, Any]:
@@ -83,7 +93,7 @@ ZSCORE_DETECTOR_CONFIG = {"type": "zscore", "threshold": 0.9, "window": 10}
 
 
 class TestCheckTrendsAlertWithDetectorBreakdowns:
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_fires_when_one_breakdown_is_anomalous(self, mock_calc: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -110,7 +120,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         # "staking" is at index 1 in the breakdown results
         assert result.triggered_metadata == {"series_index": 1}
 
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_does_not_fire_when_all_breakdowns_are_normal(self, mock_calc: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -135,7 +145,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         assert result.breaches == []
         assert result.value is None
 
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_caps_at_max_breakdown_values(self, mock_calc: MagicMock) -> None:
         # Create more than MAX_DETECTOR_BREAKDOWN_VALUES breakdown results
         # Put the anomaly in the last one (beyond the cap)
@@ -167,7 +177,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         # The anomalous breakdown is beyond the cap, so it should NOT fire
         assert result.breaches == []
 
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_skips_breakdown_with_insufficient_data(self, mock_calc: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -191,7 +201,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         # Should not error, and should not fire (stable data only)
         assert result.breaches == []
 
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_non_breakdown_still_works(self, mock_calc: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -216,7 +226,7 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         # Non-breakdown alerts should not set triggered_metadata
         assert result.triggered_metadata is None
 
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_breakdown_result_includes_anomaly_scores(self, mock_calc: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -240,10 +250,56 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         assert result.triggered_points is not None
         assert result.interval == "day"
 
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
+    def test_empty_query_result_reports_zero(self, mock_calc: MagicMock) -> None:
+        # No rows at all → the metric genuinely is 0, distinct from "couldn't compute".
+        mock_calc.return_value = InsightResult(
+            result=[], columns=[], timezone="UTC", last_refresh=None, cache_key="", is_cached=False
+        )
+
+        alert = _make_alert(MagicMock(), ZSCORE_DETECTOR_CONFIG)
+        extraction = extract_detector_series(
+            MagicMock(spec=Insight), alert.team, _make_query_without_breakdown(), ZSCORE_DETECTOR_CONFIG
+        )
+        assert extraction.series == []
+        assert extraction.empty_query_result is True
+
+        result = evaluate_with_detector(extraction, ZSCORE_DETECTOR_CONFIG)
+        assert result.value == 0
+        assert result.breaches == []
+
+    @parameterized.expand(
+        [
+            ("non_breakdown", _make_query_without_breakdown(), [_make_trend_result("signed_up", [5.0], "")]),
+            (
+                "breakdown_all_short",
+                _make_query_with_breakdown(),
+                [_make_trend_result("a", [5.0], "a"), _make_trend_result("b", [3.0], "b")],
+            ),
+        ]
+    )
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
+    def test_unscorable_series_report_uncomputed_value(
+        self, _name: str, query: TrendsQuery, result_data: list[dict[str, Any]], mock_calc: MagicMock
+    ) -> None:
+        # Rows exist but every series is too short to score → value is None (NULL), not 0.
+        mock_calc.return_value = InsightResult(
+            result=result_data, columns=[], timezone="UTC", last_refresh=None, cache_key="", is_cached=False
+        )
+
+        alert = _make_alert(MagicMock(), ZSCORE_DETECTOR_CONFIG)
+        extraction = extract_detector_series(MagicMock(spec=Insight), alert.team, query, ZSCORE_DETECTOR_CONFIG)
+        assert extraction.series == []
+        assert extraction.empty_query_result is False
+
+        result = evaluate_with_detector(extraction, ZSCORE_DETECTOR_CONFIG)
+        assert result.value is None
+        assert result.breaches == []
+
 
 class TestSimulateDetectorBreakdowns:
-    @patch("posthog.tasks.alerts.detector.upgrade_query")
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.upgrade_query")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_returns_breakdown_results(self, mock_calc: MagicMock, _mock_upgrade: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -274,8 +330,8 @@ class TestSimulateDetectorBreakdowns:
         # Aggregated totals (each series has 1 point dropped for the incomplete current interval)
         assert result["total_points"] == (len(STABLE_DATA) - 1) + (len(ANOMALOUS_DATA) - 1)
 
-    @patch("posthog.tasks.alerts.detector.upgrade_query")
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.upgrade_query")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_non_breakdown_has_no_breakdown_results(self, mock_calc: MagicMock, _mock_upgrade: MagicMock) -> None:
         mock_calc.return_value = InsightResult(
             result=[
@@ -300,8 +356,8 @@ class TestSimulateDetectorBreakdowns:
 
         assert "breakdown_results" not in result
 
-    @patch("posthog.tasks.alerts.detector.upgrade_query")
-    @patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @patch("products.alerts.backend.evaluation.detector.upgrade_query")
+    @patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_caps_breakdown_simulations(self, mock_calc: MagicMock, _mock_upgrade: MagicMock) -> None:
         breakdown_results = [
             _make_trend_result(f"origin_{i}", STABLE_DATA, f"origin_{i}")

--- a/posthog/tasks/alerts/test/test_detector_breakdowns.py
+++ b/posthog/tasks/alerts/test/test_detector_breakdowns.py
@@ -18,6 +18,7 @@ from posthog.schema import (
 
 from posthog.caching.fetch_from_cache import InsightResult
 from posthog.tasks.alerts.detector import MAX_DETECTOR_BREAKDOWN_VALUES
+from posthog.tasks.alerts.utils import AlertEvaluationResult
 
 from products.alerts.backend.evaluation.detector import (
     evaluate_with_detector,
@@ -28,7 +29,9 @@ from products.alerts.backend.models.alert import AlertConfiguration
 from products.product_analytics.backend.models.insight import Insight
 
 
-def check_trends_alert_with_detector(alert, insight, query, detector_config):
+def check_trends_alert_with_detector(
+    alert: Any, insight: Any, query: TrendsQuery, detector_config: dict[str, Any]
+) -> AlertEvaluationResult:
     """Evaluate a detector alert through the extractor + detector scorer (test convenience)."""
     series_index = (alert.config or {}).get("series_index", 0)
     result = extract_detector_series(insight, alert.team, query, detector_config, series_index=series_index)

--- a/posthog/tasks/alerts/test/test_detector_breakdowns.py
+++ b/posthog/tasks/alerts/test/test_detector_breakdowns.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
@@ -12,6 +13,7 @@ from posthog.schema import (
     ChartDisplayType,
     EventsNode,
     IntervalType,
+    NodeKind,
     TrendsFilter,
     TrendsQuery,
 )
@@ -289,6 +291,19 @@ class TestCheckTrendsAlertWithDetectorBreakdowns:
         result = evaluate_with_detector(extraction, ZSCORE_DETECTOR_CONFIG)
         assert result.value is None
         assert result.breaches == []
+
+    @parameterized.expand(
+        [
+            ("hogql", NodeKind.HOG_QL_QUERY),
+            ("funnels", NodeKind.FUNNELS_QUERY),
+        ]
+    )
+    def test_detector_alert_on_unsupported_kind_raises(self, _name: str, kind: NodeKind) -> None:
+        # Detector alerts are trends-only: a detector_config on any other insight kind is rejected
+        # loudly via the DETECTOR_EXTRACTORS miss, not silently routed to the threshold path.
+        alert = _make_alert(MagicMock(), ZSCORE_DETECTOR_CONFIG)
+        with pytest.raises(NotImplementedError):
+            check_detector_alert(alert, MagicMock(spec=Insight), {"kind": kind})
 
 
 class TestSimulateDetectorBreakdowns:

--- a/posthog/temporal/ai/anomaly_investigation/tools.py
+++ b/posthog/temporal/ai/anomaly_investigation/tools.py
@@ -105,7 +105,7 @@ def _run_detector_simulation(
     """
     # Imported lazily because the workflow module can't pull in heavy query machinery
     # at Temporal workflow-definition time — only activities can.
-    from posthog.tasks.alerts.detector import simulate_detector_on_insight
+    from products.alerts.backend.evaluation.detector import simulate_detector_on_insight
 
     try:
         return simulate_detector_on_insight(

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -10,7 +10,7 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.schema import AlertCalculationInterval, AlertState
 
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.errors import CH_TRANSIENT_ERRORS
 from posthog.exceptions_capture import capture_exception
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -201,8 +201,8 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
                 non_retryable=True,
             )
 
-        # CH workload management keys off this tag to isolate alert queries from other tenants.
-        tag_queries(alert_config_id=str(alert.id))
+        # CH workload management keys off these tags to isolate alert queries from other tenants.
+        tag_queries(alert_config_id=str(alert.id), product=Product.PRODUCT_ANALYTICS, feature=Feature.ALERTING)
 
         # Snapshot before add_alert_check mutates alert.state — needed to detect the
         # NOT_FIRING/ERRORED -> FIRING transition that triggers an investigation.

--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -39,6 +39,7 @@ from posthog.tasks.alerts.utils import (
 from posthog.utils import relative_date_parse
 
 from products.alerts.backend.api.alert_schedule_restriction import AlertScheduleRestriction
+from products.alerts.backend.evaluation.detector import simulate_detector_on_insight
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, AlertSubscription, Threshold
 from products.product_analytics.backend.models.insight import Insight
 
@@ -915,8 +916,6 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     )
     @action(detail=False, methods=["POST"], url_path="simulate", required_scopes=["alert:read"])
     def simulate(self, request, *args, **kwargs):
-        from posthog.tasks.alerts.detector import simulate_detector_on_insight
-
         serializer = AlertSimulateSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
 

--- a/products/alerts/backend/api/test/test_alert.py
+++ b/products/alerts/backend/api/test/test_alert.py
@@ -1007,7 +1007,7 @@ class TestAlertSimulate(APIBaseTest):
         }
         self.insight = self.client.post(f"/api/projects/{self.team.id}/insights", data=self.insight_data).json()
 
-    @mock.patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @mock.patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_simulate_returns_valid_response(self, mock_calculate) -> None:
         mock_calculate.return_value = mock.MagicMock(
             result=[
@@ -1073,7 +1073,7 @@ class TestAlertSimulate(APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @mock.patch("posthog.tasks.alerts.detector.calculate_for_query_based_insight")
+    @mock.patch("products.alerts.backend.evaluation.detector.calculate_for_query_based_insight")
     def test_simulate_does_not_create_alert_check_records(self, mock_calculate) -> None:
         mock_calculate.return_value = mock.MagicMock(
             result=[

--- a/products/alerts/backend/evaluation/detector.py
+++ b/products/alerts/backend/evaluation/detector.py
@@ -203,7 +203,13 @@ def simulate_detector_on_insight(
     interval_value = trends_query.interval.value if trends_query.interval else None
 
     if not result.series:
-        raise ValueError("No results found for insight.")
+        # Preserve the original, more specific diagnostics: a genuinely empty query vs rows that
+        # exist but are all too short to score (per breakdown / single-series).
+        if result.empty_query_result:
+            raise ValueError("No results found for insight.")
+        if result.is_breakdown:
+            raise ValueError("No breakdown values had enough data points for simulation.")
+        raise ValueError("No data points found for the selected series.")
 
     if result.is_breakdown:
         breakdown_sims = [_sim_from_series(s, detector_config, detector_type_str) for s in result.series]
@@ -235,7 +241,9 @@ def _sim_from_series(
     sim: dict[str, Any] = {
         "label": series.label,
         "data": [p.value for p in series.points],
-        "dates": [p.date for p in series.points],
+        # Non-time-series points carry no date; emit [] (not [None]) to match the legacy shape and
+        # satisfy the dates=ListField(child=CharField()) serializer.
+        "dates": [p.date for p in series.points if p.date is not None],
         "scores": scores,
         "triggered_indices": triggered,
         "triggered_dates": _triggered_dates(series, triggered),

--- a/products/alerts/backend/evaluation/detector.py
+++ b/products/alerts/backend/evaluation/detector.py
@@ -7,6 +7,7 @@ from posthog.schema import IntervalType, NodeKind, TrendsAlertConfig, TrendsQuer
 
 from posthog.api.services.query import ExecutionMode
 from posthog.caching.calculate_results import calculate_for_query_based_insight
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 
 # Low-level scoring/extraction primitives still live in the legacy detector module.
@@ -212,6 +213,8 @@ def simulate_detector_on_insight(
         raise ValueError("Only TrendsQuery insights are supported for simulation.")
 
     trends_query = TrendsQuery.model_validate(query)
+    # Read-only simulation runs outside the alert-check activity, so tag its query directly.
+    tag_queries(product=Product.PRODUCT_ANALYTICS, feature=Feature.ALERTING)
     detector_type_str = detector_config.get("type", "zscore")
     result = extract_detector_series(
         insight, team, trends_query, detector_config, series_index=series_index, date_from=date_from

--- a/products/alerts/backend/evaluation/detector.py
+++ b/products/alerts/backend/evaluation/detector.py
@@ -23,6 +23,7 @@ from posthog.tasks.alerts.utils import WRAPPER_NODE_KINDS, AlertEvaluationResult
 from posthog.utils import get_from_dict_or_attr, relative_date_parse
 
 from products.alerts.backend.evaluation.contract import ComparableSeries, ExtractionResult, SeriesPoint
+from products.alerts.backend.models.alert import AlertConfiguration
 from products.product_analytics.backend.models.insight import Insight
 
 
@@ -172,6 +173,21 @@ def evaluate_with_detector(result: ExtractionResult, detector_config: dict[str, 
         triggered_dates=_triggered_dates(s, detection.triggered_indices or []) or None,
         interval=interval_value,
     )
+
+
+class TrendsDetectorExtractor:
+    """Detector-path extractor for trends insights. Conforms to the same ``Extractor`` protocol as
+    the threshold ``TrendsExtractor`` and emits the same ``ComparableSeries`` — it only differs in
+    fetching the detector's wider lookback window (the whole series is scored, not a single anchor).
+    """
+
+    def extract(self, alert: AlertConfiguration, insight: Insight, query: Any) -> ExtractionResult:
+        detector_config = alert.detector_config
+        if not detector_config:
+            raise ValueError("TrendsDetectorExtractor requires detector_config — dispatcher invariant violated")
+        trends_query = TrendsQuery.model_validate(query)
+        series_index = (alert.config or {}).get("series_index", 0)
+        return extract_detector_series(insight, alert.team, trends_query, detector_config, series_index=series_index)
 
 
 def simulate_detector_on_insight(

--- a/products/alerts/backend/evaluation/detector.py
+++ b/products/alerts/backend/evaluation/detector.py
@@ -1,0 +1,248 @@
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+import numpy as np
+
+from posthog.schema import IntervalType, NodeKind, TrendsAlertConfig, TrendsQuery
+
+from posthog.api.services.query import ExecutionMode
+from posthog.caching.calculate_results import calculate_for_query_based_insight
+from posthog.schema_migrations.upgrade_manager import upgrade_query
+
+# Low-level scoring/extraction primitives still live in the legacy detector module.
+from posthog.tasks.alerts.detector import (
+    MAX_DETECTOR_BREAKDOWN_VALUES,
+    _compute_min_samples_for_detector,
+    _date_range_override_for_detector,
+    _extract_sub_detector_scores,
+    _prepare_series,
+)
+from posthog.tasks.alerts.detectors import get_detector
+from posthog.tasks.alerts.trends import TrendResult, _has_breakdown, _is_non_time_series_trend, _pick_series_result
+from posthog.tasks.alerts.utils import WRAPPER_NODE_KINDS, AlertEvaluationResult
+from posthog.utils import get_from_dict_or_attr, relative_date_parse
+
+from products.alerts.backend.evaluation.contract import ComparableSeries, ExtractionResult, SeriesPoint
+from products.product_analytics.backend.models.insight import Insight
+
+
+def extract_detector_series(
+    insight: Insight,
+    team: Any,
+    query: TrendsQuery,
+    detector_config: dict[str, Any],
+    *,
+    series_index: int = 0,
+    date_from: str | None = None,
+) -> ExtractionResult:
+    """Run a trends insight over the detector's lookback window and normalize it into series.
+
+    Each ``ComparableSeries`` carries the full (complete-interval) history the detector scores —
+    the incomplete current interval is already dropped by ``_prepare_series``. Raises on a ``None``
+    result (swallowed query error). A genuinely empty query result yields an empty series list with
+    ``empty_query_result=True``; rows that exist but are too short to score are dropped, also leaving
+    an empty series list, but with the flag False — the two cases evaluate to 0 and None respectively.
+    """
+    min_samples = _compute_min_samples_for_detector(detector_config) + 1
+    is_non_time_series = _is_non_time_series_trend(query)
+    has_breakdown = _has_breakdown(query)
+
+    if is_non_time_series:
+        filters_override = None
+    elif date_from:
+        # Use whichever goes further back: the caller's range or the detector minimum.
+        min_date_from = _date_range_override_for_detector(query, min_samples)
+        utc = ZoneInfo("UTC")
+        user_dt = relative_date_parse(date_from, utc)
+        min_dt = relative_date_parse(min_date_from["date_from"], utc) if min_date_from else None
+        filters_override = min_date_from if (min_dt and min_dt < user_dt) else {"date_from": date_from}
+    else:
+        filters_override = _date_range_override_for_detector(query, min_samples)
+
+    execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+    if query.interval == IntervalType.HOUR:
+        execution_mode = ExecutionMode.CALCULATE_BLOCKING_ALWAYS
+
+    calculation_result = calculate_for_query_based_insight(
+        insight, team=team, execution_mode=execution_mode, user=None, filters_override=filters_override
+    )
+
+    if calculation_result.result is None:
+        raise RuntimeError(f"No results found for insight with id = {insight.id}")
+    if not calculation_result.result:
+        return ExtractionResult(
+            series=[], is_breakdown=has_breakdown, interval_type=query.interval, empty_query_result=True
+        )
+
+    if has_breakdown:
+        results = cast(list[TrendResult], calculation_result.result)[:MAX_DETECTOR_BREAKDOWN_VALUES]
+    else:
+        config = TrendsAlertConfig(type="TrendsAlertConfig", series_index=series_index)
+        results = [_pick_series_result(config, calculation_result)]
+
+    series: list[ComparableSeries] = []
+    for result in results:
+        prepared = _prepare_series(result, is_non_time_series)
+        if prepared is None:
+            continue
+        points = [
+            SeriesPoint(date=(prepared.dates[i] if i < len(prepared.dates) else None), value=float(value))
+            for i, value in enumerate(prepared.data)
+        ]
+        # current_index is set for contract conformance but unread on this path: the detector scores
+        # the whole series rather than comparing against a single anchor interval.
+        series.append(ComparableSeries(label=prepared.label, points=points, current_index=len(points) - 1))
+
+    return ExtractionResult(series=series, is_breakdown=has_breakdown, interval_type=query.interval)
+
+
+def _triggered_dates(series: ComparableSeries, triggered_indices: list[int]) -> list[str]:
+    """Map triggered indices to their date strings, skipping points that carry no date."""
+    return [date for i in triggered_indices if i < len(series.points) and (date := series.points[i].date) is not None]
+
+
+def _anomaly_breach(
+    label: str, current_value: float, score: float | None, detector_type_str: str, suffix: str = ""
+) -> str:
+    score_str = f" (anomaly probability: {score:.0%})" if score is not None else ""
+    return (
+        f"Anomaly detected in {label}: value {current_value:.2f}{score_str} using {detector_type_str} detector{suffix}"
+    )
+
+
+def _format_sub_detector(sub_result: dict[str, Any]) -> str:
+    """Render one ensemble sub-detector's score for the breach message suffix."""
+    score = sub_result.get("score")
+    score_pct = f"{score:.0%}" if score is not None else "n/a"
+    fired = " [fired]" if sub_result.get("is_anomaly", False) else ""
+    return f"{sub_result.get('type', 'unknown')}: {score_pct}{fired}"
+
+
+def evaluate_with_detector(result: ExtractionResult, detector_config: dict[str, Any]) -> AlertEvaluationResult:
+    """Score an extracted trends series with an anomaly detector (the non-threshold alert path).
+
+    Breakdown alerts fire on the first anomalous breakdown value; non-breakdown alerts score the
+    single selected series.
+    """
+    detector_type_str = detector_config.get("type", "zscore")
+    interval_value = result.interval_type.value if result.interval_type else None
+
+    if not result.series:
+        # Empty query → the metric is genuinely 0; rows present but unscorable → uncomputed (None).
+        value: float | None = 0 if result.empty_query_result else None
+        return AlertEvaluationResult(value=value, breaches=[], interval=interval_value)
+
+    if result.is_breakdown:
+        for bd_index, s in enumerate(result.series):
+            data = np.array([p.value for p in s.points])
+            detection = get_detector(detector_config).detect(data)
+            if detection.is_anomaly:
+                current_value = float(data[-1])
+                return AlertEvaluationResult(
+                    value=current_value,
+                    breaches=[_anomaly_breach(s.label, current_value, detection.score, detector_type_str)],
+                    anomaly_scores=detection.all_scores or None,
+                    triggered_points=detection.triggered_indices or None,
+                    triggered_dates=_triggered_dates(s, detection.triggered_indices or []) or None,
+                    interval=interval_value,
+                    triggered_metadata={"series_index": bd_index},
+                )
+        return AlertEvaluationResult(value=None, breaches=[], interval=interval_value)
+
+    s = result.series[0]
+    data = np.array([p.value for p in s.points])
+    detection = get_detector(detector_config).detect(data)
+
+    breaches: list[str] = []
+    if detection.is_anomaly:
+        current_value = float(data[-1])
+        suffix = ""
+        if detector_type_str == "ensemble" and detection.metadata:
+            sub_results = detection.metadata.get("sub_results", [])
+            if sub_results:
+                parts = [_format_sub_detector(sr) for sr in sub_results]
+                suffix = f" | sub-detectors: {', '.join(parts)}"
+        breaches.append(_anomaly_breach(s.label, current_value, detection.score, detector_type_str, suffix))
+
+    return AlertEvaluationResult(
+        value=float(data[-1]) if len(data) > 0 else None,
+        breaches=breaches,
+        anomaly_scores=detection.all_scores or None,
+        triggered_points=detection.triggered_indices or None,
+        triggered_dates=_triggered_dates(s, detection.triggered_indices or []) or None,
+        interval=interval_value,
+    )
+
+
+def simulate_detector_on_insight(
+    insight: Insight,
+    team: Any,
+    detector_config: dict[str, Any],
+    series_index: int = 0,
+    date_from: str | None = None,
+) -> dict[str, Any]:
+    """Run a detector over historical insight data for chart visualization. Read-only (no AlertCheck)."""
+    if insight.query is None:
+        raise ValueError("Insight has no valid query.")
+
+    with upgrade_query(insight):
+        query = insight.query
+
+    kind = get_from_dict_or_attr(query, "kind")
+    if kind in WRAPPER_NODE_KINDS:
+        query = get_from_dict_or_attr(query, "source")
+        kind = get_from_dict_or_attr(query, "kind")
+    if kind != NodeKind.TRENDS_QUERY:
+        raise ValueError("Only TrendsQuery insights are supported for simulation.")
+
+    trends_query = TrendsQuery.model_validate(query)
+    detector_type_str = detector_config.get("type", "zscore")
+    result = extract_detector_series(
+        insight, team, trends_query, detector_config, series_index=series_index, date_from=date_from
+    )
+    interval_value = trends_query.interval.value if trends_query.interval else None
+
+    if not result.series:
+        raise ValueError("No results found for insight.")
+
+    if result.is_breakdown:
+        breakdown_sims = [_sim_from_series(s, detector_config, detector_type_str) for s in result.series]
+        return {
+            "data": [],
+            "dates": [],
+            "scores": [],
+            "triggered_indices": [],
+            "triggered_dates": [],
+            "interval": interval_value,
+            "total_points": sum(sim["total_points"] for sim in breakdown_sims),
+            "anomaly_count": sum(sim["anomaly_count"] for sim in breakdown_sims),
+            "breakdown_results": breakdown_sims,
+        }
+
+    sim = _sim_from_series(result.series[0], detector_config, detector_type_str)
+    sim.pop("label", None)
+    return {**sim, "interval": interval_value}
+
+
+def _sim_from_series(
+    series: ComparableSeries, detector_config: dict[str, Any], detector_type_str: str
+) -> dict[str, Any]:
+    """Score a single extracted series with detect_batch and shape it for the simulation chart."""
+    detection = get_detector(detector_config).detect_batch(np.array([p.value for p in series.points]))
+    triggered = detection.triggered_indices or []
+    scores = detection.all_scores if detection.all_scores else [None] * len(series.points)
+
+    sim: dict[str, Any] = {
+        "label": series.label,
+        "data": [p.value for p in series.points],
+        "dates": [p.date for p in series.points],
+        "scores": scores,
+        "triggered_indices": triggered,
+        "triggered_dates": _triggered_dates(series, triggered),
+        "total_points": len(series.points),
+        "anomaly_count": len(triggered),
+    }
+    sub_scores = _extract_sub_detector_scores(detector_type_str, detection)
+    if sub_scores:
+        sim["sub_detector_scores"] = sub_scores
+    return sim

--- a/products/alerts/backend/evaluation/dispatcher.py
+++ b/products/alerts/backend/evaluation/dispatcher.py
@@ -1,4 +1,4 @@
-from posthog.schema import AlertCondition, InsightThreshold, NodeKind, TrendsQuery
+from posthog.schema import AlertCondition, InsightThreshold, NodeKind
 
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.tasks.alerts.utils import WRAPPER_NODE_KINDS, AlertEvaluationResult
@@ -6,22 +6,46 @@ from posthog.utils import get_from_dict_or_attr
 
 from products.alerts.backend.evaluation.comparator import evaluate_threshold
 from products.alerts.backend.evaluation.contract import Extractor
-from products.alerts.backend.evaluation.detector import evaluate_with_detector, extract_detector_series
+from products.alerts.backend.evaluation.detector import TrendsDetectorExtractor, evaluate_with_detector
 from products.alerts.backend.evaluation.trends import TrendsExtractor
 from products.alerts.backend.models.alert import AlertConfiguration
+from products.product_analytics.backend.models.insight import Insight
 
-# Each insight kind that supports alerts maps to one extractor. The comparator is shared.
+# Each insight kind that supports threshold alerts maps to one extractor. The comparator is shared.
 EXTRACTORS: dict[NodeKind, Extractor] = {
     NodeKind.TRENDS_QUERY: TrendsExtractor(),
 }
+
+# The anomaly-detector path mirrors EXTRACTORS: one detector extractor per kind, scored by the shared
+# evaluate_with_detector. Trends-only in v1, but the dispatch no longer hardcodes the kind.
+DETECTOR_EXTRACTORS: dict[NodeKind, Extractor] = {
+    NodeKind.TRENDS_QUERY: TrendsDetectorExtractor(),
+}
+
+
+def check_detector_alert(alert: AlertConfiguration, insight: Insight, query: object) -> AlertEvaluationResult:
+    """Route a detector (anomaly) alert to its kind's detector extractor, then score the series.
+
+    Shared by the dispatcher and the detector tests. The registry lookup is the kind gate — an
+    unsupported kind raises rather than silently falling through to the threshold path.
+    """
+    detector_config = alert.detector_config
+    if not detector_config:
+        raise ValueError("check_detector_alert requires detector_config — dispatcher invariant violated")
+    kind = get_from_dict_or_attr(query, "kind")
+    detector_extractor = DETECTOR_EXTRACTORS.get(kind)
+    if detector_extractor is None:
+        raise NotImplementedError(f"AlertCheckError: Detector alerts for {kind} are not supported yet")
+    result = detector_extractor.extract(alert, insight, query)
+    return evaluate_with_detector(result, detector_config)
 
 
 def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:
     """Dispatch an alert to its insight-kind extractor, then run the shared comparator.
 
-    If ``detector_config`` is set, uses the anomaly-detector abstraction (trends-only); it has its
-    own extractor (wider window) but shares the ``ComparableSeries`` contract, so the dispatch shape
-    mirrors the threshold path. Otherwise the extractor normalizes the query result into an
+    If ``detector_config`` is set, routes through the anomaly-detector registry (trends-only in v1);
+    each detector extractor shares the ``ComparableSeries`` contract, so the dispatch shape mirrors
+    the threshold path. Otherwise the extractor normalizes the query result into an
     ``ExtractionResult`` and the comparator evaluates it against the threshold.
     """
     insight = alert.insight
@@ -34,13 +58,8 @@ def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:
             query = get_from_dict_or_attr(query, "source")
             kind = get_from_dict_or_attr(query, "kind")
 
-        if alert.detector_config and kind == NodeKind.TRENDS_QUERY:
-            trends_query = TrendsQuery.model_validate(query)
-            series_index = (alert.config or {}).get("series_index", 0)
-            detector_result = extract_detector_series(
-                insight, alert.team, trends_query, alert.detector_config, series_index=series_index
-            )
-            return evaluate_with_detector(detector_result, alert.detector_config)
+        if alert.detector_config:
+            return check_detector_alert(alert, insight, query)
 
         extractor = EXTRACTORS.get(kind)
         if extractor is None:

--- a/products/alerts/backend/evaluation/dispatcher.py
+++ b/products/alerts/backend/evaluation/dispatcher.py
@@ -1,12 +1,12 @@
 from posthog.schema import AlertCondition, InsightThreshold, NodeKind, TrendsQuery
 
 from posthog.schema_migrations.upgrade_manager import upgrade_query
-from posthog.tasks.alerts.detector import check_trends_alert_with_detector
 from posthog.tasks.alerts.utils import WRAPPER_NODE_KINDS, AlertEvaluationResult
 from posthog.utils import get_from_dict_or_attr
 
 from products.alerts.backend.evaluation.comparator import evaluate_threshold
 from products.alerts.backend.evaluation.contract import Extractor
+from products.alerts.backend.evaluation.detector import evaluate_with_detector, extract_detector_series
 from products.alerts.backend.evaluation.trends import TrendsExtractor
 from products.alerts.backend.models.alert import AlertConfiguration
 
@@ -19,9 +19,10 @@ EXTRACTORS: dict[NodeKind, Extractor] = {
 def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:
     """Dispatch an alert to its insight-kind extractor, then run the shared comparator.
 
-    If ``detector_config`` is set, evaluation goes through the anomaly-detector abstraction
-    (trends-only); otherwise the extractor normalizes the query result into an ``ExtractionResult``
-    and the comparator evaluates it against the threshold — the same path for every kind.
+    If ``detector_config`` is set, uses the anomaly-detector abstraction (trends-only); it has its
+    own extractor (wider window) but shares the ``ComparableSeries`` contract, so the dispatch shape
+    mirrors the threshold path. Otherwise the extractor normalizes the query result into an
+    ``ExtractionResult`` and the comparator evaluates it against the threshold.
     """
     insight = alert.insight
 
@@ -35,7 +36,11 @@ def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:
 
         if alert.detector_config and kind == NodeKind.TRENDS_QUERY:
             trends_query = TrendsQuery.model_validate(query)
-            return check_trends_alert_with_detector(alert, insight, trends_query, alert.detector_config)
+            series_index = (alert.config or {}).get("series_index", 0)
+            detector_result = extract_detector_series(
+                insight, alert.team, trends_query, alert.detector_config, series_index=series_index
+            )
+            return evaluate_with_detector(detector_result, alert.detector_config)
 
         extractor = EXTRACTORS.get(kind)
         if extractor is None:


### PR DESCRIPTION
## Problem

The anomaly-detector alert path lived separately from the threshold path, with its own series-preparation and result-shaping in `posthog/tasks/alerts/detector.py` and a duplicate copy for the simulation endpoint. That duplication is the same problem the evaluation refactor solves for threshold alerts — so the detector path should speak the same contract and dispatch the same way.

## Changes

Converges the detector (anomaly) path onto the shared `ComparableSeries` contract and the same registry-based dispatch as threshold alerts:

- `evaluation/detector.py` — `extract_detector_series` normalizes a trends insight into `ComparableSeries` over the detector's wider lookback window; `evaluate_with_detector` scores it. `TrendsDetectorExtractor` wraps the extraction behind the shared `Extractor` protocol. `simulate_detector_on_insight` moves here so the simulation chart reuses the same extractor.
- The dispatcher gains a `DETECTOR_EXTRACTORS` registry mirroring the threshold `EXTRACTORS` map. `check_detector_alert` looks up the kind's detector extractor and scores it with `evaluate_with_detector`. The detector branch collapses to `if alert.detector_config:` — the hardcoded `kind == NodeKind.TRENDS_QUERY` gate is gone, so detector support for a new kind is one registry entry.
- The legacy `tasks/alerts/detector.py` keeps only the low-level scoring primitives.

Preserves the empty-query (value `0`) vs unscorable-series (value `None`) distinction explicitly via `ExtractionResult.empty_query_result`, with regression tests — a subtle parity point that was previously implicit.

### How the detector path converges — before vs after

Before this PR, the foundation (#62667) had already put the **threshold** path on a kind→extractor registry feeding a shared comparator, but the **detector** path still delegated to the legacy `check_trends_alert_with_detector` in `tasks/alerts/`, which did its own series prep, scoring, and result shaping — and the simulation endpoint carried a second copy of that prep. After, the detector path dispatches exactly like threshold: a `DETECTOR_EXTRACTORS[kind]` lookup yields a kind-specific extractor that emits `ComparableSeries`, and a shared scorer (`evaluate_with_detector`) interprets it. Both registries key on `NodeKind`; only the extraction (lookback window, series picking) differs.

```mermaid
flowchart TB
    subgraph before["BEFORE (after #62667) — detector path off-contract, hardcoded kind"]
        direction TB
        B0["check_alert_for_insight()<br/>dispatcher.py"] -->|"detector_config AND kind == TRENDS_QUERY"| B1["check_trends_alert_with_detector()<br/>legacy tasks/alerts/detector.py"]
        B1 --> B2["series prep · scoring · result shaping<br/>detector-specific, off-contract"]
        B2 --> BR["AlertEvaluationResult"]
        B3["simulation endpoint"] --> B4["duplicate series-prep + scoring copy<br/>tasks/alerts/detector.py"]
        B4 --> BR
        B0 -->|"threshold"| B5["EXTRACTORS[kind].extract → evaluate_threshold<br/>already on the ComparableSeries contract"]
        B5 --> BR
    end
```

```mermaid
flowchart TB
    subgraph after["AFTER (this PR) — both paths dispatch via a kind registry"]
        direction TB
        A0["check_alert_for_insight()<br/>dispatcher.py"] -->|"detector_config"| A1["check_detector_alert()<br/>DETECTOR_EXTRACTORS[kind] lookup"]
        A1 --> A2["TrendsDetectorExtractor.extract()<br/>wraps extract_detector_series<br/>→ ComparableSeries (wider lookback)"]
        A2 --> A3["evaluate_with_detector()<br/>kind-agnostic scorer"]
        A3 --> AR["AlertEvaluationResult"]
        A4["simulate_detector_on_insight()"] -->|"reuses extractor"| A2
        A0 -->|"threshold"| A5["EXTRACTORS[kind].extract()<br/>→ evaluate_threshold()"]
        A5 --> AR
    end
```

Both paths are now `REGISTRY[kind].extract()` → shared interpreter (`evaluate_with_detector` / `evaluate_threshold`). The dispatcher carries no per-kind branching, and the simulation endpoint no longer holds a second copy of the prep logic. Detector alerts stay trends-only in v1; a second kind is a single `DETECTOR_EXTRACTORS` entry.

### Where this PR sits in the stack

```mermaid
flowchart LR
    M["master"] --> P1["#62667 — foundation<br/>extractor/comparator seam · trends only"]
    P1 --> P2["#62668 — detector-conv (this PR)<br/>detector path onto ComparableSeries + registry"]
    P2 --> P3["#62669 — HogQL<br/>+ HogQLExtractor"]
    P3 --> P4["#62670 — funnels<br/>+ FunnelsExtractor"]
```

## How did you test this code?

I am an agent (Claude Code); no manual UI testing. Automated tests run locally:

- Detector oracle green: `test_detector_breakdowns.py` (12, incl. value-semantics regression cases; now sharing `check_detector_alert` instead of a local duplicate) + `detectors/test/test_detectors.py` (126).
- `ruff` and `tach` clean; no new circular imports.

### Simulate still works 

<img width="1081" height="1348" alt="CleanShot 2026-06-11 at 17 16 17" src="https://github.com/user-attachments/assets/b40b3450-8294-4c84-a7dd-c1949d2a3ee0" />

### The alert fires as well

<img width="1165" height="547" alt="CleanShot 2026-06-11 at 17 23 26" src="https://github.com/user-attachments/assets/ba33c311-7563-473c-8eec-b7c648ee0cb0" />



## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Vasco directed this as its own stacked PR and asked for the detector path to use a registry symmetric with the threshold one, so future kinds plug in the same way.

Built with Claude Code. Threshold and detector paths each get their own extractor (they use different lookback windows) but both conform to the same `Extractor` protocol, emit `ComparableSeries`, and dispatch through a `NodeKind`-keyed registry — so the dispatcher stays uniform and per-kind branching lives only in the registries. The empty-vs-unscorable value drift was caught against `master` behavior and pinned with tests before converging.
