### PR TITLE
fix(flags): stop $feature_flag_called creating orphan person profiles

### DIFF
--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -87,6 +87,7 @@ function buildPipeline(configOverrides: Partial<AiEventSubpipelineConfig> = {}) 
             PERSON_MERGE_SYNC_BATCH_SIZE: 0,
             PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
             PERSON_PROPERTIES_UPDATE_ALL: false,
+            FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*',
         },
         outputs: mockOutputs,
         teamManager: {

--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.ts
@@ -91,7 +91,7 @@ export function createAiEventSubpipeline<TInput extends AiEventSubpipelineInput,
         )
         .pipe(createNormalizeEventStep())
         .pipe(createProcessAiEventStep())
-        .pipe(createProcessPersonlessStep())
+        .pipe(createProcessPersonlessStep(options.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS))
         .pipe(
             topHog(createProcessPersonsStep(options, outputs), [
                 timer('process_persons_time', (input) => ({

--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -83,7 +83,7 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
             ])
         )
         .pipe(createNormalizeEventStep())
-        .pipe(createProcessPersonlessStep())
+        .pipe(createProcessPersonlessStep(options.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS))
         .pipe(
             topHog(createProcessPersonsStep(options, outputs), [
                 timer('process_persons_time', (input) => ({

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -19,6 +19,9 @@ import type { PostgresRouterConfig } from '../utils/db/postgres'
 import { isDevEnv, isProdEnv } from '../utils/env-utils'
 import { INGESTION_DOWNSTREAM_PRODUCER, INGESTION_UPSTREAM_PRODUCER, type ProducerName } from './common/outputs'
 
+/** Default for FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*' enables the personless default for all teams. */
+export const DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS = '*'
+
 // =============================================================================
 // Infrastructure sub-config types
 // These group CommonConfig keys by infrastructure concern for use in server
@@ -273,7 +276,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         EVENT_SCHEMA_ENFORCEMENT_ENABLED: true,
         KAFKA_BATCH_START_LOGGING_ENABLED: false,
-        FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*',
+        FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
 
         // AI event splitting config
         INGESTION_AI_EVENT_SPLITTING_ENABLED: false,

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -160,6 +160,8 @@ export type IngestionConsumerConfig = {
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
     EVENT_SCHEMA_ENFORCEMENT_ENABLED: boolean
     KAFKA_BATCH_START_LOGGING_ENABLED: boolean
+    /** Teams whose $feature_flag_called events default to personless: '*' for all, '' to disable, or comma-separated team IDs */
+    FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: string
 
     // AI event splitting config
     INGESTION_AI_EVENT_SPLITTING_ENABLED: boolean
@@ -271,6 +273,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: false,
         EVENT_SCHEMA_ENFORCEMENT_ENABLED: true,
         KAFKA_BATCH_START_LOGGING_ENABLED: false,
+        FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*',
 
         // AI event splitting config
         INGESTION_AI_EVENT_SPLITTING_ENABLED: false,

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -19,8 +19,8 @@ import type { PostgresRouterConfig } from '../utils/db/postgres'
 import { isDevEnv, isProdEnv } from '../utils/env-utils'
 import { INGESTION_DOWNSTREAM_PRODUCER, INGESTION_UPSTREAM_PRODUCER, type ProducerName } from './common/outputs'
 
-/** Default for FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*' enables the personless default for all teams. */
-export const DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS = '*'
+/** Default for FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '' disables the personless default so it is opt-in per team via config. */
+export const DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS = ''
 
 // =============================================================================
 // Infrastructure sub-config types

--- a/nodejs/src/ingestion/event-processing/event-pipeline-options.ts
+++ b/nodejs/src/ingestion/event-processing/event-pipeline-options.ts
@@ -5,4 +5,6 @@ export interface EventPipelineRunnerOptions {
     PERSON_MERGE_SYNC_BATCH_SIZE: number
     PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
     PERSON_PROPERTIES_UPDATE_ALL: boolean
+    /** Teams whose $feature_flag_called events default to personless: '*' for all, '' to disable, or comma-separated team IDs */
+    FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: string
 }

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -148,6 +148,8 @@ describe('normalizeProcessPersonFlagStep', () => {
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
                 expect(result.value.processPerson).toBe(false)
+                // The explicit-true capture happens before the header override.
+                expect(result.value.processPersonExplicitlyTrue).toBe(true)
                 expect(result.value.forceDisablePersonProcessing).toBe(true)
             }
         })
@@ -189,7 +191,7 @@ describe('normalizeProcessPersonFlagStep', () => {
         })
 
         it('leaves $feature_flag_called events personful when no $process_person_profile property is set', async () => {
-            const input: PerDistinctIdPipelineInput = {
+            const input: StepInput = {
                 ...baseInput,
                 event: {
                     ...baseEvent,
@@ -214,43 +216,27 @@ describe('normalizeProcessPersonFlagStep', () => {
             }
         })
 
-        it('keeps processPerson=true when $process_person_profile=true explicitly', async () => {
-            const input: StepInput = {
-                ...baseInput,
-                event: {
-                    ...baseEvent,
-                    properties: { $process_person_profile: true },
-                },
+        it.each(['$pageview', '$feature_flag_called'])(
+            'keeps %s personful when $process_person_profile=true explicitly',
+            async (eventName) => {
+                const input: StepInput = {
+                    ...baseInput,
+                    event: {
+                        ...baseEvent,
+                        event: eventName,
+                        properties: { $process_person_profile: true },
+                    },
+                }
+
+                const result = await normalizeStep(input)
+
+                expect(result.type).toBe(PipelineResultType.OK)
+                if (result.type === PipelineResultType.OK) {
+                    expect(result.value.processPerson).toBe(true)
+                    expect(result.value.processPersonExplicitlyTrue).toBe(true)
+                    expect(result.value.forceDisablePersonProcessing).toBe(false)
+                }
             }
-
-            const result = await normalizeStep(input)
-
-            expect(result.type).toBe(PipelineResultType.OK)
-            if (result.type === PipelineResultType.OK) {
-                expect(result.value.processPerson).toBe(true)
-                expect(result.value.processPersonExplicitlyTrue).toBe(true)
-                expect(result.value.forceDisablePersonProcessing).toBe(false)
-            }
-        })
-
-        it('keeps $feature_flag_called personful when $process_person_profile=true explicitly', async () => {
-            const input: PerDistinctIdPipelineInput = {
-                ...baseInput,
-                event: {
-                    ...baseEvent,
-                    event: '$feature_flag_called',
-                    properties: { $process_person_profile: true },
-                },
-            }
-
-            const result = await normalizeStep(input)
-
-            expect(result.type).toBe(PipelineResultType.OK)
-            if (result.type === PipelineResultType.OK) {
-                expect(result.value.processPerson).toBe(true)
-                expect(result.value.processPersonExplicitlyTrue).toBe(true)
-                expect(result.value.forceDisablePersonProcessing).toBe(false)
-            }
-        })
+        )
     })
 })

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -186,7 +186,7 @@ describe('normalizeProcessPersonFlagStep', () => {
             }
         })
 
-        it('defaults $feature_flag_called events to personless when no $process_person_profile property is set', async () => {
+        it('leaves $feature_flag_called events personful when no $process_person_profile property is set', async () => {
             const input: PerDistinctIdPipelineInput = {
                 ...baseInput,
                 event: {
@@ -204,10 +204,10 @@ describe('normalizeProcessPersonFlagStep', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
-                expect(result.value.processPerson).toBe(false)
+                expect(result.value.processPerson).toBe(true)
                 expect(result.value.forceDisablePersonProcessing).toBe(false)
-                expect(result.value.event.properties?.$process_person_profile).toBe(false)
-                expect(result.value.event.properties?.$set).toBeUndefined()
+                expect(result.value.event.properties?.$process_person_profile).toBeUndefined()
+                expect(result.value.event.properties?.$set).toEqual({ email: 'user@example.com' })
             }
         })
 

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -186,11 +186,55 @@ describe('normalizeProcessPersonFlagStep', () => {
             }
         })
 
+        it('defaults $feature_flag_called events to personless when no $process_person_profile property is set', async () => {
+            const input: PerDistinctIdPipelineInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$feature_flag_called',
+                    properties: {
+                        $feature_flag: 'new-homepage',
+                        $feature_flag_response: 'test',
+                        $set: { email: 'user@example.com' },
+                    },
+                },
+            }
+
+            const result = await normalizeStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.forceDisablePersonProcessing).toBe(false)
+                expect(result.value.event.properties?.$process_person_profile).toBe(false)
+                expect(result.value.event.properties?.$set).toBeUndefined()
+            }
+        })
+
         it('keeps processPerson=true when $process_person_profile=true explicitly', async () => {
             const input: StepInput = {
                 ...baseInput,
                 event: {
                     ...baseEvent,
+                    properties: { $process_person_profile: true },
+                },
+            }
+
+            const result = await normalizeStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.forceDisablePersonProcessing).toBe(false)
+            }
+        })
+
+        it('keeps $feature_flag_called personful when $process_person_profile=true explicitly', async () => {
+            const input: PerDistinctIdPipelineInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$feature_flag_called',
                     properties: { $process_person_profile: true },
                 },
             }

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.test.ts
@@ -70,6 +70,7 @@ describe('normalizeProcessPersonFlagStep', () => {
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
                 expect(result.value.processPerson).toBe(false)
+                expect(result.value.processPersonExplicitlyTrue).toBe(false)
                 expect(result.value.forceDisablePersonProcessing).toBe(false)
             }
         })
@@ -182,6 +183,7 @@ describe('normalizeProcessPersonFlagStep', () => {
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
                 expect(result.value.processPerson).toBe(true)
+                expect(result.value.processPersonExplicitlyTrue).toBe(false)
                 expect(result.value.forceDisablePersonProcessing).toBe(false)
             }
         })
@@ -205,6 +207,7 @@ describe('normalizeProcessPersonFlagStep', () => {
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
                 expect(result.value.processPerson).toBe(true)
+                expect(result.value.processPersonExplicitlyTrue).toBe(false)
                 expect(result.value.forceDisablePersonProcessing).toBe(false)
                 expect(result.value.event.properties?.$process_person_profile).toBeUndefined()
                 expect(result.value.event.properties?.$set).toEqual({ email: 'user@example.com' })
@@ -225,6 +228,7 @@ describe('normalizeProcessPersonFlagStep', () => {
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
                 expect(result.value.processPerson).toBe(true)
+                expect(result.value.processPersonExplicitlyTrue).toBe(true)
                 expect(result.value.forceDisablePersonProcessing).toBe(false)
             }
         })
@@ -244,6 +248,7 @@ describe('normalizeProcessPersonFlagStep', () => {
             expect(result.type).toBe(PipelineResultType.OK)
             if (result.type === PipelineResultType.OK) {
                 expect(result.value.processPerson).toBe(true)
+                expect(result.value.processPersonExplicitlyTrue).toBe(true)
                 expect(result.value.forceDisablePersonProcessing).toBe(false)
             }
         })

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
@@ -16,6 +16,8 @@ type NormalizeProcessPersonFlagOutput = {
     forceDisablePersonProcessing: boolean
 }
 
+const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
+
 export function createNormalizeProcessPersonFlagStep<TInput extends NormalizeProcessPersonFlagInput>(): ProcessingStep<
     TInput,
     TInput & NormalizeProcessPersonFlagOutput
@@ -74,6 +76,9 @@ export function createNormalizeProcessPersonFlagStep<TInput extends NormalizePro
                         alwaysSend: false,
                     })
                 }
+            } else if (event.event === FEATURE_FLAG_CALLED_EVENT) {
+                processPerson = false
+                normalizedEvent = normalizeProcessPerson(event, processPerson)
             }
         }
 

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
@@ -13,6 +13,7 @@ type NormalizeProcessPersonFlagInput = {
 
 type NormalizeProcessPersonFlagOutput = {
     processPerson: boolean
+    processPersonExplicitlyTrue: boolean
     forceDisablePersonProcessing: boolean
 }
 
@@ -28,6 +29,9 @@ export function createNormalizeProcessPersonFlagStep<TInput extends NormalizePro
         const forceDisablePersonProcessing = input.headers.force_disable_person_processing === true
         let processPerson = true // The default.
         let normalizedEvent = event
+        // Captured here because normalizeProcessPerson later deletes the property for
+        // personful events, and downstream steps need to know it was explicitly set.
+        const processPersonExplicitlyTrue = event.properties?.$process_person_profile === true
 
         // Check if force_disable_person_processing header is set to true
         if (forceDisablePersonProcessing) {
@@ -83,6 +87,7 @@ export function createNormalizeProcessPersonFlagStep<TInput extends NormalizePro
                     ...input,
                     event: normalizedEvent,
                     processPerson,
+                    processPersonExplicitlyTrue,
                     forceDisablePersonProcessing,
                 },
                 [],

--- a/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
+++ b/nodejs/src/ingestion/event-processing/normalize-process-person-flag-step.ts
@@ -16,8 +16,6 @@ type NormalizeProcessPersonFlagOutput = {
     forceDisablePersonProcessing: boolean
 }
 
-const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
-
 export function createNormalizeProcessPersonFlagStep<TInput extends NormalizeProcessPersonFlagInput>(): ProcessingStep<
     TInput,
     TInput & NormalizeProcessPersonFlagOutput
@@ -76,9 +74,6 @@ export function createNormalizeProcessPersonFlagStep<TInput extends NormalizePro
                         alwaysSend: false,
                     })
                 }
