### PR TITLE
perf(error-tracking): fetch first/last events with a two-pass point lookup

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -270,6 +270,13 @@ def clean_varying_query_parts(query, replace_all_numbers):
     query = re.sub(r"flag_\d+_condition", r"flag_X_condition", query)
     query = re.sub(r"flag_\d+_super_condition", r"flag_X_super_condition", query)
 
+    # event uuid point lookups (error tracking first/last event fetch) embed random fixture uuids
+    query = re.sub(
+        r"in\(((?:\w+\.)?uuid), \['[0-9a-f-]{36}'(?:, '[0-9a-f-]{36}')*\]\)",
+        r"in(\1, ['00000000-0000-0000-0000-000000000000' /* ... */])",
+        query,
+    )
+
     # session_recording_linked_flag embeds feature flag IDs in JSON, normalize them
     query = re.sub(
         r"""session_recording_linked_flag" @> '{"id": \d+}'::jsonb""",

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -7,6 +7,8 @@ from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.schema.error_tracking_fingerprint_issue_state import PENDING_UPDATES_HOGQL_CONTEXT_KEY
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
@@ -102,13 +104,60 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                 context=self._hogql_context(),
             )
 
-        columns: list[str] = query_result.columns or []
+        columns, results = self._attach_events(query_result.columns or [], query_result.results)
 
         return ErrorTrackingQueryResponse(
             columns=columns,
-            results=self._builder.process_results(columns, query_result.results),
+            results=self._builder.process_results(columns, results),
             timings=query_result.timings,
             hogql=query_result.hogql,
             modifiers=self.modifiers,
             **self.paginator.response_params(),
         )
