### PR TITLE
feat(mcp): attribute exec-routed tool calls and track exec usage

### DIFF
--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -131,3 +131,43 @@ export async function trackToolCall(
         // never break the request for analytics
     }
 }
+
+/**
+ * Records an invocation of the `exec` wrapper as a distinct `mcp_exec_command`
+ * event — NOT `mcp_tool_call`. The real underlying tool is attributed separately
+ * (the inner call emits its own `mcp_tool_call` tagged `$mcp_via_exec`), so this
+ * event answers "how often is exec used, and with which command verb?" without
+ * exec masquerading as a tool name in the tool-quality dataset. `$mcp_exec_inner_tool`
+ * is set only for `call` commands; discovery verbs (`info`/`search`/`schema`/`tools`)
+ * leave it unset.
+ */
+export async function trackExecCommand(
+    state: ResolvedState,
+    args: { commandKind: string; innerToolName?: string | undefined; durationMs: number; isError: boolean }
+): Promise<void> {
+    try {
+        const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+        const requestContext = state.requestContext
+        const sessionUuid = requestContext.sessionId
+            ? await state.reqCtx.getSessionUuid(requestContext.sessionId)
+            : undefined
+
+        const { properties, groups } = buildBaseProperties(state, analyticsContext)
+
+        getPostHogClient().capture({
+            distinctId: state.distinctId,
+            event: 'mcp_exec_command',
+            ...(Object.keys(groups).length > 0 ? { groups } : {}),
+            properties: {
+                ...properties,
+                $mcp_exec_command_kind: args.commandKind,
+                ...(args.innerToolName ? { $mcp_exec_inner_tool: args.innerToolName } : {}),
+                $mcp_duration_ms: args.durationMs,
+                $mcp_is_error: args.isError,
+                ...(sessionUuid ? { $session_id: sessionUuid } : {}),
+            },
+        })
+    } catch {
+        // never break the request for analytics
+    }
+}

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -10,13 +10,11 @@ import {
     findPostHogPermissionError,
     findRecoverableApiError,
 } from '@/lib/errors'
-import { AnalyticsEvent } from '@/lib/posthog/analytics'
-import { createExecTool, type ExecInnerCallTracker } from '@/tools/exec'
+import { createExecTool, parseExecCommandKind, type ExecInnerCallTracker } from '@/tools/exec'
 import { createRenderUiTool } from '@/tools/render-ui'
-import { getToolCategory } from '@/tools/toolDefinitions'
 import type { Context, ZodObjectAny } from '@/tools/types'
 
-import { trackToolCall } from './analytics'
+import { trackExecCommand, trackToolCall } from './analytics'
 import type { InstructionsBuilder } from './instructions'
 import { getEffectiveMCPClientContext } from './mcp-context'
 import { toolCallDurationSeconds, toolCallsTotal, toolErrorsTotal } from './metrics'
