### PR TITLE
feat(dev): add POSTHOG_DEV_SANDBOX_EXCLUDE to opt procs out of the dev sandbox

### DIFF
--- a/tools/hogli-commands/hogli_commands/devenv/generator.py
+++ b/tools/hogli-commands/hogli_commands/devenv/generator.py
@@ -193,7 +193,7 @@ class MprocsGenerator(ConfigGenerator):
                 proc_config = self._add_uv_groups(proc_config, resolved)
 
             # Wrap Python/Node service commands in the dev sandbox when opted in
-            proc_config = self._add_sandbox_wrapper(proc_config)
+            proc_config = self._add_sandbox_wrapper(proc_config, name)
 
             # Add logging wrapper if enabled
             if source_config and source_config.log_to_files:
@@ -391,7 +391,7 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
     # code, so running them unsandboxed doesn't widen the untrusted attack surface.
     _SANDBOX_DOCKER_GATES = ("bin/wait-for-docker", "bin/wait-for-postgres-tables")
 
-    def _add_sandbox_wrapper(self, proc_config: dict[str, Any]) -> dict[str, Any]:
+    def _add_sandbox_wrapper(self, proc_config: dict[str, Any], name: str = "") -> dict[str, Any]:
         """Wrap a service command in bin/dev-sandbox (macOS Seatbelt) when opted in.
 
         Opt in globally with POSTHOG_DEV_SANDBOX=1 (e.g. in .env.local). A proc is
@@ -403,6 +403,12 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         a malicious dependency can't read credentials (~/.ssh, ~/.aws, ...) and denies
         the docker/agent sockets so it can't escape via a container mount.
 
+        POSTHOG_DEV_SANDBOX_EXCLUDE (comma-separated proc names) opts individual
+        procs back out. Use sparingly — it exists for procs whose feature set
+        requires the docker socket the profile denies, e.g. temporal-worker running
+        PostHog Code tasks with SANDBOX_PROVIDER=docker. Excluded procs run fully
+        unsandboxed, so the dependency-isolation guarantee no longer covers them.
+
         The docker-gate preamble (bin/wait-for-docker) is peeled out to run
         unsandboxed, since it needs the very socket the sandbox denies; the actual
         server (which reaches infra over TCP) is what gets sandboxed. bin/dev-sandbox
@@ -411,7 +417,8 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         # `sandbox` is a registry-only selector; pop it so it never leaks into the
         # emitted proc config (which phrocs/mprocs would otherwise see).
         should_sandbox = bool(proc_config.pop("sandbox", False))
-        if os.getenv("POSTHOG_DEV_SANDBOX") != "1" or not should_sandbox:
+        excluded = {p.strip() for p in os.getenv("POSTHOG_DEV_SANDBOX_EXCLUDE", "").split(",") if p.strip()}
+        if os.getenv("POSTHOG_DEV_SANDBOX") != "1" or not should_sandbox or (name and name in excluded):
             return proc_config
 
         shell = proc_config.get("shell", "")

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -150,6 +150,16 @@ class TestSandboxWrapper:
         assert result["shell"] == "bin/dev-sandbox ./bin/start-frontend"
         assert "sandbox" not in result
 
+    def test_excluded_proc_left_unwrapped(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("POSTHOG_DEV_SANDBOX", "1")
+        monkeypatch.setenv("POSTHOG_DEV_SANDBOX_EXCLUDE", "temporal-worker, other-proc")
+        generator = MprocsGenerator(MockRegistry({}))
+        excluded = generator._add_sandbox_wrapper({"shell": "./run-worker", "sandbox": True}, "temporal-worker")
+        assert excluded["shell"] == "./run-worker"
+        assert "sandbox" not in excluded
+        wrapped = generator._add_sandbox_wrapper({"shell": "./bin/start-backend", "sandbox": True}, "backend")
+        assert wrapped["shell"] == "bin/dev-sandbox ./bin/start-backend"
+
     def test_docker_gate_runs_outside_sandbox(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("POSTHOG_DEV_SANDBOX", "1")
         result = self._wrap({"shell": "bin/wait-for-docker && ./bin/start-backend", "sandbox": True})


### PR DESCRIPTION
## Problem

Some procs legitimately need the docker socket the dev sandbox profile denies — e.g. temporal-worker running PostHog Code tasks with `SANDBOX_PROVIDER=docker` — and currently there is no way to run them unsandboxed without disabling the sandbox globally via `POSTHOG_DEV_SANDBOX`.

## Changes

- New `POSTHOG_DEV_SANDBOX_EXCLUDE` env var (comma-separated proc names) opts individual procs back out of the sandbox wrapper in the mprocs generator, while `POSTHOG_DEV_SANDBOX=1` stays on for everything else. Excluded procs run fully unsandboxed, so the dependency-isolation guarantee no longer covers them — documented in the docstring as a use-sparingly escape hatch.
- Adds a test covering the exclude behavior (excluded proc left unwrapped, others still wrapped).

## How did you test this code?

I'm an agent. I ran the existing devenv test suite locally (`hogli_commands/tests/test_devenv.py`) — 66 passed, including the new `test_excluded_proc_left_unwrapped`. `ruff check` and `ruff format` pass on the changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The user supplied the diffs verbatim and asked for them to be applied, committed, and pushed to this PR. An earlier `bin/dev-sandbox.sb` change was dropped from this PR after landing on master separately; the branch was rebased against master. Done with Claude Code (Edit/Bash + GitHub MCP); the agent made no design decisions beyond running the existing tests and writing this description.

https://claude.ai/code/session_01REZcspUeWqbrKtu7NBbhm3