### PR TITLE
chore(nodejs): refuse destructive test helpers on non-test databases

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -6,13 +6,13 @@ Node.js services for PostHog: ingestion pipeline, CDP, session recording, and mo
 
 Tests run against **dedicated test databases**, never the dev stack's databases:
 
-| Store | Test database | Dev database (never used by tests) |
-| --- | --- | --- |
-| Postgres (common) | `test_posthog` | `posthog` |
-| Postgres (persons) | `test_persons` | `posthog_persons` |
-| Postgres (behavioral cohorts) | `test_behavioral_cohorts` | `behavioral_cohorts` |
-| Postgres (cyclotron) | `test_cyclotron`, `test_cyclotron_node` | `cyclotron` |
-| ClickHouse | `posthog_test` | `default` |
+| Store                         | Test database                           | Dev database (never used by tests) |
+| ----------------------------- | --------------------------------------- | ---------------------------------- |
+| Postgres (common)             | `test_posthog`                          | `posthog`                          |
+| Postgres (persons)            | `test_persons`                          | `posthog_persons`                  |
+| Postgres (behavioral cohorts) | `test_behavioral_cohorts`               | `behavioral_cohorts`               |
+| Postgres (cyclotron)          | `test_cyclotron`, `test_cyclotron_node` | `cyclotron`                        |
+| ClickHouse                    | `posthog_test`                          | `default`                          |
 
 These are the defaults whenever `NODE_ENV=test`, which `jest.setup-env.ts` forces for every jest run. The schema is owned by Django and rust migrations, so the test databases must be created before the first run:
 
@@ -31,8 +31,8 @@ pnpm jest tests/path/to.test.ts  # single file
 
 ### Destructive helper guard
 
-Test helpers like `resetTestDatabase()` and `clearDatabase()` delete all rows from most tables in the database they connect to. To protect local dev data, the helpers in `tests/helpers/sql.ts` and `tests/helpers/clickhouse.ts` verify (via `current_database()`) that the connected database has `test` in its name and refuse to run otherwise — see `tests/helpers/database-guard.ts`.
+Test helpers like `resetTestDatabase()` and `clearDatabase()` delete all rows from most tables in the database they connect to. To protect local dev data, the helpers in `tests/helpers/sql.ts` and `tests/helpers/clickhouse.ts` verify (via Postgres `current_database()` / ClickHouse `currentDatabase()`) that the connected database has `test` in its name and refuse to run otherwise — see `tests/helpers/database-guard.ts`.
 
