### PR TITLE
fix(web-analytics): reload button refreshes all tiles, not just overview

### DIFF
--- a/frontend/src/scenes/web-analytics/webTileHeaderHooks.test.tsx
+++ b/frontend/src/scenes/web-analytics/webTileHeaderHooks.test.tsx
@@ -3,11 +3,14 @@ import { cleanup, renderHook } from '@testing-library/react'
 import { examples } from '~/queries/examples'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { QuerySchema } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { InsightLogicProps } from '~/types'
 
 import { WEB_ANALYTICS_DATA_COLLECTION_NODE_ID } from './common'
 import { useWebTileExportAdapter } from './webTileHeaderHooks'
+
+const worldMapQuery = examples.WebAnalyticsWorldMap as QuerySchema
 
 describe('useWebTileExportAdapter', () => {
     let collection: ReturnType<typeof dataNodeCollectionLogic.build>
@@ -33,7 +36,7 @@ describe('useWebTileExportAdapter', () => {
             dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
         }
 
-        renderHook(() => useWebTileExportAdapter(examples.WebAnalyticsWorldMap, insightProps))
+        renderHook(() => useWebTileExportAdapter(worldMapQuery, insightProps))
 
         expect(registeredIds()).toContain(insightVizDataNodeKey(insightProps))
     })
@@ -48,10 +51,9 @@ describe('useWebTileExportAdapter', () => {
             dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
         }
 
-        const { rerender } = renderHook(
-            ({ insightProps }) => useWebTileExportAdapter(examples.WebAnalyticsWorldMap, insightProps),
-            { initialProps: { insightProps: firstProps } }
-        )
+        const { rerender } = renderHook(({ insightProps }) => useWebTileExportAdapter(worldMapQuery, insightProps), {
+            initialProps: { insightProps: firstProps },
+        })
         expect(registeredIds()).toContain(insightVizDataNodeKey(firstProps))
 
         rerender({ insightProps: secondProps })

--- a/frontend/src/scenes/web-analytics/webTileHeaderHooks.test.tsx
+++ b/frontend/src/scenes/web-analytics/webTileHeaderHooks.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, renderHook } from '@testing-library/react'
+
+import { examples } from '~/queries/examples'
+import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { initKeaTests } from '~/test/init'
+import { InsightLogicProps } from '~/types'
+
+import { WEB_ANALYTICS_DATA_COLLECTION_NODE_ID } from './common'
+import { useWebTileExportAdapter } from './webTileHeaderHooks'
+
+describe('useWebTileExportAdapter', () => {
+    let collection: ReturnType<typeof dataNodeCollectionLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        collection = dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID })
+        collection.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+        collection?.unmount()
+    })
+
+    const registeredIds = (): string[] => collection.values.mountedDataNodes.map((node) => node.id)
+
+    // Regression: the tile header renders before its chart, so this hook would let insightDataLogic build
+    // the shared, key-only dataNodeLogic first without a collection id, dropping the tile from "reload all".
+    it('registers the tile data node into the web analytics collection', () => {
+        const insightProps: InsightLogicProps = {
+            dashboardItemId: 'new-AdHoc.web-analytics-test-tile' as any,
+            dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
+        }
+
+        renderHook(() => useWebTileExportAdapter(examples.WebAnalyticsWorldMap, insightProps))
+
+        expect(registeredIds()).toContain(insightVizDataNodeKey(insightProps))
+    })
+
+    it('rebinds to the new node when insightProps change (tab switch)', () => {
+        const firstProps: InsightLogicProps = {
+            dashboardItemId: 'new-AdHoc.web-analytics-tab-a' as any,
+            dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
+        }
+        const secondProps: InsightLogicProps = {
+            dashboardItemId: 'new-AdHoc.web-analytics-tab-b' as any,
+            dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
+        }
+
+        const { rerender } = renderHook(
+            ({ insightProps }) => useWebTileExportAdapter(examples.WebAnalyticsWorldMap, insightProps),
+            { initialProps: { insightProps: firstProps } }
+        )
+        expect(registeredIds()).toContain(insightVizDataNodeKey(firstProps))
+
+        rerender({ insightProps: secondProps })
+        expect(registeredIds()).toContain(insightVizDataNodeKey(secondProps))
+    })
+})

