### PR TITLE
fix(flags): use materialized columns in flag and enrollment queries

### DIFF
--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -42,17 +42,19 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
     if not feature_flag:
         return
 
-    # Get the unique persons enrolled in the feature along with their distinct ID
+    # Get the unique persons enrolled in the feature along with their distinct ID.
+    # Property access (rather than JSONExtractString) lets the HogQL printer use
+    # materialized person-property columns when available.
     response = execute_hogql_query(
         """
         SELECT
             argMax(id, created_at) AS id,
-            JSONExtractString(properties, 'email') AS email,
+            properties.email AS email,
             argMax(pdi.distinct_id, created_at) as distinct_id
         FROM persons
-        WHERE JSONExtractString(properties, {enrollment_key}) = 'true'
-        AND notEmpty(JSONExtractString(properties, 'email'))
-        GROUP BY JSONExtractString(properties, 'email')
+        WHERE properties[{enrollment_key}] = 'true'
+        AND notEmpty(properties.email)
+        GROUP BY properties.email
         LIMIT {limit}
         """,
         placeholders={

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -24,6 +24,7 @@ from posthog.models.team.team import Team
 from products.feature_flags.backend.api.feature_flag import _create_usage_dashboard
 from products.feature_flags.backend.flag_analytics import (
     SDK_LIBRARIES,
+    _enriched_flag_key_expr_sql,
     _extract_sdk_breakdown_from_redis,
     _flag_key_filter_sql,
     capture_team_decide_usage,
@@ -1085,7 +1086,7 @@ class TestFlagKeyFilterSQL(BaseTest):
             sql = _flag_key_filter_sql()
         assert "JSONExtractString(properties, '$feature_flag')" in sql
 
-    def test_uses_materialized_column_when_available(self):
+    def test_uses_escaped_materialized_column_when_available(self):
         fake_column = MagicMock()
         fake_column.name = "mat_$feature_flag"
         with patch(
@@ -1093,5 +1094,37 @@ class TestFlagKeyFilterSQL(BaseTest):
             return_value=fake_column,
         ):
             sql = _flag_key_filter_sql()
-        assert "mat_$feature_flag" in sql
+        assert "`mat_$feature_flag` = %(flag_key)s" in sql
         assert "JSONExtractString" not in sql
+
+
+class TestEnrichedFlagKeyExprSQL(BaseTest):
+    def test_falls_back_to_json_extract_when_not_materialized(self):
+        with patch(
+            "products.feature_flags.backend.flag_analytics.get_materialized_column_for_property",
+            return_value=None,
+        ):
+            sql = _enriched_flag_key_expr_sql()
+        assert sql == "JSONExtractString(properties, 'feature_flag')"
+
+    def test_uses_escaped_materialized_column_when_available(self):
+        fake_column = MagicMock()
+        fake_column.name = "mat_feature_flag"
+        fake_column.is_nullable = False
+        with patch(
+            "products.feature_flags.backend.flag_analytics.get_materialized_column_for_property",
+            return_value=fake_column,
+        ):
+            sql = _enriched_flag_key_expr_sql()
+        assert sql == "`mat_feature_flag`"
+
+    def test_coalesces_nullable_materialized_column(self):
+        fake_column = MagicMock()
+        fake_column.name = "mat_feature_flag"
+        fake_column.is_nullable = True
+        with patch(
+            "products.feature_flags.backend.flag_analytics.get_materialized_column_for_property",
+            return_value=fake_column,
+        ):
+            sql = _enriched_flag_key_expr_sql()
+        assert sql == "ifNull(`mat_feature_flag`, '')"

--- a/products/feature_flags/backend/flag_analytics.py
+++ b/products/feature_flags/backend/flag_analytics.py
@@ -230,11 +230,24 @@ def capture_team_decide_usage(ph_client: "Posthog", team_id: int, team_uuid: str
         capture_exception(error)
 
 
+def _enriched_flag_key_expr_sql() -> str:
+    """SQL expression for the `feature_flag` property, using the materialized column when available.
+
+    This query spans all teams so it can't go through the HogQL printer; the
+    materialized-column lookup has to be done by hand, with a JSONExtractString
+    fallback for instances where the property isn't materialized.
+    """
+    column = get_materialized_column_for_property("events", "properties", "feature_flag")
+    if column is not None:
+        return column.name
+    return "JSONExtractString(properties, 'feature_flag')"
+
+
 def find_flags_with_enriched_analytics(begin: datetime, end: datetime):
     tag_queries(product=Product.FEATURE_FLAGS, feature=Feature.ENRICHMENT, name="find_flags_with_enriched_analytics")
     result = sync_execute(
-        """
-        SELECT team_id, JSONExtractString(properties, 'feature_flag') as flag_key
+        f"""
+        SELECT team_id, {_enriched_flag_key_expr_sql()} as flag_key
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s AND event = '$feature_view'
         GROUP BY team_id, flag_key

--- a/products/feature_flags/backend/flag_analytics.py
+++ b/products/feature_flags/backend/flag_analytics.py
@@ -247,17 +247,18 @@ def _enriched_flag_key_expr_sql() -> str:
     return f"`{column.name}`"
 
 
-def find_flags_with_enriched_analytics(begin: datetime, end: datetime):
-    tag_queries(product=Product.FEATURE_FLAGS, feature=Feature.ENRICHMENT, name="find_flags_with_enriched_analytics")
-    result = sync_execute(
-        f"""
+def _build_enriched_analytics_query() -> str:
+    return f"""
         SELECT team_id, {_enriched_flag_key_expr_sql()} as flag_key
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s AND event = '$feature_view'
         GROUP BY team_id, flag_key
-    """,
-        {"begin": begin, "end": end},
-    )
+    """
+
+
+def find_flags_with_enriched_analytics(begin: datetime, end: datetime):
+    tag_queries(product=Product.FEATURE_FLAGS, feature=Feature.ENRICHMENT, name="find_flags_with_enriched_analytics")
+    result = sync_execute(_build_enriched_analytics_query(), {"begin": begin, "end": end})
 
     for row in result:
         team_id = row[0]

--- a/products/feature_flags/backend/flag_analytics.py
+++ b/products/feature_flags/backend/flag_analytics.py
@@ -235,12 +235,16 @@ def _enriched_flag_key_expr_sql() -> str:
 
     This query spans all teams so it can't go through the HogQL printer; the
     materialized-column lookup has to be done by hand, with a JSONExtractString
-    fallback for instances where the property isn't materialized.
+    fallback for instances where the property isn't materialized. Nullable
+    columns are coalesced to '' to match JSONExtractString's missing-property
+    behavior.
     """
     column = get_materialized_column_for_property("events", "properties", "feature_flag")
-    if column is not None:
-        return column.name
-    return "JSONExtractString(properties, 'feature_flag')"
+    if column is None:
+        return "JSONExtractString(properties, 'feature_flag')"
+    if column.is_nullable:
+        return f"ifNull(`{column.name}`, '')"
+    return f"`{column.name}`"
 
 
 def find_flags_with_enriched_analytics(begin: datetime, end: datetime):
@@ -286,7 +290,10 @@ def _flag_key_filter_sql() -> str:
     """
     column = get_materialized_column_for_property("events", "properties", "$feature_flag")
     if column is not None:
-        return f"{column.name} = %(flag_key)s"
+        # No ifNull for nullable columns: NULL never equals a real flag key,
+        # matching the JSONExtractString('') behavior, and the bare column
+        # keeps any skip index usable.
+        return f"`{column.name}` = %(flag_key)s"
     return "JSONExtractString(properties, '$feature_flag') = %(flag_key)s"
 
 


### PR DESCRIPTION
Ran the `optimizing-clickhouse-and-hogql-queries` as requested in [this Slack chat](https://posthog.slack.com/archives/C02E3BKC78F/p1780996999377719) and this is the outcome.

## Problem

Two scheduled flag jobs parse JSON properties at query time instead of reading materialized columns:

- The early access feature stage-change task selects, filters, and groups persons with `JSONExtractString(properties, ...)`. Explicit JSON extraction bypasses the HogQL printer's materialized-column substitution, so the query parses the full `properties` blob for every person row even when a materialized column exists.
- `find_flags_with_enriched_analytics` scans every `$feature_view` event across all teams with `JSONExtractString(properties, 'feature_flag')`, with no materialized-column lookup at all.

## Changes

- `early_access_feature.py`: switch the enrollment query to HogQL property access (`properties.email`, `properties[{enrollment_key}]`). The printer now emits a direct materialized column read (`pmat_email`) where one exists and falls back to JSON extraction where it doesn't.
- `flag_analytics.py`: add `_enriched_flag_key_expr_sql()`, which resolves the `feature_flag` property via `get_materialized_column_for_property` with a `JSONExtractString` fallback. This query spans all teams so it can't go through `execute_hogql_query`; the hand-rolled lookup mirrors the existing `_flag_key_filter_sql()` pattern in the same file.

Both changes are fallback-safe: on instances where the properties aren't materialized, the generated SQL is equivalent to what these queries produce today.

## How did you test this code?

- Existing suites pass: `posthog/tasks/test/test_early_access_feature.py` and `products/feature_flags/backend/test/test_flag_analytics.py`.
- Inspected the printed SQL locally: `properties.email` resolves to `nullIf(nullIf(person.pmat_email, ''), 'null')` (direct column read, including in the where-optimization pushdown subquery), and the per-flag enrollment key correctly falls back to `JSONExtractRaw`.
- Ran the old and new enrollment queries side by side against local ClickHouse; both execute and return identical results.
- End-to-end locally: enrolled a person via a captured `$feature_enrollment_update` event with `$set`, then ran the changed enrollment query and confirmed it returns the person's id, email, and distinct_id.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?