### PR TITLE
fix(logs): use per-partition checkpoint in log list query

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -25,7 +25,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
 
 from products.logs.backend.alert_utils import MAX_BYTES_TO_READ
-from products.logs.backend.logs_query_runner import LIVE_LOGS_CHECKPOINT_SQL, LogsFilterBuilder
+from products.logs.backend.logs_query_runner import LIVE_LOGS_CHECKPOINT_QUERY, LogsFilterBuilder
 from products.logs.backend.models import LogsAlertConfiguration
 
 
@@ -519,7 +519,7 @@ def fetch_live_logs_checkpoint(team: Team) -> dt.datetime | None:
     )
     response = execute_hogql_query(
         query_type="alert_check_checkpoint",
-        query=parse_select(LIVE_LOGS_CHECKPOINT_SQL),
+        query=LIVE_LOGS_CHECKPOINT_QUERY,
         team=team,
         workload=Workload.LOGS,
         modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),

--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -25,7 +25,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
 
 from products.logs.backend.alert_utils import MAX_BYTES_TO_READ
-from products.logs.backend.logs_query_runner import LogsFilterBuilder
+from products.logs.backend.logs_query_runner import LIVE_LOGS_CHECKPOINT_SQL, LogsFilterBuilder
 from products.logs.backend.models import LogsAlertConfiguration
 
 
@@ -505,18 +505,6 @@ class BatchedAlertCheckQuery:
         )
 
 
-# Explicit per-partition `GROUP BY` is required on both the dev `MergeTree`
-# shard (no auto-merge at all) and the prod `AggregatingMergeTree` between
-# merges. A bare `min(max_observed_timestamp)` scans every raw insert and
-# returns the oldest value ever written.
-_LIVE_LOGS_CHECKPOINT_SQL = """
-    SELECT min(partition_checkpoint) FROM (
-        SELECT _topic, _partition, max(max_observed_timestamp) AS partition_checkpoint
-        FROM logs_kafka_metrics
-        GROUP BY _topic, _partition
-    )
-"""
-
 # Fall back to `now` when the checkpoint is older than this — a quiet partition
 # can pin `min(...)` hours behind while other partitions have fresh data.
 CHECKPOINT_MAX_STALENESS = dt.timedelta(minutes=5)
