### PR TITLE
feat(data-warehouse): add per-source-type + button in SQL editor sources tree

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -878,7 +878,7 @@ export const QueryDatabase = ({
                                 newInternalTab(urls.dataWarehouseSourceNew(sourceType))
                             }}
                             data-attr="sql-editor-add-source-of-type"
-                            tooltip={`Add new ${sourceType} source`}
+                            tooltip="Add new source of this type"
                         >
                             <IconPlusSmall className="text-tertiary" />
                         </ButtonPrimitive>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -36,7 +36,7 @@ import { sqlEditorLogic } from 'scenes/data-warehouse/editor/sqlEditorLogic'
 import { urls } from 'scenes/urls'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
-import { DatabaseSerializedFieldType } from '~/queries/schema/schema-general'
+import { DatabaseSerializedFieldType, externalDataSources } from '~/queries/schema/schema-general'
 import { escapePropertyAsHogQLIdentifier } from '~/queries/utils'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
@@ -834,6 +834,16 @@ export const QueryDatabase = ({
                     return null
                 }
 
+                // Render the custom "add source of type" button (no dropdown) for external source folders
+                if (
+                    item.record?.type === 'source-folder' &&
+                    externalDataSources.includes(
+                        item.record?.sourceType as (typeof externalDataSources)[number]
+                    )
+                ) {
+                    return null
+                }
+
                 return undefined
             }}
             itemSideActionButton={(item) => {
@@ -848,6 +858,29 @@ export const QueryDatabase = ({
                                 newInternalTab(urls.dataWarehouseSourceNew())
                             }}
                             data-attr="sql-editor-add-source"
+                        >
+                            <IconPlusSmall className="text-tertiary" />
+                        </ButtonPrimitive>
+                    )
+                }
+
+                // Only external source kinds have a dedicated creation page; PostHog/System/Self-managed don't
+                const sourceType = item.record?.sourceType
+                if (
+                    item.record?.type === 'source-folder' &&
+                    externalDataSources.includes(sourceType as (typeof externalDataSources)[number])
+                ) {
+                    return (
+                        <ButtonPrimitive
+                            iconOnly
+                            isSideActionRight
+                            className="z-2"
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                newInternalTab(urls.dataWarehouseSourceNew(sourceType))
+                            }}
+                            data-attr="sql-editor-add-source-of-type"
+                            tooltip={`Add new ${sourceType} source`}
                         >
                             <IconPlusSmall className="text-tertiary" />
                         </ButtonPrimitive>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -837,9 +837,7 @@ export const QueryDatabase = ({
                 // Render the custom "add source of type" button (no dropdown) for external source folders
                 if (
                     item.record?.type === 'source-folder' &&
-                    externalDataSources.includes(
-                        item.record?.sourceType as (typeof externalDataSources)[number]
-                    )
+                    externalDataSources.includes(item.record?.sourceType as (typeof externalDataSources)[number])
                 ) {
                     return null
                 }

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -872,7 +872,7 @@ export const QueryDatabase = ({
                         <ButtonPrimitive
                             iconOnly
                             isSideActionRight
-                            className="z-2"
+                            className="absolute right-0 opacity-0 group-hover/lemon-tree-button-group:opacity-100 z-10 data-[state=open]:opacity-100 -outline-offset-2 focus-visible:opacity-100"
                             onClick={(e) => {
                                 e.stopPropagation()
                                 newInternalTab(urls.dataWarehouseSourceNew(sourceType))

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -1,6 +1,7 @@
 import { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
 
 import {
@@ -853,6 +854,10 @@ export const QueryDatabase = ({
                             className="z-2"
                             onClick={(e) => {
                                 e.stopPropagation()
+                                posthog.capture('sql-editor-add-source-clicked', {
+                                    source_type: null,
+                                    location: 'sources_header',
+                                })
                                 newInternalTab(urls.dataWarehouseSourceNew())
                             }}
                             data-attr="sql-editor-add-source"
@@ -875,6 +880,10 @@ export const QueryDatabase = ({
                             className="absolute right-0 opacity-0 group-hover/lemon-tree-button-group:opacity-100 z-10 data-[state=open]:opacity-100 -outline-offset-2 focus-visible:opacity-100"
                             onClick={(e) => {
                                 e.stopPropagation()
+                                posthog.capture('sql-editor-add-source-clicked', {
+                                    source_type: sourceType,
+                                    location: 'source_type_row',
+                                })
                                 newInternalTab(urls.dataWarehouseSourceNew(sourceType))
                             }}
                             data-attr="sql-editor-add-source-of-type"


### PR DESCRIPTION
## Problem

In the SQL editor, the Sources tree groups every connected source by type (Stripe, Github, Postgres, Google Sheets, …). There's a single "+" at the top of the tree to add a brand-new source, but you then have to find your source kind again on the new-source page. Adding another source of a type you already use should be one click from that type's row.

## Changes

Each external source-type folder in the SQL editor sources tree now shows a "+" button on hover. Clicking it opens the source creation page pre-filtered to that kind — e.g. Google Sheets opens `/data-warehouse/new-source?kind=GoogleSheets`, reusing the existing `urls.dataWarehouseSourceNew(kind)` helper and `newInternalTab`.

The button is only rendered for actual external source kinds (gated on membership in `externalDataSources`); the PostHog, System, and Self-managed folders are excluded since they have no dedicated creation flow.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not perform manual browser testing. I ran the repo's frontend TypeScript check; the only reported errors are environment artifacts (missing `node_modules` / jest type defs in this sandbox) and none originate from the changed code. The change reuses existing, already-tested navigation helpers and follows the same render pattern as the existing top-level "+" button.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via a Slack thread: add a per-source-type "+" in the SQL editor sources list that deep-links to the kind-specific creation page. Implemented in `QueryDatabase.tsx` by extending `itemSideActionButton` to handle `source-folder` items and returning `null` from `itemSideAction` for those folders (the tree only renders the side-action button when `itemSideAction` is non-undefined, mirroring how the existing top-level "+" works). Gated on `externalDataSources` so built-in folders don't get the button.

Tool used: PostHog Code (Claude Opus).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A6L24BU0P/p1781116222353269)*
