### PR TITLE
fix(experiments): clicking a tag selects all its shared metrics across pages

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -27,20 +27,23 @@ export function SharedMetricModal({
         isModalOpen,
         context,
         compatibleSharedMetrics,
+        displayedMetrics,
+        availableTags,
+        filterTags,
         searchTerm,
-        canLoadMore,
         sharedMetricsResponseLoading,
+        isLoadingAllSharedMetrics,
         hasAnyCompatibleSharedMetrics,
         selectedMetricIds,
     } = useValues(sharedMetricModalLogic)
     const {
         closeSharedMetricModal,
         setSearchTerm,
-        loadNextSharedMetrics,
         toggleSelectedMetricId,
+        setSelectedMetricIds,
         clearSelectedMetricIds,
-        selectAllSelectableMetrics,
-        selectMetricsByTag,
+        toggleFilterTag,
+        clearFilterTags,
     } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
     const { updateSharedMetricTags } = useActions(sharedMetricsLogic)
@@ -61,18 +64,12 @@ export function SharedMetricModal({
         closeSharedMetricModal()
     }
 
-    const alreadyAddedIdsList = experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric)
-    const alreadyAddedIds = new Set(alreadyAddedIdsList)
+    const alreadyAddedIds = new Set(experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric))
 