+
+    # Aggregation queries return only event uuids for first/last event (reading the
+    # properties blob inside argMin/argMax decompresses every matching event's blob);
+    # the payloads are fetched here with a point lookup over just the selected uuids.
+    EVENT_UUID_COLUMNS = {"first_event_uuid": "first_event", "last_event_uuid": "last_event"}
+
+    def _attach_events(self, columns: list[str], results: list) -> tuple[list[str], list]:
+        uuid_indexes = [index for index, column in enumerate(columns) if column in self.EVENT_UUID_COLUMNS]
+        if not uuid_indexes:
+            return columns, results
+
+        uuids = {str(row[index]) for row in results for index in uuid_indexes if row[index] is not None}
+        events: dict[str, tuple] = {}
+        if uuids:
+            with self.timings.measure("error_tracking_query_event_fetch"):
+                event_result = execute_hogql_query(
+                    query=parse_select(
+                        """
+                        SELECT uuid, distinct_id, timestamp, properties
+                        FROM events
+                        WHERE event = '$exception'
+                            AND uuid IN {uuids}
+                            AND timestamp >= {date_from}
+                            AND timestamp <= {date_to}
+                        """,
+                        placeholders={
+                            "uuids": ast.Constant(value=sorted(uuids)),
+                            "date_from": ast.Constant(value=self.date_from),
+                            "date_to": ast.Constant(value=self.date_to),
+                        },
+                    ),
+                    team=self.team,
+                    query_type="ErrorTrackingEventFetchQuery",
+                    timings=self.timings,
+                    modifiers=self.modifiers,
+                    limit_context=self.limit_context,
+                )
+            events = {str(row[0]): row for row in event_result.results}
+
+        new_columns = [self.EVENT_UUID_COLUMNS.get(column, column) for column in columns]
+        new_results = []
+        for row in results:
+            row = list(row)
+            for index in uuid_indexes:
+                row[index] = events.get(str(row[index])) if row[index] is not None else None
+            new_results.append(row)
+        return new_columns, new_results

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -131,6 +131,8 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             with self.timings.measure("error_tracking_query_event_fetch"):
                 event_result = execute_hogql_query(
                     query=parse_select(
+                        # The explicit LIMIT matters: without one, execute_hogql_query applies
+                        # the default 100-row limit and silently drops payloads beyond it.
                         """
                         SELECT uuid, distinct_id, timestamp, properties
                         FROM events
@@ -138,11 +140,13 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                             AND uuid IN {uuids}
                             AND timestamp >= {date_from}
                             AND timestamp <= {date_to}
+                        LIMIT {event_limit}
                         """,
                         placeholders={
                             "uuids": ast.Constant(value=sorted(uuids)),
                             "date_from": ast.Constant(value=self.date_from),
                             "date_to": ast.Constant(value=self.date_to),
+                            "event_limit": ast.Constant(value=len(uuids)),
                         },
                     ),
                     team=self.team,

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -140,6 +140,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                             AND uuid IN {uuids}
                             AND timestamp >= toDateTime({date_from})
                             AND timestamp <= toDateTime({date_to})
+                        LIMIT 1 BY uuid
                         LIMIT {event_limit}
                         """,
                         placeholders={

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -155,6 +155,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                     timings=self.timings,
                     modifiers=self.modifiers,
                     limit_context=self.limit_context,
+                    user=self.user,
                 )
             events = {str(row[0]): row for row in event_result.results}
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -138,8 +138,8 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
                         FROM events
                         WHERE event = '$exception'
                             AND uuid IN {uuids}
-                            AND timestamp >= {date_from}
-                            AND timestamp <= {date_to}
+                            AND timestamp >= toDateTime({date_from})
+                            AND timestamp <= toDateTime({date_to})
                         LIMIT {event_limit}
                         """,
                         placeholders={

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_utils.py
@@ -175,45 +175,22 @@ def build_select_expressions(
             ]
         )
 
+    # Only the uuid is aggregated here; the runner fetches the selected events' properties
+    # in a second point lookup. Aggregating the tuple directly would decompress every
+    # matching event's properties blob just to keep one row per issue.
     if query.withFirstEvent:
         exprs.append(
             ast.Alias(
-                alias="first_event",
-                expr=ast.Call(
-                    name="argMin",
-                    args=[
-                        ast.Tuple(
-                            exprs=[
-                                ast.Field(chain=["uuid"]),
-                                ast.Field(chain=["distinct_id"]),
-                                ast.Field(chain=["timestamp"]),
-                                ast.Field(chain=["properties"]),
-                            ]
-                        ),
-                        ast.Field(chain=["timestamp"]),
-                    ],
-                ),
+                alias="first_event_uuid",
+                expr=ast.Call(name="argMin", args=[ast.Field(chain=["uuid"]), ast.Field(chain=["timestamp"])]),
             )
         )
 
     if query.withLastEvent:
         exprs.append(
             ast.Alias(
-                alias="last_event",
-                expr=ast.Call(
-                    name="argMax",
-                    args=[
-                        ast.Tuple(
-                            exprs=[
-                                ast.Field(chain=["uuid"]),
-                                ast.Field(chain=["distinct_id"]),
-                                ast.Field(chain=["timestamp"]),
-                                ast.Field(chain=["properties"]),
-                            ]
-                        ),
-                        ast.Field(chain=["timestamp"]),
-                    ],
-                ),
+                alias="last_event_uuid",
+                expr=ast.Call(name="argMax", args=[ast.Field(chain=["uuid"]), ast.Field(chain=["timestamp"])]),
             )
         )
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_v2.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_v2.py
@@ -223,10 +223,10 @@ class ErrorTrackingQueryV2Builder:
             )
 
         if self.query.withFirstEvent:
-            exprs.append(ast.Alias(alias="first_event", expr=from_agg("first_event")))
+            exprs.append(ast.Alias(alias="first_event_uuid", expr=from_agg("first_event_uuid")))
 
         if self.query.withLastEvent:
-            exprs.append(ast.Alias(alias="last_event", expr=from_agg("last_event")))
+            exprs.append(ast.Alias(alias="last_event_uuid", expr=from_agg("last_event_uuid")))
 
         exprs.append(ast.Alias(alias="library", expr=from_agg("library")))
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_v3.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_v3.py
@@ -302,24 +302,17 @@ class ErrorTrackingQueryV3Builder:
                 )
             )
 
