### PR TITLE
fix(web-analytics): warm precompute via calculate() to bypass 6h result cache

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -130,6 +130,13 @@ EAGER_PRECOMPUTE_NOT_LAZY_ELIGIBLE = Counter(
     "Teams skipped by the eager warmer because they are not lazy-precompute eligible "
     "(the gate would route every tile through the raw path).",
 )
+EAGER_PRECOMPUTE_BASELINE_NOT_PRECOMPUTED = Counter(
+    "web_analytics_eager_precompute_baseline_not_precomputed_total",
+    "Baseline queries that ran but did NOT resolve to a precompute read (fell through "
+    "to raw) — the precompute the warmer should keep fresh is stale, missing, or the "
+    "breakdown isn't precomputable. Labeled by query kind.",
+    ["query_kind"],
+)
 
 
 def _resolve_eager_audience() -> tuple[list[int], str, dict]:
@@ -232,9 +239,28 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
             # the precompute warm. It also skips the result-cache write on purpose: that
             # is `cache_warming.py`'s job (it replays real user queries with their own
             # access context), not this job's.
-            runner.calculate()
+            response = runner.calculate()
             EAGER_PRECOMPUTE_BASELINE_WARMED.labels(query_kind=label).inc()
             warmed += 1
+            # Self-check the warm actually did its job: the tile must resolve to a
+            # precompute read, not fall through to raw. `usedLazyPrecompute` is only
+            # True when the read passed the lazy executor's TTL freshness filter
+            # (`created_at + TTL >= now`, TTL = 15min today … 7d old), so True is a
+            # guarantee the precomputed value is well within the 2h threshold. A tile
+            # that comes back `not True` warmed nothing useful — surface it loudly so a
+            # stale/missing precompute or a non-precomputable breakdown can't hide.
+            if getattr(response, "usedLazyPrecompute", None) is not True:
+                EAGER_PRECOMPUTE_BASELINE_NOT_PRECOMPUTED.labels(query_kind=label).inc()
+                context.log.warning(
+                    f"eager_baseline_warming_tile_not_precomputed [{idx}/{total}] team={team.pk} query={label}"
+                )
+                logger.warning(
+                    "eager_baseline_warming_tile_not_precomputed",
+                    team_id=team.pk,
+                    query=label,
+                    tile=idx,
+                    total=total,
+                )
             tile_ms = round((time.monotonic() - tile_started) * 1000)
             context.log.info(
                 f"eager_baseline_warming_tile_done [{idx}/{total}] team={team.pk} query={label} "

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -5,10 +5,17 @@ Web analytics dashboard's main tile matrix over the trailing 28 days,
 for every team in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` setting.
 
 The job is intentionally thin: it enumerates the dashboard's query
-families and dispatches each through `get_query_runner(...).run(...)`.
+families and dispatches each through `get_query_runner(...).calculate()`.
 The runner routes through its family's lazy precompute path, which
 already knows what's stale and INSERTs only what's missing. This DAG is
 the *trigger*; the runner is the source of truth for freshness.
+
+`calculate()` is used deliberately instead of `run()`: `run()` is gated by
+the HogQL query result cache (6h staleness), which is the wrong clock for a
+precompute warmer whose buckets expire on a 2h TTL — it would skip tiles
+whose Redis result is still "fresh" while the precompute they feed has gone
+cold. `calculate()` always enters the precompute path and skips the result
+cache write, leaving Redis result-cache warming to `cache_warming.py`.
 
 Why this exists
 ---------------
@@ -51,7 +58,6 @@ from posthog.hogql.constants import LimitContext
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners
-from posthog.event_usage import EventSource
 from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.models import Team
 
@@ -217,7 +223,16 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
                 product=Product.WEB_ANALYTICS,
             )
             runner = get_query_runner(query=query, team=team, limit_context=LimitContext.QUERY_ASYNC)
-            runner.run(analytics_props={"source": EventSource.CACHE_WARMING})
+            # Call `calculate()` directly rather than `run()`. `run()` is gated by the
+            # HogQL query result cache (6h staleness for web analytics), which would let
+            # the warmer skip a tile whose Redis result is still "fresh" even though the
+            # precompute buckets it feeds expire on a 2h TTL — leaving the precompute
+            # cold for hours. `calculate()` always enters the lazy precompute path (which
+            # still INSERTs only the windows past their TTL), so every hourly tick keeps
+            # the precompute warm. It also skips the result-cache write on purpose: that
+            # is `cache_warming.py`'s job (it replays real user queries with their own
+            # access context), not this job's.
+            runner.calculate()
             EAGER_PRECOMPUTE_BASELINE_WARMED.labels(query_kind=label).inc()
             warmed += 1
             tile_ms = round((time.monotonic() - tile_started) * 1000)

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -4,18 +4,24 @@ A single Dagster job that pre-warms the lazy precompute cache for the
 Web analytics dashboard's main tile matrix over the trailing 28 days,
 for every team in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` setting.
 
-The job is intentionally thin: it enumerates the dashboard's query
-families and dispatches each through `get_query_runner(...).calculate()`.
-The runner routes through its family's lazy precompute path, which
-already knows what's stale and INSERTs only what's missing. This DAG is
-the *trigger*; the runner is the source of truth for freshness.
+The job is intentionally thin: it enumerates the dashboard's query families
+and dispatches each through `get_query_runner(...).run(...)` in force-refresh
+mode (`ExecutionMode.CALCULATE_BLOCKING_ALWAYS`). The runner routes through
+its family's lazy precompute path, which already knows what's stale and
+INSERTs only what's missing. This DAG is the *trigger*; the runner is the
+source of truth for freshness.
 
-`calculate()` is used deliberately instead of `run()`: `run()` is gated by
-the HogQL query result cache (6h staleness), which is the wrong clock for a
-precompute warmer whose buckets expire on a 2h TTL — it would skip tiles
-whose Redis result is still "fresh" while the precompute they feed has gone
-cold. `calculate()` always enters the precompute path and skips the result
-cache write, leaving Redis result-cache warming to `cache_warming.py`.
+Force-refresh is used deliberately. The DEFAULT execution mode gates on the
+HogQL query result cache (6h staleness), which is the wrong clock for a
+precompute warmer whose buckets expire on a much shorter TTL (15min for
+today's bucket) — it would skip tiles whose Redis result is still "fresh"
+while the precompute they feed has gone cold. Force-refresh always recomputes,
+so every tick re-enters the precompute path. Crucially it goes through `run()`
+(not a bare `calculate()`), so the warm stays inside the same rate-limit and
+concurrency wrappers (`_call_with_rate_limits`) as user traffic — the warmer
+must not pile unthrottled ClickHouse work on top of a saturated cluster. It
+also refreshes the (no-user) result-cache entry as a side effect, which is
+harmless; the user-facing replay warming is `cache_warming.py`'s job.
 
 Why this exists
 ---------------
@@ -58,7 +64,8 @@ from posthog.hogql.constants import LimitContext
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.dags.common import JobOwners
-from posthog.hogql_queries.query_runner import get_query_runner
+from posthog.event_usage import EventSource
+from posthog.hogql_queries.query_runner import ExecutionMode, get_query_runner
 from posthog.models import Team
 
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import is_precompute_enabled_for_team
@@ -230,9 +237,12 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
                 product=Product.WEB_ANALYTICS,
             )
             runner = get_query_runner(query=query, team=team, limit_context=LimitContext.QUERY_ASYNC)
-            # `calculate()` not `run()` — see module docstring (bypasses the 6h result
-            # cache, skips the result-cache write).
-            response = runner.calculate()
+            # Force-refresh via run() — see module docstring (recomputes every tick
+            # while staying inside run()'s rate-limit/concurrency wrappers).
+            response = runner.run(
+                execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                analytics_props={"source": EventSource.CACHE_WARMING},
+            )
             EAGER_PRECOMPUTE_BASELINE_WARMED.labels(query_kind=label).inc()
             warmed += 1
             # Self-check the warm actually did its job: the tile must resolve to a

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -230,15 +230,8 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
                 product=Product.WEB_ANALYTICS,
             )
             runner = get_query_runner(query=query, team=team, limit_context=LimitContext.QUERY_ASYNC)
