### PR TITLE
fix(llma): exclude AI Gateway generations from billable AIO count

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -5297,6 +5297,58 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
         billable_result_final = get_teams_with_billable_event_count_in_period(self.begin, self.end)
         self.assertEqual(billable_result_final[0][1], baseline_count + 1)
 
+    def test_gateway_ai_events_excluded_from_billable_ai_count(self) -> None:
+        """AI Gateway generations ($ai_gateway: true) are billed via the gateway's own ledger, so
+        they must be excluded from the AIO billable event count; normal SDK generations stay counted."""
+        from posthog.tasks.usage_report import get_teams_with_ai_event_count_in_period
+
+        # setUp already created 10 AI events for self.team, none gateway-originated.
+        baseline = get_teams_with_ai_event_count_in_period(self.begin, self.end)
+        self.assertEqual(baseline[0][1], 10)
+
+        # Gateway-originated generations must NOT be counted.
+        for i in range(4):
+            _create_event(
+                event="$ai_generation",
+                team=self.team,
+                distinct_id=f"gateway_user_{i}",
+                timestamp=self.begin + relativedelta(hours=i + 4),
+                properties={
+                    "$ai_model": "claude-3",
+                    "$ai_provider": "anthropic",
+                    "$ai_gateway": True,
+                    "$ai_ingestion_source": "gateway",
+                },
+                person_mode="full",
+            )
+
+        # Normal client generations (no $ai_gateway) must still be counted.
+        for i in range(2):
+            _create_event(
+                event="$ai_generation",
+                team=self.team,
+                distinct_id=f"sdk_user_{i}",
+                timestamp=self.begin + relativedelta(hours=i + 8),
+                properties={"$ai_model": "gpt-4", "$ai_provider": "openai"},
+                person_mode="full",
+            )
+
+        # A client passing $ai_gateway: false is explicitly billed (not excluded).
+        _create_event(
+            event="$ai_generation",
+            team=self.team,
+            distinct_id="sdk_user_explicit_false",
+            timestamp=self.begin + relativedelta(hours=11),
+            properties={"$ai_model": "gpt-4", "$ai_provider": "openai", "$ai_gateway": False},
+            person_mode="full",
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_event_count_in_period(self.begin, self.end)
+        # 10 baseline + 2 SDK + 1 explicit-false = 13; the 4 gateway events are excluded.
+        self.assertEqual(result[0][1], 13)
+
     def test_conversations_events_excluded_from_billable_count(self) -> None:
         """Test that Conversations widget events are excluded from billable event counts."""
         from posthog.tasks.usage_report import get_teams_with_billable_event_count_in_period

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1102,11 +1102,20 @@ def get_teams_with_ai_event_count_in_period(
     end: datetime,
 ) -> list[tuple[int, int]]:
     with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.USAGE_REPORT):
