### PR TITLE
fix(flags): load flag definitions in ASGI self-capture init

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -11,8 +11,8 @@ from posthoganalytics.client import Client
 from posthog.git import get_git_branch, get_git_commit_short
 from posthog.tasks.tasks import sync_all_organization_available_product_features
 from posthog.utils import (
+    _build_flag_provider,
     get_available_timezones_with_offsets,
-    get_dogfood_flags_team_id,
     get_instance_region,
     get_machine_id,
     initialize_self_capture_api_token,
@@ -88,25 +88,7 @@ class PostHogConfig(AppConfig):
         # the cache is cold. In E2E testing personal_api_key is None, so a cold cache
         # will result in no flag definitions being loaded — which is acceptable there.
         if not posthoganalytics.disabled:
-            from products.feature_flags.backend.sdk_cache_provider import HyperCacheFlagProvider
-
-            explicit_team_id = os.environ.get("POSTHOG_SELF_TEAM_ID")
-            if explicit_team_id:
-                # Operator override: pin the flag-definitions team explicitly.
-                # Truthiness, not `is not None`: an empty env var means "unset" and must
-                # fall through to the defaults below, not crash on int("").
-                provider = HyperCacheFlagProvider.for_static_team(int(explicit_team_id))
-            elif settings.SELF_CAPTURE and not settings.E2E_TESTING:
-                # Local/self-hosted: read flag definitions from the dogfood team
-                # (project.teams.first()), resolved lazily once teams/migrations exist.
-                # Intentionally the FIRST team, not self-capture's current_team — see
-                # resolve_dogfood_flags_team() in posthog/utils.py.
-                provider = HyperCacheFlagProvider.for_dynamic_resolution(get_dogfood_flags_team_id)
-            else:
-                # Cloud (SELF_CAPTURE off) or E2E: the canonical PostHog-internal team is 2.
-                provider = HyperCacheFlagProvider.for_static_team(2)
-
-            posthoganalytics.flag_definition_cache_provider = provider  # ty: ignore[invalid-assignment]
+            posthoganalytics.flag_definition_cache_provider = _build_flag_provider()  # ty: ignore[invalid-assignment]
 
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,3 +1,4 @@
+import os
 import json
 import base64
 from datetime import datetime, timedelta
@@ -12,7 +13,7 @@ from unittest.mock import call, patch
 from django.core.cache import cache
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
 from parameterized import parameterized
@@ -23,6 +24,7 @@ from posthog.models import EventDefinition, GroupTypeMapping, Organization, Team
 from posthog.settings.utils import get_from_env
 from posthog.utils import (
     PotentialSecurityProblemException,
+    _build_flag_provider,
     absolute_uri,
     base64_decode,
     filters_override_requested_by_client,
@@ -1161,3 +1163,40 @@ class TestResolveDogfoodFlagsTeam(TestCase):
     def test_returns_none_when_there_are_no_teams(self):
         assert resolve_dogfood_flags_team() is None
         assert get_dogfood_flags_team_id() is None
+
+
+class TestBuildFlagProvider(TestCase):
+    def setUp(self):
+        super().setUp()
+        # The dogfood branch reads the whole teams table; clear ambient rows so the team we
+        # create is the first one. Cascade deletes roll back with the test transaction.
+        User.objects.all().delete()
+        Organization.objects.all().delete()
+
+    @patch.dict(os.environ, {"POSTHOG_SELF_TEAM_ID": "5"}, clear=False)
+    @override_settings(SELF_CAPTURE=True, E2E_TESTING=False)
+    def test_explicit_env_team_id_wins_over_self_capture(self):
+        assert _build_flag_provider()._resolve_team_id() == 5
+
+    @patch.dict(os.environ, {}, clear=False)
+    @override_settings(SELF_CAPTURE=True, E2E_TESTING=False)
+    def test_self_capture_routes_to_dogfood_first_team(self):
+        os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
+        organization = Organization.objects.create(name="Org")
+        first_team = Team.objects.create(organization=organization, name="First")
+
+        assert _build_flag_provider()._resolve_team_id() == first_team.id
+
+    @patch.dict(os.environ, {}, clear=False)
+    @override_settings(SELF_CAPTURE=False, E2E_TESTING=False)
+    def test_falls_back_to_team_2_off_self_capture(self):
+        os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
+
+        assert _build_flag_provider()._resolve_team_id() == 2
+
+    @patch.dict(os.environ, {}, clear=False)
+    @override_settings(SELF_CAPTURE=True, E2E_TESTING=True)
+    def test_e2e_overrides_self_capture_to_team_2(self):
+        os.environ.pop("POSTHOG_SELF_TEAM_ID", None)
+
+        assert _build_flag_provider()._resolve_team_id() == 2

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
 
     from products.dashboards.backend.models.dashboard import Dashboard
     from products.dashboards.backend.models.dashboard_tile import DashboardTile
+    from products.feature_flags.backend.sdk_cache_provider import HyperCacheFlagProvider
     from products.product_analytics.backend.models.insight_variable import InsightVariable
 
 DATERANGE_MAP = {
@@ -736,8 +737,41 @@ def get_dogfood_flags_team_id() -> Optional[int]:
     return team.id if team is not None else None
 
 
+def _build_flag_provider() -> "HyperCacheFlagProvider":
+    """Construct the HyperCache flag-definition provider for this deploy.
+
+    Single source of truth shared by PostHogConfig.ready() (WSGI) and
+    initialize_self_capture_api_token() (ASGI). Callers assign the result to
+    posthoganalytics.flag_definition_cache_provider and handle loading themselves.
+    """
+    from products.feature_flags.backend.sdk_cache_provider import (  # noqa: PLC0415 — keeps the heavy dep off the import path
+        HyperCacheFlagProvider,
+    )
+
+    explicit_team_id = os.environ.get("POSTHOG_SELF_TEAM_ID")
+    if explicit_team_id:
+        # Operator override: pin the flag-definitions team explicitly.
+        # Truthiness, not `is not None`: an empty env var means "unset" and must
+        # fall through to the defaults below, not crash on int("").
+        return HyperCacheFlagProvider.for_static_team(int(explicit_team_id))
+    if settings.SELF_CAPTURE and not settings.E2E_TESTING:
+        # Local/self-hosted: read flag definitions from the dogfood team
+        # (project.teams.first()), resolved lazily once teams/migrations exist.
+        # Intentionally the FIRST team, not self-capture's current_team — see
+        # resolve_dogfood_flags_team().
+        return HyperCacheFlagProvider.for_dynamic_resolution(get_dogfood_flags_team_id)
+    # Cloud (SELF_CAPTURE off) or E2E: the canonical PostHog-internal team is 2.
+    return HyperCacheFlagProvider.for_static_team(2)
+
+
 async def initialize_self_capture_api_token():
-    """Configures `posthoganalytics` for self-capture, in an ASGI-compatible, async way."""
+    """Configure `posthoganalytics` for self-capture, ASGI-compatible (async).
+
+    Overwrites process-global SDK config (api_key, host, disabled, and the
+    flag-definition cache provider) from the DB-resolved self-capture team — the
+    async counterpart to PostHogConfig.ready()'s WSGI path. Mainly the local dev
+    self-capture bootstrap; also invoked by the Dagster PostHogAnalyticsResource.
+    """
     team = await sync_to_async(resolve_self_capture_team)()
     local_api_key = team.api_token if team else None
 
@@ -747,26 +781,12 @@ async def initialize_self_capture_api_token():
         posthoganalytics.api_key = local_api_key
         posthoganalytics.host = settings.SITE_URL
 
-        # PostHogConfig.ready() only wires up the flag-definition cache provider and loads
-        # flag definitions when posthoganalytics is enabled at that point — true for WSGI
-        # (self-capture initialized synchronously in ready()) but NOT for ASGI, where
-        # self-capture is deferred to here. Without this, the ASGI process has no local flag
-        # definitions and falls back to a remote flags call against SITE_URL (unreachable
-        # server-side in dev), so internal feature_enabled() checks always return False.
-        # Mirror the ready() setup so ASGI evaluates flags from HyperCache like WSGI does.
-        from products.feature_flags.backend.sdk_cache_provider import (  # noqa: PLC0415 — keeps the heavy dep off the import path
-            HyperCacheFlagProvider,
-        )
-
-        explicit_team_id = os.environ.get("POSTHOG_SELF_TEAM_ID")
-        if explicit_team_id:
-            provider = HyperCacheFlagProvider.for_static_team(int(explicit_team_id))
-        elif settings.SELF_CAPTURE and not settings.E2E_TESTING:
-            provider = HyperCacheFlagProvider.for_dynamic_resolution(get_dogfood_flags_team_id)
-        else:
-            provider = HyperCacheFlagProvider.for_static_team(2)
-
-        posthoganalytics.flag_definition_cache_provider = provider  # ty: ignore[invalid-assignment]
+        # ready() wires the flag-definition provider only when posthoganalytics is enabled at
+        # that point — true for WSGI but NOT for ASGI, where self-capture is deferred to here.
+        # Without this the ASGI process has no local flag definitions and falls back to a remote
+        # flags call against SITE_URL (unreachable server-side in dev), so feature_enabled()
+        # always returns False. Mirror ready() so ASGI evaluates flags from HyperCache too.
+        posthoganalytics.flag_definition_cache_provider = _build_flag_provider()  # ty: ignore[invalid-assignment]
 
         if posthoganalytics.feature_flag_definitions() is None:
             await sync_to_async(posthoganalytics.load_feature_flags)()

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -747,6 +747,30 @@ async def initialize_self_capture_api_token():
         posthoganalytics.api_key = local_api_key
         posthoganalytics.host = settings.SITE_URL
 
+        # PostHogConfig.ready() only wires up the flag-definition cache provider and loads
+        # flag definitions when posthoganalytics is enabled at that point — true for WSGI
+        # (self-capture initialized synchronously in ready()) but NOT for ASGI, where
+        # self-capture is deferred to here. Without this, the ASGI process has no local flag
+        # definitions and falls back to a remote flags call against SITE_URL (unreachable
+        # server-side in dev), so internal feature_enabled() checks always return False.
+        # Mirror the ready() setup so ASGI evaluates flags from HyperCache like WSGI does.
+        from products.feature_flags.backend.sdk_cache_provider import (  # noqa: PLC0415 — keeps the heavy dep off the import path
+            HyperCacheFlagProvider,
+        )
+
+        explicit_team_id = os.environ.get("POSTHOG_SELF_TEAM_ID")
+        if explicit_team_id:
+            provider = HyperCacheFlagProvider.for_static_team(int(explicit_team_id))
+        elif settings.SELF_CAPTURE and not settings.E2E_TESTING:
+            provider = HyperCacheFlagProvider.for_dynamic_resolution(get_dogfood_flags_team_id)
+        else:
+            provider = HyperCacheFlagProvider.for_static_team(2)
+
+        posthoganalytics.flag_definition_cache_provider = provider  # ty: ignore[invalid-assignment]
+
+        if posthoganalytics.feature_flag_definitions() is None:
+            await sync_to_async(posthoganalytics.load_feature_flags)()
+
 
 BOTH_DEFAULTS_PRESENT_TTL_SECONDS = 24 * 60 * 60
 ONE_DEFAULT_PRESENT_TTL_SECONDS = 30 * 60


### PR DESCRIPTION
## Problem

Server-side `posthoganalytics.feature_enabled()` checks always return `False` when the dev server runs under ASGI, even with the flag fully enabled — e.g. notifications never render because the list endpoint is flag-gated.

`PostHogConfig.ready()` only wires up the flag-definition cache provider when self-capture is already enabled, which holds for WSGI but not ASGI (self-capture is deferred to `initialize_self_capture_api_token()`). The ASGI process ends up with no local flag definitions and falls back to a remote flags call against `SITE_URL`, unreachable server-side in local/devbox setups.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Mirror the `ready()` flag-provider setup in `initialize_self_capture_api_token()` so the ASGI dev server evaluates flags from local HyperCache like WSGI does
- Load flag definitions via `sync_to_async` since this init runs on the event loop

This change specifically aims to fix the broken flag evaluation on devboxes, where `SITE_URL` points at an external URL that isn't reachable server-side. No production behavior change expected.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I'm an agent. No automated tests. Manual verification on an ASGI devbox: the flag-gated notifications endpoint returned `count: 0` before and the expected notification after. Ran `ruff check` and the pre-commit `ty` type check.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and fixed with Claude Code. Traced a missing dashboard notification through the delivery path, ruled out the DB row, queryset gates, and client-side flag, then isolated the server-side `feature_enabled()` gate. Confirmed the WSGI-vs-ASGI bootstrap asymmetry by comparing flag evaluation in a `manage.py shell` (WSGI) against the live granian backend (ASGI). Fix deliberately mirrors the existing `apps.py:ready()` provider setup rather than introducing a new path.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
