### PR TITLE
fix(taxonomy): stop stale background polls clobbering property value search results

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -209,7 +209,11 @@ export function PropertyValue({
 
     // show suggested values first, then any other available options that aren't in the suggested list
     const displayOptions = useMemo(() => {
-        const options = propertyOptions?.values || []
+        // Results produced for a different search input are stale — e.g. a background refresh
+        // that lands after the user kept typing. Showing them would make the dropdown filter to
+        // nothing, so fall back to the suggested values until a matching response arrives.
+        const isForCurrentInput = (propertyOptions?.searchInput ?? '') === currentSearchInput.current
+        const options = isForCurrentInput ? propertyOptions?.values || [] : []
         if (initialSuggestedValues.set.size === 0) {
             return options
         }
@@ -240,7 +244,7 @@ export function PropertyValue({
         }
 
         return [...suggestedOptions, ...otherOptions]
-    }, [propertyOptions?.values, initialSuggestedValues])
+    }, [propertyOptions?.values, propertyOptions?.searchInput, initialSuggestedValues])
 
     const onSearchTextChange = (newInput: string): void => {
         const trimmedInput = newInput.trim()

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -616,5 +616,71 @@ describe('the property definitions model', () => {
             expect(capturedUrls).toHaveLength(2)
             expect(capturedUrls[1]).toContain('refresh=force_cache')
         })
+
+        it('drops a scheduled poll once the search input has changed', async () => {
+            let pollCallback: (() => void) | null = null
+            const capturedUrls: string[] = []
+
+            const originalSetTimeout = global.setTimeout.bind(global)
+            jest.spyOn(global, 'setTimeout').mockImplementation(((
+                fn: TimerHandler,
+                delay?: number,
+                ...args: unknown[]
+            ) => {
+                if (delay === 2000) {
+                    pollCallback = () => (fn as (...a: unknown[]) => unknown)(...args)
+                    return 0 as unknown as ReturnType<typeof setTimeout>
+                }
+                return originalSetTimeout(fn, delay, ...args)
+            }) as typeof setTimeout)
+
+            useMocks({
+                get: {
+                    '/api/event/values': (req) => {
+                        capturedUrls.push(req.url.toString())
+                        const isFirst = capturedUrls.length === 1
+                        return [
+                            200,
+                            {
+                                results: isFirst ? [{ name: 'stale-value' }] : [{ name: 'fresh-value' }],
+                                refreshing: isFirst,
+                            },
+                        ]
+                    },
+                },
+            })
+
+            // First search schedules a background poll for its own input
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.Event,
+                    newInput: 'stale',
+                    propertyKey: 'browser',
+                })
+            }).toFinishAllListeners()
+
+            jest.restoreAllMocks()
+            expect(pollCallback).not.toBeNull()
+
+            // User keeps typing — a newer search lands
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.Event,
+                    newInput: 'fresh',
+                    propertyKey: 'browser',
+                })
+            }).toFinishAllListeners()
+
+            expect(logic.values.options['browser'].values).toEqual([{ name: 'fresh-value' }])
+
+            // The stale poll fires anyway — it must not fetch or overwrite the newer results
+            await expectLogic(logic, () => pollCallback!()).toFinishAllListeners()
+
+            expect(capturedUrls).toHaveLength(2)
+            expect(logic.values.options['browser'].values).toEqual([{ name: 'fresh-value' }])
+            expect(logic.values.options['browser'].searchInput).toEqual('fresh')
+        })
     })
 })

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -429,6 +429,19 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 return
             }
 
+            if (refresh === 'force_cache' && (values.options[propertyKey]?.searchInput ?? '') !== (newInput || '')) {
+                // Background refresh scheduled for an earlier search input — drop it, or its
+                // results would overwrite the options for what the user is typing now.
+                return
+            }
+
+            // A new load supersedes any scheduled background poll for this key. Without this, a
+            // poll created for an earlier input fires later and clobbers the current results.
+            if (cache.pollingTimeouts?.[propertyKey]) {
+                clearTimeout(cache.pollingTimeouts[propertyKey])
+                delete cache.pollingTimeouts[propertyKey]
+            }
+
             const start = performance.now()
 
             await breakpoint(300)


### PR DESCRIPTION
## Problem

Searching property values in the taxonomic filter sometimes shows "no results" even though the backend returns matches. The value-options store keeps one option list per property with last-write-wins, and a background refresh poll (scheduled 2s after any `refreshing: true` response) re-runs with the search input frozen from when it was scheduled. When the user keeps typing, the stale poll lands after the newer search and overwrites the option list with values matching the old input. The dropdown then fuzzy-filters those against the current input and renders nothing, while the correct results were discarded one write earlier.

Observed in production: per-keystroke requests all returned 10 matching rows from ClickHouse while the dropdown showed no results.

## Changes

- `propertyDefinitionsModel.loadPropertyValues` drops a `force_cache` poll whose search input no longer matches the recorded input for the key, and clears any pending poll timeout whenever a new load for the key fires, so superseded polls die instead of clobbering.
- `PropertyValue`'s `displayOptions` ignores option values whose recorded `searchInput` doesn't match the current input, falling back to the suggested values until a matching response arrives. This guards against any remaining stale writer.

## How did you test this code?

I'm an agent; no manual testing. Automated tests: added a regression test (`drops a scheduled poll once the search input has changed`) that schedules a poll for one input, completes a newer search, fires the stale poll, and asserts it neither fetches nor overwrites the newer results. `frontend/src/models/propertyDefinitionsModel.test.ts` 37 passed; `PropertyValue.test.tsx` 7 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Diagnosed from production query logs: every backend request for the affected search returned matches, so the loss had to be client-side; traced it to the polling refresh reusing its original search term plus last-write-wins option storage, then the dropdown's fuzzy filter emptying the mismatched list.
- Considered fixing only the component-side rendering; chose to also kill stale polls at the model layer since they otherwise keep re-scheduling themselves and waste requests.
