### PR TITLE
fix(conversations): stabilize SupportTicketsScene useMemo deps

### DIFF
--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -262,17 +262,26 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
 
     const getKey = useMemo(() => (t: Ticket) => t.id, [])
     const bulk = useBulkSelection<Ticket, string>({ pageRecords: tickets, getKey })
+    const {
+        selectedKeys,
+        clearSelection,
+        isSomeOnPageSelected,
+        isAllOnPageSelected,
+        toggleAllOnPage,
+        selectedKeysSet,
+        toggleRow,
+    } = bulk
 
     useEffect(() => {
-        setSelectedTicketIds(bulk.selectedKeys)
-    }, [bulk.selectedKeys, setSelectedTicketIds])
+        setSelectedTicketIds(selectedKeys)
+    }, [selectedKeys, setSelectedTicketIds])
 
     // Clear hook selection when kea resets (e.g. after bulk update or page reload)
     useEffect(() => {
-        if (selectedTicketIds.length === 0 && bulk.selectedKeys.length > 0) {
-            bulk.clearSelection()
+        if (selectedTicketIds.length === 0 && selectedKeys.length > 0) {
+            clearSelection()
         }
-    }, [selectedTicketIds, bulk.clearSelection, bulk, bulk.selectedKeys.length])
+    }, [selectedTicketIds, selectedKeys, clearSelection])
 
     const columns = useMemo<LemonTableColumns<Ticket>>(() => {
         const checkboxCol: LemonTableColumns<Ticket>[number] = {
@@ -280,16 +289,16 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
             width: 32,
             title: (
                 <LemonCheckbox
-                    checked={bulk.isSomeOnPageSelected ? 'indeterminate' : bulk.isAllOnPageSelected}
-                    onChange={bulk.toggleAllOnPage}
+                    checked={isSomeOnPageSelected ? 'indeterminate' : isAllOnPageSelected}
+                    onChange={toggleAllOnPage}
                     stopPropagation
                 />
             ),
             render: (_, ticket: Ticket, recordIndex: number) => (
                 <LemonCheckbox
-                    checked={bulk.selectedKeysSet.has(ticket.id)}
+                    checked={selectedKeysSet.has(ticket.id)}
                     onChange={(_value, event) =>
-                        bulk.toggleRow(ticket.id, recordIndex, (event.nativeEvent as MouseEvent).shiftKey ?? false)
+                        toggleRow(ticket.id, recordIndex, (event.nativeEvent as MouseEvent).shiftKey ?? false)
                     }
                     stopPropagation
                 />
@@ -299,14 +308,7 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
             ? SUPPORT_TICKETS_TABLE_COLUMNS.filter((col) => 'key' in col && col.key !== 'customer')
             : SUPPORT_TICKETS_TABLE_COLUMNS
         return [checkboxCol, ...base]
-    }, [
-        embedded,
-        bulk.isSomeOnPageSelected,
-        bulk.isAllOnPageSelected,
-        bulk.toggleAllOnPage,
-        bulk.selectedKeysSet,
-        bulk.toggleRow,
-    ])
+    }, [embedded, isSomeOnPageSelected, isAllOnPageSelected, toggleAllOnPage, selectedKeysSet, toggleRow])
 
     return (
         <LemonTable<Ticket>


### PR DESCRIPTION
## Problem

`SupportTicketsScene.tsx` could not survive `pnpm format`. The columns `useMemo` listed `bulk.*` member expressions (`bulk.toggleRow`, `bulk.selectedKeysSet`, ...) in its dependency array, which tripped `eslint-plugin-react-hooks(exhaustive-deps)`. The frontend `format` script runs `oxlint --fix --fix-suggestions --fix-dangerously`, and the dangerous autofix for that warning rewrote the array into `bulk.toggleRow bulk,` — a missing-comma syntax error. Once written, the parse error broke every subsequent format/lint run on the file, so the corruption kept firing for anyone who ran the formatter.

## Changes

Destructure the five members the memo actually uses (`isSomeOnPageSelected`, `isAllOnPageSelected`, `toggleAllOnPage`, `selectedKeysSet`, `toggleRow`) into plain identifiers right after the `useBulkSelection` call, and reference those in the render closures and the dependency array. `exhaustive-deps` is now fully satisfied (0 warnings) with simple identifiers, so `--fix-dangerously` has nothing to rewrite.

Depending on the whole `bulk` object was not an option: `useBulkSelection` returns a fresh object literal each render, so it would defeat the memo. The destructured members are the stable (`useCallback`) handles plus the values that genuinely should re-trigger the memo.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks I actually ran locally on the file:

- `oxlint` — 0 warnings, 0 errors (was 2 exhaustive-deps warnings before).
- `oxlint --fix --fix-suggestions --fix-dangerously` then diff — no changes (previously corrupted the deps array into `bulk.toggleRow bulk,`).
- `oxfmt` then diff — no changes.

No behavioral change: the destructured members are the same values previously read via `bulk.*`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul flagged that `SupportTicketsScene.tsx` kept getting corrupted by the formatter and asked to fix it for good. Reproduced the corruption on a copy of the file, traced it to the `exhaustive-deps` warning that `oxlint --fix-dangerously` mis-repairs, and chose destructuring (over an eslint-disable comment or depending on the whole `bulk` object) as the fix that removes the warning at its source without defeating the memo or adding noise.

Tool: PostHog Code (Claude Opus).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*