### PR TITLE
chore(signals): reframe scout authoring skill around emit-by-default

### DIFF
--- a/products/signals/skills/authoring-signals-scouts/SKILL.md
+++ b/products/signals/skills/authoring-signals-scouts/SKILL.md
@@ -8,7 +8,8 @@ description: >
   write a brand-new scout from scratch for a specific use case (a custom event, a
   product surface no canonical scout covers). Covers the scout SKILL.md anatomy, the
   emit contract, the dedupe + scratchpad-memory conventions, the per-team skills-store
-  path vs the canonical in-repo path, and the dry-run-first test loop. Trigger on
+  path vs the canonical in-repo path, and the emit-and-inspect test loop (with dry-run as an
+  optional safety net). Trigger on
   "write/edit/customize a signals scout", "new scout for X", "tune my scout schedule",
   "make a scout that watches <event>".
 metadata:
@@ -124,22 +125,34 @@ skill body. Tune with `posthog:signals-scout-config-update` (find the `id` via
 - `run_interval_minutes` — 10 to 43200. Default 60 (hourly). Slow a chatty or expensive
   scout by raising this.
 - `enabled` — `false` pauses the scout entirely (coordinator skips it).
-- `emit` — **`false` = dry-run**: the scout runs and logs its reasoning but writes nothing
-  to the inbox. **New and freshly-edited scouts should run dry-run first.**
+- `emit` — defaults to **`true`**: the scout writes its findings straight to the inbox. The
+  standard flow is to make a scout and let it emit — seeing what actually lands is the
+  fastest way to calibrate it. Set **`emit=false` (dry-run)** only when you want to be extra
+  careful: the scout still runs and logs its reasoning but writes nothing to the inbox.
+  Reach for dry-run on a scout you expect to be chatty, expensive, or high-stakes; for most
+  scouts, just emitting and watching the inbox is the better loop.
 
 ## Test loop
 
-You can't force a synchronous run as a user — scouts fire on their schedule. The feedback
-loop is **dry-run + inspect**:
+You can't force a synchronous run as a user — scouts fire on their schedule. The standard
+loop is **emit + inspect**: ship the scout live, let it emit, and calibrate against what
+actually lands.
 
-1. Ship the scout with `emit=false` and a short `run_interval_minutes` so it fires soon.
-2. After a tick, read what it did: `posthog:signals-scout-runs-list` (run summaries),
-   `-runs-retrieve` (full reasoning for one run), and `-scratchpad-search` (the durable
-   memory it wrote). In dry-run, runs show what it _would_ have emitted.
+1. Ship the scout (the default `emit=true`) with a short `run_interval_minutes` so it fires
+   soon.
+2. After a tick, read what it did: `posthog:inbox-reports-list` (the findings it actually
+   emitted), `posthog:signals-scout-runs-list` (run summaries), `-runs-retrieve` (full
+   reasoning for one run), and `-scratchpad-search` (the durable memory it wrote).
 3. Refine the body — tighten the discriminator, add disqualifiers for whatever it
    false-positived on, fix the emit calibration.
-4. When the dry-run findings look right, flip `emit=true`. Restore the interval to
-   something sustainable (hourly+).
+4. Once it's landing the right findings, restore the interval to something sustainable
+   (hourly+).
+
+**Want to be extra careful?** Set `emit=false` to dry-run first — the scout runs and logs
+what it _would_ have emitted (visible via `-runs-list` / `-runs-retrieve`) without writing to
+the inbox. Inspect, refine, then flip `emit=true`. Worth it for a scout you expect to be
+chatty, expensive, or high-stakes; otherwise just emitting and watching the inbox is the
+faster path to a calibrated scout.
 
 Repo contributors get a faster loop — `hogli sync:skill` and the harness's local run path;
 see [`references/lifecycle-and-testing.md`](references/lifecycle-and-testing.md).

--- a/products/signals/skills/authoring-signals-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-signals-scouts/references/lifecycle-and-testing.md
@@ -89,19 +89,27 @@ the standalone skills repo) automatically.
 
 ## Testing
 
