### PR TITLE
fix(tasks): evict stale DB connections mid-activity and meter swallowed push failures

### DIFF
--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -107,6 +107,12 @@ TASK_RUN_STREAM_RESUME_GAP_TOTAL = Counter(
     labelnames=["origin_product"],
 )
 
+PUSH_DISPATCHER_FAILURES_TOTAL = Counter(
+    "posthog_tasks_push_dispatcher_failures_total",
+    "Push-notification dispatch attempts that failed and were swallowed by the best-effort dispatcher",
+    labelnames=["kind", "reason"],
+)
+
 
 def _metric_label(value: object | None) -> str:
     if value is None:

--- a/products/tasks/backend/push_dispatcher.py
+++ b/products/tasks/backend/push_dispatcher.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from django.db import transaction
+from django.conf import settings
+from django.db import InterfaceError, OperationalError, close_old_connections, transaction
 from django.utils import timezone
 
 import structlog
@@ -30,6 +31,7 @@ import posthoganalytics
 from posthog.models.user_push_token import UserPushToken
 from posthog.tasks.push_notifications import send_user_push
 
+from products.tasks.backend.metrics import PUSH_DISPATCHER_FAILURES_TOTAL
 from products.tasks.backend.models import TaskPresence
 from products.tasks.backend.redis import get_tasks_cache
 
@@ -89,7 +91,8 @@ def _enqueue(task_run: TaskRun, *, kind: PushKind, body: str) -> None:
     """
     try:
         _enqueue_inner(task_run, kind=kind, body=body)
-    except Exception:
+    except Exception as exc:
+        PUSH_DISPATCHER_FAILURES_TOTAL.labels(kind=kind, reason=_failure_reason(exc)).inc()
         logger.warning(
             "push_dispatcher.enqueue_failed",
             run_id=str(task_run.id),
@@ -99,7 +102,14 @@ def _enqueue(task_run: TaskRun, *, kind: PushKind, body: str) -> None:
         )
 
 
+def _failure_reason(exc: BaseException) -> str:
+    return "db_connection" if isinstance(exc, OperationalError | InterfaceError) else "other"
+
+
 def _enqueue_inner(task_run: TaskRun, *, kind: PushKind, body: str) -> None:
+    if not settings.TEST:
+        close_old_connections()
+
     user = task_run.task.created_by
     if user is None:
         return

--- a/products/tasks/backend/tests/test_push_dispatcher.py
+++ b/products/tasks/backend/tests/test_push_dispatcher.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
 from django.core.cache import cache
+from django.db import InterfaceError, OperationalError
 from django.test import TransactionTestCase
 
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 
 from posthog.models import Organization, OrganizationMembership, Team, User
 
@@ -129,6 +131,25 @@ class TestPushDispatcher(TransactionTestCase):
         # The bare except in _enqueue should catch the RuntimeError. If it
         # doesn't, this test raises and fails — which is the regression signal.
         notify_task_run_completed(self.task_run)
+
+    @parameterized.expand(
+        [
+            (
+                "db_connection_operational",
+                "db_connection",
+                OperationalError("server closed the connection unexpectedly"),
+            ),
+            ("db_connection_interface", "db_connection", InterfaceError("connection already closed")),
+            ("other", "other", RuntimeError("redis is down")),
+        ]
+    )
+    def test_swallowed_failure_increments_metric(self, _name, expected_reason, exc):
+        labels = {"kind": "completed", "reason": expected_reason}
+        before = REGISTRY.get_sample_value("posthog_tasks_push_dispatcher_failures_total", labels) or 0.0
+        with patch("products.tasks.backend.push_dispatcher._enqueue_inner", side_effect=exc):
+            notify_task_run_completed(self.task_run)
+        after = REGISTRY.get_sample_value("posthog_tasks_push_dispatcher_failures_total", labels) or 0.0
+        self.assertEqual(after, before + 1)
 
     @patch("products.tasks.backend.push_dispatcher.notify_task_run_completed")
     def test_mark_completed_triggers_push(self, mock_notify):


### PR DESCRIPTION
## Problem

Follow-up to #62100. During the June 8 2026 stale-DB-connection event on the cloud tasks agent (`tasks-task-queue` / `process-task`), the only logged DB errors were a pair of `OperationalError: server closed the connection unexpectedly` raised from the push dispatcher inside an activity, and both were swallowed.

Two gaps surfaced:

1. `@close_db_connections` only evicts at activity entry/exit., the push dispatcher runs minutes into the SSE relay, so a connection that went stale mid-activity is still reused
2. dispatcher swallows every exception (so it can never fail the surrounding lifecycle activity), which also hides these failures from the activity/workflow failure metrics. The incident was therefore invisible to every existing dashboard panel and alert.

## Changes

- `push_dispatcher._enqueue_inner`: call Django's age-aware `close_old_connections()` before the first ORM hit
- new counter `posthog_tasks_push_dispatcher_failures_total{kind, reason}`, incremented in the swallowed `except`. `reason="db_connection"` isolates the stale-connection class so it can be alerted on at low volume
