### PR TITLE
chore(tasks): drop per-test DB flush from backend tests

### DIFF
--- a/products/tasks/backend/tests/test_event_ingest.py
+++ b/products/tasks/backend/tests/test_event_ingest.py
@@ -5,8 +5,9 @@ from collections.abc import Sequence
 
 from unittest.mock import patch
 
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, override_settings
 
+from asgiref.sync import async_to_sync
 from parameterized import parameterized
 
 from posthog.models import Organization, Team
@@ -37,7 +38,7 @@ from products.tasks.backend.stream.redis_stream import (
 from products.tasks.backend.tests.test_api import TEST_RSA_PRIVATE_KEY
 
 
-class TestTaskRunEventIngest(TransactionTestCase):
+class TestTaskRunEventIngest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         TEST_clear_clients()
@@ -129,7 +130,9 @@ class TestTaskRunEventIngest(TransactionTestCase):
             body = json.loads(sent[1]["body"])
             return status, body
 
-        return asyncio.run(_call())
+        # async_to_sync (not asyncio.run) so the handler's thread_sensitive DB
+        # access runs on the test thread's connection and sees uncommitted rows.
+        return async_to_sync(_call)()
 
     def _read_stream_events(self) -> list[dict]:
         async def _read() -> list[dict]:
@@ -252,7 +255,7 @@ class TestTaskRunEventIngest(TransactionTestCase):
             return sent[0]["status"], json.loads(sent[1]["body"])
 
         with patch("products.tasks.backend.stream.event_ingest._heartbeat_workflow", side_effect=blocking_heartbeat):
-            status, body = asyncio.run(_call())
+            status, body = async_to_sync(_call)()
 
         self.assertEqual(status, 200)
         self.assertEqual(body["accepted"], 1)

--- a/products/tasks/backend/tests/test_presence.py
+++ b/products/tasks/backend/tests/test_presence.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -166,9 +166,10 @@ class PresenceAPITestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-class PresenceFanoutSuppressionTestCase(TransactionTestCase):
-    """``send_user_push`` is dispatched via ``transaction.on_commit``; we need a
-    TransactionTestCase so the callback actually fires.
+class PresenceFanoutSuppressionTestCase(TestCase):
+    """``send_user_push`` is dispatched via ``transaction.on_commit``; the test
+    wraps dispatch in ``captureOnCommitCallbacks(execute=True)`` so the callback
+    fires despite TestCase's rolled-back transaction.
 
     The contract under test: any non-expired presence row for this user/task
     suppresses fanout to ALL of that user's push tokens — including the
@@ -239,7 +240,8 @@ class PresenceFanoutSuppressionTestCase(TransactionTestCase):
             )
             self._present(self.device_a, on_task=other_task, expires_in=timedelta(seconds=30))
 