-    // Already-added metrics stay visible but are not selectable.
-    const selectableMetrics = compatibleSharedMetrics.filter((metric: SharedMetric) => !alreadyAddedIds.has(metric.id))
-
-    /**
-     * we need to get the tags from the metrics that can be added to the experiment
-     */
-    const availableTags = Array.from(
-        new Set(selectableMetrics.flatMap((metric: SharedMetric) => metric.tags ?? []).filter(Boolean))
-    ).sort()
+    // Ids of the currently displayed metrics (after tag filtering) that can still be added.
+    const displayedSelectableIds = displayedMetrics
+        .filter((metric: SharedMetric) => !alreadyAddedIds.has(metric.id))
+        .map((metric: SharedMetric) => metric.id)
 
     return (
         <LemonModal
@@ -123,14 +120,20 @@ export function SharedMetricModal({
                             onChange={setSearchTerm}
                             fullWidth
                         />
-                        <div className="flex flex-wrap gap-2">
+                        <div className="flex flex-wrap gap-2 items-center">
                             <LemonLabel>Quick select:</LemonLabel>
                             <LemonButton
                                 size="xsmall"
                                 type="secondary"
-                                loading={sharedMetricsResponseLoading}
+                                loading={isLoadingAllSharedMetrics}
+                                disabledReason={
+                                    displayedSelectableIds.length === 0 ? 'No metrics to select' : undefined
+                                }
                                 onClick={() => {
-                                    selectAllSelectableMetrics(alreadyAddedIdsList)
+                                    // Add every currently displayed (tag-filtered) metric to the selection.
+                                    setSelectedMetricIds(
+                                        Array.from(new Set([...selectedMetricIds, ...displayedSelectableIds]))
+                                    )
                                 }}
                             >
                                 All
@@ -146,24 +149,40 @@ export function SharedMetricModal({
                                     Clear
                                 </LemonButton>
                             )}
-                            {availableTags.map((tag: string, index: number) => (
-                                <LemonButton
-                                    key={index}
-                                    size="xsmall"
-                                    type="secondary"
-                                    loading={sharedMetricsResponseLoading}
-                                    onClick={() => {
-                                        selectMetricsByTag(tag, alreadyAddedIdsList)
-                                    }}
-                                >
-                                    {tag}
-                                </LemonButton>
-                            ))}
                         </div>
+                        {availableTags.length > 0 && (
+                            <div className="flex flex-wrap gap-2 items-center">
+                                <LemonLabel>Filter by tag:</LemonLabel>
+                                {availableTags.map((tag: string) => (
+                                    <LemonButton
+                                        key={tag}
+                                        size="xsmall"
+                                        type="secondary"
+                                        active={filterTags.includes(tag)}
+                                        onClick={() => {
+                                            toggleFilterTag(tag)
+                                        }}
+                                    >
+                                        {tag}
+                                    </LemonButton>
+                                ))}
+                                {filterTags.length > 0 && (
+                                    <LemonButton size="xsmall" type="tertiary" onClick={() => clearFilterTags()}>
+                                        Clear filters
+                                    </LemonButton>
+                                )}
+                            </div>
+                        )}
                         <LemonTable
-                            dataSource={compatibleSharedMetrics}
-                            loading={sharedMetricsResponseLoading}
-                            emptyState={<div>No shared metrics match your search.</div>}
+                            dataSource={displayedMetrics}
+                            loading={sharedMetricsResponseLoading && displayedMetrics.length === 0}
+                            emptyState={
+                                filterTags.length > 0 ? (
+                                    <div>No shared metrics match the selected tags.</div>
+                                ) : (
+                                    <div>No shared metrics match your search.</div>
+                                )
+                            }
                             columns={[
                                 {
                                     title: '',
@@ -222,14 +241,8 @@ export function SharedMetricModal({
                             ]}
                             footer={
                                 <div className="flex flex-col items-center gap-2 m-2">
-                                    {canLoadMore && (
-                                        <LemonButton
-                                            type="secondary"
-                                            onClick={loadNextSharedMetrics}
-                                            loading={sharedMetricsResponseLoading}
-                                        >
-                                            Load more metrics
-                                        </LemonButton>
+                                    {isLoadingAllSharedMetrics && displayedMetrics.length > 0 && (
+                                        <span className="text-secondary text-xs">Loading all metrics…</span>
                                     )}
                                     <Link to={`${urls.experiments()}?tab=shared-metrics`} target="_blank">
                                         See all shared metrics

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
 import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonModal, Link } from '@posthog/lemon-ui'
 
@@ -32,13 +31,20 @@ export function SharedMetricModal({
         canLoadMore,
         sharedMetricsResponseLoading,
         hasAnyCompatibleSharedMetrics,
+        selectedMetricIds,
     } = useValues(sharedMetricModalLogic)
-    const { closeSharedMetricModal, setSearchTerm, loadNextSharedMetrics } = useActions(sharedMetricModalLogic)
+    const {
+        closeSharedMetricModal,
+        setSearchTerm,
+        loadNextSharedMetrics,
+        toggleSelectedMetricId,
+        clearSelectedMetricIds,
+        selectAllSelectableMetrics,
+        selectMetricsByTag,
+    } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
     const { updateSharedMetricTags } = useActions(sharedMetricsLogic)
     const { tags: allTags } = useValues(tagsModel)
-
-    const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
 
     if (!compatibleSharedMetrics) {
         return null
@@ -51,11 +57,12 @@ export function SharedMetricModal({
     }
 
     const closeModal = (): void => {
-        setSelectedMetricIds([])
+        clearSelectedMetricIds()
         closeSharedMetricModal()
     }
 
-    const alreadyAddedIds = new Set(experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric))
+    const alreadyAddedIdsList = experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric)
+    const alreadyAddedIds = new Set(alreadyAddedIdsList)
 
     // Already-added metrics stay visible but are not selectable.
     const selectableMetrics = compatibleSharedMetrics.filter((metric: SharedMetric) => !alreadyAddedIds.has(metric.id))
@@ -88,7 +95,7 @@ export function SharedMetricModal({
                                     .filter((metric): metric is SharedMetric => metric !== undefined)
 
                                 onSave(metrics, context)
-                                setSelectedMetricIds([])
+                                clearSelectedMetricIds()
                             }}
                             type="primary"
                             disabledReason={addSharedMetricDisabledReason()}
@@ -121,8 +128,9 @@ export function SharedMetricModal({
                             <LemonButton
                                 size="xsmall"
                                 type="secondary"
+                                loading={sharedMetricsResponseLoading}
                                 onClick={() => {
-                                    setSelectedMetricIds(selectableMetrics.map((metric: SharedMetric) => metric.id))
+                                    selectAllSelectableMetrics(alreadyAddedIdsList)
                                 }}
                             >
                                 All
@@ -132,7 +140,7 @@ export function SharedMetricModal({
                                     size="xsmall"
                                     type="secondary"
                                     onClick={() => {
-                                        setSelectedMetricIds([])
+                                        clearSelectedMetricIds()
                                     }}
                                 >
                                     Clear
@@ -143,12 +151,9 @@ export function SharedMetricModal({
                                     key={index}
                                     size="xsmall"
                                     type="secondary"
+                                    loading={sharedMetricsResponseLoading}
                                     onClick={() => {
-                                        setSelectedMetricIds(
-                                            selectableMetrics
-                                                .filter((metric: SharedMetric) => metric.tags?.includes(tag))
-                                                .map((metric: SharedMetric) => metric.id)
-                                        )
+                                        selectMetricsByTag(tag, alreadyAddedIdsList)
                                     }}
                                 >
                                     {tag}
@@ -168,14 +173,8 @@ export function SharedMetricModal({
                                             type="checkbox"
                                             disabled={alreadyAddedIds.has(metric.id)}
                                             checked={selectedMetricIds.includes(metric.id)}
-                                            onChange={(e) => {
-                                                if (e.target.checked) {
-                                                    setSelectedMetricIds([...selectedMetricIds, metric.id])
-                                                } else {
-                                                    setSelectedMetricIds(
-                                                        selectedMetricIds.filter((id) => id !== metric.id)
-                                                    )
-                                                }
+                                            onChange={() => {
+                                                toggleSelectedMetricId(metric.id)
                                             }}
                                         />
                                     ),

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -42,7 +42,7 @@ export function SharedMetricModal({
         toggleSelectedMetricId,
         setSelectedMetricIds,
         clearSelectedMetricIds,
-        toggleFilterTag,
+        selectByTag,
         clearFilterTags,
     } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
@@ -64,7 +64,8 @@ export function SharedMetricModal({
         closeSharedMetricModal()
     }
 
-    const alreadyAddedIds = new Set(experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric))
+    const alreadyAddedIdsList = experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric)
+    const alreadyAddedIds = new Set(alreadyAddedIdsList)
 
     // Ids of the currently displayed metrics (after tag filtering) that can still be added.
     const displayedSelectableIds = displayedMetrics
@@ -152,15 +153,17 @@ export function SharedMetricModal({
                         </div>
                         {availableTags.length > 0 && (
                             <div className="flex flex-wrap gap-2 items-center">
-                                <LemonLabel>Filter by tag:</LemonLabel>
+                                <LemonLabel>Select by tag:</LemonLabel>
                                 {availableTags.map((tag: string) => (
                                     <LemonButton
                                         key={tag}
                                         size="xsmall"
                                         type="secondary"
                                         active={filterTags.includes(tag)}
+                                        loading={isLoadingAllSharedMetrics && filterTags.includes(tag)}
                                         onClick={() => {
-                                            toggleFilterTag(tag)
+                                            // Selects (and shows) every metric carrying this tag, across all pages.
+                                            selectByTag(tag, alreadyAddedIdsList)
                                         }}
                                     >
                                         {tag}
@@ -168,7 +171,7 @@ export function SharedMetricModal({
                                 ))}
                                 {filterTags.length > 0 && (
                                     <LemonButton size="xsmall" type="tertiary" onClick={() => clearFilterTags()}>
-                                        Clear filters
+                                        Show all
                                     </LemonButton>
                                 )}
                             </div>

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -160,9 +160,13 @@ export function SharedMetricModal({
                                         size="xsmall"
                                         type="secondary"
                                         active={filterTags.includes(tag)}
-                                        loading={isLoadingAllSharedMetrics && filterTags.includes(tag)}
+                                        // Wait for every page so clicking a tag selects all of its metrics.
+                                        disabledReason={
+                                            isLoadingAllSharedMetrics ? 'Loading all metrics…' : undefined
+                                        }
                                         onClick={() => {
-                                            // Selects (and shows) every metric carrying this tag, across all pages.
+                                            // Toggle this tag: selects (and shows) every metric carrying it, across
+                                            // all pages — or deselects them if it was already active.
                                             selectByTag(tag, alreadyAddedIdsList)
                                         }}
                                     >

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -161,9 +161,7 @@ export function SharedMetricModal({
                                         type="secondary"
                                         active={filterTags.includes(tag)}
                                         // Wait for every page so clicking a tag selects all of its metrics.
-                                        disabledReason={
-                                            isLoadingAllSharedMetrics ? 'Loading all metrics…' : undefined
-                                        }
+                                        disabledReason={isLoadingAllSharedMetrics ? 'Loading all metrics…' : undefined}
                                         onClick={() => {
                                             // Toggle this tag: selects (and shows) every metric carrying it, across
                                             // all pages — or deselects them if it was already active.

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -29,17 +29,22 @@ describe('sharedMetricModalLogic', () => {
                         return [200, { count: 0, next: null, previous: null, results: [] }]
                     }
                     if (offset === 0) {
+                        // metric 1 (kept) + metric 2 (incompatible kind, filtered out) on page 1
                         return [
                             200,
                             {
                                 count: 3,
                                 next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}&search=${search}`,
                                 previous: null,
-                                results: [metric(1), metric(2, NodeKind.ExperimentTrendsQuery)],
+                                results: [metric(1, NodeKind.ExperimentMetric, ['main']), metric(2, NodeKind.ExperimentTrendsQuery)],
                             },
                         ]
                     }
-                    return [200, { count: 3, next: null, previous: null, results: [metric(3)] }]
+                    // metric 3 lives on the second page and carries a tag absent from page 1
+                    return [
+                        200,
+                        { count: 3, next: null, previous: null, results: [metric(3, NodeKind.ExperimentMetric, ['secondary'])] },
+                    ]
                 },
             },
         })
@@ -50,57 +55,105 @@ describe('sharedMetricModalLogic', () => {
 
     afterEach(() => logic.unmount())
 
-    it('openSharedMetricModal resets search and loads page 1 with limit 20 offset 0', async () => {
+    it('openSharedMetricModal resets search and requests page 1 with limit 20 offset 0', async () => {
         jest.spyOn(api, 'get')
         await expectLogic(logic, () => {
             logic.actions.setSearchTerm('stale')
             logic.actions.openSharedMetricModal(METRIC_CONTEXTS.primary)
         }).toFinishAllListeners()
         await expectLogic(logic).toMatchValues({ searchTerm: '' })
-        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining(`limit=${MODAL_PAGE_SIZE}`))
-        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining('offset=0'))
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining(`limit=${MODAL_PAGE_SIZE}`))
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining('offset=0'))
     })
 
-    it('compatibleSharedMetrics filters out non-ExperimentMetric kinds', async () => {
+    it('loading eagerly pulls in every page so compatible metrics span all of them', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
-        }).toFinishAllListeners()
-        await expectLogic(logic).toMatchValues({
-            compatibleSharedMetrics: [expect.objectContaining({ id: 1 })],
-            canLoadMore: true,
+        })
+            .toDispatchActions(['loadSharedMetricsSuccess', 'loadAllSharedMetrics', 'loadAllSharedMetricsSuccess'])
+            .toMatchValues({
+                // metric 2 (incompatible kind) is excluded; metric 3 comes from the second page
+                compatibleSharedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
+                displayedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
+            })
+    })
+
+    it('availableTags covers tags from every page, not just the rendered one', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+        // "secondary" only exists on the second page, which the eager load brought in
+        await expectLogic(logic).toMatchValues({ availableTags: ['main', 'secondary'] })
+    })
+
+    it('toggleFilterTag narrows displayedMetrics to matching metrics across pages', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+
+        await expectLogic(logic, () => {
+            logic.actions.toggleFilterTag('secondary')
+        }).toMatchValues({
+            filterTags: ['secondary'],
+            displayedMetrics: [expect.objectContaining({ id: 3 })],
+        })
+
+        // a second tag widens the filter (OR semantics)
+        await expectLogic(logic, () => {
+            logic.actions.toggleFilterTag('main')
+        }).toMatchValues({
+            displayedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
+        })
+
+        // toggling the same tag again removes it
+        await expectLogic(logic, () => {
+            logic.actions.toggleFilterTag('secondary')
+        }).toMatchValues({
+            filterTags: ['main'],
+            displayedMetrics: [expect.objectContaining({ id: 1 })],
         })
     })
 
-    it('loadNextSharedMetrics appends the next page', async () => {
+    it('clearFilterTags restores the full list', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
-        }).toFinishAllListeners()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+        logic.actions.toggleFilterTag('main')
         await expectLogic(logic, () => {
-            logic.actions.loadNextSharedMetrics(null)
-        }).toFinishAllListeners()
-        await expectLogic(logic).toMatchValues({
-            compatibleSharedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
-            canLoadMore: false,
+            logic.actions.clearFilterTags()
+        }).toMatchValues({
+            filterTags: [],
+            displayedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
         })
     })
 
-    it('setSearchTerm triggers a debounced reload with search and replaces results', async () => {
+    it('setSearchTerm reloads with the search term and clears any active tag filter', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
-        }).toFinishAllListeners()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+        logic.actions.toggleFilterTag('main')
 
         jest.spyOn(api, 'get')
         await expectLogic(logic, () => {
             logic.actions.setSearchTerm('revenue')
-        }).toFinishAllListeners()
-        expect(api.get).toHaveBeenLastCalledWith(expect.stringContaining('search=revenue'))
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining('search=revenue'))
         await expectLogic(logic).toMatchValues({
-            compatibleSharedMetrics: [expect.objectContaining({ id: 1 })],
+            filterTags: [],
+            compatibleSharedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
         })
     })
 
+    it('toggleSelectedMetricId adds then removes a metric id', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.toggleSelectedMetricId(5)
+        }).toMatchValues({ selectedMetricIds: [5] })
+        await expectLogic(logic, () => {
+            logic.actions.toggleSelectedMetricId(5)
+        }).toMatchValues({ selectedMetricIds: [] })
+    })
+
     it('tracks hasAnyCompatibleSharedMetrics from the unfiltered baseline, not the current search', async () => {
-        // initial unfiltered load establishes that compatible metrics exist
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
         }).toFinishAllListeners()
@@ -114,85 +167,6 @@ describe('sharedMetricModalLogic', () => {
             compatibleSharedMetrics: [],
             hasAnyCompatibleSharedMetrics: true,
         })
-    })
-
-    it('selectMetricsByTag pulls in metrics from unloaded pages before selecting', async () => {
-        useMocks({
-            get: {
-                '/api/projects/:team_id/experiment_saved_metrics': (req) => {
-                    const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
-                    if (offset === 0) {
-                        return [
-                            200,
-                            {
-                                count: 2,
-                                next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}`,
-                                previous: null,
-                                results: [metric(1, NodeKind.ExperimentMetric, ['main'])],
-                            },
-                        ]
-                    }
-                    // metric 3 shares the "main" tag but lives on a page that has not been rendered yet
-                    return [
-                        200,
-                        { count: 2, next: null, previous: null, results: [metric(3, NodeKind.ExperimentMetric, ['main'])] },
-                    ]
-                },
-            },
-        })
-
-        // only the first page is loaded, so metric 3 is not yet in memory
-        await expectLogic(logic, () => {
-            logic.actions.loadSharedMetrics()
-        }).toFinishAllListeners()
-        await expectLogic(logic).toMatchValues({ canLoadMore: true })
-
-        await expectLogic(logic, () => {
-            logic.actions.selectMetricsByTag('main', [])
-        }).toDispatchActions(['loadAllSharedMetrics', 'loadAllSharedMetricsSuccess', 'setSelectedMetricIds'])
-
-        await expectLogic(logic).toMatchValues({
-            selectedMetricIds: [1, 3],
-            canLoadMore: false,
-        })
-    })
-
-    it('selectAllSelectableMetrics spans every page and excludes already-added metrics', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.loadSharedMetrics()
-        }).toFinishAllListeners()
-
-        // metric 1 is already on the experiment; metric 3 lives on the unloaded second page
-        await expectLogic(logic, () => {
-            logic.actions.selectAllSelectableMetrics([1])
-        }).toDispatchActions(['loadAllSharedMetrics', 'loadAllSharedMetricsSuccess', 'setSelectedMetricIds'])
-
-        await expectLogic(logic).toMatchValues({ selectedMetricIds: [3] })
-    })
-
-    it('quick-select applies synchronously when every page is already loaded', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.loadSharedMetrics()
-        }).toFinishAllListeners()
-        await expectLogic(logic, () => {
-            logic.actions.loadNextSharedMetrics(null)
-        }).toFinishAllListeners()
-        await expectLogic(logic).toMatchValues({ canLoadMore: false })
-
-        // no further fetch is needed, so the selection is set without loading all pages again
-        await expectLogic(logic, () => {
-            logic.actions.selectAllSelectableMetrics([])
-        }).toDispatchActions(['setSelectedMetricIds'])
-        await expectLogic(logic).toMatchValues({ selectedMetricIds: [1, 3] })
-    })
-
-    it('toggleSelectedMetricId adds then removes a metric id', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.toggleSelectedMetricId(5)
-        }).toMatchValues({ selectedMetricIds: [5] })
-        await expectLogic(logic, () => {
-            logic.actions.toggleSelectedMetricId(5)
-        }).toMatchValues({ selectedMetricIds: [] })
     })
 
     it('hasAnyCompatibleSharedMetrics is false when the unfiltered load has no compatible metrics', async () => {

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -86,52 +86,66 @@ describe('sharedMetricModalLogic', () => {
         await expectLogic(logic).toMatchValues({ availableTags: ['main', 'secondary'] })
     })
 
-    it('toggleFilterTag narrows displayedMetrics to matching metrics across pages', async () => {
+    it('selectByTag selects matching metrics across pages and shows them', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
         }).toDispatchActions(['loadAllSharedMetricsSuccess'])
 
+        // "secondary" only lives on the second page, which was loaded eagerly
         await expectLogic(logic, () => {
-            logic.actions.toggleFilterTag('secondary')
+            logic.actions.selectByTag('secondary', [])
         }).toMatchValues({
             filterTags: ['secondary'],
+            selectedMetricIds: [3],
             displayedMetrics: [expect.objectContaining({ id: 3 })],
         })
+    })
 
-        // a second tag widens the filter (OR semantics)
+    it('selectByTag excludes already-added metrics from the selection', async () => {
         await expectLogic(logic, () => {
-            logic.actions.toggleFilterTag('main')
-        }).toMatchValues({
-            displayedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
-        })
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
 
-        // toggling the same tag again removes it
+        // metric 1 carries "main" but is already on the experiment, so it must not be selected
         await expectLogic(logic, () => {
-            logic.actions.toggleFilterTag('secondary')
+            logic.actions.selectByTag('main', [1])
         }).toMatchValues({
             filterTags: ['main'],
-            displayedMetrics: [expect.objectContaining({ id: 1 })],
+            selectedMetricIds: [],
         })
     })
 
-    it('clearFilterTags restores the full list', async () => {
+    it('clicking the active tag again clears its selection and filter', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
         }).toDispatchActions(['loadAllSharedMetricsSuccess'])
-        logic.actions.toggleFilterTag('main')
+
         await expectLogic(logic, () => {
-            logic.actions.clearFilterTags()
-        }).toMatchValues({
-            filterTags: [],
-            displayedMetrics: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 3 })],
-        })
+            logic.actions.selectByTag('secondary', [])
+        }).toMatchValues({ filterTags: ['secondary'], selectedMetricIds: [3] })
+
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('secondary', [])
+        }).toMatchValues({ filterTags: [], selectedMetricIds: [] })
     })
 
-    it('setSearchTerm reloads with the search term and clears any active tag filter', async () => {
+    it('selectByTag triggers a load when more pages remain, then selects across them', async () => {
+        // load only the first page, without waiting for the eager background load to finish
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
         }).toDispatchActions(['loadAllSharedMetricsSuccess'])
-        logic.actions.toggleFilterTag('main')
+
+        // metric 3 ("secondary") came from the second page — selecting its tag picks it up
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('secondary', [])
+        }).toMatchValues({ selectedMetricIds: [3] })
+    })
+
+    it('setSearchTerm reloads with the search term and clears any active tag selection', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+        logic.actions.selectByTag('main', [])
 
         jest.spyOn(api, 'get')
         await expectLogic(logic, () => {

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -36,14 +36,22 @@ describe('sharedMetricModalLogic', () => {
                                 count: 3,
                                 next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}&search=${search}`,
                                 previous: null,
-                                results: [metric(1, NodeKind.ExperimentMetric, ['main']), metric(2, NodeKind.ExperimentTrendsQuery)],
+                                results: [
+                                    metric(1, NodeKind.ExperimentMetric, ['main']),
+                                    metric(2, NodeKind.ExperimentTrendsQuery),
+                                ],
                             },
                         ]
                     }
                     // metric 3 lives on the second page and carries a tag absent from page 1
                     return [
                         200,
-                        { count: 3, next: null, previous: null, results: [metric(3, NodeKind.ExperimentMetric, ['secondary'])] },
+                        {
+                            count: 3,
+                            next: null,
+                            previous: null,
+                            results: [metric(3, NodeKind.ExperimentMetric, ['secondary'])],
+                        },
                     ]
                 },
             },

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -9,10 +9,11 @@ import { initKeaTests } from '~/test/init'
 import { METRIC_CONTEXTS } from './experimentMetricModalLogic'
 import { MODAL_PAGE_SIZE, sharedMetricModalLogic } from './sharedMetricModalLogic'
 
-const metric = (id: number, kind: NodeKind = NodeKind.ExperimentMetric): any => ({
+const metric = (id: number, kind: NodeKind = NodeKind.ExperimentMetric, tags: string[] = []): any => ({
     id,
     name: `metric ${id}`,
     query: { kind },
+    tags,
 })
 
 describe('sharedMetricModalLogic', () => {
@@ -113,6 +114,85 @@ describe('sharedMetricModalLogic', () => {
             compatibleSharedMetrics: [],
             hasAnyCompatibleSharedMetrics: true,
         })
+    })
+
+    it('selectMetricsByTag pulls in metrics from unloaded pages before selecting', async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': (req) => {
+                    const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
+                    if (offset === 0) {
+                        return [
+                            200,
+                            {
+                                count: 2,
+                                next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}`,
+                                previous: null,
+                                results: [metric(1, NodeKind.ExperimentMetric, ['main'])],
+                            },
+                        ]
+                    }
+                    // metric 3 shares the "main" tag but lives on a page that has not been rendered yet
+                    return [
+                        200,
+                        { count: 2, next: null, previous: null, results: [metric(3, NodeKind.ExperimentMetric, ['main'])] },
+                    ]
+                },
+            },
+        })
+
+        // only the first page is loaded, so metric 3 is not yet in memory
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ canLoadMore: true })
+
+        await expectLogic(logic, () => {
+            logic.actions.selectMetricsByTag('main', [])
+        }).toDispatchActions(['loadAllSharedMetrics', 'loadAllSharedMetricsSuccess', 'setSelectedMetricIds'])
+
+        await expectLogic(logic).toMatchValues({
+            selectedMetricIds: [1, 3],
+            canLoadMore: false,
+        })
+    })
+
+    it('selectAllSelectableMetrics spans every page and excludes already-added metrics', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+
+        // metric 1 is already on the experiment; metric 3 lives on the unloaded second page
+        await expectLogic(logic, () => {
+            logic.actions.selectAllSelectableMetrics([1])
+        }).toDispatchActions(['loadAllSharedMetrics', 'loadAllSharedMetricsSuccess', 'setSelectedMetricIds'])
+
+        await expectLogic(logic).toMatchValues({ selectedMetricIds: [3] })
+    })
+
+    it('quick-select applies synchronously when every page is already loaded', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toFinishAllListeners()
+        await expectLogic(logic, () => {
+            logic.actions.loadNextSharedMetrics(null)
+        }).toFinishAllListeners()
+        await expectLogic(logic).toMatchValues({ canLoadMore: false })
+
+        // no further fetch is needed, so the selection is set without loading all pages again
+        await expectLogic(logic, () => {
+            logic.actions.selectAllSelectableMetrics([])
+        }).toDispatchActions(['setSelectedMetricIds'])
+        await expectLogic(logic).toMatchValues({ selectedMetricIds: [1, 3] })
+    })
+
+    it('toggleSelectedMetricId adds then removes a metric id', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.toggleSelectedMetricId(5)
+        }).toMatchValues({ selectedMetricIds: [5] })
+        await expectLogic(logic, () => {
+            logic.actions.toggleSelectedMetricId(5)
+        }).toMatchValues({ selectedMetricIds: [] })
     })
 
     it('hasAnyCompatibleSharedMetrics is false when the unfiltered load has no compatible metrics', async () => {

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.test.ts
@@ -86,7 +86,7 @@ describe('sharedMetricModalLogic', () => {
         await expectLogic(logic).toMatchValues({ availableTags: ['main', 'secondary'] })
     })
 
-    it('selectByTag selects matching metrics across pages and shows them', async () => {
+    it('selectByTag selects a tag-matching metric from a page that was not first rendered', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
         }).toDispatchActions(['loadAllSharedMetricsSuccess'])
@@ -98,6 +98,89 @@ describe('sharedMetricModalLogic', () => {
             filterTags: ['secondary'],
             selectedMetricIds: [3],
             displayedMetrics: [expect.objectContaining({ id: 3 })],
+        })
+    })
+
+    it('tags are additive — clicking multiple tags accumulates the selection', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('main', [])
+        }).toMatchValues({ filterTags: ['main'], selectedMetricIds: [1] })
+
+        // a second tag adds to the selection rather than replacing it
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('secondary', [])
+        }).toMatchValues({
+            filterTags: ['main', 'secondary'],
+            selectedMetricIds: [1, 3],
+        })
+    })
+
+    it('clicking an active tag again deselects only that tag’s metrics', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+
+        logic.actions.selectByTag('main', [])
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('secondary', [])
+        }).toMatchValues({ selectedMetricIds: [1, 3] })
+
+        // toggling "main" back off removes metric 1 but leaves metric 3 (still under "secondary")
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('main', [])
+        }).toMatchValues({
+            filterTags: ['secondary'],
+            selectedMetricIds: [3],
+        })
+    })
+
+    it('a metric covered by another active tag stays selected when one tag is toggled off', async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/experiment_saved_metrics': (req) => {
+                    const offset = parseInt(req.url.searchParams.get('offset') ?? '0')
+                    if (offset === 0) {
+                        return [
+                            200,
+                            {
+                                count: 2,
+                                next: `http://localhost/api/projects/997/experiment_saved_metrics?limit=${MODAL_PAGE_SIZE}&offset=${MODAL_PAGE_SIZE}`,
+                                previous: null,
+                                results: [metric(1, NodeKind.ExperimentMetric, ['main', 'shared'])],
+                            },
+                        ]
+                    }
+                    return [
+                        200,
+                        {
+                            count: 2,
+                            next: null,
+                            previous: null,
+                            results: [metric(3, NodeKind.ExperimentMetric, ['secondary', 'shared'])],
+                        },
+                    ]
+                },
+            },
+        })
+        await expectLogic(logic, () => {
+            logic.actions.loadSharedMetrics()
+        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
+
+        logic.actions.selectByTag('shared', []) // selects metrics 1 and 3 (both carry "shared")
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('main', []) // metric 1 also carries "main"
+        }).toMatchValues({ selectedMetricIds: [1, 3] })
+
+        // toggling "shared" off: metric 1 stays (still under "main"), metric 3 drops
+        await expectLogic(logic, () => {
+            logic.actions.selectByTag('shared', [])
+        }).toMatchValues({
+            filterTags: ['main'],
+            selectedMetricIds: [1],
         })
     })
 
