### PR TITLE
fix(frontend): three memory-leak mop-ups from the background-tab investigation

### DIFF
--- a/frontend/src/lib/components/Map/Map.tsx
+++ b/frontend/src/lib/components/Map/Map.tsx
@@ -76,6 +76,10 @@ export function MapComponent({ center, markers, className }: MapProps): JSX.Elem
                 marker.addTo(map.current)
             }
         }
+        return () => {
+            map.current?.remove()
+            map.current = null
+        }
     }, [isDarkModeOn]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     useResizeObserver({

--- a/frontend/src/scenes/activity/live/liveEventsLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsLogic.tsx
@@ -106,10 +106,8 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
         clearEvents: () => {
             cache.batch = []
         },
-        updateEventsConnection: async () => {
-            if (cache.eventSourceController) {
-                cache.eventSourceController.abort()
-            }
+        updateEventsConnection: () => {
+            cache.disposables.dispose('eventsConnection')
 
             if (values.streamPaused) {
                 return
@@ -138,46 +136,49 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
             }
             url.searchParams.append('columns', '$current_url,$screen_name')
 
-            cache.batch = []
-            cache.eventSourceController = new AbortController()
-
-            await api.stream(url.toString(), {
-                headers: {
-                    Authorization: `Bearer ${values.currentTeam.live_events_token}`,
-                },
-                signal: cache.eventSourceController.signal,
-                onMessage: (event) => {
-                    lemonToast.dismiss(ERROR_TOAST_ID)
-                    let eventData: LiveEvent
-                    try {
-                        eventData = JSON.parse(event.data)
-                    } catch {
-                        // Drop malformed stream payloads rather than throwing inside the listener
-                        return
-                    }
-                    cache.batch.push(eventData)
-                    if (cache.batch.length >= 10 || performance.now() - (values.lastBatchTimestamp || 0) > 300) {
-                        actions.addEvents(cache.batch)
-                        cache.batch.length = 0
-                    }
-                },
-                onError: (error) => {
-                    if (!cache.hasShownLiveStreamErrorToast && props.showLiveStreamErrorToast) {
-                        console.error('Failed to poll events. You likely have no events coming in.', error)
-                        lemonToast.error(`No live events found. Continuing to retry in the background…`, {
-                            icon: <Spinner />,
-                            toastId: ERROR_TOAST_ID,
-                            autoClose: false,
-                        })
-                        cache.hasShownLiveStreamErrorToast = true
-                    }
-                },
-            })
+            // Managed as a disposable so the long-lived streaming Response is aborted when
+            // the tab is hidden and reopened on visibilitychange — an open stream on an idle
+            // background tab accumulates off-heap in Blink's partition_alloc/buffer.
+            cache.disposables.add(() => {
+                cache.batch = []
+                const controller = new AbortController()
+                void api.stream(url.toString(), {
+                    headers: {
+                        Authorization: `Bearer ${values.currentTeam?.live_events_token}`,
+                    },
+                    signal: controller.signal,
+                    onMessage: (event) => {
+                        lemonToast.dismiss(ERROR_TOAST_ID)
+                        let eventData: LiveEvent
+                        try {
+                            eventData = JSON.parse(event.data)
+                        } catch {
+                            // Drop malformed stream payloads rather than throwing inside the listener
+                            return
+                        }
+                        cache.batch.push(eventData)
+                        if (cache.batch.length >= 10 || performance.now() - (values.lastBatchTimestamp || 0) > 300) {
+                            actions.addEvents(cache.batch)
+                            cache.batch.length = 0
+                        }
+                    },
+                    onError: (error) => {
+                        if (!cache.hasShownLiveStreamErrorToast && props.showLiveStreamErrorToast) {
+                            console.error('Failed to poll events. You likely have no events coming in.', error)
+                            lemonToast.error(`No live events found. Continuing to retry in the background…`, {
+                                icon: <Spinner />,
+                                toastId: ERROR_TOAST_ID,
+                                autoClose: false,
+                            })
+                            cache.hasShownLiveStreamErrorToast = true
+                        }
+                    },
+                })
+                return () => controller.abort()
+            }, 'eventsConnection')
         },
         pauseStream: () => {
-            if (cache.eventSourceController) {
-                cache.eventSourceController.abort()
-            }
+            cache.disposables.dispose('eventsConnection')
         },
         resumeStream: () => {
             actions.updateEventsConnection()
@@ -205,14 +206,9 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
             }
         },
     })),
-    events(({ actions, cache }) => ({
+    events(({ actions }) => ({
         afterMount: () => {
             actions.updateEventsConnection()
-        },
-        beforeUnmount: () => {
-            if (cache.eventSourceController) {
-                cache.eventSourceController.abort()
-            }
         },
     })),
 ])

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -12,7 +12,6 @@ import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
 import { objectsEqual, uuid } from 'lib/utils'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene, SceneTab } from 'scenes/sceneTypes'
-import { maxSettingsLogic } from 'scenes/settings/environment/maxSettingsLogic'
 import { urls } from 'scenes/urls'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -164,8 +163,6 @@ export const maxLogic = kea<maxLogicType>([
                 'conversationHistory',
                 'conversationHistoryLoading',
             ],
-            maxSettingsLogic,
-            ['coreMemory'],
             // Actions are lazy-loaded. In order to display their names in the UI, we're loading them here.
             actionsModel({ params: 'include_count=1' }),
             ['actions'],


### PR DESCRIPTION
## Problem

The browser memory investigation tracked in #32479 surfaced three small, independently verified retention bugs that were noted but never fixed. Each one keeps work or memory alive longer than it should, and two of them specifically make backgrounded tabs more expensive.

## Changes

- **`Map.tsx`**: `MapComponent` created a maplibre `Map` in an effect but never called `map.remove()`, so the GL context, workers, and tile caches of every unmounted map instance were retained. The effect now returns a cleanup that destroys the map (this also covers the dark-mode re-create path).
- **`maxLogic`**: removed a `connect` to `maxSettingsLogic` for a `coreMemory` value that nothing in the logic reads. The connect force-mounted `maxSettingsLogic`, whose `afterMount` fetches the entire PostHog AI core memory (which can be multiple MB of markdown) and holds it in kea state on every page where `maxLogic` mounts. The one real consumer (`SidebarQuestionInputWithSuggestions`) already subscribes to `maxSettingsLogic` directly, so behavior there is unchanged.
- **`liveEventsLogic`**: the live-events SSE stream was a hand-managed `AbortController` with no visibility handling, so a backgrounded tab held its long-lived streaming `Response` open indefinitely — the same shape that #58737 fixed for the notifications stream, where it measurably accumulated off-heap memory in Blink's allocators. The connection is now a `kea-disposables` entry (`pauseOnPageHidden` default), so hidden tabs abort the stream and reopen it on `visibilitychange`, and the manual `beforeUnmount` is gone.

## How did you test this code?

I'm an agent; no manual testing claimed. Automated checks run locally:

- `jest src/scenes/activity/live/liveEventsLogic.test.ts` — 4/4 passing
- `jest src/scenes/max/maxLogic.test.ts` — 34/34 passing
- `tsc --noEmit` on the frontend — clean
- oxlint/oxfmt on the touched files — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @pauldambra as part of the #32479 memory investigation. The three bugs were identified in earlier heap/footprint analysis sessions; this PR is the mop-up. The live-events change follows the disposable pattern established in #58737 rather than inventing a new lifecycle, and the maxLogic change deliberately removes only the dead connect (a lighter-weight "does core memory exist" endpoint was considered and deferred as out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
