### PR TITLE
feat(data-deletion): allow verifying failed requests, finalize from failed

### DIFF
--- a/posthog/admin/admins/data_deletion_request_admin.py
+++ b/posthog/admin/admins/data_deletion_request_admin.py
@@ -12,6 +12,7 @@ from posthog.clickhouse.client.connection import ClickHouseUser
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.clickhouse.workload import Workload
 from posthog.models.data_deletion_request import (
+    VERIFIABLE_STATUSES,
     DataDeletionRequest,
     ExecutionMode,
     RequestStatus,
@@ -630,8 +631,13 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
                 obj.status == RequestStatus.FAILED and request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
             )
             extra_context["retry_url"] = reverse("admin:posthog_datadeletionrequest_retry", args=[obj.pk])
+            # Verify works for QUEUED (the normal deferred path) and FAILED (a job that errored
+            # after the events were already deleted). Both rely on counting matching events, which
+            # is only meaningful for event_removal requests.
             extra_context["can_verify"] = (
-                obj.status == RequestStatus.QUEUED and request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
+                obj.status in VERIFIABLE_STATUSES
+                and obj.request_type == RequestType.EVENT_REMOVAL
+                and request.user.groups.filter(name=CLICKHOUSE_TEAM_GROUP).exists()
             )
             extra_context["verify_url"] = reverse("admin:posthog_datadeletionrequest_verify", args=[obj.pk])
 
@@ -990,19 +996,24 @@ class DataDeletionRequestAdmin(admin.ModelAdmin):
             messages.error(request, "Only ClickHouse Team members can verify deletion requests.")
             return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
-        if obj.status != RequestStatus.QUEUED:
-            messages.error(request, "Only queued requests can be verified.")
+        if obj.request_type != RequestType.EVENT_REMOVAL:
+            messages.error(request, "Only event removal requests can be verified.")
             return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
 
+        if obj.status not in VERIFIABLE_STATUSES:
+            messages.error(request, "Only queued or failed requests can be verified.")
+            return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))
+
+        prior_status = obj.status
         outcome = verify_queued_request(obj)
         if outcome.promoted:
             obj.refresh_from_db()
-            self.log_change(request, obj, "Verified: 0 matching events remain, status queued → completed.")
+            self.log_change(request, obj, f"Verified: 0 matching events remain, status {prior_status} → completed.")
             messages.success(request, "Verified — no matching events remain. Marked completed.")
         else:
             messages.warning(
                 request,
                 f"{outcome.remaining} matching event(s) still present in ClickHouse. "
-                "Left queued — re-run after the next scheduled deletion.",
+                f"Left {obj.status} — re-run after the next scheduled deletion.",
             )
         return HttpResponseRedirect(reverse("admin:posthog_datadeletionrequest_change", args=[obj.pk]))

--- a/posthog/admin/test_data_deletion_request_admin.py
+++ b/posthog/admin/test_data_deletion_request_admin.py
@@ -756,13 +756,42 @@ class TestDataDeletionRequestAdminVerify(BaseTest):
         request.refresh_from_db()
         self.assertEqual(request.status, RequestStatus.QUEUED)
 
-    def test_verify_view_rejects_non_queued(self):
+    def test_verify_view_rejects_non_verifiable_status(self):
         request = self._queued_request()
         request.status = RequestStatus.APPROVED
         request.save(update_fields=["status"])
         self._call_verify(request)
         request.refresh_from_db()
         self.assertEqual(request.status, RequestStatus.APPROVED)
