### PR TITLE
fix(batch-exports): Strip leading whitespace from Azure connection str

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -48,6 +48,7 @@ NON_RETRYABLE_ERROR_TYPES = (
     "AzureBlobIntegrationError",
     "AzureBlobIntegrationNotFoundError",
     "ClientAuthenticationError",
+    "MalformedConnectionStringError",
     "MissingRequiredPermissionsError",
     "ResourceNotFoundError",
     "UnsupportedCompressionError",
@@ -95,12 +96,32 @@ class MissingRequiredPermissionsError(Exception):
         super().__init__("Missing required permissions to run this batch export")
 
 
+class MalformedConnectionStringError(Exception):
+    """Raised when Azure SDK cannot parse a connection string."""
+
+    def __init__(self):
+        super().__init__(
+            "The provided connection string was rejected by Azure. Ensure the connection string is made up of key=value pairs separated only by a semicolon (;) with no additional characters in between. Example: AccountName=name;AccountKey=key;SomeKey=somevalue"
+        )
+
+
 def _is_authorization_failure_response_error(err: HttpResponseError) -> bool:
     """Check if the provided response error is an authorization failure.
 
     'error_code' is monkey-patched dynamically so we must use 'getattr' for type checkers.
     """
     return getattr(err, "error_code", None) == StorageErrorCode.AUTHORIZATION_FAILURE
+
+
+def _strip_leading_whitespace(conn_str: str) -> str:
+    """Remove any leading whitespace from key=value pairs.
+
+    This is rejected by Azure SDK when parsing. In contrast, I like to help our users
+    get things right. I do not strip trailing whitespace as I cannot confirm whether
+    values can have trailing whitespace, in contrast to keys, which most definitely
+    don't.
+    """
+    return ";".join(value.lstrip() for value in conn_str.split(";"))
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -170,15 +191,20 @@ class AzureBlobConsumer(Consumer):
         # Blobs larger than `max_single_put_size` are uploaded in blocks of `max_block_size`.
         # These are Azure SDK defaults but we set them explicitly for visibility.
         # See: https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient
-        blob_service_client = BlobServiceClient.from_connection_string(
-            conn_str=connection_string,
-            max_single_put_size=64 * 1024 * 1024,  # 64 MiB
-            max_block_size=4 * 1024 * 1024,  # 4 MiB
-            # Increase the read timeout to 10 minutes to account for large uploads.
-            read_timeout=600,
-            # Azure SDK defaults but we set them explicitly for visibility.
-            retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
-        )
+
+        try:
+            blob_service_client = BlobServiceClient.from_connection_string(
+                conn_str=_strip_leading_whitespace(connection_string),
+                max_single_put_size=64 * 1024 * 1024,  # 64 MiB
+                max_block_size=4 * 1024 * 1024,  # 4 MiB
+                # Increase the read timeout to 10 minutes to account for large uploads.
+                read_timeout=600,
+                # Azure SDK defaults but we set them explicitly for visibility.
+                retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
+            )
+        except ValueError:
+            raise MalformedConnectionStringError()
+
         container_client = blob_service_client.get_container_client(inputs.container_name)
 
         return cls(

--- a/products/batch_exports/backend/tests/temporal/destinations/azure_blob/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/azure_blob/test_utils.py
@@ -3,10 +3,26 @@ import pytest
 from products.batch_exports.backend.temporal.destinations.azure_blob_batch_export import (
     COMPRESSION_EXTENSIONS,
     FILE_FORMAT_EXTENSIONS,
+    _strip_leading_whitespace,
 )
 from products.batch_exports.backend.temporal.destinations.utils import get_key_prefix, get_manifest_key, get_object_key
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+@pytest.mark.parametrize(
+    "conn_str,expected",
+    [
+        # No changes without leading whitespace
+        ("AccountName=name;AccountKey=key;SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
+        # Stripped leading whitespace one time
+        ("AccountName=name; AccountKey=key;SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
+        # Stripped leading whitespace two times
+        ("AccountName=name; AccountKey=key; SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
+    ],
+)
+def test_strip_leading_whitespace(conn_str: str, expected: str) -> None:
+    assert _strip_leading_whitespace(conn_str) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

Azure SDK rejects connection strings with leading whitespace: e.g. " AccountName=name" will raise a ValueError as Azure looks for "AccountName", gets a KeyError, and raises a ValueError in its place.

Due to copy & paste errors, whitespace may be included in the connection string, so let's be helpful and attempt to strip leading whitespace from all key=value pairs, as a key should never start with whitespace.

However, if that is not enough, then we raise a non-retryable error indicating to the user that Azure rejected their connection string, with examples on how to provide a valid one.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added a unit test.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Nothing.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
