### PR TITLE
fix(error-tracking): run digest team enumeration on the offline cluster

### DIFF
--- a/products/error_tracking/backend/weekly_digest.py
+++ b/products/error_tracking/backend/weekly_digest.py
@@ -102,6 +102,7 @@ def auto_select_project_for_user(user: Any, org_id: int, team_exception_counts: 
 def get_exception_counts(team_ids: list[int] | None = None) -> list:
     """Teams with at least one exception in the last 7 days, used for digest routing."""
     from posthog.clickhouse.client import sync_execute
+    from posthog.clickhouse.workload import Workload
 
     tag_queries(product=ProductKey.ERROR_TRACKING, name="weekly_digest:exception_counts")
 
@@ -121,7 +122,8 @@ def get_exception_counts(team_ids: list[int] | None = None) -> list:
     {team_filter}
     """
 
-    results = sync_execute(query, query_params)
+    # Cross-team scan for a weekly batch job — keep it off the online cluster.
+    results = sync_execute(query, query_params, workload=Workload.OFFLINE)
     return results if isinstance(results, list) else []
 
 


### PR DESCRIPTION
## Problem

The weekly error tracking digest enumerates teams with recent exceptions through a cross-team events scan. Unlike the recommendations refresh (which routes the equivalent query to the offline workload), this one runs on the online cluster and competes with user-facing queries.

## Changes

Pass `workload=Workload.OFFLINE` to the digest's `get_exception_counts` query, matching the existing pattern in the recommendations refresh activity.

## How did you test this code?

Agent-authored; automated tests only: the full weekly digest test suite passes locally (44 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during an error tracking query-performance review; this was flagged while auditing which error tracking queries run on which workload. One-line change plus the import; reviewed by a Codex autoreview pass with no findings.
