### PR TITLE
fix(error-tracking): skip deleted teams in recommendations batch refresh

### DIFF
--- a/products/error_tracking/backend/recommendations/refresh.py
+++ b/products/error_tracking/backend/recommendations/refresh.py
@@ -9,6 +9,8 @@ from django.utils import timezone
 import structlog
 from posthoganalytics import capture_exception
 
+from posthog.models import Team
+
 from products.error_tracking.backend.models import ErrorTrackingRecommendation
 from products.error_tracking.backend.recommendations import RECOMMENDATIONS
 from products.error_tracking.backend.recommendations.base import Recommendation
@@ -141,6 +143,20 @@ def refresh_teams_recommendations_batched(team_ids: list[int], on_progress: Call
     """
     now = timezone.now()
     types = [rec.type for rec in RECOMMENDATIONS]
+
+    # Team ids come from a ClickHouse scan of recent events, which retains events for teams
+    # that have since been deleted from Postgres. Writing a recommendation row for such a team
+    # violates the team_id foreign key and (since it's a single INSERT) fails the whole batch,
+    # so drop the deleted teams before any writes.
+    existing_team_ids = list(Team.objects.filter(id__in=team_ids).values_list("id", flat=True))
+    if len(existing_team_ids) != len(team_ids):
+        logger.info(
+            "error_tracking_recommendation_skipped_deleted_teams",
+            skipped=len(team_ids) - len(existing_team_ids),
+        )
+    team_ids = existing_team_ids
+    if not team_ids:
+        return 0
 
     def fetch_rows() -> dict[tuple[int, str], ErrorTrackingRecommendation]:
         return {

--- a/products/error_tracking/backend/recommendations/refresh.py
+++ b/products/error_tracking/backend/recommendations/refresh.py
@@ -131,7 +131,9 @@ def refresh_team_recommendations(team_id: int) -> int:
     return sum(_refresh_one(rec, team_id, now) for rec in RECOMMENDATIONS)
 
 
-def refresh_teams_recommendations_batched(team_ids: list[int], on_progress: Callable[[str], None] | None = None) -> int:
+def refresh_teams_recommendations_batched(
+    team_ids: list[int], on_progress: Callable[[str], None] | None = None
+) -> tuple[int, int]:
     """Compute every stale recommendation for a batch of teams with a bounded number
     of queries, independent of batch size.
 
@@ -139,7 +141,8 @@ def refresh_teams_recommendations_batched(team_ids: list[int], on_progress: Call
     the batch, and each recommendation answers all claimed teams via one
     ``compute_batch`` call. Used by the Temporal background sweep.
 
-    Returns the number of recommendations computed.
+    Returns ``(teams_processed, recommendations_computed)``, where ``teams_processed``
+    excludes any teams dropped for no longer existing in Postgres.
     """
     now = timezone.now()
     types = [rec.type for rec in RECOMMENDATIONS]
@@ -156,7 +159,7 @@ def refresh_teams_recommendations_batched(team_ids: list[int], on_progress: Call
         )
     team_ids = existing_team_ids
     if not team_ids:
-        return 0
+        return 0, 0
 
     def fetch_rows() -> dict[tuple[int, str], ErrorTrackingRecommendation]:
         return {
@@ -182,7 +185,7 @@ def refresh_teams_recommendations_batched(team_ids: list[int], on_progress: Call
         computed += _refresh_rec_for_teams(rec, team_ids, rows, now)
         if on_progress is not None:
             on_progress(rec.type)
-    return computed
+    return len(team_ids), computed
 
 
 def _refresh_rec_for_teams(

--- a/products/error_tracking/backend/temporal/recommendations_refresh/activities.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/activities.py
@@ -67,5 +67,5 @@ def get_team_batches_activity(inputs: RecommendationsRefreshInputs) -> list[list
 
 @activity.defn
 def refresh_recommendations_batch_activity(inputs: RefreshBatchInputs) -> RefreshBatchResult:
-    kicked = refresh_teams_recommendations_batched(inputs.team_ids, on_progress=activity.heartbeat)
-    return RefreshBatchResult(teams_processed=len(inputs.team_ids), recommendations_kicked=kicked)
+    teams_processed, kicked = refresh_teams_recommendations_batched(inputs.team_ids, on_progress=activity.heartbeat)
+    return RefreshBatchResult(teams_processed=teams_processed, recommendations_kicked=kicked)

--- a/products/error_tracking/backend/temporal/recommendations_refresh/test/test_recommendations_refresh.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/test/test_recommendations_refresh.py
@@ -165,7 +165,8 @@ class TestRefreshRecommendationsBatchActivity(APIBaseTest):
 
         result = _run_batch_activity(RefreshBatchInputs(team_ids=[self.team.id, deleted_team_id]))
 
-        assert result.teams_processed == 2
+        # teams_processed reflects only the surviving team, not the raw input count.
+        assert result.teams_processed == 1
         assert result.recommendations_kicked == 4
         assert ErrorTrackingRecommendation.objects.filter(team_id=self.team.id).count() == 4
         assert ErrorTrackingRecommendation.objects.filter(team_id=deleted_team_id).count() == 0
@@ -181,6 +182,7 @@ class TestRefreshRecommendationsBatchActivity(APIBaseTest):
 
         result = _run_batch_activity(RefreshBatchInputs(team_ids=[deleted_team_id]))
 
+        assert result.teams_processed == 0
         assert result.recommendations_kicked == 0
         assert ErrorTrackingRecommendation.objects.filter(team_id=deleted_team_id).count() == 0
 

--- a/products/error_tracking/backend/temporal/recommendations_refresh/test/test_recommendations_refresh.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/test/test_recommendations_refresh.py
@@ -155,6 +155,38 @@ class TestRefreshRecommendationsBatchActivity(APIBaseTest):
     @patch(_RATE_LIMITS_COMPUTE_BATCH, side_effect=_batch_meta(_RATE_LIMITS_META))
     @patch(_SOURCE_MAPS_COMPUTE_BATCH, side_effect=_batch_meta(_SOURCE_MAPS_META))
     @patch(_LONG_RUNNING_COMPUTE_BATCH, side_effect=_batch_meta(_LONG_RUNNING_META))
+    @patch(_ALERTS_COMPUTE_BATCH, side_effect=_batch_meta(_ALERTS_META))
+    def test_skips_deleted_teams_without_failing_batch(self, _alerts, _long, _source, _rate_limits):
+        # ClickHouse retains events for teams later deleted from Postgres; the batch must
+        # process surviving teams and not blow up on the missing team_id foreign key.
+        deleted_team = Team.objects.create(organization=self.organization, name="Doomed")
+        deleted_team_id = deleted_team.id
+        deleted_team.delete()
+
+        result = _run_batch_activity(RefreshBatchInputs(team_ids=[self.team.id, deleted_team_id]))
+
+        assert result.teams_processed == 2
+        assert result.recommendations_kicked == 4
+        assert ErrorTrackingRecommendation.objects.filter(team_id=self.team.id).count() == 4
+        assert ErrorTrackingRecommendation.objects.filter(team_id=deleted_team_id).count() == 0
+
+    @patch(_RATE_LIMITS_COMPUTE_BATCH, side_effect=_batch_meta(_RATE_LIMITS_META))
+    @patch(_SOURCE_MAPS_COMPUTE_BATCH, side_effect=_batch_meta(_SOURCE_MAPS_META))
+    @patch(_LONG_RUNNING_COMPUTE_BATCH, side_effect=_batch_meta(_LONG_RUNNING_META))
+    @patch(_ALERTS_COMPUTE_BATCH, side_effect=_batch_meta(_ALERTS_META))
+    def test_all_teams_deleted_kicks_nothing(self, _alerts, _long, _source, _rate_limits):
+        deleted_team = Team.objects.create(organization=self.organization, name="Doomed")
+        deleted_team_id = deleted_team.id
+        deleted_team.delete()
+
+        result = _run_batch_activity(RefreshBatchInputs(team_ids=[deleted_team_id]))
+
+        assert result.recommendations_kicked == 0
+        assert ErrorTrackingRecommendation.objects.filter(team_id=deleted_team_id).count() == 0
+
+    @patch(_RATE_LIMITS_COMPUTE_BATCH, side_effect=_batch_meta(_RATE_LIMITS_META))
+    @patch(_SOURCE_MAPS_COMPUTE_BATCH, side_effect=_batch_meta(_SOURCE_MAPS_META))
+    @patch(_LONG_RUNNING_COMPUTE_BATCH, side_effect=_batch_meta(_LONG_RUNNING_META))
     @patch(_ALERTS_COMPUTE_BATCH, side_effect=lambda team_ids: {})
     def test_missing_meta_reverts_claim(self, _alerts, _long, _source, _rate_limits):
         result = _run_batch_activity(RefreshBatchInputs(team_ids=[self.team.id]))

--- a/products/error_tracking/backend/temporal/recommendations_refresh/workflow.py
+++ b/products/error_tracking/backend/temporal/recommendations_refresh/workflow.py
@@ -48,6 +48,7 @@ class ErrorTrackingRecommendationsRefreshWorkflow(PostHogWorkflow):
             return RecommendationsRefreshResult(teams_total=0, recommendations_kicked=0, batches_failed=0)
 
         kicked = 0
+        teams_total = 0
         batches_failed = 0
         # Keep up to max_concurrent_batches activities in flight at all times: the
         # semaphore releases the moment one finishes, so the next batch starts
@@ -74,9 +75,10 @@ class ErrorTrackingRecommendationsRefreshWorkflow(PostHogWorkflow):
                 )
                 continue
             kicked += result.recommendations_kicked
+            teams_total += result.teams_processed
 
         return RecommendationsRefreshResult(
-            teams_total=sum(len(batch) for batch in batches),
+            teams_total=teams_total,
             recommendations_kicked=kicked,
             batches_failed=batches_failed,
         )


### PR DESCRIPTION
## Problem

The error tracking recommendations refresh sweep was throwing `ForeignKeyViolation` on `posthog_errortrackingrecommendation`:

```
insert or update on table "posthog_errortrackingrecommendation" violates foreign key constraint "..._team_id_..._fk_posthog_t"
DETAIL:  Key (team_id)=(...) is not present in table "posthog_team".
```

The Temporal sweep enumerates teams from a ClickHouse scan of recent `$exception` events. ClickHouse retains events for teams that have since been **deleted from Postgres**, so a batch can contain a `team_id` with no `posthog_team` row. The batched `bulk_create` of recommendation rows uses `ignore_conflicts=True`, which swallows *unique-constraint* conflicts but **not** foreign-key violations — so a single deleted team aborted the whole INSERT and failed the entire batch (and, after retries, the Temporal activity).

## Changes

Filter `team_ids` down to teams that still exist in Postgres at the start of `refresh_teams_recommendations_batched`, before any writes. Surviving teams are processed normally; deleted teams are dropped (with a log line for visibility). The on-demand single-team API path already swallowed per-recommendation exceptions, so only the background batch path needed the fix.

> Note: an earlier PR #62366 attempted this fix, but it predates the refactor to the batched sweep and patches code paths (`ensure_recommendation_row`, `get_teams_with_recent_exceptions_activity`) that no longer carry the failure — the current culprit is the batch `bulk_create`. This PR targets the live code path. Refs #62366.

## How did you test this code?

I'm an agent (PostHog Slack app). I added two automated regression tests to `TestRefreshRecommendationsBatchActivity`:
- `test_skips_deleted_teams_without_failing_batch` — a batch mixing a live team and a hard-deleted team processes the live team and writes no rows for the deleted one.
- `test_all_teams_deleted_kicks_nothing` — an all-deleted batch returns 0 and writes nothing.

I could **not** run the suite in this environment (no Postgres/ClickHouse reachable here). `ruff check` and `ruff format --check` pass on the changed files. CI should exercise the new tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a Slack thread reporting the `ForeignKeyViolation`. The user asked for the Temporal workflow to tolerate teams that no longer exist.

Approach: traced the FK violation to `refresh_teams_recommendations_batched`'s `bulk_create(..., ignore_conflicts=True)`, which does not ignore FK violations. Chose to filter at the single funnel point inside the batch function (rather than only in the enumeration activity) so the guard holds regardless of how teams are enumerated. Discovered an existing stale PR (#62366) for the same symptom that predates the batching refactor and no longer covers the failing path — noted as superseded.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087FAT5FK5/p1781101380531549?thread_ts=1781101380.531549&cid=C087FAT5FK5)*
