### PR TITLE
fix(mcp-analytics): bound session-detail queries to a 7-day lookback

### DIFF
--- a/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
+++ b/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
@@ -28,7 +28,49 @@ Suggested entry format:
 
 ---
 
-## 2026-05-28: Dropping `FROM person FINAL` via `argMax` is worse than the original; materialization is the actual win
+## 2026-06-10: Pre-filtering a window-function scan with an IN-subquery doubled the cost; JSON parsing dominates, window sorts are cheap
+
+**Context.** MCP analytics "neighbors before/after" queries (`products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts`): a CTE scans all 7 days of a team's `mcp_tool_call` events, computes `lagInFrame`/`leadInFrame` over every conversation, then filters to one target tool. Looked like wasted work — most conversations don't contain the target tool.
+
+**Question.** Does adding `AND conv_id IN (SELECT DISTINCT conv_id ... WHERE tool = '<target>')` to shrink the window input make the query faster?
+
+**What we tried.** Original shape vs the IN-subquery pre-filter, on the Test Cluster, team 2, over a ~253k-event `mcp_tool_call` slice, for both a rare tool (~2% of calls) and the dominant tool (~48% of calls). All property access via `JSONExtractString(properties, ...)` (no materialized columns for these on the Test Cluster).
+
+**Numbers.** Median of 5 from `system.query_log`, `use_uncompressed_cache=0, use_query_condition_cache=0`:
+
+| Variant                     | Duration (ms) | Read rows | Read bytes |
+| --------------------------- | ------------- | --------- | ---------- |
+| original, rare tool         | 355           | 322k      | 2.87 GB    |
+| pre-filtered, rare tool     | 607           | 651k      | 5.73 GB    |
+| original, dominant tool     | 387           | 322k      | 2.87 GB    |
+| pre-filtered, dominant tool | 721           | 739k      | 5.74 GB    |
+
+The "optimization" was ~1.8× slower and read ~2× the bytes for both tool shares.
+
+**Caveats.** With materialized columns for the filtered property, the second scan would be much cheaper and the trade-off could flip; not measured.
+
+**Takeaway.** The scan (decompress + JSON-parse `properties`) dominates; the window sort it was meant to shrink is trivial by comparison. An IN-subquery over the same events table is a second full scan, so it roughly doubles the dominant cost for zero win. Don't pre-filter partitions of a window function when the filter requires re-scanning the same table you're windowing over.
+
+Also learned while measuring: ClickHouse 26.x's **query condition cache** makes repeat runs of the same query read only the granules that matched last time (we saw 13.1M rows drop to 816 on run 2). Disable it with `use_query_condition_cache=0` when measuring, and don't credit it for production point-lookups whose predicate changes per request (e.g. per-session lookups) — each new predicate is a cold run. And Metabase caches identical native queries entirely: add a changing comment/nonce per run or your "5 runs" are 1 run.
+
+---
+
+## 2026-06-10: Single-session lookups without a timestamp bound scan boundary granules across the team's whole history
+
+**Context.** MCP analytics session-detail queries (`products/mcp_analytics/backend/logic.py` `_MCP_TOOL_CALLS_SQL`, `intent_generation.py` `_SESSION_INTENTS_SQL`): `WHERE event = 'mcp_tool_call' AND properties.$mcp_session_id = {sid}` with no timestamp predicate.
+
+**Question.** How much does an unbounded single-session point lookup cost vs the same query bounded to 30 days, given `event` is in the sort key after `toDate(timestamp)`?
+
+**Numbers.** Median of 5, Test Cluster, team 2 (history back to 2020, the event itself only present in a recent 5-day slice), `use_query_condition_cache=0`:
+
+| Variant            | Duration (ms) | Read rows | Read bytes |
+| ------------------ | ------------- | --------- | ---------- |
+| no timestamp bound | 647           | 13.1M     | 3.11 GB    |
+| `timestamp >=` 30d | 474           | 1.03M     | 2.90 GB    |
+
+**Caveats.** The snapshot only held 5 days of this event, so both variants read the same event payload bytes; the 12M extra rows are sort-key boundary granules across ~6 years of partitions (index work + narrow columns, few bytes). In production the gap widens structurally: the unbounded query also re-reads the entire ever-growing event history's `properties` on every lookup.
+
+**Takeaway.** Even when the `event` filter looks selective, with `toDate(timestamp)` unconstrained the primary index leaves ~1 boundary granule per (date, part) range, which adds up to millions of rows over years of partitions. Single-entity lookups (session, trace, etc.) should always carry a timestamp bound derived from how far back the entity can realistically be referenced.
 
 **Context.** `posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py` builds a raw ClickHouse query that does `SELECT id, JSONExtract(properties, '<key>', 'String'), ... FROM person FINAL WHERE team_id = ... AND id BETWEEN ... AND is_deleted = 0 ORDER BY id FORMAT JSONEachRow`. We flagged the `FINAL` as a smell.
 

