### PR TITLE
feat(dashboards): add feedback button to add-widget modal

### DIFF
--- a/products/dashboards/frontend/widgets/AddWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/AddWidgetModal.tsx
@@ -95,7 +95,7 @@ export function AddWidgetModal({ isOpen, onClose, loading, onAdd }: AddWidgetMod
                         onClick={handleFeedbackClicked}
                         data-attr="dashboard-add-widget-feedback"
                     >
-                        Can't find what you're looking for? Give feedback
+                        Missing a widget? Let us know
                     </LemonButton>
                     <div className="flex-1" />
                     <LemonButton type="secondary" onClick={onClose}>

--- a/products/dashboards/frontend/widgets/AddWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/AddWidgetModal.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 import { Fragment } from 'react'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -74,6 +75,11 @@ export function AddWidgetModal({ isOpen, onClose, loading, onAdd }: AddWidgetMod
         void submitAddWidgetPayloads(selectedTypes, onAdd, onClose)
     }
 
+    function handleFeedbackClicked(): void {
+        posthog.capture('dashboard add widget modal - feedback clicked')
+        onClose()
+    }
+
     return (
         <LemonModal
             isOpen={isOpen}
@@ -83,6 +89,14 @@ export function AddWidgetModal({ isOpen, onClose, loading, onAdd }: AddWidgetMod
             width={960}
             footer={
                 <>
+                    <LemonButton
+                        type="tertiary"
+                        size="small"
+                        onClick={handleFeedbackClicked}
+                        data-attr="dashboard-add-widget-feedback"
+                    >
+                        Can't find what you're looking for? Give feedback
+                    </LemonButton>
                     <div className="flex-1" />
                     <LemonButton type="secondary" onClick={onClose}>
                         Cancel


### PR DESCRIPTION
## Problem

- The dashboard **"Add widget"** modal lets users pick from the widget catalog, but there's no escape hatch when the widget they want isn't there.
- We want lightweight, in-context feedback at that exact moment to learn: **do people like widgets**, and **which widgets do they want**.

## Changes

- Adds a left-aligned footer button — **"Missing a widget? Let us know"** — to the add-widget modal (`AddWidgetModal.tsx`).
- Clicking it captures a `dashboard add widget modal - feedback clicked` event (following the existing `<area> modal - <action>` naming convention) and closes the modal so the survey popover can surface.
- Cancel / Add widget buttons stay right-aligned via the existing `flex-1` spacer.
- A draft popover survey is configured to trigger on that event — no survey UUID lives in the frontend; the survey is matched purely by its event trigger.

### Survey

- **Survey:** [\[Analytics Platform\] Dashboard widget feedback](https://us.posthog.com/project/2/surveys/019eb220-da13-0000-d576-be9f28183f07) (project 2)
- **Q1 (rating, 5-point emoji):** "How do you feel about dashboard widgets?" — *do people like widgets*
- **Q2 (open text, optional):** "What widgets would you like to see?" — *which widgets they want*
- **Status:** draft — the popover will **not** appear until the survey is launched in the Surveys UI.

## How did you test this code?

- I'm an agent. I ran the frontend formatter (lint-staged on commit) and a TypeScript check on the modified file (no errors).
- I have **not** manually exercised the popover in a running app — that requires launching the draft survey first.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Opus).
- Chose an **event-triggered native popover survey** over a custom in-app survey modal (e.g. the billing `survey shown`/`survey sent` pattern) because it reuses posthog-js's built-in survey rendering — no custom emoji-rating UI to maintain and nothing to hardcode in the frontend.
- Tradeoff: the native popover is subject to survey display throttling; `seenSurveyWaitPeriodInDays: 0` is set to mitigate.
- Initial pass mistakenly targeted the "Add insight to dashboard" modal; corrected to the actual widget catalog modal (`products/dashboards/frontend/widgets/AddWidgetModal.tsx`).
- Button copy and survey questions were aligned to the widget-feedback intent after review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
