### PR TITLE
feat(dmat): re-apply dmat_string column wiring, manual on cloud

### DIFF
--- a/posthog/clickhouse/migrations/0274_wire_up_existing_dmat_string_columns.py
+++ b/posthog/clickhouse/migrations/0274_wire_up_existing_dmat_string_columns.py
@@ -1,0 +1,94 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.dmat_slot_assignments.sql import (
+    DMAT_SLOT_ASSIGNMENTS_DICTIONARY_SQL,
+    DMAT_SLOT_ASSIGNMENTS_TABLE_SQL,
+)
+from posthog.models.event.sql import (
+    ALTER_TABLE_ADD_DMAT_STRING_COLUMNS,
+    DMAT_STRING_COLUMN_COUNT,
+    DROP_EVENTS_JSON_MV_SQL,
+    DROP_KAFKA_EVENTS_JSON_TABLE_SQL,
+    EVENTS_TABLE_JSON_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_SQL,
+)
+
+# Wire up the existing `dmat_string_0..9` columns (added to sharded_events + events by
+# migration 0179) through the rest of the events pipeline so the weekly batched dynamic
+# property materialization workflow can use them. Third attempt — 0256 was reverted in
+# #59350 and 0267 in #61041; the 0267 run caused the 2026-06-01 ingestion incident.
+#
+# This migration is a deliberate NO-OP on cloud (US/EU/DEV). Per the post-incident
+# guidance from the ClickHouse team, schema changes to the events table and the
+# ingestion pipeline on cloud are applied manually by the ClickHouse team and recorded
+# in the repo afterwards. The two reasons this cannot run unattended on cloud:
+#
+# 1. The live cloud ingestion schemas have drifted from the repo SQL. The kafka table /
+#    MV pair on cloud is the WarpStream pair (`kafka_events_json_ws` /
+#    `events_json_ws_mv`), whose definitions carry dozens of environment-specific
+#    `mat_*` columns that are not reflected in the repo — recreating them from repo SQL
+#    destroys the live schema and breaks ingestion (this is exactly what 0267 did).
+#    They are a no-go zone; see posthog/clickhouse/migrations/AGENTS.md.
+# 2. The cloud topologies differ from each other and from the repo's role assumptions
+#    (e.g. `writable_events` does not exist on DATA nodes in US prod — it lives on the
+#    ingestion layer, which is itself mid-migration from EKS to EC2).
+#
+# The manual steps for cloud are in 0274_wire_up_existing_dmat_string_columns.runbook.md
+# next to this file. Local/hobby installs match the repo SQL exactly (they only ever ran
+# our migrations), so the wiring below is safe there.
+#
+# Differences from the reverted 0267, beyond the cloud gate:
+#
+# - No DROP COLUMN. 0267 dropped the never-wired typed dmat columns
+#   (`dmat_numeric_*`/`dmat_bool_*`/`dmat_datetime_*`, also from 0179) from
+#   sharded_events/events; in EU those mutations stuck on pre-`inserted_at` parts with
+#   NOT_FOUND_COLUMN_IN_BLOCK and had to be killed by hand. Column removal now follows
+#   the two-step process (ClickHouse team drops manually first, repo records it after);
+#   the typed columns are empty and harmless in the meantime, so they stay.
+# - The additive `writable_events` ALTER runs before the kafka/MV drop. 0267 dropped
+#   the MV first, then failed on the ALTER, leaving ingestion down with nothing to
+#   recreate. Ordering the fallible-but-safe ALTER first means a failure aborts the
+#   migration with the pipeline untouched.
+#
+# Fresh installs get all of this from posthog/clickhouse/schema.py (the dmat columns and
+# the slot-assignments table/dictionary are already in the canonical CREATEs); this
+# migration only retrofits existing non-cloud installs. Every statement is idempotent
+# (IF NOT EXISTS / IF EXISTS), so installs that briefly applied 0267 converge too.
+
+if settings.CLOUD_DEPLOYMENT in ("US", "EU", "DEV"):
+    operations = []
+else:
+    operations = [
+        # Step 1: additive schema changes, safe to fail without touching ingestion.
+        # sharded_events and events already have dmat_string_0..9 from 0179;
+        # writable_events is the missing hop. It is a Distributed table (not sharded,
+        # not replicated), so the ALTER is metadata-only and both flags are False.
+        run_sql_with_exceptions(
+            ALTER_TABLE_ADD_DMAT_STRING_COLUMNS(
+                table="writable_events",
+                start=0,
+                end_exclusive=DMAT_STRING_COLUMN_COUNT,
+            ),
+            node_roles=[NodeRole.DATA],
+            sharded=False,
+            is_alter_on_replicated_table=False,
+        ),
+        # Step 2: the dmat slot-assignments backing table and dictionary, on the data
+        # nodes where the backfill mutation reads them via dictGet/dictHas. New objects
+        # with no interaction with existing schema. The dictionary's SOURCE references
+        # the table, so the table must be created first.
+        run_sql_with_exceptions(DMAT_SLOT_ASSIGNMENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
+        run_sql_with_exceptions(DMAT_SLOT_ASSIGNMENTS_DICTIONARY_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
+        # Step 3: recreate the MSK kafka table and MV so their schemas include
+        # dmat_string_0..9. The kafka table schema is fixed at CREATE time and ignores
+        # JSON keys for unknown columns, so it must be recreated for the MV to project
+        # dmat values from plugin-server into writable_events. MV dropped first to
+        # avoid a double-write window; neither object is replicated, so the drop and
+        # recreate run per-host (no SYNC needed). Ingestion pauses for the instants
+        # between the drops and the recreates and resumes from committed offsets.
+        run_sql_with_exceptions(DROP_EVENTS_JSON_MV_SQL, node_roles=[NodeRole.DATA]),
+        run_sql_with_exceptions(DROP_KAFKA_EVENTS_JSON_TABLE_SQL, node_roles=[NodeRole.DATA]),
+        run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
+        run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL(on_cluster=False), node_roles=[NodeRole.DATA]),
+    ]

--- a/posthog/clickhouse/migrations/0274_wire_up_existing_dmat_string_columns.runbook.md
+++ b/posthog/clickhouse/migrations/0274_wire_up_existing_dmat_string_columns.runbook.md
@@ -1,0 +1,274 @@
+# Manual migration runbook: dmat_string wiring on cloud (migration 0274)
+
+Migration `0274_wire_up_existing_dmat_string_columns` is a **no-op on cloud** (US/EU/DEV).
+This runbook is the manual equivalent, to be executed by (or under the supervision of) the
+ClickHouse team, one region at a time. It exists because two automated attempts (0256, 0267) failed against the real cluster topologies — 0267 caused the 2026-06-01 ingestion incident — and the agreed
+process is now: events-pipeline schema changes on cloud are applied by hand, and the repo
+records them afterwards.
+
+Goal state per region, all of it additive:
+
+1. `dmat_string_0..9 Nullable(String)` exist on `sharded_events`, `events`, and
+   `writable_events`.
+2. The live kafka table / MV pair (`kafka_events_json_ws` / `events_json_ws_mv` on the
+   ingestion layer) projects `dmat_string_0..9` from the topic into `writable_events`.
+3. `dmat_slot_assignments` (plain ReplacingMergeTree) and `dmat_slot_assignments_dict`
+   exist on every **data** node of the main cluster.
+
+Explicitly **out of scope** (do not bundle with this work):
+
+- Dropping the never-wired typed columns (`dmat_numeric_*`, `dmat_bool_*`,
+  `dmat_datetime_*`). DROP COLUMN mutations stuck on pre-`inserted_at` parts during
+  the 2026-06-01 incident and had to be killed. Cleanup is a separate ClickHouse-team task
+  (per-partition drops after the old parts are repaired).
+- Repairing old parts that physically lack `inserted_at` (seen on EU, partitions
+  ~2020–2023). Tracked separately; §6 covers how this interacts with the backfill.
+
+Region order: **dev → US → EU.** Dev is the rehearsal (it already received 0267's
+changes, so it should verify as already-done). EU goes last: its state is the messiest
+(killed mutations left typed columns half-dropped across shards, and `writable_events`
+was recreated during the incident without any dmat columns).
+
+Rules that this runbook inherits from the 2026-06-01 incident:
+
+- **Never** drop/recreate the WS kafka table or MV from repo SQL. The live definitions
+  carry environment-specific `mat_*` columns that are not in the repo. Always start from
+  the live `SHOW CREATE TABLE`.
+- **Never** drop/recreate `writable_events` (or any Distributed table) to change its
+  schema — dropping a Distributed table silently discards its async-insert queue
+  (data loss; happened during the 2026-06-01 incident). `ALTER TABLE ... ADD COLUMN` is metadata-only
+  and safe.
+- Additive DDL only: `ADD COLUMN IF NOT EXISTS`, `CREATE ... IF NOT EXISTS`. No DROP
+  COLUMN, no MATERIALIZE COLUMN.
+
+## 1. Pre-flight (per region)
+
+- [ ] ClickHouse team engineer assigned and executing/supervising; announced in
+      `#team-clickhouse` with a link to this runbook.
+- [ ] Pick a low-traffic window; do not run while any other mutation or cluster
+      maintenance is in flight: `SELECT * FROM clusterAllReplicas('posthog', system.mutations) WHERE NOT is_done`.
+- [ ] Confirm the deploy containing migration 0274 has rolled out (the migration no-ops
+      on cloud, so order is not load-bearing — but it keeps `migration-sync` green and
+      records intent).
+
+## 2. Discovery (read-only)
+
+Capture current state; every later phase is checked against this snapshot.
+
+```sql
+-- Column inventory on the main cluster
+SELECT hostName() AS host, table,
+       countIf(name LIKE 'dmat_string_%')   AS dmat_string_cols,
+       countIf(name LIKE 'dmat_numeric_%'
+            OR name LIKE 'dmat_bool_%'
+            OR name LIKE 'dmat_datetime_%') AS dmat_typed_cols
+FROM clusterAllReplicas('posthog', system.columns)
+WHERE database = 'posthog' AND table IN ('sharded_events', 'events', 'writable_events')
+GROUP BY host, table
+ORDER BY table, host;
+```
+
+On each **ingestion-layer host** (these are not necessarily reachable via the `posthog`
+cluster function — connect directly; the layer is mid-migration EKS→EC2, get the host
+list from the ClickHouse team):
+
+```sql
+SHOW CREATE TABLE posthog.writable_events;
+SHOW CREATE TABLE posthog.kafka_events_json_ws;
+SHOW CREATE TABLE posthog.events_json_ws_mv;
+SELECT database, table, consumer_id, assignments.topic, is_currently_used
+FROM system.kafka_consumers;
+```
+
+- [ ] Save every `SHOW CREATE TABLE` output to the `PostHog/clickhouse_schemas` repo
+      (during the 2026-06-01 incident there were no schema backups of the ingestion nodes; fix that as
+      part of this work).
+- [ ] Note which kafka/MV pairs are _actually consuming_ (`system.kafka_consumers`).
+      Leftover MSK-era pairs may still exist; only the live pair gets recreated in §4.
+- [ ] Expected findings: US `sharded_events` has all 40 dmat columns; EU typed columns
+      are partially dropped (mutations were killed on shards 1/3/8) — that asymmetry is
+      fine and stays; `writable_events` has no dmat columns anywhere on cloud.
+
+## 3. Additive columns (no ingestion impact, metadata-only)
+
+Order: data tables first, then the write path, so nothing references a column that
+doesn't exist downstream of it yet.
+
+```sql
+-- 3a. sharded_events — one replica per shard; replication propagates the ALTER.
+--     ADD COLUMN is metadata-only: no mutation, no part rewrite, safe even where old
+--     parts are broken. No-op where 0179 already added the columns.
+ALTER TABLE posthog.sharded_events
+    ADD COLUMN IF NOT EXISTS dmat_string_0 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_1 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_2 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_3 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_4 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_5 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_6 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_7 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_8 Nullable(String),
+    ADD COLUMN IF NOT EXISTS dmat_string_9 Nullable(String);
+
+-- 3b. events (Distributed read table) — every data node, same ADD COLUMN list.
+ALTER TABLE posthog.events
+    ADD COLUMN IF NOT EXISTS dmat_string_0 Nullable(String),
+    /* ... dmat_string_1..9 as above ... */
+    ADD COLUMN IF NOT EXISTS dmat_string_9 Nullable(String);
+
+-- 3c. writable_events — every host where it exists (ingestion layer; plus data nodes
+--     in any region where discovery found it there). ALTER, never recreate.
+ALTER TABLE posthog.writable_events
+    ADD COLUMN IF NOT EXISTS dmat_string_0 Nullable(String),
+    /* ... dmat_string_1..9 as above ... */
+    ADD COLUMN IF NOT EXISTS dmat_string_9 Nullable(String);
+```
+
+- [ ] Verify: rerun the §2 inventory; `dmat_string_cols = 10` for all three tables on
+      every host where the table exists.
+
+## 4. Kafka table + MV recreate (the only step with ingestion impact)
+
+The kafka table's column list is fixed at CREATE time, so it must be recreated for the
+MV to receive the dmat columns. The MV must be recreated to project them.
+
+1. Build the new DDL **from the §2 live `SHOW CREATE TABLE` output** (re-capture if more
+   than a day old):
+   - kafka table: live DDL + the 10 `dmat_string_N Nullable(String)` columns appended to
+     the column list (before the `SETTINGS`/engine clause).
+   - MV: live DDL with `dmat_string_0, ..., dmat_string_9` appended to the SELECT list.
+     MV→target inserts match by name, so position is irrelevant; §3c must be done first.
+2. - [ ] Diff new-vs-live DDL with a second engineer. The only delta must be the 10
+         columns. Anything else means the template went stale — stop.
+3. Roll **one ingestion host at a time** (the consumer group rebalances; remaining hosts
+   keep consuming):
+
+   ```sql
+   DROP TABLE IF EXISTS posthog.events_json_ws_mv;       -- MV first: no double-write window
+   DROP TABLE IF EXISTS posthog.kafka_events_json_ws;
+   -- CREATE the new kafka table (from step 1)
+   -- CREATE the new MV (from step 1)
+   ```
+
+   Neither object is replicated → no ZK metadata, no `SYNC` needed. Offsets only commit
+   on successful MV insert, so the gap loses nothing; consumption resumes from the last
+   committed offset.
+
+4. - [ ] Per host before moving on: `system.kafka_consumers` shows the consumer active,
+         no rows in `system.errors` for `NO_SUCH_COLUMN_IN_TABLE`/`THERE_IS_NO_COLUMN`, and
+         inserts visible in `writable_events` (`system.query_log` or part churn on
+         `sharded_events`).
+5. - [ ] Watch for 30 minutes after the last host, **both**:
+   - end-to-end ingestion lag (the usual dashboards), and
+   - the Distributed async-insert queue — during the 2026-06-01 incident Kafka lag looked fine while
+     CH buffered everything locally:
+     `SELECT hostName(), database, table, error_count, data_files FROM clusterAllReplicas('posthog', system.distribution_queue) WHERE data_files > 0`.
+6. - [ ] Commit the final `SHOW CREATE TABLE` outputs to `PostHog/clickhouse_schemas`.
+
+Rollback for this phase: re-run step 3 with the **unmodified live DDL captured in §2**
+(that is byte-for-byte the recovery performed by hand during the 2026-06-01 incident). The added columns
+from §3 are nullable, unreferenced, and harmless — they never need rolling back.
+
+## 5. Slot-assignments table + dictionary (no ingestion impact)
+
+On **every data node** of the main cluster (30 hosts US / 24 EU — loop with the team's
+host-runner of choice; the table is intentionally per-host, plain `ReplacingMergeTree`,
+no ON CLUSTER, no replication):
+
+```sql
+CREATE TABLE IF NOT EXISTS posthog.dmat_slot_assignments (
+    team_id UInt64,
+    column_index UInt8,
+    property_name String,
+    version UInt32 DEFAULT toUnixTimestamp(now())
+) ENGINE = ReplacingMergeTree(version)
+ORDER BY (team_id, column_index);
+
+CREATE DICTIONARY IF NOT EXISTS posthog.dmat_slot_assignments_dict (
+    team_id UInt64,
+    column_index UInt8,
+    property_name String
+)
+PRIMARY KEY team_id, column_index
+SOURCE(CLICKHOUSE(QUERY 'SELECT team_id, column_index, property_name FROM posthog.dmat_slot_assignments FINAL' USER '<migrations user>' PASSWORD '<from the usual secret store>'))
+LIFETIME(MIN 600 MAX 1200)
+LAYOUT(COMPLEX_KEY_HASHED());
+```
+
+These render from `posthog/models/dmat_slot_assignments/sql.py` — if in doubt, generate
+them from a prod-configured shell rather than copying from here.
+
+- [ ] Verify on a sample of hosts: `SELECT dictHas('posthog.dmat_slot_assignments_dict', (toUInt64(2), toUInt8(0)))`
+      returns `0` (empty dict resolves, doesn't throw).
+
+## 6. Before the first workflow run on cloud
+
+The weekly backfill submits an `ALTER TABLE sharded_events UPDATE dmat_string_N = ...
+WHERE dictHas(...)` bounded only by team
+(`posthog/temporal/backfill_materialized_property/activities.py`,
+`_build_dict_backed_update_command`). The missing time bound is deliberate: dmat columns
+have no DEFAULT expression to fall back on (the meaning of a column is per-team, via the
+dictionary), so historical correctness requires backfilling all of the team's rows — old
+parts included.
+
+**Precedent:** this is the same shape as the scheduled person-overrides squash
+(`posthog/dags/person_overrides.py` — an unbounded
+`UPDATE person_id = dictGet(...) WHERE dictHas(...)` over `sharded_events`), which runs
+routinely and completed successfully on the post-migration US cluster on 2026-06-08. So
+unbounded single-column UPDATEs over full history are established practice. The
+mutations that stuck during the 2026-06-01 incident were `DROP COLUMN`s, whose
+part-rewrite path failed on old parts that physically lack `inserted_at`
+(`NOT_FOUND_COLUMN_IN_BLOCK`, partitions ~2020–2023, observed on EU); a single-column
+UPDATE does not rebuild unrelated skip indexes on wide parts, which is consistent with
+the squash passing where the DROPs failed.
+
+Per region, before enabling slots for the first cloud team:
+
+- [ ] Confirm the person squash has completed on this cluster since its last topology
+      migration (Dagster `squash_person_overrides` run history). US: confirmed
+      2026-06-08. EU: outstanding — and EU is where the affected parts were
+      demonstrated. If there is no green post-migration squash, first run one
+      dmat-shaped UPDATE restricted to a single partition that contains affected parts
+      (find them with the query below) and watch it complete. If it fails, the fixes
+      are repairing the parts (per-partition `MATERIALIZE COLUMN inserted_at`, or an
+      `ALIAS NULL` rewrite) or adding a backfill floor — noting a floor changes
+      semantics (rows below it read NULL once the slot is `READY`, so it needs a
+      read-path answer too).
+- [ ] Coordinate the weekly run with the squash/deletes mutation calendar —
+      `sharded_events` mutations contend (the 2026-06-07 squash run failed because
+      earlier backfill mutations were still in flight). Don't run the dmat backfill
+      concurrently with squash or the post-squash deletes.
+- [ ] Check disk headroom on every shard before submitting — part rewrites need
+      transient space (incident-window backfills caused disk pressure on two shards).
+
+Query for old parts missing `inserted_at` (per region):
+
+```sql
+SELECT partition_id, count() AS parts_missing_inserted_at
+FROM cluster('posthog', system.parts_columns)
+WHERE database = 'posthog' AND table = 'sharded_events' AND active
+  AND part_name NOT IN (
+      SELECT part_name FROM cluster('posthog', system.parts_columns)
+      WHERE database = 'posthog' AND table = 'sharded_events' AND column = 'inserted_at'
+  )
+GROUP BY partition_id ORDER BY partition_id;
+```
+
+## 7. Feature validation (after the §6 checks)
+
+1. Assign a dmat slot to one dogfood team (team 2) via the product flow; confirm the
+   Postgres `MaterializedColumnSlot` row reaches `READY`/`BACKFILL`.
+2. Confirm new events for that team land with `dmat_string_<n>` populated (plugin-server
+   includes the value once the slot is live).
+3. Trigger the weekly workflow manually for that team only. Watch:
+   - `populate_slot_assignments` succeeds on all data hosts and the dictionary reload
+     shows rows (`SELECT count() FROM dmat_slot_assignments` per host);
+   - the mutation on the ClickHouse mutations monitor dashboard (Grafana
+     `clickhouse-mutations-monitor`) — progressing on every shard, no
+     `latest_fail_reason`;
+   - `KILL MUTATION WHERE mutation_id = '...'` is the abort lever (it was used during
+     the 2026-06-01 incident). Killing leaves the column partially backfilled, but that is invisible to
+     queries: the HogQL read path only swaps a property to its dmat column once the slot
+     reaches `READY` (`posthog/hogql/transforms/property_types.py`), and a killed
+     backfill leaves the slot in `BACKFILL`, still reading from the JSON blob.
+4. Only after one clean cycle, open slots to further teams.

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0273_query_log_archive_ops_json
+0274_wire_up_existing_dmat_string_columns

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -182,8 +182,14 @@ MATERIALIZE INDEX `minmax_inserted_at`
 # the max block size to consume from kafka such that we skip _all_ broken messages
 # this is an added safety mechanism given we control payloads to this topic
 
+KAFKA_EVENTS_JSON_TABLE = "kafka_events_json"
+EVENTS_JSON_MV = "events_json_mv"
 
-def KAFKA_EVENTS_TABLE_JSON_SQL():
+DROP_KAFKA_EVENTS_JSON_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_EVENTS_JSON_TABLE}"
+DROP_EVENTS_JSON_MV_SQL = f"DROP TABLE IF EXISTS {EVENTS_JSON_MV}"
+
+
+def KAFKA_EVENTS_TABLE_JSON_SQL(on_cluster: bool = True):
     return (
         EVENTS_TABLE_BASE_SQL
         + """
@@ -191,7 +197,7 @@ def KAFKA_EVENTS_TABLE_JSON_SQL():
 """
     ).format(
         table_name="kafka_events_json",
-        on_cluster_clause=ON_CLUSTER_CLAUSE(),
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
         engine=kafka_engine(topic=KAFKA_EVENTS_JSON, group=CONSUMER_GROUP_EVENTS_JSON),
         extra_fields="",
         dynamically_materialized_columns=EVENTS_TABLE_DYNAMICALLY_MATERIALIZED_COLUMNS(),


### PR DESCRIPTION
A placeholder PR to discuss migrations with @rorylshanks 

## Problem

Third attempt at shipping the `dmat_string` events-pipeline wiring. #58080 (migration 0256, reverted in #59350) failed because `NodeRole.ALL` fanned the new dictionary out to an unreachable satellite cluster. #59681 (migration 0267, reverted in #61041) scoped to data nodes but still failed against the real cloud topologies and caused the 2026-06-01 ingestion incident, for three distinct reasons:

1. it ALTERed `writable_events` on DATA nodes, where the table doesn't exist in US prod (it lives on the ingestion layer) — and the failure landed *after* the MV/kafka drops, leaving ingestion down;
2. its kafka/MV recreate used repo SQL, but the live `kafka_events_json_ws` / `events_json_ws_mv` definitions carry environment-specific materialized columns that are not in the repo, so the recreate destroyed the live schema;
3. its `DROP COLUMN` mutations for the legacy typed dmat columns stuck on old parts that physically lack `inserted_at` and had to be killed by hand.

The agreed process since then (now codified in `posthog/clickhouse/migrations/AGENTS.md`): events-pipeline schema changes on cloud are applied manually by the ClickHouse team, the WS kafka/MV pair is a no-go zone for migrations, and `DROP COLUMN` follows a manual-first two-step.

## Changes

Same end state as #59681, restructured to fit that process:

- **Migration `0274` is an explicit no-op on cloud** (`CLOUD_DEPLOYMENT` in US/EU/DEV). The cloud DDL is applied by hand following the step-by-step runbook shipped alongside the migration (`0274_wire_up_existing_dmat_string_columns.runbook.md`): per-region discovery from live `SHOW CREATE TABLE`, additive `ADD COLUMN IF NOT EXISTS` everywhere, kafka/MV recreate built from the captured live DDL (never repo SQL), and the slot-assignments table + dictionary on data nodes. Region order dev → US → EU.
- **Non-cloud installs get the full wiring from the migration** (their schemas match repo SQL by construction): `ADD COLUMN` on `writable_events`, create `dmat_slot_assignments` + dictionary, recreate the MSK `kafka_events_json` / `events_json_mv` pair so dmat values flow from plugin-server.
- **No `DROP COLUMN` anywhere.** The empty legacy typed columns stay until the ClickHouse team removes them manually; a follow-up migration will record that afterwards.
- **Additive operations run before the kafka/MV drop**, so a failure aborts with ingestion untouched (0267 had the opposite ordering, which is what turned a failed ALTER into an ingestion outage).
- Re-adds the `sql.py` constants reverted with #61041 (`DROP_KAFKA_EVENTS_JSON_TABLE_SQL`, `DROP_EVENTS_JSON_MV_SQL`, `on_cluster` param on `KAFKA_EVENTS_TABLE_JSON_SQL`).

The runbook also covers how the weekly backfill mutation interacts with the old parts missing `inserted_at` that stuck the incident's `DROP COLUMN` mutations. The backfill is unbounded by time deliberately (dmat columns have no DEFAULT expression to fall back on), and the same unbounded dict-backed UPDATE shape already runs in production as the person-overrides squash — so the runbook gates first enablement on verifying that precedent per region (squash confirmed green on post-migration US; outstanding on EU, where the affected parts were observed) and on coordinating with the squash/deletes mutation calendar.

Follow-up (separate branch, `aspicer/dmat3-populate-data-nodes`, to keep this PR migration-only): scope the `populate_slot_assignments` activity from `map_all_hosts` to data nodes, matching where the table/dictionary exist.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run locally:

- `posthog/clickhouse/test/test_migrations.py` passes (includes the per-`CLOUD_DEPLOYMENT` re-import of every migration; verified `operations` is empty under US/EU/DEV and 7 convention-clean operations otherwise).
- Rendered every operation's SQL under the non-cloud branch and inspected it by hand.
- `ruff` clean.

Not tested against a live multi-node cluster — by design, the cloud path is the manual runbook, to be executed with the ClickHouse team.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal migration + operator runbook only; no user-facing docs change. `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code at Sandy's direction, after reviewing the post-incident discussion and the revert PRs.
- Key decision: make the migration a no-op on cloud rather than trying to make automated DDL topology-proof — two attempts showed the repo cannot know the live ingestion-layer schemas, and the team's stated direction is manual application for events-pipeline changes. The runbook is the deliverable that encodes the manual path.
- Rejected along the way: keeping the typed-column `DROP`s (stuck-mutation risk, now forbidden by convention), and creating the dictionary via migration on cloud (kept everything in one manual pass instead).

