### PR TITLE
feat(signals): surface scout description on config API/MCP surface

### DIFF
--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -8,6 +8,8 @@ in `scout_harness/tools/` so the wire shape and Python shape stay in lockstep.
 
 from __future__ import annotations
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from posthog.schema import Severity
@@ -945,6 +947,14 @@ class SignalScoutConfigSerializer(serializers.ModelSerializer):
         read_only=True,
         help_text="The `signals-scout-*` skill this config controls. Set at creation, not editable.",
     )
+    description = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable summary of what this scout investigates, sourced from the scout "
+            "skill's `description` metadata. Use it for a quick steer on the scout's focus "
+            "without loading the full skill body. Empty if the skill is not currently present "
+            "on the team or carries no description."
+        ),
+    )
     enabled = serializers.BooleanField(
         required=False,
         help_text="Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator.",
@@ -965,7 +975,23 @@ class SignalScoutConfigSerializer(serializers.ModelSerializer):
         help_text="When the coordinator last dispatched this scout. Null if it has never run.",
     )
 
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_description(self, obj: SignalScoutConfig) -> str:
+        # Resolved by the view into `skill_descriptions` (skill_name -> description) so the
+        # list endpoint stays a single LLMSkill query rather than one lookup per config row.
+        descriptions = self.context.get("skill_descriptions") or {}
+        return descriptions.get(obj.skill_name, "")
+
     class Meta:
         model = SignalScoutConfig
-        fields = ["id", "skill_name", "enabled", "emit", "run_interval_minutes", "last_run_at", "created_at"]
+        fields = [
+            "id",
+            "skill_name",
+            "description",
+            "enabled",
+            "emit",
+            "run_interval_minutes",
+            "last_run_at",
+            "created_at",
+        ]
         read_only_fields = ["id", "created_at"]

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -40,6 +40,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
 from posthog.permissions import APIScopePermission
 
