### PR TITLE
fix(ci): retry transient errors in deploy check-wait gate

### DIFF
--- a/.github/actions/wait-for-check/action.yml
+++ b/.github/actions/wait-for-check/action.yml
@@ -25,7 +25,7 @@ outputs:
     conclusion:
         description: >-
             Conclusion of the completed check (success, failure, cancelled, ...).
-            Empty if the check did not complete before the timeout.
+            'timed_out' if the check did not complete before the timeout.
         value: ${{ steps.poll.outputs.conclusion }}
 runs:
     using: 'composite'
@@ -40,15 +40,24 @@ runs:
               TIMEOUT_SECONDS: ${{ inputs.timeoutSeconds }}
               INTERVAL_SECONDS: ${{ inputs.intervalSeconds }}
           run: |
+              # Fail fast on caller mistakes: composite `required: true` is not
+              # runner-enforced, and bad numbers would otherwise degrade into a
+              # silent no-wait or an API busy-loop.
+              if ! [[ "$CHECK_NAME" && "$REF" && "$TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$INTERVAL_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+                echo "::error::wait-for-check: invalid inputs: checkName='$CHECK_NAME' ref='$REF' timeoutSeconds='$TIMEOUT_SECONDS' intervalSeconds='$INTERVAL_SECONDS'"
+                exit 1
+              fi
               # A transient API error must not fail the wait — log it and retry
-              # until the deadline. Callers decide what a missing conclusion means.
+              # until the deadline. Callers decide what a timed_out conclusion means.
               conclusion=""
               while [ "$SECONDS" -lt "$TIMEOUT_SECONDS" ]; do
-                # app.slug filter: only GitHub Actions' own check counts; other apps
+                # Server-side check_name filtering narrows the response; the jq
+                # re-checks the name so a filter regression can't select the wrong
+                # check, and only GitHub Actions' own check counts — other apps
                 # (e.g. CI mirrors) may report checks under the same name.
                 if conclusion=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/commits/${REF}/check-runs" \
                     -f check_name="$CHECK_NAME" -f filter=latest \
-                    --jq '[.check_runs[] | select(.app.slug == "github-actions" and .status == "completed")][0].conclusion // empty'); then
+                    --jq '[.check_runs[] | select(.name == env.CHECK_NAME and .app.slug == "github-actions" and .status == "completed")][0].conclusion // empty'); then
                   if [ -n "$conclusion" ]; then
                     break
                   fi
@@ -57,7 +66,12 @@ runs:
                   conclusion=""
                   echo "GitHub API error while looking up check \"$CHECK_NAME\"; retrying in ${INTERVAL_SECONDS}s..."
                 fi
-                sleep "$INTERVAL_SECONDS"
+                remaining=$(( TIMEOUT_SECONDS - SECONDS ))
+                if [ "$remaining" -lt 1 ]; then
+                  break
+                fi
+                sleep "$(( remaining < INTERVAL_SECONDS ? remaining : INTERVAL_SECONDS ))"
               done
-              echo "Check \"$CHECK_NAME\" conclusion: ${conclusion:-<none before timeout>}"
+              conclusion="${conclusion:-timed_out}"
+              echo "Check \"$CHECK_NAME\" conclusion: $conclusion"
               echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"

--- a/.github/actions/wait-for-check/action.yml
+++ b/.github/actions/wait-for-check/action.yml
@@ -55,9 +55,14 @@ runs:
                 # re-checks the name so a filter regression can't select the wrong
                 # check, and only GitHub Actions' own check counts — other apps
                 # (e.g. CI mirrors) may report checks under the same name.
+                # filter=latest dedupes re-runs only within a check suite, and the
+                # same SHA can carry same-name runs from several suites (one per
+                # workflow run), so take the newest run (check run IDs are
+                # monotonic) and report it only once it completes — an older
+                # completed run must not mask a newer one still in flight.
                 if conclusion=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/commits/${REF}/check-runs" \
                     -f check_name="$CHECK_NAME" -f filter=latest \
-                    --jq '[.check_runs[] | select(.name == env.CHECK_NAME and .app.slug == "github-actions" and .status == "completed")][0].conclusion // empty'); then
+                    --jq '[.check_runs[] | select(.name == env.CHECK_NAME and .app.slug == "github-actions")] | max_by(.id) | select(.status == "completed") | .conclusion // empty'); then
                   if [ -n "$conclusion" ]; then
                     break
                   fi

