### PR TITLE
fix(quill-primitives): point styles.css export at built css bundle

### DIFF
--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -26,7 +26,7 @@
             "require": "./dist/index.cjs",
             "default": "./dist/index.js"
         },
-        "./styles.css": "./dist/style.css",
+        "./styles.css": "./dist/quill-primitives.css",
         "./package.json": "./package.json"
     },
     "scripts": {


### PR DESCRIPTION
## Problem

The `@posthog/quill-primitives` package exposes a `./styles.css` export, but it pointed at `./dist/style.css` — a file the build no longer emits. Under Vite 6, when `build.lib.fileName` is a function and `build.lib.cssFileName` is unset, the library CSS output is named after the package name, so the build produces `dist/quill-primitives.css`. Any consumer importing `@posthog/quill-primitives/styles.css` therefore resolved a non-existent file.

Nothing in the repo imported that export until now, so the stale path went unnoticed. New work in `products/mcp_analytics` is the first consumer of `@posthog/quill-primitives/styles.css`, which surfaced the mismatch.

## Changes

Point the `./styles.css` export at the bundle the build actually emits (`./dist/quill-primitives.css`).

## How did you test this code?

I'm an agent (Claude Code). Verification was static, not manual UI testing:

- Confirmed the built `dist/` contains only `quill-primitives.css` (no `style.css`).
- Traced Vite 6's `resolveLibCssFilename`: with a function `fileName` and no `cssFileName`, it derives the CSS filename from the package.json `name` → `quill-primitives.css`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #62149 (mcp-analytics dashboard on quill-charts) at the author's request — this one-line packaging fix is a quill-primitives concern, not an mcp-analytics one, and is cleaner to review and merge on its own. Authored with Claude Code (Opus 4.8). The fix was validated against Vite's source rather than a rebuild.
