### PR TITLE
feat(customer-analytics): add spend tab to accounts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4363,9 +4363,9 @@ snapshots:
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--light:
         hash: v1.k794b7964.dbed81a9f646d861c5fea01fbb66409ca2134d052126c83910f0d48cc7c229b9.NTmSJa7n10fuCNA-jmRnxjcAV6Na8sJSdTOwg0LZb7M
     scenes-app-customer-analytics-accounts--row-expanded-usage-populated--dark:
-        hash: v1.k794b7964.51df31b2f26139195bd36ff3a49dc9ef508ece5a82b27531c67a079b8ba0c3d5.G6zXVyDobNnlIPNswkE8aailxmojSt2QNJ5ov3tGwKs
+        hash: v1.k794b7964.d04d40247868d79a631943192b59d6770129069130c7c01c218174297ea8e211.RdxB2mQsJYtXUNAhwCxybVGkPS9s-Y4rIV5-_PiJsbk
     scenes-app-customer-analytics-accounts--row-expanded-usage-populated--light:
-        hash: v1.k794b7964.9f2f530882c939501fe180e1cf3ff3bf2af41ec6a37648b0db528aaa3d1532b9.kQ4UI7ylaSo9OoZGNrq3eIOTcrmezd00e3LSUCGpZ30
+        hash: v1.k794b7964.6ba35c84f16d06a3a8e664519ac1d4cbe045069e459be8cd8752cdcb9e1f51fc.-7O2_Vcw9A-mDb_FWHgDylXVMLolYP3xzcf0X_oNUQI
     scenes-app-customer-analytics-accounts--row-expanded-with-note--dark:
         hash: v1.k794b7964.3c9ce002ecb9931c56ef82618cc1625ee847a7f8df2a35c490006e4b356e6fb5.bK3yVZfb-U4TUMJHKvLemkMdqx6YNKdkFC2lnrWBgYg
     scenes-app-customer-analytics-accounts--row-expanded-with-note--light:

