### PR TITLE
fix(quill): ship the quill tailwind contract from charts

### DIFF
--- a/packages/quill/packages/charts/package.json
+++ b/packages/quill/packages/charts/package.json
@@ -12,7 +12,9 @@
         "dist"
     ],
     "type": "module",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css"
+    ],
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -23,6 +25,7 @@
             "require": "./dist/index.cjs",
             "default": "./dist/index.js"
         },
+        "./tailwind.css": "./dist/tailwind.css",
         "./package.json": "./package.json"
     },
     "publishConfig": {
@@ -60,6 +63,7 @@
     },
     "peerDependencies": {
         "react": "^18.3.1 || ^19.0.0",
-        "react-dom": "^18.3.1 || ^19.0.0"
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "tailwindcss": "^4.0.0"
     }
 }

--- a/packages/quill/packages/charts/vite.config.ts
+++ b/packages/quill/packages/charts/vite.config.ts
@@ -1,20 +1,57 @@
 import react from '@vitejs/plugin-react'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { resolve } from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import dts from 'vite-plugin-dts'
 
 /**
- * Builds @posthog/quill-charts for npm. Charts is pure JS/canvas — no CSS
- * pipeline. The runtime deps (d3-*, dayjs, @floating-ui/react,
+ * Builds @posthog/quill-charts for npm. Canvas does the drawing, but
+ * overlays/legends style their DOM with Tailwind classes under the same
+ * contract as @posthog/quill: no pre-compiled stylesheet — the consumer's
+ * Tailwind v4 scans our dist JS via the shipped `dist/tailwind.css`
+ * `@source` directive. The runtime deps (d3-*, dayjs, @floating-ui/react,
  * simple-statistics) stay external and are redeclared as real
  * `dependencies` so the consumer's package manager installs them; react /
  * react-dom are peers. The dev/story-only entries (testing, story-helpers)
  * are excluded — in-repo consumers reach them via tsconfig path aliases /
  * jest moduleNameMapper against src, not the published package.
  */
+
+// Mirrors @posthog/quill's dist/tailwind.css (see quill/scripts/build-css.ts).
+function emitTailwindSource(): Plugin {
+    return {
+        name: 'emit-tailwind-source',
+        closeBundle() {
+            const distDir = resolve(__dirname, 'dist')
+            mkdirSync(distDir, { recursive: true })
+            writeFileSync(
+                resolve(distDir, 'tailwind.css'),
+                [
+                    '/* @posthog/quill-charts — Tailwind source directive.',
+                    ' *',
+                    ' * Consumer imports this file from their Tailwind v4 entry. The',
+                    " * glob path is relative to THIS file's on-disk location (inside",
+                    ' * node_modules/@posthog/quill-charts/dist after install), so it',
+                    ' * works under pnpm, hoisted, and Docker layouts without needing',
+                    ' * consumer-side `../node_modules/...` paths.',
+                    ' *',
+                    ' * Tailwind scans the compiled library JS for literal class',
+                    " * strings and generates the matching utilities in the consumer's",
+                    ' * own `utilities` layer — no pre-compiled stylesheet, no',
+                    ' * cascade-layer fight with consumer Tailwind output.',
+                    ' */',
+                    '@source "./**/*.js";',
+                    '',
+                ].join('\n')
+            )
+        },
+    }
+}
+
 export default defineConfig({
     plugins: [
         react(),
+        emitTailwindSource(),
         dts({
             tsconfigPath: resolve(__dirname, 'tsconfig.build.json'),
             exclude: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1935,6 +1935,9 @@ importers:
       simple-statistics:
         specifier: ^7.8.3
         version: 7.8.8
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.4
     devDependencies:
       '@posthog/quill-tokens':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

The `@posthog/quill-charts` package styles its overlays and legends with Tailwind classes, but it shipped no CSS and no way for a consumer's Tailwind build to discover those classes. In a non-Tailwind host (or one whose `@source` globs don't reach the package), wrapper sizing and overlay positioning silently break — `services/mcp` had to add the package *source* to its own Tailwind globs to compensate.

This was flagged in the same code review as #62803, but it's an independent concern (build/packaging, not public API), so it's its own PR.

## Changes

- the build now emits `dist/tailwind.css` containing an `@source "./**/*.js"` directive (exported as `@posthog/quill-charts/tailwind.css`) — the same mechanism `@posthog/quill` uses
- declared `tailwindcss ^4` as a peer dependency and marked `*.css` as side-effectful
- a consumer `@import`s `@posthog/quill-charts/tailwind.css` from their Tailwind v4 entry; Tailwind resolves the glob relative to the installed `dist/` and compiles the utilities from the shipped JS — no pre-compiled stylesheet, no cascade-layer fight

## How did you test this code?

I'm an agent — no manual testing beyond automated checks:

- `pnpm --filter @posthog/quill-charts build` — verified `dist/tailwind.css` is emitted with the `@source` directive
- full charts jest suite via the frontend config: 45/45 suites, 1240/1240 tests pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code (Claude) authored this. A first iteration of the sibling PR replaced the Tailwind classes with inline styles; the human redirected to follow the rest of quill instead — ship an `@source` directive and a `tailwindcss` peer dep (the umbrella package's documented contract) and keep the component code on Tailwind. This PR carries only that packaging change; the public-API/layering cleanup is in #62803. Both branches branch independently off master and touch non-overlapping hunks of `package.json` / `pnpm-lock.yaml`, so they merge in either order.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*