@@ -115,33 +198,7 @@ describe('sharedMetricModalLogic', () => {
         })
     })
 
-    it('clicking the active tag again clears its selection and filter', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.loadSharedMetrics()
-        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
-
-        await expectLogic(logic, () => {
-            logic.actions.selectByTag('secondary', [])
-        }).toMatchValues({ filterTags: ['secondary'], selectedMetricIds: [3] })
-
-        await expectLogic(logic, () => {
-            logic.actions.selectByTag('secondary', [])
-        }).toMatchValues({ filterTags: [], selectedMetricIds: [] })
-    })
-
-    it('selectByTag triggers a load when more pages remain, then selects across them', async () => {
-        // load only the first page, without waiting for the eager background load to finish
-        await expectLogic(logic, () => {
-            logic.actions.loadSharedMetrics()
-        }).toDispatchActions(['loadAllSharedMetricsSuccess'])
-
-        // metric 3 ("secondary") came from the second page — selecting its tag picks it up
-        await expectLogic(logic, () => {
-            logic.actions.selectByTag('secondary', [])
-        }).toMatchValues({ selectedMetricIds: [3] })
-    })
-
-    it('setSearchTerm reloads with the search term and clears any active tag selection', async () => {
+    it('setSearchTerm reloads with the search term and clears any active tag filter', async () => {
         await expectLogic(logic, () => {
             logic.actions.loadSharedMetrics()
         }).toDispatchActions(['loadAllSharedMetricsSuccess'])

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -96,28 +96,17 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                 closeSharedMetricModal: () => [],
             },
         ],
-        // The active tag(s) used both to filter the table and to drive tag-based selection.
-        // Clicking a tag activates it (replacing any previous one); clicking it again clears it.
+        // The active tags used both to filter the table and to drive tag-based selection.
+        // Tags are additive toggles: clicking a tag activates it, clicking it again deactivates it.
         filterTags: [
             [] as string[],
             {
-                selectByTag: (state, { tag }) => (state.length === 1 && state[0] === tag ? [] : [tag]),
+                selectByTag: (state, { tag }) =>
+                    state.includes(tag) ? state.filter((existingTag) => existingTag !== tag) : [...state, tag],
                 clearFilterTags: () => [],
                 setSearchTerm: () => [],
                 openSharedMetricModal: () => [],
                 closeSharedMetricModal: () => [],
-            },
-        ],
-        // The tag selection waiting to be applied once every page has loaded.
-        pendingTagSelection: [
-            null as { tag: string; alreadyAddedIds: SharedMetric['id'][] } | null,
-            {
-                selectByTag: (_, { tag, alreadyAddedIds }) => ({ tag, alreadyAddedIds }),
-                setSelectedMetricIds: () => null,
-                clearSelectedMetricIds: () => null,
-                clearFilterTags: () => null,
-                openSharedMetricModal: () => null,
-                closeSharedMetricModal: () => null,
             },
         ],
     }),