--- a/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
@@ -32,7 +32,7 @@ export function AccountBillingExpansion({
     kind: AccountBillingKind
 }): JSX.Element {
     const logic = accountBillingLogic({ accountId, externalId, kind })
-    const { savedInsights, savedInsightsLoading, dateRange, variableOverridesByShortId } = useValues(logic)
+    const { savedInsights, savedInsightsLoading, dateRange, variableOverridesByShortId, queryKeyFor } = useValues(logic)
     const { setDateRange } = useActions(logic)
 
     if (!externalId) {
@@ -56,21 +56,25 @@ export function AccountBillingExpansion({
                 dateTo={dateRange.date_to}
                 onChange={(from, to) => setDateRange(from, to)}
             />
-            {savedInsights.map((insight) => (
-                <div key={insight.short_id} className="flex flex-col gap-1">
-                    {showTitles && insight.name ? <h4 className="mb-0 text-sm">{insight.name}</h4> : null}
-                    {/* Embedded DataVisualization collapses to a sliver without a fixed-height parent (InsightCard__viz is flex:1, min-height:0). */}
-                    <div className="h-80 flex flex-col overflow-hidden">
-                        <Query
-                            uniqueKey={`account-billing-${accountId}-${kind}-${insight.short_id}`}
-                            query={insight.query}
-                            variablesOverride={variableOverridesByShortId[insight.short_id] ?? null}
-                            readOnly
-                            embedded
-                        />
+            {savedInsights.map((insight) => {
+                const queryKey = queryKeyFor(insight.short_id)
+                return (
+                    <div key={insight.short_id} className="flex flex-col gap-1">
+                        {showTitles && insight.name ? <h4 className="mb-0 text-sm">{insight.name}</h4> : null}
+                        {/* Embedded DataVisualization collapses to a sliver without a fixed-height parent (InsightCard__viz is flex:1, min-height:0). */}
+                        <div className="h-80 flex flex-col overflow-hidden">
+                            <Query
+                                key={queryKey}
+                                uniqueKey={queryKey}
+                                query={insight.query}
+                                variablesOverride={variableOverridesByShortId[insight.short_id] ?? null}
+                                readOnly
+                                embedded
+                            />
+                        </div>
                     </div>
-                </div>
-            ))}
+                )
+            })}
         </div>
     )
 }

--- a/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountBillingExpansion.tsx
@@ -9,11 +9,6 @@ import { Query } from '~/queries/Query/Query'
 
 import { AccountBillingKind, accountBillingLogic } from './accountBillingLogic'
 
-const KIND_NOTE: Record<AccountBillingKind, string | null> = {
-    usage: null,
-    spend: 'Daily billed units (not dollars).',
-}
-
 function BillingInsightNotFound({ kind }: { kind: AccountBillingKind }): JSX.Element {
     const Hog = kind === 'spend' ? BurningMoneyHog : DetectiveHog
     return (
@@ -37,44 +32,45 @@ export function AccountBillingExpansion({
     kind: AccountBillingKind
 }): JSX.Element {
     const logic = accountBillingLogic({ accountId, externalId, kind })
-    const { savedInsight, savedInsightLoading, dateRange, variableOverrides } = useValues(logic)
+    const { savedInsights, savedInsightsLoading, dateRange, variableOverridesByShortId } = useValues(logic)
     const { setDateRange } = useActions(logic)
 
     if (!externalId) {
         return <div className="p-4 text-secondary">This account has no linked organization.</div>
     }
 
-    if (savedInsightLoading) {
+    if (savedInsightsLoading) {
         return <LemonSkeleton className="h-64 w-full" />
     }
 
-    const query = savedInsight?.query
-    if (!query) {
+    if (!savedInsights || savedInsights.length === 0) {
         return <BillingInsightNotFound kind={kind} />
     }
 
-    const note = KIND_NOTE[kind]
+    const showTitles = savedInsights.length > 1
 
     return (
-        <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-2">
-                <DateFilter
-                    dateFrom={dateRange.date_from}
-                    dateTo={dateRange.date_to}
-                    onChange={(from, to) => setDateRange(from, to)}
-                />
-                {note ? <span className="text-xs text-secondary">{note}</span> : null}
-            </div>
-            {/* Embedded DataVisualization collapses to a sliver without a fixed-height parent (InsightCard__viz is flex:1, min-height:0). */}
-            <div className="h-80 flex flex-col overflow-hidden">
-                <Query
-                    uniqueKey={`account-billing-${accountId}-${kind}`}
-                    query={query}
-                    variablesOverride={variableOverrides ?? null}
-                    readOnly
-                    embedded
-                />
-            </div>
+        <div className="flex flex-col gap-3">
+            <DateFilter
+                dateFrom={dateRange.date_from}
+                dateTo={dateRange.date_to}
+                onChange={(from, to) => setDateRange(from, to)}
+            />
+            {savedInsights.map((insight) => (
+                <div key={insight.short_id} className="flex flex-col gap-1">
+                    {showTitles && insight.name ? <h4 className="mb-0 text-sm">{insight.name}</h4> : null}
+                    {/* Embedded DataVisualization collapses to a sliver without a fixed-height parent (InsightCard__viz is flex:1, min-height:0). */}
+                    <div className="h-80 flex flex-col overflow-hidden">
+                        <Query
+                            uniqueKey={`account-billing-${accountId}-${kind}-${insight.short_id}`}
+                            query={insight.query}
+                            variablesOverride={variableOverridesByShortId[insight.short_id] ?? null}
+                            readOnly
+                            embedded
+                        />
+                    </div>
+                </div>
+            ))}
         </div>
     )
 }

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -203,6 +203,17 @@ export function AccountNotebooksExpansion({
                                     />
                                 ),
                             },
+                            {
+                                key: 'spend',
+                                label: 'Spend',
+                                content: (
+                                    <AccountBillingExpansion
+                                        accountId={accountId}
+                                        externalId={externalId}
+                                        kind="spend"
+                                    />
+                                ),
+                            },
                         ]}
                     />
                 </div>

--- a/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.test.ts
@@ -1,0 +1,96 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { insightsApi } from 'scenes/insights/utils/api'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import type { QueryBasedInsightModel } from '~/types'
+
+import { accountBillingLogic, BILLING_INSIGHT_SHORT_IDS } from './accountBillingLogic'
+
+const ORG_VARIABLE_ID = 'var-org'
+const START_VARIABLE_ID = 'var-start'
+const END_VARIABLE_ID = 'var-end'
+
+const buildSpendInsight = (shortId: string): QueryBasedInsightModel =>
+    ({
+        short_id: shortId,
+        query: {
+            kind: NodeKind.DataVisualizationNode,
+            source: {
+                kind: NodeKind.HogQLQuery,
+                query: 'SELECT 1',
+                variables: {
+                    [ORG_VARIABLE_ID]: { variableId: ORG_VARIABLE_ID, code_name: 'billing_org_id', value: null },
+                    [START_VARIABLE_ID]: {
+                        variableId: START_VARIABLE_ID,
+                        code_name: 'billing_start_date',
+                        value: null,
+                    },
+                    [END_VARIABLE_ID]: { variableId: END_VARIABLE_ID, code_name: 'billing_end_date', value: null },
+                },
+            },
+        },
+    }) as unknown as QueryBasedInsightModel
+
+describe('accountBillingLogic', () => {
+    let logic: ReturnType<typeof accountBillingLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.restoreAllMocks()
+        jest.spyOn(insightsApi, 'getByShortId').mockImplementation((shortId) =>
+            Promise.resolve(buildSpendInsight(shortId))
+        )
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+    })
+
+    it('loads every saved insight configured for the kind', async () => {
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.savedInsights?.map((insight) => insight.short_id)).toEqual(BILLING_INSIGHT_SHORT_IDS.spend)
+    })
+
+    it('injects the external id into each saved insight variables', async () => {
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+        for (const shortId of BILLING_INSIGHT_SHORT_IDS.spend) {
+            expect(logic.values.variableOverridesByShortId[shortId]?.[ORG_VARIABLE_ID]?.value).toBe('org-uuid')
+        }
+    })
+
+    it('updates the date variable overrides when the date range changes', async () => {
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setDateRange('2024-01-01', '2024-01-31')
+
+        const [firstShortId] = BILLING_INSIGHT_SHORT_IDS.spend
+        expect(logic.values.variableOverridesByShortId[firstShortId]?.[START_VARIABLE_ID]?.value).toBe('2024-01-01')
+        expect(logic.values.variableOverridesByShortId[firstShortId]?.[END_VARIABLE_ID]?.value).toBe('2024-01-31')
+    })
+
+    it('changes the query key when the date range changes so the insight refetches', async () => {
+        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        const [firstShortId] = BILLING_INSIGHT_SHORT_IDS.spend
+        const initialQueryKey = logic.values.queryKeyFor(firstShortId)
+
+        logic.actions.setDateRange('2024-01-01', '2024-01-31')
+
+        const nextQueryKey = logic.values.queryKeyFor(firstShortId)
+        expect(nextQueryKey).not.toEqual(initialQueryKey)
+        expect(nextQueryKey).toContain('2024-01-01')
+        expect(nextQueryKey).toContain('2024-01-31')
+    })
+})

--- a/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.test.ts
@@ -6,13 +6,13 @@ import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import type { QueryBasedInsightModel } from '~/types'
 
-import { accountBillingLogic, BILLING_INSIGHT_SHORT_IDS } from './accountBillingLogic'
+import { AccountBillingKind, accountBillingLogic, BILLING_INSIGHT_SHORT_IDS } from './accountBillingLogic'
 
 const ORG_VARIABLE_ID = 'var-org'
 const START_VARIABLE_ID = 'var-start'
 const END_VARIABLE_ID = 'var-end'
 
-const buildSpendInsight = (shortId: string): QueryBasedInsightModel =>
+const buildBillingInsight = (shortId: string): QueryBasedInsightModel =>
     ({
         short_id: shortId,
         query: {
@@ -40,7 +40,7 @@ describe('accountBillingLogic', () => {
         initKeaTests()
         jest.restoreAllMocks()
         jest.spyOn(insightsApi, 'getByShortId').mockImplementation((shortId) =>
-            Promise.resolve(buildSpendInsight(shortId))
+            Promise.resolve(buildBillingInsight(shortId))
         )
     })
 
@@ -48,49 +48,54 @@ describe('accountBillingLogic', () => {
         logic?.unmount()
     })
 
-    it('loads every saved insight configured for the kind', async () => {
-        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
-        logic.mount()
-
-        await expectLogic(logic).toFinishAllListeners()
-        expect(logic.values.savedInsights?.map((insight) => insight.short_id)).toEqual(BILLING_INSIGHT_SHORT_IDS.spend)
-    })
-
-    it('injects the external id into each saved insight variables', async () => {
-        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
-        logic.mount()
-
-        await expectLogic(logic).toFinishAllListeners()
-        for (const shortId of BILLING_INSIGHT_SHORT_IDS.spend) {
-            expect(logic.values.variableOverridesByShortId[shortId]?.[ORG_VARIABLE_ID]?.value).toBe('org-uuid')
+    describe.each<AccountBillingKind>(['usage', 'spend'])('kind: %s', (kind) => {
+        const mountForKind = (): void => {
+            logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind })
+            logic.mount()
         }
-    })
 
-    it('updates the date variable overrides when the date range changes', async () => {
-        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
-        logic.mount()
-        await expectLogic(logic).toFinishAllListeners()
+        it('loads every saved insight configured for the kind', async () => {
+            mountForKind()
 
-        logic.actions.setDateRange('2024-01-01', '2024-01-31')
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.savedInsights?.map((insight) => insight.short_id)).toEqual(
+                BILLING_INSIGHT_SHORT_IDS[kind]
+            )
+        })
 
-        const [firstShortId] = BILLING_INSIGHT_SHORT_IDS.spend
-        expect(logic.values.variableOverridesByShortId[firstShortId]?.[START_VARIABLE_ID]?.value).toBe('2024-01-01')
-        expect(logic.values.variableOverridesByShortId[firstShortId]?.[END_VARIABLE_ID]?.value).toBe('2024-01-31')
-    })
+        it('injects the external id into each saved insight variables', async () => {
+            mountForKind()
 
-    it('changes the query key when the date range changes so the insight refetches', async () => {
-        logic = accountBillingLogic({ accountId: 'acc-1', externalId: 'org-uuid', kind: 'spend' })
-        logic.mount()
-        await expectLogic(logic).toFinishAllListeners()
+            await expectLogic(logic).toFinishAllListeners()
+            for (const shortId of BILLING_INSIGHT_SHORT_IDS[kind]) {
+                expect(logic.values.variableOverridesByShortId[shortId]?.[ORG_VARIABLE_ID]?.value).toBe('org-uuid')
+            }
+        })
 
-        const [firstShortId] = BILLING_INSIGHT_SHORT_IDS.spend
-        const initialQueryKey = logic.values.queryKeyFor(firstShortId)
+        it('updates the date variable overrides when the date range changes', async () => {
+            mountForKind()
+            await expectLogic(logic).toFinishAllListeners()
 
-        logic.actions.setDateRange('2024-01-01', '2024-01-31')
+            logic.actions.setDateRange('2024-01-01', '2024-01-31')
 
-        const nextQueryKey = logic.values.queryKeyFor(firstShortId)
-        expect(nextQueryKey).not.toEqual(initialQueryKey)
-        expect(nextQueryKey).toContain('2024-01-01')
-        expect(nextQueryKey).toContain('2024-01-31')
+            const [firstShortId] = BILLING_INSIGHT_SHORT_IDS[kind]
+            expect(logic.values.variableOverridesByShortId[firstShortId]?.[START_VARIABLE_ID]?.value).toBe('2024-01-01')
+            expect(logic.values.variableOverridesByShortId[firstShortId]?.[END_VARIABLE_ID]?.value).toBe('2024-01-31')
+        })
+
+        it('changes the query key when the date range changes so the insight refetches', async () => {
+            mountForKind()
+            await expectLogic(logic).toFinishAllListeners()
+
+            const [firstShortId] = BILLING_INSIGHT_SHORT_IDS[kind]
+            const initialQueryKey = logic.values.queryKeyFor(firstShortId)
+
+            logic.actions.setDateRange('2024-01-01', '2024-01-31')
+
+            const nextQueryKey = logic.values.queryKeyFor(firstShortId)
+            expect(nextQueryKey).not.toEqual(initialQueryKey)
+            expect(nextQueryKey).toContain('2024-01-01')
+            expect(nextQueryKey).toContain('2024-01-31')
+        })
     })
 })

--- a/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.ts
@@ -13,10 +13,10 @@ import type { accountBillingLogicType } from './accountBillingLogicType'
 
 export type AccountBillingKind = 'usage' | 'spend'
 
-// Short IDs of the saved billing insights. Absent in environments without them — the tab then shows a not-found state.
-export const BILLING_INSIGHT_SHORT_IDS: Record<AccountBillingKind, InsightShortId> = {
-    usage: 'fiJDsKLp' as InsightShortId,
-    spend: '9cZ54LsW' as InsightShortId,
+// Short IDs of the saved billing insights per tab. Absent in environments without them — the tab then shows a not-found state.
+export const BILLING_INSIGHT_SHORT_IDS: Record<AccountBillingKind, InsightShortId[]> = {
+    usage: ['fiJDsKLp' as InsightShortId],
+    spend: ['o4I9sdFE' as InsightShortId, 'Tjo4bsux' as InsightShortId],
 }
 
 // code_names of the SQL variables defined on the saved billing insights.
@@ -29,10 +29,48 @@ export interface BillingDateRange {
     date_to: string | null
 }
 
+// Usage insights are daily, spend insights are monthly — so they want different default windows.
+const DEFAULT_DATE_RANGE: Record<AccountBillingKind, BillingDateRange> = {
+    usage: { date_from: '-30d', date_to: null },
+    spend: { date_from: '-1y', date_to: null },
+}
+
 export interface AccountBillingLogicProps {
     accountId: string
     externalId: string
     kind: AccountBillingKind
+}
+
+// Inject the account's org and the chosen date range into the saved insight's SQL variables, keyed by their
+// variableId as read from the fetched insight (so this works regardless of the variable UUIDs in each env).
+function buildVariableOverrides(
+    insight: QueryBasedInsightModel,
+    resolvedDateRange: BillingDateRange,
+    externalId: string
+): Record<string, HogQLVariable> | undefined {
+    const query = insight.query
+    if (!query || query.kind !== NodeKind.DataVisualizationNode) {
+        return undefined
+    }
+    const variables = (query as DataVisualizationNode).source.variables
+    if (!variables) {
+        return undefined
+    }
+    const valueByCodeName: Record<string, string | null> = {
+        [ORG_VARIABLE]: externalId,
+        [START_VARIABLE]: resolvedDateRange.date_from,
+        [END_VARIABLE]: resolvedDateRange.date_to,
+    }
+    const overrides: Record<string, HogQLVariable> = {}
+    for (const variable of Object.values(variables)) {
+        if (variable.code_name in valueByCodeName) {
+            overrides[variable.variableId] = {
+                ...variable,
+                value: valueByCodeName[variable.code_name],
+            }
+        }
+    }
+    return overrides
 }
 
 export const accountBillingLogic = kea<accountBillingLogicType>([
@@ -42,36 +80,43 @@ export const accountBillingLogic = kea<accountBillingLogicType>([
     actions({
         setDateRange: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
     }),
-    reducers({
+    reducers(({ props }) => ({
         dateRange: [
-            { date_from: '-30d', date_to: null } as BillingDateRange,
+            DEFAULT_DATE_RANGE[props.kind] as BillingDateRange,
             {
                 setDateRange: (_, { dateFrom, dateTo }) => ({ date_from: dateFrom, date_to: dateTo }),
             },
         ],
-    }),
+    })),
     loaders(({ props }) => ({
-        savedInsight: [
-            null as QueryBasedInsightModel | null,
+        savedInsights: [
+            null as QueryBasedInsightModel[] | null,
             {
-                loadSavedInsight: async (_ = null, breakpoint) => {
-                    try {
-                        const insight = await insightsApi.getByShortId(BILLING_INSIGHT_SHORT_IDS[props.kind])
-                        breakpoint()
-                        return insight
-                    } catch (error) {
-                        if (isBreakpoint(error as Error)) {
-                            throw error
-                        }
-                        posthog.captureException(error as Error, { scope: 'accountBillingLogic.loadSavedInsight' })
-                        return null
-                    }
+                loadSavedInsights: async (_ = null, breakpoint) => {
+                    const insights = await Promise.all(
+                        BILLING_INSIGHT_SHORT_IDS[props.kind].map(async (shortId) => {
+                            try {
+                                return await insightsApi.getByShortId(shortId)
+                            } catch (error) {
+                                if (isBreakpoint(error as Error)) {
+                                    throw error
+                                }
+                                posthog.captureException(error as Error, {
+                                    scope: 'accountBillingLogic.loadSavedInsights',
+                                    shortId,
+                                })
+                                return null
+                            }
+                        })
+                    )
+                    breakpoint()
+                    return insights.filter((insight): insight is QueryBasedInsightModel => insight !== null)
                 },
             },
         ],
     })),
     selectors({
-        // The saved insight filters on the calendar `date` column, so the range must be resolved to absolute dates.
+        // The saved insights filter on a calendar date column, so the range must be resolved to absolute dates.
         resolvedDateRange: [
             (s) => [s.dateRange],
             (dateRange): BillingDateRange => {
@@ -83,40 +128,23 @@ export const accountBillingLogic = kea<accountBillingLogicType>([
                 }
             },
         ],
-        // Inject the account's org and the chosen date range into the saved insight's SQL variables, keyed by their
-        // variableId as read from the fetched insight (so this works regardless of the variable UUIDs in each env).
-        variableOverrides: [
-            (s) => [s.savedInsight, s.resolvedDateRange, (_, p) => p.externalId],
-            (savedInsight, resolvedDateRange, externalId): Record<string, HogQLVariable> | undefined => {
-                const query = savedInsight?.query
-                if (!query || query.kind !== NodeKind.DataVisualizationNode) {
-                    return undefined
-                }
-                const variables = (query as DataVisualizationNode).source.variables
-                if (!variables) {
-                    return undefined
-                }
-                const valueByCodeName: Record<string, string | null> = {
-                    [ORG_VARIABLE]: externalId,
-                    [START_VARIABLE]: resolvedDateRange.date_from,
-                    [END_VARIABLE]: resolvedDateRange.date_to,
-                }
-                const overrides: Record<string, HogQLVariable> = {}
-                for (const variable of Object.values(variables)) {
-                    if (variable.code_name in valueByCodeName) {
-                        overrides[variable.variableId] = {
-                            ...variable,
-                            value: valueByCodeName[variable.code_name],
-                        }
+        variableOverridesByShortId: [
+            (s) => [s.savedInsights, s.resolvedDateRange, (_, p) => p.externalId],
+            (savedInsights, resolvedDateRange, externalId): Record<string, Record<string, HogQLVariable>> => {
+                const overridesByShortId: Record<string, Record<string, HogQLVariable>> = {}
+                for (const insight of savedInsights ?? []) {
+                    const overrides = buildVariableOverrides(insight, resolvedDateRange, externalId)
+                    if (overrides) {
+                        overridesByShortId[insight.short_id] = overrides
                     }
                 }
-                return overrides
+                return overridesByShortId
             },
         ],
     }),
     afterMount(({ actions, props }) => {
         if (props.externalId) {
-            actions.loadSavedInsight()
+            actions.loadSavedInsights()
         }
     }),
 ])

--- a/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountBillingLogic.ts
@@ -141,6 +141,14 @@ export const accountBillingLogic = kea<accountBillingLogicType>([
                 return overridesByShortId
             },
         ],
+        // The embedded <Query> only refetches when its query changes, not when variablesOverride changes — so a date
+        // change must remount it. Keying on the resolved range gives each insight a key that changes with the range.
+        queryKeyFor: [
+            (s) => [s.resolvedDateRange, (_, p) => p.accountId, (_, p) => p.kind],
+            (resolvedDateRange, accountId, kind) =>
+                (shortId: string): string =>
+                    `account-billing-${accountId}-${kind}-${shortId}-${resolvedDateRange.date_from}-${resolvedDateRange.date_to}`,
+        ],
     }),
     afterMount(({ actions, props }) => {
         if (props.externalId) {

--- a/products/customer_analytics/frontend/components/Accounts/accountsExpansionLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsExpansionLogic.ts
@@ -4,7 +4,7 @@ import posthog from 'posthog-js'
 import type { accountsExpansionLogicType } from './accountsExpansionLogicType'
 import { AccountsEvents } from './constants'
 
-export type AccountExpansionTab = 'notes' | 'users' | 'usage'
+export type AccountExpansionTab = 'notes' | 'users' | 'usage' | 'spend'
 
 export const DEFAULT_ACCOUNT_TAB: AccountExpansionTab = 'notes'
 


### PR DESCRIPTION
## Problem

Accounts only surfaces billed usage — there's no view of an org's actual spend.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add a **Spend** tab beside Usage in the expanded account row
- Generalize `accountBillingLogic` from one insight per tab to N — Spend renders billing history (credits/refunds) and per-product spend
- Inject the account org + date range into each insight's SQL variables, same as Usage
- Key each embedded `<Query>` on the resolved date range so a date change refetches (supersedes #62758)
- Default Spend to a `-1y` window (monthly data); Usage stays `-30d`
- Add `accountBillingLogic` tests covering multi-insight loading, override injection, and query-key change
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests (`accountBillingLogic`, 4 cases) + frontend typecheck (no errors in changed files). I'm an agent — no manual UI testing. The two saved Spend insights were updated via MCP to share Usage's `billing_org_id` / `billing_start_date` / `billing_end_date` variables and verified to execute with date filtering.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored via PostHog Code. Human-directed by @arthur.

**Autonomy:** Human-driven (agent-assisted)

The date-range refetch fix supersedes #62758: this branch refactored the same single-insight code that PR patched, so the fix was reimplemented as a per-insight `queryKeyFor(shortId)` selector keyed on the resolved range. Root cause is unchanged — the shared `dataNodeLogic`/`dataVisualizationLogic` only refetch on query change, not on a `variablesOverride` prop change, so the embedded `<Query>` is remounted via a date-derived key. #62758 to be closed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
