### PR TITLE
fix(tasks): wrap bare URLs in Slack mrkdwn emphasis so bold renders

### DIFF
--- a/products/tasks/backend/temporal/slack_relay/activities.py
+++ b/products/tasks/backend/temporal/slack_relay/activities.py
@@ -29,6 +29,17 @@ _RE_MD_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 # are left alone rather than silently rewritten into a different broken shape.
 _RE_LINK_TRAILING_MARKER = re.compile(r"(?<![*_~])(\*+|_+|~+)<([^<>]+?)\1>(?![*_~])")
 
+# Repair pattern: a bare ``http(s)`` URL wrapped directly in emphasis markers,
+# e.g. ``**https://example.com**``. The converter halves the markers in place
+# and emits ``*https://example.com*``; Slack then auto-links the URL but
+# renders the surrounding ``*`` as literal text because there is no whitespace
+# flanking the markers. Pre-wrapping the URL in ``<>`` lets the converter emit
+# the well-formed ``*<https://example.com>*`` — a clean bolded clickable link.
+# The URL group excludes whitespace and angle brackets so already well-formed
+# links (``**<url>**``) and bracketed markdown links (``**[text](url)**``) are
+# left alone.
+_RE_BARE_URL_IN_EMPHASIS = re.compile(r"(?<![*_~])(\*+|_+|~+)(https?://[^\s<>]+?)\1(?![*_~])")
+
 
 class _RelayAlreadyRecorded(Exception):
     """Raised when a relay was already recorded while holding the row lock."""
@@ -41,12 +52,14 @@ def _markdown_to_slack_mrkdwn(text: str) -> str:
     Slack ``mrkdwn`` is rendered in a proportional font — pipe-separated rows do
     not line up. A fenced code block forces monospace and the columns align.
 
-    Misplaced link markers (e.g. ``**<url**>``) are normalized first so the
+    Misplaced link markers (e.g. ``**<url**>``) and bare URLs wrapped in
+    emphasis (e.g. ``**https://example.com**``) are normalized first so the
     converter sees well-formed input.
     """
     if not text:
         return text
-    return _CONVERTER.convert(_tables_to_fenced_code_blocks(_repair_link_trailing_markers(text)))
+    repaired = _wrap_bare_urls_in_emphasis(_repair_link_trailing_markers(text))
+    return _CONVERTER.convert(_tables_to_fenced_code_blocks(repaired))
 
 
 def _repair_link_trailing_markers(text: str) -> str:
@@ -58,6 +71,17 @@ def _repair_link_trailing_markers(text: str) -> str:
     links don't cross-contaminate.
     """
     return _RE_LINK_TRAILING_MARKER.sub(r"\1<\2>\1", text)
+
+
+def _wrap_bare_urls_in_emphasis(text: str) -> str:
+    """Wrap bare ``http(s)`` URLs adjacent to emphasis markers with angle brackets.
+
+    ``**https://example.com**`` becomes ``**<https://example.com>**`` so the
+    downstream converter produces a properly formatted Slack link. Already
+    bracketed URLs (``**<url>**``) and markdown links (``**[label](url)**``)
+    are left untouched because the URL group rejects ``<`` and ``[``.
+    """
+    return _RE_BARE_URL_IN_EMPHASIS.sub(r"\1<\2>\1", text)
 
 
 def _tables_to_fenced_code_blocks(text: str) -> str:

--- a/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
+++ b/products/tasks/backend/temporal/slack_relay/tests/test_activities.py
@@ -20,6 +20,7 @@ from products.tasks.backend.temporal.slack_relay.activities import (
     _markdown_to_slack_mrkdwn,
     _repair_link_trailing_markers,
     _split_markdown_for_slack,
+    _wrap_bare_urls_in_emphasis,
     relay_slack_message,
 )
 
@@ -145,6 +146,20 @@ class TestMarkdownToSlackMrkdwn(unittest.TestCase):
                 "**<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd|pr-shepherd**>",
                 "*<https://us.posthog.com/project/2/llm-analytics/skills/pr-shepherd|pr-shepherd>*",
             ),
+            # Bare URL wrapped directly in markdown bold. Without the pre-wrap pass the
+            # converter halves the markers in place and emits ``*https://x.com*``, which
+            # Slack renders as literal asterisks around an auto-linked URL — the exact
+            # papercut on the PR-completion message that prompted this repair.
+            (
+                "agent_typo_bare_url_in_bold",
+                "Draft PR opened: **https://github.com/PostHog/posthog.com/pull/17450**",
+                "Draft PR opened: *<https://github.com/PostHog/posthog.com/pull/17450>*",
+            ),
+            (
+                "agent_typo_bare_url_in_italic_asterisk",
+                "see *https://example.com*",
+                "see _<https://example.com>_",
+            ),
             ("plain_text_unchanged", "Hello world", "Hello world"),
             ("inline_code_preserved", "Use `git commit`", "Use `git commit`"),
         ]
@@ -204,6 +219,50 @@ class TestRepairLinkTrailingMarkers(unittest.TestCase):
     )
     def test_repair(self, _name, text, expected):
         assert _repair_link_trailing_markers(text) == expected