@@ -182,7 +180,15 @@ export class ToolExecutor {
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
 
-            void trackToolCall('exec', Date.now() - startMs, false, state)
+            // The underlying tool (if any) is attributed by `trackInnerCall` as its own
+            // `mcp_tool_call`. Here we record the wrapper invocation itself as a separate
+            // `mcp_exec_command` event so exec usage is countable without polluting tool stats.
+            void trackExecCommand(state, {
+                commandKind: parseExecCommandKind(validation.data.command),
+                innerToolName: execMetrics.innerToolName,
+                durationMs: Date.now() - startMs,
+                isError: false,
+            })
 
             if (isToolCallPayload(handlerResult)) {
                 return handlerResult
@@ -203,7 +209,12 @@ export class ToolExecutor {
             }
             classifyToolError(error, metricTool)
 
-            void trackToolCall('exec', Date.now() - startMs, true, state)
+            void trackExecCommand(state, {
+                commandKind: parseExecCommandKind(validation.data.command),
+                innerToolName: execMetrics.innerToolName,
+                durationMs: Date.now() - startMs,
+                isError: true,
+            })
 
             const sessionUuid = await state.reqCtx.getSessionUuid(state.requestContext.sessionId)
             // Attribute the failure to the inner tool that actually ran (e.g. `query-logs`),
@@ -223,24 +234,15 @@ export class ToolExecutor {
             toolCallsTotal.inc({ tool: toolName, status })
             toolCallDurationSeconds.observe({ tool: toolName, status }, properties.duration_ms / 1000)
 
-            // Mirror the native path: stamp the inner tool's category so exec-routed
-            // calls share the dashboard's `$mcp_tool_category` grouping dimension.
-            const toolCategory = getToolCategory(toolName)
-
-            void (async () => {
-                const freshContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
-                await state.reqCtx.trackEvent(
-                    AnalyticsEvent.MCP_TOOL_CALL,
-                    {
-                        tool_name: toolName,
-                        ...(toolCategory ? { $mcp_tool_category: toolCategory } : {}),
-                        ...properties,
-                    },
-                    freshContext,
-                    undefined,
-                    state.distinctId
-                )
-            })().catch(() => {})
+            // Emit the SAME `mcp_tool_call` shape as the native path (including the
+            // category), tagged `$mcp_via_exec` so the inner tool is attributed
+            // correctly while the dashboard can still slice exec-routed traffic
+            // without exec masquerading as a tool name.
+            void trackToolCall(toolName, properties.duration_ms, !properties.success, state, {
+                $mcp_via_exec: true,
+                output_format: properties.output_format,
+                ...(properties.error_message ? { error_message: properties.error_message } : {}),
+            })
         }
         const clientContext = getEffectiveMCPClientContext(state.requestContext, state.sessionContext)
 

--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -9,6 +9,7 @@ export enum AnalyticsEvent {
     MCP_PROJECT_SWITCHED = 'mcp project switched',
     MCP_ORGANIZATION_SWITCHED = 'mcp organization switched',
     MCP_TOOL_CALL = 'mcp_tool_call', // matching @posthog/mcp-analytics
+    MCP_EXEC_COMMAND = 'mcp_exec_command',
     MCP_FEEDBACK_SUBMITTED = 'mcp feedback submitted',
 }
 

--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -9,7 +9,6 @@ export enum AnalyticsEvent {
     MCP_PROJECT_SWITCHED = 'mcp project switched',
     MCP_ORGANIZATION_SWITCHED = 'mcp organization switched',
     MCP_TOOL_CALL = 'mcp_tool_call', // matching @posthog/mcp-analytics
-    MCP_EXEC_COMMAND = 'mcp_exec_command',
     MCP_FEEDBACK_SUBMITTED = 'mcp feedback submitted',
 }
 

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -45,6 +45,18 @@ function parseCommand(input: string): { verb: string; rest: string } {
     return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
 }
 
+// The recognised exec command verbs. Anything else (or an empty command)
+// classifies as "unknown" so the analytics dimension stays bounded.
+const EXEC_COMMAND_VERBS = new Set(['tools', 'search', 'info', 'schema', 'call'])
+
+// Classifies an exec command by its leading verb (e.g. "call docs-search {...}"
+// → "call"). Used to record what kind of command each `exec` invocation ran,
+// independently of which underlying tool (if any) it dispatched to.
+export function parseExecCommandKind(command: string): string {
+    const { verb } = parseCommand(command)
+    return EXEC_COMMAND_VERBS.has(verb) ? verb : 'unknown'
+}
+
 // Extracts the inner tool name from an exec `call` command, e.g.
 // "call my-tool {...}" → "my-tool". Returns undefined for other verbs or
 // malformed input. Used by analytics to surface the real tool being invoked

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/lib/posthog', () => ({
     })),
 }))
 
-import { trackInitEvent, trackToolCall } from '@/hono/analytics'
+import { trackExecCommand, trackInitEvent, trackToolCall } from '@/hono/analytics'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 
 function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
