### PR TITLE
fix(experiments): handle null metrics when serializing experiments

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -304,7 +304,8 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
         }
 
         # Refresh action names in inline metrics (metrics and metrics_secondary)
-        for metrics_list in [data.get("metrics", []), data.get("metrics_secondary", [])]:
+        # The columns are nullable, so the keys can be present with a None value
+        for metrics_list in [data.get("metrics") or [], data.get("metrics_secondary") or []]:
             for i, metric in enumerate(metrics_list):
                 # Refresh action names to show current names instead of stale cached values
                 refreshed_metric = refresh_action_names_in_metric(metric, instance.team)

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -40,7 +40,14 @@ class TestExperimentCRUD(APILicensedTest):
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_can_list_experiments_with_null_metrics(self):
+    @parameterized.expand(
+        [
+            (None, None),
+            (None, []),
+            ([], None),
+        ]
+    )
+    def test_can_list_experiments_with_null_metrics(self, metrics: list | None, metrics_secondary: list | None) -> None:
         flag = FeatureFlag.objects.create(
             team=self.team,
             created_by=self.user,
@@ -59,8 +66,8 @@ class TestExperimentCRUD(APILicensedTest):
             team=self.team,
             name="Null metrics experiment",
             feature_flag=flag,
-            metrics=None,
-            metrics_secondary=None,
+            metrics=metrics,
+            metrics_secondary=metrics_secondary,
         )
 
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/")

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -40,6 +40,36 @@ class TestExperimentCRUD(APILicensedTest):
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_can_list_experiments_with_null_metrics(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="null-metrics-flag",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+        experiment = Experiment.objects.create(
+            team=self.team,
+            name="Null metrics experiment",
+            feature_flag=flag,
+            metrics=None,
+            metrics_secondary=None,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_can_list_eligible_feature_flags(self) -> None:
         FeatureFlag.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

The experiments list and detail endpoints return a 500 (`TypeError: 'NoneType' object is not iterable`) when an experiment row has `metrics` or `metrics_secondary` stored as `NULL`. Both columns are nullable (`JSONField(default=list, null=True, blank=True)`) and the API accepts `"metrics": null` (`allow_null=True`), so such rows are easy to create via the API.

`ExperimentSerializer.to_representation` iterates `data.get("metrics", [])`, but since `metrics` is a declared serializer field the key is always present in `data` — the `.get()` default never applies, so a `NULL` value reaches `enumerate(None)` and raises. Because the list endpoint serializes every experiment, a single bad row breaks the whole experiments page for a project.

## Changes

- Guard against `None` with `data.get("metrics") or []` / `data.get("metrics_secondary") or []`, matching the defensive pattern already used elsewhere (e.g. `experiment.metrics or []` on the model).
- Add a regression test that creates an experiment with `metrics=None` / `metrics_secondary=None` and asserts both the list and detail endpoints return 200.

## How did you test this code?

Agent-authored; automated tests only:

- New regression test `test_can_list_experiments_with_null_metrics` fails without the fix (`TypeError` → 500) and passes with it.
- Ran neighboring serializer tests (`test_can_list_experiments`, `test_fetching_experiment_with_stale_metric_dates_applies_experiment_date_range`, `test_saved_metrics`, `test_getting_experiments_is_not_nplus1`) — all pass.
- `ruff check` / `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Root-caused with Claude Code using the PostHog MCP: error tracking pinpointed the exception at `products/experiments/backend/presentation/serializers.py:308` in `to_representation`, with captured stack-frame locals showing `metrics_list: None` for an experiment whose `metrics` column is `NULL`.
- Considered tightening the write path (rejecting/coercing `null`) but kept the change minimal and read-side only, since existing rows with `NULL` would still need the read-side guard either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
