### PR TITLE
feat(capture): add explicit histogram buckets for capture v1 metrics

### DIFF
--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -123,6 +123,13 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         2500.0, 5000.0, 10000.0, 30000.0, 60000.0, 120000.0, 300000.0,
     ];
 
+    // Same shape as KAFKA_PRODUCE_ACK_MS, but in seconds for the v1 sink's
+    // `capture_v1_kafka_ack_duration_seconds` histogram.
+    const KAFKA_PRODUCE_ACK_SECONDS: &[f64] = &[
+        0.0005, 0.001, 0.002, 0.005, 0.01, 0.015, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.5, 1.0,
+        2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+    ];
+
     PrometheusBuilder::new()
         .add_global_label("role", role)
         .add_global_label("capture_mode", capture_mode)
@@ -206,6 +213,19 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         .set_buckets_for_metric(
             Matcher::Full("capture_kafka_produce_ack_duration_ms".to_string()),
             KAFKA_PRODUCE_ACK_MS,
+        )
+        .unwrap()
+        // v1 pipeline histograms: without explicit buckets these fall back to
+        // the metrics-exporter-prometheus defaults, which are too coarse for
+        // meaningful percentile queries in Grafana.
+        .set_buckets_for_metric(
+            Matcher::Full("capture_v1_response_time_seconds".to_string()),
+            EXPONENTIAL_SECONDS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("capture_v1_kafka_ack_duration_seconds".to_string()),
+            KAFKA_PRODUCE_ACK_SECONDS,
         )
         .unwrap()
         .install_recorder()

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -228,6 +228,19 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
             KAFKA_PRODUCE_ACK_SECONDS,
         )
         .unwrap()
+        // capture_v1_event_batch_size is covered by the Suffix("_batch_size")
+        // matcher above; only the payload-size and clock-skew histograms need
+        // explicit entries.
+        .set_buckets_for_metric(
+            Matcher::Full("capture_v1_payload_size_bytes".to_string()),
+            PAYLOAD_SIZES,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("capture_v1_clock_skew_seconds".to_string()),
+            CLOCK_SKEW_SECONDS,
+        )
+        .unwrap()
         .install_recorder()
         .unwrap()
 }

--- a/rust/capture/src/v1/analytics/handler.rs
+++ b/rust/capture/src/v1/analytics/handler.rs
@@ -36,6 +36,9 @@ pub async fn handle_request(
     // TODO: purposely chatty, for now
     ctx_log!(Level::INFO, context, "handle_request called");
 
+    let skew_seconds = context.clock_skew().num_milliseconds().saturating_abs() as f64 / 1000.0;
+    metrics::histogram!(CAPTURE_V1_CLOCK_SKEW_SECONDS).record(skew_seconds);
+
     // Non-fatal: unusable PostHog-Sdk-Info means $lib/$lib_version can't be
     // materialized for this batch. Count once per request for visibility.
     if context.sdk_lib_and_version().is_none() {
@@ -65,6 +68,9 @@ pub async fn handle_request(
         err
     })?;
 
+    metrics::histogram!(CAPTURE_V1_PAYLOAD_SIZE, "stage" => "compressed")
+        .record(raw_bytes.len() as f64);
+
     let payload = v1::util::decompress_payload(
         context.content_encoding.as_deref(),
         raw_bytes,
@@ -77,11 +83,16 @@ pub async fn handle_request(
         err
     })?;
 
+    metrics::histogram!(CAPTURE_V1_PAYLOAD_SIZE, "stage" => "decompressed")
+        .record(payload.len() as f64);
+
     let batch: Batch = serde_json::from_slice(&payload).map_err(|e| {
         let err = v1::Error::RequestParsingError(e.to_string());
         log_stat_error!(err, &context);
         err
     })?;
+
+    metrics::histogram!(CAPTURE_V1_EVENT_BATCH_SIZE).record(batch.batch.len() as f64);
 
     match super::process::process_batch(&state, &mut context, batch).await {
         Ok(resp) => Ok(resp.into_response()),

--- a/rust/capture/src/v1/constants.rs
+++ b/rust/capture/src/v1/constants.rs
@@ -52,6 +52,19 @@ pub(super) const CAPTURE_V1_WARNING_METRIC: &str = "capture_v1_analytics_warning
 /// Counter name for body-read timeouts during payload extraction.
 pub(super) const CAPTURE_V1_BODY_READ_TIMEOUT: &str = "capture_v1_body_read_timeout_total";
 
+/// Histogram of events per request batch. The `_batch_size` suffix picks up
+/// the shared BATCH_SIZES buckets configured in prometheus.rs.
+pub(super) const CAPTURE_V1_EVENT_BATCH_SIZE: &str = "capture_v1_event_batch_size";
+
+/// Histogram of request payload sizes in bytes (label: stage = compressed |
+/// decompressed). Buckets configured in prometheus.rs (PAYLOAD_SIZES).
+pub(super) const CAPTURE_V1_PAYLOAD_SIZE: &str = "capture_v1_payload_size_bytes";
+
+/// Histogram of absolute client clock skew in seconds, from the
+/// PostHog-Request-Timestamp header vs. server receive time. Buckets
+/// configured in prometheus.rs (CLOCK_SKEW_SECONDS).
+pub(super) const CAPTURE_V1_CLOCK_SKEW_SECONDS: &str = "capture_v1_clock_skew_seconds";
+
 // ---------------------------------------------------------------------------
 // Fallback values
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
New capture historgram keys and bucket cfgs. Supports the new "Capture V1 | Details" Grafana dashboard.
