### PR TITLE
fix(error-tracking): reject malformed issueId and personId params

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_breakdowns_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_breakdowns_query_runner.py
@@ -28,7 +28,9 @@ class ErrorTrackingBreakdownsQueryRunner(AnalyticsQueryRunner[ErrorTrackingBreak
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        validate_uuid_param(self.query.issueId, "issueId")
+        canonical_issue_id = validate_uuid_param(self.query.issueId, "issueId")
+        if canonical_issue_id is not None:
+            self.query.issueId = canonical_issue_id
         self.date_from = self.parse_relative_date_from(self.query.dateRange.date_from if self.query.dateRange else None)
         self.date_to = self.parse_relative_date_to(self.query.dateRange.date_to if self.query.dateRange else None)
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_breakdowns_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_breakdowns_query_runner.py
@@ -17,6 +17,8 @@ from posthog.hogql_queries.insights.utils.breakdowns import BREAKDOWN_NULL_STRIN
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.utils import relative_date_parse
 
+from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import validate_uuid_param
+
 logger = structlog.get_logger(__name__)
 
 
@@ -26,6 +28,7 @@ class ErrorTrackingBreakdownsQueryRunner(AnalyticsQueryRunner[ErrorTrackingBreak
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        validate_uuid_param(self.query.issueId, "issueId")
         self.date_from = self.parse_relative_date_from(self.query.dateRange.date_from if self.query.dateRange else None)
         self.date_to = self.parse_relative_date_to(self.query.dateRange.date_to if self.query.dateRange else None)
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_breakdowns_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_breakdowns_query_runner.py
@@ -28,9 +28,7 @@ class ErrorTrackingBreakdownsQueryRunner(AnalyticsQueryRunner[ErrorTrackingBreak
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        canonical_issue_id = validate_uuid_param(self.query.issueId, "issueId")
-        if canonical_issue_id is not None:
-            self.query.issueId = canonical_issue_id
+        self.query.issueId = validate_uuid_param(self.query.issueId, "issueId")
         self.date_from = self.parse_relative_date_from(self.query.dateRange.date_from if self.query.dateRange else None)
         self.date_to = self.parse_relative_date_to(self.query.dateRange.date_to if self.query.dateRange else None)
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -30,8 +30,8 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        validate_uuid_param(self.query.issueId, "issueId")
-        validate_uuid_param(self.query.personId, "personId")
+        self.query.issueId = validate_uuid_param(self.query.issueId, "issueId")
+        self.query.personId = validate_uuid_param(self.query.personId, "personId")
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=LimitContext.QUERY,
             limit=self.query.limit if self.query.limit else None,

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -13,6 +13,7 @@ from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.utils import relative_date_parse
 
+from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import validate_uuid_param
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_v1 import ErrorTrackingQueryV1Builder
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_v2 import ErrorTrackingQueryV2Builder
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_v3 import ErrorTrackingQueryV3Builder
@@ -29,6 +30,8 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        validate_uuid_param(self.query.issueId, "issueId")
+        validate_uuid_param(self.query.personId, "personId")
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=LimitContext.QUERY,
             limit=self.query.limit if self.query.limit else None,

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from django.core.exceptions import ValidationError
 
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
 from posthog.schema import ErrorTrackingQuery
 
 from posthog.hogql import ast
@@ -12,12 +14,13 @@ from posthog.hogql import ast
 
 def validate_uuid_param(value: str | None, name: str) -> None:
     # Malformed values otherwise reach ClickHouse and fail the whole query with CANNOT_PARSE_UUID.
+    # DRF's ValidationError, not Django's: the query API only maps the DRF one to a 400.
     if value is None:
         return
     try:
         UUID(value)
     except ValueError:
-        raise ValidationError(f"{name} must be a valid UUID")
+        raise DRFValidationError(f"{name} must be a valid UUID")
 
 
 def search_tokenizer(query: str) -> list[str]:

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
@@ -1,12 +1,23 @@
 import re
 import datetime
 from typing import Literal
+from uuid import UUID
 
 from django.core.exceptions import ValidationError
 
 from posthog.schema import ErrorTrackingQuery
 
 from posthog.hogql import ast
+
+
+def validate_uuid_param(value: str | None, name: str) -> None:
+    # Malformed values otherwise reach ClickHouse and fail the whole query with CANNOT_PARSE_UUID.
+    if value is None:
+        return
+    try:
+        UUID(value)
+    except ValueError:
+        raise ValidationError(f"{name} must be a valid UUID")
 
 
 def search_tokenizer(query: str) -> list[str]:

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
@@ -12,13 +12,17 @@ from posthog.schema import ErrorTrackingQuery
 from posthog.hogql import ast
 
 
-def validate_uuid_param(value: str | None, name: str) -> None:
-    # Malformed values otherwise reach ClickHouse and fail the whole query with CANNOT_PARSE_UUID.
-    # DRF's ValidationError, not Django's: the query API only maps the DRF one to a 400.
+def validate_uuid_param(value: str | None, name: str) -> str | None:
+    """Canonicalize a UUID query param, rejecting values ClickHouse could not parse.
+
+    Returns the dashed-hex form: Python accepts looser formats (32 hex chars, braces,
+    urn prefixes) that would still fail ClickHouse's UUID parsing at query time.
+    DRF's ValidationError, not Django's: the query API only maps the DRF one to a 400.
+    """
     if value is None:
-        return
+        return None
     try:
-        UUID(value)
+        return str(UUID(value))
     except ValueError:
         raise DRFValidationError(f"{name} must be a valid UUID")
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
@@ -1,6 +1,6 @@
 import re
 import datetime
-from typing import Literal
+from typing import Literal, overload
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
@@ -10,6 +10,14 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 from posthog.schema import ErrorTrackingQuery
 
 from posthog.hogql import ast
+
+
+@overload
+def validate_uuid_param(value: str, name: str) -> str: ...
+
+
+@overload
+def validate_uuid_param(value: None, name: str) -> None: ...
 
 
 def validate_uuid_param(value: str | None, name: str) -> str | None:

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_breakdowns_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_breakdowns_query_runner.py
@@ -7,7 +7,7 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 
-from django.core.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import BreakdownValue, DateRange, ErrorTrackingBreakdownsQuery
 

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_breakdowns_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_breakdowns_query_runner.py
@@ -7,6 +7,8 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 
+from django.core.exceptions import ValidationError
+
 from posthog.schema import BreakdownValue, DateRange, ErrorTrackingBreakdownsQuery
 
 from products.error_tracking.backend.hogql_queries.error_tracking_breakdowns_query_runner import (
@@ -72,6 +74,18 @@ class TestErrorTrackingBreakdownsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert browser_data.values[1].count == 8
         assert browser_data.values[2].value == "C"
         assert browser_data.values[2].count == 6
+
+    def test_rejects_malformed_issue_id(self):
+        with self.assertRaises(ValidationError):
+            ErrorTrackingBreakdownsQueryRunner(
+                team=self.team,
+                query=ErrorTrackingBreakdownsQuery(
+                    kind="ErrorTrackingBreakdownsQuery",
+                    issueId="test-distinct-id",
+                    breakdownProperties=["$browser"],
+                    dateRange=DateRange(date_from="-7d"),
+                ),
+            )
 
     @freeze_time("2024-01-10T12:00:00Z")
     @snapshot_clickhouse_queries

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -749,6 +749,19 @@ class TestErrorTrackingQueryRunner(ErrorTrackingQueryRunnerTestsMixin, Clickhous
         with self.assertRaises(ValidationError):
             self._calculate(**{field: "test-distinct-id"})
 
+    def test_canonicalizes_uuid_params(self):
+        runner = ErrorTrackingQueryRunner(
+            team=self.team,
+            query=ErrorTrackingQuery(
+                kind="ErrorTrackingQuery",
+                dateRange=DateRange(),
+                orderBy="last_seen",  # pyright: ignore[reportArgumentType]
+                volumeResolution=1,
+                issueId="01936E7FD7FF7314B2D47627981E34F0",
+            ),
+        )
+        self.assertEqual(runner.query.issueId, "01936e7f-d7ff-7314-b2d4-7627981e34f0")
+
     @freeze_time("2022-01-10T12:11:00")
     def test_event_filter_group_operator(self):
         firefox_issue_id = "01936e80-aa51-746f-aec4-cdf16a5c5333"

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -14,11 +14,11 @@ from posthog.test.base import (
 )
 from unittest import TestCase
 
-from django.core.exceptions import ValidationError
 from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     DateRange,

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -14,9 +14,11 @@ from posthog.test.base import (
 )
 from unittest import TestCase
 
+from django.core.exceptions import ValidationError
 from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
+from parameterized import parameterized
 
 from posthog.schema import (
     DateRange,
@@ -741,6 +743,11 @@ class ErrorTrackingQueryRunnerTestsMixin:
 class TestErrorTrackingQueryRunner(ErrorTrackingQueryRunnerTestsMixin, ClickhouseTestMixin, APIBaseTest):
     __test__ = True
     use_v2 = False
+
+    @parameterized.expand(["issueId", "personId"])
+    def test_rejects_malformed_uuid_params(self, field):
+        with self.assertRaises(ValidationError):
+            self._calculate(**{field: "test-distinct-id"})
 
     @freeze_time("2022-01-10T12:11:00")
     def test_event_filter_group_operator(self):


### PR DESCRIPTION
## Problem

A malformed `issueId` or `personId` on an `ErrorTrackingQuery` (or `ErrorTrackingBreakdownsQuery`) flows into a comparison against a UUID expression, and ClickHouse fails the whole query with `CANNOT_PARSE_UUID`. Production query logs show a steady trickle of these, surfaced to callers as internal errors instead of a request problem.

## Changes

- New `validate_uuid_param` helper canonicalizes UUID params at the runner boundary and raises DRF's `ValidationError` (a 400 through the query API) for values that don't parse.
- Canonicalization matters because Python's `UUID()` accepts forms ClickHouse rejects (32 hex chars, braces, urn prefixes) — the dashed form is written back onto the query.
- Wired into `ErrorTrackingQueryRunner` (`issueId`, `personId`) and `ErrorTrackingBreakdownsQueryRunner` (`issueId`).

## How did you test this code?

Agent-authored; automated tests only: parameterized rejection tests for both params, a canonicalization test (uppercase/undashed input), and a breakdowns rejection test. Full breakdowns suite and the touched runner tests pass locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during an error tracking query-performance investigation; the failure mode was found by querying production `query_log` for error tracking exception codes. A Codex autoreview loop caught two refinements that landed here: using DRF's `ValidationError` (Django's class would fall through to a 500 on the query API path) and canonicalizing rather than just validating, since Python's UUID parser is looser than ClickHouse's.
