### PR TITLE
chore(livestream): remove postgres stuff as it's not needed anymore

### DIFF
--- a/bin/start-go-service
+++ b/bin/start-go-service
@@ -57,9 +57,6 @@ case "$GO_SVC" in
     # MMDB path, relative to livestream directory where air runs
     export LIVESTREAM_MMDB_PATH=../share/GeoLite2-City.mmdb
 
-    # Postgres settings
-    export LIVESTREAM_POSTGRES_URL=postgres://posthog:posthog@localhost:5432/posthog
-
     # Redis (needed for real-time notifications SSE endpoint)
     export LIVESTREAM_REDIS_URL="redis://localhost:6379"
 

--- a/livestream/configs/configs.example.yml
+++ b/livestream/configs/configs.example.yml
@@ -25,8 +25,6 @@ jwt:
     # Previous secrets still accepted for verification during key rotation
     secret_fallbacks:
         - '<previous secret key>'
-postgres:
-    url: 'postgres://postgres:postgres@localhost:5432/postgres'
 cors_allow_origins:
     - "https://example.com"
     - "https://sub.example.com"

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -12,10 +12,6 @@ type MMDBConfig struct {
 	Path string
 }
 
-type PostgresConfig struct {
-	URL string
-}
-
 type JWTConfig struct {
 	Secret string
 	// Previous secrets still accepted for verification (never used for signing),
@@ -65,7 +61,6 @@ type Config struct {
 	Consumers        ConsumersConfig `mapstructure:"consumers"`
 	Parallelism      int             `mapstructure:"parallelism"`
 	CORSAllowOrigins []string        `mapstructure:"cors_allow_origins"`
-	Postgres         PostgresConfig
 	JWT              JWTConfig
 	SessionRecording SessionRecordingConfig `mapstructure:"session_recording"`
 	Redis            RedisConfig
@@ -131,9 +126,6 @@ func InitConfigs(filename, configPath string) {
 	_ = viper.BindEnv("consumers.notification.session_timeout_ms")    // LIVESTREAM_CONSUMERS_NOTIFICATION_SESSION_TIMEOUT_MS
 	_ = viper.BindEnv("consumers.notification.heartbeat_interval_ms") // LIVESTREAM_CONSUMERS_NOTIFICATION_HEARTBEAT_INTERVAL_MS
 	_ = viper.BindEnv("consumers.notification.max_poll_interval_ms")  // LIVESTREAM_CONSUMERS_NOTIFICATION_MAX_POLL_INTERVAL_MS
-
-	// Postgres settings
-	_ = viper.BindEnv("postgres.url") // LIVESTREAM_POSTGRES_URL
 
 	// JWT settings
 	_ = viper.BindEnv("jwt.secret")           // LIVESTREAM_JWT_SECRET

--- a/livestream/configs/configs_test.go
+++ b/livestream/configs/configs_test.go
@@ -20,7 +20,6 @@ func TestLoadConfig(t *testing.T) {
 			setup: func() {
 				// Values already set in setupTestConfig
 				_ = os.Setenv("LIVESTREAM_JWT_SECRET", "token")
-				_ = os.Setenv("LIVESTREAM_POSTGRES_URL", "pg url")
 			},
 			want: &Config{
 				Debug:            true,
@@ -48,9 +47,6 @@ func TestLoadConfig(t *testing.T) {
 						SecurityProtocol: "PLAINTEXT",
 						GroupID:          "livestream-dev-notifications",
 					},
-				},
-				Postgres: PostgresConfig{
-					URL: "pg url",
 				},
 				JWT: JWTConfig{
 					Secret:          "token",
@@ -80,7 +76,6 @@ func TestLoadConfig(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
-			assert.Equal(t, tt.want.Postgres.URL, viper.GetString("postgres.url"))
 			assert.Equal(t, tt.want.JWT.Secret, viper.GetString("jwt.secret"))
 		})
 	}

--- a/livestream/docker-compose.yml
+++ b/livestream/docker-compose.yml
@@ -1,20 +1,6 @@
 version: '3.8'
 
 services:
-    postgres:
-        image: postgres:16-alpine
-        restart: always
-        ports:
-            - '127.0.0.1:5432:5432'
-        environment:
-            POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
-            POSTGRES_DB: liveevents
-        healthcheck:
-            test: ['CMD-SHELL', 'pg_isready -U postgres']
-            interval: 5s
-            timeout: 5s
-
     redis:
         image: redis:7.2
         restart: always


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Livestream has a Postgres connection string exposed to it, but it doesn't use Postgres anywhere.

## Changes

Removed Postgres stuff from Livestream.

## How did you test this code?

Automated tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored with Claude Code Opus 4.8.

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
