### PR TITLE
chore(mcp_analytics): change product owner to product analytics team

### DIFF
--- a/products/mcp_analytics/product.yaml
+++ b/products/mcp_analytics/product.yaml
@@ -1,3 +1,3 @@
 name: MCP analytics
 owners:
-    - team-signals
+    - team-product-analytics


### PR DESCRIPTION
## Problem

PRs touching `products/mcp_analytics/**` keep auto-requesting review from **team signals**, even though the MCP analytics product isn't owned by that team. The reviewer auto-assigner derives reviewers from the `owners:` list in each `products/<name>/product.yaml`, and `mcp_analytics/product.yaml` still listed `team-signals`.

**Why:** the owner was set to team signals, so every mcp_analytics PR pinged them by mistake — the user wants product analytics to own it instead.

## Changes

Change the owner in `products/mcp_analytics/product.yaml` from `team-signals` to `team-product-analytics` (the slug product analytics already uses for `product_analytics`, `dashboards`, `actions`, etc.). Future `mcp_analytics` PRs will auto-assign to team product analytics.

## How did you test this code?

I'm an agent — no manual or automated testing was run. This is a one-line ownership-config change; the auto-assigner picks it up from `product.yaml` on the next PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at Sam's request. Traced the tagging behavior to the product-owner auto-assigner (`products/*/product.yaml` `owners:`), confirmed `team-product-analytics` is the correct slug used by the product analytics team's other products, and swapped the single owner entry.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1781099317934789)*