-            # Call `calculate()` directly rather than `run()`. `run()` is gated by the
-            # HogQL query result cache (6h staleness for web analytics), which would let
-            # the warmer skip a tile whose Redis result is still "fresh" even though the
-            # precompute buckets it feeds expire on a 2h TTL — leaving the precompute
-            # cold for hours. `calculate()` always enters the lazy precompute path (which
-            # still INSERTs only the windows past their TTL), so every hourly tick keeps
-            # the precompute warm. It also skips the result-cache write on purpose: that
-            # is `cache_warming.py`'s job (it replays real user queries with their own
-            # access context), not this job's.
+            # `calculate()` not `run()` — see module docstring (bypasses the 6h result
+            # cache, skips the result-cache write).
             response = runner.calculate()
             EAGER_PRECOMPUTE_BASELINE_WARMED.labels(query_kind=label).inc()
             warmed += 1

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -12,6 +12,7 @@ from structlog.testing import capture_logs
 
 from posthog.schema import WebStatsBreakdown
 
+from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Organization, Team
 
 from products.web_analytics.dags.eager_web_analytics_precompute import (
@@ -74,9 +75,9 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         t1, t2 = self._enroll_teams(count=2)
 
         ok_runner = Mock()
-        ok_runner.calculate.return_value = Mock(usedLazyPrecompute=True)
+        ok_runner.run.return_value = Mock(usedLazyPrecompute=True)
         bad_runner = Mock()
-        bad_runner.calculate.side_effect = RuntimeError("boom")
+        bad_runner.run.side_effect = RuntimeError("boom")
 
         def runner_factory(query, team, limit_context):
             return bad_runner if team.pk == t1.pk else ok_runner
@@ -90,8 +91,8 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         assert result["warmed"] == _QUERIES_PER_TEAM  # only t2 succeeds
         assert result["failed"] == _QUERIES_PER_TEAM  # only t1 fails
         assert result["skipped"] == 0
-        assert ok_runner.calculate.call_count == _QUERIES_PER_TEAM
-        assert bad_runner.calculate.call_count == _QUERIES_PER_TEAM
+        assert ok_runner.run.call_count == _QUERIES_PER_TEAM
+        assert bad_runner.run.call_count == _QUERIES_PER_TEAM
 
         called_team_ids = {
             call.kwargs.get("team", call.args[1] if len(call.args) > 1 else None).pk
@@ -124,14 +125,19 @@ class TestWarmBaselineForTeam(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_warms_full_matrix(self, get_runner, tag_queries_mock):
         runner = Mock()
-        runner.calculate.return_value = Mock(usedLazyPrecompute=True)
+        runner.run.return_value = Mock(usedLazyPrecompute=True)
         get_runner.return_value = runner
 
         warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
 
         assert warmed == _QUERIES_PER_TEAM
         assert failed == 0
-        assert runner.calculate.call_count == _QUERIES_PER_TEAM
+        assert runner.run.call_count == _QUERIES_PER_TEAM
+        # Force-refresh, not the default mode: the default respects the 6h result-cache
+        # staleness and would skip warming while the precompute goes cold. Force-blocking
+        # also keeps the warm inside run()'s rate-limit wrappers (vs a bare calculate()).
+        for call in runner.run.call_args_list:
+            assert call.kwargs["execution_mode"] == ExecutionMode.CALCULATE_BLOCKING_ALWAYS
 
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
@@ -139,7 +145,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
         # A tile whose calculate() does not come back with usedLazyPrecompute=True fell
         # through to raw — the warm populated no fresh precompute. It still counts as
         # "warmed" (it ran without error) but must be surfaced as not-precomputed.
-        get_runner.return_value = Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=None)))
+        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=None)))
 
         with capture_logs() as cap_logs:
             warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -158,7 +164,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def capture(query, team, limit_context):
             captured.append(query)
