### PR TITLE
fix(capture-v1): accept zlib-wrapped deflate payloads

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,6 +95,7 @@ async-compression = { version = "0.4", features = [
   "tokio",
   "gzip",
   "deflate",
+  "zlib",
   "brotli",
   "zstd",
 ] }

--- a/rust/capture/src/v1/util.rs
+++ b/rust/capture/src/v1/util.rs
@@ -369,6 +369,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn decompress_deflate_raw_starting_with_0x78_treated_as_zlib() {
+        // Pin the known tradeoff: a raw deflate stream whose first byte is
+        // 0x78 gets misrouted to ZlibDecoder and fails. Same strategy as nginx.
+        let raw = compress_deflate(b"test payload");
+        let mut patched = raw.clone();
+        patched[0] = 0x78;
+        let compressed = Bytes::from(patched);
+
+        let result =
+            decompress_payload(Some("deflate"), compressed, 4096, TEST_CHUNK_SIZE_KB).await;
+        assert!(
+            result.is_err(),
+            "raw deflate starting with 0x78 is misrouted to ZlibDecoder (accepted tradeoff)"
+        );
+    }
+
+    #[tokio::test]
     async fn decompress_br_exceeds_limit() {
         let big = vec![0u8; 64 * 1024];
         let compressed = Bytes::from(compress_brotli(&big));

--- a/rust/capture/src/v1/util.rs
+++ b/rust/capture/src/v1/util.rs
@@ -98,6 +98,9 @@ pub async fn decompress_payload(
         None => return Ok(bytes),
     };
 
+    // Sniff first byte before moving bytes into a reader — used by the
+    // "deflate" arm to distinguish zlib-wrapped (0x78) from raw deflate.
+    let first_byte = bytes.first().copied();
     let reader = tokio::io::BufReader::new(std::io::Cursor::new(bytes));
 
     match encoding {
@@ -110,7 +113,22 @@ pub async fn decompress_payload(
             )
             .await
         }
+        "deflate" if first_byte == Some(0x78) => {
+            // RFC 9110 §8.4.1.2: `Content-Encoding: deflate` is the zlib
+            // format (RFC 1950), which wraps raw deflate with a 2-byte header
+            // starting with 0x78. Many HTTP clients send zlib-wrapped data
+            // (including posthog-rs via flate2::ZlibEncoder). Use ZlibDecoder
+            // for zlib-wrapped payloads — same sniff strategy as nginx.
+            read_decompressed(
+                bufread::ZlibDecoder::new(reader),
+                payload_size_limit,
+                chunk_size_kb,
+                encoding,
+            )
+            .await
+        }
         "deflate" => {
+            // Raw deflate (RFC 1951) — no zlib wrapper.
             read_decompressed(
                 bufread::DeflateDecoder::new(reader),
                 payload_size_limit,
@@ -173,7 +191,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use bytes::Bytes;
-    use flate2::write::{DeflateEncoder, GzEncoder};
+    use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
     use flate2::Compression;
     use futures::stream;
     use std::io::Write;
@@ -251,6 +269,12 @@ mod tests {
         encoder.finish().unwrap()
     }
 
+    fn compress_zlib(data: &[u8]) -> Vec<u8> {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
     fn compress_brotli(data: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
         {
@@ -280,9 +304,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decompress_deflate_valid() {
+    async fn decompress_deflate_raw_valid() {
         let original = b"hello deflate world";
         let compressed = Bytes::from(compress_deflate(original));
+        assert_ne!(compressed.first(), Some(&0x78), "raw deflate must not start with zlib magic");
+        let result =
+            decompress_payload(Some("deflate"), compressed, 4096, TEST_CHUNK_SIZE_KB).await;
+        assert_eq!(result.unwrap(), Bytes::from_static(original));
+    }
+
+    #[tokio::test]
+    async fn decompress_deflate_zlib_wrapped_valid() {
+        let original = b"hello zlib-wrapped deflate world";
+        let compressed = Bytes::from(compress_zlib(original));
+        assert_eq!(compressed.first(), Some(&0x78), "zlib payload must start with 0x78 magic");
         let result =
             decompress_payload(Some("deflate"), compressed, 4096, TEST_CHUNK_SIZE_KB).await;
         assert_eq!(result.unwrap(), Bytes::from_static(original));
@@ -313,9 +348,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decompress_deflate_exceeds_limit() {
+    async fn decompress_deflate_raw_exceeds_limit() {
         let big = vec![0u8; 64 * 1024];
         let compressed = Bytes::from(compress_deflate(&big));
+        let result =
+            decompress_payload(Some("deflate"), compressed, 1024, TEST_CHUNK_SIZE_KB).await;
+        assert!(matches!(result, Err(Error::PayloadTooLarge(_))));
+    }
+
+    #[tokio::test]
+    async fn decompress_deflate_zlib_exceeds_limit() {
+        let big = vec![0u8; 64 * 1024];
+        let compressed = Bytes::from(compress_zlib(&big));
+        assert_eq!(compressed.first(), Some(&0x78));
         let result =
             decompress_payload(Some("deflate"), compressed, 1024, TEST_CHUNK_SIZE_KB).await;
         assert!(matches!(result, Err(Error::PayloadTooLarge(_))));

--- a/rust/capture/src/v1/util.rs
+++ b/rust/capture/src/v1/util.rs
@@ -98,8 +98,6 @@ pub async fn decompress_payload(
         None => return Ok(bytes),
     };
 
-    // Sniff first byte before moving bytes into a reader — used by the
-    // "deflate" arm to distinguish zlib-wrapped (0x78) from raw deflate.
     let first_byte = bytes.first().copied();
     let reader = tokio::io::BufReader::new(std::io::Cursor::new(bytes));
 
@@ -113,12 +111,9 @@ pub async fn decompress_payload(
             )
             .await
         }
+        // RFC 9110: Content-Encoding "deflate" = zlib (RFC 1950, 0x78 prefix).
+        // Sniff first byte: zlib-wrapped → ZlibDecoder, raw → DeflateDecoder.
         "deflate" if first_byte == Some(0x78) => {
-            // RFC 9110 §8.4.1.2: `Content-Encoding: deflate` is the zlib
-            // format (RFC 1950), which wraps raw deflate with a 2-byte header
-            // starting with 0x78. Many HTTP clients send zlib-wrapped data
-            // (including posthog-rs via flate2::ZlibEncoder). Use ZlibDecoder
-            // for zlib-wrapped payloads — same sniff strategy as nginx.
             read_decompressed(
                 bufread::ZlibDecoder::new(reader),
                 payload_size_limit,
@@ -128,7 +123,6 @@ pub async fn decompress_payload(
             .await
         }
         "deflate" => {
-            // Raw deflate (RFC 1951) — no zlib wrapper.
             read_decompressed(
                 bufread::DeflateDecoder::new(reader),
                 payload_size_limit,
@@ -307,7 +301,11 @@ mod tests {
     async fn decompress_deflate_raw_valid() {
         let original = b"hello deflate world";
         let compressed = Bytes::from(compress_deflate(original));
-        assert_ne!(compressed.first(), Some(&0x78), "raw deflate must not start with zlib magic");
+        assert_ne!(
+            compressed.first(),
+            Some(&0x78),
+            "raw deflate must not start with zlib magic"
+        );
         let result =
             decompress_payload(Some("deflate"), compressed, 4096, TEST_CHUNK_SIZE_KB).await;
         assert_eq!(result.unwrap(), Bytes::from_static(original));
@@ -317,7 +315,11 @@ mod tests {
     async fn decompress_deflate_zlib_wrapped_valid() {
         let original = b"hello zlib-wrapped deflate world";
         let compressed = Bytes::from(compress_zlib(original));
-        assert_eq!(compressed.first(), Some(&0x78), "zlib payload must start with 0x78 magic");
+        assert_eq!(
+            compressed.first(),
+            Some(&0x78),
+            "zlib payload must start with 0x78 magic"
+        );
         let result =
             decompress_payload(Some("deflate"), compressed, 4096, TEST_CHUNK_SIZE_KB).await;
         assert_eq!(result.unwrap(), Bytes::from_static(original));


### PR DESCRIPTION
## Problem
Small fixes to address corner cases found in prod smoke testing today using new `posthog-rs` SDK's capture v1 functionality:

- `Content-Encoding: deflate` is defined as the zlib format (RFC 9110), but backend only used raw deflate decoder
- `posthog-rs` SDK correctly sends zlib-wrapped payloads (`flate2::ZlibEncoder`) — backend rejected them with 400 `request_decoding_error`
- Found by smoke tests against prod-us: `sdk::deflate_compression` failed

## Fix
- Sniff first byte of payload: `0x78` = zlib-wrapped, use `ZlibDecoder`; anything else = raw deflate, use `DeflateDecoder`
- Same approach as nginx and most HTTP servers
- Add `zlib` feature to `async-compression` workspace dep

## Tests
- `decompress_deflate_raw_valid` — existing raw path still works
- `decompress_deflate_zlib_wrapped_valid` — new, covers SDK path
- `decompress_deflate_raw_exceeds_limit` + `decompress_deflate_zlib_exceeds_limit` — limit enforcement on both paths
- All 33 util tests pass