@@ -199,57 +188,47 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
 
-    listeners(({ actions, values }) => {
-        // Select every (still-addable) metric carrying the pending tag. Runs once all pages are loaded.
-        const applyPendingTagSelection = (): void => {
-            const pending = values.pendingTagSelection
-            if (!pending) {
+    listeners(({ actions, values }) => ({
+        openSharedMetricModal: () => {
+            actions.loadSharedMetrics()
+        },
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadSharedMetrics()
+        },
+        loadSharedMetricsSuccess: () => {
+            // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
+            if (!values.searchTerm) {
+                actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+            }
+            // Eagerly pull in the rest of the pages so the tag list and tag selection cover every metric.
+            if (values.sharedMetricsResponse?.next) {
+                actions.loadAllSharedMetrics(null)
+            }
+        },
+        // Additive toggle: clicking a tag selects its metrics, clicking it again deselects them.
+        // The tag buttons stay disabled until the full load finishes, so every page is available here.
+        selectByTag: ({ tag, alreadyAddedIds }) => {
+            const alreadyAdded = new Set(alreadyAddedIds)
+            const tagMetricIds = values.compatibleSharedMetrics
+                .filter((metric) => !alreadyAdded.has(metric.id) && metric.tags?.includes(tag))
+                .map((metric) => metric.id)
+
+            // filterTags already reflects the toggle: present → just activated, absent → just deactivated.
+            if (values.filterTags.includes(tag)) {
+                actions.setSelectedMetricIds(Array.from(new Set([...values.selectedMetricIds, ...tagMetricIds])))
                 return
             }
-            const alreadyAdded = new Set(pending.alreadyAddedIds)
-            const matching = values.compatibleSharedMetrics.filter(
-                (metric) => !alreadyAdded.has(metric.id) && metric.tags?.includes(pending.tag)
+            // Deactivated: drop this tag's metrics unless another active tag still covers them.
+            const activeTags = new Set(values.filterTags)
+            const removableIds = new Set(
+                values.compatibleSharedMetrics
+                    .filter(
+                        (metric) => metric.tags?.includes(tag) && !metric.tags?.some((other) => activeTags.has(other))
+                    )
+                    .map((metric) => metric.id)
             )
-            actions.setSelectedMetricIds(matching.map((metric) => metric.id))
-        }
-        return {
-            openSharedMetricModal: () => {
-                actions.loadSharedMetrics()
-            },
-            setSearchTerm: async (_, breakpoint) => {
-                await breakpoint(300)
-                actions.loadSharedMetrics()
-            },
-            loadSharedMetricsSuccess: () => {
-                // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
-                if (!values.searchTerm) {
-                    actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
-                }
-                // Eagerly pull in the rest of the pages so tag selection covers every metric.
-                if (values.sharedMetricsResponse?.next) {
-                    actions.loadAllSharedMetrics(null)
-                }
-            },
-            selectByTag: () => {
-                // Clicking the active tag again clears the filter and its selection.
-                if (values.filterTags.length === 0) {
-                    actions.clearSelectedMetricIds()
-                    return
-                }
-                // Wait for any in-flight (or still-needed) full load before selecting, so the
-                // selection includes metrics that have not been rendered yet.
-                if (values.sharedMetricsResponseLoading) {
-                    return
-                }
-                if (values.sharedMetricsResponse?.next) {
-                    actions.loadAllSharedMetrics(null)
-                    return
-                }
-                applyPendingTagSelection()
-            },
-            loadAllSharedMetricsSuccess: () => {
-                applyPendingTagSelection()
-            },
-        }
-    }),
+            actions.setSelectedMetricIds(values.selectedMetricIds.filter((id) => !removableIds.has(id)))
+        },
+    })),
 ])

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -34,7 +34,8 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         setSelectedMetricIds: (ids: SharedMetric['id'][]) => ({ ids }),
         toggleSelectedMetricId: (id: SharedMetric['id']) => ({ id }),
         clearSelectedMetricIds: true,