-            } else if (event.event === FEATURE_FLAG_CALLED_EVENT) {
-                processPerson = false
-                normalizedEvent = normalizeProcessPerson(event, processPerson)
             }
         }
 

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -138,6 +138,53 @@ describe('createProcessPersonlessStep', () => {
         }
     })
 
+    it('keeps $feature_flag_called personful when a person already exists', async () => {
+        const personUuid = new UUIDT().toString()
+
+        await createPerson(hub, timestamp, { name: 'John' }, {}, {}, teamId, null, false, personUuid, {
+            distinctId: pluginEvent.distinct_id,
+        })
+
+        const step = createProcessPersonlessStep(personsStore)
+        const result = await step(
+            createInput({
+                processPerson: true,
+                normalizedEvent: {
+                    ...pluginEvent,
+                    event: '$feature_flag_called',
+                    properties: { $feature_flag: 'new-homepage', $feature_flag_response: 'test' },
+                },
+            })
+        )
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.processPerson).toBe(true)
+            expect(result.value.personlessPerson).toBeUndefined()
+        }
+    })
+
+    it('defaults $feature_flag_called to personless when no person exists', async () => {
+        const step = createProcessPersonlessStep(personsStore)
+        const result = await step(
+            createInput({
+                processPerson: true,
+                normalizedEvent: {
+                    ...pluginEvent,
+                    event: '$feature_flag_called',
+                    properties: { $feature_flag: 'new-homepage', $feature_flag_response: 'test' },
+                },
+            })
+        )
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.processPerson).toBe(false)
+            expect(result.value.personlessPerson).toBeDefined()
+            expect(result.value.personlessPerson!.properties).toEqual({})
+        }
+    })
+
     describe('basic personless functionality', () => {
         it('returns fake person when no existing person found', async () => {
             const step = createProcessPersonlessStep()

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -130,8 +130,12 @@ describe('createProcessPersonlessStep', () => {
         ...overrides,
     })
 
+    // Builds the step with the flag-called personless default enabled for all teams. The
+    // production default is '' (opt-in per team), so tests opt in explicitly here.
+    const buildStep = () => createProcessPersonlessStep('*')
+
     it('passes through when processPerson is true', async () => {
-        const step = createProcessPersonlessStep()
+        const step = buildStep()
         const input = createInput({ processPerson: true })
 
         const result = await step(input)
@@ -156,7 +160,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -169,7 +173,7 @@ describe('createProcessPersonlessStep', () => {
         it('keeps the event personful when it carries group keys', async () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(
                 createInput({
                     processPerson: true,
@@ -186,7 +190,7 @@ describe('createProcessPersonlessStep', () => {
         })
 
         it('still defaults to personless when $groups is empty', async () => {
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(
                 createInput({ processPerson: true, normalizedEvent: flagCalledEvent({ $groups: {} }) })
             )
@@ -226,7 +230,7 @@ describe('createProcessPersonlessStep', () => {
         it('keeps the event personful when $process_person_profile was explicitly true', async () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(
                 createInput({
                     processPerson: true,
@@ -246,7 +250,7 @@ describe('createProcessPersonlessStep', () => {
         it('defaults to personless and records the distinct ID when no person exists', async () => {
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(
                 createInput({
                     processPerson: true,
@@ -270,7 +274,7 @@ describe('createProcessPersonlessStep', () => {
             jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(false)
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -290,7 +294,7 @@ describe('createProcessPersonlessStep', () => {
             jest.spyOn(personsStore, 'addPersonlessDistinctId').mockResolvedValue(true)
             const fetchForUpdateSpy = jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(person)
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -306,7 +310,7 @@ describe('createProcessPersonlessStep', () => {
             jest.spyOn(personsStore, 'addPersonlessDistinctId').mockResolvedValue(true)
             jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(null)
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -320,7 +324,7 @@ describe('createProcessPersonlessStep', () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(
                 createInput({ normalizedEvent: flagCalledEvent(), forceDisablePersonProcessing: true })
             )
@@ -356,7 +360,7 @@ describe('createProcessPersonlessStep', () => {
         }
 
         it('keeps an explicit-true event personful after normalization strips the property', async () => {
-            const personlessStep = createProcessPersonlessStep()
+            const personlessStep = buildStep()
             const normalized = await runThroughNormalization(flagCalledEvent({ $process_person_profile: true }))
 
             // Normalization removes the explicit-true property for personful events, so the
@@ -373,7 +377,7 @@ describe('createProcessPersonlessStep', () => {
         })
 
         it('defaults an event without the property to personless through normalization', async () => {
-            const personlessStep = createProcessPersonlessStep()
+            const personlessStep = buildStep()
             const normalized = await runThroughNormalization(flagCalledEvent())
 
             const result = await personlessStep(normalized)
@@ -389,7 +393,7 @@ describe('createProcessPersonlessStep', () => {
         it('skips the defaulting branch for explicit $process_person_profile=false events', async () => {
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 
-            const personlessStep = createProcessPersonlessStep()
+            const personlessStep = buildStep()
             const normalized = await runThroughNormalization(flagCalledEvent({ $process_person_profile: false }))
 
             const result = await personlessStep(normalized)
@@ -406,7 +410,7 @@ describe('createProcessPersonlessStep', () => {
 
     describe('basic personless functionality', () => {
         it('returns fake person when no existing person found', async () => {
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -427,7 +431,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -442,7 +446,7 @@ describe('createProcessPersonlessStep', () => {
         it('checks batch result for personless distinct ID when no person exists', async () => {
             const getPersonlessBatchResultSpy = jest.spyOn(personsStore, 'getPersonlessBatchResult')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             await step(createInput())
 
             expect(getPersonlessBatchResultSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
@@ -451,7 +455,7 @@ describe('createProcessPersonlessStep', () => {
         it('returns fake person when batch result indicates no merge', async () => {
             jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(false)
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -471,7 +475,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -490,7 +494,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -511,7 +515,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -545,7 +549,7 @@ describe('createProcessPersonlessStep', () => {
             jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(true)
             const fetchForUpdateSpy = jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(person)
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput())
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -558,7 +562,7 @@ describe('createProcessPersonlessStep', () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
             const getPersonlessBatchResultSpy = jest.spyOn(personsStore, 'getPersonlessBatchResult')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             const result = await step(createInput({ forceDisablePersonProcessing: true }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -576,7 +580,7 @@ describe('createProcessPersonlessStep', () => {
         it('performs normal processing when false', async () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
 
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
             await step(createInput())
 
             expect(fetchForCheckingSpy).toHaveBeenCalled()
@@ -584,7 +588,7 @@ describe('createProcessPersonlessStep', () => {
 
         it('works with different distinct IDs', async () => {
             const distinctIds = ['user-1', 'user-2', 'user-3']
-            const step = createProcessPersonlessStep()
+            const step = buildStep()
 
             for (const distinctId of distinctIds) {
                 const result = await step(

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -156,7 +156,7 @@ describe('createProcessPersonlessStep', () => {
                 distinctId: pluginEvent.distinct_id,
             })
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -166,10 +166,67 @@ describe('createProcessPersonlessStep', () => {
             }
         })
 
+        it('keeps the event personful when it carries group keys', async () => {
+            const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
+
+            const step = createProcessPersonlessStep()
+            const result = await step(
+                createInput({
+                    processPerson: true,
+                    normalizedEvent: flagCalledEvent({ $groups: { organization: 'org-1' } }),
+                })
+            )
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.personlessPerson).toBeUndefined()
+            }
+            expect(fetchForCheckingSpy).not.toHaveBeenCalled()
+        })
+
+        it('still defaults to personless when $groups is empty', async () => {
+            const step = createProcessPersonlessStep()
+            const result = await step(
+                createInput({ processPerson: true, normalizedEvent: flagCalledEvent({ $groups: {} }) })
+            )
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.personlessPerson).toBeDefined()
+            }
+        })
+
+        it('keeps the event personful when the default is disabled via config', async () => {
+            const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
+
+            const step = createProcessPersonlessStep('')
+            const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.personlessPerson).toBeUndefined()
+            }
+            expect(fetchForCheckingSpy).not.toHaveBeenCalled()
+        })
+
+        it('applies the default when the team is in the configured team list', async () => {
+            const step = createProcessPersonlessStep(`${teamId}`)
+            const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.personlessPerson).toBeDefined()
+            }
+        })
+
         it('keeps the event personful when $process_person_profile was explicitly true', async () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(
                 createInput({
                     processPerson: true,
@@ -189,7 +246,7 @@ describe('createProcessPersonlessStep', () => {
         it('defaults to personless and records the distinct ID when no person exists', async () => {
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(
                 createInput({
                     processPerson: true,
@@ -206,14 +263,14 @@ describe('createProcessPersonlessStep', () => {
                 expect(result.value.normalizedEvent.properties?.$set).toBeUndefined()
                 expect(result.value.normalizedEvent.properties?.$process_person_profile).toBe(false)
             }
-            expect(addPersonlessDistinctIdSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
+            expect(addPersonlessDistinctIdSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id, 0)
         })
 
         it('skips the personless distinct ID insert when the batch already has a result', async () => {
             jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(false)
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -233,7 +290,7 @@ describe('createProcessPersonlessStep', () => {
             jest.spyOn(personsStore, 'addPersonlessDistinctId').mockResolvedValue(true)
             const fetchForUpdateSpy = jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(person)
 
-            const step = createProcessPersonlessStep(personsStore)
+            const step = createProcessPersonlessStep()
             const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
             expect(result.type).toBe(PipelineResultType.OK)
@@ -241,7 +298,39 @@ describe('createProcessPersonlessStep', () => {
                 expect(result.value.processPerson).toBe(true)
                 expect(result.value.personlessPerson).toBeUndefined()
             }
-            expect(fetchForUpdateSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
+            expect(fetchForUpdateSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id, 0)
+        })
+
+        it('defaults to personless when the merged person cannot be fetched from the leader', async () => {
+            jest.spyOn(personsStore, 'fetchForChecking').mockResolvedValue(null)
+            jest.spyOn(personsStore, 'addPersonlessDistinctId').mockResolvedValue(true)
+            jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(null)
+
+            const step = createProcessPersonlessStep()
+            const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.personlessPerson).toBeDefined()
+            }
+        })
+
+        it('skips the defaulting branch when person processing is force-disabled', async () => {
+            const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            const step = createProcessPersonlessStep()
+            const result = await step(
+                createInput({ normalizedEvent: flagCalledEvent(), forceDisablePersonProcessing: true })
+            )
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.personlessPerson).toBeDefined()
+            }
+            expect(fetchForCheckingSpy).not.toHaveBeenCalled()
+            expect(addPersonlessDistinctIdSpy).not.toHaveBeenCalled()
         })
 
         // Pipes an event through the same normalization steps that precede the personless
@@ -263,11 +352,11 @@ describe('createProcessPersonlessStep', () => {
             if (!isOkResult(normalizeResult)) {
                 throw new Error('expected normalize event step to return ok')
             }
-            return normalizeResult.value
+            return { ...normalizeResult.value, personsStoreForBatch: new BatchBoundPersonsStore(personsStore, 0) }
         }
 
         it('keeps an explicit-true event personful after normalization strips the property', async () => {
-            const personlessStep = createProcessPersonlessStep(personsStore)
+            const personlessStep = createProcessPersonlessStep()
             const normalized = await runThroughNormalization(flagCalledEvent({ $process_person_profile: true }))
 
             // Normalization removes the explicit-true property for personful events, so the
@@ -284,7 +373,7 @@ describe('createProcessPersonlessStep', () => {
         })
 
         it('defaults an event without the property to personless through normalization', async () => {
-            const personlessStep = createProcessPersonlessStep(personsStore)
+            const personlessStep = createProcessPersonlessStep()
             const normalized = await runThroughNormalization(flagCalledEvent())
 
             const result = await personlessStep(normalized)
@@ -295,6 +384,23 @@ describe('createProcessPersonlessStep', () => {
                 expect(result.value.personlessPerson).toBeDefined()
                 expect(result.value.normalizedEvent.properties?.$process_person_profile).toBe(false)
             }
+        })
+
+        it('skips the defaulting branch for explicit $process_person_profile=false events', async () => {
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            const personlessStep = createProcessPersonlessStep()
+            const normalized = await runThroughNormalization(flagCalledEvent({ $process_person_profile: false }))
+
+            const result = await personlessStep(normalized)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.personlessPerson).toBeDefined()
+            }
+            // The plain personless path leaves the insert to the batch step.
+            expect(addPersonlessDistinctIdSpy).not.toHaveBeenCalled()
         })
     })
 

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -316,7 +316,7 @@ describe('createProcessPersonlessStep', () => {
             }
         })
 
-        it('skips the defaulting branch when person processing is force-disabled', async () => {
+        it('takes the generic personless path, not the defaulting branch, when already force-disabled', async () => {
             const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
             const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
 

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -8,15 +8,18 @@ import { BatchWritingPersonsStore } from '~/worker/ingestion/persons/batch-writi
 import { BatchBoundPersonsStore } from '~/worker/ingestion/persons/persons-store-for-batch'
 import { PostgresPersonRepository } from '~/worker/ingestion/persons/repositories/postgres-person-repository'
 
+import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
 import { createOrganization, createTeam, getTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID } from '../../config/kafka-topics'
-import { Hub, InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../types'
+import { EventHeaders, Hub, InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
 import { UUIDT } from '../../utils/utils'
 import { PERSONS_OUTPUT, PERSON_DISTINCT_IDS_OUTPUT } from '../analytics/outputs'
 import { INGESTION_WARNINGS_OUTPUT } from '../common/outputs'
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '../outputs/single-ingestion-output'
+import { createNormalizeEventStep } from './normalize-event-step'
+import { createNormalizeProcessPersonFlagStep } from './normalize-process-person-flag-step'
 import { ProcessPersonlessInput, createProcessPersonlessStep } from './process-personless-step'
 
 function createPersonOutputs(_hub: Hub) {
@@ -121,6 +124,7 @@ describe('createProcessPersonlessStep', () => {
         team,
         timestamp,
         processPerson: false,
+        processPersonExplicitlyTrue: false,
         forceDisablePersonProcessing: false,
         personsStoreForBatch: new BatchBoundPersonsStore(personsStore, 0),
         ...overrides,
@@ -138,51 +142,160 @@ describe('createProcessPersonlessStep', () => {
         }
     })
 
-    it('keeps $feature_flag_called personful when a person already exists', async () => {
-        const personUuid = new UUIDT().toString()
-
-        await createPerson(hub, timestamp, { name: 'John' }, {}, {}, teamId, null, false, personUuid, {
-            distinctId: pluginEvent.distinct_id,
+    describe('$feature_flag_called personless default', () => {
+        const flagCalledEvent = (properties: Properties = {}): PluginEvent => ({
+            ...pluginEvent,
+            event: '$feature_flag_called',
+            properties: { $feature_flag: 'new-homepage', $feature_flag_response: 'test', ...properties },
         })
 
-        const step = createProcessPersonlessStep(personsStore)
-        const result = await step(
-            createInput({
-                processPerson: true,
-                normalizedEvent: {
-                    ...pluginEvent,
-                    event: '$feature_flag_called',
-                    properties: { $feature_flag: 'new-homepage', $feature_flag_response: 'test' },
-                },
+        it('keeps the event personful when a person already exists', async () => {
+            const personUuid = new UUIDT().toString()
+
+            await createPerson(hub, timestamp, { name: 'John' }, {}, {}, teamId, null, false, personUuid, {
+                distinctId: pluginEvent.distinct_id,
             })
-        )
 
-        expect(result.type).toBe(PipelineResultType.OK)
-        if (isOkResult(result)) {
-            expect(result.value.processPerson).toBe(true)
-            expect(result.value.personlessPerson).toBeUndefined()
-        }
-    })
+            const step = createProcessPersonlessStep(personsStore)
+            const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
 
-    it('defaults $feature_flag_called to personless when no person exists', async () => {
-        const step = createProcessPersonlessStep(personsStore)
-        const result = await step(
-            createInput({
-                processPerson: true,
-                normalizedEvent: {
-                    ...pluginEvent,
-                    event: '$feature_flag_called',
-                    properties: { $feature_flag: 'new-homepage', $feature_flag_response: 'test' },
-                },
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.personlessPerson).toBeUndefined()
+            }
+        })
+
+        it('keeps the event personful when $process_person_profile was explicitly true', async () => {
+            const fetchForCheckingSpy = jest.spyOn(personsStore, 'fetchForChecking')
+
+            const step = createProcessPersonlessStep(personsStore)
+            const result = await step(
+                createInput({
+                    processPerson: true,
+                    processPersonExplicitlyTrue: true,
+                    normalizedEvent: flagCalledEvent(),
+                })
+            )
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.personlessPerson).toBeUndefined()
+            }
+            expect(fetchForCheckingSpy).not.toHaveBeenCalled()
+        })
+
+        it('defaults to personless and records the distinct ID when no person exists', async () => {
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            const step = createProcessPersonlessStep(personsStore)
+            const result = await step(
+                createInput({
+                    processPerson: true,
+                    normalizedEvent: flagCalledEvent({ $set: { email: 'user@example.com' } }),
+                })
+            )
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.personlessPerson).toBeDefined()
+                expect(result.value.personlessPerson!.properties).toEqual({})
+                // The event is re-normalized as personless: $set stripped, personless stamp added.
+                expect(result.value.normalizedEvent.properties?.$set).toBeUndefined()
+                expect(result.value.normalizedEvent.properties?.$process_person_profile).toBe(false)
+            }
+            expect(addPersonlessDistinctIdSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
+        })
+
+        it('skips the personless distinct ID insert when the batch already has a result', async () => {
+            jest.spyOn(personsStore, 'getPersonlessBatchResult').mockReturnValue(false)
+            const addPersonlessDistinctIdSpy = jest.spyOn(personsStore, 'addPersonlessDistinctId')
+
+            const step = createProcessPersonlessStep(personsStore)
+            const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+            }
+            expect(addPersonlessDistinctIdSpy).not.toHaveBeenCalled()
+        })
+
+        it('keeps the event personful when the distinct ID turns out to be merged', async () => {
+            const personUuid = new UUIDT().toString()
+            const person = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, personUuid, {
+                distinctId: 'merge-target',
             })
-        )
 
-        expect(result.type).toBe(PipelineResultType.OK)
-        if (isOkResult(result)) {
-            expect(result.value.processPerson).toBe(false)
-            expect(result.value.personlessPerson).toBeDefined()
-            expect(result.value.personlessPerson!.properties).toEqual({})
+            jest.spyOn(personsStore, 'fetchForChecking').mockResolvedValue(null)
+            jest.spyOn(personsStore, 'addPersonlessDistinctId').mockResolvedValue(true)
+            const fetchForUpdateSpy = jest.spyOn(personsStore, 'fetchForUpdate').mockResolvedValue(person)
+
+            const step = createProcessPersonlessStep(personsStore)
+            const result = await step(createInput({ processPerson: true, normalizedEvent: flagCalledEvent() }))
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.personlessPerson).toBeUndefined()
+            }
+            expect(fetchForUpdateSpy).toHaveBeenCalledWith(teamId, pluginEvent.distinct_id)
+        })
+
+        // Pipes an event through the same normalization steps that precede the personless
+        // step in the real subpipeline, so these tests cover the boundary where
+        // normalizeProcessPerson strips the explicit $process_person_profile property.
+        const runThroughNormalization = async (event: PluginEvent): Promise<ProcessPersonlessInput> => {
+            const normalizeFlagStep = createNormalizeProcessPersonFlagStep<{
+                event: PluginEvent
+                headers: EventHeaders
+                team: Team
+            }>()
+            const flagResult = await normalizeFlagStep({ event, team, headers: createTestEventHeaders() })
+            if (!isOkResult(flagResult)) {
+                throw new Error('expected normalize flag step to return ok')
+            }
+
+            const normalizeEventStep = createNormalizeEventStep<typeof flagResult.value>()
+            const normalizeResult = await normalizeEventStep(flagResult.value)
+            if (!isOkResult(normalizeResult)) {
+                throw new Error('expected normalize event step to return ok')
+            }
+            return normalizeResult.value
         }
+
+        it('keeps an explicit-true event personful after normalization strips the property', async () => {
+            const personlessStep = createProcessPersonlessStep(personsStore)
+            const normalized = await runThroughNormalization(flagCalledEvent({ $process_person_profile: true }))
+
+            // Normalization removes the explicit-true property for personful events, so the
+            // personless step must rely on the captured processPersonExplicitlyTrue flag.
+            expect(normalized.normalizedEvent.properties?.$process_person_profile).toBeUndefined()
+
+            const result = await personlessStep(normalized)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(true)
+                expect(result.value.personlessPerson).toBeUndefined()
+            }
+        })
+
+        it('defaults an event without the property to personless through normalization', async () => {
+            const personlessStep = createProcessPersonlessStep(personsStore)
+            const normalized = await runThroughNormalization(flagCalledEvent())
+
+            const result = await personlessStep(normalized)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (isOkResult(result)) {
+                expect(result.value.processPerson).toBe(false)
+                expect(result.value.personlessPerson).toBeDefined()
+                expect(result.value.normalizedEvent.properties?.$process_person_profile).toBe(false)
+            }
+        })
     })
 
     describe('basic personless functionality', () => {

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -12,6 +12,7 @@ import {
     personlessDistinctIdCacheOperationsCounter,
 } from '../../worker/ingestion/persons/personless-distinct-id-cache'
 import { PersonsStoreForBatch } from '../../worker/ingestion/persons/persons-store-for-batch'
+import { DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS } from '../config'
 import { PipelineResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
@@ -59,7 +60,7 @@ function eventHasGroups(properties: PluginEvent['properties']): boolean {
  * 4. Returns person (real or fake) with potential force_upgrade flag
  */
 export function createProcessPersonlessStep<TInput extends ProcessPersonlessInput>(
-    flagCalledPersonlessDefaultTeams: string = '*'
+    flagCalledPersonlessDefaultTeams: string = DEFAULT_FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS
 ): ProcessingStep<TInput, TInput & ProcessPersonlessOutput> {
     const flagCalledDefaultEnabledForTeam = buildIntegerMatcher(flagCalledPersonlessDefaultTeams.trim(), true)
 
@@ -150,9 +151,9 @@ async function applyFeatureFlagCalledPersonlessDefault<TInput extends ProcessPer
                 // The LRU keeps repeat distinct IDs from re-inserting on every event; a stale
                 // hit just means the event goes personless, the same trade-off the batch step
                 // accepts.
-                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit' })
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit', source: 'flag_called' })
             } else {
-                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss' })
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss', source: 'flag_called' })
                 // The batch step (processPersonlessDistinctIdsBatchStep) only inserts rows for
                 // events with explicit $process_person_profile=false, so record this distinct ID
                 // here. Without the row, a later identify/merge would never re-point these

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -21,6 +21,8 @@ export type ProcessPersonlessOutput = {
     personlessPerson?: Person
 }
 
+const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
+
 /**
  * Pipeline step that handles personless event processing checks.
  *
@@ -37,7 +39,12 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
     return async function processPersonlessStep(
         input: TInput
     ): Promise<PipelineResult<TInput & ProcessPersonlessOutput>> {
-        if (input.processPerson) {
+        const shouldApplyFeatureFlagCalledDefault =
+            input.processPerson &&
+            input.normalizedEvent.event === FEATURE_FLAG_CALLED_EVENT &&
+            input.normalizedEvent.properties?.$process_person_profile !== true
+
+        if (input.processPerson && !shouldApplyFeatureFlagCalledDefault) {
             return ok(input)
         }
 
@@ -68,6 +75,10 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
         if (existingPerson) {
             const person = existingPerson as Person
 
+            if (shouldApplyFeatureFlagCalledDefault) {
+                return ok(input)
+            }
+
             // Ensure person properties don't propagate elsewhere, such as onto the event itself.
             person.properties = {}
 
@@ -86,7 +97,11 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
             return ok({ ...input, personlessPerson: person })
         }
 
-        return ok({ ...input, personlessPerson: createFakePerson(team.id, distinctId) })
+        return ok({
+            ...input,
+            processPerson: false,
+            personlessPerson: createFakePerson(team.id, distinctId),
+        })
     }
 }
 

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -2,9 +2,15 @@ import { DateTime } from 'luxon'
 
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { buildIntegerMatcher } from '../../config/config'
 import { Person, Team } from '../../types'
 import { normalizeProcessPerson } from '../../utils/event'
 import { uuidFromDistinctId } from '../../worker/ingestion/person-uuid'
+import {
+    hasInsertedPersonlessDistinctId,
+    markPersonlessDistinctIdInserted,
+    personlessDistinctIdCacheOperationsCounter,
+} from '../../worker/ingestion/persons/personless-distinct-id-cache'
 import { PersonsStoreForBatch } from '../../worker/ingestion/persons/persons-store-for-batch'
 import { PipelineResult, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
@@ -26,12 +32,23 @@ export type ProcessPersonlessOutput = {
 const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
 
 /**
+ * Group-keyed experiment exposure queries read the $group_N columns from the exposure
+ * event, and createEvent strips those for personless events. Events carrying group keys
+ * must stay personful or their exposures disappear from group-aggregated experiments.
+ * The $groups property is still raw here; it expands to $group_N in the later groups step.
+ */
+function eventHasGroups(properties: PluginEvent['properties']): boolean {
+    const groups = properties?.$groups
+    return typeof groups === 'object' && groups !== null && !Array.isArray(groups) && Object.keys(groups).length > 0
+}
+
+/**
  * Pipeline step that handles personless event processing checks.
  *
  * Runs when processPerson=false, and also for $feature_flag_called events that did not
  * explicitly set $process_person_profile=true — so server-side flag evaluation does not
  * create orphan person profiles (see #60581). Flag-called events that find an existing
- * person stay personful; the rest are defaulted to personless.
+ * person, or that carry group keys, stay personful; the rest are defaulted to personless.
  *
  * For personless events, this step:
  * 1. Fetches existing person from cache (populated by prefetchPersonsStep)
@@ -39,22 +56,26 @@ const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
  * 3. Calculates force_upgrade flag
  * 4. Returns person (real or fake) with potential force_upgrade flag
  */
-export function createProcessPersonlessStep<TInput extends ProcessPersonlessInput>(): ProcessingStep<
-    TInput,
-    TInput & ProcessPersonlessOutput
-> {
+export function createProcessPersonlessStep<TInput extends ProcessPersonlessInput>(
+    flagCalledPersonlessDefaultTeams: string = '*'
+): ProcessingStep<TInput, TInput & ProcessPersonlessOutput> {
+    const flagCalledDefaultEnabledForTeam = buildIntegerMatcher(flagCalledPersonlessDefaultTeams, true)
+
     return async function processPersonlessStep(
         input: TInput
     ): Promise<PipelineResult<TInput & ProcessPersonlessOutput>> {
         if (input.processPerson) {
             const mayDefaultFlagCalledToPersonless =
-                input.normalizedEvent.event === FEATURE_FLAG_CALLED_EVENT && !input.processPersonExplicitlyTrue
+                input.normalizedEvent.event === FEATURE_FLAG_CALLED_EVENT &&
+                !input.processPersonExplicitlyTrue &&
+                !eventHasGroups(input.normalizedEvent.properties) &&
+                flagCalledDefaultEnabledForTeam(input.team.id)
 
             if (!mayDefaultFlagCalledToPersonless) {
                 return ok(input)
             }
 
-            return await applyFeatureFlagCalledPersonlessDefault(input, personsStore)
+            return await applyFeatureFlagCalledPersonlessDefault(input, input.personsStoreForBatch)
         }
 
         const { normalizedEvent, team, timestamp, forceDisablePersonProcessing, personsStoreForBatch } = input
@@ -112,7 +133,7 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
  */
 async function applyFeatureFlagCalledPersonlessDefault<TInput extends ProcessPersonlessInput>(
     input: TInput,
-    personsStore: PersonsStore
+    personsStore: PersonsStoreForBatch
 ): Promise<PipelineResult<TInput & ProcessPersonlessOutput>> {
     const { normalizedEvent, team } = input
     const distinctId = normalizedEvent.distinct_id
@@ -123,11 +144,20 @@ async function applyFeatureFlagCalledPersonlessDefault<TInput extends ProcessPer
         let personIsMerged = personsStore.getPersonlessBatchResult(team.id, distinctId)
 
         if (personIsMerged === undefined) {
-            // The batch step (processPersonlessDistinctIdsBatchStep) only inserts rows for
-            // events with explicit $process_person_profile=false, so record this distinct ID
-            // here. Without the row, a later identify/merge would never re-point these
-            // events at the merged person.
-            personIsMerged = await personsStore.addPersonlessDistinctId(team.id, distinctId)
+            if (hasInsertedPersonlessDistinctId(team.id, distinctId)) {
+                // The LRU keeps repeat distinct IDs from re-inserting on every event; a stale
+                // hit just means the event goes personless, the same trade-off the batch step
+                // accepts.
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit' })
+            } else {
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss' })
+                // The batch step (processPersonlessDistinctIdsBatchStep) only inserts rows for
+                // events with explicit $process_person_profile=false, so record this distinct ID
+                // here. Without the row, a later identify/merge would never re-point these
+                // events at the merged person.
+                personIsMerged = await personsStore.addPersonlessDistinctId(team.id, distinctId)
+                markPersonlessDistinctIdInserted(team.id, distinctId)
+            }
         }
 
         if (personIsMerged) {

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { Person, Team } from '../../types'
+import { normalizeProcessPerson } from '../../utils/event'
 import { uuidFromDistinctId } from '../../worker/ingestion/person-uuid'
 import { PersonsStoreForBatch } from '../../worker/ingestion/persons/persons-store-for-batch'
 import { PipelineResult, ok } from '../pipelines/results'
@@ -13,6 +14,7 @@ export type ProcessPersonlessInput = {
     team: Team
     timestamp: DateTime
     processPerson: boolean
+    processPersonExplicitlyTrue: boolean
     forceDisablePersonProcessing: boolean
     personsStoreForBatch: PersonsStoreForBatch
 }
@@ -26,7 +28,12 @@ const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
 /**
  * Pipeline step that handles personless event processing checks.
  *
- * When processPerson=false, this step:
+ * Runs when processPerson=false, and also for $feature_flag_called events that did not
+ * explicitly set $process_person_profile=true — so server-side flag evaluation does not
+ * create orphan person profiles (see #60581). Flag-called events that find an existing
+ * person stay personful; the rest are defaulted to personless.
+ *
+ * For personless events, this step:
  * 1. Fetches existing person from cache (populated by prefetchPersonsStep)
  * 2. Checks batch results for is_merged flag (populated by processPersonlessDistinctIdsBatchStep)
  * 3. Calculates force_upgrade flag
@@ -39,13 +46,15 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
     return async function processPersonlessStep(
         input: TInput
     ): Promise<PipelineResult<TInput & ProcessPersonlessOutput>> {
-        const shouldApplyFeatureFlagCalledDefault =
-            input.processPerson &&
-            input.normalizedEvent.event === FEATURE_FLAG_CALLED_EVENT &&
-            input.normalizedEvent.properties?.$process_person_profile !== true
+        if (input.processPerson) {
+            const mayDefaultFlagCalledToPersonless =
+                input.normalizedEvent.event === FEATURE_FLAG_CALLED_EVENT && !input.processPersonExplicitlyTrue
 
-        if (input.processPerson && !shouldApplyFeatureFlagCalledDefault) {
-            return ok(input)
+            if (!mayDefaultFlagCalledToPersonless) {
+                return ok(input)
+            }
+
+            return await applyFeatureFlagCalledPersonlessDefault(input, personsStore)
         }
 
         const { normalizedEvent, team, timestamp, forceDisablePersonProcessing, personsStoreForBatch } = input
@@ -75,10 +84,6 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
         if (existingPerson) {
             const person = existingPerson as Person
 
-            if (shouldApplyFeatureFlagCalledDefault) {
-                return ok(input)
-            }
-
             // Ensure person properties don't propagate elsewhere, such as onto the event itself.
             person.properties = {}
 
@@ -97,12 +102,54 @@ export function createProcessPersonlessStep<TInput extends ProcessPersonlessInpu
             return ok({ ...input, personlessPerson: person })
         }
 
-        return ok({
-            ...input,
-            processPerson: false,
-            personlessPerson: createFakePerson(team.id, distinctId),
-        })
+        return ok({ ...input, personlessPerson: createFakePerson(team.id, distinctId) })
     }
+}
+
+/**
+ * Defaults a $feature_flag_called event to personless unless a person already exists for
+ * its distinct ID, so server-side flag evaluation does not create orphan person profiles.
+ */
+async function applyFeatureFlagCalledPersonlessDefault<TInput extends ProcessPersonlessInput>(
+    input: TInput,
+    personsStore: PersonsStore
+): Promise<PipelineResult<TInput & ProcessPersonlessOutput>> {
+    const { normalizedEvent, team } = input
+    const distinctId = normalizedEvent.distinct_id
+
+    let existingPerson = await personsStore.fetchForChecking(team.id, distinctId)
+
+    if (!existingPerson) {
+        let personIsMerged = personsStore.getPersonlessBatchResult(team.id, distinctId)
+
+        if (personIsMerged === undefined) {
+            // The batch step (processPersonlessDistinctIdsBatchStep) only inserts rows for
+            // events with explicit $process_person_profile=false, so record this distinct ID
+            // here. Without the row, a later identify/merge would never re-point these
+            // events at the merged person.
+            personIsMerged = await personsStore.addPersonlessDistinctId(team.id, distinctId)
+        }
+
+        if (personIsMerged) {
+            // The posthog_personlessdistinctid row was updated by a merge, so fetch the
+            // person again (using the leader) to associate this event with the merge target.
+            existingPerson = await personsStore.fetchForUpdate(team.id, distinctId)
+        }
+    }
+
+    if (existingPerson) {
+        // A person already exists for this distinct ID, so keep the event personful.
+        return ok(input)
+    }
+
+    return ok({
+        ...input,
+        // The event was normalized as personful upstream, so re-normalize it to strip
+        // $set/$set_once and stamp $process_person_profile=false.
+        normalizedEvent: normalizeProcessPerson(normalizedEvent, false),
+        processPerson: false,
+        personlessPerson: createFakePerson(team.id, distinctId),
+    })
 }
 
 /**

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -35,7 +35,9 @@ const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
  * Group-keyed experiment exposure queries read the $group_N columns from the exposure
  * event, and createEvent strips those for personless events. Events carrying group keys
  * must stay personful or their exposures disappear from group-aggregated experiments.
- * The $groups property is still raw here; it expands to $group_N in the later groups step.
+ * Checking $groups alone is sufficient: SDKs only ever send group keys as $groups, and
+ * $group_N is an internal representation the groups step derives from $groups (and only
+ * when processPerson stays true), so it never arrives here pre-expanded from a client.
  */
 function eventHasGroups(properties: PluginEvent['properties']): boolean {
     const groups = properties?.$groups

--- a/nodejs/src/ingestion/event-processing/process-personless-step.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.ts
@@ -59,7 +59,7 @@ function eventHasGroups(properties: PluginEvent['properties']): boolean {
 export function createProcessPersonlessStep<TInput extends ProcessPersonlessInput>(
     flagCalledPersonlessDefaultTeams: string = '*'
 ): ProcessingStep<TInput, TInput & ProcessPersonlessOutput> {
-    const flagCalledDefaultEnabledForTeam = buildIntegerMatcher(flagCalledPersonlessDefaultTeams, true)
+    const flagCalledDefaultEnabledForTeam = buildIntegerMatcher(flagCalledPersonlessDefaultTeams.trim(), true)
 
     return async function processPersonlessStep(
         input: TInput

--- a/nodejs/src/ingestion/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-persons-step.integration.test.ts
@@ -47,6 +47,7 @@ describe('createProcessPersonsStep', () => {
         PERSON_MERGE_SYNC_BATCH_SIZE: 1,
         PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0,
         PERSON_PROPERTIES_UPDATE_ALL: false,
+        FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: '*',
     }
 
     beforeEach(async () => {

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -276,6 +276,7 @@ export class IngestionConsumer {
                 PERSON_MERGE_SYNC_BATCH_SIZE: this.config.PERSON_MERGE_SYNC_BATCH_SIZE,
                 PERSON_JSONB_SIZE_ESTIMATE_ENABLE: this.config.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
                 PERSON_PROPERTIES_UPDATE_ALL: this.config.PERSON_PROPERTIES_UPDATE_ALL,
+                FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: this.config.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
         }

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -348,6 +348,7 @@ export class IngestionApiServer implements NodeServer {
                 PERSON_MERGE_SYNC_BATCH_SIZE: this.config.PERSON_MERGE_SYNC_BATCH_SIZE,
                 PERSON_JSONB_SIZE_ESTIMATE_ENABLE: this.config.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
                 PERSON_PROPERTIES_UPDATE_ALL: this.config.PERSON_PROPERTIES_UPDATE_ALL,
+                FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS: this.config.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
             },
             concurrentBatches: this.config.INGESTION_WORKER_CONCURRENT_BATCHES,
         }

--- a/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
@@ -59,14 +59,15 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
             }
 
             if (cacheHits > 0) {
-                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit' }, cacheHits)
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'hit', source: 'batch' }, cacheHits)
             }
 
             const storeCalls = Array.from(entriesByStore.entries()).filter(([, { entries }]) => entries.length > 0)
 
             if (storeCalls.length > 0) {
                 const totalMisses = storeCalls.reduce((sum, [, { entries }]) => sum + entries.length, 0)
-                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss' }, totalMisses)
+                personlessDistinctIdCacheOperationsCounter.inc(
+                    { operation: 'miss', source: 'batch' }, totalMisses)
 
                 await Promise.all(
                     storeCalls.map(async ([store, { entries }]) => {

--- a/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
@@ -66,8 +66,7 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
 
             if (storeCalls.length > 0) {
                 const totalMisses = storeCalls.reduce((sum, [, { entries }]) => sum + entries.length, 0)
-                personlessDistinctIdCacheOperationsCounter.inc(
-                    { operation: 'miss', source: 'batch' }, totalMisses)
+                personlessDistinctIdCacheOperationsCounter.inc({ operation: 'miss', source: 'batch' }, totalMisses)
 
                 await Promise.all(
                     storeCalls.map(async ([store, { entries }]) => {

--- a/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/processPersonlessDistinctIdsBatchStep.ts
@@ -1,10 +1,11 @@
-import { LRUCache } from 'lru-cache'
-import { Counter } from 'prom-client'
-
 import { PipelineResult, ok } from '~/ingestion/pipelines/results'
 import { PipelineEvent, Team } from '~/types'
 
-import { ONE_HOUR } from '../../../config/constants'
+import {
+    hasInsertedPersonlessDistinctId,
+    markPersonlessDistinctIdInserted,
+    personlessDistinctIdCacheOperationsCounter,
+} from '../persons/personless-distinct-id-cache'
 import { PersonsStoreForBatch } from '../persons/persons-store-for-batch'
 
 type ProcessPersonlessDistinctIdsBatchStepInput = {
@@ -12,20 +13,6 @@ type ProcessPersonlessDistinctIdsBatchStepInput = {
     team: Team
     personsStoreForBatch: PersonsStoreForBatch
 }
-
-export const personlessDistinctIdCacheOperationsCounter = new Counter({
-    name: 'personless_distinct_id_cache_operations_total',
-    help: 'Number of cache hits and misses for the personless distinct ID inserted cache',
-    labelNames: ['operation'],
-})
-
-// Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
-// (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
-const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRUCache<string, boolean>({
-    max: 100_000,
-    ttl: ONE_HOUR * 4,
-    updateAgeOnGet: true,
-})
 
 /**
  * Batch step that inserts personless distinct IDs for events where processPerson=false
@@ -64,7 +51,7 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
                 }
                 storeData.seenInBatch.add(cacheKey)
 
-                if (PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(cacheKey)) {
+                if (hasInsertedPersonlessDistinctId(e.team.id, e.event.distinct_id)) {
                     cacheHits++
                 } else {
                     storeData.entries.push({ teamId: e.team.id, distinctId: e.event.distinct_id })
@@ -85,7 +72,7 @@ export function processPersonlessDistinctIdsBatchStep<T extends ProcessPersonles
                     storeCalls.map(async ([store, { entries }]) => {
                         await store.processPersonlessDistinctIdsBatch(entries)
                         for (const entry of entries) {
-                            PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(`${entry.teamId}|${entry.distinctId}`, true)
+                            markPersonlessDistinctIdInserted(entry.teamId, entry.distinctId)
                         }
                     })
                 )

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.test.ts
@@ -1520,7 +1520,7 @@ describe('BatchWritingPersonStore', () => {
             const mockRepo = createMockRepository()
             const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs)
 
-            const result = await personStore.addPersonlessDistinctId(teamId, 'test-distinct')
+            const result = await personStore.addPersonlessDistinctId(teamId, 'test-distinct', 0)
 
             expect(mockRepo.addPersonlessDistinctId).toHaveBeenCalledWith(teamId, 'test-distinct')
             expect(result).toBe(true)
@@ -1531,7 +1531,7 @@ describe('BatchWritingPersonStore', () => {
             mockRepo.addPersonlessDistinctId = jest.fn().mockResolvedValue(false)
             const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs)
 
-            const result = await personStore.addPersonlessDistinctId(teamId, 'test-distinct')
+            const result = await personStore.addPersonlessDistinctId(teamId, 'test-distinct', 0)
 
             expect(mockRepo.addPersonlessDistinctId).toHaveBeenCalledWith(teamId, 'test-distinct')
             expect(result).toBe(false)

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -1520,8 +1520,9 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         }
     }
 
-    // Returns undefined when no insert was attempted this batch, false when one was
-    // attempted and the row wasn't merged, true when the distinct ID was merged.
+    // Returns true when the distinct ID was merged this batch, undefined otherwise.
+    // Only merged results are cached (see processPersonlessDistinctIdsBatch), so a
+    // non-merged insert is indistinguishable from no insert at all.
     getPersonlessBatchResult(teamId: number, distinctId: string): boolean | undefined {
         return this.personCache.getPersonlessBatchResult(teamId, distinctId)
     }

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -1477,9 +1477,12 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         await (tx || this.personRepository).updateCohortsAndFeatureFlagsForMerge(teamID, sourcePersonID, targetPersonID)
     }
 
-    async addPersonlessDistinctId(teamId: Team['id'], distinctId: string): Promise<boolean> {
+    async addPersonlessDistinctId(teamId: Team['id'], distinctId: string, batchId: number): Promise<boolean> {
         this.incrementCount('addPersonlessDistinctId', distinctId)
-        return await this.personRepository.addPersonlessDistinctId(teamId, distinctId)
+        const isMerged = await this.personRepository.addPersonlessDistinctId(teamId, distinctId)
+        // Cache the result so later events for this distinct ID in the same batch skip the insert.
+        this.personCache.obtainForBatchId(batchId).setPersonlessBatchResult(teamId, distinctId, isMerged)
+        return isMerged
     }
 
     async addPersonlessDistinctIdForMerge(
@@ -1517,6 +1520,8 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         }
     }
 
+    // Returns undefined when no insert was attempted this batch, false when one was
+    // attempted and the row wasn't merged, true when the distinct ID was merged.
     getPersonlessBatchResult(teamId: number, distinctId: string): boolean | undefined {
         return this.personCache.getPersonlessBatchResult(teamId, distinctId)
     }

--- a/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
+++ b/nodejs/src/worker/ingestion/persons/batch-writing-person-store.ts
@@ -1520,9 +1520,10 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         }
     }
 
-    // Returns true when the distinct ID was merged this batch, undefined otherwise.
-    // Only merged results are cached (see processPersonlessDistinctIdsBatch), so a
-    // non-merged insert is indistinguishable from no insert at all.
+    // Returns the cached merge result for a distinct ID inserted earlier this batch:
+    // true if the row was merged, false if addPersonlessDistinctId inserted it without a
+    // merge, undefined if no insert was recorded. The batch and forMerge paths only cache
+    // merged rows, so a non-merged insert from those paths also reads back as undefined.
     getPersonlessBatchResult(teamId: number, distinctId: string): boolean | undefined {
         return this.personCache.getPersonlessBatchResult(teamId, distinctId)
     }

--- a/nodejs/src/worker/ingestion/persons/personless-distinct-id-cache.ts
+++ b/nodejs/src/worker/ingestion/persons/personless-distinct-id-cache.ts
@@ -6,7 +6,9 @@ import { ONE_HOUR } from '../../../config/constants'
 export const personlessDistinctIdCacheOperationsCounter = new Counter({
     name: 'personless_distinct_id_cache_operations_total',
     help: 'Number of cache hits and misses for the personless distinct ID inserted cache',
-    labelNames: ['operation'],
+    // `source` separates the batched personless step from the per-event $feature_flag_called
+    // path so a high-volume flag-called miss rate can be read on its own during rollout.
+    labelNames: ['operation', 'source'],
 })
 
 // Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given

--- a/nodejs/src/worker/ingestion/persons/personless-distinct-id-cache.ts
+++ b/nodejs/src/worker/ingestion/persons/personless-distinct-id-cache.ts
@@ -1,0 +1,26 @@
+import { LRUCache } from 'lru-cache'
+import { Counter } from 'prom-client'
+
+import { ONE_HOUR } from '../../../config/constants'
+
+export const personlessDistinctIdCacheOperationsCounter = new Counter({
+    name: 'personless_distinct_id_cache_operations_total',
+    help: 'Number of cache hits and misses for the personless distinct ID inserted cache',
+    labelNames: ['operation'],
+})
+
+// Tracks whether we know we've already inserted a `posthog_personlessdistinctid` for the given
+// (team_id, distinct_id) pair. If we have, then we can skip the INSERT attempt.
+const PERSONLESS_DISTINCT_ID_INSERTED_CACHE = new LRUCache<string, boolean>({
+    max: 100_000,
+    ttl: ONE_HOUR * 4,
+    updateAgeOnGet: true,
+})
+
+export function hasInsertedPersonlessDistinctId(teamId: number, distinctId: string): boolean {
+    return PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(`${teamId}|${distinctId}`) === true
+}
+
+export function markPersonlessDistinctIdInserted(teamId: number, distinctId: string): void {
+    PERSONLESS_DISTINCT_ID_INSERTED_CACHE.set(`${teamId}|${distinctId}`, true)
+}

--- a/nodejs/src/worker/ingestion/persons/persons-store-for-batch.ts
+++ b/nodejs/src/worker/ingestion/persons/persons-store-for-batch.ts
@@ -78,6 +78,7 @@ export type PersonsStoreForBatch = Omit<
     | 'updatePersonWithPropertiesDiffForUpdate'
     | 'addDistinctId'
     | 'moveDistinctIds'
+    | 'addPersonlessDistinctId'
     | 'addPersonlessDistinctIdForMerge'
     | 'prefetchPersons'
     | 'processPersonlessDistinctIdsBatch'
@@ -115,6 +116,7 @@ export type PersonsStoreForBatch = Omit<
         tx?: PersonRepositoryTransaction
     ): Promise<[InternalPerson, PersonMessage[], boolean]>
     addDistinctId(person: InternalPerson, distinctId: string, version: number): Promise<PersonMessage[]>
+    addPersonlessDistinctId(teamId: number, distinctId: string): Promise<boolean>
     addPersonlessDistinctIdForMerge(
         teamId: number,
         distinctId: string,
@@ -350,7 +352,7 @@ export class BatchBoundPersonsStore implements PersonsStoreForBatch {
     }
 
     addPersonlessDistinctId(teamId: number, distinctId: string): Promise<boolean> {
-        return this.store.addPersonlessDistinctId(teamId, distinctId)
+        return this.store.addPersonlessDistinctId(teamId, distinctId, this.batchId)
     }
 
     addPersonlessDistinctIdForMerge(

--- a/nodejs/src/worker/ingestion/persons/persons-store.ts
+++ b/nodejs/src/worker/ingestion/persons/persons-store.ts
@@ -121,7 +121,7 @@ export interface PersonsStore extends BatchWritingStore {
     /**
      * Adds a personless distinct ID
      */
-    addPersonlessDistinctId(teamId: number, distinctId: string): Promise<boolean>
+    addPersonlessDistinctId(teamId: number, distinctId: string, batchId: number): Promise<boolean>
 
     /**
      * Adds a personless distinct ID during merge


### PR DESCRIPTION
## Problem

Every server-side SDK auto-fires a `$feature_flag_called` event when evaluating a flag, and none of them mark it personless. Ingestion treats any event with a `distinct_id` as personful by default, so backend services that evaluate flags for large or short-lived sets of distinct IDs accumulate empty, orphaned person profiles that cost storage and person volume but tell you nothing.

Closes #60581

This builds on #60975 by @harsh21234i (the first four commits are from that branch). Opened as a new PR to finish the remaining review items and reframe the title and description around the final design.

## Changes

`$feature_flag_called` events without an explicit `$process_person_profile` now default to personless. The decision happens in the personless step, after person lookup, so only the orphan case changes behavior:

- A person already exists for the distinct ID: the event stays personful, exactly as today. Person-property snapshots and experiment breakdowns are unaffected.
- Explicit `$process_person_profile: true` still wins. The flag step captures `processPersonExplicitlyTrue` before normalization strips the property, and the personless step honors it.
- Events carrying `$groups` stay personful. Group-keyed experiment exposure queries read the `$group_N` columns from the exposure event, and those are stripped for personless events.
- Otherwise the event goes personless: it is re-normalized (`$set`/`$set_once` stripped, `$process_person_profile: false` stamped), gets a deterministic fake person, and its distinct ID is recorded in `posthog_personlessdistinctid` so a later identify/merge re-points the exposures at the merged person.

Supporting changes:

- The per-event `addPersonlessDistinctId` write is deduplicated: the batch store caches the result for same-batch repeats, and the cross-batch LRU (extracted to `worker/ingestion/persons/personless-distinct-id-cache.ts` and shared with the existing batch step) prevents re-inserting the same distinct ID on every event. Hits and misses are recorded on the existing `personless_distinct_id_cache_operations_total` metric.
- `FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS` controls rollout: `'*'` (default) enables all teams, `''` disables entirely, and a comma-separated team ID list enables per team.

## How did you test this code?

- `pnpm exec jest src/ingestion/event-processing/process-personless-step.test.ts src/ingestion/event-processing/normalize-process-person-flag-step.test.ts` runs 40 tests, including integration-style tests that pipe events through the real normalize steps against Postgres to cover the boundary where normalization strips the explicit property, plus coverage for the group-keys exclusion, the config gate, merge re-pointing, and the dedup skip paths.
- `tsc --noEmit` is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?