### PR TITLE
fix(llma): use bare channel ID for eval report Slack delivery

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/delivery.py
@@ -303,7 +303,9 @@ def deliver_slack_report(
 
         integration_id = target.get("integration_id")
         # The frontend SlackChannelPicker stores "<channel_id>|#<channel_name>" — Slack only accepts the ID.
-        channel = target.get("channel", "").split("|")[0]
+        # str() + `or ""` keep a malformed stored value (null, non-string) on the skip/error path
+        # instead of raising outside the try block and failing the whole delivery loop.
+        channel = str(target.get("channel") or "").split("|")[0]
         if not integration_id or not channel:
             continue
 

--- a/posthog/temporal/ai_observability/eval_reports/delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/delivery.py
@@ -302,7 +302,8 @@ def deliver_slack_report(
             continue
 
         integration_id = target.get("integration_id")
-        channel = target.get("channel", "")
+        # The frontend SlackChannelPicker stores "<channel_id>|#<channel_name>" — Slack only accepts the ID.
+        channel = target.get("channel", "").split("|")[0]
         if not integration_id or not channel:
             continue
 

--- a/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
@@ -317,11 +317,19 @@ class TestDeliverSlackReport(SimpleTestCase):
         for call in client.chat_postMessage.call_args_list:
             self.assertEqual(call.kwargs["channel"], expected_channel)
 
+    @parameterized.expand(
+        [
+            # A stored value like "|#name" splits to an empty channel ID — the guard should skip it.
+            ("blank_channel_id", "|#some-channel"),
+            ("null_channel", None),
+        ]
+    )
     @patch("posthog.models.integration.SlackIntegration")
     @patch("posthog.models.integration.Integration.objects")
-    def test_skips_target_with_blank_channel_id(self, mock_integration_qs, mock_slack_integration):
-        # A stored value like "|#name" splits to an empty channel ID — the guard should skip it.
-        targets = [{"type": "slack", "integration_id": 1, "channel": "|#some-channel"}]
+    def test_skips_target_with_unusable_channel(
+        self, _name, stored_channel, mock_integration_qs, mock_slack_integration
+    ):
+        targets = [{"type": "slack", "integration_id": 1, "channel": stored_channel}]
         client = MagicMock()
         mock_slack_integration.return_value.client = client
 

--- a/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
+
 from posthog.temporal.ai_observability.eval_reports.delivery import (
     _format_period_for_display,
     _inline_email_styles,
@@ -11,6 +13,7 @@ from posthog.temporal.ai_observability.eval_reports.delivery import (
     _render_section_mrkdwn,
     _strip_redundant_leading_heading,
     deliver_report,
+    deliver_slack_report,
 )
 from posthog.temporal.ai_observability.eval_reports.report_agent.schema import (
     Citation,
@@ -265,6 +268,75 @@ class TestMetricsBlockHtml(SimpleTestCase):
         self.assertNotIn("▲", html)
         self.assertNotIn("▼", html)
         self.assertNotIn("pp vs previous", html)
+
+
+class TestDeliverSlackReport(SimpleTestCase):
+    """Tests deliver_slack_report with a mocked Slack client."""
+
+    def _make_report_run(self, section_count: int = 2):
+        run = MagicMock()
+        run.content = EvalReportContent(
+            title="A nice punchline",
+            sections=[ReportSection(title=f"Section {i}", content="Body.") for i in range(section_count)],
+            citations=[],
+            metrics=EvalReportMetrics(total_runs=10, pass_count=9, pass_rate=90.0),
+        ).to_dict()
+        return run
+
+    @parameterized.expand(
+        [
+            # The SlackChannelPicker stores "<channel_id>|#<channel_name>" — the Slack API
+            # must receive only the channel ID or it returns channel_not_found.
+            ("composite_value", "C012345|#some-channel", "C012345"),
+            ("bare_channel_id", "C012345", "C012345"),
+        ]
+    )
+    @patch("posthog.models.integration.SlackIntegration")
+    @patch("posthog.models.integration.Integration.objects")
+    def test_normalizes_channel_before_posting(
+        self, _name, stored_channel, expected_channel, mock_integration_qs, mock_slack_integration
+    ):
+        targets = [{"type": "slack", "integration_id": 1, "channel": stored_channel}]
+        client = MagicMock()
+        client.chat_postMessage.return_value = {"ts": "1234.5678"}
+        mock_slack_integration.return_value.client = client
+
+        errors = deliver_slack_report(
+            self._make_report_run(section_count=2),
+            targets,
+            evaluation_name="Test Eval",
+            team_id=1,
+            project_id=1,
+            period_start="2026-03-01T00:00:00+00:00",
+            period_end="2026-03-02T00:00:00+00:00",
+        )
+
+        self.assertEqual(errors, [])
+        # Main message + one thread reply, both with the bare channel ID
+        self.assertEqual(client.chat_postMessage.call_count, 2)
+        for call in client.chat_postMessage.call_args_list:
+            self.assertEqual(call.kwargs["channel"], expected_channel)
+
+    @patch("posthog.models.integration.SlackIntegration")
+    @patch("posthog.models.integration.Integration.objects")
+    def test_skips_target_with_blank_channel_id(self, mock_integration_qs, mock_slack_integration):
+        # A stored value like "|#name" splits to an empty channel ID — the guard should skip it.
+        targets = [{"type": "slack", "integration_id": 1, "channel": "|#some-channel"}]
+        client = MagicMock()
+        mock_slack_integration.return_value.client = client
+
+        errors = deliver_slack_report(
+            self._make_report_run(section_count=1),
+            targets,
+            evaluation_name="Test Eval",
+            team_id=1,
+            project_id=1,
+            period_start="2026-03-01T00:00:00+00:00",
+            period_end="2026-03-02T00:00:00+00:00",
+        )
+
+        self.assertEqual(errors, [])
+        client.chat_postMessage.assert_not_called()
 
 
 class TestDeliverReport(SimpleTestCase):


### PR DESCRIPTION
## Problem

Slack delivery of AI observability evaluation reports always failed with `channel_not_found`. The shared `SlackChannelPicker` stores the selected channel as a combined `"<channel_id>|#<channel_name>"` string, but `deliver_slack_report()` passed that whole value verbatim to Slack's `chat.postMessage` — so any Slack target configured through the UI never delivered.

Reported via support (ZenDesk ticket [#60135](https://posthoghelp.zendesk.com/agent/tickets/60135)).

## Changes

In `posthog/temporal/ai_observability/eval_reports/delivery.py`, split the stored channel value on `|` and send only the channel ID, following the established pattern used by subscriptions delivery (`ee/tasks/subscriptions/slack_subscriptions.py`). Both `chat_postMessage` calls (main message and thread replies) use the same variable, so one split covers both. A blank channel ID after the split (e.g. a stored `"|#name"` value) is skipped by the existing guard.

## How did you test this code?

I'm an agent; automated tests plus a human-verified manual test:

- Added `TestDeliverSlackReport`: a parameterized test asserting both the composite `"C012345|#some-channel"` and bare `"C012345"` formats result in `chat_postMessage(channel="C012345", ...)` for the main message and the thread reply, plus a guard test that a blank channel ID makes no Slack call. All 46 tests in `posthog/temporal/ai_observability/eval_reports/test/test_delivery.py` pass.
- Manually verified end-to-end on a local instance (human-driven): connected a Slack workspace, configured a report Slack target through the UI picker (storing the composite value), and confirmed the report delivered to the channel — main message and thread reply — where it previously failed with `channel_not_found`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Diagnosis came from a support-ticket investigation session; this session verified the root cause against the code (picker storage format, subscriptions split pattern), applied the one-line fix, and added tests.
- Code-reviewer agent ran twice: first round suggested parameterizing the tests and adding a blank-channel-ID guard test (both applied); final round approved, specifically verifying the `@parameterized.expand` + `@patch` decorator stacking and that patch targets match the function's runtime import.
- Considered and rejected normalizing the value on write (frontend or serializer): the composite format is the established storage convention; consumers split on read.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