-        notify_task_run_completed(self.task_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(self.task_run)
 
         mock_delay.assert_called_once()
         suppressed = mock_delay.call_args.args[4]

--- a/products/tasks/backend/tests/test_push_dispatcher.py
+++ b/products/tasks/backend/tests/test_push_dispatcher.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.core.cache import cache
 from django.db import InterfaceError, OperationalError
-from django.test import TransactionTestCase
+from django.test import TestCase
 
 from parameterized import parameterized
 from prometheus_client import REGISTRY
@@ -18,9 +18,11 @@ from products.tasks.backend.push_dispatcher import (
 )
 
 
-# TransactionTestCase so transaction.on_commit callbacks (which we use to defer
-# the Celery dispatch) actually fire during the test instead of being rolled back.
-class TestPushDispatcher(TransactionTestCase):
+# The Celery dispatch is deferred via transaction.on_commit, which never fires
+# inside TestCase's rolled-back transaction — tests wrap notify calls in
+# captureOnCommitCallbacks(execute=True) to run the deferred callback (or assert
+# none was registered) without TransactionTestCase's per-test full-DB flush.
+class TestPushDispatcher(TestCase):
     def setUp(self) -> None:
         cache.clear()
         self.organization = Organization.objects.create(name="Test Org")
@@ -49,7 +51,8 @@ class TestPushDispatcher(TransactionTestCase):
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")
     def test_notify_enqueues_push(self, _name, notify_fn, expected_body_fragment, mock_delay, _flag):
-        notify_fn(self.task_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_fn(self.task_run)
         mock_delay.assert_called_once()
         user_id, title, body, data, suppressed = mock_delay.call_args.args
         self.assertEqual(user_id, self.user.id)
@@ -63,7 +66,8 @@ class TestPushDispatcher(TransactionTestCase):
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=False)
     @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")
     def test_feature_flag_off_skips_dispatch(self, mock_delay, _flag):
-        notify_task_run_completed(self.task_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(self.task_run)
         mock_delay.assert_not_called()
 
     @patch(
@@ -72,23 +76,26 @@ class TestPushDispatcher(TransactionTestCase):
     )
     @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")
     def test_flag_error_fails_closed(self, mock_delay, _flag):
-        notify_task_run_completed(self.task_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(self.task_run)
         mock_delay.assert_not_called()
 
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")
     def test_cooldown_collapses_duplicates(self, mock_delay, _flag):
-        notify_task_run_completed(self.task_run)
-        notify_task_run_completed(self.task_run)
-        notify_task_run_completed(self.task_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(self.task_run)
+            notify_task_run_completed(self.task_run)
+            notify_task_run_completed(self.task_run)
         self.assertEqual(mock_delay.call_count, 1)
 
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
     @patch("products.tasks.backend.push_dispatcher.send_user_push.delay")
     def test_cooldown_is_per_kind(self, mock_delay, _flag):
         # Different push kinds on the same run shouldn't share a cooldown key.
-        notify_task_run_completed(self.task_run)
-        notify_task_run_awaiting_input(self.task_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(self.task_run)
+            notify_task_run_awaiting_input(self.task_run)
         self.assertEqual(mock_delay.call_count, 2)
 
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
@@ -106,7 +113,8 @@ class TestPushDispatcher(TransactionTestCase):
         )
         outsider_run = TaskRun.objects.create(task=outsider_task, team=self.team)
 
-        notify_task_run_completed(outsider_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(outsider_run)
         mock_delay.assert_not_called()
 
     @patch("products.tasks.backend.push_dispatcher.posthoganalytics.feature_enabled", return_value=True)
@@ -120,7 +128,8 @@ class TestPushDispatcher(TransactionTestCase):
             created_by=None,
         )
         anonymous_run = TaskRun.objects.create(task=anonymous_task, team=self.team)
-        notify_task_run_completed(anonymous_run)
+        with self.captureOnCommitCallbacks(execute=True):
+            notify_task_run_completed(anonymous_run)
         mock_delay.assert_not_called()
 
     @patch("products.tasks.backend.push_dispatcher._enqueue_inner", side_effect=RuntimeError("redis is down"))

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock, Mock, patch
 
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, override_settings
 
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
@@ -17,7 +17,7 @@ from products.tasks.backend.temporal.client import (
 
 
 @override_settings(DEBUG=False)
-class TestExecuteTaskProcessingWorkflow(TransactionTestCase):
+class TestExecuteTaskProcessingWorkflow(TestCase):
     def setUp(self) -> None:
         self.organization = Organization.objects.create(name="Test Org")
         self.team = Team.objects.create(organization=self.organization, name="Test Team")


### PR DESCRIPTION
## Problem

`TransactionTestCase` truncates every table and re-runs `post_migrate` after **every test** (~1-2s/test in CI, regardless of test size). Four tasks test classes used it — ~106s of the tasks product's ~185s CI session. The flush also destabilizes local `--reuse-db` runs (`auth_permission` duplicate keys, truncate deadlocks).

## Changes

All four classes → `TestCase`:

- `test_push_dispatcher`, `test_presence`: notify calls wrapped in `captureOnCommitCallbacks(execute=True)` — dispatch is deferred via `transaction.on_commit`
- `test_event_ingest`: invoke the ASGI handler via `async_to_sync` instead of `asyncio.run`, so thread-sensitive DB access shares the test connection (same mechanism as Django's async test client)
- `test_temporal_client`: plain swap — synchronous `atomic()` writes only

Rejected `available_apps`: swaps the app registry, and the `posthog` app dominates the schema anyway.

## Measured result (CI evidence)

[Baseline job (2026-06-05)](https://github.com/PostHog/posthog/actions/runs/27034782544/job/79802128416) vs [this PR's job](https://github.com/PostHog/posthog/actions/runs/27291605814/job/80614064697), per-test timestamp deltas from the `-v` job logs:

| file | before | after |
|---|---|---|
| test_event_ingest.py | 68.5s | 3.3s |
| test_presence.py | 8.3s | 4.2s |
| test_push_dispatcher.py | 17.2s | 4.7s |
| test_temporal_client.py | 12.3s | 0.6s |
| **total** | **106.3s** | **12.8s** |

Full tasks session: **184.6s → 146.3s**, while running 78 more tests (master moved between the runs).

## How did you test this code?

I'm an agent — automated tests only:

- Converted files: 63/63 pass locally, 5 consecutive runs green
- Full tasks suite locally: 1208 passed (only failures are `TestDockerSandboxIntegration` — `skipif`-excluded from CI, environmental)
- Full Backend CI green on this PR (tasks is non-isolated, so all products + Django ran)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Audited every `TransactionTestCase` in `products/` — only these 4 are real usages (data_warehouse / mcp_analytics just mention it in comments). Timing evidence derived from raw CI job logs, not `.test_durations`.
