### PR TITLE
fix(quill): extract shared chart shell from Chart and RadialChart

### DIFF
--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { AxisLabels } from '../overlays/AxisLabels'
 import { AxisTitles } from '../overlays/AxisTitles'
@@ -8,6 +8,7 @@ import { normalizeAxisLabel } from '../utils/axis-labels'
 import { composeDrawHoverWithCrosshair } from './canvas-renderer'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
 import type { ChartHoverContextValue, ChartLayoutContextValue } from './chart-context'
+import { ChartShell, countVisibleSeries, useCanvasBounds, useColoredSeries } from './chart-shell'
 import { useChartCanvas } from './hooks/useChartCanvas'
 import { useChartDraw } from './hooks/useChartDraw'
 import { useChartInteraction } from './hooks/useChartInteraction'
@@ -23,38 +24,11 @@ import type {
     CreateScalesFn,
     DrawHoverResult,
     PointClickData,
-    ResolvedSeries,
     ResolveValueFn,
     Series,
     TooltipContext,
 } from './types'
 
-const OVERLAY_STYLE: React.CSSProperties = {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    pointerEvents: 'none',
-}
-
-const WRAPPER_STYLE_BASE: React.CSSProperties = {
-    position: 'relative',
-    width: '100%',
-    flex: 1,
-    minHeight: 0,
-    overflow: 'hidden',
-}
-const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
-const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
-
-const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
-const OVERLAY_CANVAS_STYLE: React.CSSProperties = {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    pointerEvents: 'none',
-}
 const DEFAULT_AXIS_COLOR = 'rgba(0, 0, 0, 0.5)'
 const DEFAULT_HOVER_ANIMATION_MS = 150
 
@@ -66,10 +40,6 @@ function resolveHoverAnimationMs(animateHover: boolean | number | undefined): nu
         return animateHover
     }
     return 0
