### PR TITLE
feat(hogli): add devbox:start --start-app flag

### DIFF
--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -127,7 +127,7 @@ Run `hogli devbox` to see all available commands, and `hogli <command> --help` f
 
 Region selection is available for `devbox:start` via `--region` (`us-east-1` or `eu-central-1`, default `us-east-1`). The region is set once at creation and cannot be changed. Workspaces in `eu-central-1` get an `-eu` name suffix (e.g. `devbox-alice-eu`). `devbox:list` and `devbox:status` show which region a workspace is in.
 
-`devbox:start --start-app` opts a workspace into bringing the PostHog app up (`hogli up`) in the background on every start — useful for scripted, ephemeral devboxes that should be usable without an interactive `hogli up`. The setting is stored as a mutable workspace parameter (`auto_start_app`), so it stays in effect for future starts until flipped with `--no-start-app`. Requires a template version that defines the parameter; on older templates hogli drops it with a warning.
+`devbox:start --start-app` opts a workspace into bringing the PostHog app up (`hogli up`) in the background on every start — useful for scripted, ephemeral devboxes that should be usable without an interactive `hogli up`. The setting is stored as a mutable workspace parameter (`auto_start_app`), so it stays in effect for future starts until flipped with `--no-start-app`. The flag is applied at creation or when starting a stopped devbox; on a running or transitioning devbox it is not applied (hogli prints a note) — re-run it once the devbox is stopped. Requires a template version that defines the parameter; on older templates hogli drops it with a warning.
 
 Runtime commands assume setup is already complete.
 If they fail with `Run hogli devbox:setup`, rerun setup on your laptop first.

--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -127,6 +127,8 @@ Run `hogli devbox` to see all available commands, and `hogli <command> --help` f
 
 Region selection is available for `devbox:start` via `--region` (`us-east-1` or `eu-central-1`, default `us-east-1`). The region is set once at creation and cannot be changed. Workspaces in `eu-central-1` get an `-eu` name suffix (e.g. `devbox-alice-eu`). `devbox:list` and `devbox:status` show which region a workspace is in.
 
+`devbox:start --start-app` opts a workspace into bringing the PostHog app up (`hogli up`) in the background on every start — useful for scripted, ephemeral devboxes that should be usable without an interactive `hogli up`. The setting is stored as a mutable workspace parameter (`auto_start_app`), so it stays in effect for future starts until flipped with `--no-start-app`. Requires a template version that defines the parameter; on older templates hogli drops it with a warning.
+
 Runtime commands assume setup is already complete.
 If they fail with `Run hogli devbox:setup`, rerun setup on your laptop first.
 When in doubt, `hogli devbox:doctor` reports which prerequisite is missing.

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -122,6 +122,11 @@ WORKSPACE_STATUS_COLORS = {
 }
 PENDING_WORKSPACE_STATES = {"starting", "stopping", "deleting"}
 