@@ -531,7 +519,7 @@ def fetch_live_logs_checkpoint(team: Team) -> dt.datetime | None:
     )
     response = execute_hogql_query(
         query_type="alert_check_checkpoint",
-        query=parse_select(_LIVE_LOGS_CHECKPOINT_SQL),
+        query=parse_select(LIVE_LOGS_CHECKPOINT_SQL),
         team=team,
         workload=Workload.LOGS,
         modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -31,12 +31,6 @@ if TYPE_CHECKING:
     from posthog.models import Team, User
 
 
-# Explicit per-partition `GROUP BY` is required on both the dev `MergeTree` shard
-# (no auto-merge at all) and the prod `AggregatingMergeTree` between merges. A bare
-# `min(max_observed_timestamp)` scans every raw insert and returns the oldest value
-# ever written. Parsed once at import and shared with alert_check_query so the two
-# callers can't drift; execute_hogql_query clones before mutating, so reusing the
-# AST as both a subquery placeholder and a standalone query is safe.
 LIVE_LOGS_CHECKPOINT_QUERY = parse_select(
     """
     SELECT min(partition_checkpoint) FROM (

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -31,6 +31,19 @@ if TYPE_CHECKING:
     from posthog.models import Team, User
 
 
+# Explicit per-partition `GROUP BY` is required on both the dev `MergeTree` shard
+# (no auto-merge at all) and the prod `AggregatingMergeTree` between merges. A bare
+# `min(max_observed_timestamp)` scans every raw insert and returns the oldest value
+# ever written. Shared with alert_check_query so the two callers can't drift.
+LIVE_LOGS_CHECKPOINT_SQL = """
+    SELECT min(partition_checkpoint) FROM (
+        SELECT _topic, _partition, max(max_observed_timestamp) AS partition_checkpoint
+        FROM logs_kafka_metrics
+        GROUP BY _topic, _partition
+    )
+"""
+
+
 def _trace_id_normalise_to_base64(value: str) -> str:
     """Accept either hex or base64 encoded trace_id/span_id values.
 
@@ -558,12 +571,13 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMi
                 resource_fingerprint,
                 instrumentation_scope,
                 event_name,
-                (select min(max_observed_timestamp) from logs_kafka_metrics) as live_logs_checkpoint
+                {live_logs_checkpoint} as live_logs_checkpoint
             FROM logs
             WHERE {where}
         """,
                 placeholders={
                     "where": self.where(),
+                    "live_logs_checkpoint": parse_select(LIVE_LOGS_CHECKPOINT_SQL),
                     # Attribute maps dominate payload size. When excluded we still SELECT a column
                     # (an empty map) so the positional result mapping in _calculate stays stable.
                     "attributes": parse_expr("map() AS attributes" if self.query.excludeAttributes else "attributes"),

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -34,14 +34,18 @@ if TYPE_CHECKING:
 # Explicit per-partition `GROUP BY` is required on both the dev `MergeTree` shard
 # (no auto-merge at all) and the prod `AggregatingMergeTree` between merges. A bare
 # `min(max_observed_timestamp)` scans every raw insert and returns the oldest value
-# ever written. Shared with alert_check_query so the two callers can't drift.
-LIVE_LOGS_CHECKPOINT_SQL = """
+# ever written. Parsed once at import and shared with alert_check_query so the two
+# callers can't drift; execute_hogql_query clones before mutating, so reusing the
+# AST as both a subquery placeholder and a standalone query is safe.
+LIVE_LOGS_CHECKPOINT_QUERY = parse_select(
+    """
     SELECT min(partition_checkpoint) FROM (
         SELECT _topic, _partition, max(max_observed_timestamp) AS partition_checkpoint
         FROM logs_kafka_metrics
         GROUP BY _topic, _partition
     )
 """
+)
 
 
 def _trace_id_normalise_to_base64(value: str) -> str:
@@ -577,7 +581,7 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMi
         """,
                 placeholders={
                     "where": self.where(),
-                    "live_logs_checkpoint": parse_select(LIVE_LOGS_CHECKPOINT_SQL),
+                    "live_logs_checkpoint": LIVE_LOGS_CHECKPOINT_QUERY,
                     # Attribute maps dominate payload size. When excluded we still SELECT a column
                     # (an empty map) so the positional result mapping in _calculate stays stable.
                     "attributes": parse_expr("map() AS attributes" if self.query.excludeAttributes else "attributes"),


### PR DESCRIPTION
## Problem

The log list query returns a `live_logs_checkpoint` field (used by the UI to know how far ingestion has caught up). It was computed inline on **every page load** as `min(max_observed_timestamp)` taken directly over `logs_kafka_metrics`.

That bare form is wrong for this table: it scans every raw insert and returns the *oldest* value ever written instead of the live ingestion checkpoint. The alerting path (`fetch_live_logs_checkpoint`) already documented this exact pitfall and used the correct per-partition rollup — but the list query carried its own broken copy, so the two had drifted.

## Changes

- Hoist the canonical checkpoint SQL into a shared `LIVE_LOGS_CHECKPOINT_SQL` constant in `logs_query_runner.py`. It takes `max(max_observed_timestamp)` per `(_topic, _partition)` and then `min()` across partitions, which is required on both the dev `MergeTree` shard and the prod `AggregatingMergeTree` between merges.
- The log list query now references it via a `{live_logs_checkpoint}` placeholder (rendered as a scalar subquery) instead of an inline `min(...)`.
- `alert_check_query.py` imports the shared constant instead of defining its own, so the two callers can no longer drift.

This fixes both a correctness bug (the checkpoint surfaced to the UI was the oldest value ever written) and a per-page scan over raw inserts.

## How did you test this code?

I'm an agent. I ran the existing automated tests only — no manual testing:

- `products/logs/backend/test/test_logs_query_runner.py` (34 passed) — exercises `LogsQueryRunner.to_query()` SQL generation, confirming the placeholder renders as a valid scalar subquery.
- `products/logs/backend/test/test_alert_check_query.py::TestFetchLiveLogsCheckpoint` (4 passed) — the shared-helper path after switching to the imported constant.
- `ruff check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while running the `optimizing-clickhouse-and-hogql-queries` skill across the `@PostHog/logs` team's products (Logs, Tracing, Metrics) with Claude Code. The audit surfaced several candidates; the human scoped this PR to just this fix — the only finding that is an unambiguous correctness bug independent of any performance tradeoff (the others involve projection-vs-skip-index choices that need measurement on the logs cluster).

A first attempt added an SQL-shape assertion test; it was dropped on review because it just asserted the generated SQL matched the hand-written SQL rather than verifying behaviour. The existing `TestFetchLiveLogsCheckpoint` covers the now-shared helper.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
