### PR TITLE
fix(experiments): quick-select by tag loads all metric pages first

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
 import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonModal, Link } from '@posthog/lemon-ui'
 
@@ -32,13 +31,20 @@ export function SharedMetricModal({
         canLoadMore,
         sharedMetricsResponseLoading,
         hasAnyCompatibleSharedMetrics,
+        selectedMetricIds,
     } = useValues(sharedMetricModalLogic)
-    const { closeSharedMetricModal, setSearchTerm, loadNextSharedMetrics } = useActions(sharedMetricModalLogic)
+    const {
+        closeSharedMetricModal,
+        setSearchTerm,
+        loadNextSharedMetrics,
+        toggleMetricSelected,
+        clearSelectedMetricIds,
+        selectAllMetrics,
+        selectMetricsByTag,
+    } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
     const { updateSharedMetricTags } = useActions(sharedMetricsLogic)
     const { tags: allTags } = useValues(tagsModel)
-
-    const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
 
     if (!compatibleSharedMetrics) {
         return null
@@ -51,11 +57,11 @@ export function SharedMetricModal({
     }
 
     const closeModal = (): void => {
-        setSelectedMetricIds([])
         closeSharedMetricModal()
     }
 
     const alreadyAddedIds = new Set(experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric))
+    const excludeIds = Array.from(alreadyAddedIds)
 
     // Already-added metrics stay visible but are not selectable.
     const selectableMetrics = compatibleSharedMetrics.filter((metric: SharedMetric) => !alreadyAddedIds.has(metric.id))
@@ -88,7 +94,7 @@ export function SharedMetricModal({
                                     .filter((metric): metric is SharedMetric => metric !== undefined)
 
                                 onSave(metrics, context)
-                                setSelectedMetricIds([])
+                                clearSelectedMetricIds()
                             }}
                             type="primary"
                             disabledReason={addSharedMetricDisabledReason()}
@@ -121,8 +127,10 @@ export function SharedMetricModal({
                             <LemonButton
                                 size="xsmall"
                                 type="secondary"
+                                // Quick-select loads any unfetched pages first, so guard against re-clicks mid-load.
+                                disabledReason={sharedMetricsResponseLoading ? 'Loading metrics…' : undefined}
                                 onClick={() => {
-                                    setSelectedMetricIds(selectableMetrics.map((metric: SharedMetric) => metric.id))
+                                    selectAllMetrics(excludeIds)
                                 }}
                             >
                                 All
@@ -132,7 +140,7 @@ export function SharedMetricModal({
                                     size="xsmall"
                                     type="secondary"
                                     onClick={() => {
-                                        setSelectedMetricIds([])
+                                        clearSelectedMetricIds()
                                     }}
                                 >
                                     Clear
@@ -143,12 +151,9 @@ export function SharedMetricModal({
                                     key={index}
                                     size="xsmall"
                                     type="secondary"
+                                    disabledReason={sharedMetricsResponseLoading ? 'Loading metrics…' : undefined}
                                     onClick={() => {
-                                        setSelectedMetricIds(
-                                            selectableMetrics
-                                                .filter((metric: SharedMetric) => metric.tags?.includes(tag))
-                                                .map((metric: SharedMetric) => metric.id)
-                                        )
+                                        selectMetricsByTag(tag, excludeIds)
                                     }}
                                 >
                                     {tag}
@@ -168,14 +173,8 @@ export function SharedMetricModal({
                                             type="checkbox"
                                             disabled={alreadyAddedIds.has(metric.id)}
                                             checked={selectedMetricIds.includes(metric.id)}
-                                            onChange={(e) => {
-                                                if (e.target.checked) {
-                                                    setSelectedMetricIds([...selectedMetricIds, metric.id])
-                                                } else {
-                                                    setSelectedMetricIds(
-                                                        selectedMetricIds.filter((id) => id !== metric.id)
-                                                    )
-                                                }
+                                            onChange={() => {
+                                                toggleMetricSelected(metric.id)
                                             }}
                                         />
                                     ),

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -9,10 +9,11 @@ import { initKeaTests } from '~/test/init'
 import { METRIC_CONTEXTS } from './experimentMetricModalLogic'
 import { MODAL_PAGE_SIZE, sharedMetricModalLogic } from './sharedMetricModalLogic'
 
-const metric = (id: number, kind: NodeKind = NodeKind.ExperimentMetric): any => ({
+const metric = (id: number, kind: NodeKind = NodeKind.ExperimentMetric, tags: string[] = []): any => ({
     id,
     name: `metric ${id}`,
     query: { kind },
+    tags,
 })
 
 describe('sharedMetricModalLogic', () => {
@@ -129,5 +130,130 @@ describe('sharedMetricModalLogic', () => {
             logic.actions.loadSharedMetrics()
         }).toFinishAllListeners()
         await expectLogic(logic).toMatchValues({ hasAnyCompatibleSharedMetrics: false })
+    })
+
+    it('selectMetricsByTag loads every remaining page, then selects compatible metrics carrying the tag', async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': (req) => {
+                    const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
+                    if (offset === 0) {
+                        return [
+                            200,
+                            {
+                                count: 3,
+                                next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}`,
+                                previous: null,
+                                // metric 2 carries "main" but is a trends query → not compatible, must be skipped
+                                results: [
+                                    metric(1, NodeKind.ExperimentMetric, ['main']),
+                                    metric(2, NodeKind.ExperimentTrendsQuery, ['main']),
+                                ],
+                            },
+                        ]
+                    }
+                    // metric 3 lives on page 2 — it would be silently skipped without the load-all walk
+                    return [
+                        200,
+                        {
+                            count: 3,
+                            next: null,
+                            previous: null,
+                            results: [metric(3, NodeKind.ExperimentMetric, ['main'])],
+                        },
+                    ]
+                },
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ canLoadMore: true })
+
+        await expectLogic(logic, () => {
+            logic.actions.selectMetricsByTag('main', [])
+        })
+            .toDispatchActions(['loadAllSharedMetrics', 'loadAllSharedMetricsSuccess', 'setSelectedMetricIds'])
+            .toMatchValues({ selectedMetricIds: [1, 3], canLoadMore: false })
+    })
+
+    it('selectAllMetrics loads every page and selects all compatible metrics except already-added ones', async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': (req) => {
+                    const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
+                    if (offset === 0) {
+                        return [
+                            200,
+                            {
+                                count: 3,
+                                next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}`,
+                                previous: null,
+                                results: [metric(10), metric(11)],
+                            },
+                        ]
+                    }
+                    return [200, { count: 3, next: null, previous: null, results: [metric(12)] }]
+                },
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+
+        await expectLogic(logic, () => {
+            logic.actions.selectAllMetrics([11])
+        })
+            .toDispatchActions(['loadAllSharedMetrics', 'loadAllSharedMetricsSuccess', 'setSelectedMetricIds'])
+            .toMatchValues({ selectedMetricIds: [10, 12] })
+    })
+
+    it('quick-select resolves immediately without re-fetching when every page is already loaded', async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': () => [
+                    200,
+                    {
+                        count: 2,
+                        next: null,
+                        previous: null,
+                        results: [metric(1, NodeKind.ExperimentMetric, ['main']), metric(2)],
+                    },
+                ],
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                canLoadMore: false,
+                compatibleSharedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
+            })
+
+        await expectLogic(logic, () => {
+            logic.actions.selectMetricsByTag('main', [])
+        })
+            .toDispatchActions(['setSelectedMetricIds'])
+            .toNotHaveDispatchedActions(['loadAllSharedMetrics'])
+            .toMatchValues({ selectedMetricIds: [1] })
+    })
+
+    it('toggleMetricSelected and clearSelectedMetricIds manage the selection', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.toggleMetricSelected(1)
+            logic.actions.toggleMetricSelected(2)
+        }).toMatchValues({ selectedMetricIds: [1, 2] })
+
+        await expectLogic(logic, () => {
+            logic.actions.toggleMetricSelected(1)
+        }).toMatchValues({ selectedMetricIds: [2] })
+
+        await expectLogic(logic, () => {
+            logic.actions.clearSelectedMetricIds()
+        }).toMatchValues({ selectedMetricIds: [] })
     })
 })

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -14,6 +14,26 @@ import type { sharedMetricModalLogicType } from './sharedMetricModalLogicType'
 
 export const MODAL_PAGE_SIZE = 20
 
+/**
+ * A quick-select intent captured when the user clicks "All" or a tag button. We can't apply it
+ * immediately because matching metrics may live on pages that haven't been fetched yet — so we
+ * stash the intent, load every remaining page, then resolve it against the full set.
+ */
+export type QuickSelect = {
+    /** `null` means "all compatible metrics"; otherwise only metrics carrying this tag. */
+    tag: string | null
+    /** Metric ids already on the experiment — never selectable, so excluded from the result. */
+    excludeIds: SharedMetric['id'][]
+}
+
+const resolveQuickSelect = (metrics: SharedMetric[], { tag, excludeIds }: QuickSelect): SharedMetric['id'][] => {
+    const excluded = new Set(excludeIds)
+    return metrics
+        .filter((metric) => !excluded.has(metric.id))
+        .filter((metric) => tag === null || (metric.tags?.includes(tag) ?? false))
+        .map((metric) => metric.id)
+}
+
 export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
     path(['scenes', 'experiments', 'Metrics', 'sharedMetricModalLogic']),
 
@@ -31,6 +51,12 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         setSharedMetric: (sharedMetric: SharedMetric) => ({ sharedMetric }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setHasAnyCompatibleSharedMetrics: (hasAny: boolean) => ({ hasAny }),
+        setSelectedMetricIds: (ids: SharedMetric['id'][]) => ({ ids }),
+        toggleMetricSelected: (id: SharedMetric['id']) => ({ id }),
+        clearSelectedMetricIds: true,
+        // Quick-select "All" / by-tag — both load every remaining page before resolving the selection.
+        selectAllMetrics: (excludeIds: SharedMetric['id'][]) => ({ excludeIds }),
+        selectMetricsByTag: (tag: string, excludeIds: SharedMetric['id'][]) => ({ tag, excludeIds }),
     }),
 
     reducers({
@@ -79,6 +105,30 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                 openSharedMetricModal: () => false,
             },
         ],