-You can't trigger a synchronous run as a user — scouts fire on their schedule. The loop is
-**dry-run + inspect**:
+You can't trigger a synchronous run as a user — scouts fire on their schedule. The standard
+loop is **emit + inspect**: ship the scout live (`emit=true` is the default), let it emit,
+and calibrate against what actually lands.
 
-1. Ship with `emit=false` and a short `run_interval_minutes` (e.g. 10) so it fires soon.
+1. Ship with the default `emit=true` and a short `run_interval_minutes` (e.g. 10) so it
+   fires soon.
 2. After a tick, inspect:
-   - `posthog:signals-scout-runs-list` — run summaries (in dry-run, what it _would_ have
-     emitted and why).
+   - `posthog:inbox-reports-list` — the findings it actually emitted.
+   - `posthog:signals-scout-runs-list` — run summaries.
    - `posthog:signals-scout-runs-retrieve` — the full reasoning for one run.
    - `posthog:signals-scout-scratchpad-search` — the durable memory it wrote.
 3. Refine the body for whatever it false-positived or missed — tighten the discriminator,
    add disqualifiers, fix emit calibration. Re-edit via `llma-skill-update`.
-4. When dry-run output looks right, `config-update` to `emit=true` and restore a sustainable
-   interval (hourly or slower).
+4. Once it's landing the right findings, `config-update` to restore a sustainable interval
+   (hourly or slower).
+
+**Extra-careful variant — dry-run first.** For a scout you expect to be chatty, expensive,
+or high-stakes, set `emit=false` so it runs and logs what it _would_ have emitted (visible in
+`-runs-list` / `-runs-retrieve`) without writing to the inbox. Inspect, refine, then
+`config-update` to `emit=true`. For most scouts, emitting straight away and watching the
+inbox is the faster calibration.
 
 Repo contributors additionally get `hogli sync:skill` to run the scout against the local
 harness for a tighter loop before merging.


### PR DESCRIPTION
## Problem

Signals scouts are created with `emit=true` by default, and the standard, recommended way to use one is to make the scout, let it emit, and calibrate against what actually lands in the inbox. The `authoring-signals-scouts` skill didn't reflect this — it pushed dry-run (`emit=false`) as the default posture for any new or freshly-edited scout, so an agent following the skill would steer users toward the slower, more cautious path even when it isn't warranted.

## Changes

Reframed the run-posture and test-loop guidance so the emit-by-default ethos comes through:

- **Run posture (`emit` bullet)** now leads with `emit=true` as the default and the "make a scout and let it emit" flow, with `emit=false` (dry-run) repositioned as an optional extra-careful path for scouts you expect to be chatty, expensive, or high-stakes.
- **Test loop** retitled from "dry-run + inspect" to "emit + inspect": ship live, watch `inbox-reports-list` for what actually emitted, iterate. Dry-run is kept as a clearly-labelled "want to be extra careful?" variant.
- Same reframe applied to the `references/lifecycle-and-testing.md` Testing section, and the frontmatter description ("emit-and-inspect test loop, with dry-run as an optional safety net").

Docs/skill-only change. These are canonical scout-fleet docs, so `lazy_seed` mirrors the updated skill onto enrolled teams on the next coordinator tick.

## How did you test this code?

I'm an agent (Claude Opus 4.8, via Claude Code). No manual testing — this is a markdown-only skill change. I ran `hogli lint:skills`, which passed (76 skills OK).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy pointed out that the standard scout flow is emit-by-default — just make a scout and watch what it emits — and that the skill was instead suggesting `emit=false` as the recommended starting posture. I reframed the run-posture and test-loop sections (and the matching reference + frontmatter) so emit-and-inspect is the default and dry-run is the optional careful path, without dropping the dry-run instructions entirely. Verified with `hogli lint:skills`.
