### PR TITLE
chore: recommend com.posthog.verification_token in CIMD token settings

### DIFF
--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -118,10 +118,11 @@ export const getCimdVerificationTokensListUrl = (organizationId: string, params?
 /**
  * Manage CIMD verification tokens for an organization.
  *
- * A partner embeds the plaintext token in their CIMD metadata document under
- * `posthog_verification_token`. When PostHog fetches the metadata, matching
- * the token links the partner app to this organization and grants a higher
- * default rate limit for account provisioning.
+ * A partner embeds the plaintext token in their CIMD metadata document as
+ * `verification_token` inside the `com.posthog` object (the legacy top-level
+ * `posthog_verification_token` field still works as a fallback). When PostHog fetches
+ * the metadata, matching the token links the partner app to this organization and
+ * grants a higher default rate limit for account provisioning.
  *
  * The plaintext value is only available on creation; we store a hash.
  */
@@ -143,10 +144,11 @@ export const getCimdVerificationTokensCreateUrl = (organizationId: string) => {
 /**
  * Manage CIMD verification tokens for an organization.
  *
- * A partner embeds the plaintext token in their CIMD metadata document under
- * `posthog_verification_token`. When PostHog fetches the metadata, matching
- * the token links the partner app to this organization and grants a higher
- * default rate limit for account provisioning.
+ * A partner embeds the plaintext token in their CIMD metadata document as
+ * `verification_token` inside the `com.posthog` object (the legacy top-level
+ * `posthog_verification_token` field still works as a fallback). When PostHog fetches
+ * the metadata, matching the token links the partner app to this organization and
+ * grants a higher default rate limit for account provisioning.
  *
  * The plaintext value is only available on creation; we store a hash.
  */
@@ -170,10 +172,11 @@ export const getCimdVerificationTokensRetrieveUrl = (organizationId: string, id:
 /**
  * Manage CIMD verification tokens for an organization.
  *
- * A partner embeds the plaintext token in their CIMD metadata document under
- * `posthog_verification_token`. When PostHog fetches the metadata, matching
- * the token links the partner app to this organization and grants a higher
- * default rate limit for account provisioning.
+ * A partner embeds the plaintext token in their CIMD metadata document as
+ * `verification_token` inside the `com.posthog` object (the legacy top-level
+ * `posthog_verification_token` field still works as a fallback). When PostHog fetches
+ * the metadata, matching the token links the partner app to this organization and
+ * grants a higher default rate limit for account provisioning.
  *
  * The plaintext value is only available on creation; we store a hash.
  */
@@ -195,10 +198,11 @@ export const getCimdVerificationTokensDestroyUrl = (organizationId: string, id: 
 /**
  * Manage CIMD verification tokens for an organization.
  *
- * A partner embeds the plaintext token in their CIMD metadata document under
- * `posthog_verification_token`. When PostHog fetches the metadata, matching
- * the token links the partner app to this organization and grants a higher
- * default rate limit for account provisioning.
+ * A partner embeds the plaintext token in their CIMD metadata document as
+ * `verification_token` inside the `com.posthog` object (the legacy top-level
+ * `posthog_verification_token` field still works as a fallback). When PostHog fetches
+ * the metadata, matching the token links the partner app to this organization and
+ * grants a higher default rate limit for account provisioning.
  *
  * The plaintext value is only available on creation; we store a hash.
  */

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -12,10 +12,11 @@ import * as zod from 'zod'
 /**
  * Manage CIMD verification tokens for an organization.
  *
- * A partner embeds the plaintext token in their CIMD metadata document under
- * `posthog_verification_token`. When PostHog fetches the metadata, matching
- * the token links the partner app to this organization and grants a higher
- * default rate limit for account provisioning.
+ * A partner embeds the plaintext token in their CIMD metadata document as
+ * `verification_token` inside the `com.posthog` object (the legacy top-level
+ * `posthog_verification_token` field still works as a fallback). When PostHog fetches
+ * the metadata, matching the token links the partner app to this organization and
+ * grants a higher default rate limit for account provisioning.
  *
  * The plaintext value is only available on creation; we store a hash.
  */

--- a/frontend/src/scenes/settings/organization/CIMDVerificationTokens.tsx
+++ b/frontend/src/scenes/settings/organization/CIMDVerificationTokens.tsx
@@ -20,8 +20,8 @@ export function CIMDVerificationTokens(): JSX.Element {
         <div className="space-y-4">
             <p className="text-secondary">
                 Verification tokens link a CIMD partner application to this organization. Add the token to your CIMD
-                metadata document under <code>posthog_verification_token</code>. Verified partners get a higher default
-                rate limit for account provisioning and a clear identity trail. See the{' '}
+                metadata document under <code>com.posthog.verification_token</code>. Verified partners get a higher
+                default rate limit for account provisioning and a clear identity trail. See the{' '}
                 <Link
                     to="https://posthog.com/docs/integrate/provisioning#host-a-cimd-metadata-document"
                     target="_blank"
@@ -165,7 +165,8 @@ export function CIMDVerificationTokens(): JSX.Element {
                             revoke and create a new one.
                         </LemonBanner>
                         <p className="text-secondary">
-                            Add it to your CIMD metadata document as the <code>posthog_verification_token</code> field.
+                            Add it to your CIMD metadata document under the <code>com.posthog</code> namespace as{' '}
+                            <code>verification_token</code>.
                         </p>
                         <CodeSnippet language={Language.Text}>{justCreatedToken.value}</CodeSnippet>
                     </div>

--- a/frontend/src/scenes/settings/organization/CIMDVerificationTokens.tsx
+++ b/frontend/src/scenes/settings/organization/CIMDVerificationTokens.tsx
@@ -20,9 +20,9 @@ export function CIMDVerificationTokens(): JSX.Element {
         <div className="space-y-4">
             <p className="text-secondary">
                 Verification tokens link a CIMD partner application to this organization. Add the token to your CIMD
-                metadata document as <code>verification_token</code> inside the <code>com.posthog</code> object. Verified
-                partners get a higher default rate limit for account provisioning and a clear identity trail. See the
-                {' '}
+                metadata document as <code>verification_token</code> inside the <code>com.posthog</code> object.
+                Verified partners get a higher default rate limit for account provisioning and a clear identity trail.
+                See the{' '}
                 <Link
                     to="https://posthog.com/docs/integrate/provisioning#host-a-cimd-metadata-document"
                     target="_blank"

--- a/frontend/src/scenes/settings/organization/CIMDVerificationTokens.tsx
+++ b/frontend/src/scenes/settings/organization/CIMDVerificationTokens.tsx
@@ -20,8 +20,9 @@ export function CIMDVerificationTokens(): JSX.Element {
         <div className="space-y-4">
             <p className="text-secondary">
                 Verification tokens link a CIMD partner application to this organization. Add the token to your CIMD
-                metadata document under <code>com.posthog.verification_token</code>. Verified partners get a higher
-                default rate limit for account provisioning and a clear identity trail. See the{' '}
+                metadata document as <code>verification_token</code> inside the <code>com.posthog</code> object. Verified
+                partners get a higher default rate limit for account provisioning and a clear identity trail. See the
+                {' '}
                 <Link
                     to="https://posthog.com/docs/integrate/provisioning#host-a-cimd-metadata-document"
                     target="_blank"
@@ -165,8 +166,8 @@ export function CIMDVerificationTokens(): JSX.Element {
                             revoke and create a new one.
                         </LemonBanner>
                         <p className="text-secondary">
-                            Add it to your CIMD metadata document under the <code>com.posthog</code> namespace as{' '}
-                            <code>verification_token</code>.
+                            Add it to your CIMD metadata document as <code>verification_token</code> inside the{' '}
+                            <code>com.posthog</code> object.
                         </p>
                         <CodeSnippet language={Language.Text}>{justCreatedToken.value}</CodeSnippet>
                     </div>

--- a/posthog/api/cimd_verification_token.py
+++ b/posthog/api/cimd_verification_token.py
@@ -67,10 +67,11 @@ class CIMDVerificationTokenViewSet(
 ):
     """Manage CIMD verification tokens for an organization.
 
-    A partner embeds the plaintext token in their CIMD metadata document under
-    `posthog_verification_token`. When PostHog fetches the metadata, matching
-    the token links the partner app to this organization and grants a higher
-    default rate limit for account provisioning.
+    A partner embeds the plaintext token in their CIMD metadata document as
+    `verification_token` inside the `com.posthog` object (the legacy top-level
+    `posthog_verification_token` field still works as a fallback). When PostHog fetches
+    the metadata, matching the token links the partner app to this organization and
+    grants a higher default rate limit for account provisioning.
 
     The plaintext value is only available on creation; we store a hash.
     """


### PR DESCRIPTION
## Problem

Partners onboarding via CIMD create a verification token in **Organization settings → CIMD verification tokens**, and the settings page told them to embed it under the flat top-level `posthog_verification_token` field. We've since moved partner guidance to a `com.posthog` namespace as the go-forward format, and the [posthog.com provisioning doc](https://github.com/PostHog/posthog.com/pull/17366) now recommends `com.posthog.verification_token`. This leaves the in-product copy out of step with the docs.

## Changes

Updated the two copy strings on the CIMD verification-token settings page (`CIMDVerificationTokens.tsx`) to recommend `com.posthog.verification_token` instead of the legacy top-level `posthog_verification_token`.

Copy-only, no behavior change — the backend already reads the namespaced field first and falls back to the flat one (`_resolve_verification_token` in `posthog/api/oauth/cimd.py`), so existing partners on the flat field keep working.

## How did you test this code?

Agent-authored, no manual UI testing performed. No new automated tests (copy-only). Confirmed `com.posthog.verification_token` is the field the backend resolves first. Frontend lint and typecheck run in CI.

## Automatic notifications

- [ ] Publish to changelog? No
- [ ] Alert Sales and Marketing teams? No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Matt directed this.

Follow-up to the posthog.com provisioning doc that moved partner guidance to the `com.posthog` namespace; this aligns the in-product settings copy so partners get one consistent instruction. Tool: Claude Code.

Note: the verification-token API endpoint docstring in `cimd_verification_token.py` still references the flat field. Left as a separate follow-up because updating it requires regenerating the OpenAPI/frontend types (`hogli build:openapi`), which didn't run cleanly in this environment.