### PR TITLE
fix(replay): bound capture diagnostics session lookup by timestamp

### DIFF
--- a/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.test.ts
@@ -1,0 +1,43 @@
+import { dayjs } from 'lib/dayjs'
+
+import { sessionIdTimestampBounds } from './replayCaptureDiagnosticsPanelLogic'
+
+describe('sessionIdTimestampBounds', () => {
+    const now = dayjs('2026-06-10T12:00:00Z')
+    // UUIDv7 whose first 48 bits encode 2025-06-13T02:53:58.656Z
+    const sessionStart = dayjs(parseInt('019767355800', 16))
+    const uuidv7SessionId = '01976735-5800-7abc-8def-0123456789ab'
+
+    it.each([
+        [
+            'uuidv7 id derives a window around the embedded timestamp',
+            uuidv7SessionId,
+            { from: sessionStart.subtract(3, 'day'), to: sessionStart.add(4, 'day') },
+        ],
+        [
+            'non-uuid id falls back to the retention window',
+            'custom-session-id',
+            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+        ],
+        [
+            'uuidv4 id falls back to the retention window',
+            '7c10ab30-3a9c-4b75-89ce-09e51c826989',
+            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+        ],
+        [
+            'uuidv7 with an implausibly old embedded timestamp falls back',
+            // first 48 bits encode 1970-02-19, long before uuidv7 session ids existed
+            '0000ffff-ffff-7abc-8def-0123456789ab',
+            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+        ],
+        [
+            'uuidv7 with a far-future embedded timestamp falls back',
+            'ffffffff-ffff-7abc-8def-0123456789ab',
+            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+        ],
+    ])('%s', (_name, sessionId, expected) => {
+        const bounds = sessionIdTimestampBounds(sessionId, now)
+        expect(bounds.from.toISOString()).toEqual(expected.from.toISOString())
+        expect(bounds.to.toISOString()).toEqual(expected.to.toISOString())
+    })
+})

--- a/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.test.ts
@@ -1,43 +1,119 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 
-import { sessionIdTimestampBounds } from './replayCaptureDiagnosticsPanelLogic'
+import { initKeaTests } from '~/test/init'
 
