### PR TITLE
fix(customer-analytics): Refetch billing insight on date range change

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
@@ -37,7 +37,7 @@ export function AccountBillingExpansion({
     kind: AccountBillingKind
 }): JSX.Element {
     const logic = accountBillingLogic({ accountId, externalId, kind })
-    const { savedInsight, savedInsightLoading, dateRange, variableOverrides } = useValues(logic)
+    const { savedInsight, savedInsightLoading, dateRange, variableOverrides, queryKey } = useValues(logic)
     const { setDateRange } = useActions(logic)
 
     if (!externalId) {
@@ -68,7 +68,8 @@ export function AccountBillingExpansion({
             {/* Embedded DataVisualization collapses to a sliver without a fixed-height parent (InsightCard__viz is flex:1, min-height:0). */}
             <div className="h-80 flex flex-col overflow-hidden">
                 <Query
-                    uniqueKey={`account-billing-${accountId}-${kind}`}
+                    key={queryKey}
+                    uniqueKey={queryKey}
                     query={query}
                     variablesOverride={variableOverrides ?? null}
                     readOnly

--- a/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.test.ts
@@ -1,0 +1,85 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { insightsApi } from 'scenes/insights/utils/api'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import type { QueryBasedInsightModel } from '~/types'
+
+import { accountBillingLogic } from './accountBillingLogic'
+
+const ORG_VARIABLE_ID = 'var-org'
+const START_VARIABLE_ID = 'var-start'
+const END_VARIABLE_ID = 'var-end'
+
+const buildUsageInsight = (): QueryBasedInsightModel =>
+    ({
+        query: {
+            kind: NodeKind.DataVisualizationNode,
+            source: {
+                kind: NodeKind.HogQLQuery,
+                query: 'SELECT 1',
+                variables: {
+                    [ORG_VARIABLE_ID]: { variableId: ORG_VARIABLE_ID, code_name: 'billing_org_id', value: null },
+                    [START_VARIABLE_ID]: {
+                        variableId: START_VARIABLE_ID,
+                        code_name: 'billing_start_date',
+                        value: null,
+                    },
+                    [END_VARIABLE_ID]: { variableId: END_VARIABLE_ID, code_name: 'billing_end_date', value: null },
+                },
+            },
+        },
+    }) as unknown as QueryBasedInsightModel
+
+describe('accountBillingLogic', () => {
+    let logic: ReturnType<typeof accountBillingLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.restoreAllMocks()
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('injects the external id into the saved insight variables', async () => {
+        jest.spyOn(insightsApi, 'getByShortId').mockResolvedValue(buildUsageInsight())
+
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'usage' })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.variableOverrides?.[ORG_VARIABLE_ID]?.value).toBe('org-uuid')
+    })
+
+    it('updates the date variable overrides when the date range changes', async () => {
+        jest.spyOn(insightsApi, 'getByShortId').mockResolvedValue(buildUsageInsight())
+
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'usage' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setDateRange('2024-01-01', '2024-01-31')
+
+        expect(logic.values.variableOverrides?.[START_VARIABLE_ID]?.value).toBe('2024-01-01')
+        expect(logic.values.variableOverrides?.[END_VARIABLE_ID]?.value).toBe('2024-01-31')
+    })
+
+    it('changes the query key when the date range changes so the insight refetches', async () => {
+        jest.spyOn(insightsApi, 'getByShortId').mockResolvedValue(buildUsageInsight())
+
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'usage' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        const initialQueryKey = logic.values.queryKey
+
+        logic.actions.setDateRange('2024-01-01', '2024-01-31')
+
+        expect(logic.values.queryKey).not.toEqual(initialQueryKey)
+        expect(logic.values.queryKey).toContain('2024-01-01')
+        expect(logic.values.queryKey).toContain('2024-01-31')
+    })
+})

--- a/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.ts
@@ -113,6 +113,11 @@ export const accountBillingLogic = kea<accountBillingLogicType>([
                 return overrides
             },
         ],
+        queryKey: [
+            (s) => [s.resolvedDateRange, (_, p) => p.accountId, (_, p) => p.kind],
+            (resolvedDateRange, accountId, kind): string =>
+                `account-billing-${accountId}-${kind}-${resolvedDateRange.date_from}-${resolvedDateRange.date_to}`,
+        ],
     }),
     afterMount(({ actions, props }) => {
         if (props.externalId) {


### PR DESCRIPTION
## Problem

Changing the date range in an expanded account's Usage tab didn't update the rendered insight — the picker moved but the chart kept showing the original range.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Derive a `queryKey` in `accountBillingLogic` from the account + resolved date range
- Key the embedded `<Query>` by it, so a date change remounts and refetches the insight
- Add `accountBillingLogic` tests covering the override values and the query-key change
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Agent-run: `accountBillingLogic` unit tests (3 cases) + full Accounts jest suite (62) + frontend typecheck (no errors in changed files). No manual UI testing — the saved billing insights aren't present in this local environment.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

No docs changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored via PostHog Code. Root cause: only the `variablesOverride` prop changed on the embedded `<Query>`, and the shared `dataNodeLogic`/`dataVisualizationLogic` only refetch on query changes — never on a `variablesOverride` prop change. Chose to remount the embedded `<Query>` via a date-derived `queryKey` (matching how the standalone insight scene already handles override changes) rather than make the shared insight stack react to `variablesOverride`, to avoid an app-wide blast radius and double-fetches on dashboards.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->
<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->
<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. -->
<!-- Agent-authored PRs always require human review — do not self-merge or auto-approve. Do NOT claim manual testing you haven't done. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
