### PR TITLE
fix(error-tracking): speed up symbol set cleanup

### DIFF
--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -89,6 +89,10 @@ class ObjectStorageClient(metaclass=abc.ABCMeta):
     def delete(self, bucket: str, key: str) -> None:
         pass
 
+    @abc.abstractmethod
+    def delete_objects(self, bucket: str, keys: list[str]) -> list[str]:
+        pass
+
 
 class UnavailableStorage(ObjectStorageClient):
     def head_bucket(self, bucket: str):
@@ -141,6 +145,9 @@ class UnavailableStorage(ObjectStorageClient):
 
     def delete(self, bucket: str, key: str) -> None:
         pass
+
+    def delete_objects(self, bucket: str, keys: list[str]) -> list[str]:
+        return []
 
 
 class ObjectStorage(ObjectStorageClient):
@@ -366,6 +373,34 @@ class ObjectStorage(ObjectStorageClient):
             capture_exception(e)
             raise ObjectStorageError("delete failed") from e
 
+    def delete_objects(self, bucket: str, keys: list[str]) -> list[str]:
+        failed_keys: list[str] = []
+
+        for index in range(0, len(keys), 1000):
+            chunk = keys[index : index + 1000]
+            if not chunk:
+                continue
+
+            response = {}
+            try:
+                response = self.aws_client.delete_objects(
+                    Bucket=bucket,
+                    Delete={"Objects": [{"Key": key} for key in chunk], "Quiet": True},
+                )
+                failed_keys.extend(error["Key"] for error in response.get("Errors", []))
+            except Exception as e:
+                logger.exception(
+                    "object_storage.delete_objects_failed",
+                    bucket=bucket,
+                    keys_count=len(chunk),
+                    error=e,
+                    s3_response=response,
+                )
+                capture_exception(e)
+                failed_keys.extend(chunk)
+
+        return failed_keys
+
 
 _client: ObjectStorageClient = UnavailableStorage()
 
@@ -432,6 +467,10 @@ def write_stream(file_name: str, fileobj: IO[bytes], extras: dict | None = None,
 
 def delete(file_name: str, bucket: str | None = None) -> None:
     return object_storage_client().delete(bucket=bucket or settings.OBJECT_STORAGE_BUCKET, key=file_name)
+
+
+def delete_objects(file_names: list[str], bucket: str | None = None) -> list[str]:
+    return object_storage_client().delete_objects(bucket=bucket or settings.OBJECT_STORAGE_BUCKET, keys=file_names)
 
 
 def tag(file_name: str, tags: dict[str, str]) -> None:

--- a/posthog/storage/test/test_object_storage.py
+++ b/posthog/storage/test/test_object_storage.py
@@ -213,3 +213,18 @@ class TestStorage(APIBaseTest):
 
         with self.assertRaises(ObjectStorageError):
             storage.read_bytes("test-bucket", "test-key")
+
+    def test_delete_objects_batches_keys_and_returns_failures(self) -> None:
+        mock_client = MagicMock()
+        mock_client.delete_objects.side_effect = [
+            {"Errors": [{"Key": "key-2"}]},
+            {},
+        ]
+        storage = ObjectStorage(mock_client)
+
+        failed_keys = storage.delete_objects("test-bucket", [f"key-{index}" for index in range(1001)])
+
+        assert failed_keys == ["key-2"]
+        assert mock_client.delete_objects.call_count == 2
+        assert len(mock_client.delete_objects.call_args_list[0].kwargs["Delete"]["Objects"]) == 1000
+        assert len(mock_client.delete_objects.call_args_list[1].kwargs["Delete"]["Objects"]) == 1

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -574,6 +574,16 @@ def delete_symbol_set_contents(upload_path: str) -> None:
         )
 
 
