### PR TITLE
fix(quill): clean up charts package public API and core layering

### DIFF
--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react'
 
 import { Stage, useReactiveTheme } from '../../story-helpers'
 import { BoxPlot } from './BoxPlot'
-import type { BoxPlotSeries } from './computeBoxLayout'
+import type { BoxPlotSeries } from './types'
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.test.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.test.tsx
@@ -3,7 +3,7 @@ import { waitFor } from '@testing-library/react'
 import type { ChartTheme } from '../../core/types'
 import { renderHogChart, waitForHogChartTooltip } from '../../testing'
 import { BoxPlot, type BoxPlotClickData } from './BoxPlot'
-import type { BoxPlotDatum, BoxPlotSeries } from './computeBoxLayout'
+import type { BoxPlotDatum, BoxPlotSeries } from './types'
 
 const THEME: ChartTheme = {
     colors: ['#1f77b4', '#ff7f0e', '#2ca02c'],

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.tsx
@@ -18,7 +18,8 @@ import type {
     TooltipContext,
 } from '../../core/types'
 import { BoxPlotTooltip } from './BoxPlotTooltip'
-import { computeBoxRect, computeSeriesBoxes, type BoxPlotDatum, type BoxPlotSeries } from './computeBoxLayout'
+import { computeBoxRect, computeSeriesBoxes } from './computeBoxLayout'
+import type { BoxPlotDatum, BoxPlotSeries } from './types'
 import { seriesKeysAtCursor } from './utils/boxes-under-cursor'
 
 /** Stash slot — survives a render via `ChartScales._private` so drawStatic/drawHover

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import type { TooltipContext } from '../../core/types'
 import { TooltipSurface, TooltipSwatch } from '../../overlays/TooltipSurface'
 import type { BoxPlotAdaptedMeta } from './BoxPlot'
-import type { BoxPlotDatum } from './computeBoxLayout'
+import type { BoxPlotDatum } from './types'
 
 /** Rows shown per box, in the same order the legacy BoxPlotChart used. */
 const ROWS: { label: string; key: keyof BoxPlotDatum }[] = [

--- a/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.test.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.test.ts
@@ -1,7 +1,8 @@
 import { createBarScales } from '../../core/scales'
 import type { ChartDimensions } from '../../core/types'
 import { makeSeries } from '../../testing'
-import { computeBoxRect, computeSeriesBoxes, type BoxPlotDatum } from './computeBoxLayout'
+import { computeBoxRect, computeSeriesBoxes } from './computeBoxLayout'
+import type { BoxPlotDatum } from './types'
 
 const PIXEL_TEST_DIMENSIONS: ChartDimensions = {
     width: 400,

--- a/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/computeBoxLayout.ts
@@ -1,40 +1,6 @@
-import type { BoxRect } from '../../core/canvas-renderer'
 import { type BarScaleSet, groupedBandSlot } from '../../core/scales'
-import type { BandSlot } from '../../core/types'
-
-export type { BoxRect }
-
-/** The six-number summary the chart renders. Kept structurally compatible with the canonical
- *  `BoxPlotDatum` in the frontend's `queries/schema-general.ts` so consumers can pass it directly. */
-type BoxPlotSummary = { min: number; p25: number; median: number; mean: number; p75: number; max: number }
-
-/** Six-number summary plus an opaque `day` identifier (`day` is the consumer-side key for click
- *  handlers / persons-modal labels). */
-export type BoxPlotDatum = BoxPlotSummary & {
-    /** Optional identifier for this x position (e.g. ISO date). The chart treats it as opaque. */
-    day?: string
-}
-
-/** Series shape for the BoxPlot chart. Unlike the generic `Series` (whose `data` is
- *  `number[]`), each entry is a six-number summary. `data.length` must match the chart's
- *  `labels.length`; entries may be `null` for missing x positions. */
-export interface BoxPlotSeries<Meta = unknown> {
-    /** Unique identifier — used for React keys, scale group keys, and tooltip joins. */
-    key: string
-    /** Human-readable label used in legends/tooltips. */
-    label: string
-    /** Optional CSS color. When omitted (or empty), the chart picks one from `theme.colors`. */
-    color?: string
-    /** One six-number summary per x label, or `null` for missing data at that index. */
-    data: (BoxPlotDatum | null)[]
-    /** Free-form metadata flowed through to tooltip / click handlers. */
-    meta?: Meta
-    /** Visibility controls. Mirrors `Series.visibility` but with only the flags BoxPlot honors. */
-    visibility?: {
-        excluded?: boolean
-        tooltip?: boolean
-    }
-}
+import type { BandSlot, BoxRect } from '../../core/types'
+import type { BoxPlotDatum } from './types'
 
 /** Resolve only the band-axis extent of a (series, x) slot. Cheap — touches the band/group
  *  scales and nothing on the value axis — so callers like band-only hit-testing don't pay

--- a/packages/quill/packages/charts/src/charts/BoxPlot/types.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/types.ts
@@ -1,0 +1,31 @@
+/** The six-number summary the chart renders. Kept structurally compatible with the canonical
+ *  `BoxPlotDatum` in the frontend's `queries/schema-general.ts` so consumers can pass it directly. */
+type BoxPlotSummary = { min: number; p25: number; median: number; mean: number; p75: number; max: number }
+
+/** Six-number summary plus an opaque `day` identifier (`day` is the consumer-side key for click
+ *  handlers / persons-modal labels). */
+export type BoxPlotDatum = BoxPlotSummary & {
+    /** Optional identifier for this x position (e.g. ISO date). The chart treats it as opaque. */
+    day?: string
+}
+
+/** Series shape for the BoxPlot chart. Unlike the generic `Series` (whose `data` is
+ *  `number[]`), each entry is a six-number summary. `data.length` must match the chart's
+ *  `labels.length`; entries may be `null` for missing x positions. */
+export interface BoxPlotSeries<Meta = unknown> {
+    /** Unique identifier — used for React keys, scale group keys, and tooltip joins. */
+    key: string
+    /** Human-readable label used in legends/tooltips. */
+    label: string
+    /** Optional CSS color. When omitted (or empty), the chart picks one from `theme.colors`. */
+    color?: string
+    /** One six-number summary per x label, or `null` for missing data at that index. */
+    data: (BoxPlotDatum | null)[]
+    /** Free-form metadata flowed through to tooltip / click handlers. */
+    meta?: Meta
+    /** Visibility controls. Mirrors `Series.visibility` but with only the flags BoxPlot honors. */
+    visibility?: {
+        excluded?: boolean
+        tooltip?: boolean
+    }
+}

--- a/packages/quill/packages/charts/src/charts/BoxPlot/utils/boxes-under-cursor.test.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/utils/boxes-under-cursor.test.ts
@@ -1,7 +1,7 @@
 import { createBarScales } from '../../../core/scales'
 import type { ChartDimensions } from '../../../core/types'
 import { makeSeries } from '../../../testing'
-import type { BoxPlotDatum, BoxPlotSeries } from '../computeBoxLayout'
+import type { BoxPlotDatum, BoxPlotSeries } from '../types'
 import { cursorInsideBoxBand, seriesKeysAtCursor } from './boxes-under-cursor'
 
 const DIMS: ChartDimensions = {

--- a/packages/quill/packages/charts/src/charts/BoxPlot/utils/boxes-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/utils/boxes-under-cursor.ts
@@ -1,6 +1,6 @@
 import type { BarScaleSet } from '../../../core/scales'
 import { computeBoxBand } from '../computeBoxLayout'
-import type { BoxPlotSeries } from '../computeBoxLayout'
+import type { BoxPlotSeries } from '../types'
 
 /** Whether the cursor lies inside the band-axis extent of a box. Mirrors the
  *  bar-chart pattern of resolving "which sub-band is under the cursor" with a

--- a/packages/quill/packages/charts/src/charts/PieChart/computePieLayout.ts
+++ b/packages/quill/packages/charts/src/charts/PieChart/computePieLayout.ts
@@ -1,35 +1,10 @@
 import { pie } from 'd3-shape'
 
+import type { PieLayout, PieSlice } from '../../core/radial-layout'
 import type { ResolvedSeries } from '../../core/types'
 
-export interface PieSlice<Meta = unknown> {
-    /** Index into the *original* (pre-exclusion) series array. */
-    seriesIndex: number
-    series: ResolvedSeries<Meta>
-    /** Absolute slice magnitude. Negative inputs are clamped to 0 — a pie can't render them. */
-    value: number
-    /** value / total (0 when total is 0). */
-    fraction: number
-    /** Radians, 12 o'clock = 0, increasing clockwise (d3.pie convention). */
-    startAngle: number
-    endAngle: number
-    /** Bisector angle — anchor for pop-out and on-slice labels. */
-    centroidAngle: number
-    color: string
-}
-
-export interface PieLayout<Meta = unknown> {
-    slices: PieSlice<Meta>[]
-    total: number
-    cx: number
-    cy: number
-    /** Outer slice radius, *excluding* hover pop-out room. */
-    outerRadius: number
-    /** Inner radius (0 for pie, > 0 for donut). */
-    innerRadius: number
-    /** Radians gap between adjacent slices. */
-    padAngle: number
-}
+export { cursorOffsetToAngle, sliceAt } from '../../core/radial-layout'
+export type { PieLayout, PieSlice, SliceAtOptions } from '../../core/radial-layout'
 
 export interface PlotBox {
     plotLeft: number
@@ -133,67 +108,4 @@ export function computePieLayout<Meta = unknown>(opts: ComputePieLayoutOptions<M
     })
 
     return { slices, total, cx, cy, outerRadius, innerRadius, padAngle }
-}
-
-/** Maps a cursor offset (dx, dy) from the chart center to an angle in radians, matching
- *  the d3.pie convention: 12 o'clock = 0, increasing clockwise, range [0, 2π). */
-export function cursorOffsetToAngle(dx: number, dy: number): number {
-    // 12 o'clock = (0, -1) → atan2(0, 1) = 0
-    // 3 o'clock = (1, 0) → atan2(1, 0) = π/2
-    // 6 o'clock = (0, 1) → atan2(0, -1) = π
-    // 9 o'clock = (-1, 0) → atan2(-1, 0) = -π/2 → normalized to 3π/2
-    let a = Math.atan2(dx, -dy)
-    if (a < 0) {
-        a += 2 * Math.PI
-    }
-    return a
-}
-
-export interface SliceAtOptions {
-    /** Allowance beyond `outerRadius` so the popped-out slice still registers as hovered. */
-    outerSlack?: number
-}
-
-/** Returns the index of the slice under the cursor, or -1.
- *  - Misses the donut inner hole (`r < innerRadius`).
- *  - Misses past the outer edge plus optional slack.
- *  - Treats `padAngle/2` of each slice's start/end as a gap (no hit).
- *  - Handles d3.pie's 12 o'clock wraparound (slice that crosses 0). */
-export function sliceAt<Meta>(
-    layout: PieLayout<Meta>,
-    cursor: { x: number; y: number },
-    { outerSlack = 0 }: SliceAtOptions = {}
-): number {
-    if (layout.slices.length === 0) {
-        return -1
-    }
-    const dx = cursor.x - layout.cx
-    const dy = cursor.y - layout.cy
-    const r = Math.hypot(dx, dy)
-    if (r < layout.innerRadius || r > layout.outerRadius + outerSlack) {
-        return -1
-    }
-    const a = cursorOffsetToAngle(dx, dy)
-    const halfPad = layout.padAngle / 2
-    for (let i = 0; i < layout.slices.length; i++) {
-        const s = layout.slices[i]
-        let start = s.startAngle + halfPad
-        let end = s.endAngle - halfPad
-        if (start >= end) {
-            continue
-        }
-        if (start < 0 || end > 2 * Math.PI) {
-            // Wraparound — slice crosses 12 o'clock. Split into the [start, 2π) ∪ [0, end mod 2π) check.
-            const sNorm = ((start % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)
-            const eNorm = ((end % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)
-            if (a >= sNorm || a < eNorm) {
-                return i
-            }
-            continue
-        }
-        if (a >= start && a < end) {
-            return i
-        }
-    }
-    return -1
 }

--- a/packages/quill/packages/charts/src/core/RadialChart.tsx
+++ b/packages/quill/packages/charts/src/core/RadialChart.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
 
-import type { PieLayout } from '../charts/PieChart/computePieLayout'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { Tooltip } from '../overlays/Tooltip'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
@@ -11,6 +10,7 @@ import { useRadialInteraction } from './hooks/useRadialInteraction'
 import type { RadialSlicePayload } from './hooks/useRadialInteraction'
 import { RadialLayoutContext } from './radial-context'
 import type { RadialLayoutContextValue } from './radial-context'
+import type { PieLayout } from './radial-layout'
 import type {
     ChartDrawArgs,
     ChartMargins,

--- a/packages/quill/packages/charts/src/core/canvas-renderer.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.ts
@@ -2,7 +2,7 @@ import { type ScaleLinear, type ScaleLogarithmic } from 'd3-scale'
 
 import { barColorAt, mixColors } from './color-utils'
 import { yTickCountForHeight } from './scales'
-import type { BarFillStyle, ChartDimensions, ChartDrawArgs, DrawHoverResult, ResolvedSeries } from './types'
+import type { BarFillStyle, BoxRect, ChartDimensions, ChartDrawArgs, DrawHoverResult, ResolvedSeries } from './types'
 
 export interface DrawContext {
     ctx: CanvasRenderingContext2D
@@ -706,20 +706,6 @@ export interface DrawBoxOptions {
     lineWidth?: number
     /** Width of the whisker caps (as a fraction of the box width). Defaults to 0.6. */
     whiskerCapRatio?: number
-}
-
-/** A laid-out box-and-whisker for a single (series, x) slot. Same shape contract as
- *  {@link BarRect} — pre-computed pixel coordinates so the draw primitives don't touch scales. */
-export interface BoxRect {
-    x: number
-    width: number
-    top: number
-    bottom: number
-    medianY: number
-    mean: { x: number; y: number }
-    whiskerTop: number
-    whiskerBottom: number
-    dataIndex: number
 }
 
 /** Paint a whole series of box-and-whiskers, batching path operations so the number of

--- a/packages/quill/packages/charts/src/core/hooks/useRadialInteraction.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useRadialInteraction.ts
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { sliceAt } from '../../charts/PieChart/computePieLayout'
-import type { PieLayout, PieSlice } from '../../charts/PieChart/computePieLayout'
+import { sliceAt } from '../radial-layout'
+import type { PieLayout, PieSlice } from '../radial-layout'
 import type { ResolvedSeries, TooltipContext } from '../types'
 import { useLatest } from './useLatest'
 import { useTooltipLifecycle } from './useTooltipLifecycle'

--- a/packages/quill/packages/charts/src/core/radial-context.ts
+++ b/packages/quill/packages/charts/src/core/radial-context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 
-import type { PieLayout } from '../charts/PieChart/computePieLayout'
+import type { PieLayout } from './radial-layout'
 
 /** Layout-stable values exposed to radial overlays (slice labels, custom decorations). Identity
  *  does NOT change on hover. */

--- a/packages/quill/packages/charts/src/core/radial-layout.ts
+++ b/packages/quill/packages/charts/src/core/radial-layout.ts
@@ -1,0 +1,93 @@
+import type { ResolvedSeries } from './types'
+
+export interface PieSlice<Meta = unknown> {
+    /** Index into the *original* (pre-exclusion) series array. */
+    seriesIndex: number
+    series: ResolvedSeries<Meta>
+    /** Absolute slice magnitude. Negative inputs are clamped to 0 — a pie can't render them. */
+    value: number
+    /** value / total (0 when total is 0). */
+    fraction: number
+    /** Radians, 12 o'clock = 0, increasing clockwise (d3.pie convention). */
+    startAngle: number
+    endAngle: number
+    /** Bisector angle — anchor for pop-out and on-slice labels. */
+    centroidAngle: number
+    color: string
+}
+
+export interface PieLayout<Meta = unknown> {
+    slices: PieSlice<Meta>[]
+    total: number
+    cx: number
+    cy: number
+    /** Outer slice radius, *excluding* hover pop-out room. */
+    outerRadius: number
+    /** Inner radius (0 for pie, > 0 for donut). */
+    innerRadius: number
+    /** Radians gap between adjacent slices. */
+    padAngle: number
+}
+
+/** Maps a cursor offset (dx, dy) from the chart center to an angle in radians, matching
+ *  the d3.pie convention: 12 o'clock = 0, increasing clockwise, range [0, 2π). */
+export function cursorOffsetToAngle(dx: number, dy: number): number {
+    // 12 o'clock = (0, -1) → atan2(0, 1) = 0
+    // 3 o'clock = (1, 0) → atan2(1, 0) = π/2
+    // 6 o'clock = (0, 1) → atan2(0, -1) = π
+    // 9 o'clock = (-1, 0) → atan2(-1, 0) = -π/2 → normalized to 3π/2
+    let a = Math.atan2(dx, -dy)
+    if (a < 0) {
+        a += 2 * Math.PI
+    }
+    return a
+}
+
+export interface SliceAtOptions {
+    /** Allowance beyond `outerRadius` so the popped-out slice still registers as hovered. */
+    outerSlack?: number
+}
+
+/** Returns the index of the slice under the cursor, or -1.
+ *  - Misses the donut inner hole (`r < innerRadius`).
+ *  - Misses past the outer edge plus optional slack.
+ *  - Treats `padAngle/2` of each slice's start/end as a gap (no hit).
+ *  - Handles d3.pie's 12 o'clock wraparound (slice that crosses 0). */
+export function sliceAt<Meta>(
+    layout: PieLayout<Meta>,
+    cursor: { x: number; y: number },
+    { outerSlack = 0 }: SliceAtOptions = {}
+): number {
+    if (layout.slices.length === 0) {
+        return -1
+    }
+    const dx = cursor.x - layout.cx
+    const dy = cursor.y - layout.cy
+    const r = Math.hypot(dx, dy)
+    if (r < layout.innerRadius || r > layout.outerRadius + outerSlack) {
+        return -1
+    }
+    const a = cursorOffsetToAngle(dx, dy)
+    const halfPad = layout.padAngle / 2
+    for (let i = 0; i < layout.slices.length; i++) {
+        const s = layout.slices[i]
+        let start = s.startAngle + halfPad
+        let end = s.endAngle - halfPad
+        if (start >= end) {
+            continue
+        }
+        if (start < 0 || end > 2 * Math.PI) {
+            // Wraparound — slice crosses 12 o'clock. Split into the [start, 2π) ∪ [0, end mod 2π) check.
+            const sNorm = ((start % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)
+            const eNorm = ((end % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)
+            if (a >= sNorm || a < eNorm) {
+                return i
+            }
+            continue
+        }
+        if (a >= start && a < end) {
+            return i
+        }
+    }
+    return -1
+}

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -354,6 +354,20 @@ export interface BandSlot {
     width: number
 }
 
+/** A laid-out box-and-whisker for a single (series, x) slot — pre-computed pixel coordinates so
+ *  the draw primitives don't touch scales. Same shape contract as a bar's `BarRect`. */
+export interface BoxRect {
+    x: number
+    width: number
+    top: number
+    bottom: number
+    medianY: number
+    mean: { x: number; y: number }
+    whiskerTop: number
+    whiskerBottom: number
+    dataIndex: number
+}
+
 /** Generic scale interface that Chart uses for shared overlays and interaction. */
 export interface ChartScales {
     /** Maps a label to an x pixel coordinate. For chart types where data points

--- a/packages/quill/packages/charts/src/index.ts
+++ b/packages/quill/packages/charts/src/index.ts
@@ -36,8 +36,8 @@ export type {
     BoxPlotProps,
     BoxPlotTooltipContext,
 } from './charts/BoxPlot/BoxPlot'
-export { computeBoxBand, computeBoxRect, computeSeriesBoxes } from './charts/BoxPlot/computeBoxLayout'
-export type { BoxPlotDatum, BoxPlotSeries, BoxRect } from './charts/BoxPlot/computeBoxLayout'
+export type { BoxPlotDatum, BoxPlotSeries } from './charts/BoxPlot/types'
+export type { BoxRect } from './core/types'
 export { BoxPlotTooltip } from './charts/BoxPlot/BoxPlotTooltip'
 export type { BoxPlotTooltipProps } from './charts/BoxPlot/BoxPlotTooltip'
 


### PR DESCRIPTION
## Problem

A code review of the published `@posthog/quill-charts` package flagged public-API and internal-layering issues for consumers outside the repo:

- `computeBoxBand`/`computeBoxRect`/`computeSeriesBoxes` were barrel-exported with raw `d3-scale` param types, and the published `dist/*.d.ts` transitively reached a `d3-scale` import from the public entry — so external TS consumers got unresolved type refs (silent `any` under `skipLibCheck`, hard errors without). The helpers had zero consumers anyway.
- `core/` imported from `charts/` (`PieLayout`, `PieSlice`, and the `sliceAt` function), a dependency inversion that hard-couples the radial base to the pie chart.

## Changes

- removed the three box-plot helpers from the public barrel
- closed the `d3-scale` type leak: the public box-plot types now live in d3-free modules — `BoxPlotDatum`/`BoxPlotSeries` in a new `charts/BoxPlot/types.ts`, `BoxRect` in `core/types.ts` — so `index.d.ts` no longer transitively imports `d3-scale`. `@types/d3-scale` stays a `devDependency` (the d3-scale imports remain only in internal `.d.ts` files the public entry doesn't reach).
- moved `PieLayout`/`PieSlice`/`sliceAt`/`cursorOffsetToAngle` into a new `core/radial-layout.ts`; `computePieLayout.ts` re-exports them so the public API is unchanged

No dependency or `package.json` changes — this is a pure source refactor; the diff is almost entirely code moving between files.

Two sibling findings from the same review are split out: #62847 (shared chart-shell dedup, stacked on this PR) and #62841 (Tailwind contract, independent).

## How did you test this code?

I'm an agent — no manual testing beyond automated checks:

- `pnpm --filter @posthog/quill-charts build` (clean) — then traced the emitted `dist/index.d.ts` import graph and confirmed it no longer reaches any `d3-scale` import
- full charts jest suite via the frontend config: 45/45 suites, 1240/1240 tests pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code (Claude) authored this from a pasted code-review findings list.

An earlier revision fixed the `d3-scale` leak by promoting `@types/d3-scale` from `devDependencies` to `dependencies`. A review gate denied the deps reclassification, so this revision severs the leak at the source instead: the public box-plot types were the only door from `index.d.ts` into the d3-scale-importing internal modules (`core/scales`, `core/canvas-renderer`), so moving them into d3-free files removes the need for any dependency change.

The chart-shell extraction originally in this PR was split into #62847 (stacked on this branch) to keep this diff small.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*