### PR TITLE
fix(data-warehouse): validate RevenueCat project id against projects list

### DIFF
--- a/posthog/temporal/data_imports/sources/revenuecat/revenuecat.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/revenuecat.py
@@ -91,7 +91,7 @@ def _normalize_project_id(raw: str | None) -> str:
 
 
 def _accessible_project_ids(payload: dict[str, Any] | None) -> list[str]:
-    """Pull the project ids out of a ``GET /v2/projects`` response.
+    """Pull the project ids out of a ``GET /v2/projects`` response page.
 
     We deliberately keep only the ids (opaque ``proj...`` tokens), never the
     project names — the error string built from this is captured into our
@@ -101,6 +101,36 @@ def _accessible_project_ids(payload: dict[str, Any] | None) -> list[str]:
     if not isinstance(items, list):
         return []
     return [str(item["id"]) for item in items if isinstance(item, dict) and item.get("id")]
+
+
+def _list_accessible_project_ids(session: requests.Session) -> list[str] | None:
+    """Return every project id the key can see, following cursor pages.
+
+    Returns ``None`` when a page comes back 200 but unparseable — callers can't
+    distinguish "no projects" from "couldn't read the list", and the two demand
+    opposite treatment, so we surface the difference. HTTP/network errors
+    propagate to the caller.
+    """
+    ids: list[str] = []
+    url = f"{REVENUECAT_API_BASE_URL}/projects"
+    params: dict[str, Any] | None = {"limit": DEFAULT_PAGE_SIZE}
+
+    while True:
+        response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        try:
+            payload = response.json() or {}
+        except (ValueError, requests.exceptions.JSONDecodeError):
+            return None
+
+        ids.extend(_accessible_project_ids(payload))
+
+        next_page = payload.get("next_page")
+        if not next_page:
+            return ids
+        # next_page already carries its own query string — see iterate_list_endpoint.
+        url = next_page if next_page.startswith("http") else urljoin(REVENUECAT_API_BASE_URL, next_page)
+        params = None
 
 
 def _project_not_found_error(entered_project_id: str, accessible_ids: list[str]) -> str:
