### PR TITLE
fix(capture-v1): short-circuit all-invalid batches before quota limiter

### DIFF
--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -53,6 +53,13 @@ pub async fn process_batch(
 
     let mut events = validate_events(context, batch)?;
 
+    // Every event already dropped by validation — skip the rest of the
+    // pipeline (quota limiter, restrictions, overflow, sinks) and return
+    // 200 with per-event drop details immediately.
+    if events.iter().all(|ev| ev.result != EventResult::Ok) {
+        return Ok(BatchResponse::build(context, &events));
+    }
+
     crate::v1::quota_limiter_shim::apply_quota_limits(
         &state.quota_limiter,
         &context.api_token,
@@ -2449,6 +2456,39 @@ mod tests {
             matches!(err, Error::ServiceUnavailable(_)),
             "expected ServiceUnavailable, got: {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn process_batch_all_validation_dropped_returns_200_not_402() {
+        let test_state = crate::v1::test_utils::TestStateBuilder::new().build();
+        let state = test_state.state;
+
+        let mut ctx = test_utils::test_context();
+        // Every event is invalid — empty name, empty distinct_id, bad timestamp.
+        let batch = valid_batch(vec![
+            Event {
+                event: String::new(),
+                ..valid_event()
+            },
+            Event {
+                distinct_id: String::new(),
+                ..valid_event()
+            },
+            Event {
+                timestamp: "not-a-date".to_string(),
+                ..valid_event()
+            },
+        ]);
+
+        let resp = process_batch(&state, &mut ctx, batch).await.unwrap();
+        assert_eq!(resp.entries().len(), 3);
+        for (_, entry) in resp.entries() {
+            assert_eq!(
+                entry.result,
+                EventResult::Drop,
+                "all-invalid batch must return 200 with per-event drops, not 402"
+            );
+        }
     }
 
     // =========================================================================

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -53,9 +53,7 @@ pub async fn process_batch(
 
     let mut events = validate_events(context, batch)?;
 
-    // Every event already dropped by validation — skip the rest of the
-    // pipeline (quota limiter, restrictions, overflow, sinks) and return
-    // 200 with per-event drop details immediately.
+    // Nothing left to process — return 200 with per-event drops.
     if events.iter().all(|ev| ev.result != EventResult::Ok) {
         return Ok(BatchResponse::build(context, &events));
     }

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -19,13 +19,10 @@ const SCOPED_CHECKS: &[ScopedCheck] = &[
 
 /// Apply billing quota limits to a batch of events in-place.
 ///
-/// Checks the global limiter first (short-circuit on full batch drop), then
-/// iterates scoped limiters, marking matching events as `Limited` / `Drop`.
-/// Returns `Error::BillingLimitExceeded` when the entire batch is limited.
-///
-/// Callers must ensure at least one event is `Ok` before calling — batches
-/// where every event was already dropped by validation should short-circuit
-/// upstream (see `process_batch`).
+/// Checks global limiter first (short-circuit), then scoped limiters.
+/// Returns `Error::BillingLimitExceeded` when every event is limited.
+/// Expects at least one `Ok` event — all-dropped batches should
+/// short-circuit in `process_batch` before reaching here.
 pub async fn apply_quota_limits(
     limiter: &CaptureQuotaLimiter,
     token: &str,

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -22,6 +22,10 @@ const SCOPED_CHECKS: &[ScopedCheck] = &[
 /// Checks the global limiter first (short-circuit on full batch drop), then
 /// iterates scoped limiters, marking matching events as `Limited` / `Drop`.
 /// Returns `Error::BillingLimitExceeded` when the entire batch is limited.
+///
+/// Callers must ensure at least one event is `Ok` before calling — batches
+/// where every event was already dropped by validation should short-circuit
+/// upstream (see `process_batch`).
 pub async fn apply_quota_limits(
     limiter: &CaptureQuotaLimiter,
     token: &str,


### PR DESCRIPTION
## Problem
Small fixes to address corner cases found in prod smoke testing today using new `posthog-rs` SDK's capture v1 functionality:

All-invalid batches (every event dropped by validation) hit the quota limiter, which mistakenly escalated them to 402 `billing_limit_exceeded`


## Fix
- Early exit in `process_batch` right after `validate_events`: if every event is already non-Ok, return 200 with per-event drops immediately
- Skips quota limiter, restrictions, overflow, rate limits, and sink publishing — no wasted Redis roundtrips on dead batches
- Quota shim unchanged; its `all_non_ok` post-check can now only fire when quota drops genuinely caused all-non-Ok

## Test
- `process_batch_all_validation_dropped_returns_200_not_402`: 3 invalid events, asserts 200 + per-event drops
- 113 process tests + 17 quota shim tests pass