### PR TITLE
chore(conversations): add soft codeowners for support email templates

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -334,3 +334,9 @@ products/user_interviews/** @pauldambra @fivestarspicy @ksvat
 posthog/api/documentation.py @PostHog/team-devex
 posthog/api/mixins.py @PostHog/team-devex
 posthog/management/commands/find_enum_collisions.py @PostHog/team-devex
+
+# Conversations (support product) - owned by @PostHog/conversations
+# products/conversations/** and products/business_knowledge/** are auto-assigned from their
+# product.yaml owners; these email templates live outside the product directory so are listed here.
+posthog/templates/email/new_conversation_ticket.html @PostHog/conversations
+posthog/templates/email/conversation_restore.html @PostHog/conversations


### PR DESCRIPTION
## Problem

The conversations team (PostHog's Zendesk-competitor support product) owns `products/conversations/**` and `products/business_knowledge/**`, which are auto-assigned as soft codeowners from each product's `product.yaml` `owners:` list. But two conversations-specific email templates live *outside* the product directory, in the shared `posthog/templates/email/` folder, so no one on the conversations team gets tagged when they change:

- `posthog/templates/email/new_conversation_ticket.html`
- `posthog/templates/email/conversation_restore.html`

Both are rendered exclusively by the conversations product (`posthog/tasks/email.py` → `send_new_conversation_ticket_email` / `send_conversation_restore_email`, triggered from `products/conversations/backend/`).

## Changes

Add a `Conversations` section to `.github/CODEOWNERS-soft` claiming those two templates for `@PostHog/conversations`. This is the file's intended use: per its header, top-level `products/<name>/**` ownership comes from `product.yaml`, and `CODEOWNERS-soft` covers "ownership of paths outside `products/`". These are soft (non-blocking) reviewer assignments — they tag the team but don't gate merges. The hard `CODEOWNERS` file is deliberately left untouched, in line with its "extraordinary justification only" policy.

This mirrors the existing precedent of teams owning their specific email templates outside their product dir (e.g. `posthog/templates/email/ai_observability_*.html @PostHog/team-ai-observability`).

Deliberately **not** claimed (to avoid false ownership / dual ownership):
- `temporal/data_imports/signals/conversations_*.py` — part of the **Signals** product (`@PostHog/team-signals`), it reads support tickets but is signals-owned.
- `frontend/src/scenes/notebooks/Nodes/NotebookNodeSupportTickets.tsx` — sits inside `frontend/src/scenes/notebooks/`, already owned by `@PostHog/team-platform-features`.
- Shared registry/utility files (`posthog/tasks/email.py`, `posthog/tasks/scheduled.py`, `posthog/email.py`) that merely reference conversations alongside many other teams' code.

## How did you test this code?

I'm an agent (Claude Code). No automated tests apply to a CODEOWNERS change. I verified by reading `.github/scripts/assign-reviewers.js`, which loads `.github/CODEOWNERS-soft` (line ~553) and layers `product.yaml` rules on top — so the two new exact-path rules resolve to a non-blocking `@PostHog/conversations` review request when those templates change. The `@PostHog/conversations` handle matches the existing `owners:` slug already used by both `products/conversations/product.yaml` and `products/business_knowledge/product.yaml` (same bare-slug convention as `@PostHog/logs`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by Robbie.

Robbie asked whether the conversations team had anything in CODEOWNERS and to add what was missing. Tool: Claude Code (Opus 4.8).

Findings: the product directories themselves are already covered via `product.yaml` → auto-assigner, so the team isn't absent from the ownership system. The genuine gap was the two support email templates outside `products/conversations/`. I scoped the change tightly to dedicated conversations files and deliberately excluded coincidental keyword matches and files that already belong to other teams (signals, platform-features), to keep ownership precise and avoid the anti-patterns called out in the CODEOWNERS header.
