### PR TITLE
feat(insights): add area chart display to retention insights

### DIFF
--- a/frontend/src/scenes/insights/filters/RetentionChartPicker.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionChartPicker.tsx
@@ -3,6 +3,8 @@ import { useActions, useValues } from 'kea'
 import { IconGraph, IconTrends } from '@posthog/icons'
 import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 
+import { IconAreaChart } from 'lib/lemon-ui/icons'
+
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
@@ -29,6 +31,17 @@ const OPTIONS: LemonSelectOptions<ChartDisplayType> = [
                     <ChartFilterOptionLabel
                         label="Line chart"
                         description="Retention over time plotted as a continuous line for each cohort."
+                    />
+                ),
+            },
+            {
+                value: ChartDisplayType.ActionsAreaGraph,
+                icon: <IconAreaChart />,
+                label: 'Area chart',
+                labelInMenu: (
+                    <ChartFilterOptionLabel
+                        label="Area chart"
+                        description="Retention over time plotted as a filled area for each cohort."
                     />
                 ),
             },

--- a/frontend/src/scenes/insights/stories/Retention.stories.tsx
+++ b/frontend/src/scenes/insights/stories/Retention.stories.tsx
@@ -1,0 +1,64 @@
+import { FEATURE_FLAGS } from 'lib/constants'
+import { samplePersonProperties, sampleRetentionPeopleResponse } from 'scenes/insights/__mocks__/insight.mocks'
+
+import { Meta, StoryObj } from '@storybook/react'
+
+import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene'
+
+import { mswDecorator } from '~/mocks/browser'
+
+type Story = StoryObj<{}>
+const meta: Meta = {
+    title: 'Scenes-App/Insights/Retention',
+    parameters: {
+        layout: 'fullscreen',
+        testOptions: {
+            snapshotBrowsers: ['chromium'],
+            viewport: {
+                width: 1300,
+                height: 720,
+            },
+        },
+        viewMode: 'story',
+        mockDate: '2022-03-11',
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:team_id/persons/retention': sampleRetentionPeopleResponse,
+                '/api/environments/:team_id/persons/properties': samplePersonProperties,
+                '/api/projects/:team_id/groups_types': [],
+            },
+            post: {
+                '/api/projects/:team_id/cohorts/': { id: 1 },
+            },
+        }),
+    ],
+}
+export default meta
+/* eslint-disable @typescript-eslint/no-var-requires */
+const retentionFixture = require('../../../mocks/fixtures/api/projects/team_id/insights/retention.json')
+
+// Retention rendered as an area chart on the new quill-charts path
+// (PRODUCT_ANALYTICS_HOG_CHARTS_RETENTION). `display: ActionsAreaGraph` flows through
+// `buildRetentionSeries` as `fill: {}` per cohort, which the chart auto-stacks.
+const retentionArea = {
+    ...retentionFixture,
+    query: {
+        ...retentionFixture.query,
+        source: {
+            ...retentionFixture.query.source,
+            retentionFilter: {
+                ...retentionFixture.query.source.retentionFilter,
+                display: 'ActionsAreaGraph',
+            },
+        },
+    },
+}
+
+export const RetentionAreaGraphHogCharts: Story = createInsightStory(retentionArea)
+RetentionAreaGraphHogCharts.parameters = {
+    featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_HOG_CHARTS_RETENTION],
+    testOptions: { waitForSelector: '[data-attr=trend-line-graph] canvas' },
+}
+/* eslint-enable @typescript-eslint/no-var-requires */

--- a/frontend/src/scenes/retention/RetentionGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionGraph.tsx
@@ -72,6 +72,7 @@ export function RetentionGraph({ inSharedMode = false }: RetentionGraphProps): J
             datasets={filteredTrendSeries as GraphDataset[]}
             labels={xAxisLabels}
             isInProgress={incompletenessOffsetFromEnd < 0}
