### PR TITLE
feat(cymbal): verify SDK-signed exceptions; reserve $exception_verified

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2630,6 +2630,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "cyclotron-core"
 version = "0.1.0"
 dependencies = [
@@ -2701,9 +2728,11 @@ dependencies = [
  "common-types",
  "cymbal-proto",
  "cymbal-resolution",
+ "ed25519-dalek",
  "envconfig",
  "futures",
  "health",
+ "hex",
  "hogvm",
  "httpmock",
  "insta",
@@ -3130,6 +3159,30 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3582,6 +3635,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -33,6 +33,7 @@ zip = "4.0"
 proguard = "5.6.2"
 reqwest = { workspace = true }
 sha2 = "0.10.8"
+ed25519-dalek = { version = "2.1", features = ["pkcs8", "pem"] }
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 uuid = { workspace = true }
@@ -57,6 +58,7 @@ httpmock = { workspace = true }
 mockall = { workspace = true }
 insta = { version = "1.46.0", features = ["json", "redactions"] }
 tower.workspace = true
+hex = "0.4"
 
 [lints]
 workspace = true

--- a/rust/cymbal/src/exception_signing.rs
+++ b/rust/cymbal/src/exception_signing.rs
@@ -1,0 +1,234 @@
+//! Verification of SDK-signed `$exception` events.
+//!
+//! A backend SDK (e.g. posthog-python with `enable_exception_signing`) signs each exception
+//! over a canonical projection of its `$exception_list` using the customer's Ed25519 private
+//! key, and attaches `$exception_signature` + `$exception_signature_key_id`. Here we re-derive
+//! the *same* canonical bytes from the raw event properties and verify them against the
+//! project's registered public key, so ingestion can stamp a trusted `$exception_verified`
+//! flag. Because the public ingest key is shared, this is the only way to prove an exception
+//! genuinely came from the customer's backend rather than being forged.
+//!
+//! CRITICAL: the canonical encoding must stay byte-identical to the SDK's `build_canonical`
+//! (posthog-python `exception_signing.py`). The cross-language parity vector in the tests below
+//! is the guard against drift — it is the exact output of the Python implementation.
+//!
+//! Verification runs on the RAW pre-ingestion properties (before cymbal sanitises/truncates the
+//! exception list and rewrites frames), so the bytes match what the SDK signed.
+
+use base64::Engine;
+use ed25519_dalek::pkcs8::DecodePublicKey;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+pub const SIGNATURE_PROPERTY: &str = "$exception_signature";
+pub const KEY_ID_PROPERTY: &str = "$exception_signature_key_id";
+pub const VERIFIED_PROPERTY: &str = "$exception_verified";
+pub const VERIFIED_KEY_ID_PROPERTY: &str = "$exception_verified_key_id";
+
+const CANONICAL_MAGIC: &[u8] = b"PHEXC1\n";
+
+fn lp(out: &mut Vec<u8>, value: Option<&str>) {
+    let bytes = value.unwrap_or("").as_bytes();
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn str_field<'a>(v: &'a Value, key: &str) -> Option<&'a str> {
+    v.get(key).and_then(|x| x.as_str())
+}
+
+/// Deterministic, length-prefixed encoding of the signable projection of `$exception_list`.
+/// Must produce identical bytes to the SDK. Reads only stable string/int fields (never floats,
+/// never the in-app/abs_path/context/mechanism/exception_id fields that ingestion mutates).
+pub fn build_canonical(exception_list: &Value) -> Vec<u8> {
+    let mut out = CANONICAL_MAGIC.to_vec();
+    let empty = Vec::new();
+    let excs = exception_list.as_array().unwrap_or(&empty);
+    out.extend_from_slice(&(excs.len() as u32).to_be_bytes());
+    for exc in excs {
+        lp(&mut out, str_field(exc, "type"));
+        lp(&mut out, str_field(exc, "value"));
+        let frames = exc
+            .get("stacktrace")
+            .and_then(|s| s.get("frames"))
+            .and_then(|f| f.as_array())
+            .cloned()
+            .unwrap_or_default();
+        out.extend_from_slice(&(frames.len() as u32).to_be_bytes());
+        for frame in &frames {
+            lp(&mut out, str_field(frame, "function"));
+            lp(&mut out, str_field(frame, "filename"));
+            let lineno = frame.get("lineno").and_then(|l| l.as_i64()).map(|n| n.to_string());
+            lp(&mut out, lineno.as_deref());
+            lp(&mut out, str_field(frame, "module"));
+        }
+    }
+    out
+}
+
+/// Stable short fingerprint of a raw 32-byte Ed25519 public key. Matches the SDK and the
+/// Django key-registration API so a signature's `key_id` resolves to the stored key.
+pub fn derive_key_id(public_key_raw: &[u8]) -> String {
+    let digest = Sha256::digest(public_key_raw);
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+    b64.chars().take(16).collect()
+}
+
+/// A team's registered public key, as needed for verification.
+pub struct PublicKey {
+    pub key_id: String,
+    pub public_key_pem: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verification {
+    /// No signature on the event — not a signed exception.
+    Unsigned,
+    /// A valid signature from a registered key. Carries the matched key id.
+    Verified(String),
+    /// A signature was present but did not verify (no matching key, bad signature, or tampered).
+    Invalid,
+}
+
+fn verify_bytes(canonical: &[u8], signature_b64: &str, public_key_pem: &str) -> bool {
+    let Ok(sig_bytes) = base64::engine::general_purpose::STANDARD.decode(signature_b64) else {
+        return false;
+    };
+    let Ok(sig_arr): Result<[u8; 64], _> = sig_bytes.try_into() else {
+        return false;
+    };
+    let Ok(vk) = VerifyingKey::from_public_key_pem(public_key_pem) else {
+        return false;
+    };
+    vk.verify(canonical, &Signature::from_bytes(&sig_arr)).is_ok()
+}
+
+/// Verify the signature (if any) on a raw `$exception` event's properties against the team's
+/// registered keys. `properties` is the raw, pre-ingestion JSON object.
+pub fn verify_properties(properties: &Value, keys: &[PublicKey]) -> Verification {
+    let Some(signature) = str_field(properties, SIGNATURE_PROPERTY) else {
+        return Verification::Unsigned;
+    };
+    let key_id = str_field(properties, KEY_ID_PROPERTY);
+    let exception_list = match properties.get("$exception_list") {
+        Some(v) => v,
+        None => return Verification::Invalid,
+    };
+    let canonical = build_canonical(exception_list);
+
+    // Prefer the key the signature names; fall back to trying all team keys.
+    let candidates: Vec<&PublicKey> = match key_id {
+        Some(id) => keys.iter().filter(|k| k.key_id == id).collect(),
+        None => keys.iter().collect(),
+    };
+    for key in candidates {
+        if verify_bytes(&canonical, signature, &key.public_key_pem) {
+            return Verification::Verified(key.key_id.clone());
+        }
+    }
+    Verification::Invalid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- Cross-language parity vector (must equal posthog-python's output) --------------------
+    const PARITY_CANONICAL_HEX: &str = "5048455843310a0000000100000009485454504572726f720000001e34303120436c69656e74204572726f723a20556e617574686f72697a65640000000200000007726571756573740000001272657175657374732f6d6f64656c732e707900000004313032310000000f72657175657374732e6d6f64656c730000000b73796e635f73747269706500000036706f7374686f672f74656d706f72616c2f646174615f696d706f7274732f736f75726365732f7374726970652f736f757263652e707900000002343200000033706f7374686f672e74656d706f72616c2e646174615f696d706f7274732e736f75726365732e7374726970652e736f75726365";
+    const PARITY_SIGNATURE_B64: &str = "Fyh19k2cC1k9M8cJr54TNH91MDdd67oaUnydyKm7E+QCPN3mK+h3N9Yp5nkM7xYtngD8km7ljqVXARGDmnfzAQ==";
+    const PARITY_KEY_ID: &str = "Vkdap1RjR0wChd9d";
+    const PARITY_PUBKEY_PEM: &str = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAA6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=\n-----END PUBLIC KEY-----\n";
+
+    fn parity_exception_list() -> Value {
+        json!([{
+            "type": "HTTPError",
+            "value": "401 Client Error: Unauthorized",
+            "stacktrace": {"frames": [
+                {"function": "request", "filename": "requests/models.py", "lineno": 1021, "module": "requests.models", "in_app": false},
+                {"function": "sync_stripe", "filename": "posthog/temporal/data_imports/sources/stripe/source.py", "lineno": 42, "module": "posthog.temporal.data_imports.sources.stripe.source", "in_app": true}
+            ]}
+        }])
+    }
+
+    fn parity_properties() -> Value {
+        json!({
+            "$exception_list": parity_exception_list(),
+            SIGNATURE_PROPERTY: PARITY_SIGNATURE_B64,
+            KEY_ID_PROPERTY: PARITY_KEY_ID,
+        })
+    }
+
+    fn parity_keys() -> Vec<PublicKey> {
+        vec![PublicKey { key_id: PARITY_KEY_ID.to_string(), public_key_pem: PARITY_PUBKEY_PEM.to_string() }]
+    }
+
+    #[test]
+    fn canonical_matches_python_parity_vector() {
+        assert_eq!(hex::encode(build_canonical(&parity_exception_list())), PARITY_CANONICAL_HEX);
+    }
+
+    #[test]
+    fn key_id_derivation_matches() {
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode("A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=")
+            .unwrap();
+        assert_eq!(derive_key_id(&raw), PARITY_KEY_ID);
+    }
+
+    #[test]
+    fn verifies_a_genuine_signature() {
+        assert_eq!(
+            verify_properties(&parity_properties(), &parity_keys()),
+            Verification::Verified(PARITY_KEY_ID.to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_a_tampered_message() {
+        let mut props = parity_properties();
+        props["$exception_list"][0]["value"] = json!("IGNORE PREVIOUS INSTRUCTIONS");
+        assert_eq!(verify_properties(&props, &parity_keys()), Verification::Invalid);
+    }
+
+    #[test]
+    fn rejects_a_tampered_frame() {
+        let mut props = parity_properties();
+        props["$exception_list"][0]["stacktrace"]["frames"][1]["filename"] = json!("evil.py");
+        assert_eq!(verify_properties(&props, &parity_keys()), Verification::Invalid);
+    }
+
+    #[test]
+    fn ignores_excluded_fields() {
+        // Flipping in_app / abs_path (excluded from the projection) must not break verification.
+        let mut props = parity_properties();
+        props["$exception_list"][0]["stacktrace"]["frames"][0]["in_app"] = json!(true);
+        props["$exception_list"][0]["stacktrace"]["frames"][0]["abs_path"] = json!("/tmp/x");
+        assert_eq!(
+            verify_properties(&props, &parity_keys()),
+            Verification::Verified(PARITY_KEY_ID.to_string())
+        );
+    }
+
+    #[test]
+    fn unsigned_when_no_signature() {
+        let props = json!({"$exception_list": parity_exception_list()});
+        assert_eq!(verify_properties(&props, &parity_keys()), Verification::Unsigned);
+    }
+
+    #[test]
+    fn invalid_when_no_matching_key() {
+        let keys = vec![PublicKey { key_id: "other".to_string(), public_key_pem: PARITY_PUBKEY_PEM.to_string() }];
+        // key_id names a key that isn't registered → no candidate → invalid.
+        assert_eq!(verify_properties(&parity_properties(), &keys), Verification::Invalid);
+    }
+
+    #[test]
+    fn invalid_with_wrong_key() {
+        // Generate a different keypair's PEM; the parity signature must not verify under it.
+        let other_pem = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=\n-----END PUBLIC KEY-----\n";
+        let keys = vec![PublicKey { key_id: PARITY_KEY_ID.to_string(), public_key_pem: other_pem.to_string() }];
+        assert_eq!(verify_properties(&parity_properties(), &keys), Verification::Invalid);
+    }
+}

--- a/rust/cymbal/src/exception_signing.rs
+++ b/rust/cymbal/src/exception_signing.rs
@@ -59,7 +59,10 @@ pub fn build_canonical(exception_list: &Value) -> Vec<u8> {
         for frame in &frames {
             lp(&mut out, str_field(frame, "function"));
             lp(&mut out, str_field(frame, "filename"));
-            let lineno = frame.get("lineno").and_then(|l| l.as_i64()).map(|n| n.to_string());
+            let lineno = frame
+                .get("lineno")
+                .and_then(|l| l.as_i64())
+                .map(|n| n.to_string());
             lp(&mut out, lineno.as_deref());
             lp(&mut out, str_field(frame, "module"));
         }
@@ -101,14 +104,19 @@ fn verify_bytes(canonical: &[u8], signature_b64: &str, public_key_pem: &str) -> 
     let Ok(vk) = VerifyingKey::from_public_key_pem(public_key_pem) else {
         return false;
     };
-    vk.verify(canonical, &Signature::from_bytes(&sig_arr)).is_ok()
+    vk.verify(canonical, &Signature::from_bytes(&sig_arr))
+        .is_ok()
 }
 
 /// Verify the signature (if any) on a raw `$exception` event's properties against the team's
 /// registered keys. `properties` is the raw, pre-ingestion JSON object.
 pub fn verify_properties(properties: &Value, keys: &[PublicKey]) -> Verification {
-    let Some(signature) = str_field(properties, SIGNATURE_PROPERTY) else {
-        return Verification::Unsigned;
+    // Absent signature -> genuinely unsigned. Present but not a usable string (null, number,
+    // empty, object) -> malformed, treat as Invalid rather than silently "unsigned".
+    let signature = match properties.get(SIGNATURE_PROPERTY) {
+        None => return Verification::Unsigned,
+        Some(Value::String(s)) if !s.is_empty() => s.as_str(),
+        Some(_) => return Verification::Invalid,
     };
     let key_id = str_field(properties, KEY_ID_PROPERTY);
     let exception_list = match properties.get("$exception_list") {
@@ -137,7 +145,8 @@ mod tests {
 
     // --- Cross-language parity vector (must equal posthog-python's output) --------------------
     const PARITY_CANONICAL_HEX: &str = "5048455843310a0000000100000009485454504572726f720000001e34303120436c69656e74204572726f723a20556e617574686f72697a65640000000200000007726571756573740000001272657175657374732f6d6f64656c732e707900000004313032310000000f72657175657374732e6d6f64656c730000000b73796e635f73747269706500000036706f7374686f672f74656d706f72616c2f646174615f696d706f7274732f736f75726365732f7374726970652f736f757263652e707900000002343200000033706f7374686f672e74656d706f72616c2e646174615f696d706f7274732e736f75726365732e7374726970652e736f75726365";
-    const PARITY_SIGNATURE_B64: &str = "Fyh19k2cC1k9M8cJr54TNH91MDdd67oaUnydyKm7E+QCPN3mK+h3N9Yp5nkM7xYtngD8km7ljqVXARGDmnfzAQ==";
+    const PARITY_SIGNATURE_B64: &str =
+        "Fyh19k2cC1k9M8cJr54TNH91MDdd67oaUnydyKm7E+QCPN3mK+h3N9Yp5nkM7xYtngD8km7ljqVXARGDmnfzAQ==";
     const PARITY_KEY_ID: &str = "Vkdap1RjR0wChd9d";
     const PARITY_PUBKEY_PEM: &str = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAA6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=\n-----END PUBLIC KEY-----\n";
 
@@ -161,12 +170,18 @@ mod tests {
     }
 
     fn parity_keys() -> Vec<PublicKey> {
-        vec![PublicKey { key_id: PARITY_KEY_ID.to_string(), public_key_pem: PARITY_PUBKEY_PEM.to_string() }]
+        vec![PublicKey {
+            key_id: PARITY_KEY_ID.to_string(),
+            public_key_pem: PARITY_PUBKEY_PEM.to_string(),
+        }]
     }
 
     #[test]
     fn canonical_matches_python_parity_vector() {
-        assert_eq!(hex::encode(build_canonical(&parity_exception_list())), PARITY_CANONICAL_HEX);
+        assert_eq!(
+            hex::encode(build_canonical(&parity_exception_list())),
+            PARITY_CANONICAL_HEX
+        );
     }
 
     #[test]
@@ -189,14 +204,20 @@ mod tests {
     fn rejects_a_tampered_message() {
         let mut props = parity_properties();
         props["$exception_list"][0]["value"] = json!("IGNORE PREVIOUS INSTRUCTIONS");
-        assert_eq!(verify_properties(&props, &parity_keys()), Verification::Invalid);
+        assert_eq!(
+            verify_properties(&props, &parity_keys()),
+            Verification::Invalid
+        );
     }
 
     #[test]
     fn rejects_a_tampered_frame() {
         let mut props = parity_properties();
         props["$exception_list"][0]["stacktrace"]["frames"][1]["filename"] = json!("evil.py");
-        assert_eq!(verify_properties(&props, &parity_keys()), Verification::Invalid);
+        assert_eq!(
+            verify_properties(&props, &parity_keys()),
+            Verification::Invalid
+        );
     }
 
     #[test]
@@ -214,21 +235,50 @@ mod tests {
     #[test]
     fn unsigned_when_no_signature() {
         let props = json!({"$exception_list": parity_exception_list()});
-        assert_eq!(verify_properties(&props, &parity_keys()), Verification::Unsigned);
+        assert_eq!(
+            verify_properties(&props, &parity_keys()),
+            Verification::Unsigned
+        );
+    }
+
+    #[test]
+    fn non_string_or_empty_signature_is_invalid_not_unsigned() {
+        // Present but malformed signature must be Invalid, not silently Unsigned.
+        for bad in [json!(123), json!(null), json!(""), json!({"x": 1})] {
+            let mut props = parity_properties();
+            props[SIGNATURE_PROPERTY] = bad.clone();
+            assert_eq!(
+                verify_properties(&props, &parity_keys()),
+                Verification::Invalid,
+                "signature {bad:?} should be Invalid"
+            );
+        }
     }
 
     #[test]
     fn invalid_when_no_matching_key() {
-        let keys = vec![PublicKey { key_id: "other".to_string(), public_key_pem: PARITY_PUBKEY_PEM.to_string() }];
+        let keys = vec![PublicKey {
+            key_id: "other".to_string(),
+            public_key_pem: PARITY_PUBKEY_PEM.to_string(),
+        }];
         // key_id names a key that isn't registered → no candidate → invalid.
-        assert_eq!(verify_properties(&parity_properties(), &keys), Verification::Invalid);
+        assert_eq!(
+            verify_properties(&parity_properties(), &keys),
+            Verification::Invalid
+        );
     }
 
     #[test]
     fn invalid_with_wrong_key() {
         // Generate a different keypair's PEM; the parity signature must not verify under it.
         let other_pem = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=\n-----END PUBLIC KEY-----\n";
-        let keys = vec![PublicKey { key_id: PARITY_KEY_ID.to_string(), public_key_pem: other_pem.to_string() }];
-        assert_eq!(verify_properties(&parity_properties(), &keys), Verification::Invalid);
+        let keys = vec![PublicKey {
+            key_id: PARITY_KEY_ID.to_string(),
+            public_key_pem: other_pem.to_string(),
+        }];
+        assert_eq!(
+            verify_properties(&parity_properties(), &keys),
+            Verification::Invalid
+        );
     }
 }

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -11,6 +11,7 @@ pub mod app_context;
 pub mod assignment_rules;
 pub mod config;
 pub mod error;
+pub mod exception_signing;
 pub mod fingerprinting;
 pub mod frames;
 pub mod issue_resolution;

--- a/rust/cymbal/src/types/exception_properties.rs
+++ b/rust/cymbal/src/types/exception_properties.rs
@@ -123,6 +123,8 @@ impl ExceptionProperties {
             values,
             sources,
             functions,
+            verified: None,
+            verified_key_id: None,
         })
     }
 }

--- a/rust/cymbal/src/types/exception_properties.rs
+++ b/rust/cymbal/src/types/exception_properties.rs
@@ -12,7 +12,7 @@ use crate::{
     issue_resolution::Issue,
     langs::apple::AppleDebugImage,
     recursively_sanitize_properties,
-    types::{event::AnyEvent, ExceptionList, OutputErrProps},
+    types::{event::AnyEvent, strip_reserved_properties, ExceptionList, OutputErrProps},
 };
 
 pub const MAX_EXCEPTION_VALUE_LENGTH: usize = 10_000;
@@ -116,7 +116,9 @@ impl ExceptionProperties {
             proposed_fingerprint,
             fingerprint_record: self.fingerprint_record.clone().unwrap_or_default(),
             issue_id,
-            other: self.props.clone(),
+            // Strip reserved $exception_* keys so a client can't forge server-controlled fields
+            // (e.g. $exception_verified) in the HTTP ingestion path, which uses this to_output.
+            other: strip_reserved_properties(self.props.clone()),
             handled,
             releases,
             types,

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -194,9 +194,16 @@ pub struct OutputErrProps {
     pub sources: Vec<String>,
     #[serde(rename = "$exception_functions")]
     pub functions: Vec<String>,
+    // Authenticity: set true only when the event carried a valid signature from one of the
+    // team's registered Ed25519 keys (see crate::exception_signing). Server-controlled — listed
+    // in RESERVED_PROPERTIES so any client-supplied value is stripped and can't be forged.
+    #[serde(rename = "$exception_verified", skip_serializing_if = "Option::is_none")]
+    pub verified: Option<bool>,
+    #[serde(rename = "$exception_verified_key_id", skip_serializing_if = "Option::is_none")]
+    pub verified_key_id: Option<String>,
 }
 
-const RESERVED_PROPERTIES: [&str; 11] = [
+const RESERVED_PROPERTIES: [&str; 13] = [
     "$exception_list",
     "$exception_fingerprint",
     "$exception_issue_id",
@@ -208,6 +215,8 @@ const RESERVED_PROPERTIES: [&str; 11] = [
     "$exception_values",
     "$exception_sources",
     "$exception_functions",
+    "$exception_verified",
+    "$exception_verified_key_id",
 ];
 
 impl FingerprintComponent for Exception {
@@ -330,6 +339,11 @@ impl FingerprintedErrProps {
             functions,
             handled,
             releases,
+            // Populated by the signature-verification step in the ingestion pipeline (see
+            // crate::exception_signing). None until that wiring lands; the RESERVED_PROPERTIES
+            // filter above already strips any client-supplied value so it can't be forged.
+            verified: None,
+            verified_key_id: None,
         }
     }
 }

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -197,9 +197,15 @@ pub struct OutputErrProps {
     // Authenticity: set true only when the event carried a valid signature from one of the
     // team's registered Ed25519 keys (see crate::exception_signing). Server-controlled — listed
     // in RESERVED_PROPERTIES so any client-supplied value is stripped and can't be forged.
-    #[serde(rename = "$exception_verified", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "$exception_verified",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub verified: Option<bool>,
-    #[serde(rename = "$exception_verified_key_id", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "$exception_verified_key_id",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub verified_key_id: Option<String>,
 }
 
@@ -215,9 +221,21 @@ const RESERVED_PROPERTIES: [&str; 13] = [
     "$exception_values",
     "$exception_sources",
     "$exception_functions",
-    "$exception_verified",
-    "$exception_verified_key_id",
+    // Reference the canonical constants so this can't drift from exception_signing — if these
+    // weren't stripped, a client could forge the verified flag.
+    crate::exception_signing::VERIFIED_PROPERTY,
+    crate::exception_signing::VERIFIED_KEY_ID_PROPERTY,
 ];
+
+/// Drop any client-supplied reserved `$exception_*` properties, so server-controlled fields
+/// (fingerprint, issue id, verified, …) can never be forged by a client sending them directly.
+/// Applied in every path that turns event properties into output.
+pub(crate) fn strip_reserved_properties(other: HashMap<String, Value>) -> HashMap<String, Value> {
+    other
+        .into_iter()
+        .filter(|(k, _)| !RESERVED_PROPERTIES.contains(&k.as_str()))
+        .collect()
+}
 
 impl FingerprintComponent for Exception {
     fn update(&self, fp: &mut FingerprintBuilder) {
@@ -319,11 +337,7 @@ impl FingerprintedErrProps {
             .unwrap_or_else(|| self.exception_list.get_is_handled());
 
         // If users send properties that are reserved, it will results in property keys being duplicated
-        let sanitized_others = self
-            .other
-            .into_iter()
-            .filter(|(k, _)| !RESERVED_PROPERTIES.contains(&k.as_str()))
-            .collect();
+        let sanitized_others = strip_reserved_properties(self.other);
 
         OutputErrProps {
             exception_list: self.exception_list,
@@ -556,7 +570,28 @@ mod test {
 
     use crate::{frames::RawFrame, types::Stacktrace};
 
-    use super::RawErrProps;
+    use super::{strip_reserved_properties, RawErrProps};
+
+    #[test]
+    fn strip_reserved_properties_drops_forgeable_server_fields() {
+        let other = std::collections::HashMap::from([
+            ("$exception_verified".to_string(), serde_json::json!(true)),
+            (
+                "$exception_verified_key_id".to_string(),
+                serde_json::json!("forged"),
+            ),
+            (
+                "$exception_fingerprint".to_string(),
+                serde_json::json!("nope"),
+            ),
+            ("custom".to_string(), serde_json::json!("kept")),
+        ]);
+        let stripped = strip_reserved_properties(other);
+        assert!(!stripped.contains_key("$exception_verified"));
+        assert!(!stripped.contains_key("$exception_verified_key_id"));
+        assert!(!stripped.contains_key("$exception_fingerprint"));
+        assert_eq!(stripped.get("custom"), Some(&serde_json::json!("kept")));
+    }
 
     #[test]
     fn it_deserialises_error_props() {


### PR DESCRIPTION
## Problem

The public ingest key means a `$exception` event can be forged. To let downstream consumers trust an exception's provenance, ingestion must verify the SDK's signature and emit a flag they can rely on. (Stacked on #62750, which adds the per-team public-key registry.)

## Changes

- `cymbal::exception_signing` — re-derives the **canonical, length-prefixed projection** of the raw `$exception_list` (byte-identical to the posthog-python SDK's `build_canonical`) and verifies the Ed25519 `$exception_signature` against a registered public key. Runs on the raw pre-ingestion properties, so it sees exactly what the SDK signed (before we sanitise/truncate/symbolicate).
- `$exception_verified` + `$exception_verified_key_id` added to `OutputErrProps` and to `RESERVED_PROPERTIES` — so any **client-supplied** `$exception_verified` is stripped and the flag can only be set by the server.
- Adds `ed25519-dalek`.

## How tested

Agent-assisted. The canonical-encoding + Ed25519 verification logic is covered by unit tests built around a **committed cross-language parity vector** — the exact canonical bytes + signature produced by the Python SDK (`posthog-python`) — asserting byte-for-byte canonical equality and verify/tamper/wrong-key behaviour. This logic was validated end-to-end in a standalone Rust harness that reproduced the parity vector and verified a Python-generated signature.

Note: local rustc (1.85) predates the workspace MSRV (≥1.91), so I could not compile the full `cymbal` crate locally — CI does the full build. The changes are the new module (faithful port of the validated standalone code) + mechanical schema additions.

## Follow-up (error-tracking team)

This PR adds the verification primitive and the (stripped, server-only) `$exception_verified` schema. The remaining wiring is yours to place: load a team's keys via `TeamManager` (mirroring `assignment_rules`/`suppression_rules`), call `exception_signing::verify_properties` on the raw event in the pipeline, and populate `OutputErrProps.verified` (+ bump the key's `last_used_at`). Happy to pair on the right stage/threading.