+
+
+class TestWrapBareUrlsInEmphasis(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("bold_bare_url", "**https://x.com**", "**<https://x.com>**"),
+            ("italic_bare_url", "*https://x.com*", "*<https://x.com>*"),
+            ("underscore_bare_url", "_https://x.com_", "_<https://x.com>_"),
+            ("strike_bare_url", "~~https://x.com~~", "~~<https://x.com>~~"),
+            (
+                "url_with_path_and_query",
+                "**https://github.com/PostHog/posthog.com/pull/17450?foo=bar**",
+                "**<https://github.com/PostHog/posthog.com/pull/17450?foo=bar>**",
+            ),
+            (
+                "two_bare_urls_in_one_line",
+                "**https://a.com** and *https://b.com*",
+                "**<https://a.com>** and *<https://b.com>*",
+            ),
+            # Surrounded by sentence text — only the wrapped URL should be touched.
+            (
+                "url_inside_sentence",
+                "Draft PR opened: **https://x.com/pr/1**",
+                "Draft PR opened: **<https://x.com/pr/1>**",
+            ),
+            # Already bracketed — leave alone so we don't double-wrap.
+            ("autolink_already_bracketed", "**<https://x.com>**", "**<https://x.com>**"),
+            # Standard markdown link — handled correctly by the converter as-is.
+            ("markdown_link_in_bold_unchanged", "**[label](https://x.com)**", "**[label](https://x.com)**"),
+            # Non-URL bold spans must not be rewritten.
+            ("plain_bold_unchanged", "**hello world**", "**hello world**"),
+            ("plain_text_unchanged", "Visit https://x.com without bolding", "Visit https://x.com without bolding"),
+            # A bare URL not directly adjacent to the marker shouldn't be wrapped — the
+            # surrounding text means the emphasis already flanks whitespace and Slack
+            # renders it correctly without help.
+            (
+                "url_inside_bold_span_with_surrounding_text",
+                "**check https://x.com later**",
+                "**check https://x.com later**",
+            ),
+        ]
+    )
+    def test_wrap(self, _name, text, expected):
+        assert _wrap_bare_urls_in_emphasis(text) == expected
 
 
 class TestSplitTextForSlack(TestCase):


### PR DESCRIPTION
## Problem

Follow-up to #62322. That fix repaired the `**<url**>` shape — bold markers placed _inside_ the angle brackets of an already-bracketed Slack link. A new report ([Slack thread](https://posthog.slack.com/archives/C0ALU3889A6/p1781073431369949?thread_ts=1781043633.708419&cid=C0ALU3889A6)) surfaced a related but distinct shape the previous repair did not cover: a **bare URL** wrapped directly in markdown bold with no angle brackets at all.

In the captured agent run the PR-completion message emitted:

\`\`\`
Draft PR opened: **https://github.com/PostHog/posthog.com/pull/17450**
\`\`\`

\`markdown_to_mrkdwn\` halves the markers in place and produces \`*https://…*\`. Slack then auto-detects the URL but renders the surrounding \`*\`s as literal text rather than as bold, because the asterisks are directly adjacent to URL characters with no whitespace flanking. The result is the same stray-asterisk papercut on the bolded PR link that the original fix was meant to eliminate.

## Changes

- \`products/tasks/backend/temporal/slack_relay/activities.py\`: add \`_wrap_bare_urls_in_emphasis\` to the markdown-to-mrkdwn preprocessing chain. It rewrites \`**https://x.com**\` → \`**<https://x.com>**\` (and the \`*\`/\`_\`/\`~~\` variants) ahead of the converter so the output is the well-formed \`*<https://x.com>*\` — a clean bolded clickable Slack link. The URL group rejects \`<\`, \`[\`, and whitespace, so already-bracketed (\`**<url>**\`) and markdown (\`**[label](url)**\`) links are left alone, and bold spans whose content is not a bare URL (\`**hello world**\`, \`**check https://x.com later**\`) are not touched.
- \`products/tasks/backend/temporal/slack_relay/tests/test_activities.py\`: new \`TestWrapBareUrlsInEmphasis\` parametrized class plus two end-to-end converter cases pinning the exact agent-typo shape from this report.

## How did you test this code?

Tested locally:

- \`pytest products/tasks/backend/temporal/slack_relay/tests/test_activities.py::TestMarkdownToSlackMrkdwn ::TestRepairLinkTrailingMarkers ::TestWrapBareUrlsInEmphasis\` → 46 passed. Includes:
  - 12 new cases in \`TestWrapBareUrlsInEmphasis\` covering bold/italic/underscore/strike variants, multiple URLs per line, sentence context, plus negative cases for already-bracketed, markdown-link, plain-bold, and plain-text inputs.
  - 2 new end-to-end cases on \`TestMarkdownToSlackMrkdwn.test_inline_conversions\` pinning the converter output for the captured bare-URL agent shape.

## Showcase

<img width="863" height="95" alt="Screenshot 2026-06-11 at 9 41 49" src="https://github.com/user-attachments/assets/01b55ae8-bf40-4844-a288-365e31d5ed3d" />


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.7).