### PR TITLE
fix(posthog-ai): Fix search tool crash for accounts kind

### DIFF
--- a/ee/hogai/context/entity_search/context.py
+++ b/ee/hogai/context/entity_search/context.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import Any, Literal
 
 from django.conf import settings
-from django.db.models import Max
+from django.db.models import Max, Q, QuerySet
 from django.utils import timezone
 
 from pydantic import ValidationError
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from posthog.schema import ArtifactContentType, InsightVizNode
 
 from posthog.api.search import (
+    LIMIT as SEARCH_LIMIT,
     EntityConfig,
     search_entities as search_entities_fts,
 )
@@ -166,14 +167,28 @@ class EntitySearchContext:
         if entity_types == "all":
             entity_types = set(ENTITY_MAP.keys())
 
-        results, counts, _ = await database_sync_to_async(search_entities_fts, thread_sensitive=False)(
-            entity_types,
-            query,
-            self._team.project_id,
-            self,  # type: ignore
-            ENTITY_MAP,
-        )
-        assert counts is not None
+        results: list[dict] = []
+        counts: dict[str, int | None] = {}
+
+        if "account" in entity_types:
+            # Account uses a fail-closed manager and is not in ENTITY_MAP, so it can't go through the shared FTS path
+            entity_types = entity_types - {"account"}
+            account_results, account_count = await self._search_accounts(query)
+            results.extend(account_results)
+            counts["account"] = account_count
+
+        if entity_types:
+            fts_results, fts_counts, _ = await database_sync_to_async(search_entities_fts, thread_sensitive=False)(
+                entity_types,
+                query,
+                self._team.project_id,
+                self,  # type: ignore
+                ENTITY_MAP,
+            )
+            assert fts_counts is not None
+            results.extend(fts_results)
+            counts.update(fts_counts)
+
         return results, counts
 
     async def list_entities(
@@ -343,18 +358,15 @@ class EntitySearchContext:
 
         return all_entities, total_count
 
-    async def _list_accounts(self, limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
-        """List customer accounts, newest first. Uses the unscoped manager since Account is fail-closed."""
-        return await database_sync_to_async(self._list_accounts_sync, thread_sensitive=False)(limit, offset)
-
-    def _list_accounts_sync(self, limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
-        queryset = self.user_access_control.filter_queryset_by_access_level(
-            Account.objects.unscoped().filter(team=self._team).order_by("-created_at")
+    def _accounts_queryset(self) -> QuerySet[Account]:
+        """Base accounts queryset. Uses the unscoped manager since Account is fail-closed."""
+        return self.user_access_control.filter_queryset_by_access_level(
+            Account.objects.unscoped().filter(team=self._team)
         )
-        total_count = queryset.count()
-        accounts = list(queryset[offset : offset + limit].values("id", "name", "external_id"))
 
-        all_entities: list[dict[str, Any]] = [
+    @staticmethod
+    def _account_entities(accounts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
             {
                 "type": "account",
                 "result_id": str(account["id"]),
@@ -362,7 +374,26 @@ class EntitySearchContext:
             }
             for account in accounts
         ]
-        return all_entities, total_count
+
+    async def _search_accounts(self, query: str) -> tuple[list[dict[str, Any]], int]:
+        """Search accounts by name or external id."""
+        return await database_sync_to_async(self._search_accounts_sync, thread_sensitive=False)(query)
+
+    def _search_accounts_sync(self, query: str) -> tuple[list[dict[str, Any]], int]:
+        queryset = self._accounts_queryset().filter(Q(name__icontains=query) | Q(external_id__icontains=query))
+        total_count = queryset.count()
+        accounts = list(queryset.order_by("name")[:SEARCH_LIMIT].values("id", "name", "external_id"))
+        return self._account_entities(accounts), total_count
+
+    async def _list_accounts(self, limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
+        """List customer accounts, newest first."""
+        return await database_sync_to_async(self._list_accounts_sync, thread_sensitive=False)(limit, offset)
+
+    def _list_accounts_sync(self, limit: int = 100, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
+        queryset = self._accounts_queryset().order_by("-created_at")
+        total_count = queryset.count()
+        accounts = list(queryset[offset : offset + limit].values("id", "name", "external_id"))
+        return self._account_entities(accounts), total_count
 
     def _get_entity_row_values(self, result: dict, extra_columns: list[str], include_type: bool) -> list[str]:
         """

--- a/ee/hogai/context/entity_search/context.py
+++ b/ee/hogai/context/entity_search/context.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable, Mapping
 from datetime import timedelta
 from enum import StrEnum
 from typing import Any, Literal
@@ -360,12 +361,14 @@ class EntitySearchContext:
 
     def _accounts_queryset(self) -> QuerySet[Account]:
         """Base accounts queryset. Uses the unscoped manager since Account is fail-closed."""
+        if not self.user_access_control.check_access_level_for_resource("account", "viewer"):
+            return Account.objects.unscoped().none()
         return self.user_access_control.filter_queryset_by_access_level(
             Account.objects.unscoped().filter(team=self._team)
         )
 
     @staticmethod
-    def _account_entities(accounts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _account_entities(accounts: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
         return [
             {
                 "type": "account",

--- a/ee/hogai/context/entity_search/test/test_context.py
+++ b/ee/hogai/context/entity_search/test/test_context.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from django.conf import settings
 from django.utils import timezone
 
+from asgiref.sync import sync_to_async
 from parameterized import parameterized
+
+from posthog.models import Team
 
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
@@ -399,6 +402,57 @@ class TestEntitySearchContext(NonAtomicBaseTest):
 
         assert entities == []
         assert total == 0
+
+    async def test_search_entities_account_by_partial_name(self):
+        account = await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="globex-1")
+        await Account.objects.unscoped().acreate(team=self.team, name="Acme Corp", external_id="acme-1")
+
+        results, counts = await self.context.search_entities({"account"}, "glob")
+
+        assert len(results) == 1
+        assert results[0]["type"] == "account"
+        assert results[0]["result_id"] == str(account.id)
+        assert results[0]["extra_fields"]["name"] == "Globex"
+        assert results[0]["extra_fields"]["external_id"] == "globex-1"
+        assert counts["account"] == 1
+
+    async def test_search_entities_account_by_external_id(self):
+        account = await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="0190da51-0b0e")
+        await Account.objects.unscoped().acreate(team=self.team, name="Acme Corp", external_id="acme-1")
+
+        results, counts = await self.context.search_entities({"account"}, "0190da51")
+
+        assert len(results) == 1
+        assert results[0]["result_id"] == str(account.id)
+        assert counts["account"] == 1
+
+    async def test_search_entities_account_excludes_other_teams(self):
+        other_team = await sync_to_async(lambda: Team.objects.create(organization=self.organization))()
+        await Account.objects.unscoped().acreate(team=other_team, name="Globex", external_id="globex-1")
+
+        results, counts = await self.context.search_entities({"account"}, "globex")
+
+        assert results == []
+        assert counts["account"] == 0
+
+    async def test_search_entities_account_no_match(self):
+        await Account.objects.unscoped().acreate(team=self.team, name="Acme Corp", external_id="acme-1")
+
+        results, counts = await self.context.search_entities({"account"}, "globex")
+
+        assert results == []
+        assert counts["account"] == 0
+
+    async def test_search_entities_account_combined_with_fts_kinds(self):
+        await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="globex-1")
+        await Dashboard.objects.acreate(team=self.team, name="Globex dashboard", deleted=False, created_by=self.user)
+
+        results, counts = await self.context.search_entities({"account", "dashboard"}, "globex")
+
+        result_types = {r["type"] for r in results}
+        assert result_types == {"account", "dashboard"}
+        assert counts["account"] == 1
+        assert counts["dashboard"] == 1
 
     async def test_list_entities_pagination(self):
         for i in range(5):

--- a/ee/hogai/context/entity_search/test/test_context.py
+++ b/ee/hogai/context/entity_search/test/test_context.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
 
+from posthog.constants import AvailableFeature
 from posthog.models import Team
 
 from products.actions.backend.models.action import Action
@@ -21,6 +22,7 @@ from products.surveys.backend.models import Survey
 
 from ee.hogai.context import AssistantContextManager
 from ee.hogai.context.entity_search import EntitySearchContext
+from ee.models.rbac.access_control import AccessControl
 
 
 class TestEntitySearchContext(NonAtomicBaseTest):
@@ -442,6 +444,29 @@ class TestEntitySearchContext(NonAtomicBaseTest):
 
         assert results == []
         assert counts["account"] == 0
+
+    def _deny_customer_analytics_access(self):
+        AccessControl.objects.create(team=self.team, resource="customer_analytics", access_level="none")
+        self.organization.available_product_features.append({"key": AvailableFeature.ACCESS_CONTROL})  # type: ignore[union-attr]
+        self.organization.save()
+
+    async def test_search_entities_account_denied_resource_access(self):
+        await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="globex-1")
+        await sync_to_async(self._deny_customer_analytics_access)()
+
+        results, counts = await self.context.search_entities({"account"}, "globex")
+
+        assert results == []
+        assert counts["account"] == 0
+
+    async def test_list_entities_account_denied_resource_access(self):
+        await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="globex-1")
+        await sync_to_async(self._deny_customer_analytics_access)()
+
+        entities, total = await self.context.list_entities("account", limit=10, offset=0)
+
+        assert entities == []
+        assert total == 0
 
     async def test_search_entities_account_combined_with_fts_kinds(self):
         await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="globex-1")

--- a/ee/hogai/tools/full_text_search/test/test_tool.py
+++ b/ee/hogai/tools/full_text_search/test/test_tool.py
@@ -3,6 +3,8 @@ from unittest.mock import ANY, patch
 
 from langchain_core.runnables import RunnableConfig
 
+from products.customer_analytics.backend.models import Account
+
 from ee.hogai.context import AssistantContextManager
 from ee.hogai.context.entity_search.context import ENTITY_MAP
 from ee.hogai.core.shared_prompts import HYPERLINK_USAGE_INSTRUCTIONS
@@ -102,3 +104,11 @@ class TestEntitySearchToolkit(NonAtomicBaseTest):
         result = await self.toolkit.execute(query="test query", search_kind="invalid_type")  # type: ignore
 
         assert "Invalid entity kind: invalid_type. Please provide a valid entity kind for the tool." in result
+
+    async def test_search_accounts_end_to_end(self):
+        await Account.objects.unscoped().acreate(team=self.team, name="Globex", external_id="globex-1")
+
+        result = await self.toolkit.execute(query="globex", search_kind=EntityKind.ACCOUNTS)
+
+        assert "Globex" in result
+        assert "globex-1" in result


### PR DESCRIPTION
## Problem

Searching accounts via the PostHog AI `search` tool (`kind="accounts"`) always crashes with `KeyError: 'account'`. The customer analytics agent mode special-cased the **list** path around `Account`'s fail-closed manager, but the **search** path still routes accounts into the shared FTS machinery, whose `ENTITY_MAP` has no account entry.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Route the accounts kind around the FTS path in `EntitySearchContext.search_entities`
- Search accounts by name or external id (`icontains`) on the unscoped, team-filtered, access-controlled queryset
- Extract shared account queryset/row helpers used by both list and search paths
- Add regression tests reproducing the crash at context and tool level

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Red/green TDD: the new tests first reproduced the `KeyError: 'account'`, then passed with the fix. Ran `ee/hogai/context/entity_search/test/test_context.py` (49 passed), `ee/hogai/tools/full_text_search/test/test_tool.py` (6 passed), and `ee/hogai/tools/test/test_list_data.py` (5 passed).

Manually in the UI
<img width="1642" height="692" alt="image" src="https://github.com/user-attachments/assets/30fa4a26-85d6-48e5-9778-e624a75596c8" />

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code. Root cause was pinpointed from an LLM trace of a failing chat and confirmed against the captured exception in error tracking before touching code. Substring matching (`icontains` on name/external id) was chosen over registering accounts in the FTS `ENTITY_MAP`: the fail-closed manager can't go through the shared path, and substring matching suits short account names better than token-based FTS.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
