### PR TITLE
feat(navigation): add browse-all-products entry to my apps sidebar

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconApps, IconCheck, IconGear, IconPencil, IconPlusSmall } from '@posthog/icons'
+import { IconCheck, IconGear, IconPencil, IconPlusSmall } from '@posthog/icons'
 
 import { ItemSelectModalButton } from 'lib/components/FileSystem/ItemSelectModal/ItemSelectModal'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -133,19 +133,6 @@ export function PinnedFolder(): JSX.Element {
                 ))}
             <div className="flex flex-col mt-[-0.5rem] h-full group/colorful-product-icons colorful-product-icons-true">
                 <ProjectTree root={pinnedFolder} onlyTree treeSize={isLayoutNavCollapsed ? 'narrow' : 'default'} />
-                {pinnedFolder === 'custom-products://' && !isLayoutNavCollapsed ? (
-                    <ButtonPrimitive
-                        menuItem
-                        onClick={openEditCustomProductsModal}
-                        className="mt-1 text-tertiary"
-                        tooltip="See every product, including ones not in your sidebar"
-                        tooltipPlacement="top"
-                        data-attr="browse-all-products-button"
-                    >
-                        <IconApps className="size-4" />
-                        Browse all products
-                    </ButtonPrimitive>
-                ) : null}
             </div>
             <EditCustomProductsModal />
         </>

--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCheck, IconGear, IconPencil, IconPlusSmall } from '@posthog/icons'
+import { IconApps, IconCheck, IconGear, IconPencil, IconPlusSmall } from '@posthog/icons'
 
 import { ItemSelectModalButton } from 'lib/components/FileSystem/ItemSelectModal/ItemSelectModal'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -142,7 +142,7 @@ export function PinnedFolder(): JSX.Element {
                         tooltipPlacement="top"
                         data-attr="browse-all-products-button"
                     >
-                        <IconPlusSmall className="size-4" />
+                        <IconApps className="size-4" />
                         Browse all products
                     </ButtonPrimitive>
                 ) : null}

--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -133,6 +133,19 @@ export function PinnedFolder(): JSX.Element {
                 ))}
             <div className="flex flex-col mt-[-0.5rem] h-full group/colorful-product-icons colorful-product-icons-true">
                 <ProjectTree root={pinnedFolder} onlyTree treeSize={isLayoutNavCollapsed ? 'narrow' : 'default'} />
+                {pinnedFolder === 'custom-products://' && !isLayoutNavCollapsed ? (
+                    <ButtonPrimitive
+                        menuItem
+                        onClick={openEditCustomProductsModal}
+                        className="mt-1 text-tertiary"
+                        tooltip="See every product, including ones not in your sidebar"
+                        tooltipPlacement="top"
+                        data-attr="browse-all-products-button"
+                    >
+                        <IconPlusSmall className="size-4" />
+                        Browse all products
+                    </ButtonPrimitive>
+                ) : null}
             </div>
             <EditCustomProductsModal />
         </>

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -426,6 +426,22 @@ export function NavTabBrowse(): JSX.Element {
                                 }
                             />
                         )}
+                        {(expandedNavSections.apps ?? false) && !isEditMode && !isLayoutNavCollapsed && (
+                            <ButtonPrimitive
+                                menuItem
+                                onClick={() => {
+                                    posthog.capture('nav browse all products clicked')
+                                    enterEditMode()
+                                }}
+                                tooltip="See every product, including ones not in your sidebar"
+                                tooltipPlacement="top"
+                                data-attr="browse-all-products-button"
+                                className="mt-1 text-tertiary"
+                            >
+                                <IconApps className="size-4" />
+                                Browse all products
+                            </ButtonPrimitive>
+                        )}
                     </Collapsible.Panel>
                 </Collapsible>
             )}


### PR DESCRIPTION
## Problem

The "My Apps" sidebar shows only a curated subset of products. The only way to reach the rest is the small edit pencil in the section header, which is easy to miss. If a product a user relies on isn't in their curated list, it effectively disappears from navigation with no obvious way to bring it back.

This is the discoverability gap behind the recurring "product X vanished from my sidebar" reports. It solves the same user problem as auto-adding products by data signals, but without putting anything in people's sidebars that they don't need.

## Changes

<img width="396" height="1730" alt="browse-all-products-edit-mode" src="https://github.com/user-attachments/assets/4b33b76e-9a69-4152-84a4-b6087c12ecbf" />

<img width="396" height="1800" alt="browse-all-products-entry" src="https://github.com/user-attachments/assets/1a3240a5-3bbc-4a06-9e4d-452154c36893" />

Adds a persistent **"Browse all products"** entry beneath the My Apps list in the nav. It triggers the section's existing inline edit mode, which lists every product with checkboxes so any of them can be toggled into the sidebar. No change to what's seeded by default; purely a visible entry point to the full catalog.

- `frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx`: a `ButtonPrimitive` (matching the existing tree-row styling) under the apps `Collapsible.Panel`, wired to `inlineEditAppsLogic.enterEditMode()`, shown when the section is expanded, not already in edit mode, and the nav isn't collapsed.

Note: an earlier revision of this PR put the entry in `PinnedFolder.tsx`. That component turned out to have no usages — it isn't mounted anywhere — so the change was a no-op in the running app. Verifying in a sandbox surfaced this; the entry now lives in `NavTabBrowse`, the nav that actually renders.

## How did you test this code?

I'm an agent (Claude Code, directed by the PR author). What I verified, end to end in a PostHog sandbox (logged in, `custom-products-sidebar` flag on):

- The "Browse all products" entry renders at the bottom of the My Apps list (screenshot captured).
- Clicking it enters the inline edit mode: the tree re-renders the full product catalog with checkboxes (confirmed 20 product checkboxes appear), so a user can pick any product into their sidebar.
- Lint clean (`oxlint`, `oxfmt`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Replaces an earlier approach that auto-added products when a team was sending the data that powers them; that was closed after review feedback that team-level data presence shouldn't push products into every member's sidebar. This affordance solves the same discoverability problem with zero default sidebar changes. The first implementation targeted a dead component (`PinnedFolder`); a sandbox e2e check caught it and the affordance was moved to the rendered nav (`NavTabBrowse`), reusing its existing edit-mode mechanism rather than a separate modal.