+        selectedMetricIds: [
+            [] as SharedMetric['id'][],
+            {
+                setSelectedMetricIds: (_, { ids }) => ids,
+                toggleMetricSelected: (state, { id }) =>
+                    state.includes(id) ? state.filter((existing) => existing !== id) : [...state, id],
+                clearSelectedMetricIds: () => [],
+                openSharedMetricModal: () => [],
+                closeSharedMetricModal: () => [],
+            },
+        ],
+        // Set when a quick-select needs more pages; consumed once loadAllSharedMetrics finishes.
+        pendingQuickSelect: [
+            null as QuickSelect | null,
+            {
+                selectAllMetrics: (_, { excludeIds }) => ({ tag: null, excludeIds }),
+                selectMetricsByTag: (_, { tag, excludeIds }) => ({ tag, excludeIds }),
+                setSelectedMetricIds: () => null,
+                clearSelectedMetricIds: () => null,
+                openSharedMetricModal: () => null,
+                closeSharedMetricModal: () => null,
+                setSearchTerm: () => null,
+            },
+        ],
     }),
 
     loaders(({ values }) => ({
@@ -109,6 +159,32 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                         results: [...baseResults, ...response.results],
                     }
                 },
+                // Walk every remaining page so quick-select by tag / "All" sees the full set, not just
+                // the rows already rendered. This is the "keep clicking Load more until done" mechanism.
+                loadAllSharedMetrics: async (_, breakpoint) => {
+                    let response = values.sharedMetricsResponse
+                    if (!response) {
+                        const params = toParams({
+                            limit: MODAL_PAGE_SIZE,
+                            offset: 0,
+                            search: values.searchTerm || undefined,
+                        })
+                        response = (await api.get(
+                            `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
+                        )) as CountedPaginatedResponse<SharedMetric>
+                        breakpoint()
+                    }
+                    const results = [...response.results]
+                    let next = response.next
+                    while (next) {
+                        const page: CountedPaginatedResponse<SharedMetric> = await api.get(next)
+                        // Abort if a concurrent load (e.g. a new search) superseded this run.
+                        breakpoint()
+                        results.push(...page.results)
+                        next = page.next ?? null
+                    }
+                    return { ...response, results, next: null }
+                },
             },
         ],
     })),
@@ -124,19 +200,44 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
 
-    listeners(({ actions, values }) => ({
-        openSharedMetricModal: () => {
-            actions.loadSharedMetrics()
-        },
-        setSearchTerm: async (_, breakpoint) => {
-            await breakpoint(300)
-            actions.loadSharedMetrics()
-        },
-        loadSharedMetricsSuccess: () => {
-            // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
-            if (!values.searchTerm) {
-                actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+    listeners(({ actions, values }) => {
+        // A quick-select either resolves immediately (everything already loaded) or kicks off a
+        // full load, with loadAllSharedMetricsSuccess resolving the stashed intent afterwards.
+        const startQuickSelect = (): void => {
+            if (!values.pendingQuickSelect) {
+                return
             }
-        },
-    })),
+            // Resolve immediately only when every page is already loaded; otherwise fetch the rest first.
+            if (values.canLoadMore || !values.sharedMetricsResponse) {
+                actions.loadAllSharedMetrics(null)
+                return
+            }
+            actions.setSelectedMetricIds(resolveQuickSelect(values.compatibleSharedMetrics, values.pendingQuickSelect))
+        }
+
+        return {
+            openSharedMetricModal: () => {
+                actions.loadSharedMetrics()
+            },
+            setSearchTerm: async (_, breakpoint) => {
+                await breakpoint(300)
+                actions.loadSharedMetrics()
+            },
+            loadSharedMetricsSuccess: () => {
+                // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
+                if (!values.searchTerm) {
+                    actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+                }
+            },
+            selectAllMetrics: startQuickSelect,
+            selectMetricsByTag: startQuickSelect,
+            loadAllSharedMetricsSuccess: () => {
+                if (values.pendingQuickSelect) {
+                    actions.setSelectedMetricIds(
+                        resolveQuickSelect(values.compatibleSharedMetrics, values.pendingQuickSelect)
+                    )
+                }
+            },
+        }
+    }),
 ])


### PR DESCRIPTION
## Problem

In the experiment shared-metric picker, metrics are paginated (20 per page) with a "Load more metrics" button. The **Quick select** tag buttons — and the "All" button — only operated on the rows already fetched into the modal. A metric carrying the clicked tag that lived on a not-yet-loaded page was silently skipped.

Example: a `signed_up` metric tagged `main` would not be selected when clicking the `main` tag if its page hadn't been loaded yet. The only workaround was to keep clicking "Load more metrics" until every page with that tag was rendered.

## Changes

- Moved the modal's selection state out of component React state into `sharedMetricModalLogic` (kea), in line with our "business logic lives in kea" convention.
- Added a `loadAllSharedMetrics` loader that walks every remaining page — the "keep clicking Load more until done" mechanism, done automatically.
- **Quick select by tag** and **All** now load all remaining pages before resolving the selection against the full compatible set, excluding metrics already on the experiment. When every page is already loaded, the selection resolves immediately without an extra fetch.
- The quick-select buttons are disabled while pages are loading, so they can't be re-triggered mid-load.

The table still paginates as before for browsing; the full load only happens on demand when a quick-select needs it.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). I did not perform manual UI testing. Automated checks I actually ran in a worktree:

- **Jest** (`sharedMetricModalLogic.test.ts`) — 10/10 passing, including new cases:
  - tag quick-select walks all pages and skips incompatible (non-`ExperimentMetric`) metrics that happen to share the tag
  - "All" across pages, excluding already-added metrics
  - quick-select resolves immediately without re-fetching when everything is already loaded
  - `toggleMetricSelected` / `clearSelectedMetricIds` selection management
- **oxlint** and **oxfmt** — clean on the changed files.
- **kea-typegen** — regenerated (`911 logic types up to date`).
- **tsc --noEmit** — no type errors in the changed files (the only remaining errors are pre-existing `@posthog/hogvm` module-resolution errors in unrelated files, an unbuilt-package artifact of a fresh local checkout that CI resolves).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8), driven by the repo owner.
- The bug report described the symptom as "the tag select only operates on loaded/rendered metrics" with a manual workaround of repeatedly clicking "Load more metrics". The fix automates exactly that: a `loadAllSharedMetrics` loader paginates to the end, then the stashed quick-select intent (tag or "All") is resolved against the complete set.
- Considered eagerly loading all pages on modal open (simplest, also fixes which tag chips appear) but rejected it to preserve the existing pagination UX and keep initial open fast; chose on-demand full load triggered by the quick-select action instead.
- Selection state was lifted from component `useState` into the logic so the async load-then-select flow could be coordinated in kea rather than via React effects.