-If your test database legitimately doesn't match (e.g. a custom CI setup), set `ALLOW_NON_TEST_DATABASE_RESET=1` to bypass the guard. Do not set this in a local dev environment.
+If your test database legitimately doesn't match (e.g. a custom CI setup), set `ALLOW_NON_TEST_DATABASE_RESET=1` (or `true`/`yes`) to bypass the guard; any other value keeps it active. Do not set this in a local dev environment.
 
 If you hit the guard error locally, it means `DATABASE_URL`, `PERSONS_DATABASE_URL`, `CLICKHOUSE_DATABASE`, or similar leaked into the test process from your shell or IDE — unset them and rely on the test defaults.

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -29,10 +29,4 @@ pnpm test                      # full suite (sharded in CI)
 pnpm jest tests/path/to.test.ts  # single file
 ```
 
-### Destructive helper guard
-
-Test helpers like `resetTestDatabase()` and `clearDatabase()` delete all rows from most tables in the database they connect to. To protect local dev data, the helpers in `tests/helpers/sql.ts` and `tests/helpers/clickhouse.ts` verify (via Postgres `current_database()` / ClickHouse `currentDatabase()`) that the connected database has `test` in its name and refuse to run otherwise — see `tests/helpers/database-guard.ts`.
-
-If your test database legitimately doesn't match (e.g. a custom CI setup), set `ALLOW_NON_TEST_DATABASE_RESET=1` (or `true`/`yes`) to bypass the guard; any other value keeps it active. Do not set this in a local dev environment.
-
-If you hit the guard error locally, it means `DATABASE_URL`, `PERSONS_DATABASE_URL`, `CLICKHOUSE_DATABASE`, or similar leaked into the test process from your shell or IDE — unset them and rely on the test defaults.
+Destructive test helpers refuse to run against a database without `test` in its name — see `tests/helpers/database-guard.ts`. The guard's error message explains how to fix a misconfigured environment.

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,0 +1,38 @@
+# PostHog Node.js services
+
+Node.js services for PostHog: ingestion pipeline, CDP, session recording, and more.
+
+## Running tests
+
+Tests run against **dedicated test databases**, never the dev stack's databases:
+
+| Store | Test database | Dev database (never used by tests) |
+| --- | --- | --- |
+| Postgres (common) | `test_posthog` | `posthog` |
+| Postgres (persons) | `test_persons` | `posthog_persons` |
+| Postgres (behavioral cohorts) | `test_behavioral_cohorts` | `behavioral_cohorts` |
+| Postgres (cyclotron) | `test_cyclotron`, `test_cyclotron_node` | `cyclotron` |
+| ClickHouse | `posthog_test` | `default` |
+
+These are the defaults whenever `NODE_ENV=test`, which `jest.setup-env.ts` forces for every jest run. The schema is owned by Django and rust migrations, so the test databases must be created before the first run:
+
+```bash
+# From the repo root, with the dev stack's Postgres/ClickHouse/Kafka/Redis running:
+pnpm --filter=@posthog/nodejs setup:test
+```
+
+This runs Django's `setup_test_environment` (creates `test_posthog` and the ClickHouse `posthog_test` schema) plus the rust migrations for the persons, behavioral cohorts, and cyclotron test databases. Then:
+
+```bash
+cd nodejs
+pnpm test                      # full suite (sharded in CI)
+pnpm jest tests/path/to.test.ts  # single file
+```
+
+### Destructive helper guard
+
+Test helpers like `resetTestDatabase()` and `clearDatabase()` delete all rows from most tables in the database they connect to. To protect local dev data, the helpers in `tests/helpers/sql.ts` and `tests/helpers/clickhouse.ts` verify (via `current_database()`) that the connected database has `test` in its name and refuse to run otherwise — see `tests/helpers/database-guard.ts`.
+
+If your test database legitimately doesn't match (e.g. a custom CI setup), set `ALLOW_NON_TEST_DATABASE_RESET=1` to bypass the guard. Do not set this in a local dev environment.
+
+If you hit the guard error locally, it means `DATABASE_URL`, `PERSONS_DATABASE_URL`, `CLICKHOUSE_DATABASE`, or similar leaked into the test process from your shell or IDE — unset them and rely on the test defaults.

--- a/nodejs/jest.config.js
+++ b/nodejs/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
     testEnvironment: 'node',
     clearMocks: true,
     coverageProvider: 'v8',
+    setupFiles: ['./jest.setup-env.ts'],
     setupFilesAfterEnv: ['./jest.setup.ts'],
     testMatch: ['<rootDir>/tests/**/*.test.ts', '<rootDir>/src/**/*.test.ts'],
     testTimeout: 60000,

--- a/nodejs/jest.setup-env.ts
+++ b/nodejs/jest.setup-env.ts
@@ -1,0 +1,10 @@
+// Jest's CLI only sets NODE_ENV=test when it is unset. When tests are launched
+// from an environment where NODE_ENV or DEBUG is already set (IDE test runners,
+// debuggers, flox exports DEBUG=1), `determineNodeEnv()` resolves to dev and
+// every config default (DATABASE_URL, PERSONS_DATABASE_URL, CLICKHOUSE_DATABASE,
+// CYCLOTRON_DATABASE_URL, ...) points at the real dev databases — which
+// destructive test helpers would then wipe. Force the test environment so the
+// defaults always resolve to their test_* counterparts. Explicitly exported
+// *_DATABASE_URL variables still win; tests/helpers/database-guard.ts catches
+// those when they point at a non-test database.
+process.env.NODE_ENV = 'test'

--- a/nodejs/tests/helpers/clickhouse.ts
+++ b/nodejs/tests/helpers/clickhouse.ts
@@ -21,6 +21,7 @@ import { fetch } from '~/utils/request'
 
 import { logger } from '../../src/utils/logger'
 import { delay, escapeClickHouseString } from '../../src/utils/utils'
+import { assertTestDatabaseName } from './database-guard'
 
 // Extracts the topic(s) a ClickHouse Kafka engine table consumes from its `engine_full` string.
 // Handles both the keyword form (`kafka_topic_list = 'a,b'`) and the positional form
@@ -75,12 +76,25 @@ export class Clickhouse {
         this.client.close()
     }
 
+    // Memoized so repeated truncates don't re-query the database name.
+    private databaseGuard?: Promise<void>
+    private ensureTestDatabase(): Promise<void> {
+        this.databaseGuard ??= this.query<{ name: string }>('SELECT currentDatabase() AS name').then((rows) =>
+            assertTestDatabaseName(rows[0].name, 'ClickHouse')
+        )
+        return this.databaseGuard
+    }
+
     async truncate(table: string) {
+        await this.ensureTestDatabase()
         await this.exec(`TRUNCATE ${table}`)
     }
 
     async resetTestDatabase(): Promise<void> {
         await this.waitForHealthy()
+        // Guard before the truncates: Promise.allSettled below would swallow
+        // the guard error if it only surfaced inside truncate().
+        await this.ensureTestDatabase()
         // NOTE: Don't do more than 5 at once otherwise we get socket timeout errors
         await Promise.allSettled([
             this.truncate('sharded_events'),

--- a/nodejs/tests/helpers/clickhouse.ts
+++ b/nodejs/tests/helpers/clickhouse.ts
@@ -76,11 +76,17 @@ export class Clickhouse {
         this.client.close()
     }
 
-    // Memoized so repeated truncates don't re-query the database name.
+    // Memoized so repeated truncates don't re-query the database name. Reset
+    // on failure so a transient connection error doesn't get cached as a
+    // permanently rejected promise.
     private databaseGuard?: Promise<void>
     private ensureTestDatabase(): Promise<void> {
-        this.databaseGuard ??= this.query<{ name: string }>('SELECT currentDatabase() AS name').then((rows) =>
-            assertTestDatabaseName(rows[0].name, 'ClickHouse')
+        this.databaseGuard ??= this.query<{ name: string }>('SELECT currentDatabase() AS name').then(
+            (rows) => assertTestDatabaseName(rows[0].name, 'ClickHouse'),
+            (error) => {
+                this.databaseGuard = undefined
+                throw error
+            }
         )
         return this.databaseGuard
     }

--- a/nodejs/tests/helpers/clickhouse.ts
+++ b/nodejs/tests/helpers/clickhouse.ts
@@ -76,9 +76,12 @@ export class Clickhouse {
         this.client.close()
     }
 
-    // Memoized so repeated truncates don't re-query the database name. Reset
-    // on failure so a transient connection error doesn't get cached as a
-    // permanently rejected promise.
+    // Memoized so repeated truncates don't re-query the database name. The
+    // onRejected handler resets the cache when the `query` itself fails (a
+    // transient connection error), so it isn't cached as a permanently rejected
+    // promise. An assertTestDatabaseName failure throws from onFulfilled and
+    // stays cached on purpose: it's a deterministic verdict on a fixed database
+    // name, so re-querying would only reach the same conclusion.
     private databaseGuard?: Promise<void>
     private ensureTestDatabase(): Promise<void> {
         this.databaseGuard ??= this.query<{ name: string }>('SELECT currentDatabase() AS name').then(

--- a/nodejs/tests/helpers/database-guard.test.ts
+++ b/nodejs/tests/helpers/database-guard.test.ts
@@ -16,14 +16,20 @@ describe('database-guard', () => {
             }
         )
 
-        it.each(['posthog', 'posthog_persons', 'behavioral_cohorts', 'cyclotron', 'default'])(
-            'refuses non-test database %s',
-            (name) => {
-                expect(() => assertTestDatabaseName(name, 'unit test', emptyEnv)).toThrow(
-                    /Refusing to run a destructive test helper/
-                )
-            }
-        )
+        it.each([
+            'posthog',
+            'posthog_persons',
+            'behavioral_cohorts',
+            'cyclotron',
+            'default',
+            // "test" embedded in another word must not pass the guard.
+            'latest',
+            'posthog_latest',
+        ])('refuses non-test database %s', (name) => {
+            expect(() => assertTestDatabaseName(name, 'unit test', emptyEnv)).toThrow(
+                /Refusing to run a destructive test helper/
+            )
+        })
 
         it('includes the database name, source and escape hatch in the error', () => {
             expect(() => assertTestDatabaseName('posthog', 'Postgres COMMON_WRITE', emptyEnv)).toThrow(

--- a/nodejs/tests/helpers/database-guard.test.ts
+++ b/nodejs/tests/helpers/database-guard.test.ts
@@ -35,9 +35,16 @@ describe('database-guard', () => {
             )
         })
 
-        it('allows non-test databases when the escape hatch is set', () => {
-            const env = { [UNSAFE_DATABASE_RESET_ENV_VAR]: '1' }
+        it.each(['1', 'true', 'TRUE', 'yes'])('allows non-test databases when the escape hatch is %s', (value) => {
+            const env = { [UNSAFE_DATABASE_RESET_ENV_VAR]: value }
             expect(() => assertTestDatabaseName('posthog', 'unit test', env)).not.toThrow()
+        })
+
+        it.each(['0', 'false', 'no', ''])('keeps the guard active when the escape hatch is %s', (value) => {
+            const env = { [UNSAFE_DATABASE_RESET_ENV_VAR]: value }
+            expect(() => assertTestDatabaseName('posthog', 'unit test', env)).toThrow(
+                /Refusing to run a destructive test helper/
+            )
         })
     })
 

--- a/nodejs/tests/helpers/database-guard.test.ts
+++ b/nodejs/tests/helpers/database-guard.test.ts
@@ -1,0 +1,68 @@
+import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
+import {
+    UNSAFE_DATABASE_RESET_ENV_VAR,
+    assertRouterTargetsTestDatabase,
+    assertTestDatabaseName,
+} from './database-guard'
+
+describe('database-guard', () => {
+    const emptyEnv = {}
+
+    describe('assertTestDatabaseName', () => {
+        it.each(['test_posthog', 'test_persons', 'test_persons_parity', 'test_behavioral_cohorts', 'posthog_test'])(
+            'allows test database %s',
+            (name) => {
+                expect(() => assertTestDatabaseName(name, 'unit test', emptyEnv)).not.toThrow()
+            }
+        )
+
+        it.each(['posthog', 'posthog_persons', 'behavioral_cohorts', 'cyclotron', 'default'])(
+            'refuses non-test database %s',
+            (name) => {
+                expect(() => assertTestDatabaseName(name, 'unit test', emptyEnv)).toThrow(
+                    /Refusing to run a destructive test helper/
+                )
+            }
+        )
+
+        it('includes the database name, source and escape hatch in the error', () => {
+            expect(() => assertTestDatabaseName('posthog', 'Postgres COMMON_WRITE', emptyEnv)).toThrow(
+                expect.objectContaining({
+                    message: expect.stringMatching(
+                        /"posthog" \(Postgres COMMON_WRITE\)[\s\S]*ALLOW_NON_TEST_DATABASE_RESET=1/
+                    ),
+                })
+            )
+        })
+
+        it('allows non-test databases when the escape hatch is set', () => {
+            const env = { [UNSAFE_DATABASE_RESET_ENV_VAR]: '1' }
+            expect(() => assertTestDatabaseName('posthog', 'unit test', env)).not.toThrow()
+        })
+    })
+
+    describe('assertRouterTargetsTestDatabase', () => {
+        const routerReturning = (name: string): PostgresRouter =>
+            ({
+                query: jest.fn().mockResolvedValue({ rows: [{ name }] }),
+            }) as unknown as PostgresRouter
+
+        it('passes when the pool connects to a test database', async () => {
+            await expect(
+                assertRouterTargetsTestDatabase(routerReturning('test_posthog'), PostgresUse.COMMON_WRITE, emptyEnv)
+            ).resolves.toBeUndefined()
+        })
+
+        it('throws when the pool connects to a non-test database', async () => {
+            await expect(
+                assertRouterTargetsTestDatabase(routerReturning('posthog'), PostgresUse.COMMON_WRITE, emptyEnv)
+            ).rejects.toThrow(/Refusing to run a destructive test helper/)
+        })
+
+        it('names the postgres use in the error', async () => {
+            await expect(
+                assertRouterTargetsTestDatabase(routerReturning('posthog_persons'), PostgresUse.PERSONS_WRITE, emptyEnv)
+            ).rejects.toThrow(/Postgres PERSONS_WRITE/)
+        })
+    })
+})

--- a/nodejs/tests/helpers/database-guard.test.ts
+++ b/nodejs/tests/helpers/database-guard.test.ts
@@ -1,18 +1,12 @@
 import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
-import {
-    UNSAFE_DATABASE_RESET_ENV_VAR,
-    assertRouterTargetsTestDatabase,
-    assertTestDatabaseName,
-} from './database-guard'
+import { assertRouterTargetsTestDatabase, assertTestDatabaseName } from './database-guard'
 
 describe('database-guard', () => {
-    const emptyEnv = {}
-
     describe('assertTestDatabaseName', () => {
         it.each(['test_posthog', 'test_persons', 'test_persons_parity', 'test_behavioral_cohorts', 'posthog_test'])(
             'allows test database %s',
             (name) => {
-                expect(() => assertTestDatabaseName(name, 'unit test', emptyEnv)).not.toThrow()
+                expect(() => assertTestDatabaseName(name, 'unit test')).not.toThrow()
             }
         )
 
@@ -26,30 +20,14 @@ describe('database-guard', () => {
             'latest',
             'posthog_latest',
         ])('refuses non-test database %s', (name) => {
-            expect(() => assertTestDatabaseName(name, 'unit test', emptyEnv)).toThrow(
-                /Refusing to run a destructive test helper/
-            )
+            expect(() => assertTestDatabaseName(name, 'unit test')).toThrow(/Refusing to run a destructive test helper/)
         })
 
-        it('includes the database name, source and escape hatch in the error', () => {
-            expect(() => assertTestDatabaseName('posthog', 'Postgres COMMON_WRITE', emptyEnv)).toThrow(
+        it('includes the database name and source in the error', () => {
+            expect(() => assertTestDatabaseName('posthog', 'Postgres COMMON_WRITE')).toThrow(
                 expect.objectContaining({
-                    message: expect.stringMatching(
-                        /"posthog" \(Postgres COMMON_WRITE\)[\s\S]*ALLOW_NON_TEST_DATABASE_RESET=1/
-                    ),
+                    message: expect.stringMatching(/"posthog" \(Postgres COMMON_WRITE\)/),
                 })
-            )
-        })
-
-        it.each(['1', 'true', 'TRUE', 'yes'])('allows non-test databases when the escape hatch is %s', (value) => {
-            const env = { [UNSAFE_DATABASE_RESET_ENV_VAR]: value }
-            expect(() => assertTestDatabaseName('posthog', 'unit test', env)).not.toThrow()
-        })
-
-        it.each(['0', 'false', 'no', ''])('keeps the guard active when the escape hatch is %s', (value) => {
-            const env = { [UNSAFE_DATABASE_RESET_ENV_VAR]: value }
-            expect(() => assertTestDatabaseName('posthog', 'unit test', env)).toThrow(
-                /Refusing to run a destructive test helper/
             )
         })
     })
@@ -62,19 +40,19 @@ describe('database-guard', () => {
 
         it('passes when the pool connects to a test database', async () => {
             await expect(
-                assertRouterTargetsTestDatabase(routerReturning('test_posthog'), PostgresUse.COMMON_WRITE, emptyEnv)
+                assertRouterTargetsTestDatabase(routerReturning('test_posthog'), PostgresUse.COMMON_WRITE)
             ).resolves.toBeUndefined()
         })
 
         it('throws when the pool connects to a non-test database', async () => {
             await expect(
-                assertRouterTargetsTestDatabase(routerReturning('posthog'), PostgresUse.COMMON_WRITE, emptyEnv)
+                assertRouterTargetsTestDatabase(routerReturning('posthog'), PostgresUse.COMMON_WRITE)
             ).rejects.toThrow(/Refusing to run a destructive test helper/)
         })
 
         it('names the postgres use in the error', async () => {
             await expect(
-                assertRouterTargetsTestDatabase(routerReturning('posthog_persons'), PostgresUse.PERSONS_WRITE, emptyEnv)
+                assertRouterTargetsTestDatabase(routerReturning('posthog_persons'), PostgresUse.PERSONS_WRITE)
             ).rejects.toThrow(/Postgres PERSONS_WRITE/)
         })
     })

--- a/nodejs/tests/helpers/database-guard.ts
+++ b/nodejs/tests/helpers/database-guard.ts
@@ -7,7 +7,10 @@ import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
  */
 export const UNSAFE_DATABASE_RESET_ENV_VAR = 'ALLOW_NON_TEST_DATABASE_RESET'
 
-const TEST_DATABASE_NAME_PATTERN = /test/i
+// Matches "test" only as an underscore- or boundary-delimited token, so real
+// test databases (test_posthog, posthog_test) pass while names that merely
+// embed the substring (latest, posthog_latest) are still refused.
+const TEST_DATABASE_NAME_PATTERN = /(^|_)test(_|$)/i
 const ESCAPE_HATCH_VALUES = new Set(['1', 'true', 'yes'])
 
 /**

--- a/nodejs/tests/helpers/database-guard.ts
+++ b/nodejs/tests/helpers/database-guard.ts
@@ -2,11 +2,13 @@ import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
 
 /**
  * Escape hatch for environments whose test database legitimately doesn't have
- * "test" in its name. Set to a truthy value to skip the guard.
+ * "test" in its name. Set to `1`, `true`, or `yes` to skip the guard; any
+ * other value (including `0` and `false`) keeps it active.
  */
 export const UNSAFE_DATABASE_RESET_ENV_VAR = 'ALLOW_NON_TEST_DATABASE_RESET'
 
 const TEST_DATABASE_NAME_PATTERN = /test/i
+const ESCAPE_HATCH_VALUES = new Set(['1', 'true', 'yes'])
 
 /**
  * Throws unless `databaseName` looks like a test database (contains "test").
@@ -21,7 +23,7 @@ export function assertTestDatabaseName(
     source: string,
     env: Record<string, string | undefined> = process.env
 ): void {
-    if (env[UNSAFE_DATABASE_RESET_ENV_VAR]) {
+    if (ESCAPE_HATCH_VALUES.has((env[UNSAFE_DATABASE_RESET_ENV_VAR] ?? '').toLowerCase())) {
         return
     }
     if (TEST_DATABASE_NAME_PATTERN.test(databaseName)) {

--- a/nodejs/tests/helpers/database-guard.ts
+++ b/nodejs/tests/helpers/database-guard.ts
@@ -1,17 +1,9 @@
 import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
 
-/**
- * Escape hatch for environments whose test database legitimately doesn't have
- * "test" in its name. Set to `1`, `true`, or `yes` to skip the guard; any
- * other value (including `0` and `false`) keeps it active.
- */
-export const UNSAFE_DATABASE_RESET_ENV_VAR = 'ALLOW_NON_TEST_DATABASE_RESET'
-
 // Matches "test" only as an underscore- or boundary-delimited token, so real
 // test databases (test_posthog, posthog_test) pass while names that merely
 // embed the substring (latest, posthog_latest) are still refused.
 const TEST_DATABASE_NAME_PATTERN = /(^|_)test(_|$)/i
-const ESCAPE_HATCH_VALUES = new Set(['1', 'true', 'yes'])
 
 /**
  * Throws unless `databaseName` looks like a test database — i.e. it contains
@@ -24,14 +16,7 @@ const ESCAPE_HATCH_VALUES = new Set(['1', 'true', 'yes'])
  * DATABASE_URL pointing at the dev `posthog` database leaking in from a shell
  * or IDE) produces a loud error instead of silently wiping real dev data.
  */
-export function assertTestDatabaseName(
-    databaseName: string,
-    source: string,
-    env: Record<string, string | undefined> = process.env
-): void {
-    if (ESCAPE_HATCH_VALUES.has((env[UNSAFE_DATABASE_RESET_ENV_VAR] ?? '').toLowerCase())) {
-        return
-    }
+export function assertTestDatabaseName(databaseName: string, source: string): void {
     if (TEST_DATABASE_NAME_PATTERN.test(databaseName)) {
         return
     }
@@ -44,8 +29,7 @@ export function assertTestDatabaseName(
             `test_behavioral_cohorts on Postgres; posthog_test on ClickHouse). This error\n` +
             `usually means DATABASE_URL, PERSONS_DATABASE_URL, CLICKHOUSE_DATABASE or similar\n` +
             `leaked in from your shell or IDE. Unset them, or create the test databases with\n` +
-            `\`pnpm --filter=@posthog/nodejs setup:test\`.\n\n` +
-            `If you really do want to wipe "${databaseName}", set ${UNSAFE_DATABASE_RESET_ENV_VAR}=1.`
+            `\`pnpm --filter=@posthog/nodejs setup:test\`.`
     )
 }
 