--- a/.github/actions/wait-for-check/action.yml
+++ b/.github/actions/wait-for-check/action.yml
@@ -1,0 +1,63 @@
+name: 'Wait for check'
+description: >-
+    Poll a commit for a named GitHub Actions check run until it completes, tolerating
+    transient API errors. First-party replacement for fountainhead/action-wait-for-check,
+    which crashed on a single bad API response and runs on a deprecated Node runtime.
+inputs:
+    token:
+        description: 'GitHub token used to read check runs'
+        required: true
+    checkName:
+        description: 'Exact name of the check run to wait for'
+        required: true
+    ref:
+        description: 'Commit SHA whose check runs are polled'
+        required: true
+    timeoutSeconds:
+        description: 'Give up after this many seconds'
+        required: false
+        default: '3600'
+    intervalSeconds:
+        description: 'Seconds between polls'
+        required: false
+        default: '30'
+outputs:
+    conclusion:
+        description: >-
+            Conclusion of the completed check (success, failure, cancelled, ...).
+            Empty if the check did not complete before the timeout.
+        value: ${{ steps.poll.outputs.conclusion }}
+runs:
+    using: 'composite'
+    steps:
+        - name: Poll for check run
+          id: poll
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.token }}
+              CHECK_NAME: ${{ inputs.checkName }}
+              REF: ${{ inputs.ref }}
+              TIMEOUT_SECONDS: ${{ inputs.timeoutSeconds }}
+              INTERVAL_SECONDS: ${{ inputs.intervalSeconds }}
+          run: |
+              # A transient API error must not fail the wait — log it and retry
+              # until the deadline. Callers decide what a missing conclusion means.
+              conclusion=""
+              while [ "$SECONDS" -lt "$TIMEOUT_SECONDS" ]; do
+                # app.slug filter: only GitHub Actions' own check counts; other apps
+                # (e.g. CI mirrors) may report checks under the same name.
+                if conclusion=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/commits/${REF}/check-runs" \
+                    -f check_name="$CHECK_NAME" -f filter=latest \
+                    --jq '[.check_runs[] | select(.app.slug == "github-actions" and .status == "completed")][0].conclusion // empty'); then
+                  if [ -n "$conclusion" ]; then
+                    break
+                  fi
+                  echo "Check \"$CHECK_NAME\" has not completed yet; retrying in ${INTERVAL_SECONDS}s..."
+                else
+                  conclusion=""
+                  echo "GitHub API error while looking up check \"$CHECK_NAME\"; retrying in ${INTERVAL_SECONDS}s..."
+                fi
+                sleep "$INTERVAL_SECONDS"
+              done
+              echo "Check \"$CHECK_NAME\" conclusion: ${conclusion:-<none before timeout>}"
+              echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -239,15 +239,19 @@ jobs:
                       });
 
                       fs.appendFileSync(process.env.GITHUB_OUTPUT, `deployment-id=${deployment.id}\n`);
+            - name: Check out .github for local actions
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github
             - name: Wait for container image build to complete
-              uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
+              uses: ./.github/actions/wait-for-check
               id: wait-for-image
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   checkName: Build Docker image
                   ref: ${{ github.event.pull_request.head.sha }}
-                  timeoutSeconds: 3600
-                  intervalSeconds: 30
+                  timeoutSeconds: '3600'
+                  intervalSeconds: '30'
             - name: Update comment - Docker build failed
               if: always() && steps.check-preview.outputs.preview == 'true' && steps.wait-for-image.outputs.conclusion != 'success'
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -141,14 +141,13 @@ jobs:
             # (ci-backend.yml runs in parallel on the same commit) — we only hold the
             # deploy *dispatch* to Charts until this commit's backend suite is green.
             # A stale merge once shipped a red master commit to prod because the dispatch
-            # fired regardless of test results; this is the backstop. Cross-workflow
-            # check-waiting on the same SHA mirrors the pattern in ci-hobby.yml.
+            # fired regardless of test results; this is the backstop.
             - name: Wait for backend/product checks to pass
               # Only gate automatic master pushes. A manual workflow_dispatch is the
               # break-glass: it skips the wait so an operator can force a deploy.
               if: github.event_name == 'push'
               id: wait-for-backend
-              uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
+              uses: ./.github/actions/wait-for-check
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   checkName: Django Tests Pass
@@ -156,8 +155,8 @@ jobs:
                   # Must outlast the longest backend job (django tests: 45m in
                   # ci-backend.yml) plus its start lag, so a slow-but-green check
                   # still reports before we give up and block the deploy.
-                  timeoutSeconds: 3300
-                  intervalSeconds: 30
+                  timeoutSeconds: '3300'
+                  intervalSeconds: '30'
 
             - name: Block deploy if backend/product checks did not pass
               if: github.event_name == 'push'


### PR DESCRIPTION
## Problem

`fountainhead/action-wait-for-check` crashes on a single transient API error — no retry. Hit 2 of 12 master commits on 2026-06-10 ([one](https://github.com/PostHog/posthog/actions/runs/27285357701/job/80590925734), [two](https://github.com/PostHog/posthog/actions/runs/27286806560/job/80596166929)): red `Build and push PostHog` + the green commit's deploy never fired. The action is also [unmaintained](https://github.com/fountainhead/action-wait-for-check) (last release 2021) and runs Node 20, [force-upgraded to Node 24 on June 16](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Changes

- New local composite action `.github/actions/wait-for-check`: same interface and sentinels as fountainhead (`timed_out` on timeout), `gh api` poll that retries transient errors; only checks from the `github-actions` app with the exact requested name count
- Fails fast on invalid inputs (composite `required: true` isn't runner-enforced)
- `container-images-cd.yml` + `ci-hobby.yml` swapped to it (fountainhead fully removed); ci-hobby gets a sparse `.github` checkout
- Gate semantics unchanged: both consumers treat `!= 'success'` as not passed

Rejected [lewagon/wait-on-check-action](https://github.com/lewagon/wait-on-check-action): same crash mode ([unrescued polling loop](https://github.com/lewagon/wait-on-check-action/blob/master/app/services/github_checks_verifier.rb)) plus [latest-run selection issue (#85)](https://github.com/lewagon/wait-on-check-action/issues/85).

## How did you test this code?

Agent-authored: `actionlint`/shellcheck clean vs master; live `gh api` test of the filtered query against a real master commit; stubbed-`gh` behavioral test of all three loop paths (transient-error-then-success, timeout → `timed_out` exactly at deadline, invalid input → fail fast). Gate path only runs on master pushes — will watch the first runs post-merge. Adding the `hobby-preview` label exercises the ci-hobby path on this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: traced red master CD runs to the wait action crashing mid-poll (vs one legit gate block from a hung shard); chose a first-party action after checking the marketplace alternative's source for the same failure mode. A max-effort multi-agent review of the branch produced the `timed_out` parity, name re-check, input-guard, and sleep-cap hardening in the second commit.