+        # Only the uuid is aggregated here; the runner fetches the selected events' properties
+        # in a second point lookup. Aggregating the tuple directly would decompress every
+        # matching event's properties blob just to keep one row per fingerprint.
         if self.query.withFirstEvent:
             exprs.append(
                 ast.Alias(
-                    alias="first_event_state",
+                    alias="first_event_uuid_state",
                     expr=_state(
                         ast.Call(
                             name="argMin",
-                            args=[
-                                ast.Tuple(
-                                    exprs=[
-                                        ast.Field(chain=["e", "uuid"]),
-                                        ast.Field(chain=["e", "distinct_id"]),
-                                        ast.Field(chain=["e", "timestamp"]),
-                                        ast.Field(chain=["e", "properties"]),
-                                    ]
-                                ),
-                                ast.Field(chain=["e", "timestamp"]),
-                            ],
+                            args=[ast.Field(chain=["e", "uuid"]), ast.Field(chain=["e", "timestamp"])],
                         )
                     ),
                 )
@@ -328,21 +321,11 @@ class ErrorTrackingQueryV3Builder:
         if self.query.withLastEvent:
             exprs.append(
                 ast.Alias(
-                    alias="last_event_state",
+                    alias="last_event_uuid_state",
                     expr=_state(
                         ast.Call(
                             name="argMax",
-                            args=[
-                                ast.Tuple(
-                                    exprs=[
-                                        ast.Field(chain=["e", "uuid"]),
-                                        ast.Field(chain=["e", "distinct_id"]),
-                                        ast.Field(chain=["e", "timestamp"]),
-                                        ast.Field(chain=["e", "properties"]),
-                                    ]
-                                ),
-                                ast.Field(chain=["e", "timestamp"]),
-                            ],
+                            args=[ast.Field(chain=["e", "uuid"]), ast.Field(chain=["e", "timestamp"])],
                         )
                     ),
                 )
@@ -455,10 +438,10 @@ class ErrorTrackingQueryV3Builder:
             )
 
         if self.query.withFirstEvent:
-            exprs.append(ast.Alias(alias="first_event", expr=_merge("first_event_state", "argMin")))
+            exprs.append(ast.Alias(alias="first_event_uuid", expr=_merge("first_event_uuid_state", "argMin")))
 
         if self.query.withLastEvent:
-            exprs.append(ast.Alias(alias="last_event", expr=_merge("last_event_state", "argMax")))
+            exprs.append(ast.Alias(alias="last_event_uuid", expr=_merge("last_event_uuid_state", "argMax")))
 
         exprs.append(ast.Alias(alias="library", expr=_merge("library_state", "argMax")))
 
@@ -595,23 +578,13 @@ class ErrorTrackingQueryV3Builder:
                 )
             )
 
+        # uuid-only here too — the runner attaches the event payloads in a second point lookup.
         if self.query.withFirstEvent:
             exprs.append(
                 ast.Alias(
-                    alias="first_event",
+                    alias="first_event_uuid",
                     expr=ast.Call(
-                        name="argMin",
-                        args=[
-                            ast.Tuple(
-                                exprs=[
-                                    ast.Field(chain=["e", "uuid"]),
-                                    ast.Field(chain=["e", "distinct_id"]),
-                                    ast.Field(chain=["e", "timestamp"]),
-                                    ast.Field(chain=["e", "properties"]),
-                                ]
-                            ),
-                            ast.Field(chain=["e", "timestamp"]),
-                        ],
+                        name="argMin", args=[ast.Field(chain=["e", "uuid"]), ast.Field(chain=["e", "timestamp"])]
                     ),
                 )
             )
