### PR TITLE
feat(web-analytics): bump query concurrency limits to 6

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -116,9 +116,9 @@ export const AUTOLOAD_INTERVAL = 30000
 const LOAD_MORE_ROWS_LIMIT = 10000
 
 const concurrencyController = new ConcurrencyController(1)
-const webAnalyticsConcurrencyController = new ConcurrencyController(3)
-const webAnalyticsPreAggConcurrencyController = new ConcurrencyController(5)
-const marketingAnalyticsConcurrencyController = new ConcurrencyController(5)
+const webAnalyticsConcurrencyController = new ConcurrencyController(6)
+const webAnalyticsPreAggConcurrencyController = new ConcurrencyController(6)
+const marketingAnalyticsConcurrencyController = new ConcurrencyController(6)
 
 function getConcurrencyController(query: DataNode, currentTeam: TeamType): ConcurrencyController {
     const mountedSceneLogic = sceneLogic.findMounted()


### PR DESCRIPTION
## Problem

The reload-all-tiles change (#62823) makes the dashboard fire all tiles at once on a manual refresh, so more web-analytics queries are in flight concurrently. The old per-controller caps (3 raw / 5 pre-agg / 5 marketing) throttle that burst and make a full reload feel slow.

## Changes

Bump the three web-analytics client-side concurrency controllers in `dataNodeLogic.ts` to 6:

| Controller | Before | After |
|---|---|---|
| `webAnalyticsConcurrencyController` | 3 | 6 |
| `webAnalyticsPreAggConcurrencyController` | 5 | 6 |
| `marketingAnalyticsConcurrencyController` | 5 | 6 |

These bound how many queries a single web-analytics scene dispatches in parallel from the browser; raising the cap lets a full dashboard reload fan out instead of queuing.

## How did you test this code?

Agent-assisted. No automated tests cover these constants; change is a three-value config bump verified by reading the diff. No manual UI testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The bump was committed locally but stranded on a branch whose PR (#62823) had already squash-merged without it. Lifted the commit onto a fresh branch off master and opened this PR. The value 6 is a uniform cap across the three controllers, chosen to absorb the all-tiles reload burst.