--- a/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
+++ b/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
@@ -28,49 +28,7 @@ Suggested entry format:
 
 ---
 
-## 2026-06-10: Pre-filtering a window-function scan with an IN-subquery doubled the cost; JSON parsing dominates, window sorts are cheap
-
-**Context.** MCP analytics "neighbors before/after" queries (`products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts`): a CTE scans all 7 days of a team's `mcp_tool_call` events, computes `lagInFrame`/`leadInFrame` over every conversation, then filters to one target tool. Looked like wasted work — most conversations don't contain the target tool.
-
-**Question.** Does adding `AND conv_id IN (SELECT DISTINCT conv_id ... WHERE tool = '<target>')` to shrink the window input make the query faster?
-
-**What we tried.** Original shape vs the IN-subquery pre-filter, on the Test Cluster, team 2, over a ~253k-event `mcp_tool_call` slice, for both a rare tool (~2% of calls) and the dominant tool (~48% of calls). All property access via `JSONExtractString(properties, ...)` (no materialized columns for these on the Test Cluster).
-
-**Numbers.** Median of 5 from `system.query_log`, `use_uncompressed_cache=0, use_query_condition_cache=0`:
-
-| Variant                     | Duration (ms) | Read rows | Read bytes |
-| --------------------------- | ------------- | --------- | ---------- |
-| original, rare tool         | 355           | 322k      | 2.87 GB    |
-| pre-filtered, rare tool     | 607           | 651k      | 5.73 GB    |
-| original, dominant tool     | 387           | 322k      | 2.87 GB    |
-| pre-filtered, dominant tool | 721           | 739k      | 5.74 GB    |
-
-The "optimization" was ~1.8× slower and read ~2× the bytes for both tool shares.
-
-**Caveats.** With materialized columns for the filtered property, the second scan would be much cheaper and the trade-off could flip; not measured.
-
-**Takeaway.** The scan (decompress + JSON-parse `properties`) dominates; the window sort it was meant to shrink is trivial by comparison. An IN-subquery over the same events table is a second full scan, so it roughly doubles the dominant cost for zero win. Don't pre-filter partitions of a window function when the filter requires re-scanning the same table you're windowing over.
-
-Also learned while measuring: ClickHouse 26.x's **query condition cache** makes repeat runs of the same query read only the granules that matched last time (we saw 13.1M rows drop to 816 on run 2). Disable it with `use_query_condition_cache=0` when measuring, and don't credit it for production point-lookups whose predicate changes per request (e.g. per-session lookups) — each new predicate is a cold run. And Metabase caches identical native queries entirely: add a changing comment/nonce per run or your "5 runs" are 1 run.
-
----
-
-## 2026-06-10: Single-session lookups without a timestamp bound scan boundary granules across the team's whole history
-
-**Context.** MCP analytics session-detail queries (`products/mcp_analytics/backend/logic.py` `_MCP_TOOL_CALLS_SQL`, `intent_generation.py` `_SESSION_INTENTS_SQL`): `WHERE event = 'mcp_tool_call' AND properties.$mcp_session_id = {sid}` with no timestamp predicate.
-
-**Question.** How much does an unbounded single-session point lookup cost vs the same query bounded to 30 days, given `event` is in the sort key after `toDate(timestamp)`?
-
-**Numbers.** Median of 5, Test Cluster, team 2 (history back to 2020, the event itself only present in a recent 5-day slice), `use_query_condition_cache=0`:
-
-| Variant            | Duration (ms) | Read rows | Read bytes |
-| ------------------ | ------------- | --------- | ---------- |
-| no timestamp bound | 647           | 13.1M     | 3.11 GB    |
-| `timestamp >=` 30d | 474           | 1.03M     | 2.90 GB    |
-
-**Caveats.** The snapshot only held 5 days of this event, so both variants read the same event payload bytes; the 12M extra rows are sort-key boundary granules across ~6 years of partitions (index work + narrow columns, few bytes). In production the gap widens structurally: the unbounded query also re-reads the entire ever-growing event history's `properties` on every lookup.
-
-**Takeaway.** Even when the `event` filter looks selective, with `toDate(timestamp)` unconstrained the primary index leaves ~1 boundary granule per (date, part) range, which adds up to millions of rows over years of partitions. Single-entity lookups (session, trace, etc.) should always carry a timestamp bound derived from how far back the entity can realistically be referenced.
+## 2026-05-28: Dropping `FROM person FINAL` via `argMax` is worse than the original; materialization is the actual win
 
 **Context.** `posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py` builds a raw ClickHouse query that does `SELECT id, JSONExtract(properties, '<key>', 'String'), ... FROM person FINAL WHERE team_id = ... AND id BETWEEN ... AND is_deleted = 0 ORDER BY id FORMAT JSONEachRow`. We flagged the `FINAL` as a smell.
 