@@ -619,20 +592,9 @@ class ErrorTrackingQueryV3Builder:
         if self.query.withLastEvent:
             exprs.append(
                 ast.Alias(
-                    alias="last_event",
+                    alias="last_event_uuid",
                     expr=ast.Call(
-                        name="argMax",
-                        args=[
-                            ast.Tuple(
-                                exprs=[
-                                    ast.Field(chain=["e", "uuid"]),
-                                    ast.Field(chain=["e", "distinct_id"]),
-                                    ast.Field(chain=["e", "timestamp"]),
-                                    ast.Field(chain=["e", "properties"]),
-                                ]
-                            ),
-                            ast.Field(chain=["e", "timestamp"]),
-                        ],
+                        name="argMax", args=[ast.Field(chain=["e", "uuid"]), ast.Field(chain=["e", "timestamp"])]
                     ),
                 )
             )

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -120,7 +120,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['5a89fa54-b472-402a-8a91-00dddb75fc11', 'b6b03156-cf9d-4c2a-a61f-a24a0fe445aa', 'd0c37a93-334f-48e3-a7a3-d75bea24e4a1']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['6ea7f91f-74c7-43cd-8c23-3baf2789e66f', 'c216eb70-92db-4c09-baa4-a90004e035e0', 'dd4d5ef6-8e0e-4e51-806b-dca832b986d9']), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 3 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
@@ -188,7 +188,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['d0c37a93-334f-48e3-a7a3-d75bea24e4a1']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['6ea7f91f-74c7-43cd-8c23-3baf2789e66f']), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -120,7 +120,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 1 BY events.uuid
   LIMIT 3 SETTINGS readonly=2,
                    max_execution_time=60,
@@ -189,7 +189,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 1 BY events.uuid
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -85,7 +85,7 @@
          min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
          argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function,
          argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source,
-         argMin(tuple(e.uuid, e.distinct_id, toTimeZone(e.timestamp, 'UTC'), e.properties), toTimeZone(e.timestamp, 'UTC')) AS first_event,
+         argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS first_event_uuid,
          argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
   FROM events AS e
   LEFT OUTER JOIN
