### PR TITLE
feat(web-analytics): precompute exit page, drop screen name from eager warmer

### DIFF
--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
@@ -39,6 +39,7 @@ PARITY_BREAKDOWNS = [
     ("initial_referring_domain", WebStatsBreakdown.INITIAL_REFERRING_DOMAIN),
     ("initial_referring_url", WebStatsBreakdown.INITIAL_REFERRING_URL),
     ("language", WebStatsBreakdown.LANGUAGE),
+    ("exit_page", WebStatsBreakdown.EXIT_PAGE),
 ]
 
 

--- a/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
@@ -107,6 +107,12 @@ SUPPORTED_BREAKDOWNS: set[WebStatsBreakdown] = {
     WebStatsBreakdown.CITY,
     WebStatsBreakdown.TIMEZONE,
     WebStatsBreakdown.LANGUAGE,
+    # EXIT_PAGE is a session-scoped path (`session.$end_pathname`) served as a simple
+    # breakdown — no bounce-rate join, unlike PAGE/INITIAL_PAGE which route to the
+    # paths precompute family. It reads a materialized sessions column, so it carries
+    # none of the unmaterialized-property OOM risk that keeps INITIAL_REFERRING_URL
+    # out of the eager warmer.
+    WebStatsBreakdown.EXIT_PAGE,
 }
 
 # Breakdowns whose value is a tuple — JSON-decoded as a list and converted back

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -182,6 +182,15 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
         # through to the raw stats query and the paths preagg table stays cold.
         if breakdown in (WebStatsBreakdown.PAGE, WebStatsBreakdown.INITIAL_PAGE):
             query["includeBounceRate"] = True
+        # EXIT_PAGE is served by the simple precompute, which bakes the cleaned-or-raw
+        # path into the stored breakdown value and the job hash (unlike PAGE/INITIAL_PAGE,
+        # whose paths precompute stores raw paths and cleans at read time). The End-paths
+        # tile sends `doPathCleaning=isPathCleaningEnabled` (true for teams with cleaning
+        # rules), so without this the warmer fills the raw variant while the dashboard
+        # reads the cleaned one and misses. True is a no-op for teams without cleaning
+        # rules (`apply_path_cleaning` returns the bare expression → identical hash).
+        if breakdown == WebStatsBreakdown.EXIT_PAGE:
+            query["doPathCleaning"] = True
         queries.append(query)
 
     warmed = 0

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -75,7 +75,10 @@ BASELINE_BREAKDOWNS: tuple[WebStatsBreakdown, ...] = (
     WebStatsBreakdown.PAGE,
     WebStatsBreakdown.INITIAL_PAGE,
     WebStatsBreakdown.EXIT_PAGE,
-    WebStatsBreakdown.SCREEN_NAME,
+    # SCREEN_NAME is deliberately excluded. It reads `$screen_name`, a
+    # mobile-only ($screen) property that is empty for web teams, and there is
+    # no precompute family for it — warming it only ever ran a raw query that
+    # populated nothing. It stays available as an on-demand breakdown.
     WebStatsBreakdown.INITIAL_CHANNEL_TYPE,
     WebStatsBreakdown.INITIAL_REFERRING_DOMAIN,
     # INITIAL_REFERRING_URL is deliberately excluded. Unlike its domain

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -167,6 +167,12 @@ class TestWarmBaselineForTeam(APIBaseTest):
                 assert q["includeBounceRate"] is True
             else:
                 assert "includeBounceRate" not in q
+            # EXIT_PAGE (simple precompute) bakes path cleaning into the stored value,
+            # so the warmer must match the dashboard's cleaned End-paths request.
+            if q["breakdownBy"] == WebStatsBreakdown.EXIT_PAGE.value:
+                assert q["doPathCleaning"] is True
+            else:
+                assert "doPathCleaning" not in q
 
         # Every baseline breakdown must be covered.
         seen_breakdowns = {q["breakdownBy"] for q in captured if q["kind"] == "WebStatsTableQuery"}


### PR DESCRIPTION
## Problem

The web analytics eager precompute warmer runs the dashboard's tile queries per enrolled team every hour. Auditing what each warmed query actually populates showed a few tiles never populated the precompute table — they fell through to a raw scan every cycle: Language, ExitPage, and ScreenName.

Language is already fixed by #62602 (pending deploy). This PR closes the remaining two gaps so every query the warmer runs populates precompute.

## Changes

- **ExitPage → precomputed.** `EXIT_PAGE` reads `session.$end_pathname` (+ path cleaning) — a session-scoped value structurally identical to the simple breakdowns already precomputed, runs as `stats_table_simple_breakdown_query` with no bounce-rate join, and reads a materialized sessions column (no unmaterialized-property OOM risk). Added it to `SUPPORTED_BREAKDOWNS`. It also serves on-demand dashboard reads, which were eligible but going raw.
- **ScreenName → dropped from the warmer.** `$screen_name` is a mobile-only property with no precompute family; warming it only ever ran a raw query that populated nothing. Removed from `BASELINE_BREAKDOWNS`; it stays available as an on-demand breakdown.

## How did you test this code?

I'm an agent (Claude Code, directed by the assignee). Automated only:

- `test_web_stats_lazy_precompute.py` — added `EXIT_PAGE` to the lazy-vs-raw parity matrix (normal + compare); full file green.
- `test_eager_web_analytics_precompute.py` — green; it derives its expected tile set from `BASELINE_BREAKDOWNS`, so the ScreenName removal is covered.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Audited the eager warmer's per-tile query types to find which warmed queries fall through to raw, then verified statically (paths-precompute gate only accepts PAGE/INITIAL_PAGE; ExitPage/ScreenName route to the simple family). Chose to *precompute* ExitPage (real, useful tile + materialized column, low risk) but *drop* ScreenName (mobile-only, empty for web teams, no family) rather than precompute noise. Language was handled separately in #62602.