--- a/products/mcp_analytics/backend/intent_generation.py
+++ b/products/mcp_analytics/backend/intent_generation.py
@@ -5,7 +5,10 @@ and condense them into a short natural-language summary via an LLM. Pure
 generation only — caching and persistence live in ``logic.generate_session_intent``.
 """
 
+from datetime import timedelta
+
 from django.conf import settings
+from django.utils import timezone
 
 import openai
 import posthoganalytics
@@ -23,6 +26,11 @@ from products.mcp_analytics.backend.facade.contracts import IntentGenerationUnav
 MCP_TOOL_CALL_EVENT = "mcp_tool_call"
 INTENT_MODEL = "gpt-4.1-mini"
 MAX_INTENTS = 500
+# Session-detail queries look up one $mcp_session_id; without a timestamp bound
+# the events sort key (team_id, toDate(timestamp), event, ...) can't prune and
+# the scan covers the team's full history. Sessions reachable in the UI are at
+# most MCP_SESSIONS_LOOKBACK (24h) old, so 7 days is a generous safety margin.
+SESSION_EVENTS_LOOKBACK = timedelta(days=7)
 # Persisted (and returned) when a session has no recorded intents, so callers
 # get a definitive answer and we don't re-query ClickHouse on the next request.
 NO_INTENT_MESSAGE = "No agent intent was recorded for this session."
@@ -43,6 +51,7 @@ _SESSION_INTENTS_SQL = """
 SELECT toString(properties.$mcp_intent) AS intent
 FROM events
 WHERE event = {event}
+    AND timestamp >= {date_from}
     AND properties.$mcp_session_id = {session_id}
     AND coalesce(properties.$mcp_intent, '') != ''
 ORDER BY timestamp ASC
@@ -56,6 +65,7 @@ def fetch_session_intents(team: Team, session_id: str) -> list[str]:
         _SESSION_INTENTS_SQL,
         placeholders={
             "event": ast.Constant(value=MCP_TOOL_CALL_EVENT),
+            "date_from": ast.Constant(value=timezone.now() - SESSION_EVENTS_LOOKBACK),
             "session_id": ast.Constant(value=session_id),
             "limit": ast.Constant(value=MAX_INTENTS),
         },

--- a/products/mcp_analytics/backend/logic.py
+++ b/products/mcp_analytics/backend/logic.py
@@ -38,6 +38,7 @@ SELECT
     toString(properties.$mcp_duration_ms) AS duration_ms_raw
 FROM events
 WHERE event = {event}
+    AND timestamp >= {date_from}
     AND properties.$mcp_session_id = {session_id}
 ORDER BY timestamp ASC
 LIMIT 500
@@ -306,6 +307,7 @@ def list_mcp_tool_calls(team: Team, session_id: str) -> list[contracts.MCPToolCa
         _MCP_TOOL_CALLS_SQL,
         placeholders={
             "event": ast.Constant(value=MCP_TOOL_CALL_EVENT),
+            "date_from": ast.Constant(value=timezone.now() - intent_generation.SESSION_EVENTS_LOOKBACK),
             "session_id": ast.Constant(value=session_id),
         },
     )

--- a/products/mcp_analytics/backend/logic.py
+++ b/products/mcp_analytics/backend/logic.py
@@ -68,6 +68,10 @@ DEFAULT_SESSION_SORT_COLUMN = "session_start"
 # disabled Temporal backfill.
 MCP_SESSIONS_LOOKBACK = timedelta(hours=24)
 