-            return Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=True)))
+            return Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
 
         get_runner.side_effect = capture
         _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -206,7 +212,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def record_get_runner(**kwargs):
             call_order.append("get_runner")
-            return Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=True)))
+            return Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
 
         tag_queries_mock.side_effect = record_tag
         get_runner.side_effect = record_get_runner
@@ -229,7 +235,7 @@ class TestEagerBaselineLogging(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_emits_structured_lifecycle_events_on_success(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=True)))
+        get_runner.return_value = Mock(run=Mock(return_value=Mock(usedLazyPrecompute=True)))
 
         with _eager_audience([self.team.pk]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())
@@ -269,7 +275,7 @@ class TestEagerBaselineLogging(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_emits_query_failed_event_with_error_type(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(calculate=Mock(side_effect=RuntimeError("boom")))
+        get_runner.return_value = Mock(run=Mock(side_effect=RuntimeError("boom")))
 
         with _eager_audience([self.team.pk]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -74,7 +74,7 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         t1, t2 = self._enroll_teams(count=2)
 
         ok_runner = Mock()
-        ok_runner.calculate.return_value = None
+        ok_runner.calculate.return_value = Mock(usedLazyPrecompute=True)
         bad_runner = Mock()
         bad_runner.calculate.side_effect = RuntimeError("boom")
 
@@ -124,7 +124,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_warms_full_matrix(self, get_runner, tag_queries_mock):
         runner = Mock()
-        runner.calculate.return_value = None
+        runner.calculate.return_value = Mock(usedLazyPrecompute=True)
         get_runner.return_value = runner
 
         warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -135,6 +135,22 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
+    def test_flags_tiles_that_do_not_resolve_to_precompute(self, get_runner, tag_queries_mock):
+        # A tile whose calculate() does not come back with usedLazyPrecompute=True fell
+        # through to raw — the warm populated no fresh precompute. It still counts as
+        # "warmed" (it ran without error) but must be surfaced as not-precomputed.
+        get_runner.return_value = Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=None)))
+
+        with capture_logs() as cap_logs:
+            warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
+
+        assert warmed == _QUERIES_PER_TEAM
+        assert failed == 0
+        not_precomputed = [log for log in cap_logs if log.get("event") == "eager_baseline_warming_tile_not_precomputed"]
+        assert len(not_precomputed) == _QUERIES_PER_TEAM
+
+    @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
+    @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_warms_every_breakdown_with_correct_quirks(self, get_runner, tag_queries_mock):
         # PAGE/INITIAL_PAGE need includeBounceRate; vitals needs doPathCleaning.
         # Other breakdowns must NOT carry includeBounceRate.
