### PR TITLE
fix(vercel): allow plans fetch before installation exists

### DIFF
--- a/ee/api/vercel/test/test_vercel_installation.py
+++ b/ee/api/vercel/test/test_vercel_installation.py
@@ -61,6 +61,16 @@ class TestVercelInstallationAPI(VercelTestBase):
         assert response.status_code == status.HTTP_200_OK
         mock_plans.assert_called_once()
 
+    @patch("ee.vercel.integration.VercelIntegration.get_vercel_plans")
+    def test_plans_allows_placeholder_installation_id(self, mock_plans):
+        # Vercel fetches plans before an installation exists, using the literal
+        # path segment "new" instead of a real installation ID.
+        mock_plans.return_value = [{"id": "free"}, {"id": "paid"}]
+        response = self._request("get", url="/api/vercel/v1/installations/new/plans/", auth_type="system")
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_plans.assert_called_once()
+
     @patch("ee.vercel.integration.VercelIntegration.update_installation")
     def test_update_calls_upsert_installation(self, mock_update):
         response = self._request("patch", data=self.update_payload)

--- a/ee/api/vercel/vercel_permission.py
+++ b/ee/api/vercel/vercel_permission.py
@@ -17,6 +17,10 @@ class VercelPermission(BasePermission):
     ADMIN_ONLY_ACTIONS = {"update", "partial_update", "create", "destroy"}
     # Actions that allow USER role (read-only operations)
     READ_ONLY_ACTIONS = {"list", "retrieve", "plans"}
+    # Actions that serve static, non-tenant data. Vercel calls plans before an
+    # installation exists, with the literal path segment "new" in place of an
+    # installation ID, so the token-to-installation binding cannot apply.
+    INSTALLATION_MATCH_EXEMPT_ACTIONS = {"plans"}
 
     def has_permission(self, request: Request, view) -> bool:
         self._validate_auth_type_allowed(request, view)
@@ -28,7 +32,9 @@ class VercelPermission(BasePermission):
         # Bind the token to its own installation. These viewsets resolve their target by
         # the URL installation_id without calling check_object_permissions, so the match
         # must be enforced here for every installation-scoped endpoint.
-        if "installation_id" in view.kwargs or "parent_lookup_installation_id" in view.kwargs:
+        if (
+            "installation_id" in view.kwargs or "parent_lookup_installation_id" in view.kwargs
+        ) and view.action not in self.INSTALLATION_MATCH_EXEMPT_ACTIONS:
             self._validate_installation_id_match(request, view)
         return True
 


### PR DESCRIPTION
## Problem

Vercel marketplace installations of PostHog are blocked. During the install flow, Vercel upserts the installation first and then fetches billing plans — but the plans request uses the literal path segment `new` in place of an installation ID (`GET /api/vercel/v1/installations/new/plans`) while the token is bound to the real installation it just created. The token-to-installation binding added in #61901 compares the token's installation claim against the URL segment, so the request fails with `403 Installation ID mismatch` and the installation cannot complete.

## Changes

Exempt the `plans` action from the installation ID match in `VercelPermission`. The endpoint serves only the static plan catalog (no tenant data, no `get_object` call), so the binding adds no protection there, and the URL segment can legitimately be the `new` placeholder. All other installation-scoped endpoints keep the binding from #61901.

## How did you test this code?

I'm an agent; testing was a mix of automated tests and a live end-to-end run against a local dev stack driven with human direction.

**Automated:**
- New test `test_plans_allows_placeholder_installation_id` reproduces the failure on unfixed master (system-auth `GET /api/vercel/v1/installations/new/plans` returns 403 with the exact reported error body) and passes with the fix.
- Full Vercel suite: `pytest ee/api/vercel/test/` — 245 passed.

**Live end-to-end (local backend tunneled to the Vercel marketplace dev integration):**
- Ran the full marketplace install flow against unfixed master and then with the fix applied: ToS accept → installation upsert → plan selection → confirmation → resource provisioning, completing with `Successfully created Vercel resource`.
- Confirmed the request ordering that produces the prod failure: Vercel upserts the installation first, so by the time plans are fetched the token's installation claim refers to an existing installation, and only the URL uses the `new` placeholder. This is also why the region-proxy layer doesn't 404 these requests in production — the claimed installation exists by then.
- The `installations/new/plans` URL variant is sent by Vercel's newer install flow and could not be elicited from the dev integration (it used the documented product-plans route and real installation IDs); the unit test covers that request shape byte-for-byte at the HTTP layer.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by Claude Code with human direction. Root cause traced from the marketplace error report: `has_permission` installation binding (added in #61901) rejects Vercel's pre-validated plans request that uses `new` as a placeholder installation ID. Reproduced via unit test on master before fixing, then validated the install flow end-to-end against a tunneled local dev stack.