### PR TITLE
feat(tasks): render agent log messages as markdown with toggle

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
@@ -27,6 +27,11 @@ export interface LemonMarkdownProps {
     lowKeyHeadings?: boolean
     /** Whether to disable the docs sidebar panel behavior and always open links in a new tab */
     disableDocsRedirect?: boolean
+    /**
+     * Whether to render images as plain links instead of <img> elements. Use for untrusted content
+     * (e.g. LLM/agent output), where auto-loading images would fire requests to arbitrary URLs.
+     */
+    disableImages?: boolean
     className?: string
     wrapCode?: boolean
     /** Whether to generate id attributes on heading elements for anchor linking. */
@@ -71,6 +76,7 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
     children,
     lowKeyHeadings = false,
     disableDocsRedirect = false,
+    disableImages = false,
     wrapCode = false,
     generateHeadingIds = false,
     renderMermaid,
@@ -114,6 +120,15 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
                 }
                 return <span className={className} {...props} />
             },
+            ...(disableImages
+                ? {
+                      img: ({ src, alt }: any): JSX.Element => (
+                          <Link to={src} target="_blank" targetBlankIcon disableDocsPanel>
+                              {alt || src}
+                          </Link>
+                      ),
+                  }
+                : {}),
             li: ({ children, node }: any): JSX.Element => {
                 const isTaskItem = node?.properties?.className?.includes('task-list-item')
                 if (isTaskItem) {
@@ -157,7 +172,7 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
                     )
                   : {}),
         }),