-describe('sessionIdTimestampBounds', () => {
-    const now = dayjs('2026-06-10T12:00:00Z')
-    // UUIDv7 whose first 48 bits encode 2025-06-13T02:53:58.656Z
-    const sessionStart = dayjs(parseInt('019767355800', 16))
-    const uuidv7SessionId = '01976735-5800-7abc-8def-0123456789ab'
+import { replayCaptureDiagnosticsPanelLogic, sessionIdTimestampBounds } from './replayCaptureDiagnosticsPanelLogic'
 
-    it.each([
-        [
-            'uuidv7 id derives a window around the embedded timestamp',
-            uuidv7SessionId,
-            { from: sessionStart.subtract(3, 'day'), to: sessionStart.add(4, 'day') },
-        ],
-        [
-            'non-uuid id falls back to the retention window',
-            'custom-session-id',
-            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
-        ],
-        [
-            'uuidv4 id falls back to the retention window',
-            '7c10ab30-3a9c-4b75-89ce-09e51c826989',
-            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
-        ],
-        [
-            'uuidv7 with an implausibly old embedded timestamp falls back',
-            // first 48 bits encode 1970-02-19, long before uuidv7 session ids existed
-            '0000ffff-ffff-7abc-8def-0123456789ab',
-            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
-        ],
-        [
-            'uuidv7 with a far-future embedded timestamp falls back',
-            'ffffffff-ffff-7abc-8def-0123456789ab',
-            { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
-        ],
-    ])('%s', (_name, sessionId, expected) => {
-        const bounds = sessionIdTimestampBounds(sessionId, now)
-        expect(bounds.from.toISOString()).toEqual(expected.from.toISOString())
-        expect(bounds.to.toISOString()).toEqual(expected.to.toISOString())
+function uuidv7WithEmbeddedStart(startMs: number): string {
+    const hex = startMs.toString(16).padStart(12, '0')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-7abc-8def-0123456789ab`
+}
+
+describe('replayCaptureDiagnosticsPanelLogic', () => {
+    describe('sessionIdTimestampBounds', () => {
+        const now = dayjs('2026-06-10T12:00:00Z')
+        // UUIDv7 whose first 48 bits encode 2025-06-13T02:53:58.656Z
+        const sessionStart = dayjs(parseInt('019767355800', 16))
+        const uuidv7SessionId = '01976735-5800-7abc-8def-0123456789ab'
+        // UUIDv7 whose embedded timestamp is six hours after `now` — a mildly
+        // fast client clock, still inside the now + 1 day grace.
+        const futureStart = now.add(6, 'hour')
+        const futureUuidv7SessionId = uuidv7WithEmbeddedStart(futureStart.valueOf())
+
+        it.each([
+            [
+                'uuidv7 id derives a window around the embedded timestamp',
+                uuidv7SessionId,
+                { from: sessionStart.subtract(3, 'day'), to: sessionStart.add(4, 'day') },
+            ],
+            [
+                'uuidv7 id a few hours in the future stays inside the grace and derives a window',
+                futureUuidv7SessionId,
+                { from: futureStart.subtract(3, 'day'), to: futureStart.add(4, 'day') },
+            ],
+            [
+                'non-uuid id falls back to the retention window',
+                'custom-session-id',
+                { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+            ],
+            [
+                'uuidv4 id falls back to the retention window',
+                '7c10ab30-3a9c-4b75-89ce-09e51c826989',
+                { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+            ],
+            [
+                'uuidv7 with an implausibly old embedded timestamp falls back',
+                // first 48 bits encode 1970-02-19, long before uuidv7 session ids existed
+                '0000ffff-ffff-7abc-8def-0123456789ab',
+                { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+            ],
+            [
+                'uuidv7 with a far-future embedded timestamp falls back',
+                'ffffffff-ffff-7abc-8def-0123456789ab',
+                { from: now.subtract(90, 'day'), to: now.add(1, 'day') },
+            ],
+        ])('%s', (_name, sessionId, expected) => {
+            const bounds = sessionIdTimestampBounds(sessionId, now)
+            expect(bounds.from.toISOString()).toEqual(expected.from.toISOString())
+            expect(bounds.to.toISOString()).toEqual(expected.to.toISOString())
+        })
+    })
+
+    describe('loadSessionEventProperties', () => {
+        let queryHogQL: jest.SpyInstance
+
+        // A UUIDv7 whose embedded timestamp is one hour ago, so the derived
+        // window is narrower than the 90-day fallback and a retry is possible.
+        const recentUuidv7SessionId = uuidv7WithEmbeddedStart(dayjs().subtract(1, 'hour').valueOf())
+
+        beforeEach(() => {
+            initKeaTests()
+            queryHogQL = jest.spyOn(api, 'queryHogQL')
+        })
+
+        afterEach(() => {
+            queryHogQL.mockRestore()
+        })
+
+        async function loadFor(sessionId: string): Promise<Record<string, any> | null> {
+            const logic = replayCaptureDiagnosticsPanelLogic({ sessionId })
+            logic.mount()
+            await expectLogic(logic, () => {
+                logic.actions.loadSessionEventProperties()
+            }).toDispatchActions(['loadSessionEventPropertiesSuccess'])
+            return logic.values.sessionEventProperties
+        }
+
+        it('parses the row from the tight window without a retry', async () => {
+            queryHogQL.mockResolvedValue({ results: [['{"$has_recording":true}']] } as any)
+
+            const properties = await loadFor(recentUuidv7SessionId)
+
+            expect(properties).toEqual({ $has_recording: true })
+            expect(queryHogQL).toHaveBeenCalledTimes(1)
+        })
+
+        it('retries with the fallback window when the tight uuidv7 window is empty', async () => {
+            queryHogQL
+                .mockResolvedValueOnce({ results: [] } as any)
+                .mockResolvedValueOnce({ results: [['{"$has_recording":true}']] } as any)
+
+            const properties = await loadFor(recentUuidv7SessionId)
+
+            expect(properties).toEqual({ $has_recording: true })
+            expect(queryHogQL).toHaveBeenCalledTimes(2)
+        })
+
+        it('does not retry for a non-uuidv7 id that already used the fallback window', async () => {
+            queryHogQL.mockResolvedValue({ results: [] } as any)
+
+            const properties = await loadFor('custom-session-id')
+
+            expect(properties).toBeNull()
+            expect(queryHogQL).toHaveBeenCalledTimes(1)
+        })
     })
 })

--- a/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
@@ -2,6 +2,7 @@ import { defaults, kea, key, path, props } from 'kea'
 import { lazyLoaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { Dayjs, dayjs } from 'lib/dayjs'
 
 import { hogql } from '~/queries/utils'
 
@@ -9,6 +10,33 @@ import type { replayCaptureDiagnosticsPanelLogicType } from './replayCaptureDiag
 
 export interface ReplayCaptureDiagnosticsPanelLogicProps {
     sessionId: string
+}
+
+const UUIDV7_SESSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// posthog-js sessions last at most 24 hours, but the session id's embedded
+// timestamp comes from the client clock while event timestamps are
+// server-corrected, so allow a few days of slack either side.
+const CLOCK_SKEW_SLACK_DAYS = 3
+const MAX_SESSION_DURATION_DAYS = 1
+
+// Fallback window for session ids that don't parse as UUIDv7: wide enough to
+// cover any session whose recording could still be within retention.
+const FALLBACK_LOOKBACK_DAYS = 90
+
+export function sessionIdTimestampBounds(sessionId: string, now: Dayjs = dayjs()): { from: Dayjs; to: Dayjs } {
+    if (UUIDV7_SESSION_ID.test(sessionId)) {
+        const sessionStart = dayjs(parseInt(sessionId.replaceAll('-', '').slice(0, 12), 16))
+        const plausible =
+            sessionStart.isValid() && sessionStart.year() >= 2020 && sessionStart.isBefore(now.add(1, 'day'))
+        if (plausible) {
+            return {
+                from: sessionStart.subtract(CLOCK_SKEW_SLACK_DAYS, 'day'),
+                to: sessionStart.add(MAX_SESSION_DURATION_DAYS + CLOCK_SKEW_SLACK_DAYS, 'day'),
+            }
+        }
+    }
+    return { from: now.subtract(FALLBACK_LOOKBACK_DAYS, 'day'), to: now.add(1, 'day') }
 }
 
 export const replayCaptureDiagnosticsPanelLogic = kea<replayCaptureDiagnosticsPanelLogicType>([
@@ -21,10 +49,16 @@ export const replayCaptureDiagnosticsPanelLogic = kea<replayCaptureDiagnosticsPa
     lazyLoaders(({ props }) => ({
         sessionEventProperties: {
             loadSessionEventProperties: async (_, breakpoint): Promise<Record<string, any> | null> => {
+                // The timestamp bounds let the events sort key prune the scan;
+                // without them this single-session lookup reads the team's
+                // entire event history.
+                const { from, to } = sessionIdTimestampBounds(props.sessionId)
                 const query = hogql`
 SELECT properties
 FROM events
 WHERE $session_id = ${props.sessionId}
+AND timestamp >= ${from}
+AND timestamp <= ${to}
 ORDER BY timestamp DESC
 LIMIT 1`
                 const result = await api.queryHogQL(query, {

--- a/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
@@ -1,4 +1,4 @@
-import { defaults, kea, key, path, props } from 'kea'
+import { BreakPointFunction, defaults, kea, key, path, props } from 'kea'
 import { lazyLoaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -59,7 +59,10 @@ export const replayCaptureDiagnosticsPanelLogic = kea<replayCaptureDiagnosticsPa
     }),
     lazyLoaders(({ props }) => ({
         sessionEventProperties: {
-            loadSessionEventProperties: async (_, breakpoint): Promise<Record<string, any> | null> => {
+            loadSessionEventProperties: async (
+                _?: any,
+                breakpoint?: BreakPointFunction
+            ): Promise<Record<string, any> | null> => {
                 // The timestamp bounds let the events sort key prune the scan;
                 // without them this single-session lookup reads the team's
                 // entire event history.
@@ -82,7 +85,7 @@ LIMIT 1`
                         scene: 'ReplayCaptureDiagnostics',
                         productKey: 'session_replay',
                     })
-                    breakpoint()
+                    breakpoint?.()
                     const row = result?.results?.[0]?.[0]
                     if (!row) {
                         return null

--- a/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
@@ -20,15 +20,22 @@ const UUIDV7_SESSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-
 const CLOCK_SKEW_SLACK_DAYS = 3
 const MAX_SESSION_DURATION_DAYS = 1
 
-// Fallback window for session ids that don't parse as UUIDv7: wide enough to
-// cover any session whose recording could still be within retention.
+// Fallback window for session ids that don't parse as UUIDv7, or when the
+// bounded window returns no results (e.g. severe client clock skew): wide
+// enough to cover any session within the default retention period.
 const FALLBACK_LOOKBACK_DAYS = 90
+
+// UUIDv7 session ids were introduced after PostHog's GA; any embedded year
+// before this is implausible and indicates a corrupt or pre-epoch timestamp.
+const EARLIEST_PLAUSIBLE_SESSION_YEAR = 2020
 
 export function sessionIdTimestampBounds(sessionId: string, now: Dayjs = dayjs()): { from: Dayjs; to: Dayjs } {
     if (UUIDV7_SESSION_ID.test(sessionId)) {
         const sessionStart = dayjs(parseInt(sessionId.replaceAll('-', '').slice(0, 12), 16))
         const plausible =
-            sessionStart.isValid() && sessionStart.year() >= 2020 && sessionStart.isBefore(now.add(1, 'day'))
+            sessionStart.isValid() &&
+            sessionStart.year() >= EARLIEST_PLAUSIBLE_SESSION_YEAR &&
+            sessionStart.isBefore(now.add(1, 'day'))
         if (plausible) {
             return {
                 from: sessionStart.subtract(CLOCK_SKEW_SLACK_DAYS, 'day'),
@@ -36,6 +43,10 @@ export function sessionIdTimestampBounds(sessionId: string, now: Dayjs = dayjs()
             }
         }
     }
+    return { from: now.subtract(FALLBACK_LOOKBACK_DAYS, 'day'), to: now.add(1, 'day') }
+}
+
+export function fallbackSessionTimestampBounds(now: Dayjs = dayjs()): { from: Dayjs; to: Dayjs } {
     return { from: now.subtract(FALLBACK_LOOKBACK_DAYS, 'day'), to: now.add(1, 'day') }
 }
 
@@ -52,8 +63,14 @@ export const replayCaptureDiagnosticsPanelLogic = kea<replayCaptureDiagnosticsPa
                 // The timestamp bounds let the events sort key prune the scan;
                 // without them this single-session lookup reads the team's
                 // entire event history.
-                const { from, to } = sessionIdTimestampBounds(props.sessionId)
-                const query = hogql`
+                const fetchWithin = async ({
+                    from,
+                    to,
+                }: {
+                    from: Dayjs
+                    to: Dayjs
+                }): Promise<Record<string, any> | null> => {
+                    const query = hogql`
 SELECT properties
 FROM events
 WHERE $session_id = ${props.sessionId}
@@ -61,18 +78,35 @@ AND timestamp >= ${from}
 AND timestamp <= ${to}
 ORDER BY timestamp DESC
 LIMIT 1`
-                const result = await api.queryHogQL(query, {
-                    scene: 'ReplayCaptureDiagnostics',
-                    productKey: 'session_replay',
-                })
+                    const result = await api.queryHogQL(query, {
+                        scene: 'ReplayCaptureDiagnostics',
+                        productKey: 'session_replay',
+                    })
+                    breakpoint()
+                    const row = result?.results?.[0]?.[0]
+                    if (!row) {
+                        return null
+                    }
+                    return typeof row === 'string' ? JSON.parse(row) : row
+                }
 
-                breakpoint()
+                const bounds = sessionIdTimestampBounds(props.sessionId)
+                const properties = await fetchWithin(bounds)
+                if (properties !== null) {
+                    return properties
+                }
 
-                const row = result?.results?.[0]?.[0]
-                if (!row) {
+                // A UUIDv7-derived window comes from the client clock, so a badly
+                // skewed clock can place it outside the session's server-corrected
+                // timestamps and the tight query finds nothing. Widen to the
+                // retention fallback before giving up so a skewed clock degrades to
+                // slower-but-correct rather than fast-but-blank. Only worth retrying
+                // when the first window was actually narrower than the fallback.
+                const fallback = fallbackSessionTimestampBounds()
+                if (!bounds.from.isAfter(fallback.from)) {
                     return null
                 }
-                return typeof row === 'string' ? JSON.parse(row) : row
+                return fetchWithin(fallback)
             },
         },
     })),


### PR DESCRIPTION
## Problem

The replay capture diagnostics panel (shown on RecordingNotFound and the sessions scene) fetches one event's properties with `WHERE $session_id = X ORDER BY timestamp DESC LIMIT 1` and no timestamp predicate. The events sort key starts `(team_id, toDate(timestamp), ...)`, so with the date unconstrained the lookup scans the team's entire event history — and the `minmax_$session_id` skip index can't rescue it, because the column also holds `'null'` strings and arbitrary values that widen each granule's min/max range past any UUIDv7.

## Changes

Session ids from our SDKs are UUIDv7, so the id itself embeds the session's start time. The logic now derives a tight window from the id client-side (start ± clock-skew slack), falling back to a 90-day window for ids that don't parse as UUIDv7. A parameterized jest test covers the derivation and fallbacks.

Measured on the Test Cluster (median of 5 cold runs from `query_log`, condition cache disabled), against a real high-volume session on team 2:

| Variant | duration | rows read | bytes read |
| --- | --- | --- | --- |
| unbounded (current) | 16,485 ms | 2.44B | 76.8 GiB |
| 90-day bound | 4,993 ms | 452M | 20.8 GiB |
| UUIDv7-derived bound | 503 ms | 35.7M | 10.4 GiB |

That's a 33x duration and 68x rows-read improvement for the common (UUIDv7) case.

## How did you test this code?

Agent-authored; no manual testing claimed. New parameterized test `replayCaptureDiagnosticsPanelLogic.test.ts` covers the bound derivation (UUIDv7, non-UUID, UUIDv4, implausibly-old and far-future embedded timestamps); the existing `ReplayCaptureDiagnosticsPanel.test.tsx` suite still passes (18 tests total). Query variants measured against the Test Cluster as above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session running `/optimizing-clickhouse-and-hogql-queries` over the frontend session replay queries, at the author's request — the follow-up to the same sweep over MCP analytics (#62719).
- All four replay frontend HogQL queries were reviewed; the other three (recording-list properties, session player events, full-event-data fetch) are already correctly time-bounded and were left unchanged.
- The skip-index hypothesis ("minmax on $session_id should prune this") was tested and disproven on the Test Cluster before changing anything — measurements above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