@@ -54,16 +38,12 @@ export function assertTestDatabaseName(
  * use is a test database. Queries `current_database()` so the check reflects
  * ground truth regardless of how the connection URL was assembled.
  */
-export async function assertRouterTargetsTestDatabase(
-    router: PostgresRouter,
-    use: PostgresUse,
-    env: Record<string, string | undefined> = process.env
-): Promise<void> {
+export async function assertRouterTargetsTestDatabase(router: PostgresRouter, use: PostgresUse): Promise<void> {
     const result = await router.query<{ name: string }>(
         use,
         'SELECT current_database() AS name',
         undefined,
         'database-guard'
     )
-    assertTestDatabaseName(result.rows[0].name, `Postgres ${PostgresUse[use]}`, env)
+    assertTestDatabaseName(result.rows[0].name, `Postgres ${PostgresUse[use]}`)
 }

--- a/nodejs/tests/helpers/database-guard.ts
+++ b/nodejs/tests/helpers/database-guard.ts
@@ -1,0 +1,60 @@
+import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
+
+/**
+ * Escape hatch for environments whose test database legitimately doesn't have
+ * "test" in its name. Set to a truthy value to skip the guard.
+ */
+export const UNSAFE_DATABASE_RESET_ENV_VAR = 'ALLOW_NON_TEST_DATABASE_RESET'
+
+const TEST_DATABASE_NAME_PATTERN = /test/i
+
+/**
+ * Throws unless `databaseName` looks like a test database (contains "test").
+ *
+ * Destructive test helpers (mass DELETE/TRUNCATE) call this before touching a
+ * database, so a misconfigured environment (e.g. NODE_ENV/DEBUG or a
+ * DATABASE_URL pointing at the dev `posthog` database leaking in from a shell
+ * or IDE) produces a loud error instead of silently wiping real dev data.
+ */
+export function assertTestDatabaseName(
+    databaseName: string,
+    source: string,
+    env: Record<string, string | undefined> = process.env
+): void {
+    if (env[UNSAFE_DATABASE_RESET_ENV_VAR]) {
+        return
+    }
+    if (TEST_DATABASE_NAME_PATTERN.test(databaseName)) {
+        return
+    }
+    throw new Error(
+        `🛑 Refusing to run a destructive test helper against database "${databaseName}" (${source}).\n\n` +
+            `The database name does not contain "test", so it looks like a real development\n` +
+            `or production database. Continuing would have deleted data from it.\n\n` +
+            `Plugin-server tests expect dedicated test databases (test_posthog, test_persons,\n` +
+            `test_behavioral_cohorts on Postgres; posthog_test on ClickHouse). This error\n` +
+            `usually means DATABASE_URL, PERSONS_DATABASE_URL, CLICKHOUSE_DATABASE or similar\n` +
+            `leaked in from your shell or IDE. Unset them, or create the test databases with\n` +
+            `\`pnpm --filter=@posthog/nodejs setup:test\`.\n\n` +
+            `If you really do want to wipe "${databaseName}", set ${UNSAFE_DATABASE_RESET_ENV_VAR}=1.`
+    )
+}
+
+/**
+ * Asserts that the database a router's pool actually connects to for the given
+ * use is a test database. Queries `current_database()` so the check reflects
+ * ground truth regardless of how the connection URL was assembled.
+ */
+export async function assertRouterTargetsTestDatabase(
+    router: PostgresRouter,
+    use: PostgresUse,
+    env: Record<string, string | undefined> = process.env
+): Promise<void> {
+    const result = await router.query<{ name: string }>(
+        use,
+        'SELECT current_database() AS name',
+        undefined,
+        'database-guard'
+    )
+    assertTestDatabaseName(result.rows[0].name, `Postgres ${PostgresUse[use]}`, env)
+}

--- a/nodejs/tests/helpers/database-guard.ts
+++ b/nodejs/tests/helpers/database-guard.ts
@@ -14,7 +14,10 @@ const TEST_DATABASE_NAME_PATTERN = /(^|_)test(_|$)/i
 const ESCAPE_HATCH_VALUES = new Set(['1', 'true', 'yes'])
 
 /**
- * Throws unless `databaseName` looks like a test database (contains "test").
+ * Throws unless `databaseName` looks like a test database — i.e. it contains
+ * "test" as an underscore- or boundary-delimited token (test_posthog,
+ * posthog_test). Names that merely embed the substring (latest, mytest) are
+ * refused.
  *
  * Destructive test helpers (mass DELETE/TRUNCATE) call this before touching a
  * database, so a misconfigured environment (e.g. NODE_ENV/DEBUG or a
@@ -34,9 +37,10 @@ export function assertTestDatabaseName(
     }
     throw new Error(
         `🛑 Refusing to run a destructive test helper against database "${databaseName}" (${source}).\n\n` +
-            `The database name does not contain "test", so it looks like a real development\n` +
-            `or production database. Continuing would have deleted data from it.\n\n` +
-            `Plugin-server tests expect dedicated test databases (test_posthog, test_persons,\n` +
+            `The database name does not contain "test" as a standalone segment, so it looks\n` +
+            `like a real development or production database. Continuing would have deleted\n` +
+            `data from it.\n\n` +
+            `The nodejs tests expect dedicated test databases (test_posthog, test_persons,\n` +
             `test_behavioral_cohorts on Postgres; posthog_test on ClickHouse). This error\n` +
             `usually means DATABASE_URL, PERSONS_DATABASE_URL, CLICKHOUSE_DATABASE or similar\n` +
             `leaked in from your shell or IDE. Unset them, or create the test databases with\n` +

--- a/nodejs/tests/helpers/sql.ts
+++ b/nodejs/tests/helpers/sql.ts
@@ -4,6 +4,7 @@ import { defaultConfig } from '../../src/config/config'
 import { CookielessServerHashMode, InternalPerson, ProjectId, RawOrganization, RawPerson, Team } from '../../src/types'
 import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
 import { UUIDT } from '../../src/utils/utils'
+import { assertRouterTargetsTestDatabase } from './database-guard'
 
 export const commonUserId = 1001
 export const commonOrganizationMembershipId = '0177364a-fc7b-0000-511c-137090b9e4e1'
@@ -101,6 +102,11 @@ END $$;
 `
 
 export async function clearDatabase(db: PostgresRouter) {
+    await Promise.all([
+        assertRouterTargetsTestDatabase(db, PostgresUse.COMMON_WRITE),
+        assertRouterTargetsTestDatabase(db, PostgresUse.PERSONS_WRITE),
+    ])
+
     await db
         .query(PostgresUse.COMMON_WRITE, POSTGRES_DELETE_COMMON_TABLES_QUERY, undefined, 'delete-common-tables')
         .catch((e) => {
@@ -122,21 +128,7 @@ export async function resetTestDatabase(): Promise<void> {
     const config = { ...defaultConfig, POSTGRES_CONNECTION_POOL_SIZE: 1 }
     const pg = new PostgresRouter(config)
 
-    // Delete common tables using COMMON_WRITE
-    await pg
-        .query(PostgresUse.COMMON_WRITE, POSTGRES_DELETE_COMMON_TABLES_QUERY, undefined, 'delete-common-tables')
-        .catch((e) => {
-            console.error('Error deleting common tables', e)
-            throw e
-        })
-
-    // Delete persons tables using PERSONS_WRITE
-    await pg
-        .query(PostgresUse.PERSONS_WRITE, POSTGRES_DELETE_PERSONS_TABLES_QUERY, undefined, 'delete-persons-tables')
-        .catch((e) => {
-            console.error('Error deleting persons tables', e)
-            throw e
-        })
+    await clearDatabase(pg)
 
     const teamIdToCreate = 2 // TODO: This might be wrong
     await createUserTeamAndOrganization(pg, teamIdToCreate)
@@ -505,6 +497,7 @@ export async function fetchPostgresDistinctIdsForPerson(postgres: PostgresRouter
 }
 
 export async function resetBehavioralCohortsDatabase(postgres: PostgresRouter): Promise<void> {
+    await assertRouterTargetsTestDatabase(postgres, PostgresUse.BEHAVIORAL_COHORTS_RW)
     await postgres.query(
         PostgresUse.BEHAVIORAL_COHORTS_RW,
         'TRUNCATE TABLE cohort_membership',


### PR DESCRIPTION
## Problem

My local dev database was recently wiped, and I believe a plugin-server test run was the cause. Jest only sets `NODE_ENV=test` when it is unset. If `NODE_ENV` or `DEBUG` is already exported (flox exports `DEBUG=1`, and IDE test runners often set these too), `determineNodeEnv()` resolves to dev, every config default (`DATABASE_URL`, `PERSONS_DATABASE_URL`, `CLICKHOUSE_DATABASE`, ...) points at the real dev databases, and `resetTestDatabase()` then mass-deletes from them. I want to make sure this can't happen again.

## Changes

- `jest.setup-env.ts` forces `NODE_ENV=test` before config loads, so defaults always resolve to the `test_*` databases regardless of what the shell exports.
- `tests/helpers/database-guard.ts` adds a runtime guard: destructive helpers query `current_database()` / `currentDatabase()` and throw a loud, actionable error unless the connected database has `test` in its name. This catches the remaining case where an explicit `*_DATABASE_URL` pointing at dev leaks in from the environment.
- The guard is wired into `resetTestDatabase()` / `clearDatabase()` in `tests/helpers/sql.ts` and `Clickhouse.truncate()` / `resetTestDatabase()` in `tests/helpers/clickhouse.ts`.
- `ALLOW_NON_TEST_DATABASE_RESET=1` is an escape hatch for environments whose test database legitimately doesn't match the pattern.
- New `nodejs/README.md` documents the test database setup and the guard.

## How did you test this code?

Added `tests/helpers/database-guard.test.ts` covering allowed test database names, refused dev database names, the error message contents, the escape hatch, and the Postgres router check. All 15 tests pass locally.