--- a/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
+++ b/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { IconExpand45 } from '@posthog/icons'
@@ -8,6 +8,8 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
+import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataCollectionId, insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import {
     ProductIntentContext,
     ProductKey,
@@ -37,6 +39,27 @@ export function useWebTileExportAdapter(
     query: QuerySchema | undefined,
     insightProps: InsightLogicProps
 ): ExportAdapter | null {
+    // This header hook renders before the tile's chart. insightDataLogic (mounted below) connects to
+    // the shared, key-only dataNodeLogic without forwarding dataNodeCollectionId, so it would build
+    // that logic first and bind it to a fallback collection — dropping the tile from the dashboard's
+    // "reload all" (only the overview, which isn't an insight viz, kept reloading). Bind the node to
+    // the web analytics collection up front, keyed by the node key so it tracks tab switches, so the
+    // chart reuses the same correctly-bound instance and reload reaches every tile.
+    const dataNodeKey = insightVizDataNodeKey(insightProps)
+    const collectionBoundDataNodeLogic = useMemo(
+        () =>
+            dataNodeLogic({
+                key: dataNodeKey,
+                dataNodeCollectionId: insightVizDataCollectionId(insightProps, dataNodeKey),
+                loadPriority: insightProps.loadPriority,
+            } as DataNodeLogicProps),
+        // Rebind only when the node key changes (tile/tab switch); avoid re-running on every render so
+        // we never clobber the query the chart sets on the shared instance.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [dataNodeKey]
+    )
+    useMountedLogic(collectionBoundDataNodeLogic)
+
     const builtInsightDataLogic = insightDataLogic(insightProps)
     const { insightDataRaw } = useValues(builtInsightDataLogic)
 


### PR DESCRIPTION
## Problem

In Web Analytics, the "Reload" button only refreshed the web overview tile — every other tile stayed stale. The regression was introduced by the dashboard simplification in #59105.

## Changes

`dataNodeLogic` is keyed only by `props.key`, and its `connect()` (which binds it to a `dataNodeCollectionLogic`) runs once at build time. The new per-tile header (`useWebTileExportAdapter` → `insightDataLogic`) renders in the parent tile component, *before* the child chart, and `insightDataLogic` builds the shared node **without** forwarding `dataNodeCollectionId`. When that build wins the race, the node binds to a fallback collection instead of `web-analytics`, so `ReloadAll` (which iterates the `web-analytics` collection) never refreshes it. The overview tile is a `WebOverviewQuery` bound directly to `web-analytics`, so its key never collided — which is why it was the only tile still reloading.

The fix binds the shared `dataNodeLogic` to the web analytics collection up front inside `useWebTileExportAdapter`, memoized on the node key (so it tracks tab switches and never clobbers the query the chart sets). The chart then reuses the same correctly-bound instance and reload reaches every tile. For non-insight tiles (e.g. overview) this only adds a query-less node, which `loadData` no-ops on.

The fix is scoped entirely to web analytics code — `insightDataLogic` is untouched.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual in-app testing. Automated tests I ran locally:

- New `webTileHeaderHooks.test.tsx` — asserts the tile data node registers into the `web-analytics` collection and rebinds on tab switch. Verified both tests **fail without the fix and pass with it**.
- Existing `WebTileHeader` and `webAnalyticsTile` suites pass; oxlint clean; formatted.

Reviewer note: the original bug was render-order-dependent, so a quick live check with the tile-header-V2 flag on is recommended.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @lricoy. Root-caused the regression to a kea build-order race on the key-only `dataNodeLogic`: whichever caller builds the shared node first decides its collection binding, and the parent-rendered tile-header export hook was winning that race with a missing collection id. A global fix in `insightDataLogic` (forwarding the existing `dataNodeCollectionId` prop) was considered and rejected in favor of keeping the change scoped to web analytics.