-        toggleFilterTag: (tag: string) => ({ tag }),
+        // Click a tag to select (and show) every metric carrying it, loading any unloaded pages first.
+        selectByTag: (tag: string, alreadyAddedIds: SharedMetric['id'][]) => ({ tag, alreadyAddedIds }),
         clearFilterTags: true,
     }),
 
@@ -95,16 +96,28 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                 closeSharedMetricModal: () => [],
             },
         ],
-        // Tags chosen as a display filter — the metric table only shows metrics carrying one of these.
+        // The active tag(s) used both to filter the table and to drive tag-based selection.
+        // Clicking a tag activates it (replacing any previous one); clicking it again clears it.
         filterTags: [
             [] as string[],
             {
-                toggleFilterTag: (state, { tag }) =>
-                    state.includes(tag) ? state.filter((existingTag) => existingTag !== tag) : [...state, tag],
+                selectByTag: (state, { tag }) => (state.length === 1 && state[0] === tag ? [] : [tag]),
                 clearFilterTags: () => [],
                 setSearchTerm: () => [],
                 openSharedMetricModal: () => [],
                 closeSharedMetricModal: () => [],
+            },
+        ],
+        // The tag selection waiting to be applied once every page has loaded.
+        pendingTagSelection: [
+            null as { tag: string; alreadyAddedIds: SharedMetric['id'][] } | null,
+            {
+                selectByTag: (_, { tag, alreadyAddedIds }) => ({ tag, alreadyAddedIds }),
+                setSelectedMetricIds: () => null,
+                clearSelectedMetricIds: () => null,
+                clearFilterTags: () => null,
+                openSharedMetricModal: () => null,
+                closeSharedMetricModal: () => null,
             },
         ],
     }),