-        [disableDocsRedirect, lowKeyHeadings, wrapCode, generateHeadingIds, renderMermaid]
+        [disableDocsRedirect, disableImages, lowKeyHeadings, wrapCode, generateHeadingIds, renderMermaid]
     )
 
     return (
@@ -173,6 +188,7 @@ function LemonMarkdownComponent({
     children,
     lowKeyHeadings = false,
     disableDocsRedirect = false,
+    disableImages = false,
     wrapCode = false,
     generateHeadingIds = false,
     renderMermaid,
@@ -183,6 +199,7 @@ function LemonMarkdownComponent({
             <LemonMarkdownRenderer
                 lowKeyHeadings={lowKeyHeadings}
                 disableDocsRedirect={disableDocsRedirect}
+                disableImages={disableImages}
                 wrapCode={wrapCode}
                 generateHeadingIds={generateHeadingIds}
                 renderMermaid={renderMermaid}

--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -165,7 +165,7 @@ function LogEntryRenderer({ entry, renderMarkdown }: { entry: LogEntry; renderMa
                     </div>
                     <div className="border-l-2 border-primary pl-3 max-w-[90%]">
                         {renderMarkdown && entry.message ? (
-                            <LemonMarkdown className="text-sm font-sans" lowKeyHeadings>
+                            <LemonMarkdown className="text-sm font-sans" lowKeyHeadings disableImages>
                                 {entry.message}
                             </LemonMarkdown>
                         ) : (
@@ -229,6 +229,7 @@ export function TaskSessionView({
         () => entries.filter((entry) => entry.type === 'console' && entry.level === 'debug').length,
         [entries]
     )
+    const agentCount = useMemo(() => entries.filter((entry) => entry.type === 'agent').length, [entries])
     const visibleEntries = useMemo(
         () => (showDebug ? entries : entries.filter((entry) => !(entry.type === 'console' && entry.level === 'debug'))),
         [entries, showDebug]
@@ -264,13 +265,15 @@ export function TaskSessionView({
                     <span className="text-sm font-semibold">Logs ({visibleEntries.length})</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <LemonSwitch
-                        label="Markdown"
-                        checked={renderMarkdown}
-                        onChange={setRenderMarkdown}
-                        size="xsmall"
-                        bordered
-                    />
+                    {agentCount > 0 && (
+                        <LemonSwitch
+                            label="Markdown"
+                            checked={renderMarkdown}
+                            onChange={setRenderMarkdown}
+                            size="xsmall"
+                            bordered
+                        />
+                    )}
                     {debugCount > 0 && (
                         <LemonSwitch
                             label={`Show debug (${debugCount})`}

--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -4,6 +4,7 @@ import { TextMorph } from 'torph/react'
 import { IconCopy } from '@posthog/icons'
 import { LemonButton, LemonSwitch, LemonTag, Spinner } from '@posthog/lemon-ui'
 
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
 import { LogEntry, parseLogs } from '../lib/parse-logs'
@@ -108,7 +109,7 @@ export function mergeDuplicateUserPromptEntries(entries: LogEntry[]): LogEntry[]
     }, [])
 }
 
-function LogEntryRenderer({ entry }: { entry: LogEntry }): JSX.Element | null {
+function LogEntryRenderer({ entry, renderMarkdown }: { entry: LogEntry; renderMarkdown: boolean }): JSX.Element | null {
     switch (entry.type) {
         case 'console':
             return (
@@ -163,7 +164,13 @@ function LogEntryRenderer({ entry }: { entry: LogEntry }): JSX.Element | null {
                         <span className="text-xs font-medium">Agent</span>
                     </div>
                     <div className="border-l-2 border-primary pl-3 max-w-[90%]">
-                        <div className="text-sm whitespace-pre-wrap">{entry.message}</div>
+                        {renderMarkdown && entry.message ? (
+                            <LemonMarkdown className="text-sm font-sans" lowKeyHeadings>
+                                {entry.message}
+                            </LemonMarkdown>
+                        ) : (
+                            <div className="text-sm whitespace-pre-wrap">{entry.message}</div>
+                        )}
                     </div>
                 </div>
             )
@@ -210,6 +217,7 @@ export function TaskSessionView({
 }: TaskSessionViewProps): JSX.Element {
     // Debug lines are noise by default; opt in to show them.
     const [showDebug, setShowDebug] = useState(false)
+    const [renderMarkdown, setRenderMarkdown] = useState(true)
     const parsedLogs = useMemo(() => parseLogs(logs), [logs])
     // Use stream entries when available (real-time), otherwise fall back to parsed S3 logs
     const entries = useMemo(() => {
@@ -256,6 +264,13 @@ export function TaskSessionView({
                     <span className="text-sm font-semibold">Logs ({visibleEntries.length})</span>
                 </div>
                 <div className="flex items-center gap-2">
+                    <LemonSwitch
+                        label="Markdown"
+                        checked={renderMarkdown}
+                        onChange={setRenderMarkdown}
+                        size="xsmall"
+                        bordered
+                    />
                     {debugCount > 0 && (
                         <LemonSwitch
                             label={`Show debug (${debugCount})`}
@@ -272,7 +287,7 @@ export function TaskSessionView({
             </div>
             <div className="flex-1 overflow-auto p-4 font-mono text-sm bg-bg-3000">
                 {visibleEntries.map((entry) => (
-                    <LogEntryRenderer key={entry.id} entry={entry} />
+                    <LogEntryRenderer key={entry.id} entry={entry} renderMarkdown={renderMarkdown} />
                 ))}
                 {(isPolling || isStreaming) && <HedgehogStatus />}
             </div>


### PR DESCRIPTION
## Problem

Agent messages in the task run log viewer render as plain pre-wrapped text, so markdown the agent emits (`**bold**`, backtick code spans, lists, headings) shows up as raw syntax. Long agent reasoning blocks are hard to read.

## Changes

- Agent message blocks in `TaskSessionView` now render through the existing `LemonMarkdown` component, with `lowKeyHeadings` to keep headings compact in the dense log view and `font-sans` so prose escapes the log's monospace font (inline code and fences still render monospace via `CodeSnippet`).
- Added a "Markdown" switch in the log header next to the existing "Show debug" toggle, defaulting to on. Toggling it off restores the original raw `whitespace-pre-wrap` rendering.
- Scope is agent messages only — user messages and thinking blocks are unchanged.

## How did you test this code?

I'm an agent. Automated tests run: existing `products/tasks/frontend/components/TaskSessionView.test.ts` suite passes (8/8). The file typechecks clean and oxfmt reports no formatting changes. No manual browser testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. The driver asked for a markdown toggle on agent text blocks in the tasks viewer, defaulting to on.
- Reused `LemonMarkdown` rather than adding a new renderer; kept the toggle as local component state to mirror the existing `showDebug` pattern in the same component instead of adding it to `taskDetailSceneLogic`, since it's purely presentational.
