### PR TITLE
fix(cohorts): de-flake performed_event_regularly variable counts test

### DIFF
--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1086,6 +1086,12 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             assert sorted([p1.uuid, p2.uuid]) == sorted([r[0] for r in res])
 
     def test_performed_event_regularly_with_variable_event_counts_in_each_period(self):
+        # Pin to midnight so events at now-12h stay on yesterday: the cohort date range ends
+        # at "-1d", so when CI runs after noon UTC those events land on today and get excluded
+        with freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)):
+            self._assert_performed_event_regularly_with_variable_event_counts()
+
+    def _assert_performed_event_regularly_with_variable_event_counts(self):
         p1 = _create_person(
             team_id=self.team.pk,
             distinct_ids=["p1"],


### PR DESCRIPTION
## Problem

`test_performed_event_regularly_with_variable_event_counts_in_each_period` has been flaking in CI for months, always in a narrow window around noon UTC. Test events are created at `now - 12h - i min`, and the cohort's date range ends at `-1d` — so when CI runs at ~12:00–12:02 UTC, those events straddle midnight: some land on "today" and get excluded from the range, and a single period's events can split across adjacent cohort buckets, dropping an expected person from the cohort.

## Changes

- Pin the test clock to midnight with `freeze_time` (the idiom other tests in this file already use), so event placement relative to the date range and bucket boundaries no longer depends on when CI runs.
- Test body moves into a helper so the freeze wraps event creation and both query executions.

## How did you test this code?

Agent-authored; automated testing only:

- Reproduced deterministically: freezing the clock to 12:00:30 makes the unfixed test fail at the same assertion as the CI failures.
- With the midnight freeze the test passed 10/10 consecutive local runs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a CI flake triage session. Traced the failure pattern (occurrences cluster ~12:00–12:45 UTC) to the midnight-straddling mechanism, confirmed by reproducing the failure under a frozen noon clock before applying the fix.
- An alternative fix — changing the production cohort query's `date_to="-1d"` boundary — was rejected: that's a product behavior decision, and the test comparison that motivated it (HogQL vs legacy raw SQL parity) no longer exists. This PR only makes the test deterministic.