@@ -186,23 +199,57 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
 
-    listeners(({ actions, values }) => ({
-        openSharedMetricModal: () => {
-            actions.loadSharedMetrics()
-        },
-        setSearchTerm: async (_, breakpoint) => {
-            await breakpoint(300)
-            actions.loadSharedMetrics()
-        },
-        loadSharedMetricsSuccess: () => {
-            // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
-            if (!values.searchTerm) {
-                actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+    listeners(({ actions, values }) => {
+        // Select every (still-addable) metric carrying the pending tag. Runs once all pages are loaded.
+        const applyPendingTagSelection = (): void => {
+            const pending = values.pendingTagSelection
+            if (!pending) {
+                return
             }
-            // Eagerly pull in the rest of the pages so the tag filter operates on every metric.
-            if (values.sharedMetricsResponse?.next) {
-                actions.loadAllSharedMetrics()
-            }
-        },
-    })),
+            const alreadyAdded = new Set(pending.alreadyAddedIds)
+            const matching = values.compatibleSharedMetrics.filter(
+                (metric) => !alreadyAdded.has(metric.id) && metric.tags?.includes(pending.tag)
+            )
+            actions.setSelectedMetricIds(matching.map((metric) => metric.id))
+        }
+        return {
+            openSharedMetricModal: () => {
+                actions.loadSharedMetrics()
+            },
+            setSearchTerm: async (_, breakpoint) => {
+                await breakpoint(300)
+                actions.loadSharedMetrics()
+            },
+            loadSharedMetricsSuccess: () => {
+                // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
+                if (!values.searchTerm) {
+                    actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+                }
+                // Eagerly pull in the rest of the pages so tag selection covers every metric.
+                if (values.sharedMetricsResponse?.next) {
+                    actions.loadAllSharedMetrics(null)
+                }
+            },
+            selectByTag: () => {
+                // Clicking the active tag again clears the filter and its selection.
+                if (values.filterTags.length === 0) {
+                    actions.clearSelectedMetricIds()
+                    return
+                }
+                // Wait for any in-flight (or still-needed) full load before selecting, so the
+                // selection includes metrics that have not been rendered yet.
+                if (values.sharedMetricsResponseLoading) {
+                    return
+                }
+                if (values.sharedMetricsResponse?.next) {
+                    actions.loadAllSharedMetrics(null)
+                    return
+                }
+                applyPendingTagSelection()
+            },
+            loadAllSharedMetricsSuccess: () => {
+                applyPendingTagSelection()
+            },
+        }
+    }),
 ])

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -140,13 +140,13 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                         )) as CountedPaginatedResponse<SharedMetric>
                         breakpoint()
                     }
-                    let results = [...(response.results ?? [])]
+                    const results = [...(response.results ?? [])]
                     let next = response.next
                     while (next) {
                         const page: CountedPaginatedResponse<SharedMetric> = await api.get(next)
                         // Abort if a concurrent loadSharedMetrics (e.g. a new search) superseded this load.
                         breakpoint()
-                        results = [...results, ...page.results]
+                        results.push(...page.results)
                         next = page.next
                         response = page
                     }

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -34,9 +34,8 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         setSelectedMetricIds: (ids: SharedMetric['id'][]) => ({ ids }),
         toggleSelectedMetricId: (id: SharedMetric['id']) => ({ id }),
         clearSelectedMetricIds: true,
