### PR TITLE
chore(stamphog): bump reviewer model to fable 5

### DIFF
--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     _POSTHOG_AI_AVAILABLE = False
 
-MODEL = "claude-sonnet-4-6"
+MODEL = "claude-fable-5"
 
 
 _CONTROL_CHARS_RE = re.compile(r"[^\x20-\x7E\n\t]")


### PR DESCRIPTION
## Problem

The stamphog PR reviewer runs on Claude Sonnet 4.6. Claude Fable 5 is the most capable current model, and review quality (bug finding, judgment on escalate-vs-approve) benefits from the stronger model.

## Changes

- Bump the `MODEL` constant in `tools/pr-approval-agent/reviewer.py` from `claude-sonnet-4-6` to `claude-fable-5`.
- No other changes needed: the call site already matches Fable 5's API surface — no sampling params, no `thinking` param (Fable 5 rejects an explicit `disabled`), and `effort` ("low"/"high") plus structured outputs are both supported.

Note: Fable 5 is priced at $10/$50 per MTok vs Sonnet 4.6's $3/$15 — roughly a 3.3x cost increase per review.

## How did you test this code?

Agent-authored; ran the tool's test suite (`hogli test tools/pr-approval-agent/`) — 137 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Before the bump, verified the reviewer's `ClaudeAgentOptions` against Fable 5's breaking changes (no `budget_tokens`, no sampling parameters, no assistant prefills, effort levels supported) — the existing options are fully compatible, so this is a pure model-ID swap.
