### PR TITLE
fix(replay): recover stuck player when full snapshot is missing

### DIFF
--- a/common/replay-shared/src/snapshot-store/SnapshotStore.ts
+++ b/common/replay-shared/src/snapshot-store/SnapshotStore.ts
@@ -184,6 +184,30 @@ export class SnapshotStore {
         return { sourceIndex: bestSourceIndex, timestamp: bestTs }
     }
 
+    /**
+     * Returns the earliest loaded FullSnapshot at or after `ts`, or null if none.
+     * Used to recover playback when the data before `ts` has no FullSnapshot to
+     * render from (e.g. the initial full snapshot was lost at capture time).
+     */
+    findNextFullSnapshot(ts: number): { sourceIndex: number; timestamp: number } | null {
+        let bestTs = Infinity
+        let bestSourceIndex = -1
+
+        for (const entry of this.entries) {
+            for (const fullTs of entry.fullSnapshotTimestamps) {
+                if (fullTs >= ts && fullTs < bestTs) {
+                    bestTs = fullTs
+                    bestSourceIndex = entry.index
+                }
+            }
+        }
+
+        if (bestSourceIndex === -1) {
+            return null
+        }
+        return { sourceIndex: bestSourceIndex, timestamp: bestTs }
+    }
+
     syncFullSnapshotTimestamps(processedSnapshots: RecordingSnapshot[]): boolean {
         let changed = false
         for (const entry of this.entries) {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -413,12 +413,12 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
                     return false
                 }
 
-                const anyWindowMissingFullSnapshot = !Object.values(windowsHaveFullSnapshot).some((x) => x)
-                const everyWindowMissingFullSnapshot = !Object.values(windowsHaveFullSnapshot).every((x) => x)
+                const noWindowHasFullSnapshot = !Object.values(windowsHaveFullSnapshot).some((x) => x)
+                const someWindowMissingFullSnapshot = !Object.values(windowsHaveFullSnapshot).every((x) => x)
 
                 const recordingAgeMs = now().diff(start, 'millisecond')
 
-                if (everyWindowMissingFullSnapshot) {
+                if (noWindowHasFullSnapshot) {
                     // video is definitely unplayable
                     posthog.capture('recording_has_no_full_snapshot', {
                         watchedSession: sessionRecordingId,
@@ -426,7 +426,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
                         teamName: currentTeam?.name,
                         recordingAgeMs,
                     })
-                } else if (anyWindowMissingFullSnapshot) {
+                } else if (someWindowMissingFullSnapshot) {
                     posthog.capture('recording_window_missing_full_snapshot', {
                         watchedSession: sessionRecordingId,
                         teamID: currentTeam?.id,
@@ -435,7 +435,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
                     })
                 }
 
-                return everyWindowMissingFullSnapshot
+                return noWindowHasFullSnapshot
             },
         ],
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -411,6 +411,114 @@ describe('sessionRecordingPlayerLogic', () => {
         })
     })
 