+        # Gateway-originated generations ($ai_gateway: true) are billed by the AI Gateway's own
+        # ledger, so excluding them here stops the same call being double-billed when it also lands
+        # as an $ai_generation event (gateway-emitted or SDK/OTel double-capture). Events are kept,
+        # only the billable count drops. NOTE: $ai_gateway is a client-settable event property and is
+        # not (yet) enforced server-side at ingestion, so this is forgeable — the robust fix is for
+        # billing to reconcile against the gateway's trusted ledger rather than this property.
         return sync_execute(
             """
             SELECT team_id, COUNT() as count
             FROM events
-            WHERE event IN %(ai_events)s AND timestamp >= %(begin)s AND timestamp < %(end)s
+            WHERE event IN %(ai_events)s
+                AND timestamp >= %(begin)s
+                AND timestamp < %(end)s
+                AND NOT JSONExtractBool(properties, '$ai_gateway')
             GROUP BY team_id
         """,
             {"begin": begin, "end": end, "ai_events": AI_EVENTS},


### PR DESCRIPTION
## Problem

The PostHog AI Gateway emits `$ai_generation` events stamped `$ai_gateway: true` (and `$ai_ingestion_source: "gateway"`) and bills those calls through the gateway's own separate ledger. When a team also runs the PostHog SDK/OTel instrumentation, the same call is double-captured as an `$ai_generation` event in their project. The AI-observability (AIO) metering counter — which bills by counting `$ai_generation` events — then counted that gateway call a second time, so the team was billed twice for one generation (once on the gateway ledger, once on the AIO event allowance).

This was listed as remaining v0 work for the AI Gateway.

## Changes

Exclude `$ai_generation` events with `$ai_gateway: true` from `get_teams_with_ai_event_count_in_period` in `posthog/tasks/usage_report.py`. This is the single counter that feeds:

- the billing-service usage report (`ai_event_count_in_period`),
- quota limiting (`ee/billing/quota_limiting.py`, the `llm_events` quota), and
- the Temporal usage-report workflow (`posthog/temporal/usage_report/queries.py`),

so all three billing paths pick up the exclusion from one place. The filter uses `NOT JSONExtractBool(properties, '$ai_gateway')`, mirroring the existing `$ai_billable` boolean convention in the same module. **Events are not dropped** — they remain fully queryable in LLM analytics; only the billed count changes. Gateway events stay billed by the gateway; normal SDK/OTel generations stay billed by AIO.

### ⚠️ Security caveat — this signal is forgeable

`$ai_gateway` is a plain, **client-settable** event property. Nothing in ingestion (Rust `capture` or the Node plugin-server) stamps or protects `$ai_*` properties, and the gateway emits into the customer's project using that project's own ingestion token — indistinguishable from SDK events. So a team could set `$ai_gateway: true` on every SDK generation to dodge AIO billing while keeping the full product. `$ai_base_url` is no better (also fully client-controlled). The robust fix is for billing to **reconcile against the gateway's trusted ledger** rather than trust an event property; that work lives where the ledger lives (gateway/billing service), not in this query. The risk is documented inline at the call site so it isn't lost.

### Reporting/usage dashboards needing the same filter

`get_all_ai_metrics` in `posthog/tasks/ai_observability_usage_report.py` (the internal "llm analytics usage" analytics report) also counts `$ai_generation` without this filter. It is **product-usage analytics, not billing**, so it is intentionally left counting all events. If it should ever reflect *billable* usage, add the equivalent map-based filter there: `properties_group_ai['$ai_gateway'] != 'true'`.

## How did you test this code?

I'm an agent. I added an automated test, `TestQuerySplitting::test_gateway_ai_events_excluded_from_billable_ai_count`, covering:

- gateway events (`$ai_gateway: true`) excluded from the billable count,
- normal client generations (no property) still counted,
- explicit `$ai_gateway: false` still counted.

These tests are ClickHouse-backed. I could **not execute them in the sandbox** (no Docker/ClickHouse/Postgres available there), so they need to run in CI. The change compiles (`py_compile`) and passes `ruff check` / `ruff format --check`. The SQL predicate follows the existing `JSONExtractBool(properties, '$ai_billable')` pattern already used for billing in the same module.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The human flagged a gaming concern up front — can a user pass `$ai_gateway: true` themselves to avoid billing, and would checking `$ai_base_url` be safer? I investigated the full ingestion path (Rust `capture`, Node plugin-server) and the gateway capture callback before writing code, and confirmed both properties are client-forgeable: there is no reserved/server-stamped `$ai_*` property mechanism, and the gateway uses the project's own token so its events are indistinguishable from SDK events at ingestion. The genuinely safe design is ledger reconciliation, which lives outside this repo.

The human chose to ship the property-based exclusion now (gateway events should not be billed by AIO; the residual forgeability is accepted and monitorable), so this PR implements that at the single metering chokepoint and documents the forgeability + the ledger-reconciliation long-term fix both inline and above. Tools used: Claude Code with the Explore subagent for codebase investigation.