+from products.ai_observability.backend.models.skills import LLMSkill
 from products.signals.backend.models import SignalProjectProfile, SignalScoutConfig, SignalScoutEmission, SignalScoutRun
 from products.signals.backend.scout_harness.serializers import (
     EmitFindingRequestSerializer,
@@ -568,6 +569,22 @@ class SignalProjectProfileViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSe
         return Response(ProjectProfileSerializer(profile.as_dict()).data)
 
 
+def _skill_descriptions_for(team_id: int, skill_names: list[str]) -> dict[str, str]:
+    """Map each scout `skill_name` to the latest `LLMSkill.description` on the team.
+
+    One query for the whole config list — feeds the serializer's `description` field so
+    callers get a quick steer on each scout without loading the full skill body. Skills the
+    team no longer has simply drop out of the map (serializer falls back to "").
+    """
+    names = list(set(skill_names))
+    if not names:
+        return {}
+    rows = LLMSkill.objects.filter(team_id=team_id, name__in=names, is_latest=True, deleted=False).values_list(
+        "name", "description"
+    )
+    return dict(rows)
+
+
 class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """Per-scout config: list and tune each scout's schedule, enablement, and emit posture.
 
@@ -599,8 +616,11 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         operation_id="signals_scout_config_list",
     )
     def list(self, request: Request, *args, **kwargs) -> Response:
-        configs = SignalScoutConfig.objects.unscoped().filter(team_id=_canonical_team_id(self)).order_by("skill_name")
-        return Response(SignalScoutConfigSerializer(configs, many=True).data)
+        team_id = _canonical_team_id(self)
+        configs = list(SignalScoutConfig.objects.unscoped().filter(team_id=team_id).order_by("skill_name"))
+        descriptions = _skill_descriptions_for(team_id, [c.skill_name for c in configs])
+        serializer = SignalScoutConfigSerializer(configs, many=True, context={"skill_descriptions": descriptions})
+        return Response(serializer.data)
 
     @extend_schema(
         request=SignalScoutConfigSerializer,
@@ -617,8 +637,9 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         operation_id="signals_scout_config_update",
     )
     def partial_update(self, request: Request, *args, **kwargs) -> Response:
+        team_id = _canonical_team_id(self)
         config_id = _parse_run_id_or_404(kwargs)
-        config = SignalScoutConfig.objects.unscoped().filter(team_id=_canonical_team_id(self), id=config_id).first()
+        config = SignalScoutConfig.objects.unscoped().filter(team_id=team_id, id=config_id).first()
         if config is None:
             raise exceptions.NotFound()
         serializer = SignalScoutConfigSerializer(config, data=request.data, partial=True)
@@ -628,4 +649,5 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if not config.enabled and serializer.validated_data.get("enabled"):
             save_kwargs["enabled_by"] = request.user
         instance = serializer.save(**save_kwargs)
-        return Response(SignalScoutConfigSerializer(instance).data)
+        descriptions = _skill_descriptions_for(team_id, [instance.skill_name])
+        return Response(SignalScoutConfigSerializer(instance, context={"skill_descriptions": descriptions}).data)

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -588,28 +588,24 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         assert body[0]["emit"] is True
         assert body[0]["run_interval_minutes"] == 60
 
-    def test_list_surfaces_skill_description_from_metadata(self) -> None:
+    @parameterized.expand(
+        [
+            ("skill_present", "Watches error tracking for new and spiking issues."),
+            ("skill_absent", None),
+        ]
+    )
+    def test_list_surfaces_skill_description(self, _name: str, skill_description: str | None) -> None:
         SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-errors")
-        LLMSkill.objects.create(
-            team=self.team,
-            name="signals-scout-errors",
-            description="Watches error tracking for new and spiking issues.",
-            body="...",
-        )
+        if skill_description is not None:
+            LLMSkill.objects.create(
+                team=self.team, name="signals-scout-errors", description=skill_description, body="..."
+            )
 
         response = self.client.get(self._list_url())
 
         assert response.status_code == status.HTTP_200_OK
-        body = response.json()
-        assert body[0]["description"] == "Watches error tracking for new and spiking issues."
-
-    def test_list_description_blank_when_skill_absent(self) -> None:
-        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-errors")
-
-        response = self.client.get(self._list_url())
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()[0]["description"] == ""
+        # Absent skill (or no description) falls back to "".
+        assert response.json()[0]["description"] == (skill_description or "")
 
     def test_list_description_ignores_non_latest_and_other_team_skills(self) -> None:
         SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-errors")

--- a/products/signals/backend/test/test_scout_harness_api.py
+++ b/products/signals/backend/test/test_scout_harness_api.py
@@ -15,6 +15,7 @@ from posthog.temporal.oauth import (
     create_oauth_access_token_for_user,
 )
 
+from products.ai_observability.backend.models.skills import LLMSkill
 from products.signals.backend.models import (
     SignalProjectProfile,
     SignalScoutConfig,
@@ -586,6 +587,63 @@ class TestScoutHarnessConfigAPI(APIBaseTest):
         assert body[0]["enabled"] is True
         assert body[0]["emit"] is True
         assert body[0]["run_interval_minutes"] == 60
+
+    def test_list_surfaces_skill_description_from_metadata(self) -> None:
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-errors")
+        LLMSkill.objects.create(
+            team=self.team,
+            name="signals-scout-errors",
+            description="Watches error tracking for new and spiking issues.",
+            body="...",
+        )
+
+        response = self.client.get(self._list_url())
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body[0]["description"] == "Watches error tracking for new and spiking issues."
+
+    def test_list_description_blank_when_skill_absent(self) -> None:
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-errors")
+
+        response = self.client.get(self._list_url())
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()[0]["description"] == ""
+
+    def test_list_description_ignores_non_latest_and_other_team_skills(self) -> None:
+        SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-errors")
+        LLMSkill.objects.create(
+            team=self.team,
+            name="signals-scout-errors",
+            description="stale",
+            body="...",
+            version=1,
+            is_latest=False,
+        )
+        LLMSkill.objects.create(
+            team=self.team,
+            name="signals-scout-errors",
+            description="current",
+            body="...",
+            version=2,
+            is_latest=True,
+        )
+        other_team = Team.objects.create(organization=self.organization, name="other")
+        LLMSkill.objects.create(team=other_team, name="signals-scout-errors", description="other team", body="...")
+
+        response = self.client.get(self._list_url())
+
+        assert response.json()[0]["description"] == "current"
+
+    def test_partial_update_surfaces_skill_description(self) -> None:
+        config = SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-foo", enabled=False)
+        LLMSkill.objects.create(team=self.team, name="signals-scout-foo", description="Foo scout.", body="...")
+
+        response = self.client.patch(self._detail_url(str(config.id)), data={"enabled": True}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["description"] == "Foo scout."
 
     def test_partial_update_changes_schedule_emit_and_records_enabled_by(self) -> None:
         config = SignalScoutConfig.objects.create(team=self.team, skill_name="signals-scout-foo", enabled=False)

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -151,6 +151,8 @@ export interface SignalScoutConfigApi {
     readonly id: string
     /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
     readonly skill_name: string
+    /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
+    readonly description: string
     /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
     enabled?: boolean
     /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
@@ -179,6 +181,8 @@ export interface PatchedSignalScoutConfigApi {
     readonly id?: string
     /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
     readonly skill_name?: string
+    /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
+    readonly description?: string
     /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
     enabled?: boolean
     /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33007,6 +33007,8 @@ export namespace Schemas {
       readonly id?: string;
       /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
       readonly skill_name?: string;
+      /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
+      readonly description?: string;
       /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
       enabled?: boolean;
       /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */
@@ -39591,6 +39593,8 @@ export namespace Schemas {
       readonly id: string;
       /** The `signals-scout-*` skill this config controls. Set at creation, not editable. */
       readonly skill_name: string;
+      /** Human-readable summary of what this scout investigates, sourced from the scout skill's `description` metadata. Use it for a quick steer on the scout's focus without loading the full skill body. Empty if the skill is not currently present on the team or carries no description. */
+      readonly description: string;
       /** Whether this scout runs on its schedule. Disabled scouts are skipped by the coordinator. */
       enabled?: boolean;
       /** Whether the scout writes findings to the inbox. False = dry-run: it runs and logs but emits nothing. */


### PR DESCRIPTION
## Problem

When a bot, agent, or the UI explores the Signals scouts surface via the API/MCP (`signals-scout-config-list`), each scout was identified by `skill_name` alone — e.g. `signals-scout-error-tracking`. There was no quick, human-readable steer on what a scout actually does without loading and reading the scout's full skill body. This hurts both agents introspecting the fleet and UI work that wants to give users a feel for each scout beyond its name.

## Changes

Surface a `description` field on `SignalScoutConfigSerializer`, exposed on both the list (`signals_scout_config_list`) and update (`signals_scout_config_update`) responses across the HTTP API and the generated MCP tool schemas.

The description is **not** a new model field — it is sourced from the scout skill's existing `LLMSkill.description` metadata, which is already synced from each scout's `SKILL.md` frontmatter. This keeps the description canonical with the skill itself (no drift, no migration, no duplicate source of truth). A scout config's `skill_name` maps directly to the skill's `name`, so the latest non-deleted `LLMSkill` row provides the text.

To keep the list endpoint a single query rather than one lookup per config row, the view resolves a `skill_name -> description` map in one `LLMSkill` query and passes it to the serializer via context; the `SerializerMethodField` reads from that map and falls back to an empty string when the team no longer has the matching skill.

Regenerated downstream artifacts (`hogli build:openapi`): `products/signals/frontend/generated/api.schemas.ts` and `services/mcp/src/api/generated.ts` now carry the new field.

## How did you test this code?

I'm an agent (Claude Code). Verification performed in this environment:

- **Static / schema:** the full Django app loads and `manage.py spectacular --fail-on-warn` regenerates the OpenAPI schema cleanly with the new field; `ruff check` and `ruff format` pass on the changed Python.
- **Codegen:** regenerated the frontend and MCP types; the only diffs are the new `description` field on `SignalScoutConfigApi` / `PatchedSignalScoutConfigApi`, with the help-text JSDoc, typed as `string`.
- **Automated tests added** in `test_scout_harness_api.py` covering: description surfaced from skill metadata on list, blank when the skill is absent, latest-version/own-team resolution only, and surfaced on `partial_update`. These use `APIBaseTest` (Postgres + ClickHouse) and **were not executed here** — this web sandbox has no ClickHouse server, so the DB-backed suite cannot run. They should run in CI.

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code at the request of a PostHog engineer (the human DRI driving the work). The driving question was whether the scout API/MCP surface already had a description and, if not, to add one — explicitly open to either reusing skill description metadata or adding a new model field.

Key decision: reuse the existing `LLMSkill.description` metadata rather than adding a `description` column to `SignalScoutConfig`. The skill description is already the canonical "what does this scout do" text (parsed from `SKILL.md` frontmatter and synced onto each team's `LLMSkill` rows), so a new model field would have duplicated it and risked drift. Resolved via a single batched query in the viewset to avoid N+1 on the config list.