+            isArea={retentionFilter?.display === ChartDisplayType.ActionsAreaGraph}
             inSharedMode={!!inSharedMode}
             showPersonsModal={false}
             labelGroupType={labelGroupType}

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.stories.tsx
@@ -84,3 +84,23 @@ const realisticFixture = {
 export const RealisticCurve: Story = {
     render: () => renderRetentionLineChart(realisticFixture),
 }
+
+// `display: ActionsAreaGraph` flows through `buildRetentionSeries` as `fill: {}` on every
+// cohort series, which the chart auto-stacks once 2+ series are filled — same as Trends area.
+const areaFixture = {
+    ...realisticFixture,
+    query: {
+        ...realisticFixture.query,
+        source: {
+            ...(realisticFixture.query.source as any),
+            retentionFilter: {
+                ...(realisticFixture.query.source as any).retentionFilter,
+                display: 'ActionsAreaGraph',
+            },
+        },
+    },
+}
+
+export const AreaChart: Story = {
+    render: () => renderRetentionLineChart(areaFixture),
+}

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -14,7 +14,7 @@ import { retentionModalLogic } from 'scenes/retention/retentionModalLogic'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
-import type { GroupTypeIndex, LabelGroupType } from '~/types'
+import { ChartDisplayType, type GroupTypeIndex, type LabelGroupType } from '~/types'
 
 import {
     buildRetentionLineChartConfig,
@@ -73,6 +73,7 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
     const period = retentionFilter?.period
     const isPercentage = !retentionFilter?.aggregationType || retentionFilter.aggregationType === 'count'
     const isIntervalView = selectedInterval !== null
+    const isArea = retentionFilter?.display === ChartDisplayType.ActionsAreaGraph
     // Shared (public) views don't have the persons modal mounted — disable click-to-open there.
     const canClick = !shouldShowMeanPerBreakdown && !inSharedMode
 
@@ -81,8 +82,9 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
             buildRetentionSeries(filteredTrendSeries as RetentionTrendSeriesEntry[], {
                 incompletenessOffsetFromEnd,
                 isIntervalView,
+                isArea,
             }),
-        [filteredTrendSeries, incompletenessOffsetFromEnd, isIntervalView]
+        [filteredTrendSeries, incompletenessOffsetFromEnd, isIntervalView, isArea]
     )
 
     const groupTypeLabel = resolveGroupTypeLabel(labelGroupType, aggregationLabel)

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.test.ts
@@ -133,6 +133,19 @@ describe('retentionChartTransforms', () => {
             expect(series[0].stroke).toBeUndefined()
         })
 
+        it('sets an area fill on every series when isArea is true', () => {
+            const series = buildRetentionSeries([makeEntry({ index: 0 }), makeEntry({ index: 1 })], {
+                isIntervalView: false,
+                isArea: true,
+            })
+            expect(series.map((s) => s.fill)).toEqual([{}, {}])
+        })
+
+        it('leaves the fill undefined when isArea is not set (line chart)', () => {
+            const series = buildRetentionSeries([makeEntry()], { isIntervalView: false })
+            expect(series[0].fill).toBeUndefined()
+        })
+
         it('carries cohort metadata through to series meta', () => {
             const series = buildRetentionSeries(
                 [makeEntry({ index: 2, breakdown_value: 'Chrome', count: 42, label: '2024-01-03' })],

--- a/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/retention/shared/retentionChartTransforms.ts
@@ -43,13 +43,15 @@ export interface BuildRetentionSeriesOpts {
     /** True when an interval is selected (x-axis is cohorts, not interval offsets).
      *  In this layout the partial-stroke "in-progress" segment doesn't apply per-series. */
     isIntervalView: boolean
+    /** Render each series with an area fill below the line (ActionsAreaGraph display). */
+    isArea?: boolean
 }
 
 export function buildRetentionSeries(
     seriesPayloads: RetentionTrendSeriesEntry[],
     opts: BuildRetentionSeriesOpts
 ): Series<RetentionSeriesMeta>[] {
-    const { incompletenessOffsetFromEnd, isIntervalView } = opts
+    const { incompletenessOffsetFromEnd, isIntervalView, isArea } = opts
     return seriesPayloads.map((s, i) => {
         const rowIndex = s.index ?? i
         const dataLength = s.data.length
@@ -72,6 +74,7 @@ export function buildRetentionSeries(
                 cohortLabel: s.label,
                 cohortCount: s.count,
             },
+            fill: isArea ? {} : undefined,
             stroke: dashedFromIndex !== undefined ? { partial: { fromIndex: dashedFromIndex } } : undefined,
         }
     })


### PR DESCRIPTION
## Problem

Retention insights only supported line and bar chart displays. Users who want to see cohort retention as a filled area chart — the way Trends already supports it — had no option for it.

## Changes

Adds an **Area chart** option to the retention chart-type picker, wired through the same template Trends uses:

- `RetentionChartPicker` gains an "Area chart" option (using `IconAreaChart`, matching Trends' `ChartFilter`).
- `buildRetentionSeries` accepts an `isArea` flag and, when set, applies `fill: {}` to each cohort series — identical to `buildMainTrendsSeries` in `trendsChartTransforms.ts`.
- `RetentionLineChart` (the new quill-charts path) reads `display === ActionsAreaGraph` and passes `isArea` into the series builder.

The retention `display` schema field already accepts any `ChartDisplayType`, so no backend/schema change was needed.

**Stacking behaviour:** in the quill-charts renderer, area series stack automatically once 2+ filled series are present. Retention is virtually always multi-cohort, so this reproduces the legacy `LineGraph` area behaviour (which sets the y-scale `stacked: true` for any area chart). A single-cohort area renders identically either way — so no explicit stacking config is needed (quill-charts exposes none for absolute stacking).

A one-line change to the legacy `RetentionGraph` path is included too, so picking "Area chart" with the new-charts feature flag off still renders an area rather than a flat line.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not perform manual UI testing. I added unit tests to `retentionChartTransforms.test.ts` covering that `isArea: true` sets `fill: {}` on every series and that the fill stays undefined for the default line chart. I was not able to run the frontend typecheck or Jest locally because this session's checkout has no installed dependencies — please rely on CI to confirm.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Samuel Pennington via a Slack thread: add area chart support to retention insights using the same approach as Trends, focusing on the new quill-charts implementation and making it behave like the legacy one.

Built with PostHog Code (Claude Code harness). The agent located the Trends area-chart mechanism (`fill: {}` on series + automatic stacking in quill-charts), confirmed retention's `display` field already accepts the value, and mirrored it into the retention series builder and picker. The key decision was that no new stacking config is required — quill-charts auto-stacks 2+ filled series, which matches the legacy y-scale stacking — rather than inventing a stacking flag.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781116452300109?thread_ts=1781116452.300109&cid=C0ACRAMJUAG)*