+    describe('stuck player recovery', () => {
+        // Mock recording: start=1682952380877
+        const START = 1682952380877
+        const LATE_FS_TS = START + 300000
+
+        const SOURCE_A = {
+            source: 'blob_v2',
+            blob_key: '0',
+            start_timestamp: new Date(START).toISOString(),
+            end_timestamp: new Date(START + 60000).toISOString(),
+        }
+        const SOURCE_B = {
+            source: 'blob_v2',
+            blob_key: '1',
+            start_timestamp: new Date(START + 60000).toISOString(),
+            end_timestamp: new Date(LATE_FS_TS + 60000).toISOString(),
+        }
+
+        const makeSnapshot = (timestamp: number, type: EventType): eventWithTime =>
+            ({ timestamp, type, windowId: 1, data: {} }) as unknown as eventWithTime
+
+        const seedStore = ({
+            laterSnapshotType,
+            loadSecondSource,
+        }: {
+            laterSnapshotType: EventType
+            loadSecondSource: boolean
+        }): void => {
+            const dataLogic = snapshotDataLogic({ sessionRecordingId: '2' })
+            dataLogic.actions.loadSnapshotSourcesSuccess([SOURCE_A, SOURCE_B] as any)
+            const store = dataLogic.cache.store
+            store.markLoaded(0, [
+                makeSnapshot(START, EventType.IncrementalSnapshot),
+                makeSnapshot(START + 1000, EventType.IncrementalSnapshot),
+            ])
+            if (loadSecondSource) {
+                store.markLoaded(1, [makeSnapshot(LATE_FS_TS, laterSnapshotType)])
+            }
+            dataLogic.actions.storeUpdated()
+        }
+
+        const skipRepeatedly = (times: number): void => {
+            for (let i = 0; i < times; i++) {
+                logic.actions.skipPlayerForward(0, 16)
+            }
+        }
+
+        beforeEach(async () => {
+            await expectLogic(logic)
+                .toDispatchActions([snapshotDataLogic({ sessionRecordingId: '2' }).actionTypes.loadSnapshotSources])
+                .toFinishAllListeners()
+        })
+
+        it('jumps to the next full snapshot when stuck with no renderable base', async () => {
+            seedStore({ laterSnapshotType: EventType.FullSnapshot, loadSecondSource: true })
+            logic.actions.setCurrentTimestamp(START + 1000)
+
+            await expectLogic(logic, () => {
+                skipRepeatedly(10)
+            }).toDispatchActions(['seekToTimestamp'])
+
+            expect(logic.values.currentTimestamp).toBe(LATE_FS_TS)
+            expect(logic.values.playerError).toBeNull()
+        })
+
+        it('errors when stuck, fully loaded, and no full snapshot exists anywhere ahead', async () => {
+            seedStore({ laterSnapshotType: EventType.IncrementalSnapshot, loadSecondSource: true })
+            logic.actions.setCurrentTimestamp(START + 1000)
+
+            await expectLogic(logic, () => {
+                skipRepeatedly(10)
+            }).toDispatchActions(['setPlayerError'])
+
+            expect(logic.values.playerError).toBe('stuckWithNoPlayableFullSnapshot')
+        })
+
+        it('keeps nudging while data is still loading', async () => {
+            seedStore({ laterSnapshotType: EventType.IncrementalSnapshot, loadSecondSource: false })
+            logic.actions.setCurrentTimestamp(START + 1000)
+            // drain unrelated mount/seeding listeners, and reset the recorded
+            // action history so only the skips below are asserted against
+            await expectLogic(logic).toFinishAllListeners().clearHistory()
+
+            await expectLogic(logic, () => {
+                skipRepeatedly(10)
+            }).toNotHaveDispatchedActions(['seekToTimestamp', 'setPlayerError'])
+        })
+
+        it('does not interfere when a full snapshot exists before the current position', async () => {
+            const dataLogic = snapshotDataLogic({ sessionRecordingId: '2' })
+            dataLogic.actions.loadSnapshotSourcesSuccess([SOURCE_A, SOURCE_B] as any)
+            dataLogic.cache.store.markLoaded(0, [
+                makeSnapshot(START, EventType.FullSnapshot),
+                makeSnapshot(START + 1000, EventType.IncrementalSnapshot),
+            ])
+            dataLogic.cache.store.markLoaded(1, [makeSnapshot(LATE_FS_TS, EventType.IncrementalSnapshot)])
+            dataLogic.actions.storeUpdated()
+            logic.actions.setCurrentTimestamp(START + 1000)
+            // drain unrelated mount/seeding listeners, and reset the recorded
+            // action history so only the skips below are asserted against
+            await expectLogic(logic).toFinishAllListeners().clearHistory()
+
+            await expectLogic(logic, () => {
+                skipRepeatedly(20)
+            }).toNotHaveDispatchedActions(['seekToTimestamp', 'setPlayerError'])
+        })
+    })
+
     describe('delete session recording', () => {
         const mockedDeleteRecording = deleteRecordingMock as jest.MockedFunction<typeof deleteRecordingMock>
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -143,6 +143,12 @@ export interface SessionRecordingPlayerLogicProps extends SessionRecordingDataCo
 
 const ReplayIframeDatakeyPrefix = 'ph_replay_fixed_heatmap_'
 
+// How many consecutive stuck-player skips to tolerate before trying to recover
+// by jumping to the next FullSnapshot (when the current position has none to
+// render from). Each skip fires roughly once per animation frame, so this is
+// well under a second of visible stuckness.
+const MAX_STUCK_SKIPS_BEFORE_RECOVERY = 10
+
 // weights should add up to 1
 const smoothingWeights = [
     0.07,
@@ -475,7 +481,14 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
     connect((props: SessionRecordingPlayerLogicProps) => ({
         values: [
             snapshotDataLogic(props),
-            ['snapshotsLoaded', 'snapshotsLoading', 'snapshotSources', 'isWaitingForPlayableFullSnapshot'],
+            [
+                'snapshotsLoaded',
+                'snapshotsLoading',
+                'snapshotSources',
+                'isWaitingForPlayableFullSnapshot',
+                'snapshotStore',
+                'allSourcesLoaded',
+            ],
             sessionRecordingDataCoordinatorLogic(props),
             [
                 'urls',
@@ -1234,6 +1247,40 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             actions.fingerprintReported(fingerprint)
         },
         skipPlayerForward: ({ rrWebPlayerTime, skip }) => {
+            cache.consecutiveStuckSkips = (cache.consecutiveStuckSkips ?? 0) + 1
+
+            // If we keep getting stuck and there is no FullSnapshot at or before the
+            // current position, rrweb has nothing to render from and skipping a frame
+            // at a time will never recover (e.g. the initial full snapshot was lost at
+            // capture time). Jump to the next FullSnapshot instead, or give up with an
+            // error if the recording has none at all.
+            if (
+                cache.consecutiveStuckSkips >= MAX_STUCK_SKIPS_BEFORE_RECOVERY &&
+                values.currentTimestamp !== undefined
+            ) {
+                const hasRenderableBase = values.snapshotStore.findNearestFullSnapshot(values.currentTimestamp) !== null
+                if (!hasRenderableBase) {
+                    const nextFullSnapshot = values.snapshotStore.findNextFullSnapshot(values.currentTimestamp)
+                    if (nextFullSnapshot) {
+                        posthog.capture('stuck session player jumped to next full snapshot', {
+                            sessionId: values.sessionRecordingId,
+                            stuckTimestamp: values.currentTimestamp,
+                            jumpedToTimestamp: nextFullSnapshot.timestamp,
+                        })
+                        actions.seekToTimestamp(nextFullSnapshot.timestamp, true)
+                        return
+                    }
+                    if (values.allSourcesLoaded) {
+                        // Fully loaded and no FullSnapshot anywhere ahead — this part of
+                        // the recording can never play, so surface an error instead of
+                        // skipping forward forever.
+                        actions.setPlayerError('stuckWithNoPlayableFullSnapshot')
+                        return
+                    }
+                    // Data is still loading — a FullSnapshot may yet arrive, keep nudging.
+                }
+            }
+
             // if the player has got stuck on the same timestamp for several animation frames
             // then we skip ahead a little to get past the blockage
             // this is a KLUDGE to get around what might be a bug in rrweb
@@ -1692,6 +1739,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         seekToTimestamp: ({ timestamp, forcePlay }, breakpoint) => {
             actions.stopAnimation()
             actions.pauseIframePlayback()
+            cache.consecutiveStuckSkips = 0
 
             cache.pausedMediaElements = []
             actions.setCurrentTimestamp(timestamp)
@@ -1879,6 +1927,9 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     cache._frameState ?? initialFrameState()
                 )
                 cache._frameState = frameResult.newState
+                if (frameResult.newState.stuckFrames === 0) {
+                    cache.consecutiveStuckSkips = 0
+                }
                 let newTimestamp = frameResult.resolvedTimestamp
 
                 // If we're beyond buffered position, set to buffering

--- a/frontend/src/scenes/session-recordings/player/snapshot-store/SnapshotStore.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-store/SnapshotStore.test.ts
@@ -330,6 +330,52 @@ describe('SnapshotStore', () => {
         })
     })
 
+    describe('findNextFullSnapshot', () => {
+        it('returns null when no FullSnapshots exist', () => {
+            const store = new SnapshotStore()
+            store.setSources(makeSources(3))
+            store.markLoaded(0, [makeSnapshot(1000)])
+
+            expect(store.findNextFullSnapshot(2000)).toBeNull()
+        })
+
+        it('finds the earliest FullSnapshot at or after the target', () => {
+            const store = new SnapshotStore()
+            store.setSources(makeSources(5))
+
+            const fs1 = new Date(Date.UTC(2023, 7, 11, 12, 1, 30)).getTime()
+            const fs3 = new Date(Date.UTC(2023, 7, 11, 12, 3, 30)).getTime()
+
+            store.markLoaded(1, [makeFullSnapshot(fs1)])
+            store.markLoaded(3, [makeFullSnapshot(fs3)])
+
+            const target = new Date(Date.UTC(2023, 7, 11, 12, 2, 0)).getTime()
+            const result = store.findNextFullSnapshot(target)
+            expect(result).toEqual({ sourceIndex: 3, timestamp: fs3 })
+        })
+
+        it('includes a FullSnapshot exactly at the target timestamp', () => {
+            const store = new SnapshotStore()
+            store.setSources(makeSources(3))
+
+            const fs1 = new Date(Date.UTC(2023, 7, 11, 12, 1, 30)).getTime()
+            store.markLoaded(1, [makeFullSnapshot(fs1)])
+
+            expect(store.findNextFullSnapshot(fs1)).toEqual({ sourceIndex: 1, timestamp: fs1 })
+        })
+
+        it('returns null when all FullSnapshots are before the target', () => {
+            const store = new SnapshotStore()
+            store.setSources(makeSources(3))
+
+            const fs1 = new Date(Date.UTC(2023, 7, 11, 12, 1, 30)).getTime()
+            store.markLoaded(1, [makeFullSnapshot(fs1)])
+
+            const target = new Date(Date.UTC(2023, 7, 11, 12, 2, 0)).getTime()
+            expect(store.findNextFullSnapshot(target)).toBeNull()
+        })
+    })
+
     describe('syncFullSnapshotTimestamps', () => {
         it('syncs synthetic full snapshot timestamps from processed results', () => {
             const store = new SnapshotStore()


### PR DESCRIPTION
## Problem

Some recordings arrive without their initial full snapshot (the first stored block is a few KB of incremental events instead of the usual full DOM snapshot). When that happens, rrweb has nothing to render from, and the player's stuck-detection kludge nudges playback forward 16ms per animation frame, forever. To the viewer the recording just buffers indefinitely; in telemetry a single playback session can emit over ten thousand `stuck session player skipped forward` events.

Two related telemetry bugs made this hard to diagnose:

- the `snapshotsInvalid` selector had its any/every semantics swapped, so `recording_has_no_full_snapshot` fired when only one of several windows was missing a full snapshot, and `recording_window_missing_full_snapshot` was unreachable
- the stuck-skip loop never terminated, so there was no error state to alert on

## Changes

- `SnapshotStore.findNextFullSnapshot(ts)`: returns the earliest loaded full snapshot at or after a timestamp (mirror of the existing `findNearestFullSnapshot`)
- `sessionRecordingPlayerLogic`: after a few consecutive stuck-skips, if there's no full snapshot at or before the current position:
  - seek to the next available full snapshot (recovers recordings where the initial full snapshot was lost but a later periodic one exists)
  - if the recording is fully loaded and has no full snapshot anywhere ahead, set a player error (`stuckWithNoPlayableFullSnapshot`) instead of skipping forever
  - if data is still loading, keep the existing nudge behavior
- `sessionRecordingDataCoordinatorLogic`: fix the swapped semantics so `recording_has_no_full_snapshot` only fires (and `snapshotsInvalid` is only true) when **no** window has a full snapshot, and `recording_window_missing_full_snapshot` fires when only some windows are missing one

## How did you test this code?

I'm an agent; no manual testing was done. Automated tests added and run:

- `SnapshotStore.test.ts`: new `findNextFullSnapshot` cases (none exist, earliest-after, exactly-at, all-before)
- `sessionRecordingPlayerLogic.test.ts`: new `stuck player recovery` suite covering the seek-to-next-full-snapshot path, the error path when fully loaded with no full snapshot, the keep-nudging path while data is still loading, and non-interference when a renderable full snapshot already exists
- existing player/coordinator/snapshot-store suites all pass (203 tests), plus kea typegen and lint on touched files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Cursor agent session while investigating a report of recordings that buffer forever with the player stuck. Telemetry analysis showed affected sessions were missing their initial full snapshot at capture time and the player emitted thousands of stuck-skip events per viewing. We chose a targeted recovery in the existing stuck-skip path (rather than changing buffering or scheduler logic) so behavior is unchanged for recordings that are merely slow: recovery only activates when the current position has no renderable full snapshot at all. The capture-side cause of the missing initial snapshot is being investigated separately.

Made with [Cursor](https://cursor.com)