-        // Quick-select across the whole result set, not just the pages already loaded.
-        selectAllSelectableMetrics: (alreadyAddedIds: SharedMetric['id'][]) => ({ alreadyAddedIds }),
-        selectMetricsByTag: (tag: string, alreadyAddedIds: SharedMetric['id'][]) => ({ tag, alreadyAddedIds }),
+        toggleFilterTag: (tag: string) => ({ tag }),
+        clearFilterTags: true,
     }),
 
     reducers({
@@ -96,16 +95,16 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                 closeSharedMetricModal: () => [],
             },
         ],
-        // A pending quick-select intent kept while the remaining pages load, applied once
-        // every page is in memory so the selection covers metrics beyond the first page.
-        pendingQuickSelect: [
-            null as { tag: string | null; alreadyAddedIds: SharedMetric['id'][] } | null,
+        // Tags chosen as a display filter — the metric table only shows metrics carrying one of these.
+        filterTags: [
+            [] as string[],
             {
-                selectAllSelectableMetrics: (_, { alreadyAddedIds }) => ({ tag: null, alreadyAddedIds }),
-                selectMetricsByTag: (_, { tag, alreadyAddedIds }) => ({ tag, alreadyAddedIds }),
-                setSelectedMetricIds: () => null,
-                openSharedMetricModal: () => null,
-                closeSharedMetricModal: () => null,
+                toggleFilterTag: (state, { tag }) =>
+                    state.includes(tag) ? state.filter((existingTag) => existingTag !== tag) : [...state, tag],
+                clearFilterTags: () => [],
+                setSearchTerm: () => [],
+                openSharedMetricModal: () => [],
+                closeSharedMetricModal: () => [],
             },
         ],
     }),
@@ -124,22 +123,8 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                         `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
                     )) as CountedPaginatedResponse<SharedMetric>
                 },
-                loadNextSharedMetrics: async (_, breakpoint) => {
-                    const next = values.sharedMetricsResponse?.next
-                    if (!next) {
-                        return values.sharedMetricsResponse
-                    }
-                    const baseResults = values.sharedMetricsResponse?.results ?? []
-                    const response: CountedPaginatedResponse<SharedMetric> = await api.get(next)
-                    // Abort if a concurrent loadSharedMetrics (e.g. a new search) superseded this page request.
-                    breakpoint()
-                    return {
-                        ...response,
-                        results: [...baseResults, ...response.results],
-                    }
-                },
-                // Page through every remaining result so quick-select-by-tag operates on the full
-                // set, not just the rows currently rendered in the table.
+                // Page through every remaining result so the tag filter and tag chip list cover the
+                // whole set of shared metrics, not just the first page rendered in the table.
                 loadAllSharedMetrics: async (_, breakpoint) => {
                     let response = values.sharedMetricsResponse
                     if (!response) {
@@ -157,6 +142,7 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                     let next = response.next
                     while (next) {
                         const page: CountedPaginatedResponse<SharedMetric> = await api.get(next)
+                        // Abort if a concurrent loadSharedMetrics (e.g. a new search) superseded this load.
                         breakpoint()
                         results = [...results, ...page.results]
                         next = page.next
@@ -175,56 +161,48 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
             (loadedSharedMetrics: SharedMetric[]): SharedMetric[] =>
                 loadedSharedMetrics.filter((metric) => metric.query.kind === NodeKind.ExperimentMetric),
         ],
-        canLoadMore: [(s) => [s.sharedMetricsResponse], (response): boolean => !!response?.next],
+        // Every tag present across the loaded compatible metrics — shown as filter chips.
+        availableTags: [
+            (s) => [s.compatibleSharedMetrics],
+            (compatibleSharedMetrics: SharedMetric[]): string[] =>
+                Array.from(
+                    new Set(compatibleSharedMetrics.flatMap((metric) => metric.tags ?? []).filter(Boolean))
+                ).sort(),
+        ],
+        // The metrics actually rendered: filtered to the chosen tags when any are active.
+        displayedMetrics: [
+            (s) => [s.compatibleSharedMetrics, s.filterTags],
+            (compatibleSharedMetrics: SharedMetric[], filterTags: string[]): SharedMetric[] =>
+                filterTags.length === 0
+                    ? compatibleSharedMetrics
+                    : compatibleSharedMetrics.filter((metric) => metric.tags?.some((tag) => filterTags.includes(tag))),
+        ],
+        // True while the remaining pages are still being fetched in the background.
+        isLoadingAllSharedMetrics: [
+            (s) => [s.sharedMetricsResponseLoading, s.sharedMetricsResponse],
+            (sharedMetricsResponseLoading: boolean, response: CountedPaginatedResponse<SharedMetric> | null): boolean =>
+                sharedMetricsResponseLoading || !!response?.next,
+        ],
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
 
-    listeners(({ actions, values }) => {
-        // Apply a queued quick-select once every page is loaded, so the selection spans
-        // all metrics matching the tag rather than only the rows already rendered.
-        const applyPendingQuickSelect = (): void => {
-            const pending = values.pendingQuickSelect
-            if (!pending) {
-                return
+    listeners(({ actions, values }) => ({
+        openSharedMetricModal: () => {
+            actions.loadSharedMetrics()
+        },
+        setSearchTerm: async (_, breakpoint) => {
+            await breakpoint(300)
+            actions.loadSharedMetrics()
+        },
+        loadSharedMetricsSuccess: () => {
+            // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
+            if (!values.searchTerm) {
+                actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
             }
-            const alreadyAdded = new Set(pending.alreadyAddedIds)
-            const selectable = values.compatibleSharedMetrics.filter((metric) => !alreadyAdded.has(metric.id))
-            const matched =
-                pending.tag === null
-                    ? selectable
-                    : selectable.filter((metric) => metric.tags?.includes(pending.tag as string))
-            actions.setSelectedMetricIds(matched.map((metric) => metric.id))
-        }
-        const startQuickSelect = (): void => {
-            if (values.canLoadMore) {
+            // Eagerly pull in the rest of the pages so the tag filter operates on every metric.
+            if (values.sharedMetricsResponse?.next) {
                 actions.loadAllSharedMetrics()
-                return
             }
-            applyPendingQuickSelect()
-        }
-        return {
-            openSharedMetricModal: () => {
-                actions.loadSharedMetrics()
-            },
-            setSearchTerm: async (_, breakpoint) => {
-                await breakpoint(300)
-                actions.loadSharedMetrics()
-            },
-            loadSharedMetricsSuccess: () => {
-                // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
-                if (!values.searchTerm) {
-                    actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
-                }
-            },
-            selectAllSelectableMetrics: () => {
-                startQuickSelect()
-            },
-            selectMetricsByTag: () => {
-                startQuickSelect()
-            },
-            loadAllSharedMetricsSuccess: () => {
-                applyPendingQuickSelect()
-            },
-        }
-    }),
+        },
+    })),
 ])

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -31,6 +31,12 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         setSharedMetric: (sharedMetric: SharedMetric) => ({ sharedMetric }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setHasAnyCompatibleSharedMetrics: (hasAny: boolean) => ({ hasAny }),
+        setSelectedMetricIds: (ids: SharedMetric['id'][]) => ({ ids }),
+        toggleSelectedMetricId: (id: SharedMetric['id']) => ({ id }),
+        clearSelectedMetricIds: true,
+        // Quick-select across the whole result set, not just the pages already loaded.
+        selectAllSelectableMetrics: (alreadyAddedIds: SharedMetric['id'][]) => ({ alreadyAddedIds }),
+        selectMetricsByTag: (tag: string, alreadyAddedIds: SharedMetric['id'][]) => ({ tag, alreadyAddedIds }),
     }),
 
     reducers({
@@ -79,6 +85,29 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                 openSharedMetricModal: () => false,
             },
         ],
+        selectedMetricIds: [
+            [] as SharedMetric['id'][],
+            {
+                setSelectedMetricIds: (_, { ids }) => ids,
+                toggleSelectedMetricId: (state, { id }) =>
+                    state.includes(id) ? state.filter((existingId) => existingId !== id) : [...state, id],
+                clearSelectedMetricIds: () => [],
+                openSharedMetricModal: () => [],
+                closeSharedMetricModal: () => [],
+            },
+        ],
+        // A pending quick-select intent kept while the remaining pages load, applied once
+        // every page is in memory so the selection covers metrics beyond the first page.
+        pendingQuickSelect: [
+            null as { tag: string | null; alreadyAddedIds: SharedMetric['id'][] } | null,
+            {
+                selectAllSelectableMetrics: (_, { alreadyAddedIds }) => ({ tag: null, alreadyAddedIds }),
+                selectMetricsByTag: (_, { tag, alreadyAddedIds }) => ({ tag, alreadyAddedIds }),
+                setSelectedMetricIds: () => null,
+                openSharedMetricModal: () => null,
+                closeSharedMetricModal: () => null,
+            },
+        ],
     }),
 
     loaders(({ values }) => ({
@@ -109,6 +138,32 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
                         results: [...baseResults, ...response.results],
                     }
                 },
+                // Page through every remaining result so quick-select-by-tag operates on the full
+                // set, not just the rows currently rendered in the table.
+                loadAllSharedMetrics: async (_, breakpoint) => {
+                    let response = values.sharedMetricsResponse
+                    if (!response) {
+                        const params = toParams({
+                            limit: MODAL_PAGE_SIZE,
+                            offset: 0,
+                            search: values.searchTerm || undefined,
+                        })
+                        response = (await api.get(
+                            `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
+                        )) as CountedPaginatedResponse<SharedMetric>
+                        breakpoint()
+                    }
+                    let results = [...(response.results ?? [])]
+                    let next = response.next
+                    while (next) {
+                        const page: CountedPaginatedResponse<SharedMetric> = await api.get(next)
+                        breakpoint()
+                        results = [...results, ...page.results]
+                        next = page.next
+                        response = page
+                    }
+                    return { ...response, results, next: null }
+                },
             },
         ],
     })),