@@ -142,7 +158,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def capture(query, team, limit_context):
             captured.append(query)
-            return Mock(calculate=Mock())
+            return Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=True)))
 
         get_runner.side_effect = capture
         _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -190,7 +206,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def record_get_runner(**kwargs):
             call_order.append("get_runner")
-            return Mock(calculate=Mock())
+            return Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=True)))
 
         tag_queries_mock.side_effect = record_tag
         get_runner.side_effect = record_get_runner
@@ -213,7 +229,7 @@ class TestEagerBaselineLogging(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_emits_structured_lifecycle_events_on_success(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(calculate=Mock(return_value=None))
+        get_runner.return_value = Mock(calculate=Mock(return_value=Mock(usedLazyPrecompute=True)))
 
         with _eager_audience([self.team.pk]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -74,9 +74,9 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         t1, t2 = self._enroll_teams(count=2)
 
         ok_runner = Mock()
-        ok_runner.run.return_value = None
+        ok_runner.calculate.return_value = None
         bad_runner = Mock()
-        bad_runner.run.side_effect = RuntimeError("boom")
+        bad_runner.calculate.side_effect = RuntimeError("boom")
 
         def runner_factory(query, team, limit_context):
             return bad_runner if team.pk == t1.pk else ok_runner
@@ -90,8 +90,8 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         assert result["warmed"] == _QUERIES_PER_TEAM  # only t2 succeeds
         assert result["failed"] == _QUERIES_PER_TEAM  # only t1 fails
         assert result["skipped"] == 0
-        assert ok_runner.run.call_count == _QUERIES_PER_TEAM
-        assert bad_runner.run.call_count == _QUERIES_PER_TEAM
+        assert ok_runner.calculate.call_count == _QUERIES_PER_TEAM
+        assert bad_runner.calculate.call_count == _QUERIES_PER_TEAM
 
         called_team_ids = {
             call.kwargs.get("team", call.args[1] if len(call.args) > 1 else None).pk
@@ -124,14 +124,14 @@ class TestWarmBaselineForTeam(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_warms_full_matrix(self, get_runner, tag_queries_mock):
         runner = Mock()
-        runner.run.return_value = None
+        runner.calculate.return_value = None
         get_runner.return_value = runner
 
         warmed, failed = _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
 
         assert warmed == _QUERIES_PER_TEAM
         assert failed == 0
-        assert runner.run.call_count == _QUERIES_PER_TEAM
+        assert runner.calculate.call_count == _QUERIES_PER_TEAM
 
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
@@ -142,7 +142,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def capture(query, team, limit_context):
             captured.append(query)
-            return Mock(run=Mock())
+            return Mock(calculate=Mock())
 
         get_runner.side_effect = capture
         _warm_baseline_for_team(Mock(spec=dagster.OpExecutionContext), self.team)
@@ -190,7 +190,7 @@ class TestWarmBaselineForTeam(APIBaseTest):
 
         def record_get_runner(**kwargs):
             call_order.append("get_runner")
-            return Mock(run=Mock())
+            return Mock(calculate=Mock())
 
         tag_queries_mock.side_effect = record_tag
         get_runner.side_effect = record_get_runner
@@ -213,7 +213,7 @@ class TestEagerBaselineLogging(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_emits_structured_lifecycle_events_on_success(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(run=Mock(return_value=None))
+        get_runner.return_value = Mock(calculate=Mock(return_value=None))
 
         with _eager_audience([self.team.pk]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())
@@ -253,7 +253,7 @@ class TestEagerBaselineLogging(APIBaseTest):
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.tag_queries")
     @patch("products.web_analytics.dags.eager_web_analytics_precompute.get_query_runner")
     def test_emits_query_failed_event_with_error_type(self, get_runner, _tag, _is_cloud):
-        get_runner.return_value = Mock(run=Mock(side_effect=RuntimeError("boom")))
+        get_runner.return_value = Mock(calculate=Mock(side_effect=RuntimeError("boom")))
 
         with _eager_audience([self.team.pk]), capture_logs() as cap_logs:
             warm_eager_baseline_op(dagster.build_op_context())


### PR DESCRIPTION
## Problem

The eager web-analytics warmer exists to keep the **lazy precompute** warm — but it dispatched each tile through `runner.run()` in the **default** execution mode, which is gated by the HogQL query **result cache** (Redis, ~6h staleness for web analytics). The precompute buckets it feeds expire on a much shorter TTL (15min for today's bucket), so for most of each 6h window the warmer saw a "fresh" Redis result and skipped the tile, while the precompute underneath had already gone cold. The warmer was gated by the wrong cache.

There was also no signal when a warmed tile silently fell through to raw — the class of bug behind recent gaps (Language, ExitPage, ScreenName).

## Changes

1. **Dispatch each tile via `run(execution_mode=CALCULATE_BLOCKING_ALWAYS)`** — the same force-refresh path the UI's refresh uses. It always recomputes (so every hourly tick re-enters the precompute path, which still INSERTs only the windows past their TTL), bypassing the result-cache staleness that was skipping warms. Crucially it stays inside `run()` — so the warm keeps the same `_call_with_rate_limits()` concurrency/rate-limit wrappers as user traffic, rather than piling unthrottled ClickHouse work on a busy cluster. (An earlier revision called `calculate()` bare, which dropped that guard — fixed.)
2. **Self-verify each warmed tile resolves to precompute.** After the run, assert `usedLazyPrecompute is True` — which the runner only sets when the read passed the executor's TTL freshness filter, so it guarantees the precomputed value is well within the staleness threshold. A tile that comes back otherwise is surfaced via a `web_analytics_eager_precompute_baseline_not_precomputed_total{query_kind}` metric + a structured warning. This would have flagged the recent raw-fallthrough gaps automatically.

No change to the tile matrix, audience, gating, or schedule.

## How did you test this code?

I'm an agent (Claude Code, directed by the assignee). Automated only: `test_eager_web_analytics_precompute.py` — asserts each tile is dispatched via `run(execution_mode=CALCULATE_BLOCKING_ALWAYS)`, healthy mocks return `usedLazyPrecompute=True`, plus a new test that a not-precomputed tile is flagged. Full file green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Traced the warmer's caching while auditing why precomputed tiles still went raw: the default mode's result-cache gate (6h) sits in front of the precompute, whose bucket TTL is far shorter. First tried bare `calculate()` to bypass the gate; a reviewer correctly flagged that it also bypasses `run()`'s rate-limit wrapper. Switched to `run(CALCULATE_BLOCKING_ALWAYS)` — the blessed force-refresh path — which forces recompute, keeps rate limits, and refreshes the (harmless) no-user result-cache entry. Audited all proactive precompute-warming paths: the eager job is the only precompute warmer (`cache_warming.py` is the result-cache warmer; dimensional/v2 use separate `ensure_*` paths).