+# Printed whenever --start-app/--no-start-app is passed but cannot be applied:
+# the parameter is only pushed on the pre-start sync of a stopped workspace,
+# so the flag is dropped (not queued) on running/transitioning boxes.
+_START_APP_NOT_APPLIED_NOTE = "Note: --start-app/--no-start-app was not applied; re-run it once the devbox is stopped."
+
 
 def resolve_workspace_name(
     workspace: str | None, *, region: str | None = None
@@ -343,13 +348,15 @@ def _start_existing_workspace(
         if start_app is not None:
             # Pushing the parameter needs `coder update`, which rebuilds a
             # running workspace -- only safe on the pre-start sync below.
-            click.echo("Note: --start-app/--no-start-app takes effect on the next start.")
+            click.echo(_START_APP_NOT_APPLIED_NOTE)
         _print_connection_info(name)
         return
 
     if status in PENDING_WORKSPACE_STATES:
         click.echo(f"Devbox '{name}' is in state: {status}")
         click.echo("Wait for the current operation to complete.")
+        if start_app is not None:
+            click.echo(_START_APP_NOT_APPLIED_NOTE)
         return
 
     _sync_workspace_parameters(name, extra=_start_app_param(start_app))

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -23,7 +23,6 @@ from hogli.manifest import get_manifest
 
 from . import mutagen
 from .coder import (
-    AUTO_START_APP_PARAMETER,
     CLAUDE_CODE_OAUTH_ENV,
     DEFAULT_PRESET,
     DEFAULT_REGION,
@@ -35,6 +34,7 @@ from .coder import (
     REGIONS,
     _diagnose_unreachable_coder,
     _fail,
+    _start_app_param,
     coder_authenticated,
     coder_installed,
     coder_reachable,
@@ -331,13 +331,6 @@ def _sync_workspace_parameters(name: str, extra: dict[str, str] | None = None) -
 
     if params:
         update_workspace_parameters(name, params)
-
-
-def _start_app_param(start_app: bool | None) -> dict[str, str]:
-    """Map the tri-state --start-app flag to a parameter dict (empty = leave as-is)."""
-    if start_app is None:
-        return {}
-    return {AUTO_START_APP_PARAMETER: "true" if start_app else "false"}
 
 
 def _start_existing_workspace(
@@ -1347,7 +1340,7 @@ def devbox_start(
         region=effective_region,
         template=template,
         preset=preset,
-        start_app=start_app is True,
+        start_app=start_app,
         verbose=verbose,
     )
     click.echo("Created.")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -23,6 +23,7 @@ from hogli.manifest import get_manifest
 
 from . import mutagen
 from .coder import (
+    AUTO_START_APP_PARAMETER,
     CLAUDE_CODE_OAUTH_ENV,
     DEFAULT_PRESET,
     DEFAULT_REGION,
@@ -305,7 +306,7 @@ def _render_sync_status(workspace_name: str) -> str:
     return click.style(f"● {status}", fg="green")
 
 
-def _sync_workspace_parameters(name: str) -> None:
+def _sync_workspace_parameters(name: str, extra: dict[str, str] | None = None) -> None:
     """Push local config (git identity, dotfiles) to workspace parameters before start.
 
     `workspace_region` is intentionally not forwarded: it is immutable, so Coder
@@ -325,15 +326,31 @@ def _sync_workspace_parameters(name: str) -> None:
     if dotfiles_uri:
         params[DOTFILES_URI_PARAMETER] = dotfiles_uri
 
+    if extra:
+        params.update(extra)
+
     if params:
         update_workspace_parameters(name, params)
 
 
-def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: bool) -> None:
+def _start_app_param(start_app: bool | None) -> dict[str, str]:
+    """Map the tri-state --start-app flag to a parameter dict (empty = leave as-is)."""
+    if start_app is None:
+        return {}
+    return {AUTO_START_APP_PARAMETER: "true" if start_app else "false"}
+
+
+def _start_existing_workspace(
+    name: str, workspace: dict[str, Any], *, start_app: bool | None = None, verbose: bool
+) -> None:
     """Handle `devbox:start` when the workspace already exists."""
     status = get_workspace_status(workspace)
     if status == "running":
         click.echo(f"Devbox '{name}' is already running.")
+        if start_app is not None:
+            # Pushing the parameter needs `coder update`, which rebuilds a
+            # running workspace -- only safe on the pre-start sync below.
+            click.echo("Note: --start-app/--no-start-app takes effect on the next start.")
         _print_connection_info(name)
         return
 
@@ -342,7 +359,7 @@ def _start_existing_workspace(name: str, workspace: dict[str, Any], *, verbose: 
         click.echo("Wait for the current operation to complete.")
         return
 
-    _sync_workspace_parameters(name)
+    _sync_workspace_parameters(name, extra=_start_app_param(start_app))
 
     if status == "stopped":
         click.echo(f"Starting devbox '{name}'...")
@@ -1284,6 +1301,15 @@ def devbox_unshare(workspace: str | None, users: tuple[str, ...]) -> None:
         "Defaults to the value saved by `devbox:setup --configure-region`, then us-east-1."
     ),
 )
+@click.option(
+    "--start-app/--no-start-app",
+    "start_app",
+    default=None,
+    help=(
+        "Bring the PostHog app up in the background on every workspace start. "
+        "Sticky on the workspace until flipped with --no-start-app."
+    ),
+)
 @click.option("-v", "--verbose", is_flag=True, help="Show full Coder/Terraform build output")
 def devbox_start(
     workspace: str | None,
@@ -1291,6 +1317,7 @@ def devbox_start(
     template: str,
     preset: str,
     region: str | None,
+    start_app: bool | None,
     verbose: bool,
 ) -> None:
     """Start or create the remote devbox."""
@@ -1303,7 +1330,7 @@ def devbox_start(
     ws = get_workspace(name, workspaces)
 
     if ws is not None:
-        _start_existing_workspace(name, ws, verbose=verbose)
+        _start_existing_workspace(name, ws, start_app=start_app, verbose=verbose)
         return
 
     config = load_config()
@@ -1320,6 +1347,7 @@ def devbox_start(
         region=effective_region,
         template=template,
         preset=preset,
+        start_app=bool(start_app),
         verbose=verbose,
     )
     click.echo("Created.")

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -1347,7 +1347,7 @@ def devbox_start(
         region=effective_region,
         template=template,
         preset=preset,
-        start_app=bool(start_app),
+        start_app=start_app is True,
         verbose=verbose,
     )
     click.echo("Created.")

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -45,6 +45,13 @@ DOTFILES_URI_PARAMETER = "dotfiles_uri"
 DOTFILES_BRANCH_PARAMETER = "dotfiles_branch"
 JETBRAINS_IDES_PARAMETER = "jetbrains_ides"
 
+# Opt-in: bring the PostHog app (the `hogli up` dev stack) up in the
+# background on every workspace start. Mutable and sticky on the workspace, so
+# it stays in effect for future starts until explicitly flipped off. On
+# template versions that don't define it yet, the retry shim drops it with a
+# visible warning.
+AUTO_START_APP_PARAMETER = "auto_start_app"
+
 # Create-time region selector. The template defines `workspace_region` with a
 # us-east-1 default; eu-central-1 became a valid option when the EU
 # infrastructure went live. The value is immutable after creation, so it is
@@ -1137,6 +1144,7 @@ def create_workspace(
     region: str = DEFAULT_REGION,
     template: str = DEFAULT_TEMPLATE,
     preset: str = DEFAULT_PRESET,
+    start_app: bool = False,
     verbose: bool = False,
 ) -> None:
     """Create a new Coder workspace.
@@ -1169,6 +1177,8 @@ def create_workspace(
         parameters[GIT_EMAIL_PARAMETER] = git_email
     if dotfiles_uri:
         parameters[DOTFILES_URI_PARAMETER] = dotfiles_uri
+    if start_app:
+        parameters[AUTO_START_APP_PARAMETER] = "true"
 
     resolved_preset = resolve_template_preset(template, preset)
     base_args = [

--- a/tools/hogli-commands/hogli_commands/devbox/coder.py
+++ b/tools/hogli-commands/hogli_commands/devbox/coder.py
@@ -1133,6 +1133,19 @@ def resolve_template_preset(template: str, requested: str) -> str:
     return NO_PRESET
 
 
+def _start_app_param(start_app: bool | None) -> dict[str, str]:
+    """Map the tri-state --start-app flag to a parameter dict (empty = leave as-is).
+
+    ``None`` (flag omitted) returns ``{}`` so the value stays sticky on an
+    existing workspace and falls back to the template default on creation.
+    ``True``/``False`` are written explicitly so the choice survives even if the
+    template default changes.
+    """
+    if start_app is None:
+        return {}
+    return {AUTO_START_APP_PARAMETER: "true" if start_app else "false"}
+
+
 def create_workspace(
     name: str,
     disk_size: int,
@@ -1144,7 +1157,7 @@ def create_workspace(
     region: str = DEFAULT_REGION,
     template: str = DEFAULT_TEMPLATE,
     preset: str = DEFAULT_PRESET,
-    start_app: bool = False,
+    start_app: bool | None = None,
     verbose: bool = False,
 ) -> None:
     """Create a new Coder workspace.
@@ -1177,8 +1190,7 @@ def create_workspace(
         parameters[GIT_EMAIL_PARAMETER] = git_email
     if dotfiles_uri:
         parameters[DOTFILES_URI_PARAMETER] = dotfiles_uri
-    if start_app:
-        parameters[AUTO_START_APP_PARAMETER] = "true"
+    parameters.update(_start_app_param(start_app))
 
     resolved_preset = resolve_template_preset(template, preset)
     base_args = [

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -2273,23 +2273,24 @@ class TestStartExistingWorkspace:
         else:
             assert captured == {coder.AUTO_START_APP_PARAMETER: expected}
 
-    def test_start_app_flag_never_updates_running_workspace(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    @pytest.mark.parametrize("status", ["running", "starting", "stopping"])
+    def test_start_app_flag_never_pushed_unless_stopped(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], status: str
     ) -> None:
         """`coder update` stops a running workspace, so the flag must only note, never push."""
-        monkeypatch.setattr(devbox_cli, "get_workspace_status", lambda ws: "running")
+        monkeypatch.setattr(devbox_cli, "get_workspace_status", lambda ws: status)
         monkeypatch.setattr(
             devbox_cli,
             "update_workspace_parameters",
-            lambda name, params: pytest.fail("update_workspace_parameters must not run on a running workspace"),
+            lambda name, params: pytest.fail("update_workspace_parameters must not run unless stopped"),
         )
         monkeypatch.setattr(devbox_cli, "extract_workspace_label", lambda name: None)
 
         devbox_cli._start_existing_workspace(
-            "devbox-test-user", {"latest_build": {"status": "running"}}, start_app=True, verbose=False
+            "devbox-test-user", {"latest_build": {"status": status}}, start_app=True, verbose=False
         )
 
-        assert "takes effect on the next start" in capsys.readouterr().out
+        assert "was not applied" in capsys.readouterr().out
 
     def test_sync_never_forwards_immutable_workspace_region(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The pre-start sync must omit `workspace_region`.

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -855,6 +855,7 @@ def _stub_create_workspace(captured: dict[str, str | None]) -> Callable[..., Non
         region: str = coder.DEFAULT_REGION,
         template: str = coder.DEFAULT_TEMPLATE,
         preset: str = coder.DEFAULT_PRESET,
+        start_app: bool = False,
         verbose: bool = False,
     ) -> None:
         captured.update(
@@ -867,6 +868,7 @@ def _stub_create_workspace(captured: dict[str, str | None]) -> Callable[..., Non
                 "region": region,
                 "template": template,
                 "preset": preset,
+                "start_app": str(start_app),
             }
         )
 
@@ -990,6 +992,16 @@ class TestWorkspaceCreation:
         params = _parse_parameter_flags(args)
         assert "claude_oauth_token" not in params
         assert params == expected_params
+
+    def test_create_workspace_forwards_start_app_parameter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(coder, "_run_build", _fake_run_build_capturing(captured))
+        monkeypatch.setattr(coder, "_list_template_presets", lambda template: ["Default (warm)"])
+
+        coder.create_workspace("devbox-test-user", 100, start_app=True)
+
+        params = _parse_parameter_flags(captured["args"])
+        assert params[coder.AUTO_START_APP_PARAMETER] == "true"
 
     @pytest.mark.parametrize(
         "outputs, dropped, raises",
@@ -1503,6 +1515,7 @@ class TestDevboxCommands:
             "region": coder.DEFAULT_REGION,
             "template": coder.DEFAULT_TEMPLATE,
             "preset": coder.DEFAULT_PRESET,
+            "start_app": "False",
         }
 
     def test_devbox_start_with_name_creates_labeled_workspace(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1585,6 +1598,28 @@ class TestDevboxCommands:
         assert result.exit_code == 0, result.output
         assert captured["region"] == "eu-central-1"
         assert "region=eu-central-1" in result.output
+
+    @pytest.mark.parametrize(
+        "flag, expected",
+        [("--start-app", "True"), ("--no-start-app", "False")],
+        ids=["enable", "disable"],
+    )
+    def test_devbox_start_forwards_start_app_flag(
+        self, monkeypatch: pytest.MonkeyPatch, flag: str, expected: str
+    ) -> None:
+        captured: dict[str, str | None] = {}
+
+        monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
+        monkeypatch.setattr(devbox_cli, "resolve_workspace_name", lambda ws, **kw: ("devbox-test-user", []))
+        monkeypatch.setattr(devbox_cli, "get_workspace", lambda name, workspaces=None: None)
+        monkeypatch.setattr(devbox_cli, "extract_workspace_label", lambda name: None)
+        monkeypatch.setattr(devbox_cli, "load_config", lambda: {})
+        monkeypatch.setattr(devbox_cli, "create_workspace", _stub_create_workspace(captured))
+
+        result = runner.invoke(cli, ["devbox:start", flag])
+
+        assert result.exit_code == 0, result.output
+        assert captured["start_app"] == expected
 
     def test_devbox_start_rejects_unknown_region(self) -> None:
         # click.Choice rejects the value during option parsing, before the
@@ -2195,6 +2230,53 @@ class TestStartExistingWorkspace:
         devbox_cli._start_existing_workspace("devbox-test-user", {"latest_build": {"status": "stopped"}}, verbose=False)
 
         assert calls == ["start"]
+
+    @pytest.mark.parametrize(
+        "start_app, expected",
+        [(True, "true"), (False, "false")],
+        ids=["enable", "disable"],
+    )
+    def test_pushes_start_app_param_before_starting(
+        self, monkeypatch: pytest.MonkeyPatch, start_app: bool, expected: str
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        monkeypatch.setattr(devbox_cli, "get_workspace_status", lambda ws: "stopped")
+        monkeypatch.setattr(devbox_cli, "load_config", lambda: {})
+        monkeypatch.setattr(
+            devbox_cli,
+            "update_workspace_parameters",
+            lambda name, params: captured.update(params),
+        )
+        monkeypatch.setattr(devbox_cli, "start_workspace", lambda name, verbose=False: None)
+        monkeypatch.setattr(devbox_cli, "extract_workspace_label", lambda name: None)
+
+        devbox_cli._start_existing_workspace(
+            "devbox-test-user",
+            {"latest_build": {"status": "stopped"}},
+            start_app=start_app,
+            verbose=False,
+        )
+
+        assert captured == {coder.AUTO_START_APP_PARAMETER: expected}
+
+    def test_start_app_flag_never_updates_running_workspace(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`coder update` stops a running workspace, so the flag must only note, never push."""
+        monkeypatch.setattr(devbox_cli, "get_workspace_status", lambda ws: "running")
+        monkeypatch.setattr(
+            devbox_cli,
+            "update_workspace_parameters",
+            lambda name, params: pytest.fail("update_workspace_parameters must not run on a running workspace"),
+        )
+        monkeypatch.setattr(devbox_cli, "extract_workspace_label", lambda name: None)
+
+        devbox_cli._start_existing_workspace(
+            "devbox-test-user", {"latest_build": {"status": "running"}}, start_app=True, verbose=False
+        )
+
+        assert "takes effect on the next start" in capsys.readouterr().out
 
     def test_sync_never_forwards_immutable_workspace_region(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The pre-start sync must omit `workspace_region`.

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -2233,11 +2233,11 @@ class TestStartExistingWorkspace:
 
     @pytest.mark.parametrize(
         "start_app, expected",
-        [(True, "true"), (False, "false")],
-        ids=["enable", "disable"],
+        [(True, "true"), (False, "false"), (None, None)],
+        ids=["enable", "disable", "omit"],
     )
     def test_pushes_start_app_param_before_starting(
-        self, monkeypatch: pytest.MonkeyPatch, start_app: bool, expected: str
+        self, monkeypatch: pytest.MonkeyPatch, start_app: bool | None, expected: str | None
     ) -> None:
         captured: dict[str, object] = {}
 
@@ -2258,7 +2258,10 @@ class TestStartExistingWorkspace:
             verbose=False,
         )
 
-        assert captured == {coder.AUTO_START_APP_PARAMETER: expected}
+        if expected is None:
+            assert coder.AUTO_START_APP_PARAMETER not in captured
+        else:
+            assert captured == {coder.AUTO_START_APP_PARAMETER: expected}
 
     def test_start_app_flag_never_updates_running_workspace(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -855,7 +855,7 @@ def _stub_create_workspace(captured: dict[str, str | None]) -> Callable[..., Non
         region: str = coder.DEFAULT_REGION,
         template: str = coder.DEFAULT_TEMPLATE,
         preset: str = coder.DEFAULT_PRESET,
-        start_app: bool = False,
+        start_app: bool | None = None,
         verbose: bool = False,
     ) -> None:
         captured.update(
@@ -993,15 +993,25 @@ class TestWorkspaceCreation:
         assert "claude_oauth_token" not in params
         assert params == expected_params
 
-    def test_create_workspace_forwards_start_app_parameter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize(
+        "start_app, expected",
+        [(True, "true"), (False, "false"), (None, None)],
+        ids=["enable", "disable", "omit"],
+    )
+    def test_create_workspace_forwards_start_app_parameter(
+        self, monkeypatch: pytest.MonkeyPatch, start_app: bool | None, expected: str | None
+    ) -> None:
         captured: dict[str, object] = {}
         monkeypatch.setattr(coder, "_run_build", _fake_run_build_capturing(captured))
         monkeypatch.setattr(coder, "_list_template_presets", lambda template: ["Default (warm)"])
 
-        coder.create_workspace("devbox-test-user", 100, start_app=True)
+        coder.create_workspace("devbox-test-user", 100, start_app=start_app)
 
         params = _parse_parameter_flags(captured["args"])
-        assert params[coder.AUTO_START_APP_PARAMETER] == "true"
+        if expected is None:
+            assert coder.AUTO_START_APP_PARAMETER not in params
+        else:
+            assert params[coder.AUTO_START_APP_PARAMETER] == expected
 
     @pytest.mark.parametrize(
         "outputs, dropped, raises",
@@ -1515,7 +1525,7 @@ class TestDevboxCommands:
             "region": coder.DEFAULT_REGION,
             "template": coder.DEFAULT_TEMPLATE,
             "preset": coder.DEFAULT_PRESET,
-            "start_app": "False",
+            "start_app": "None",
         }
 
     def test_devbox_start_with_name_creates_labeled_workspace(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

Devboxes don't bring PostHog up on workspace start — every box needs an interactive `hogli up` first. For scripted, ephemeral devboxes (e.g. one box per worktree for parallel feature testing) that's a manual step in an otherwise automated loop. The agent template auto-starts the stack, but it gates readiness on a healthy stack and its prebuild pool is capacity-planned for Tasks, so it's the wrong vehicle for human boxes.

## Changes

- `hogli devbox:start --start-app/--no-start-app`: opt-in auto-start of the PostHog app on every workspace start, stored as a mutable `auto_start_app` workspace parameter
- Strictly opt-in and backwards compatible:
  - no flag → no parameter sent, identical coder calls to today (tri-state, default leave-as-is)
  - older template versions → the existing param-retry shim drops the key with a visible warning (same rollout pattern as `workspace_region`)
  - sticky by coder semantics: `coder update` carries existing parameter values forward until flipped with `--no-start-app`
  - on a running box the flag only prints a note — `coder update` stops a running workspace, so the parameter is only pushed in the pre-start sync
- Companion template change (parameter + conditional background `hogli up` in bootstrap) ships in posthog-cloud-infra; this flag is inert until that lands

## How did you test this code?

Agent-authored; no manual testing. Automated: `tools/hogli-commands/hogli_commands/tests/test_devbox.py` (311 passed) covering flag forwarding on create, tri-state pre-start parameter sync, `auto_start_app=true` in the coder argv, and the running-workspace no-update guard.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`docs/internal/coder-workspaces.md` updated with the new flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @rauln. Considered reusing the posthog-agent template (already auto-starts the stack) — rejected because it blocks login until the stack is healthy and its prebuild pool is Task-scoped. Chose a mutable bool rich parameter on posthog-linux (canonical Coder pattern, same shape as `dotfiles_uri`). Flag renamed from `--start-stack` to `--start-app` per reviewer preference. Backwards compatibility verified against coder CLI v2.33.5 semantics (`--use-parameter-defaults` only fills unset parameters; `coder update` pulls existing values).
