### PR TITLE
fix(data-management): property definition save now toasts and navigates

### DIFF
--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.test.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.test.ts
@@ -12,9 +12,7 @@ import { initKeaTests } from '~/test/init'
 import { mockEventDefinitions, mockEventPropertyDefinition } from '~/test/mocks'
 
 describe('definitionEditLogic', () => {
-    let logic: ReturnType<typeof definitionEditLogic.build>
-
-    beforeEach(async () => {
+    beforeEach(() => {
         useMocks({
             get: {
                 '/api/projects/:team/event_definitions/:id': mockEventDefinitions[0],
@@ -34,21 +32,43 @@ describe('definitionEditLogic', () => {
             },
         })
         initKeaTests()
-        await expectLogic(definitionLogic({ id: '1' })).toFinishAllListeners()
         eventDefinitionsTableLogic.mount()
         propertyDefinitionsTableLogic.mount()
-        logic = definitionEditLogic({ id: '1', definition: mockEventDefinitions[0] })
-        logic.mount()
     })
 
-    it('save definition', async () => {
-        router.actions.push(urls.eventDefinition('1'))
+    // The property branch reads `propertyAccessControlLogic`, which is only mounted when the
+    // access-control panel renders (behind a feature flag). Saving with it unmounted must still
+    // toast and navigate — guarded by `findMounted` in definitionEditLogic.
+    it.each([
+        {
+            kind: 'event',
+            id: '1',
+            editUrl: urls.eventDefinitionEdit('1'),
+            detailUrl: urls.eventDefinition(mockEventDefinitions[0].id),
+            localAction: (): any =>
+                eventDefinitionsTableLogic.actionCreators.setLocalEventDefinition(mockEventDefinitions[0]),
+        },
+        {
+            kind: 'property',
+            id: mockEventPropertyDefinition.id,
+            editUrl: urls.propertyDefinitionEdit(mockEventPropertyDefinition.id),
+            detailUrl: urls.propertyDefinition(mockEventPropertyDefinition.id),
+            localAction: (): any =>
+                propertyDefinitionsTableLogic.actionCreators.setLocalPropertyDefinition(mockEventPropertyDefinition),
+        },
+    ])('saves a $kind definition and navigates back', async ({ id, editUrl, detailUrl, localAction }) => {
+        // isEvent is derived from the route, so set it before the definition loads
+        router.actions.push(editUrl)
+        await expectLogic(definitionLogic({ id })).toFinishAllListeners()
+
+        const logic = definitionEditLogic({ id })
+        logic.mount()
+
         await expectLogic(logic, () => {
-            logic.actions.saveDefinition(mockEventDefinitions[0])
-        }).toDispatchActionsInAnyOrder([
-            'saveDefinition',
-            'setDefinition',
-            eventDefinitionsTableLogic.actionCreators.setLocalEventDefinition(mockEventDefinitions[0]),
-        ])
+            logic.actions.saveDefinition({})
+        }).toDispatchActionsInAnyOrder(['saveDefinition', 'setDefinition', localAction()])
+
+        // navigated away from the edit page back to the definition detail page
+        expect(router.values.location.pathname.endsWith(detailUrl)).toBe(true)
     })
 })

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -83,11 +83,11 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
                         // Save field access control changes if any
                         const currentTeamId = teamLogic.values.currentTeamId
                         if (currentTeamId) {
-                            const facLogic = propertyAccessControlLogic({
+                            const facLogic = propertyAccessControlLogic.findMounted({
                                 propertyDefinitionId: definition.id,
                                 teamId: currentTeamId,
                             })
-                            if (facLogic.values.hasChanges) {
+                            if (facLogic?.values.hasChanges) {
                                 facLogic.actions.saveAccessControls()
                             }
                         }


### PR DESCRIPTION
## Problem

On the property definition edit page (`/data-management/properties/:id/edit`), clicking **Save** persisted the change to the backend but the UI did nothing — no "Property saved" toast and no redirect back to the property detail page. The change saved silently, so it looked broken to the user.

Event definitions were unaffected; only properties exhibited this.

## Changes

The `saveDefinition` loader in `definitionEditLogic.ts` has a property-only block (added with the property access-control UI) that reads `propertyAccessControlLogic` to persist any pending field-access-control edits:

```ts
const facLogic = propertyAccessControlLogic({ propertyDefinitionId: definition.id, teamId: currentTeamId })
if (facLogic.values.hasChanges) { ... }
```

In kea 4, accessing a proxied field like `.values` on a logic that is **not mounted** throws (`Can not access "values" ... because it is not mounted`). `propertyAccessControlLogic` only mounts when the access-control panel renders, which is gated behind the `property-access-control` feature flag. With the flag off (the common case), `.values.hasChanges` threw — and crucially this happened *after* the successful API call but *before* the toast and `router.actions.push`, so the loader aborted into `saveDefinitionFailure`: data saved, UI silent.

The fix guards the read with `findMounted`, mirroring the adjacent `updatePropertyDefinitions` call (`propertyDefinitionsModel.findMounted()?.actions...`) in the same handler:

```ts
const facLogic = propertyAccessControlLogic.findMounted({ propertyDefinitionId: definition.id, teamId: currentTeamId })
if (facLogic?.values.hasChanges) {
    facLogic.actions.saveAccessControls()
}
```

When the logic is unmounted, the access-control panel was never shown, so there can be no pending edits to save — skipping is the correct behavior, not just a safe one. The existing toast + navigation then run as intended.

## How did you test this code?

I'm an agent — I did not manually exercise the browser. Automated coverage:

- Parameterized the existing `definitionEditLogic.test.ts` over the event and property paths. The prior test only covered events, which is why this slipped through.
- The new property-path case reproduces the regression condition (a current team is present and `propertyAccessControlLogic` is unmounted). I confirmed it **fails against the pre-fix code** (`setDefinition` / `setLocalPropertyDefinition` never dispatch because the handler throws) and **passes with the fix**, and asserts navigation lands back on the detail page.

```
✓ saves a event definition and navigates back
✓ saves a property definition and navigates back
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (claude-opus-4-8), directed by the PR author. Root cause was traced by reading the kea 4 `proxyFieldToLogic` source to confirm that `.values` access on an unmounted logic throws, then narrowing the failure to the property-only access-control block sitting between the successful API call and the toast/navigation. The `findMounted` guard was chosen over alternatives (e.g. broad try/catch around the side effects) because it matches the established codebase idiom — `findMounted({ props })?.values`/`?.actions` is used in dozens of logics, including the immediately adjacent line in this same handler.

Agent-authored change; requires human review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
