### PR TITLE
fix(workflows): read correct SES list_resource_tenants response key

### DIFF
--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -2242,7 +2242,7 @@ class TestEmailIntegrationCrossTenantStaleVerification(BaseTest):
 
         def _list_resource_tenants(ResourceArn: str) -> dict:
             domain = ResourceArn.split("/")[-1]
-            return {"Tenants": [{"TenantName": t} for t in (tenants_for_domain or {}).get(domain, [])]}
+            return {"ResourceTenants": [{"TenantName": t} for t in (tenants_for_domain or {}).get(domain, [])]}
 
         provider.ses_v2_client.list_resource_tenants.side_effect = _list_resource_tenants
         return provider

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -53,7 +53,7 @@ class SESProvider:
             if e.response["Error"]["Code"] == "NotFoundException":
                 return set()
             raise
-        return {t.get("TenantName") for t in resp.get("Tenants", []) if t.get("TenantName")}
+        return {t.get("TenantName") for t in resp.get("ResourceTenants", []) if t.get("TenantName")}
 
     def create_email_domain(
         self,

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -223,7 +223,7 @@ class TestSESProvider(TestCase):
             mock_mail_from_attrs.return_value = {
                 "MailFromDomainAttributes": {TEST_DOMAIN: {"MailFromDomainStatus": "Success"}}
             }
-            mock_list_tenants.return_value = {"Tenants": [{"TenantName": "team-1"}]}
+            mock_list_tenants.return_value = {"ResourceTenants": [{"TenantName": "team-1"}]}
 
             result = provider.verify_email_domain(TEST_DOMAIN, mail_from_subdomain="mail", team_id=1)
 


### PR DESCRIPTION
## Problem

The multi-tenant gate added in #62290 reads the wrong key from the SES v2 `ListResourceTenants` response. The SDK returns `ResourceTenants`; the helper reads `Tenants`. That key never exists, so `_list_identity_tenants` returned an empty set for every real call.

Downstream, `verify_email_domain` interpreted "no friendly tenant found" as "the identity must be foreign-owned" and downgraded every successful SES sender back to `pending`. Customers saw all DNS checks green but the channel stuck on unverified, the modal CTA frozen on *Save & finish later*, and test sends rejected with `"The selected email integration domain is not verified"`.

The same helper backs `create_email_domain`'s `foreign_tenants` check, which means the cross-org SES-state guard has been silently inert since the security fix shipped. The DB-row guard in `create_native_integration` still works.

## Changes

- `_list_identity_tenants` reads `resp.get("ResourceTenants", [])` instead of `resp.get("Tenants", [])`.
- Test mocks updated to return the correct response key.

Three-character change across three files.

## How did you test this code?

I'm an agent — no manual UI testing. Automated tests: `products/workflows/backend/test/test_ses_provider.py` (14 pass) and `posthog/models/test/test_integration_model.py::TestEmailIntegrationCrossTenantStaleVerification` (covers the corrected gate behavior).

Once deployed, affected senders recover on their next *Re-check DNS records* click — no backfill or customer migration needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.7). Initial hypothesis was wrong — assumed the symptom was legacy senders missing a tenant association — and added self-heal + org-aware logic on top of the gate. Inspecting the SES SDK service model showed the response key is `ResourceTenants`, not `Tenants`, which is the actual bug. Reset the branch to the three-character fix.