+assert intent_generation.SESSION_EVENTS_LOOKBACK >= MCP_SESSIONS_LOOKBACK, (
+    "SESSION_EVENTS_LOOKBACK must be >= MCP_SESSIONS_LOOKBACK or detail views will silently truncate for listed sessions"
+)
+
 # Short TTL so concurrent dashboard tabs / auto-refreshes share one ClickHouse
 # aggregation instead of each re-running it — long enough to absorb a burst,
 # short enough that "Reload" still feels live.

--- a/products/mcp_analytics/backend/tests/test_api.py
+++ b/products/mcp_analytics/backend/tests/test_api.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from django.core.cache import cache
 
+from parameterized import parameterized
+
 from posthog.models.utils import uuid7
 
 from products.mcp_analytics.backend import intent_generation
@@ -375,3 +377,46 @@ class TestGenerateSessionIntent(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTest
 
         assert len(sessions) == 1
         assert sessions[0].intent == "Persisted summary."
+
+
+class TestSessionEventsLookbackBound(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin, APIBaseTest):
+    """Session-detail queries bound the scan to SESSION_EVENTS_LOOKBACK so the
+    events sort key can prune instead of reading the team's full history."""
+
+    def _seed_tool_call(self, session_id: str, *, timestamp: datetime, tool: str, intent: str) -> None:
+        _create_event(
+            team=self.team,
+            event="mcp_tool_call",
+            distinct_id="seed",
+            timestamp=timestamp,
+            properties={"$mcp_session_id": session_id, "$mcp_tool_name": tool, "$mcp_intent": intent},
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "tool_calls",
+                lambda self, sid: [c.tool_name for c in api.list_mcp_tool_calls(self.team, session_id=sid)],
+                ["recent_tool"],
+            ),
+            (
+                "session_intents",
+                lambda self, sid: intent_generation.fetch_session_intents(self.team, sid),
+                ["recent intent"],
+            ),
+        ]
+    )
+    def test_excludes_events_older_than_lookback(self, _name, fetch, expected) -> None:
+        session_id = str(uuid7())
+        now = datetime.now(tz=UTC)
+        self._seed_tool_call(
+            session_id, timestamp=now - timedelta(minutes=5), tool="recent_tool", intent="recent intent"
+        )
+        self._seed_tool_call(
+            session_id,
+            timestamp=now - intent_generation.SESSION_EVENTS_LOOKBACK - timedelta(days=1),
+            tool="ancient_tool",
+            intent="ancient intent",
+        )
+
+        assert fetch(self, session_id) == expected


### PR DESCRIPTION
## Problem

The MCP analytics session-detail queries (`_MCP_TOOL_CALLS_SQL` and `_SESSION_INTENTS_SQL`) look up a single `$mcp_session_id` with no timestamp predicate. The events sort key is `(team_id, toDate(timestamp), event, ...)`, so with the date unconstrained the primary index leaves boundary granules across every partition of the team's history, and the query re-reads the entire (ever-growing) MCP event history on every session-detail view.

## Changes

- Add a `timestamp >= {date_from}` bound to both queries, driven by a shared `SESSION_EVENTS_LOOKBACK = 7 days` constant. Sessions reachable in the UI are at most 24h old (`MCP_SESSIONS_LOOKBACK`), so 7 days is a generous safety margin.
- The measured case studies for the ClickHouse optimization skill's learnings log are split into #62732 for separate review by that file's owner.

Measured on the Test Cluster (median of 5 cold runs from `query_log`, condition cache disabled): the bound cuts rows read by 92% (13.1M to 1.03M) and duration by ~27% (647ms to 474ms). The snapshot understates the win: it holds only a few days of `mcp_tool_call` events, so both variants read the same payload bytes; in production the unbounded variant's read also grows without limit as history accumulates.

## How did you test this code?

Agent-authored; no manual testing claimed. New parameterized test (`TestSessionEventsLookbackBound`) seeds one event inside and one outside the lookback window and asserts only the in-window one is returned, for both query paths; verified the tests fail with the bound removed. Full `products/mcp_analytics/backend/tests/` suite passes (95 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session running the `/optimizing-clickhouse-and-hogql-queries` skill across all MCP analytics queries (backend + frontend).
- Both candidate optimizations were measured on the Test Cluster before deciding: the timestamp bound won and is applied here; a pre-filter rewrite of the frontend neighbors queries doubled cost (scan dominates, window sort is trivial) and was rejected — recorded in the skill's learnings log instead.
- All other queries in the section were reviewed and found already well-shaped (time-bounded, printer-path property access, conditional aggregation, no `FINAL`/self-joins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