+def delete_symbol_set_contents_many(upload_paths: list[str]) -> list[str]:
+    if settings.OBJECT_STORAGE_ENABLED:
+        return object_storage.delete_objects(file_names=upload_paths)
+    else:
+        raise ValidationError(
+            code="object_storage_required",
+            detail="Object storage must be available to delete source maps.",
+        )
+
+
 class ErrorTrackingSpikeDetectionConfig(models.Model):
     team = models.OneToOneField(
         "posthog.Team",

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/activities.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/activities.py
@@ -82,7 +82,8 @@ def cleanup_symbol_sets_activity(inputs: SymbolSetCleanupInputs) -> SymbolSetCle
 
     total_processed = 0
     total_deleted = 0
-    total_failed = 0
+    total_db_failed = 0
+    total_storage_failed = 0
     failed_ids: set[str] = set()
 
     while total_processed < inputs.total_per_run:
@@ -103,7 +104,7 @@ def cleanup_symbol_sets_activity(inputs: SymbolSetCleanupInputs) -> SymbolSetCle
 
         deleted_count, batch_failed_ids = _delete_symbol_set_batch(symbol_set_ids)
         total_deleted += deleted_count
-        total_failed += len(batch_failed_ids)
+        total_db_failed += len(batch_failed_ids)
         failed_ids.update(batch_failed_ids)
 
         deleted_storage_ptrs = [
@@ -118,14 +119,14 @@ def cleanup_symbol_sets_activity(inputs: SymbolSetCleanupInputs) -> SymbolSetCle
                 failed_storage_ptrs = deleted_storage_ptrs
                 logger.exception(
                     "error_tracking.symbol_set_cleanup.s3_batch_delete_failed",
-                    objects_failed=len(failed_storage_ptrs),
+                    storage_objects_failed=len(failed_storage_ptrs),
                     error=str(exc),
                 )
             if failed_storage_ptrs:
-                total_failed += len(failed_storage_ptrs)
+                total_storage_failed += len(failed_storage_ptrs)
                 logger.warning(
                     "error_tracking.symbol_set_cleanup.s3_delete_failures",
-                    objects_failed=len(failed_storage_ptrs),
+                    storage_objects_failed=len(failed_storage_ptrs),
                 )
 
         total_processed += len(symbol_sets)
@@ -133,18 +134,21 @@ def cleanup_symbol_sets_activity(inputs: SymbolSetCleanupInputs) -> SymbolSetCle
             "error_tracking.symbol_set_cleanup.progress",
             objects_processed=total_processed,
             objects_deleted=total_deleted,
-            objects_failed=total_failed,
+            objects_failed=total_db_failed,
+            storage_objects_failed=total_storage_failed,
         )
 
-    if total_failed > 0:
+    if total_db_failed > 0 or total_storage_failed > 0:
         logger.warning(
             "error_tracking.symbol_set_cleanup.failures",
             objects_processed=total_processed,
-            objects_failed=total_failed,
+            objects_failed=total_db_failed,
+            storage_objects_failed=total_storage_failed,
         )
 
     return SymbolSetCleanupResult(
         objects_processed=total_processed,
         objects_deleted=total_deleted,
-        objects_failed=total_failed,
+        objects_failed=total_db_failed,
+        storage_objects_failed=total_storage_failed,
     )

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/activities.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/activities.py
@@ -1,13 +1,17 @@
 import datetime
 
-from django.db import close_old_connections
+from django.db import close_old_connections, transaction
 from django.db.models import Q
 from django.utils import timezone
 
 import structlog
 from temporalio import activity
 
-from products.error_tracking.backend.models import ErrorTrackingSymbolSet
+from products.error_tracking.backend.models import (
+    ErrorTrackingStackFrame,
+    ErrorTrackingSymbolSet,
+    delete_symbol_set_contents_many,
+)
 from products.error_tracking.backend.temporal.symbol_set_cleanup.types import (
     SymbolSetCleanupInputs,
     SymbolSetCleanupResult,
@@ -22,6 +26,27 @@ def _cleanup_filter(inputs: SymbolSetCleanupInputs) -> Q:
     if inputs.delete_unused:
         query_filter = query_filter | (Q(last_used__isnull=True) & Q(created_at__lt=cutoff_date))
     return query_filter
+
+
+def _delete_symbol_set_batch(symbol_set_ids: list[str]) -> tuple[int, set[str]]:
+    try:
+        with transaction.atomic():
+            ErrorTrackingStackFrame.objects.filter(symbol_set_id__in=symbol_set_ids, resolved=False).delete()
+            ErrorTrackingSymbolSet.objects.filter(id__in=symbol_set_ids).delete()
+        return len(symbol_set_ids), set()
+    except Exception as exc:
+        if len(symbol_set_ids) == 1:
+            logger.exception(
+                "error_tracking.symbol_set_cleanup.delete_failed",
+                symbol_set_id=symbol_set_ids[0],
+                error=str(exc),
+            )
+            return 0, {symbol_set_ids[0]}
+
+        midpoint = len(symbol_set_ids) // 2
+        left_deleted, left_failed = _delete_symbol_set_batch(symbol_set_ids[:midpoint])
+        right_deleted, right_failed = _delete_symbol_set_batch(symbol_set_ids[midpoint:])
+        return left_deleted + right_deleted, left_failed | right_failed
 
 
 @activity.defn
@@ -63,25 +88,44 @@ def cleanup_symbol_sets_activity(inputs: SymbolSetCleanupInputs) -> SymbolSetCle
     while total_processed < inputs.total_per_run:
         remaining = inputs.total_per_run - total_processed
         chunk_size = min(inputs.batch_size, remaining)
-        symbol_sets = list(ErrorTrackingSymbolSet.objects.filter(query_filter).exclude(id__in=failed_ids)[:chunk_size])
+        symbol_sets = list(
+            ErrorTrackingSymbolSet.objects.filter(query_filter)
+            .exclude(id__in=failed_ids)
+            .order_by("id")
+            .values_list("id", "storage_ptr")[:chunk_size]
+        )
 
         if not symbol_sets:
             break
 
-        for symbol_set in symbol_sets:
+        symbol_set_ids = [str(symbol_set_id) for symbol_set_id, _ in symbol_sets]
+        storage_ptrs_by_id = {str(symbol_set_id): storage_ptr for symbol_set_id, storage_ptr in symbol_sets}
+
+        deleted_count, batch_failed_ids = _delete_symbol_set_batch(symbol_set_ids)
+        total_deleted += deleted_count
+        total_failed += len(batch_failed_ids)
+        failed_ids.update(batch_failed_ids)
+
+        deleted_storage_ptrs = [
+            storage_ptr
+            for symbol_set_id, storage_ptr in storage_ptrs_by_id.items()
+            if storage_ptr and symbol_set_id not in batch_failed_ids
+        ]
+        if deleted_storage_ptrs:
             try:
-                # Calls ErrorTrackingSymbolSet.delete(), which also removes unresolved frames and S3 contents.
-                symbol_set.delete()
-                total_deleted += 1
+                failed_storage_ptrs = delete_symbol_set_contents_many(deleted_storage_ptrs)
             except Exception as exc:
-                total_failed += 1
-                failed_ids.add(str(symbol_set.id))
+                failed_storage_ptrs = deleted_storage_ptrs
                 logger.exception(
-                    "error_tracking.symbol_set_cleanup.delete_failed",
-                    symbol_set_id=str(symbol_set.id),
-                    ref=symbol_set.ref,
-                    team_id=symbol_set.team_id,
+                    "error_tracking.symbol_set_cleanup.s3_batch_delete_failed",
+                    objects_failed=len(failed_storage_ptrs),
                     error=str(exc),
+                )
+            if failed_storage_ptrs:
+                total_failed += len(failed_storage_ptrs)
+                logger.warning(
+                    "error_tracking.symbol_set_cleanup.s3_delete_failures",
+                    objects_failed=len(failed_storage_ptrs),
                 )
 
         total_processed += len(symbol_sets)

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py
@@ -102,6 +102,28 @@ class TestSymbolSetCleanupActivity(BaseTest):
         assert result == SymbolSetCleanupResult(objects_processed=1, objects_deleted=1, objects_failed=0)
         assert list(ErrorTrackingSymbolSet.objects.values_list("ref", flat=True)) == ["old-unused"]
 
+    def test_storage_delete_failures_are_reported_separately(self) -> None:
+        self._create_symbol_set(
+            "old-used", created_at_days_ago=45, last_used_days_ago=31, storage_ptr="symbols/old-used"
+        )
+
+        with (
+            patch(
+                "products.error_tracking.backend.temporal.symbol_set_cleanup.activities.delete_symbol_set_contents_many",
+                return_value=["symbols/old-used"],
+            ),
+            patch("products.error_tracking.backend.temporal.symbol_set_cleanup.activities.close_old_connections"),
+        ):
+            result = cleanup_symbol_sets_activity(SymbolSetCleanupInputs(batch_size=10, total_per_run=10))
+
+        assert result == SymbolSetCleanupResult(
+            objects_processed=1,
+            objects_deleted=1,
+            objects_failed=0,
+            storage_objects_failed=1,
+        )
+        assert ErrorTrackingSymbolSet.objects.count() == 0
+
     def test_dry_run_returns_eligible_count_without_deleting(self) -> None:
         self._create_symbol_set("old-used", created_at_days_ago=45, last_used_days_ago=31)
         self._create_symbol_set("old-unused", created_at_days_ago=45, last_used_days_ago=None)

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py
@@ -73,18 +73,24 @@ class TestSymbolSetCleanupActivity(BaseTest):
         )
 
         with (
-            patch("products.error_tracking.backend.models.delete_symbol_set_contents") as delete_contents,
+            patch(
+                "products.error_tracking.backend.temporal.symbol_set_cleanup.activities.delete_symbol_set_contents_many",
+                return_value=[],
+            ) as delete_contents,
             patch("products.error_tracking.backend.temporal.symbol_set_cleanup.activities.close_old_connections"),
         ):
-            result = cleanup_symbol_sets_activity(SymbolSetCleanupInputs(batch_size=1, total_per_run=10))
+            result = cleanup_symbol_sets_activity(SymbolSetCleanupInputs(batch_size=10, total_per_run=10))
 
         assert result == SymbolSetCleanupResult(objects_processed=2, objects_deleted=2, objects_failed=0)
         assert set(ErrorTrackingSymbolSet.objects.values_list("ref", flat=True)) == {"recent-used", "recent-unused"}
         assert not ErrorTrackingStackFrame.objects.filter(id=unresolved_frame.id).exists()
         resolved_frame.refresh_from_db()
         assert resolved_frame.symbol_set_id is None
-        assert {call.args[0] for call in delete_contents.call_args_list} == {"symbols/old-used", "symbols/old-unused"}
-        assert delete_contents.call_count == 2
+        assert {storage_ptr for call in delete_contents.call_args_list for storage_ptr in call.args[0]} == {
+            "symbols/old-used",
+            "symbols/old-unused",
+        }
+        assert delete_contents.call_count == 1
 
     def test_delete_unused_false_only_deletes_old_used_symbol_sets(self) -> None:
         self._create_symbol_set("old-used", created_at_days_ago=45, last_used_days_ago=31)
@@ -158,8 +164,8 @@ class TestSymbolSetCleanupWorkflow:
         assert ErrorTrackingSymbolSetCleanupWorkflow.parse_inputs([]) == SymbolSetCleanupInputs(
             days_old=30,
             delete_unused=True,
-            total_per_run=50000,
-            batch_size=2000,
+            total_per_run=500000,
+            batch_size=10000,
             dry_run=False,
         )
 

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/types.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/types.py
@@ -15,4 +15,5 @@ class SymbolSetCleanupResult:
     objects_processed: int
     objects_deleted: int
     objects_failed: int
+    storage_objects_failed: int = 0
     eligible_count: int | None = None

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/types.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/types.py
@@ -5,8 +5,8 @@ import dataclasses
 class SymbolSetCleanupInputs:
     days_old: int = 30
     delete_unused: bool = True
-    total_per_run: int = 50000
-    batch_size: int = 2000
+    total_per_run: int = 500000
+    batch_size: int = 10000
     dry_run: bool = False
 
 


### PR DESCRIPTION
## Problem

Symbol set cleanup processes large batches slowly because it deletes each symbol set and S3 object individually. This makes it hard for the hourly cleanup schedule to keep up with larger backlogs.

## Changes

- Add batched object-storage deletion with S3-compatible 1000-key chunks and per-key failure reporting.
- Update symbol set cleanup to bulk delete database rows per chunk, while preserving the existing behavior of deleting unresolved frames and retaining resolved frames.
- Delete S3 contents only after the database transaction commits, preserving the safer failure mode of possible orphaned objects instead of rows pointing at missing objects.
- Increase the scheduled cleanup defaults to 500k symbol sets per run with 10k database chunks.

## How did you test this code?

Automated tests run by agent:

```bash
flox activate -- bash -c "./bin/hogli test products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py posthog/storage/test/test_object_storage.py::TestStorage::test_delete_objects_batches_keys_and_returns_failures"
flox activate -- bash -c "ruff check posthog/storage/object_storage.py posthog/storage/test/test_object_storage.py products/error_tracking/backend/models.py products/error_tracking/backend/temporal/symbol_set_cleanup/activities.py products/error_tracking/backend/temporal/symbol_set_cleanup/types.py products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py"
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this changes an internal cleanup job and object-storage helper.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent. The main design choice was to keep database deletion and S3 deletion separated: each database chunk runs in a bounded transaction, then S3 keys are deleted in batches after commit so object-store latency does not extend database locks.