-}
-
-function OverlayLayer({ children }: { children: React.ReactNode }): React.ReactElement {
-    return <div style={OVERLAY_STYLE}>{children}</div>
 }
 
 export interface ChartProps<Meta = unknown> {
@@ -174,14 +144,7 @@ export function Chart<Meta = unknown>({
 
     const { canvasRef, overlayCanvasRef, wrapperRef, dimensions, ctx, overlayCtx } = useChartCanvas({ margins })
 
-    const coloredSeries = useMemo<ResolvedSeries<Meta>[]>(
-        () =>
-            series.map((s, i) => ({
-                ...s,
-                color: s.color || theme.colors[i % theme.colors.length],
-            })),
-        [series, theme.colors]
-    )
+    const coloredSeries = useColoredSeries<Meta>(series, theme)
 
     const scales = useMemo<ChartScales | null>(() => {
         if (!dimensions) {
@@ -237,11 +200,8 @@ export function Chart<Meta = unknown>({
         hoverAnimationMs,
     })
 
-    const wrapperStyle = hoverIndex >= 0 && onPointClick ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
-
     const ariaLabel = useMemo(() => {
-        const visible = coloredSeries.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)
-        const parts = [`Chart with ${visible} data series`]
+        const parts = [`Chart with ${countVisibleSeries(coloredSeries)} data series`]
         const cleanXAxisLabel = normalizeAxisLabel(xAxisLabel)
         const cleanYAxisLabel = normalizeAxisLabel(yAxisLabel)
         if (!hideXAxis && cleanXAxisLabel) {
@@ -253,10 +213,7 @@ export function Chart<Meta = unknown>({
         return parts.join('. ')
     }, [coloredSeries, hideXAxis, hideYAxis, xAxisLabel, yAxisLabel])
 
-    const canvasBounds = useCallback(
-        (): DOMRect | null => canvasRef.current?.getBoundingClientRect() ?? null,
-        [canvasRef]
-    )
+    const canvasBounds = useCanvasBounds(canvasRef)
 
     // Overlays (value labels) anchor at the stacked top, so expose the position resolver —
     // falling back to the value resolver when the chart doesn't stack.
@@ -289,51 +246,42 @@ export function Chart<Meta = unknown>({
     return (
         <ChartLayoutContext.Provider value={layoutValue}>
             <ChartHoverContext.Provider value={hoverValue}>
-                <div
-                    ref={wrapperRef}
+                <ChartShell
+                    wrapperRef={wrapperRef}
+                    canvasRef={canvasRef}
+                    overlayCanvasRef={overlayCanvasRef}
                     className={className}
-                    data-attr={dataAttr}
-                    style={wrapperStyle}
-                    onMouseMove={handlers.onMouseMove}
-                    onMouseLeave={handlers.onMouseLeave}
-                    onClick={handlers.onClick}
+                    dataAttr={dataAttr}
+                    pointer={hoverIndex >= 0 && !!onPointClick}
+                    ariaLabel={ariaLabel}
+                    handlers={handlers}
+                    showOverlay={!!(dimensions && scales)}
                 >
-                    <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
-                    <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
+                    <AxisLabels
+                        xTickFormatter={xTickFormatter}
+                        yTickFormatter={resolvedYFormatter}
+                        userYTickFormatter={yTickFormatter}
+                        hideXAxis={hideXAxis}
+                        hideYAxis={hideYAxis}
+                        axisColor={axisColor}
+                        orientation={axisOrientation}
+                        labelToCoord={labelToCoord}
+                        maxCategoryLabelWidth={maxCategoryLabelWidth}
+                    />
+                    <AxisTitles
+                        xAxisLabel={xAxisLabel}
+                        yAxisLabel={yAxisLabel}
+                        hideXAxis={hideXAxis}
+                        hideYAxis={hideYAxis}
+                        axisColor={axisColor}
+                    />
 
-                    {dimensions && scales && (
-                        <OverlayLayer>
-                            <AxisLabels
-                                xTickFormatter={xTickFormatter}
-                                yTickFormatter={resolvedYFormatter}
-                                userYTickFormatter={yTickFormatter}
-                                hideXAxis={hideXAxis}
-                                hideYAxis={hideYAxis}
-                                axisColor={axisColor}
-                                orientation={axisOrientation}
-                                labelToCoord={labelToCoord}
-                                maxCategoryLabelWidth={maxCategoryLabelWidth}
-                            />
-                            <AxisTitles
-                                xAxisLabel={xAxisLabel}
-                                yAxisLabel={yAxisLabel}
-                                hideXAxis={hideXAxis}
-                                hideYAxis={hideYAxis}
-                                axisColor={axisColor}
-                            />
+                    {children}
 
-                            {children}
-
-                            {tooltipCtx && showTooltip && (
-                                <Tooltip
-                                    context={tooltipCtx}
-                                    renderTooltip={renderTooltip}
-                                    placement={tooltipPlacement}
-                                />
-                            )}
-                        </OverlayLayer>
+                    {tooltipCtx && showTooltip && (
+                        <Tooltip context={tooltipCtx} renderTooltip={renderTooltip} placement={tooltipPlacement} />
                     )}
-                </div>
+                </ChartShell>
             </ChartHoverContext.Provider>
         </ChartLayoutContext.Provider>
     )

--- a/packages/quill/packages/charts/src/core/RadialChart.tsx
+++ b/packages/quill/packages/charts/src/core/RadialChart.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { Tooltip } from '../overlays/Tooltip'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
 import type { ChartHoverContextValue, ChartLayoutContextValue } from './chart-context'
+import { ChartShell, countVisibleSeries, useCanvasBounds, useColoredSeries } from './chart-shell'
 import { useChartCanvas } from './hooks/useChartCanvas'
 import { useChartDraw } from './hooks/useChartDraw'
 import { useRadialInteraction } from './hooks/useRadialInteraction'
@@ -22,32 +23,6 @@ import type {
     TooltipContext,
 } from './types'
 import { defaultResolveValue } from './types'
-
-const OVERLAY_STYLE: React.CSSProperties = {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    pointerEvents: 'none',
-}
-const WRAPPER_STYLE_BASE: React.CSSProperties = {
-    position: 'relative',
-    width: '100%',
-    flex: 1,
-    minHeight: 0,
-    overflow: 'hidden',
-}
-const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
-const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
-
-const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
-const OVERLAY_CANVAS_STYLE: React.CSSProperties = {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    pointerEvents: 'none',
-}
 
 /** Near-zero margins — the radial chart computes center + radius from the full plot box and
  *  pulls the outer edge back via `radiusPadding`. The tiny pad here keeps slice strokes off
@@ -98,14 +73,7 @@ export function RadialChart<Meta = unknown>({
         margins: RADIAL_MARGINS,
     })
 
-    const coloredSeries = useMemo<ResolvedSeries<Meta>[]>(
-        () =>
-            series.map((s, i) => ({
-                ...s,
-                color: s.color || theme.colors[i % theme.colors.length],
-            })),
-        [series, theme.colors]
-    )
+    const coloredSeries = useColoredSeries<Meta>(series, theme)
 
     const layout = useMemo(() => {
         if (!dimensions) {
@@ -155,17 +123,9 @@ export function RadialChart<Meta = unknown>({
         hoverAnimationMs,
     })
 
-    const ariaLabel = useMemo(() => {
-        const visible = coloredSeries.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)
-        return `Pie chart with ${visible} slices`
-    }, [coloredSeries])
+    const ariaLabel = useMemo(() => `Pie chart with ${countVisibleSeries(coloredSeries)} slices`, [coloredSeries])
 
-    const wrapperStyle = hoverIndex >= 0 && onSliceClick ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT
-
-    const canvasBounds = useCallback(
-        (): DOMRect | null => canvasRef.current?.getBoundingClientRect() ?? null,
-        [canvasRef]
-    )
+    const canvasBounds = useCanvasBounds(canvasRef)
 
     // Provide the standard ChartLayoutContext so existing shared overlays (e.g. custom user
     // overlays accessing `useChartLayout()` for `theme`) continue to work. Most cartesian-only
@@ -200,31 +160,22 @@ export function RadialChart<Meta = unknown>({
         <ChartLayoutContext.Provider value={layoutValue as ChartLayoutContextValue | null}>
             <RadialLayoutContext.Provider value={radialValue as RadialLayoutContextValue | null}>
                 <ChartHoverContext.Provider value={hoverValue}>
-                    <div
-                        ref={wrapperRef}
+                    <ChartShell
+                        wrapperRef={wrapperRef}
+                        canvasRef={canvasRef}
+                        overlayCanvasRef={overlayCanvasRef}
                         className={className}
-                        data-attr={dataAttr}
-                        style={wrapperStyle}
-                        onMouseMove={handlers.onMouseMove}
-                        onMouseLeave={handlers.onMouseLeave}
-                        onClick={handlers.onClick}
+                        dataAttr={dataAttr}
+                        pointer={hoverIndex >= 0 && !!onSliceClick}
+                        ariaLabel={ariaLabel}
+                        handlers={handlers}
+                        showOverlay={!!(dimensions && layout)}
                     >
-                        <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
-                        <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
-
-                        {dimensions && layout && (
-                            <div style={OVERLAY_STYLE}>
-                                {children}
-                                {tooltipCtx && showTooltip && (
-                                    <Tooltip
-                                        context={tooltipCtx}
-                                        renderTooltip={renderTooltip}
-                                        placement="cursor"
-                                    />
-                                )}
-                            </div>
+                        {children}
+                        {tooltipCtx && showTooltip && (
+                            <Tooltip context={tooltipCtx} renderTooltip={renderTooltip} placement="cursor" />
                         )}
-                    </div>
+                    </ChartShell>
                 </ChartHoverContext.Provider>
             </RadialLayoutContext.Provider>
         </ChartLayoutContext.Provider>

--- a/packages/quill/packages/charts/src/core/chart-shell.tsx
+++ b/packages/quill/packages/charts/src/core/chart-shell.tsx
@@ -2,19 +2,12 @@ import React, { useCallback, useMemo } from 'react'
 
 import type { ChartTheme, ResolvedSeries, Series } from './types'
 
-const WRAPPER_STYLE_BASE: React.CSSProperties = {
-    position: 'relative',
-    width: '100%',
-    flex: 1,
-    minHeight: 0,
-    overflow: 'hidden',
-}
-const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
-const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
-
-const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
-const OVERLAY_CANVAS_STYLE: React.CSSProperties = { ...STATIC_CANVAS_STYLE, pointerEvents: 'none' }
-const OVERLAY_STYLE: React.CSSProperties = { ...OVERLAY_CANVAS_STYLE, width: '100%', height: '100%' }
+// Literal class strings (no runtime concat) so Tailwind v4's `dist/*.js`
+// source scan can see every utility — see the package's tailwind contract.
+const WRAPPER_CLASS = 'relative w-full flex-1 min-h-0 overflow-hidden'
+const STATIC_CANVAS_CLASS = 'absolute top-0 left-0'
+const OVERLAY_CANVAS_CLASS = 'absolute top-0 left-0 pointer-events-none'
+const OVERLAY_CLASS = 'absolute top-0 left-0 w-full h-full pointer-events-none'
 
 /** Applies the theme's color fallback to series missing an explicit `color`. */
 export function useColoredSeries<Meta = unknown>(series: Series<Meta>[], theme: ChartTheme): ResolvedSeries<Meta>[] {
@@ -66,17 +59,18 @@ export function ChartShell({
     return (
         <div
             ref={wrapperRef}
-            className={className}
+            className={[WRAPPER_CLASS, pointer ? 'cursor-pointer' : 'cursor-default', className]
+                .filter(Boolean)
+                .join(' ')}
             data-attr={dataAttr}
-            style={pointer ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT}
             onMouseMove={handlers.onMouseMove}
             onMouseLeave={handlers.onMouseLeave}
             onClick={handlers.onClick}
         >
-            <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
-            <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
+            <canvas ref={canvasRef} role="img" aria-label={ariaLabel} className={STATIC_CANVAS_CLASS} />
+            <canvas ref={overlayCanvasRef} aria-hidden="true" className={OVERLAY_CANVAS_CLASS} />
 
-            {showOverlay && <div style={OVERLAY_STYLE}>{children}</div>}
+            {showOverlay && <div className={OVERLAY_CLASS}>{children}</div>}
         </div>
     )
 }

--- a/packages/quill/packages/charts/src/core/chart-shell.tsx
+++ b/packages/quill/packages/charts/src/core/chart-shell.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useMemo } from 'react'
+
+import type { ChartTheme, ResolvedSeries, Series } from './types'
+
+const WRAPPER_STYLE_BASE: React.CSSProperties = {
+    position: 'relative',
+    width: '100%',
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+}
+const WRAPPER_STYLE_DEFAULT: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'default' }
+const WRAPPER_STYLE_POINTER: React.CSSProperties = { ...WRAPPER_STYLE_BASE, cursor: 'pointer' }
+
+const STATIC_CANVAS_STYLE: React.CSSProperties = { position: 'absolute', top: 0, left: 0 }
+const OVERLAY_CANVAS_STYLE: React.CSSProperties = { ...STATIC_CANVAS_STYLE, pointerEvents: 'none' }
+const OVERLAY_STYLE: React.CSSProperties = { ...OVERLAY_CANVAS_STYLE, width: '100%', height: '100%' }
+
+/** Applies the theme's color fallback to series missing an explicit `color`. */
+export function useColoredSeries<Meta = unknown>(series: Series<Meta>[], theme: ChartTheme): ResolvedSeries<Meta>[] {
+    return useMemo<ResolvedSeries<Meta>[]>(
+        () =>
+            series.map((s, i) => ({
+                ...s,
+                color: s.color || theme.colors[i % theme.colors.length],
+            })),
+        [series, theme.colors]
+    )
+}
+
+export function useCanvasBounds(canvasRef: React.RefObject<HTMLCanvasElement>): () => DOMRect | null {
+    return useCallback((): DOMRect | null => canvasRef.current?.getBoundingClientRect() ?? null, [canvasRef])
+}
+
+export const countVisibleSeries = (series: ResolvedSeries[]): number =>
+    series.reduce((n, s) => n + (s.visibility?.excluded ? 0 : 1), 0)
+
+export interface ChartShellProps {
+    wrapperRef: React.RefObject<HTMLDivElement>
+    canvasRef: React.RefObject<HTMLCanvasElement>
+    overlayCanvasRef: React.RefObject<HTMLCanvasElement>
+    className?: string
+    dataAttr?: string
+    /** Show the pointer cursor — the hovered element is clickable. */
+    pointer: boolean
+    ariaLabel: string
+    handlers: Required<Pick<React.DOMAttributes<HTMLDivElement>, 'onMouseMove' | 'onMouseLeave' | 'onClick'>>
+    /** Render the overlay layer — bases gate this on layout readiness (dimensions + scales). */
+    showOverlay: boolean
+    children?: React.ReactNode
+}
+
+/** Shared DOM shell of the chart bases — behavior (interaction, drawing, contexts) stays in the bases. */
+export function ChartShell({
+    wrapperRef,
+    canvasRef,
+    overlayCanvasRef,
+    className,
+    dataAttr,
+    pointer,
+    ariaLabel,
+    handlers,
+    showOverlay,
+    children,
+}: ChartShellProps): React.ReactElement {
+    return (
+        <div
+            ref={wrapperRef}
+            className={className}
+            data-attr={dataAttr}
+            style={pointer ? WRAPPER_STYLE_POINTER : WRAPPER_STYLE_DEFAULT}
+            onMouseMove={handlers.onMouseMove}
+            onMouseLeave={handlers.onMouseLeave}
+            onClick={handlers.onClick}
+        >
+            <canvas ref={canvasRef} role="img" aria-label={ariaLabel} style={STATIC_CANVAS_STYLE} />
+            <canvas ref={overlayCanvasRef} aria-hidden="true" style={OVERLAY_CANVAS_STYLE} />
+
+            {showOverlay && <div style={OVERLAY_STYLE}>{children}</div>}
+        </div>
+    )
+}


### PR DESCRIPTION
## Problem

~70 lines of base-component shell are copy-pasted between `Chart` and `RadialChart` in `@posthog/quill-charts` — style constants, the color-fallback memo, the cursor switch, the `canvasBounds` getter, the visible-series count for the aria-label, and the wrapper + canvases + overlay-layer DOM. The copies had already drifted once (overlay layer handling), so fixes to base behavior must be made twice and will eventually be missed.

This was flagged in the same code review as #62803; it's split out so that PR stays focused on the public API / type-leak fixes.

## Changes

- new `core/chart-shell.tsx` with the shared pieces: `useColoredSeries`, `useCanvasBounds`, `countVisibleSeries`, and a `ChartShell` component rendering the wrapper, both canvases, and the pointer-events-none overlay layer
- `Chart` and `RadialChart` both render `ChartShell`; behavior (interaction, drawing, context providers) stays in the bases

Pure dedup — no behavior or public API change.

**Stacked on #62803** (both rewrite the same regions of `Chart.tsx`/`RadialChart.tsx`); merge that first.

## How did you test this code?

I'm an agent — no manual testing beyond automated checks:

- `pnpm --filter @posthog/quill-charts build` (clean)
- full charts jest suite via the frontend config: 45/45 suites, 1240/1240 tests pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code (Claude) authored this as part of a review-findings cleanup the human asked to split into reviewable pieces: #62803 (public API + core layering), #62841 (Tailwind contract), and this PR (shell dedup, stacked on #62803).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*