### PR TITLE
fix(experiments/mcp): Trim write-tool responses to relevant fields for mcp efficiency (follow-up)

### DIFF
--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -120,6 +120,8 @@ tools:
                 - end_date
                 - created_at
                 - parameters
+                - metrics
+                - metrics_secondary
                 - conclusion
                 - conclusion_comment
     experiment-delete:
@@ -292,6 +294,8 @@ tools:
                 - end_date
                 - created_at
                 - parameters
+                - metrics
+                - metrics_secondary
                 - conclusion
                 - conclusion_comment
     experiment-list:

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -126,6 +126,8 @@ const experimentCreate = (): ToolBase<typeof ExperimentCreateSchema, WithPostHog
                 'end_date',
                 'created_at',
                 'parameters',
+                'metrics',
+                'metrics_secondary',
                 'conclusion',
                 'conclusion_comment',
             ]) as typeof result
@@ -316,6 +318,8 @@ const experimentLaunch = (): ToolBase<typeof ExperimentLaunchSchema, WithPostHog
                 'end_date',
                 'created_at',
                 'parameters',
+                'metrics',
+                'metrics_secondary',
                 'conclusion',
                 'conclusion_comment',
             ]) as typeof result


### PR DESCRIPTION
Follow up for https://github.com/PostHog/posthog/pull/62795 to keep metrics, as mentioned in the original PR