### PR TITLE
feat(mcp): inject agent notices into tool responses

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -485,6 +485,7 @@ export class ApiClient {
                     },
                 }
             },
+
         }
     }
 
@@ -515,6 +516,16 @@ export class ApiClient {
         return {
             get: async ({ projectId }: { projectId: string }): Promise<Result<Schemas.ProjectBackwardCompat>> => {
                 return this.fetchJson<Schemas.ProjectBackwardCompat>(`${this.baseUrl}/api/projects/${projectId}/`)
+            },
+
+            agentNotices: ({ projectId }: { projectId: string }) => {
+                return {
+                    list: async (): Promise<Result<Schemas.AgentNotice[]>> => {
+                        return this.fetchJson<Schemas.AgentNotice[]>(
+                            `${this.baseUrl}/api/projects/${projectId}/agent_notices/`
+                        )
+                    },
+                }
             },
 
             propertyDefinitions: async ({

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -1,4 +1,5 @@
 import { MCPClientProfile } from '@/lib/client-detection'
+import { MCP_AGENT_NOTICES_FLAG } from '@/lib/constants'
 import { buildMCPAnalyticsGroups } from '@/lib/posthog/analytics'
 import {
     type EvaluatedFlags,
@@ -36,7 +37,8 @@ export interface ResolvedState {
     allTools: Tool<ZodObjectAny>[]
     scopeGatedTools: ScopeGatedTool[]
     distinctId: string
-    renderUiEnabled: boolean
+    renderUiEnabled: boolean;
+    agentNoticesEnabled: boolean
 }
 
 // ─── Pure helpers ───
@@ -112,7 +114,7 @@ export class RequestStateResolver {
         // `mcp-render-ui` isn't a catalog tool flag, but it rides the same batched
         // evaluation and lives in the same map so the instructions layer can gate
         // the rendering prompt section on it (like `mcp-feedback-tool`).
-        const allFlagKeys = [...toolFlagKeys, RENDER_UI_FEATURE_FLAG]
+        const allFlagKeys = [...new Set([...toolFlagKeys, RENDER_UI_FEATURE_FLAG, MCP_AGENT_NOTICES_FLAG])]
 
         const flagAnalyticsContext = await reqCtx.getAnalyticsContextSafe(context)
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
@@ -200,6 +202,7 @@ export class RequestStateResolver {
             scopeGatedTools,
             distinctId,
             renderUiEnabled,
+            agentNoticesEnabled: mergedFlags[MCP_AGENT_NOTICES_FLAG] === true,
         }
     }
 

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -1,5 +1,6 @@
 import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
 
+import { maybeInjectAgentNotice } from '@/lib/agent-notices'
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
 import {
     handleToolError,
@@ -71,7 +72,7 @@ export class ToolExecutor {
         }
 
         if (toolName === 'exec') {
-            return this.callExecTool(params, state)
+            return maybeInjectAgentNotice(await this.callExecTool(params, state), state, toolName)
         }
 
         if (toolName === 'render-ui') {
@@ -94,7 +95,7 @@ export class ToolExecutor {
             return { content: [{ type: 'text', text: `Tool ${toolName} not found` }], isError: true }
         }
 
-        return this.callTool(
+        const result = await this.callTool(
             {
                 name: toolName,
                 schema: preBuilt.base.schema,
@@ -104,6 +105,7 @@ export class ToolExecutor {
             params,
             state
         )
+        return maybeInjectAgentNotice(result, state, toolName)
     }
 
     private async callTool(

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -6,7 +6,7 @@ import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
 import { getPostHogClient } from '@/lib/posthog'
 import { sanitizeHeaderValue } from '@/lib/utils'
 import type { ApiUser } from '@/schema/api'
-import type { CachedOrg, CachedProject, CachedUser, State } from '@/tools/types'
+import type { CachedAgentNotice, CachedOrg, CachedProject, CachedUser, State } from '@/tools/types'
 
 const CACHE_TTL_MS = 10 * 60 * 1000 // 10 minutes
 
@@ -128,7 +128,10 @@ export class StateManager {
         // with no `current_organization` / `current_team` (newly provisioned
         // accounts, users who left their last org) — fall through to the
         // scoped-org fallback below when either is missing.
-        if (activeOrganization && (scoped_organizations.length === 0 || scoped_organizations.includes(activeOrganization.id))) {
+        if (
+            activeOrganization &&
+            (scoped_organizations.length === 0 || scoped_organizations.includes(activeOrganization.id))
+        ) {
             return activeTeam
                 ? { organizationId: activeOrganization.id, projectId: activeTeam.id }
                 : { organizationId: activeOrganization.id }
@@ -310,6 +313,28 @@ export class StateManager {
             fetchedAtKey: `cachedOrgFetchedAt:${orgId}` as const,
             fetcher: async () => {
                 const result = await this._api.organizations().get({ orgId })
+                if (!result.success) {
+                    throw result.error
+                }
+                return result.data
+            },
+        })
+    }
+
+    async getCachedOrFetchAgentNotices(): Promise<CachedAgentNotice[] | undefined> {
+        // Best-effort: a session without resolvable project context simply gets no notices.
+        let projectId: string
+        try {
+            projectId = await this.getProjectId()
+        } catch {
+            return undefined
+        }
+        return this.getOrFetchCached({
+            name: 'agent_notices',
+            cacheKey: `agentNotices:${projectId}` as const,
+            fetchedAtKey: `agentNoticesFetchedAt:${projectId}` as const,
+            fetcher: async () => {
+                const result = await this._api.projects().agentNotices({ projectId }).list()
                 if (!result.success) {
                     throw result.error
                 }

--- a/services/mcp/src/lib/agent-notices.ts
+++ b/services/mcp/src/lib/agent-notices.ts
@@ -1,0 +1,101 @@
+import type { ResolvedState } from '@/hono/request-state-resolver'
+import { AnalyticsEvent, buildMCPAnalyticsGroups } from '@/lib/posthog/analytics'
+import { type EvaluatedFlags, evaluateFeatureFlags } from '@/lib/posthog/flags'
+import type { CachedAgentNotice } from '@/tools/types'
+
+const RESOLVE_TIMEOUT_MS = 1500
+
+type ContentItem = { type: string; text?: string }
+
+function hasInjectableContent(payload: unknown): payload is { content: ContentItem[]; isError?: boolean } {
+    return (
+        typeof payload === 'object' &&
+        payload !== null &&
+        Array.isArray((payload as { content?: unknown }).content) &&
+        (payload as { isError?: boolean }).isError !== true
+    )
+}
+
+async function resolvePendingNotices(
+    state: ResolvedState,
+    delivered: string[]
+): Promise<CachedAgentNotice[] | undefined> {
+    const notices = await state.context.stateManager.getCachedOrFetchAgentNotices()
+    if (!notices?.length) {
+        return undefined
+    }
+
+    // Re-check expiry here: the token cache holds notices for up to 10 minutes.
+    const now = Date.now()
+    const pending = notices.filter((n) => !delivered.includes(n.id) && Date.parse(n.expires_at) > now)
+
+    const gatedKeys = [...new Set(pending.map((n) => n.feature_flag_key).filter((k): k is string => !!k))]
+    if (!gatedKeys.length) {
+        return pending
+    }
+
+    // Flag-gated notices are targeting: a flag's person/group conditions decide
+    // who receives the notice. Evaluated like tool flags (org + project groups).
+    // Fail closed for gated notices only — ungated ones still deliver.
+    let flags: EvaluatedFlags = {}
+    try {
+        const analyticsContext = await state.reqCtx.getAnalyticsContextSafe(state.context)
+        const groups = analyticsContext ? buildMCPAnalyticsGroups(analyticsContext) : undefined
+        flags = await evaluateFeatureFlags(gatedKeys, state.distinctId, groups)
+    } catch {
+        flags = {}
+    }
+    return pending.filter((n) => !n.feature_flag_key || flags[n.feature_flag_key] === true)
+}
+
+/**
+ * Appends pending agent notices (staff-authored, org- or flag-targeted messages) to
+ * a tool result, at most once per notice per MCP session. Strictly fail-open: any
+ * error or slow resolution returns the payload unchanged, and undelivered notices
+ * retry on the next successful tool call.
+ */
+export async function maybeInjectAgentNotice(
+    payload: unknown,
+    state: ResolvedState,
+    toolName: string
+): Promise<unknown> {
+    try {
+        if (!state.agentNoticesEnabled || !state.requestContext.mcpSessionId || !hasInjectableContent(payload)) {
+            return payload
+        }
+
+        const delivered = (await state.reqCtx.sessionCache.get('agentNoticesDelivered')) ?? []
+
+        const pending = await Promise.race([
+            resolvePendingNotices(state, delivered),
+            new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), RESOLVE_TIMEOUT_MS)),
+        ])
+        if (!pending?.length) {
+            return payload
+        }
+
+        // Re-read and record delivery before touching the payload: overlapping tool
+        // calls race on the first read, and the slow notice fetch sits between read
+        // and write. Re-checking here shrinks that window to adjacent cache ops —
+        // a duplicate on a true tie is harmless and RedisCache has no atomic CAS.
+        const deliveredNow = (await state.reqCtx.sessionCache.get('agentNoticesDelivered')) ?? []
+        const toDeliver = pending.filter((n) => !deliveredNow.includes(n.id))
+        if (!toDeliver.length) {
+            return payload
+        }
+        await state.reqCtx.sessionCache.set('agentNoticesDelivered', [...deliveredNow, ...toDeliver.map((n) => n.id)])
+
+        const messages = toDeliver.map((n) => n.message).join('\n---\n')
+        const text = `<posthog-notice>\nNotice from PostHog — surface this to the user:\n${messages}\n</posthog-notice>`
+        payload.content.push({ type: 'text', text })
+
+        void state.context.trackEvent(AnalyticsEvent.MCP_AGENT_NOTICE_DELIVERED, {
+            notice_ids: toDeliver.map((n) => n.id),
+            tool_name: toolName,
+        })
+
+        return payload
+    } catch {
+        return payload
+    }
+}

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -21,3 +21,4 @@ export const getAuthorizationServerUrl = (): string => resolveAuthorizationServe
 export const MCP_SERVER_NAME = 'PostHog'
 export const MCP_SERVER_VERSION = '1.0.0'
 export const MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
+export const MCP_AGENT_NOTICES_FLAG = 'mcp-agent-notices'

--- a/services/mcp/src/lib/posthog/analytics.ts
+++ b/services/mcp/src/lib/posthog/analytics.ts
@@ -10,6 +10,7 @@ export enum AnalyticsEvent {
     MCP_ORGANIZATION_SWITCHED = 'mcp organization switched',
     MCP_TOOL_CALL = 'mcp_tool_call', // matching @posthog/mcp-analytics
     MCP_FEEDBACK_SUBMITTED = 'mcp feedback submitted',
+    MCP_AGENT_NOTICE_DELIVERED = 'mcp agent notice delivered',
 }
 
 // Emitted as `$mcp_version` / `mcp_version` on analytics events. The MCP server

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -18,6 +18,7 @@ export type SessionState = {
 export type CachedUser = ApiUser
 export type CachedOrg = Schemas.OrganizationBasic
 export type CachedProject = Schemas.ProjectBackwardCompat
+export type CachedAgentNotice = Schemas.AgentNotice
 
 export type State = {
     projectId: string | undefined
@@ -31,6 +32,7 @@ export type State = {
     mcpProtocolVersion: string | undefined
     mcpConsumer: string | undefined
     mcpVendorClient: string | undefined
+    agentNoticesDelivered: string[] | undefined
 } & Record<PrefixedString<'session'>, SessionState> &
     Record<PrefixedString<'groupTypes'>, GroupType[] | undefined> &
     Record<PrefixedString<'groupTypesFetchedAt'>, number | undefined> &
@@ -39,7 +41,9 @@ export type State = {
     Record<PrefixedString<'cachedOrg'>, CachedOrg | undefined> &
     Record<PrefixedString<'cachedOrgFetchedAt'>, number | undefined> &
     Record<PrefixedString<'cachedProject'>, CachedProject | undefined> &
-    Record<PrefixedString<'cachedProjectFetchedAt'>, number | undefined>
+    Record<PrefixedString<'cachedProjectFetchedAt'>, number | undefined> &
+    Record<PrefixedString<'agentNotices'>, CachedAgentNotice[] | undefined> &
+    Record<PrefixedString<'agentNoticesFetchedAt'>, number | undefined>
 
 export type Env = {
     /**

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -56,6 +56,7 @@ function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
         scopeGatedTools: [],
         distinctId: 'distinct-id',
         renderUiEnabled: false,
+        agentNoticesEnabled: false,
         ...overrides,
     }
 }

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -78,6 +78,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         scopeGatedTools: [],
         distinctId: 'test-distinct-id',
         renderUiEnabled: false,
+        agentNoticesEnabled: false,
         ...overrides,
     }
 }

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -60,6 +60,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         scopeGatedTools: [],
         distinctId: 'test-distinct-id',
         renderUiEnabled: false,
+        agentNoticesEnabled: false,
         ...overrides,
     }
 }
@@ -145,6 +146,63 @@ describe('ToolExecutor', () => {
             expect(text).toContain('execute-sql')
             expect(text).toContain('organization-get')
             expect(text).not.toContain('feature-flag-get-all')
+        })
+    })
+
+    describe('agent notice injection', () => {
+        function makeNoticeState(sessionStore: Map<string, unknown>): ResolvedState {
+            const base = makeState([], { useSingleExec: true, agentNoticesEnabled: true })
+            const notice = {
+                id: 'notice-1',
+                message: 'The materialization bug you hit was fixed.',
+                feature_flag_key: null,
+                starts_at: new Date(Date.now() - 3600_000).toISOString(),
+                expires_at: new Date(Date.now() + 3600_000).toISOString(),
+                created_at: new Date(Date.now() - 3600_000).toISOString(),
+            }
+            base.requestContext = { ...base.requestContext, mcpSessionId: 'mcp-sess-1' }
+            ;(base.reqCtx as any).sessionCache = {
+                get: vi.fn(async (k: string) => sessionStore.get(k)),
+                set: vi.fn(async (k: string, v: unknown) => {
+                    sessionStore.set(k, v)
+                }),
+            }
+            ;(base.context as any).stateManager = {
+                getCachedOrFetchAgentNotices: vi.fn(async () => [notice]),
+            }
+            return base
+        }
+
+        it('appends the notice to the first successful exec call only', async () => {
+            const sessionStore = new Map<string, unknown>()
+
+            const first = (await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'tools' } },
+                makeNoticeState(sessionStore)
+            )) as any
+            const firstText = first.content.map((c: any) => c.text).join('\n')
+            expect(firstText).toContain('<posthog-notice>')
+            expect(firstText).toContain('The materialization bug you hit was fixed.')
+
+            const second = (await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'tools' } },
+                makeNoticeState(sessionStore)
+            )) as any
+            const secondText = second.content.map((c: any) => c.text).join('\n')
+            expect(secondText).not.toContain('<posthog-notice>')
+        })
+
+        it('does not inject when the flag is off', async () => {
+            const sessionStore = new Map<string, unknown>()
+            const state = makeNoticeState(sessionStore)
+            state.agentNoticesEnabled = false
+
+            const result = (await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'tools' } },
+                state
+            )) as any
+
+            expect(result.content.map((c: any) => c.text).join('\n')).not.toContain('<posthog-notice>')
         })
     })
 

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -493,6 +493,59 @@ describe('StateManager', () => {
         )
     })
 
+    describe('getCachedOrFetchAgentNotices', () => {
+        const mockNotice = {
+            id: 'notice-1',
+            message: 'A fix shipped.',
+            feature_flag_key: null,
+            starts_at: '2026-06-01T00:00:00Z',
+            expires_at: '2026-12-01T00:00:00Z',
+            created_at: '2026-06-01T00:00:00Z',
+        }
+
+        function mockNoticesApi(listFn: ReturnType<typeof vi.fn>): void {
+            ;(stateManager as any)._api = {
+                projects: () => ({ agentNotices: () => ({ list: listFn }) }),
+            }
+        }
+
+        it('returns undefined when no project context can be resolved', async () => {
+            vi.spyOn(stateManager, 'getProjectId').mockRejectedValue(new Error('no project'))
+            const list = vi.fn()
+            mockNoticesApi(list)
+
+            const result = await stateManager.getCachedOrFetchAgentNotices()
+
+            expect(result).toBeUndefined()
+            expect(list).not.toHaveBeenCalled()
+        })
+
+        it('fetches notices once and serves the cache afterwards', async () => {
+            await cache.set('projectId', '123')
+            const list = vi.fn().mockResolvedValue({ success: true, data: [mockNotice] })
+            mockNoticesApi(list)
+
+            const first = await stateManager.getCachedOrFetchAgentNotices()
+            const second = await stateManager.getCachedOrFetchAgentNotices()
+
+            expect(first).toEqual([mockNotice])
+            expect(second).toEqual([mockNotice])
+            expect(list).toHaveBeenCalledOnce()
+        })
+
+        it('returns the stale cached value when the fetch fails', async () => {
+            await cache.set('projectId', '123')
+            await cache.set('agentNotices:123' as any, [mockNotice] as any)
+            await cache.set('agentNoticesFetchedAt:123' as any, (Date.now() - 11 * 60 * 1000) as any)
+            const list = vi.fn().mockResolvedValue({ success: false, error: new Error('boom') })
+            mockNoticesApi(list)
+
+            const result = await stateManager.getCachedOrFetchAgentNotices()
+
+            expect(result).toEqual([mockNotice])
+        })
+    })
+
     describe('getProjectId', () => {
         it('should return cached projectId if available', async () => {
             await cache.set('projectId', 'cached-project-id')

--- a/services/mcp/tests/unit/agent-notices.test.ts
+++ b/services/mcp/tests/unit/agent-notices.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ResolvedState } from '@/hono/request-state-resolver'
+import { maybeInjectAgentNotice } from '@/lib/agent-notices'
+import { evaluateFeatureFlags } from '@/lib/posthog/flags'
+
+vi.mock('@/lib/posthog/flags', () => ({
+    evaluateFeatureFlags: vi.fn(async () => ({})),
+}))
+
+type NoticeFixture = {
+    id: string
+    message: string
+    feature_flag_key: string | null
+    starts_at: string
+    expires_at: string
+    created_at: string
+}
+
+type StateFixture = {
+    state: ResolvedState
+    sessionCache: { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> }
+    trackEvent: ReturnType<typeof vi.fn>
+    fetchNotices: ReturnType<typeof vi.fn>
+}
+
+function makeNotice(overrides: Partial<NoticeFixture> = {}): NoticeFixture {
+    return {
+        id: 'notice-1',
+        message: 'The bug you hit was fixed.',
+        feature_flag_key: null,
+        starts_at: new Date(Date.now() - 3600_000).toISOString(),
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+        created_at: new Date(Date.now() - 3600_000).toISOString(),
+        ...overrides,
+    }
+}
+
+function makeState(
+    overrides: {
+        enabled?: boolean
+        sessionId?: string | undefined
+        fetchNotices?: () => Promise<unknown>
+        delivered?: string[]
+    } = {}
+): StateFixture {
+    const sessionStore = new Map<string, unknown>()
+    if (overrides.delivered) {
+        sessionStore.set('agentNoticesDelivered', overrides.delivered)
+    }
+    const sessionCache = {
+        get: vi.fn(async (k: string) => sessionStore.get(k)),
+        set: vi.fn(async (k: string, v: unknown) => {
+            sessionStore.set(k, v)
+        }),
+    }
+    const trackEvent = vi.fn(async () => undefined)
+    const fetchNotices = vi.fn(overrides.fetchNotices ?? (async () => [makeNotice()]))
+    const state = {
+        agentNoticesEnabled: overrides.enabled ?? true,
+        requestContext: { mcpSessionId: 'sessionId' in overrides ? overrides.sessionId : 'session-1' },
+        reqCtx: { sessionCache, getAnalyticsContextSafe: vi.fn(async () => ({ organizationId: 'org-1' })) },
+        distinctId: 'user-distinct-id',
+        context: {
+            trackEvent,
+            stateManager: { getCachedOrFetchAgentNotices: fetchNotices },
+        },
+    } as unknown as ResolvedState
+    return { state, sessionCache, trackEvent, fetchNotices }
+}
+
+function makePayload(): { content: Array<{ type: string; text: string }>; structuredContent: { rows: number[] } } {
+    return { content: [{ type: 'text', text: 'tool result' }], structuredContent: { rows: [1] } }
+}
+
+function noticeText(result: unknown): string | undefined {
+    const content = (result as { content: Array<{ text: string }> }).content
+    return content.find((c) => c.text.includes('<posthog-notice>'))?.text
+}
+
+describe('maybeInjectAgentNotice', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.clearAllMocks()
+    })
+
+    it('returns payload unchanged when the flag is off', async () => {
+        const { state, fetchNotices } = makeState({ enabled: false })
+        const payload = makePayload()
+
+        const result = await maybeInjectAgentNotice(payload, state, 'query-trends')
+
+        expect(result).toEqual(makePayload())
+        expect(fetchNotices).not.toHaveBeenCalled()
+    })
+
+    it('returns payload unchanged when there is no MCP session id', async () => {
+        const { state, fetchNotices } = makeState({ sessionId: undefined })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(result).toEqual(makePayload())
+        expect(fetchNotices).not.toHaveBeenCalled()
+    })
+
+    it('returns error payloads unchanged', async () => {
+        const { state, fetchNotices } = makeState()
+        const payload = { ...makePayload(), isError: true }
+
+        const result = await maybeInjectAgentNotice(payload, state, 'query-trends')
+
+        expect(result).toEqual({ ...makePayload(), isError: true })
+        expect(fetchNotices).not.toHaveBeenCalled()
+    })
+
+    it('returns non-object payloads unchanged', async () => {
+        const { state } = makeState()
+
+        expect(await maybeInjectAgentNotice('plain string', state, 'query-trends')).toBe('plain string')
+        expect(await maybeInjectAgentNotice(undefined, state, 'query-trends')).toBeUndefined()
+    })
+
+    it('appends a notice block, records delivery, and tracks an event', async () => {
+        const { state, sessionCache, trackEvent } = makeState()
+        const payload = makePayload()
+
+        const result = await maybeInjectAgentNotice(payload, state, 'query-trends')
+
+        const text = noticeText(result)
+        expect(text).toContain('The bug you hit was fixed.')
+        expect(text).toContain('</posthog-notice>')
+        expect((result as { content: unknown[] }).content).toHaveLength(2)
+        expect((result as { structuredContent: unknown }).structuredContent).toEqual({ rows: [1] })
+        expect(sessionCache.set).toHaveBeenCalledWith('agentNoticesDelivered', ['notice-1'])
+        expect(trackEvent).toHaveBeenCalledWith('mcp agent notice delivered', {
+            notice_ids: ['notice-1'],
+            tool_name: 'query-trends',
+        })
+    })
+
+    it('does not deliver the same notice twice in a session', async () => {
+        const { state } = makeState({ delivered: ['notice-1'] })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(noticeText(result)).toBeUndefined()
+    })
+
+    it('skips notices a concurrent call delivered between the first read and the re-check', async () => {
+        const { state, sessionCache } = makeState()
+        sessionCache.get.mockResolvedValueOnce([]).mockResolvedValueOnce(['notice-1'])
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(noticeText(result)).toBeUndefined()
+        expect(sessionCache.set).not.toHaveBeenCalled()
+    })
+
+    it('delivers a notice published mid-session alongside the dedup of earlier ones', async () => {
+        const { state, sessionCache } = makeState({
+            delivered: ['notice-1'],
+            fetchNotices: async () => [makeNotice(), makeNotice({ id: 'notice-2', message: 'Second update.' })],
+        })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        const text = noticeText(result)
+        expect(text).toContain('Second update.')
+        expect(text).not.toContain('The bug you hit was fixed.')
+        expect(sessionCache.set).toHaveBeenCalledWith('agentNoticesDelivered', ['notice-1', 'notice-2'])
+    })
+
+    it('skips notices the token cache still holds past their expiry', async () => {
+        const { state } = makeState({
+            fetchNotices: async () => [makeNotice({ expires_at: new Date(Date.now() - 60_000).toISOString() })],
+        })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(noticeText(result)).toBeUndefined()
+    })
+
+    it('returns payload unchanged and records nothing when the fetch throws', async () => {
+        const { state, sessionCache } = makeState({
+            fetchNotices: async () => {
+                throw new Error('django down')
+            },
+        })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(result).toEqual(makePayload())
+        expect(sessionCache.set).not.toHaveBeenCalled()
+    })
+
+    it('delivers a flag-gated notice when its flag evaluates true', async () => {
+        vi.mocked(evaluateFeatureFlags).mockResolvedValueOnce({ 'dw-release-december': true })
+        const { state } = makeState({
+            fetchNotices: async () => [
+                makeNotice({ id: 'gated', message: 'DW December is live.', feature_flag_key: 'dw-release-december' }),
+            ],
+        })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(noticeText(result)).toContain('DW December is live.')
+        expect(evaluateFeatureFlags).toHaveBeenCalledWith(['dw-release-december'], 'user-distinct-id', {
+            organization: 'org-1',
+        })
+    })
+
+    it('withholds a flag-gated notice when its flag is false or unevaluated', async () => {
+        vi.mocked(evaluateFeatureFlags).mockResolvedValueOnce({ 'dw-release-december': false })
+        const { state, sessionCache } = makeState({
+            fetchNotices: async () => [makeNotice({ feature_flag_key: 'dw-release-december' })],
+        })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(noticeText(result)).toBeUndefined()
+        expect(sessionCache.set).not.toHaveBeenCalled()
+    })
+
+    it('still delivers ungated notices when flag evaluation throws', async () => {
+        vi.mocked(evaluateFeatureFlags).mockRejectedValueOnce(new Error('flags down'))
+        const { state, sessionCache } = makeState({
+            fetchNotices: async () => [
+                makeNotice({ id: 'ungated', message: 'Plain notice.' }),
+                makeNotice({ id: 'gated', message: 'Gated notice.', feature_flag_key: 'dw-release-december' }),
+            ],
+        })
+
+        const result = await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        const text = noticeText(result)
+        expect(text).toContain('Plain notice.')
+        expect(text).not.toContain('Gated notice.')
+        expect(sessionCache.set).toHaveBeenCalledWith('agentNoticesDelivered', ['ungated'])
+    })
+
+    it('does not evaluate flags when no pending notice is gated', async () => {
+        const { state } = makeState()
+
+        await maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+
+        expect(evaluateFeatureFlags).not.toHaveBeenCalled()
+    })
+
+    it('gives up after the soft timeout when the fetch hangs', async () => {
+        vi.useFakeTimers()
+        const { state, sessionCache } = makeState({ fetchNotices: () => new Promise(() => {}) })
+
+        const resultPromise = maybeInjectAgentNotice(makePayload(), state, 'query-trends')
+        await vi.advanceTimersByTimeAsync(1500)
+        const result = await resultPromise
+
+        expect(result).toEqual(makePayload())
+        expect(sessionCache.set).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Problem

Companion to #62723. With agent notices stored and readable, the MCP server needs to actually deliver them: append pending notices to the first successful tool response of a session so the customer's agent sees them in context — without ever delaying or breaking a tool call.

## Changes

- `maybeInjectAgentNotice()` (`src/lib/agent-notices.ts`) wraps both return paths of `ToolExecutor.handleToolCall`, covering plain tools, exec-wrapped tools, and exec-built payloads. It appends a `<posthog-notice>` text content item — never touching `structuredContent` — and records delivered notice IDs in the session cache, so each notice delivers at most once per session while notices published mid-session still go out.
- **Targeting at delivery time**: notices carrying a `feature_flag_key` are batch-evaluated through the existing `evaluateFeatureFlags` path with the same org+project groups as tool flags. Gated notices fail closed (unevaluable flag → withhold); ungated notices and the overall injection fail open (any error or a slow fetch returns the payload unchanged and retries next call).
- `StateManager.getCachedOrFetchAgentNotices()` fetches `GET /api/projects/:id/agent_notices/` with the standard 10-minute stale-while-cached token cache; expiry is re-checked at injection time so a cached notice can't deliver past its `expires_at`.
- Gated behind the `mcp-agent-notices` feature flag, evaluated in the existing batched flag resolution (rolled out at 0% initially; org groups allow per-customer rollout).
- Delivery emits an `mcp agent notice delivered` analytics event with notice IDs and tool name.

## How did you test this code?

I'm an agent; automated tests plus a live local run:

- `tests/unit/agent-notices.test.ts` (14 tests): bail conditions (flag off, no session, error/non-object payloads), happy path, ID dedup, mid-session second notice, stale-cache expiry, flag-gated deliver/withhold, flag-eval failure (ungated still delivers), fetch failure and hung-fetch timeout
- `tests/unit/StateManager.test.ts`: project-context guard, caching, stale-on-failure; `tests/hono/tool-executor.test.ts`: first-call injects, second doesn't, exec path covered
- Live against `./bin/start` + the local MCP server: team-targeted and broadcast notices delivered on the first tool call, withheld on the second; a notice gated on a non-matching flag never delivered

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Injection point chosen after verifying `buildToolResultPayload` is bypassed by exec-built payloads — `handleToolCall` is the only chokepoint covering all paths. Flag evaluation deliberately lives MCP-side (not in the Django viewset) because the team-nested endpoint lacks the project-group context that flag conditions need; the MCP server already evaluates tool flags with those groups.
