### PR TITLE
chore(max): clarify AI consent copy to say third-party models

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -182,7 +182,7 @@ function HomepageAiInput(): JSX.Element {
                     PostHog AI needs your approval to potentially process identifying user data with external AI
                     providers.
                 </p>
-                <p className="text-muted text-xs m-0">Your data won't be used for training models.</p>
+                <p className="text-muted text-xs m-0">Your data won't be used for training third-party models.</p>
                 {isAdmin ? (
                     <LemonButton
                         type="primary"

--- a/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
+++ b/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
@@ -28,7 +28,7 @@ export function AIConsentPopoverContent({
                 <Tooltip title={getExternalAIProvidersTooltipTitle()}>
                     <dfn>external AI providers</dfn>
                 </Tooltip>
-                . <i>Your data won't be used for training models.</i>
+                . <i>Your data won't be used for training third-party models.</i>
             </p>
             <div className="flex gap-1.5 self-end">
                 <LemonButton data-attr="ai-consent-cancel" type="secondary" size="xsmall" onClick={onDismiss}>


### PR DESCRIPTION
## Problem

Our AI consent copy was inconsistent. The longer versions (org settings "AI service providers" section and the Max AI liability notice) state "Your data will not be used for training **third-party** models," but the two shorter inline consent strings just said "Your data won't be used for training models." The shorter wording is less precise — the assurance is specifically about not training the third-party LLM providers' (Alphabet, Anthropic, Microsoft, OpenAI) models.

## Changes

Reworded the two shorter consent strings to match the longer copy:

- `AIConsentPopoverWrapper.tsx` — the inline AI consent popover
- `HomepageInput.tsx` — the homepage AI input consent block

Both now read "Your data won't be used for training third-party models."

Copy-only change, no behavior change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