@@ -124,19 +179,52 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         isCreateMode: [(s) => [s.isEditMode], (isEditMode: boolean) => !isEditMode],
     }),
 
-    listeners(({ actions, values }) => ({
-        openSharedMetricModal: () => {
-            actions.loadSharedMetrics()
-        },
-        setSearchTerm: async (_, breakpoint) => {
-            await breakpoint(300)
-            actions.loadSharedMetrics()
-        },
-        loadSharedMetricsSuccess: () => {
-            // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
-            if (!values.searchTerm) {
-                actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+    listeners(({ actions, values }) => {
+        // Apply a queued quick-select once every page is loaded, so the selection spans
+        // all metrics matching the tag rather than only the rows already rendered.
+        const applyPendingQuickSelect = (): void => {
+            const pending = values.pendingQuickSelect
+            if (!pending) {
+                return
             }
-        },
-    })),
+            const alreadyAdded = new Set(pending.alreadyAddedIds)
+            const selectable = values.compatibleSharedMetrics.filter((metric) => !alreadyAdded.has(metric.id))
+            const matched =
+                pending.tag === null
+                    ? selectable
+                    : selectable.filter((metric) => metric.tags?.includes(pending.tag as string))
+            actions.setSelectedMetricIds(matched.map((metric) => metric.id))
+        }
+        const startQuickSelect = (): void => {
+            if (values.canLoadMore) {
+                actions.loadAllSharedMetrics()
+                return
+            }
+            applyPendingQuickSelect()
+        }
+        return {
+            openSharedMetricModal: () => {
+                actions.loadSharedMetrics()
+            },
+            setSearchTerm: async (_, breakpoint) => {
+                await breakpoint(300)
+                actions.loadSharedMetrics()
+            },
+            loadSharedMetricsSuccess: () => {
+                // Only the unfiltered load establishes the baseline "are there any compatible metrics" answer.
+                if (!values.searchTerm) {
+                    actions.setHasAnyCompatibleSharedMetrics(values.compatibleSharedMetrics.length > 0)
+                }
+            },
+            selectAllSelectableMetrics: () => {
+                startQuickSelect()
+            },
+            selectMetricsByTag: () => {
+                startQuickSelect()
+            },
+            loadAllSharedMetricsSuccess: () => {
+                applyPendingQuickSelect()
+            },
+        }
+    }),
 ])


### PR DESCRIPTION
## Problem

Closes #62801

In the experiment shared-metric selection modal, the tag quick-select only operated on the metrics already fetched into the table. The list is paginated, so two things broke:
- **Tag buttons only appeared for loaded metrics** — tags belonging only to not-yet-loaded metrics (e.g. `taggeroni`, `pasture`) were missing until you clicked "Load more metrics" repeatedly.
- **Selecting a tag only selected loaded metrics** — matching metrics on unloaded pages were silently skipped.

## Changes

- **The full tag list is always available.** When the modal opens it shows the first page immediately, then eagerly pages through the rest in the background (with a "Loading all metrics…" indicator), so every tag is offered regardless of pagination.
- **Tags are additive toggles that drive selection.** Clicking a tag selects every metric carrying it (across all pages, already-added metrics excluded); clicking more tags accumulates the selection; clicking an active tag again deselects that tag's metrics (keeping any still covered by another active tag). The table also filters to the active tags so you can review before applying.
- The tag buttons stay disabled until the background load finishes, guaranteeing a click captures every matching metric across all pages.
- **"Show all"** clears the tag filter while keeping the selection.
- Removed the manual "Load more metrics" button, superseded by the automatic background load.

Implementation moved the selection and tag logic into `sharedMetricModalLogic` (kea): `displayedMetrics`, `availableTags`, `isLoadingAllSharedMetrics` selectors, an eager load-all cascade, and an additive `selectByTag` action.

## How did you test this code?

I'm an agent (PostHog Slack app). I ran the unit suite (`sharedMetricModalLogic.test.ts`, 12 tests) and a TypeScript check on the changed files locally — both pass (the local run required first building workspace packages and generating kea types, mirroring CI). Coverage maps directly to the two reported issues plus the additive semantics:
- All tags shown regardless of pagination: `availableTags covers tags from every page, not just the rendered one`.
- Tag selection spans unloaded pages: `selectByTag selects a tag-matching metric from a page that was not first rendered`.
- Additive accumulation: `tags are additive — clicking multiple tags accumulates the selection`.
- Toggle-off removal (incl. overlap): `clicking an active tag again deselects only that tag’s metrics` and `a metric covered by another active tag stays selected when one tag is toggled off`.
- Plus: exclusion of already-added metrics and search clearing the active tag filter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread, tracking issue #62801. Behavior was refined across review rounds to the final shape: additive, toggleable tag selection over the complete (eagerly loaded) set of shared metrics. Eager background loading was chosen over lazy pagination because a complete tag list and cross-page selection inherently need the full set; shared-metric counts are modest in practice.