@@ -108,5 +108,39 @@ describe('Hono MCP analytics contexts', () => {
         await trackToolCall('exec', 5, false, makeState())
 
         expect(mockCapture.mock.calls[0]![0].properties).not.toHaveProperty('$mcp_tool_category')
+    })
+
+    it('passes extra properties through to the captured event', async () => {
+        await trackToolCall('query-logs', 5, false, makeState(), { $mcp_via_exec: true })
+
+        expect(mockCapture.mock.calls[0]![0].properties.$mcp_via_exec).toBe(true)
+        expect(mockCapture.mock.calls[0]![0].properties.$mcp_tool_category).toBe('Logs')
+    })
+
+    it('emits mcp_exec_command with the command kind and inner tool', async () => {
+        await trackExecCommand(makeState(), {
+            commandKind: 'call',
+            innerToolName: 'query-logs',
+            durationMs: 7,
+            isError: false,
+        })
+
+        const call = mockCapture.mock.calls[0]![0]
+        expect(call.event).toBe('mcp_exec_command')
+        expect(call.properties).toMatchObject({
+            $mcp_exec_command_kind: 'call',
+            $mcp_exec_inner_tool: 'query-logs',
+            $mcp_duration_ms: 7,
+            $mcp_is_error: false,
+        })
+    })
+
+    it('omits $mcp_exec_inner_tool for non-call exec commands', async () => {
+        await trackExecCommand(makeState(), { commandKind: 'search', durationMs: 2, isError: false })
+
+        const call = mockCapture.mock.calls[0]![0]
+        expect(call.event).toBe('mcp_exec_command')
+        expect(call.properties).not.toHaveProperty('$mcp_exec_inner_tool')
+        expect(call.properties.$mcp_exec_command_kind).toBe('search')
     })
 })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/hono/metrics', () => ({
 
 vi.mock('@/hono/analytics', () => ({
     trackToolCall: vi.fn(),
+    trackExecCommand: vi.fn(),
 }))
 
 vi.mock('@/resources/internals', () => ({

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -7,7 +7,12 @@ import { buildQueryToolsBlock, buildToolDomainsBlock } from '@/lib/instructions'
 import { InstructionsFormatter } from '@/lib/instructions-formatter'
 import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
-import { createExecTool, type ExecInnerCallProperties, parseExecCallInnerToolName } from '@/tools/exec'
+import {
+    createExecTool,
+    type ExecInnerCallProperties,
+    parseExecCallInnerToolName,
+    parseExecCommandKind,
+} from '@/tools/exec'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import {
     POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
@@ -672,6 +677,26 @@ describe('exec tool', () => {
         ])('returns undefined for "%s"', (command) => {
             expect(parseExecCallInnerToolName(command)).toBeUndefined()
         })
+    })
+
+    describe('parseExecCommandKind', () => {
+        it.each([
+            ['call my-tool {}', 'call'],
+            ['  call   my-tool {}', 'call'],
+            ['info my-tool', 'info'],
+            ['schema my-tool field', 'schema'],
+            ['search query-', 'search'],
+            ['tools', 'tools'],
+        ])('classifies "%s" as "%s"', (command, expected) => {
+            expect(parseExecCommandKind(command)).toBe(expected)
+        })
+
+        it.each([['bogus my-tool'], [''], ['   '], ['CALL my-tool']])(
+            'classifies unrecognised command "%s" as "unknown"',
+            (command) => {
+                expect(parseExecCommandKind(command)).toBe('unknown')
+            }
+        )
     })
 
     describe('exec tool description', () => {


### PR DESCRIPTION
## Problem

MCP analytics added a category dimension (`$mcp_tool_category`) so teams can slice usage by ownership. But most traffic on the busiest projects flows through the `exec` meta-tool wrapper, and exec attribution was broken in two ways:

- The wrapper emitted an unattributed `mcp_tool_call` with `tool_name = 'exec'` (no category) on **every** invocation — the single largest bucket, dominating the "Uncategorized" slice and double-counting alongside the real inner-tool event.
- The inner-tool event used a **non-canonical shape**: it set `tool_name` and `duration_ms`/`success`, but never `$mcp_tool_name`, `$mcp_duration_ms`, or `$mcp_is_error` — the exact properties the tool-quality dashboard keys on (`breakdown: $mcp_tool_name`, latency `math_property: $mcp_duration_ms`, error `breakdown: $mcp_is_error`).

Net effect: exec-routed tool calls were essentially invisible to the per-tool, latency, and error views, and the per-team usage split under-counted every team whose traffic comes through `exec`.

## Changes

- **Inner tool calls now emit the canonical `mcp_tool_call`** via the shared `trackToolCall` (same shape + category as native calls), tagged with `$mcp_via_exec: true` so exec-routed traffic is still sliceable.
- **The wrapper invocation is recorded as a separate `mcp_exec_command` event** carrying `$mcp_exec_command_kind` (`call`/`info`/`search`/`schema`/`tools`/`unknown`) and, for `call` commands, `$mcp_exec_inner_tool`. This keeps exec usage fully countable without it masquerading as a tool name in the tool-quality dataset.
- Added `parseExecCommandKind` helper to classify the command verb.

A single `exec call query-logs` now produces exactly one `mcp_tool_call` (`query-logs`, category `Logs`, `$mcp_via_exec`) **and** one `mcp_exec_command` (`kind=call`, `inner_tool=query-logs`) — no double-count inside the tool dataset, and discovery verbs (`info`/`search`) stop inflating tool metrics while remaining countable.

Prometheus counters/timers are unchanged.

### Dashboard follow-up (no code here)

The tool-quality tiles keep working as-is. To surface exec explicitly, build a tile off `mcp_exec_command` rather than `mcp_tool_call`, and optionally add a `$mcp_via_exec` breakdown to the tool views. A residual slice of catalogued tools still arrives with no category, consistent with not-all-instances-on-the-new-build — worth confirming via a `$mcp_server_version` / `mcp_runtime` breakdown that no second/older runtime is serving un-stamped events.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** manually exercise a live MCP client. Automated tests only:

- Added unit tests for `parseExecCommandKind` (verbs + unknown fallback).
- Added tests for `trackExecCommand` (event name, command kind, inner-tool presence/absence) and for `trackToolCall` passing `$mcp_via_exec` through alongside the category.
- Updated the `@/hono/analytics` mock in the tool-executor metrics suite for the new export.
- Ran: full hono suite (`test:hono`, 250 passed / 1 pre-existing skip), `tests/unit/exec.test.ts` (70 passed), `tests/unit/posthog/analytics.test.ts` (27 passed). `tsc --noEmit` clean for touched files (only pre-existing `@posthog/quill` build-artifact errors remain). `oxlint` clean on all four source files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at a maintainer's request, originating from a discussion about MCP usage-by-team analytics looking inaccurate. Investigation traced the inaccuracy to the `exec` wrapper: live event queries showed `tool_name='exec'` as the dominant uncategorized bucket and catalogued tools arriving with null `$mcp_tool_name` (the inner-event shape mismatch). 

Design decision: rather than dropping the exec event (which would lose exec-usage visibility), exec-ness is modeled as a dimension — a `$mcp_via_exec` tag on the canonical tool event plus a dedicated `mcp_exec_command` event for wrapper-level counting — so both "which underlying tool ran" and "how often is exec used" are answerable from clean, separate datasets.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1781094161942289?thread_ts=1781094161.942289&cid=C09BDQLM8KA)*