+
+    def test_verify_view_promotes_failed_when_events_gone(self):
+        request = self._queued_request()
+        request.status = RequestStatus.FAILED
+        request.save(update_fields=["status"])
+        with patch("posthog.models.data_deletion_request.count_remaining_matching_events", return_value=0):
+            self._call_verify(request)
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.COMPLETED)
+
+    def test_verify_view_keeps_failed_when_events_remain(self):
+        request = self._queued_request()
+        request.status = RequestStatus.FAILED
+        request.save(update_fields=["status"])
+        with patch("posthog.models.data_deletion_request.count_remaining_matching_events", return_value=3):
+            self._call_verify(request)
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.FAILED)
+
+    def test_verify_view_rejects_non_event_removal(self):
+        request = self._queued_request()
+        request.request_type = RequestType.PROPERTY_REMOVAL
+        request.status = RequestStatus.FAILED
+        request.save(update_fields=["request_type", "status"])
+        with patch("posthog.models.data_deletion_request.count_remaining_matching_events", return_value=0) as counted:
+            self._call_verify(request)
+        counted.assert_not_called()
+        request.refresh_from_db()
+        self.assertEqual(request.status, RequestStatus.FAILED)
 
     def test_verify_view_rejects_non_clickhouse_team(self):
         request = self._queued_request()

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -932,9 +932,12 @@ def finalize_deletion_request(
     else:
         next_status = RequestStatus.COMPLETED
 
+    # Accept FAILED in addition to IN_PROGRESS: when an op fails the failure hook flips the request
+    # to FAILED, so re-running the job from the failed op in Dagster (where load_* is reused and not
+    # re-executed) leaves it FAILED. Allowing FAILED here lets that re-run finalize the request.
     DataDeletionRequest.objects.filter(
         pk=deletion_request.request_id,
-        status=RequestStatus.IN_PROGRESS,
+        status__in=[RequestStatus.IN_PROGRESS, RequestStatus.FAILED],
     ).update(status=next_status, updated_at=timezone.now())
 
     context.log.info(f"Deletion request {deletion_request.request_id} marked as {next_status.value}.")
@@ -948,9 +951,11 @@ def finalize_person_removal(
     """Mark a person_removal request as COMPLETED."""
     from django.utils import timezone
 
+    # Accept FAILED too so a Dagster re-run after a mid-job failure (where the failure hook already
+    # flipped the request to FAILED) can still finalize it. See finalize_deletion_request.
     DataDeletionRequest.objects.filter(
         pk=person_removal.request_id,
-        status=RequestStatus.IN_PROGRESS,
+        status__in=[RequestStatus.IN_PROGRESS, RequestStatus.FAILED],
     ).update(status=RequestStatus.COMPLETED, updated_at=timezone.now())
 
     context.log.info(f"Person removal request {person_removal.request_id} marked as completed.")

--- a/posthog/dags/tests/test_data_deletion_requests.py
+++ b/posthog/dags/tests/test_data_deletion_requests.py
@@ -186,13 +186,17 @@ def test_load_deletion_request_rejects_property_removal():
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "execution_mode, expected_status",
+    "execution_mode, start_status, expected_status",
     [
-        (ExecutionMode.IMMEDIATE, RequestStatus.COMPLETED),
-        (ExecutionMode.DEFERRED, RequestStatus.QUEUED),
+        (ExecutionMode.IMMEDIATE, RequestStatus.IN_PROGRESS, RequestStatus.COMPLETED),
+        (ExecutionMode.DEFERRED, RequestStatus.IN_PROGRESS, RequestStatus.QUEUED),
+        # A Dagster re-run after a mid-job failure starts from FAILED (the failure hook flipped it);
+        # finalize must still be able to complete/queue it.
+        (ExecutionMode.IMMEDIATE, RequestStatus.FAILED, RequestStatus.COMPLETED),
+        (ExecutionMode.DEFERRED, RequestStatus.FAILED, RequestStatus.QUEUED),
     ],
 )
-def test_finalize_deletion_request_transitions_status(execution_mode, expected_status):
+def test_finalize_deletion_request_transitions_status(execution_mode, start_status, expected_status):
     start_time = datetime.now() - timedelta(days=7)
     end_time = datetime.now()
     request = DataDeletionRequest.objects.create(
@@ -201,7 +205,7 @@ def test_finalize_deletion_request_transitions_status(execution_mode, expected_s
         events=["$pageview"],
         start_time=start_time,
         end_time=end_time,
-        status=RequestStatus.IN_PROGRESS,
+        status=start_status,
         execution_mode=execution_mode,
     )
 

--- a/posthog/models/data_deletion_request.py
+++ b/posthog/models/data_deletion_request.py
@@ -398,17 +398,24 @@ class VerifyOutcome:
     promoted: bool
 
 
-def verify_queued_request(request: "DataDeletionRequest") -> VerifyOutcome:
-    """Verify a QUEUED event-removal request and promote it to COMPLETED when its events are gone.
+# Statuses from which verification may promote an event-removal request to COMPLETED. QUEUED is the
+# normal deferred path; FAILED is included so the ClickHouse Team can confirm a request whose job
+# errored after the events were actually deleted (e.g. a failure in the finalize step) without
+# re-running the whole deletion.
+VERIFIABLE_STATUSES = (RequestStatus.QUEUED, RequestStatus.FAILED)
 
-    Counts events still matching the request in ClickHouse. When zero remain and the request is
-    still QUEUED, atomically promotes QUEUED → COMPLETED via a status-guarded update. Idempotent;
-    safe to call from both the Dagster sweep job and the Django admin button.
+
+def verify_queued_request(request: "DataDeletionRequest") -> VerifyOutcome:
+    """Verify an event-removal request and promote it to COMPLETED when its events are gone.
+
+    Counts events still matching the request in ClickHouse. When zero remain and the request is in a
+    verifiable status (QUEUED or FAILED), atomically promotes it to COMPLETED via a status-guarded
+    update. Idempotent; safe to call from both the Dagster sweep job and the Django admin button.
     """
     remaining = count_remaining_matching_events(request)
-    if remaining > 0 or request.status != RequestStatus.QUEUED:
+    if remaining > 0 or request.status not in VERIFIABLE_STATUSES:
         return VerifyOutcome(remaining=remaining, promoted=False)
-    promoted = DataDeletionRequest.objects.filter(pk=request.pk, status=RequestStatus.QUEUED).update(
+    promoted = DataDeletionRequest.objects.filter(pk=request.pk, status__in=VERIFIABLE_STATUSES).update(
         status=RequestStatus.COMPLETED, updated_at=timezone.now()
     )
     return VerifyOutcome(remaining=remaining, promoted=bool(promoted))

--- a/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
+++ b/posthog/templates/admin/posthog/datadeletionrequest/change_form.html
@@ -145,10 +145,10 @@
     {% if can_verify %}
     <div class="submit-row" style="margin-top: 20px; padding: 20px; border-radius: 5px; border: 1px solid #417690; display: flex; align-items: center; gap: 10px;">
         <div class="info">
-            This request is <strong>queued</strong> for deferred deletion. Verify to re-check ClickHouse now —
-            if no matching events remain, it will be marked completed.
+            This request is <strong>{{ original.get_status_display|lower }}</strong>. Verify to re-check ClickHouse now —
+            if no matching events remain, it will be marked completed{% if original.status == "failed" %} (use this when the job errored after the events were already deleted){% endif %}.
         </div>
-        <button type="submit" formaction="{{ verify_url }}" formmethod="post" formnovalidate class="button" style="padding: 10px 15px; background: #417690; color: white;" onclick="return confirm('Verify this queued request against ClickHouse now?');">Verify deletion</button>
+        <button type="submit" formaction="{{ verify_url }}" formmethod="post" formnovalidate class="button" style="padding: 10px 15px; background: #417690; color: white;" onclick="return confirm('Verify this request against ClickHouse now?');">Verify deletion</button>
     </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Problem

Two gaps in the data-deletion-request operator workflow when a deletion job errors:

1. The admin "Verify" action (re-count matching events in ClickHouse and promote to `COMPLETED` when none remain) was only available for `QUEUED` requests. If a job errored *after* the events were actually deleted — e.g. a transient failure in the finalize step — the request was stuck in `FAILED` with no way to confirm-and-close it short of re-running the whole heavyweight deletion.
2. When a deletion job is re-run from the failed op directly in Dagster, the `load_*` op output is reused (not re-executed), so the request stays in the `FAILED` status the failure hook set. The finalize ops only transitioned from `IN_PROGRESS`, so a successful re-run left the request stuck in `FAILED` even though the deletion completed.

## Changes

- `verify_queued_request` now promotes to `COMPLETED` from either `QUEUED` or `FAILED` (new `VERIFIABLE_STATUSES`), via a status-guarded atomic update — still idempotent.
- Admin: the "Verify" button and `verify_view` accept `QUEUED`/`FAILED`, scoped to `event_removal` requests (the only type where the matching-event count is meaningful). Messages/audit log report the prior status.
- `change_form.html`: the verify button text is no longer hardcoded to "queued"; for failed requests it explains the use case.
- Dagster `finalize_deletion_request` and `finalize_person_removal` accept `FAILED` in addition to `IN_PROGRESS`, so a re-run after a mid-job failure can finalize the request.

## How did you test this code?

Automated tests (run locally):

- `posthog/admin/test_data_deletion_request_admin.py::TestDataDeletionRequestAdminVerify` — added cases for promoting a `FAILED` request when events are gone, keeping it `FAILED` when events remain, and rejecting non-`event_removal` requests (count not invoked). 7 passed.
- `posthog/dags/tests/test_data_deletion_requests.py::test_finalize_deletion_request_transitions_status` — extended to cover `FAILED` start states for both immediate and deferred modes. 4 passed.