@@ -115,6 +115,28 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_column_names.3
   '''
+  SELECT events.uuid AS uuid,
+         events.distinct_id AS distinct_id,
+         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+         events.properties AS properties
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['17ce3153-abde-40fe-90d5-f5b6ba43732d', '5c0196a0-44f2-41a4-b8ee-bc6934b1f555', 'd395f031-13a9-45d1-a4d2-862d64783b5a']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_column_names.4
+  '''
   SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(e.`mat_$exception_issue_id`, 'UUID')) AS id,
          max(toTimeZone(e.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
@@ -124,7 +146,7 @@
          count(DISTINCT nullIf(e.`$session_id`, '')) AS sessions,
          count(DISTINCT coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users,
          sumForEach(arrayMap(bin -> if(and(greater(toTimeZone(e.timestamp, 'UTC'), bin), lessOrEquals(dateDiff('seconds', bin, toTimeZone(e.timestamp, 'UTC')), divide(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1))), 1, 0), arrayMap(i -> dateAdd(toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toIntervalSecond(multiply(i, divide(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))), range(0, 1)))) AS volumeRange,
-         argMin(tuple(e.uuid, e.distinct_id, toTimeZone(e.timestamp, 'UTC'), e.properties), toTimeZone(e.timestamp, 'UTC')) AS first_event,
+         argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS first_event_uuid,
          argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
   FROM events AS e
   LEFT OUTER JOIN
@@ -157,6 +179,28 @@
                     optimize_min_inequality_conjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_column_names.5
+  '''
+  SELECT events.uuid AS uuid,
+         events.distinct_id AS distinct_id,
+         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+         events.properties AS properties
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['17ce3153-abde-40fe-90d5-f5b6ba43732d']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_persons

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -120,7 +120,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['6ea7f91f-74c7-43cd-8c23-3baf2789e66f', 'c216eb70-92db-4c09-baa4-a90004e035e0', 'dd4d5ef6-8e0e-4e51-806b-dca832b986d9']), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 3 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
@@ -188,7 +188,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['6ea7f91f-74c7-43cd-8c23-3baf2789e66f']), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -120,19 +120,19 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['17ce3153-abde-40fe-90d5-f5b6ba43732d', '5c0196a0-44f2-41a4-b8ee-bc6934b1f555', 'd395f031-13a9-45d1-a4d2-862d64783b5a']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['5a89fa54-b472-402a-8a91-00dddb75fc11', 'b6b03156-cf9d-4c2a-a61f-a24a0fe445aa', 'd0c37a93-334f-48e3-a7a3-d75bea24e4a1']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  LIMIT 3 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_column_names.4
@@ -188,19 +188,19 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['17ce3153-abde-40fe-90d5-f5b6ba43732d']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['d0c37a93-334f-48e3-a7a3-d75bea24e4a1']), greaterOrEquals(events.timestamp, toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_persons

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -121,6 +121,7 @@
          events.properties AS properties
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  LIMIT 1 BY events.uuid
   LIMIT 3 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,
@@ -189,6 +190,7 @@
          events.properties AS properties
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  LIMIT 1 BY events.uuid
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner_v2.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner_v2.ambr
@@ -273,6 +273,7 @@
          events.properties AS properties
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  LIMIT 1 BY events.uuid
   LIMIT 3 SETTINGS readonly=2,
                    max_execution_time=60,
                    allow_experimental_object_type=1,

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner_v2.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner_v2.ambr
@@ -204,7 +204,7 @@
          assignment.role_id AS assignee_role_id,
          agg.function AS function,
          agg.source AS source,
-         agg.first_event AS first_event,
+         agg.first_event_uuid AS first_event_uuid,
          agg.library AS library
   FROM
     (SELECT if(not(empty(e__exception_issue_override.issue_id)), e__exception_issue_override.issue_id, accurateCastOrNull(e.`mat_$exception_issue_id`, 'UUID')) AS id,
@@ -212,7 +212,7 @@
             min(toTimeZone(e.timestamp, 'UTC')) AS first_seen,
             argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function,
             argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source,
-            argMin(tuple(e.uuid, e.distinct_id, toTimeZone(e.timestamp, 'UTC'), e.properties), toTimeZone(e.timestamp, 'UTC')) AS first_event,
+            argMin(e.uuid, toTimeZone(e.timestamp, 'UTC')) AS first_event_uuid,
             argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library
      FROM events AS e
      LEFT OUTER JOIN
@@ -263,6 +263,28 @@
                     optimize_min_inequality_conjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunnerV2.test_column_names.3
+  '''
+  SELECT events.uuid AS uuid,
+         events.distinct_id AS distinct_id,
+         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+         events.properties AS properties
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  LIMIT 3 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunnerV2.test_correctly_counts_persons
@@ -645,7 +667,7 @@
      WHERE and(equals(system__error_tracking_issue_assignments.team_id, 99999), in(system__error_tracking_issue_assignments.issue_id,
                                                                                      (SELECT issue_ids.issue_id AS issue_id
                                                                                       FROM issue_ids)))) AS assignment ON equals(assignment.issue_id, issues.id)
-  WHERE ifNull(greaterOrEquals(fp.first_seen, parseDateTime64BestEffort('2020-01-10T10:11:00+00:00', 6, 'UTC')), 0)
+  WHERE ifNull(greaterOrEquals(fp.first_seen, parseDateTime64BestEffort('2022-01-10T10:11:00+00:00', 6, 'UTC')), 0)
   ORDER BY last_seen DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -729,7 +751,7 @@
      WHERE and(equals(system__error_tracking_issue_assignments.team_id, 99999), in(system__error_tracking_issue_assignments.issue_id,
                                                                                      (SELECT issue_ids.issue_id AS issue_id
                                                                                       FROM issue_ids)))) AS assignment ON equals(assignment.issue_id, issues.id)
-  WHERE ifNull(less(fp.first_seen, parseDateTime64BestEffort('2020-01-10T10:11:00+00:00', 6, 'UTC')), 0)
+  WHERE ifNull(less(fp.first_seen, parseDateTime64BestEffort('2022-01-10T10:11:00+00:00', 6, 'UTC')), 0)
   ORDER BY last_seen DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner_v2.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner_v2.ambr
@@ -272,7 +272,7 @@
          toTimeZone(events.timestamp, 'UTC') AS timestamp,
          events.properties AS properties
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2022-01-03 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), in(events.uuid, ['00000000-0000-0000-0000-000000000000' /* ... */]), greaterOrEquals(events.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(events.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
   LIMIT 1 BY events.uuid
   LIMIT 3 SETTINGS readonly=2,
                    max_execution_time=60,
@@ -668,7 +668,7 @@
      WHERE and(equals(system__error_tracking_issue_assignments.team_id, 99999), in(system__error_tracking_issue_assignments.issue_id,
                                                                                      (SELECT issue_ids.issue_id AS issue_id
                                                                                       FROM issue_ids)))) AS assignment ON equals(assignment.issue_id, issues.id)
-  WHERE ifNull(greaterOrEquals(fp.first_seen, parseDateTime64BestEffort('2022-01-10T10:11:00+00:00', 6, 'UTC')), 0)
+  WHERE ifNull(greaterOrEquals(fp.first_seen, parseDateTime64BestEffort('2020-01-10T10:11:00+00:00', 6, 'UTC')), 0)
   ORDER BY last_seen DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -752,7 +752,7 @@
      WHERE and(equals(system__error_tracking_issue_assignments.team_id, 99999), in(system__error_tracking_issue_assignments.issue_id,
                                                                                      (SELECT issue_ids.issue_id AS issue_id
                                                                                       FROM issue_ids)))) AS assignment ON equals(assignment.issue_id, issues.id)
-  WHERE ifNull(less(fp.first_seen, parseDateTime64BestEffort('2022-01-10T10:11:00+00:00', 6, 'UTC')), 0)
+  WHERE ifNull(less(fp.first_seen, parseDateTime64BestEffort('2020-01-10T10:11:00+00:00', 6, 'UTC')), 0)
   ORDER BY last_seen DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,


### PR DESCRIPTION
## Problem

When an `ErrorTrackingQuery` asks for `withFirstEvent`/`withLastEvent`, every builder aggregates `argMin/argMax(tuple(uuid, distinct_id, timestamp, properties), timestamp)` — which decompresses every matching event's `properties` blob (stack traces, ~16 KB/row unmaterialized) just to keep one row per issue. This is the dominant per-query cost of the issue scene's initial-event load and the Max AI stack-trace context.

Measured on the Test Cluster against the busiest issue in the team 2 snapshot (2.6M events, median of 5 with `use_uncompressed_cache=0`): the current shape reads **173.5 GB** in 1.55 s with 813 MB peak memory; the two-pass shape reads **0.9 GB** in 0.27 s with 10 MB — an identical result, ~193× less read.

## Changes

- All three builders (V1 utils, shared by V2's inner query; V3 optimized State path; V3 legacy shape) now aggregate only `argMin/argMax(uuid, timestamp)` as `first_event_uuid`/`last_event_uuid`.
- The runner's new `_attach_events` fetches the selected events' payloads with one bounded point lookup (`uuid IN (...)`, same `toDateTime`-wrapped range bounds as the aggregation for identical boundary semantics, `LIMIT 1 BY uuid` against pre-merge duplicate rows, and an explicit `LIMIT len(uuids)` since `execute_hogql_query` otherwise injects a default 100-row limit). Columns are renamed back to `first_event`/`last_event`, so builders' `process_results` and all consumers are unchanged.
- Snapshot infra: `clean_varying_query_parts` learns to normalize `in(events.uuid, ['...'])` lists, since the lookup embeds per-run-random fixture event uuids.

Originally stacked on #62718 for snapshot-conflict convenience; now based directly on master (snapshots regenerated against it) so it can ship first.

## How did you test this code?

Agent-authored; automated tests only: the full runner test directory (V1 + V2 + V3, 87 tests) passes twice in a row against a flushed query cache (the second run proves snapshot stability), plus the Max AI context suite (12, exercising the real `withFirstEvent` path end-to-end) and the query API suite (25). Snapshots now record both the aggregation and the point lookup explicitly. The 193× figure is from a production-snapshot Test Cluster measurement, median of 5, reading `system.query_log`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as part of an error tracking query-performance investigation (same series as #62718, #62714, #62715, #62716); the rewrite was measured on the Test Cluster before implementation. Three Codex autoreview rounds caught and shaped real fixes: the missing explicit LIMIT (default 100-row truncation), the `toDateTime` boundary-precision mismatch between passes, and pre-merge duplicate uuid rows starving the row limit (now `LIMIT 1 BY uuid`).