@@ -151,16 +181,17 @@ def validate_credentials(api_key: str, project_id: str | None) -> tuple[bool, st
     """Confirm the key works and (when set) that it can reach ``project_id``.
 
     ``GET /v2/projects`` both validates the key and tells us every project the
-    key can see. We keep that list so that if the per-project follow-up 404s —
-    by far the most common failure — we can name the project ids the key *can*
-    reach instead of a dead-end "double-check the project id". The entered id is
-    normalized first so a pasted dashboard URL or stray whitespace doesn't
-    masquerade as a missing project.
+    key can see, so the project check is a membership test against that list.
+    There is no ``GET /v2/projects/{id}`` endpoint in the RevenueCat v2 API —
+    probing it 404s even for a perfectly valid id, so never "verify" a project
+    that way. The entered id is normalized first so a pasted dashboard URL or
+    stray whitespace doesn't masquerade as a missing project; on a miss, the
+    error names the project ids the key *can* reach instead of a dead-end
+    "double-check the project id".
     """
     session = _session(api_key)
     try:
-        response = session.get(f"{REVENUECAT_API_BASE_URL}/projects", timeout=REQUEST_TIMEOUT_SECONDS)
-        response.raise_for_status()
+        accessible_ids = _list_accessible_project_ids(session)
     except requests.HTTPError as e:
         return False, _format_http_error(e)
     except requests.RequestException as e:
@@ -170,25 +201,14 @@ def validate_credentials(api_key: str, project_id: str | None) -> tuple[bool, st
     if not normalized_project_id:
         return True, None
 
-    try:
-        accessible_ids = _accessible_project_ids(response.json() or {})
-    except (ValueError, requests.exceptions.JSONDecodeError):
-        accessible_ids = []
+    # The list came back 200 but unreadable — the key itself is good, and we
+    # have no way to check the project, so fail open rather than block setup.
+    if accessible_ids is None:
+        return True, None
 
-    try:
-        response = session.get(
-            f"{REVENUECAT_API_BASE_URL}/projects/{normalized_project_id}",
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-    except requests.HTTPError as e:
-        if e.response is not None and e.response.status_code == 404:
-            return False, _project_not_found_error(normalized_project_id, accessible_ids)
-        return False, _format_http_error(e)
-    except requests.RequestException as e:
-        return False, f"Could not reach RevenueCat: {e}"
-
-    return True, None
+    if normalized_project_id in accessible_ids:
+        return True, None
+    return False, _project_not_found_error(normalized_project_id, accessible_ids)
 
 
 def _ms_to_seconds(value: Any) -> Any:

--- a/posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py
@@ -39,18 +39,32 @@ class TestValidateCredentials:
         assert called_url == f"{REVENUECAT_API_BASE_URL}/projects"
 
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_also_checks_project_when_id_provided(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": []}),
-            _ok_json_response({"id": "proj_test"}),
-        ]
+    def test_accepts_project_id_found_in_projects_list(self, mock_session):
+        # The project check is a membership test against `GET /projects` — the
+        # v2 API has no `GET /projects/{id}` endpoint (probing it 404s even for
+        # a valid id, which used to fail every connection attempt).
+        mock_session.return_value.get.return_value = _ok_json_response({"items": [{"id": "proj_test"}]})
 
-        success, _ = api_client.validate_credentials("sk_test", project_id="proj_test")
+        success, error = api_client.validate_credentials("sk_test", project_id="proj_test")
 
         assert success is True
-        # Second call hits the project-specific endpoint.
-        second_call_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert second_call_url == f"{REVENUECAT_API_BASE_URL}/projects/proj_test"
+        assert error is None
+        assert mock_session.return_value.get.call_count == 1
+        called_url = mock_session.return_value.get.call_args.args[0]
+        assert called_url == f"{REVENUECAT_API_BASE_URL}/projects"
+
+    @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
+    def test_follows_pagination_when_project_is_on_a_later_page(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _ok_json_response({"items": [{"id": "proj_a"}], "next_page": "/v2/projects?starting_after=proj_a"}),
+            _ok_json_response({"items": [{"id": "proj_b"}], "next_page": None}),
+        ]
+
+        success, error = api_client.validate_credentials("sk_test", project_id="proj_b")
+
+        assert success is True
+        assert error is None
+        assert mock_session.return_value.get.call_count == 2
 
     @parameterized.expand(
         [
@@ -81,32 +95,6 @@ class TestValidateCredentials:
         assert error is not None
         assert "Could not reach RevenueCat" in error
 
-    @parameterized.expand(
-        [
-            (401, "rejected the API key"),
-            (403, "denied"),
-            (404, "could not find"),
-            (429, "rate-limited"),
-            (500, "RevenueCat API error"),
-        ]
-    )
-    @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_returns_false_when_project_specific_call_fails(self, status_code, expected_substring, mock_session):
-        # The first call (`GET /projects`) succeeds, but the per-project follow-up
-        # (`GET /projects/{id}`) fails. `_format_http_error` is shared between
-        # both call sites, so without this branch a regression in the per-project
-        # path would go unnoticed.
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": []}),
-            _http_error_response(status_code),
-        ]
-
-        success, error = api_client.validate_credentials("sk_test", project_id="proj_test")
-
-        assert success is False
-        assert error is not None
-        assert expected_substring.lower() in error.lower()
-
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
     def test_skips_project_check_when_id_normalizes_to_empty(self, mock_session):
         # A whitespace-only id is truthy as a raw string but empty once trimmed,
@@ -120,15 +108,12 @@ class TestValidateCredentials:
         assert mock_session.return_value.get.call_count == 1
 
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_tolerates_invalid_json_on_projects_list(self, mock_session):
-        # If `GET /projects` returns a 200 with an unparseable body, we should
-        # still run the per-project check rather than crashing on `.json()`.
+    def test_fails_open_on_invalid_json_on_projects_list(self, mock_session):
+        # If `GET /projects` returns a 200 with an unparseable body, the key is
+        # good but we can't run the membership check — accept rather than block.
         bad_list = _ok_json_response({"items": []})
         bad_list.json.side_effect = requests.exceptions.JSONDecodeError("boom", "", 0)
-        mock_session.return_value.get.side_effect = [
-            bad_list,
-            _ok_json_response({"id": "proj_test"}),
-        ]
+        mock_session.return_value.get.return_value = bad_list
 
         success, error = api_client.validate_credentials("sk_test", project_id="proj_test")
 
@@ -508,13 +493,12 @@ class TestAccessibleProjectIds:
 
 class TestValidateCredentialsProjectSuggestions:
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_404_lists_single_accessible_project(self, mock_session):
+    def test_miss_lists_single_accessible_project(self, mock_session):
         # The key works (it can list projects) but the entered id doesn't exist.
         # The error should name the one project the key can actually reach.
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": [{"id": "proj_real", "name": "My App"}]}),
-            _http_error_response(404),
-        ]
+        mock_session.return_value.get.return_value = _ok_json_response(
+            {"items": [{"id": "proj_real", "name": "My App"}]}
+        )
 
         success, error = api_client.validate_credentials("sk_test", project_id="proj_typo")
 
@@ -526,11 +510,8 @@ class TestValidateCredentialsProjectSuggestions:
         assert "My App" not in error
 
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_404_lists_multiple_accessible_projects(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": [{"id": "proj_a"}, {"id": "proj_b"}]}),
-            _http_error_response(404),
-        ]
+    def test_miss_lists_multiple_accessible_projects(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_json_response({"items": [{"id": "proj_a"}, {"id": "proj_b"}]})
 
         success, error = api_client.validate_credentials("sk_test", project_id="proj_typo")
 
@@ -539,11 +520,8 @@ class TestValidateCredentialsProjectSuggestions:
         assert "proj_a" in error and "proj_b" in error
 
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_404_with_no_accessible_projects_falls_back_to_generic_message(self, mock_session):
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": []}),
-            _http_error_response(404),
-        ]
+    def test_miss_with_no_accessible_projects_falls_back_to_generic_message(self, mock_session):
+        mock_session.return_value.get.return_value = _ok_json_response({"items": []})
 
         success, error = api_client.validate_credentials("sk_test", project_id="proj_typo")
 
@@ -553,12 +531,9 @@ class TestValidateCredentialsProjectSuggestions:
 
     @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
     def test_normalizes_pasted_url_before_checking_project(self, mock_session):
-        # A user pastes the whole dashboard URL — we should look up the bare id,
-        # so the per-project request must hit `/projects/proj_real`, not the URL.
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": [{"id": "proj_real"}]}),
-            _ok_json_response({"id": "proj_real"}),
-        ]
+        # A user pastes the whole dashboard URL — the bare id pulled out of it
+        # must match against the accessible-projects list.
+        mock_session.return_value.get.return_value = _ok_json_response({"items": [{"id": "proj_real"}]})
 
         success, error = api_client.validate_credentials(
             "sk_test", project_id="https://app.revenuecat.com/projects/proj_real/overview"
@@ -566,23 +541,6 @@ class TestValidateCredentialsProjectSuggestions:
 
         assert success is True
         assert error is None
-        second_call_url = mock_session.return_value.get.call_args_list[1].args[0]
-        assert second_call_url == f"{REVENUECAT_API_BASE_URL}/projects/proj_real"
-
-    @patch("posthog.temporal.data_imports.sources.revenuecat.revenuecat._session")
-    def test_non_404_project_error_still_uses_generic_formatter(self, mock_session):
-        # A 403 on the per-project call isn't a "wrong id" problem, so it should
-        # not be reworded into a project-suggestion message.
-        mock_session.return_value.get.side_effect = [
-            _ok_json_response({"items": [{"id": "proj_real"}]}),
-            _http_error_response(403),
-        ]
-
-        success, error = api_client.validate_credentials("sk_test", project_id="proj_real")
-
-        assert success is False
-        assert error is not None
-        assert "denied" in error.lower()
 
 
 class TestIterateListEndpointNormalization:


### PR DESCRIPTION
## Problem

No one has been able to connect the RevenueCat data warehouse source since the connection-error improvements in #62414. Credential validation probes `GET /v2/projects/{project_id}` to confirm the entered project exists — but that endpoint does not exist in the RevenueCat v2 API (only `GET /v2/projects` and sub-resources like `/projects/{id}/customers` do), so the probe 404s for every connection attempt, even with a perfectly valid project ID. Client-side `warehouse credentials invalid` events confirm this: the error message names the entered ID and the "accessible" ID as the exact same string.

## Changes

- Replace the phantom per-project request with a membership test against the `GET /v2/projects` response we already fetch during key validation, following `next_page` pagination in case a key sees more than one page of projects.
- Keep the actionable not-found error (naming the project IDs the key *can* reach) for genuine mistakes — typos and un-prefixed IDs still get the corrective suggestion.
- If the projects list comes back 200 but unparseable, fail open (the key already proved valid) instead of checking against an empty list and rejecting a correct ID.

## How did you test this code?

Updated the validation tests to cover the regression directly (entered ID present in the projects list → success), pagination across `next_page`, the suggestion messages on a membership miss, and the fail-open path on unparseable JSON. All 56 tests in `posthog/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py` pass locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update
