### PR TITLE
perf(experiments): Eliminate duplicate CTE scans in metric queries

### DIFF
--- a/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
+++ b/.agents/skills/optimizing-clickhouse-and-hogql-queries/references/learnings.md
@@ -28,7 +28,22 @@ Suggested entry format:
 
 ---
 
-## 2026-05-28: Dropping `FROM person FINAL` via `argMax` is worse than the original; materialization is the actual win
+## 2026-06-11: Experiment-query CTE references multiply events scans; window functions beat percentile CTEs; verify with `ReadFromMergeTree` counts
+
+**Context.** Directory-wide optimization pass over `products/experiments/backend/hogql_queries/`. Experiment metric queries are built as named-CTE chains (`exposures`, `metric_events`, `entity_metrics`, …); the printed ClickHouse SQL keeps the `WITH name AS (...)` form.
+
+**Question.** How many times does each CTE actually execute, and what do de-duplicating rewrites buy?
+
+**What we tried.** `EXPLAIN` on a ratio-metric-shaped query (the `exposures` CTE referenced three times: two pre-aggregation joins + final entity join) counted **5 `ReadFromMergeTree` nodes** — ClickHouse inlines and re-executes a CTE at every reference, exactly as the SKILL warns; counting `ReadFromMergeTree` nodes in EXPLAIN output is a fast, reliable way to audit this. The per-metric reference counts for experiment queries were: mean 2 scans, retention 4, ratio 5, winsorized variants ×2 on top (winsorized ratio = 10 events scans), because the `percentiles` CTE + `CROSS JOIN percentiles` shape re-executes the entire upstream `entity_metrics` chain. Each duplicated exposure scan also drags its `person_distinct_id_overrides` join and (with person-property test-account filters) a `person`-table join along with it.
+
+Two rewrites measured on local dev ClickHouse (team 1 demo data, ~600k events, median of 5, `use_uncompressed_cache=0`; results byte-identical across shapes):
+
+- Ratio: combining numerator+denominator into one conditional-aggregation scan and dropping redundant `exposures` references — read_rows 2.30M (3 refs) → 1.44M (2 refs) → 0.97M (1 ref, mean-shaped); memory flat.
+- Winsorization: replacing the `percentiles` CTE + `CROSS JOIN` with `quantileExact(p)(value) OVER ()` window aggregates (breakdowns → `OVER (PARTITION BY breakdown_value_N)`) — read_rows and read_bytes exactly halved (1.75M→0.88M rows, 1.67GiB→856MiB), duration 610→455ms, memory flat (244→229MiB). The window form computes bounds in the same pass that reads the rows, so the doubling disappears.
+
+**Caveats.** Local single-node, small parts, JSON unmaterialized (prod materializes `$feature_flag_response`, so prod exposure scans are cheaper per scan — the multiplication factor is unchanged). Wall-clock locally is noise; rows/bytes are the signal. Not yet timed on the Test Cluster.
+
+**Takeaway.** In HogQL-built query chains, count references to every CTE that scans a fact table — each reference is a full re-execution, and shapes that look like "compute stats, then join them back" (`percentiles` + `CROSS JOIN`) silently double the whole upstream pipeline. Window aggregates (`agg(...) OVER (PARTITION BY ...)`) are the single-pass replacement for full-set/per-group bounds and cost no extra memory. HogQL supports parametric window aggregates (`quantileExact(0.9)(x) OVER ()`) end to end.
 
 **Context.** `posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py` builds a raw ClickHouse query that does `SELECT id, JSONExtract(properties, '<key>', 'String'), ... FROM person FINAL WHERE team_id = ... AND id BETWEEN ... AND is_deleted = 0 ORDER BY id FORMAT JSONEachRow`. We flagged the `FINAL` as a smell.
 

--- a/products/experiments/backend/hogql_queries/base_query_utils.py
+++ b/products/experiments/backend/hogql_queries/base_query_utils.py
@@ -375,6 +375,28 @@ def get_source_aggregation_expr(
     return parse_expr(f"sum(coalesce(toFloat({table_alias}.value), 0))")
 
 
+def apply_winsorization_breakdown_partitioning(breakdowns: list | None, *bound_exprs: ast.Expr) -> None:
+    """
+    Partition winsorization bound windows by the breakdown columns so each
+    breakdown group is capped at its own threshold (pooled across variations).
+
+    The bound expressions are window aggregates over entity_metrics
+    (e.g. ``quantileExact(0.99)(entity_metrics.value) OVER ()``); with
+    breakdowns configured this rewrites them to
+    ``... OVER (PARTITION BY entity_metrics.breakdown_value_1, ...)``.
+    """
+    if not breakdowns:
+        return
+    for expr in bound_exprs:
+        assert isinstance(expr, ast.WindowFunction)
+        expr.over_expr = ast.WindowExpr(
+            partition_by=[
+                ast.Field(chain=["entity_metrics", f"breakdown_value_{i + 1}"]) for i in range(len(breakdowns))
+            ]
+        )
+        expr.over_identifier = None
+
+
 def funnel_steps_to_filter(
     team: Team, funnel_steps: list[EventsNode | ActionsNode | ExperimentDataWarehouseNode]
 ) -> ast.Expr:

--- a/products/experiments/backend/hogql_queries/breakdown_injector.py
+++ b/products/experiments/backend/hogql_queries/breakdown_injector.py
@@ -268,57 +268,16 @@ class BreakdownInjector:
                 for alias in aliases:
                     entity_metrics_cte.expr.group_by.append(ast.Field(chain=["exposures", alias]))
 
-        # Inject into percentiles CTE (only for winsorization queries)
-        if query.ctes and "percentiles" in query.ctes:
-            percentiles_cte = query.ctes["percentiles"]
-            if isinstance(percentiles_cte, ast.CTE) and isinstance(percentiles_cte.expr, ast.SelectQuery):
-                # Add breakdown columns to SELECT
-                for alias in aliases:
-                    percentiles_cte.expr.select.append(
-                        ast.Alias(alias=alias, expr=ast.Field(chain=["entity_metrics", alias]))
-                    )
-                # Initialize and populate GROUP BY for per-breakdown percentiles
-                if percentiles_cte.expr.group_by is None:
-                    percentiles_cte.expr.group_by = []
-                for alias in aliases:
-                    percentiles_cte.expr.group_by.append(ast.Field(chain=["entity_metrics", alias]))
-
-        # Inject into winsorized_entity_metrics CTE (only when final_cte_name is winsorized_entity_metrics)
+        # Inject into winsorized_entity_metrics CTE (only when final_cte_name is winsorized_entity_metrics).
+        # The winsorization bounds are window aggregates partitioned by breakdown (set by the
+        # metric builder), so only the passthrough columns are added here.
         if query.ctes and final_cte_name == "winsorized_entity_metrics":
             winsorized_cte = query.ctes["winsorized_entity_metrics"]
             if isinstance(winsorized_cte, ast.CTE) and isinstance(winsorized_cte.expr, ast.SelectQuery):
-                # Add breakdown columns to SELECT
                 for alias in aliases:
                     winsorized_cte.expr.select.append(
                         ast.Alias(alias=alias, expr=ast.Field(chain=["entity_metrics", alias]))
                     )
-                # Convert CROSS JOIN to proper JOIN with breakdown conditions
-                if winsorized_cte.expr.select_from:
-                    join_expr = winsorized_cte.expr.select_from.next_join
-                    if join_expr and isinstance(join_expr, ast.JoinExpr):
-                        # Change from CROSS JOIN to INNER JOIN
-                        join_expr.join_type = "JOIN"
-                        # Build join condition: percentiles.bd1 = entity_metrics.bd1 AND ...
-                        join_conditions = []
-                        for alias in aliases:
-                            join_conditions.append(
-                                ast.CompareOperation(
-                                    op=ast.CompareOperationOp.Eq,
-                                    left=ast.Field(chain=["percentiles", alias]),
-                                    right=ast.Field(chain=["entity_metrics", alias]),
-                                )
-                            )
-                        # Combine conditions with AND
-                        condition_expr: ast.Expr
-                        if len(join_conditions) == 1:
-                            condition_expr = join_conditions[0]
-                        else:
-                            combined: ast.Expr = join_conditions[0]
-                            for condition in join_conditions[1:]:
-                                combined = ast.And(exprs=[combined, condition])
-                            condition_expr = combined
-                        # Wrap in JoinConstraint with ON clause
-                        join_expr.constraint = ast.JoinConstraint(expr=condition_expr, constraint_type="ON")
 
         # Inject into final SELECT - breakdown columns must come right after variant
         for i, alias in enumerate(aliases):
@@ -343,10 +302,10 @@ class BreakdownInjector:
         - entity_metrics gets breakdown columns directly from exposures
         - No need for breakdown join conditions on the event joins
 
-        When ``winsorized`` is set the query has extra ``percentiles`` and
-        ``winsorized_entity_metrics`` CTEs: percentiles are computed per breakdown group
-        (so each group is capped at its own threshold, pooled across variations) and the
-        final aggregation reads from ``winsorized_entity_metrics``.
+        When ``winsorized`` is set the query has an extra ``winsorized_entity_metrics``
+        CTE whose bound expressions are window aggregates partitioned by breakdown
+        (set by the metric builder, so each group is capped at its own threshold,
+        pooled across variations); only the passthrough columns are added here.
         """
         if not self._has_breakdown():
             return
@@ -367,22 +326,7 @@ class BreakdownInjector:
                 for alias in aliases:
                     entity_metrics_cte.expr.group_by.append(ast.Field(chain=["exposures", alias]))
 
-        # Inject into percentiles CTE (only for winsorization queries) so each breakdown
-        # group gets its own thresholds, pooled across variations.
-        if winsorized and query.ctes and "percentiles" in query.ctes:
-            percentiles_cte = query.ctes["percentiles"]
-            if isinstance(percentiles_cte, ast.CTE) and isinstance(percentiles_cte.expr, ast.SelectQuery):
-                for alias in aliases:
-                    percentiles_cte.expr.select.append(
-                        ast.Alias(alias=alias, expr=ast.Field(chain=["entity_metrics", alias]))
-                    )
-                if percentiles_cte.expr.group_by is None:
-                    percentiles_cte.expr.group_by = []
-                for alias in aliases:
-                    percentiles_cte.expr.group_by.append(ast.Field(chain=["entity_metrics", alias]))
-
-        # Inject into winsorized_entity_metrics CTE: add breakdown columns and convert the
-        # CROSS JOIN to percentiles into a per-breakdown JOIN.
+        # Inject passthrough breakdown columns into winsorized_entity_metrics
         if winsorized and query.ctes and "winsorized_entity_metrics" in query.ctes:
             winsorized_cte = query.ctes["winsorized_entity_metrics"]
             if isinstance(winsorized_cte, ast.CTE) and isinstance(winsorized_cte.expr, ast.SelectQuery):
@@ -390,28 +334,6 @@ class BreakdownInjector:
                     winsorized_cte.expr.select.append(
                         ast.Alias(alias=alias, expr=ast.Field(chain=["entity_metrics", alias]))
                     )
-                if winsorized_cte.expr.select_from:
-                    join_expr = winsorized_cte.expr.select_from.next_join
-                    if join_expr and isinstance(join_expr, ast.JoinExpr):
-                        join_expr.join_type = "JOIN"
-                        join_conditions: list[ast.Expr] = []
-                        for alias in aliases:
-                            join_conditions.append(
-                                ast.CompareOperation(
-                                    op=ast.CompareOperationOp.Eq,
-                                    left=ast.Field(chain=["percentiles", alias]),
-                                    right=ast.Field(chain=["entity_metrics", alias]),
-                                )
-                            )
-                        condition_expr: ast.Expr
-                        if len(join_conditions) == 1:
-                            condition_expr = join_conditions[0]
-                        else:
-                            combined: ast.Expr = join_conditions[0]
-                            for condition in join_conditions[1:]:
-                                combined = ast.And(exprs=[combined, condition])
-                            condition_expr = combined
-                        join_expr.constraint = ast.JoinConstraint(expr=condition_expr, constraint_type="ON")
 
         # Inject into final SELECT - breakdown columns must come right after variant
         for i, alias in enumerate(aliases):
@@ -431,17 +353,30 @@ class BreakdownInjector:
         Injects breakdown columns into retention query AST.
         Modifies query in-place.
 
-        Retention breakdown injection is simpler than ratio because:
-        - Only entity_metrics CTE needs modification
-        - No JOIN conditions require breakdown columns
-        - Breakdowns come from exposures only
+        Breakdowns come from exposures, which entity_metrics no longer joins
+        directly (exposures is referenced once, inside start_events), so the
+        breakdown columns flow exposures -> start_events -> entity_metrics.
         """
         if not self._has_breakdown():
             return
 
         aliases = self._get_breakdown_aliases()
 
-        # Inject into entity_metrics CTE SELECT and GROUP BY (carry breakdown from exposures)
+        # Inject into start_events CTE SELECT and GROUP BY (carry breakdown from exposures)
+        if query.ctes and "start_events" in query.ctes:
+            start_events_cte = query.ctes["start_events"]
+            if isinstance(start_events_cte, ast.CTE) and isinstance(start_events_cte.expr, ast.SelectQuery):
+                for i, alias in enumerate(aliases):
+                    start_events_cte.expr.select.insert(
+                        2 + i,  # After entity_id (0), variant (1)
+                        ast.Alias(alias=alias, expr=ast.Field(chain=["exposures", alias])),
+                    )
+                if start_events_cte.expr.group_by is None:
+                    start_events_cte.expr.group_by = []
+                for alias in aliases:
+                    start_events_cte.expr.group_by.append(ast.Field(chain=["exposures", alias]))
+
+        # Inject into entity_metrics CTE SELECT and GROUP BY (carry breakdown from start_events)
         if query.ctes and "entity_metrics" in query.ctes:
             entity_metrics_cte = query.ctes["entity_metrics"]
             if isinstance(entity_metrics_cte, ast.CTE) and isinstance(entity_metrics_cte.expr, ast.SelectQuery):
@@ -449,14 +384,14 @@ class BreakdownInjector:
                 for i, alias in enumerate(aliases):
                     entity_metrics_cte.expr.select.insert(
                         2 + i,  # After entity_id (0), variant (1)
-                        ast.Alias(alias=alias, expr=ast.Field(chain=["exposures", alias])),
+                        ast.Alias(alias=alias, expr=ast.Field(chain=["start_events", alias])),
                     )
 
                 # Add breakdown columns to GROUP BY
                 if entity_metrics_cte.expr.group_by is None:
                     entity_metrics_cte.expr.group_by = []
                 for alias in aliases:
-                    entity_metrics_cte.expr.group_by.append(ast.Field(chain=["exposures", alias]))
+                    entity_metrics_cte.expr.group_by.append(ast.Field(chain=["start_events", alias]))
 
         # Inject into final SELECT - breakdown columns must come right after variant
         for i, alias in enumerate(aliases):

--- a/products/experiments/backend/hogql_queries/experiment_funnel_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_funnel_query_builder.py
@@ -393,8 +393,8 @@ class FunnelQueryBuilder:
                     {uuid_to_session_map} AS uuid_to_session,
                     {uuid_to_timestamp_map} AS uuid_to_timestamp"""
 
-        first_exposures_cte_str, temporal_join, having_clause = self.build_funnel_optimized_temporal_setup(
-            is_unordered_funnel
+        first_exposures_cte_str, temporal_join, having_clause, temporal_placeholders = (
+            self.build_funnel_optimized_temporal_setup(is_unordered_funnel)
         )
 
         ctes_sql = f"""
@@ -420,6 +420,7 @@ class FunnelQueryBuilder:
             "funnel_steps_filter": self.build_funnel_steps_filter(),
             "funnel_aggregation": self.build_funnel_aggregation_expr_optimized(),
             "num_steps_minus_1": ast.Constant(value=num_steps - 1),
+            **temporal_placeholders,
         }
         if not self._b.funnel_steps_data_disabled:
             placeholders["uuid_to_session_map"] = self.build_uuid_to_session_map_optimized()
@@ -513,10 +514,12 @@ class FunnelQueryBuilder:
 
         return query
 
-    def build_funnel_optimized_temporal_setup(self, is_unordered_funnel: bool) -> tuple[str, str, str]:
+    def build_funnel_optimized_temporal_setup(
+        self, is_unordered_funnel: bool
+    ) -> tuple[str, str, str, dict[str, ast.Expr]]:
         """
-        Returns (first_exposures_cte_str, temporal_join, having_clause) for the
-        optimized funnel query.
+        Returns (first_exposures_cte_str, temporal_join, having_clause,
+        extra_placeholders) for the optimized funnel query.
 
         Three call sites collapse into one place:
 
@@ -530,20 +533,31 @@ class FunnelQueryBuilder:
           with step_X=1 (X>0) are never used in the post-window result.
         - Otherwise, no first_exposures CTE; HAVING countIf(step_0 = 1) > 0
           is the cheapest way to keep only exposed entities.
+
+        first_exposures scans events with only the exposure predicate rather
+        than re-reading base_events: ClickHouse executes a CTE once per
+        reference, so deriving it from base_events would run the full
+        (exposure OR funnel steps) scan twice. base_events rows with step_0 = 1
+        are by construction exactly the rows matching the exposure predicate,
+        and the exposure-only scan reads a subset of the OR scan's granules.
         """
         needs_first_exposures = is_unordered_funnel or self._b.cuped_config.enabled
 
-        first_exposures_cte_str = (
-            """
+        extra_placeholders: dict[str, ast.Expr] = {}
+        if needs_first_exposures:
+            first_exposures_cte_str = """
             first_exposures AS (
-                SELECT entity_id, min(timestamp) AS first_exposure_time
-                FROM base_events
-                WHERE step_0 = 1
+                SELECT {first_exposures_entity_key} AS entity_id, min(timestamp) AS first_exposure_time
+                FROM events
+                WHERE {first_exposures_predicate}
                 GROUP BY entity_id
             ),"""
-            if needs_first_exposures
-            else ""
-        )
+            extra_placeholders = {
+                "first_exposures_entity_key": parse_expr(self._b.entity_key),
+                "first_exposures_predicate": self._b._build_exposure_predicate(),
+            }
+        else:
+            first_exposures_cte_str = ""
 
         if is_unordered_funnel:
             temporal_join = """INNER JOIN first_exposures
@@ -559,7 +573,7 @@ class FunnelQueryBuilder:
             having_clause = """
                 HAVING countIf(step_0 = 1) > 0"""
 
-        return first_exposures_cte_str, temporal_join, having_clause
+        return first_exposures_cte_str, temporal_join, having_clause, extra_placeholders
 
     def build_variant_expr_for_funnel(self) -> ast.Expr:
         """

--- a/products/experiments/backend/hogql_queries/experiment_mean_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_mean_query_builder.py
@@ -6,6 +6,7 @@ from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
 
 from products.experiments.backend.hogql_queries.base_query_utils import (
+    apply_winsorization_breakdown_partitioning,
     is_session_property_metric,
     validate_session_property,
 )
@@ -298,33 +299,44 @@ class MeanQueryBuilder:
         """
         Builds query for mean metrics with winsorization (outlier handling).
         This clamps entity-level values to percentile-based bounds.
+
+        The bounds are window aggregates over entity_metrics rather than a
+        separate percentiles CTE: ClickHouse executes a CTE once per reference,
+        so the old percentiles + CROSS JOIN shape ran the whole entity_metrics
+        chain (including its events scans) twice. The window form computes the
+        bounds in the same pass that reads the rows.
         """
         assert isinstance(self._b.metric, ExperimentMeanMetric)
 
         # Build lower bound expression
         if self._b.metric.lower_bound_percentile is not None:
             lower_bound_expr = parse_expr(
-                "quantileExact({level})(entity_metrics.value)",
+                "quantileExact({level})(entity_metrics.value) OVER ()",
                 placeholders={"level": ast.Constant(value=self._b.metric.lower_bound_percentile)},
             )
         else:
-            lower_bound_expr = parse_expr("min(entity_metrics.value)")
+            lower_bound_expr = parse_expr("min(entity_metrics.value) OVER ()")
 
         # Build upper bound expression
         if self._b.metric.upper_bound_percentile is not None:
             # Handle ignore_zeros flag for upper bound calculation
             if getattr(self._b.metric, "ignore_zeros", False):
                 upper_bound_expr = parse_expr(
-                    "quantileExact({level})(if(entity_metrics.value != 0, entity_metrics.value, null))",
+                    "quantileExact({level})(if(entity_metrics.value != 0, entity_metrics.value, null)) OVER ()",
                     placeholders={"level": ast.Constant(value=self._b.metric.upper_bound_percentile)},
                 )
             else:
                 upper_bound_expr = parse_expr(
-                    "quantileExact({level})(entity_metrics.value)",
+                    "quantileExact({level})(entity_metrics.value) OVER ()",
                     placeholders={"level": ast.Constant(value=self._b.metric.upper_bound_percentile)},
                 )
         else:
-            upper_bound_expr = parse_expr("max(entity_metrics.value)")
+            upper_bound_expr = parse_expr("max(entity_metrics.value) OVER ()")
+
+        # Partition the bound windows by breakdown so each group is capped at
+        # its own threshold (pooled across variations), matching the old
+        # per-breakdown percentiles GROUP BY.
+        apply_winsorization_breakdown_partitioning(self._b.breakdowns, lower_bound_expr, upper_bound_expr)
 
         common_ctes = self.get_mean_query_common_ctes()
         placeholders = self.get_mean_query_common_placeholders()
@@ -351,24 +363,13 @@ class MeanQueryBuilder:
             f"""
             WITH {common_ctes},
 
-            percentiles AS (
-                SELECT
-                    {{lower_bound}} AS lower_bound,
-                    {{upper_bound}} AS upper_bound
-                    -- breakdown columns added programmatically below
-                FROM entity_metrics
-                -- GROUP BY added programmatically below if breakdowns exist
-            ),
-
             winsorized_entity_metrics AS (
                 SELECT
                     entity_metrics.entity_id AS entity_id,
                     entity_metrics.variant AS variant,
-                    least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value{winsorized_cuped_select}
+                    least(greatest({{lower_bound}}, entity_metrics.value), {{upper_bound}}) AS value{winsorized_cuped_select}
                     -- breakdown columns added programmatically below
                 FROM entity_metrics
-                CROSS JOIN percentiles
-                -- JOIN conditions added programmatically below if breakdowns exist
             )
 
             SELECT

--- a/products/experiments/backend/hogql_queries/experiment_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_builder.py
@@ -501,10 +501,12 @@ class ExperimentQueryBuilder:
     def _extend_date_from_for_funnel_cuped(self, date_from: ast.Expr) -> ast.Expr:
         return self._cuped_query_builder().extend_date_from_for_funnel_cuped(date_from)
 
-    def _build_funnel_optimized_temporal_setup(self, is_unordered_funnel: bool) -> tuple[str, str, str]:
+    def _build_funnel_optimized_temporal_setup(
+        self, is_unordered_funnel: bool
+    ) -> tuple[str, str, str, dict[str, ast.Expr]]:
         """
-        Returns (first_exposures_cte_str, temporal_join, having_clause) for the
-        optimized funnel query.
+        Returns (first_exposures_cte_str, temporal_join, having_clause,
+        extra_placeholders) for the optimized funnel query.
 
         Three call sites collapse into one place:
 
@@ -846,9 +848,10 @@ class ExperimentQueryBuilder:
 
         Structure:
         - exposures: all exposures with variant assignment
-        - start_events: when each entity performed the start_event (with start_handling logic)
+        - start_events: when each entity performed the start_event (with start_handling logic),
+                        joined to exposures once and carrying variant through
         - completion_events: when each entity performed the completion_event
-        - entity_metrics: join exposures + start_events + completion_events
+        - entity_metrics: join start_events + completion_events
                           Calculate retention per entity (1 if retained, 0 if not)
         - Final SELECT: aggregated statistics per variant
 

--- a/products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_ratio_query_builder.py
@@ -5,6 +5,7 @@ from posthog.schema import ExperimentDataWarehouseNode, ExperimentMetricOutlierH
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
 
+from products.experiments.backend.hogql_queries.base_query_utils import apply_winsorization_breakdown_partitioning
 from products.experiments.backend.hogql_queries.metric_source import MetricSourceInfo
 
 if TYPE_CHECKING:
@@ -87,7 +88,12 @@ class RatioQueryBuilder:
         value_field: str,
     ) -> tuple[ast.Expr, ast.Expr]:
         """
-        Build (lower_bound, upper_bound) expressions over entity_metrics.<value_field>.
+        Build (lower_bound, upper_bound) window expressions over entity_metrics.<value_field>.
+
+        The bounds are window aggregates (``... OVER ()``) computed in the same pass
+        that reads entity_metrics, instead of a separate percentiles CTE: ClickHouse
+        executes a CTE once per reference, so the CTE + CROSS JOIN shape ran the whole
+        entity_metrics chain (including its events scans) twice.
 
         When a bound is not configured the threshold falls back to min()/max() so the
         least(greatest(...)) clamp becomes a no-op for that side. This lets the numerator
@@ -103,25 +109,25 @@ class RatioQueryBuilder:
 
         if lower_pct is not None:
             lower_bound_expr = parse_expr(
-                f"quantileExact({{level}})(entity_metrics.{value_field})",
+                f"quantileExact({{level}})(entity_metrics.{value_field}) OVER ()",
                 placeholders={"level": ast.Constant(value=lower_pct)},
             )
         else:
-            lower_bound_expr = parse_expr(f"min(entity_metrics.{value_field})")
+            lower_bound_expr = parse_expr(f"min(entity_metrics.{value_field}) OVER ()")
 
         if upper_pct is not None:
             if ignore_zeros:
                 upper_bound_expr = parse_expr(
-                    f"quantileExact({{level}})(if(entity_metrics.{value_field} != 0, entity_metrics.{value_field}, null))",
+                    f"quantileExact({{level}})(if(entity_metrics.{value_field} != 0, entity_metrics.{value_field}, null)) OVER ()",
                     placeholders={"level": ast.Constant(value=upper_pct)},
                 )
             else:
                 upper_bound_expr = parse_expr(
-                    f"quantileExact({{level}})(entity_metrics.{value_field})",
+                    f"quantileExact({{level}})(entity_metrics.{value_field}) OVER ()",
                     placeholders={"level": ast.Constant(value=upper_pct)},
                 )
         else:
-            upper_bound_expr = parse_expr(f"max(entity_metrics.{value_field})")
+            upper_bound_expr = parse_expr(f"max(entity_metrics.{value_field}) OVER ()")
 
         return lower_bound_expr, upper_bound_expr
 
@@ -147,6 +153,16 @@ class RatioQueryBuilder:
             self._b.metric.denominator_outlier_handling, "denominator_value"
         )
 
+        # Partition the bound windows by breakdown so each group is capped at
+        # its own threshold (pooled across variations).
+        apply_winsorization_breakdown_partitioning(
+            self._b.breakdowns,
+            num_lower_bound,
+            num_upper_bound,
+            denom_lower_bound,
+            denom_upper_bound,
+        )
+
         placeholders["numerator_lower_bound"] = num_lower_bound
         placeholders["numerator_upper_bound"] = num_upper_bound
         placeholders["denominator_lower_bound"] = denom_lower_bound
@@ -156,27 +172,14 @@ class RatioQueryBuilder:
             f"""
             WITH {common_ctes},
 
-            percentiles AS (
-                SELECT
-                    {{numerator_lower_bound}} AS numerator_lower_bound,
-                    {{numerator_upper_bound}} AS numerator_upper_bound,
-                    {{denominator_lower_bound}} AS denominator_lower_bound,
-                    {{denominator_upper_bound}} AS denominator_upper_bound
-                    -- breakdown columns added programmatically below
-                FROM entity_metrics
-                -- GROUP BY added programmatically below if breakdowns exist
-            ),
-
             winsorized_entity_metrics AS (
                 SELECT
                     entity_metrics.entity_id AS entity_id,
                     entity_metrics.variant AS variant,
-                    least(greatest(percentiles.numerator_lower_bound, entity_metrics.numerator_value), percentiles.numerator_upper_bound) AS numerator_value,
-                    least(greatest(percentiles.denominator_lower_bound, entity_metrics.denominator_value), percentiles.denominator_upper_bound) AS denominator_value
+                    least(greatest({{numerator_lower_bound}}, entity_metrics.numerator_value), {{numerator_upper_bound}}) AS numerator_value,
+                    least(greatest({{denominator_lower_bound}}, entity_metrics.denominator_value), {{denominator_upper_bound}}) AS denominator_value
                     -- breakdown columns added programmatically below
                 FROM entity_metrics
-                CROSS JOIN percentiles
-                -- JOIN conditions added programmatically below if breakdowns exist
             )
 
             SELECT

--- a/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
+++ b/products/experiments/backend/hogql_queries/experiment_retention_query_builder.py
@@ -107,9 +107,10 @@ class RetentionQueryBuilder:
 
         Structure:
         - exposures: all exposures with variant assignment
-        - start_events: when each entity performed the start_event (with start_handling logic)
+        - start_events: when each entity performed the start_event (with start_handling logic),
+                        joined to exposures once and carrying variant through
         - completion_events: when each entity performed the completion_event
-        - entity_metrics: join exposures + start_events + completion_events
+        - entity_metrics: join start_events + completion_events
                           Calculate retention per entity (1 if retained, 0 if not)
         - Final SELECT: aggregated statistics per variant
 
@@ -121,7 +122,15 @@ class RetentionQueryBuilder:
         """
         assert isinstance(self._b.metric, ExperimentRetentionMetric)
 
-        # Build the CTEs
+        # Build the CTEs.
+        #
+        # ClickHouse executes a CTE once per reference, so exposures (an events
+        # scan plus person joins) must be referenced exactly once. start_events
+        # already joins exposures for the after-exposure filter, so it carries
+        # variant through, and entity_metrics reads start_events instead of
+        # joining exposures again. The INNER JOIN semantics are unchanged: only
+        # entities with a start event count, and exposures has one row per
+        # entity, so grouping by (entity_id, variant) equals grouping by entity.
         common_ctes = """
             exposures AS (
                 {exposure_select_query}
@@ -130,12 +139,13 @@ class RetentionQueryBuilder:
             start_events AS (
                 SELECT
                     exposures.entity_id AS entity_id,
+                    exposures.variant AS variant,
                     {start_timestamp_expr} AS start_timestamp
                 FROM events
                 INNER JOIN exposures ON {entity_key} = exposures.entity_id
                 WHERE {start_event_predicate}
                     AND {start_after_exposure_predicate}
-                GROUP BY exposures.entity_id
+                GROUP BY exposures.entity_id, exposures.variant
             ),
 
             completion_events AS (
@@ -148,8 +158,8 @@ class RetentionQueryBuilder:
 
             entity_metrics AS (
                 SELECT
-                    exposures.entity_id AS entity_id,
-                    exposures.variant AS variant,
+                    start_events.entity_id AS entity_id,
+                    start_events.variant AS variant,
                     MAX(if(
                         completion_events.completion_timestamp IS NOT NULL
                         AND {truncated_completion_timestamp} >= {truncated_start_timestamp} + {retention_window_start_interval}
@@ -157,13 +167,11 @@ class RetentionQueryBuilder:
                         1,
                         0
                     )) AS value
-                FROM exposures
-                INNER JOIN start_events
-                    ON exposures.entity_id = start_events.entity_id
+                FROM start_events
                 LEFT JOIN completion_events
-                    ON exposures.entity_id = completion_events.entity_id
+                    ON start_events.entity_id = completion_events.entity_id
                     AND {completion_retention_window_predicate}
-                GROUP BY exposures.entity_id, exposures.variant
+                GROUP BY start_events.entity_id, start_events.variant
             )
         """
 

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_breakdown.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_breakdown.ambr
@@ -1018,19 +1018,12 @@
      GROUP BY exposures.entity_id,
               exposures.variant,
               exposures.breakdown_value_1),
-       percentiles AS
-    (SELECT quantileExact(0.05)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.95)(entity_metrics.value) AS upper_bound,
-            entity_metrics.breakdown_value_1 AS breakdown_value_1
-     FROM entity_metrics
-     GROUP BY entity_metrics.breakdown_value_1),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value,
+            least(greatest(quantileExact(0.05)(entity_metrics.value) OVER (PARTITION BY entity_metrics.breakdown_value_1), entity_metrics.value), quantileExact(0.95)(entity_metrics.value) OVER (PARTITION BY entity_metrics.breakdown_value_1)) AS value,
             entity_metrics.breakdown_value_1 AS breakdown_value_1
-     FROM entity_metrics
-     JOIN percentiles ON equals(percentiles.breakdown_value_1, entity_metrics.breakdown_value_1))
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          winsorized_entity_metrics.breakdown_value_1 AS breakdown_value_1,
          count(winsorized_entity_metrics.entity_id) AS num_users,
@@ -1704,6 +1697,8 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            exposures.breakdown_value_1 AS breakdown_value_1,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1715,7 +1710,9 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant,
+              exposures.breakdown_value_1),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1729,16 +1726,15 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
-            exposures.breakdown_value_1 AS breakdown_value_1,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
+            start_events.breakdown_value_1 AS breakdown_value_1,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant,
-              exposures.breakdown_value_1)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant,
+              start_events.breakdown_value_1)
   SELECT entity_metrics.variant AS variant,
          entity_metrics.breakdown_value_1 AS breakdown_value_1,
          count(entity_metrics.entity_id) AS num_users,
@@ -1798,6 +1794,8 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            exposures.breakdown_value_1 AS breakdown_value_1,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1809,7 +1807,9 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant,
+              exposures.breakdown_value_1),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1823,16 +1823,15 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
-            exposures.breakdown_value_1 AS breakdown_value_1,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
+            start_events.breakdown_value_1 AS breakdown_value_1,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant,
-              exposures.breakdown_value_1)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant,
+              start_events.breakdown_value_1)
   SELECT entity_metrics.variant AS variant,
          entity_metrics.breakdown_value_1 AS breakdown_value_1,
          count(entity_metrics.entity_id) AS num_users,
@@ -1892,6 +1891,9 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            exposures.breakdown_value_1 AS breakdown_value_1,
+            exposures.breakdown_value_2 AS breakdown_value_2,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1903,7 +1905,10 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant,
+              exposures.breakdown_value_1,
+              exposures.breakdown_value_2),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1917,18 +1922,17 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
-            exposures.breakdown_value_1 AS breakdown_value_1,
-            exposures.breakdown_value_2 AS breakdown_value_2,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
+            start_events.breakdown_value_1 AS breakdown_value_1,
+            start_events.breakdown_value_2 AS breakdown_value_2,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant,
-              exposures.breakdown_value_1,
-              exposures.breakdown_value_2)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant,
+              start_events.breakdown_value_1,
+              start_events.breakdown_value_2)
   SELECT entity_metrics.variant AS variant,
          entity_metrics.breakdown_value_1 AS breakdown_value_1,
          entity_metrics.breakdown_value_2 AS breakdown_value_2,

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_funnel_metric.ambr
@@ -231,11 +231,28 @@
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
      WHERE and(equals(events.team_id, 99999), or(and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test'])), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), or(equals(events.event, '$pageview'), equals(events.event, 'purchase')))))),
        first_exposures AS
-    (SELECT base_events.entity_id AS entity_id,
-            min(toTimeZone(base_events.timestamp, 'UTC')) AS first_exposure_time
-     FROM base_events
-     WHERE equals(base_events.step_0, 1)
-     GROUP BY base_events.entity_id),
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+     GROUP BY entity_id),
        entity_metrics AS
     (SELECT base_events.entity_id AS entity_id,
             if(ifNull(greater(uniqExactIf(base_events.variant_value, equals(base_events.step_0, 1)), 1), 0), '$multiple', anyIf(base_events.variant_value, equals(base_events.step_0, 1))) AS variant,
@@ -641,11 +658,28 @@
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
      WHERE and(equals(events.team_id, 99999), or(and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test'])), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), or(equals(events.event, '$pageview'), equals(events.event, 'purchase')))))),
        first_exposures AS
-    (SELECT base_events.entity_id AS entity_id,
-            min(toTimeZone(base_events.timestamp, 'UTC')) AS first_exposure_time
-     FROM base_events
-     WHERE equals(base_events.step_0, 1)
-     GROUP BY base_events.entity_id),
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+     GROUP BY entity_id),
        entity_metrics AS
     (SELECT base_events.entity_id AS entity_id,
             if(ifNull(greater(uniqExactIf(base_events.variant_value, equals(base_events.step_0, 1)), 1), 0), '$multiple', anyIf(base_events.variant_value, equals(base_events.step_0, 1))) AS variant,
@@ -1591,11 +1625,28 @@
                                                        HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
      WHERE and(equals(events.team_id, 99999), or(and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test'])), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), or(equals(events.event, '$pageview'), equals(events.event, 'purchase')))))),
        first_exposures AS
-    (SELECT base_events.entity_id AS entity_id,
-            min(toTimeZone(base_events.timestamp, 'UTC')) AS first_exposure_time
-     FROM base_events
-     WHERE equals(base_events.step_0, 1)
-     GROUP BY base_events.entity_id),
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+     GROUP BY entity_id),
        entity_metrics AS
     (SELECT base_events.entity_id AS entity_id,
             if(ifNull(greater(uniqExactIf(base_events.variant_value, equals(base_events.step_0, 1)), 1), 0), '$multiple', anyIf(base_events.variant_value, equals(base_events.step_0, 1))) AS variant,

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_mean_metric.ambr
@@ -433,16 +433,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT quantileExact(0.1)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(entity_metrics.value) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(quantileExact(0.1)(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(entity_metrics.value) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -498,16 +493,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT quantileExact(0.1)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(entity_metrics.value) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(quantileExact(0.1)(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(entity_metrics.value) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -711,16 +701,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT quantileExact(0.1)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(entity_metrics.value) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(quantileExact(0.1)(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(entity_metrics.value) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -776,16 +761,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT quantileExact(0.1)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(entity_metrics.value) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(quantileExact(0.1)(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(entity_metrics.value) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -859,16 +839,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT quantileExact(0.1)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(entity_metrics.value) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(quantileExact(0.1)(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(entity_metrics.value) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -924,16 +899,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT quantileExact(0.1)(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(entity_metrics.value) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(quantileExact(0.1)(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(entity_metrics.value) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -1007,16 +977,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT min(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(if(ifNull(notEquals(entity_metrics.value, 0), 1), entity_metrics.value, NULL)) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(min(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(if(ifNull(notEquals(entity_metrics.value, 0), 1), entity_metrics.value, NULL)) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,
@@ -1072,16 +1037,11 @@
      LEFT JOIN metric_events ON and(equals(exposures.entity_id, metric_events.entity_id), greaterOrEquals(toTimeZone(metric_events.timestamp, 'UTC'), exposures.first_exposure_time))
      GROUP BY exposures.entity_id,
               exposures.variant),
-       percentiles AS
-    (SELECT min(entity_metrics.value) AS lower_bound,
-            quantileExact(0.9)(if(ifNull(notEquals(entity_metrics.value, 0), 1), entity_metrics.value, NULL)) AS upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.lower_bound, entity_metrics.value), percentiles.upper_bound) AS value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(min(entity_metrics.value) OVER (), entity_metrics.value), quantileExact(0.9)(if(ifNull(notEquals(entity_metrics.value, 0), 1), entity_metrics.value, NULL)) OVER ()) AS value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.value) AS total_sum,

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_ratio_metric.ambr
@@ -456,19 +456,12 @@
      LEFT JOIN denominator_agg ON equals(exposures.entity_id, denominator_agg.entity_id)
      GROUP BY exposures.variant,
               exposures.entity_id),
-       percentiles AS
-    (SELECT min(entity_metrics.numerator_value) AS numerator_lower_bound,
-            quantileExact(0.9)(entity_metrics.numerator_value) AS numerator_upper_bound,
-            min(entity_metrics.denominator_value) AS denominator_lower_bound,
-            quantileExact(0.9)(entity_metrics.denominator_value) AS denominator_upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.numerator_lower_bound, entity_metrics.numerator_value), percentiles.numerator_upper_bound) AS numerator_value,
-            least(greatest(percentiles.denominator_lower_bound, entity_metrics.denominator_value), percentiles.denominator_upper_bound) AS denominator_value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(min(entity_metrics.numerator_value) OVER (), entity_metrics.numerator_value), quantileExact(0.9)(entity_metrics.numerator_value) OVER ()) AS numerator_value,
+            least(greatest(min(entity_metrics.denominator_value) OVER (), entity_metrics.denominator_value), quantileExact(0.9)(entity_metrics.denominator_value) OVER ()) AS denominator_value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.numerator_value) AS total_sum,
@@ -554,19 +547,12 @@
      LEFT JOIN denominator_agg ON equals(exposures.entity_id, denominator_agg.entity_id)
      GROUP BY exposures.variant,
               exposures.entity_id),
-       percentiles AS
-    (SELECT min(entity_metrics.numerator_value) AS numerator_lower_bound,
-            quantileExact(0.9)(entity_metrics.numerator_value) AS numerator_upper_bound,
-            min(entity_metrics.denominator_value) AS denominator_lower_bound,
-            quantileExact(0.9)(entity_metrics.denominator_value) AS denominator_upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.numerator_lower_bound, entity_metrics.numerator_value), percentiles.numerator_upper_bound) AS numerator_value,
-            least(greatest(percentiles.denominator_lower_bound, entity_metrics.denominator_value), percentiles.denominator_upper_bound) AS denominator_value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(min(entity_metrics.numerator_value) OVER (), entity_metrics.numerator_value), quantileExact(0.9)(entity_metrics.numerator_value) OVER ()) AS numerator_value,
+            least(greatest(min(entity_metrics.denominator_value) OVER (), entity_metrics.denominator_value), quantileExact(0.9)(entity_metrics.denominator_value) OVER ()) AS denominator_value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.numerator_value) AS total_sum,
@@ -670,19 +656,12 @@
      LEFT JOIN denominator_agg ON equals(exposures.entity_id, denominator_agg.entity_id)
      GROUP BY exposures.variant,
               exposures.entity_id),
-       percentiles AS
-    (SELECT min(entity_metrics.numerator_value) AS numerator_lower_bound,
-            quantileExact(0.9)(entity_metrics.numerator_value) AS numerator_upper_bound,
-            min(entity_metrics.denominator_value) AS denominator_lower_bound,
-            max(entity_metrics.denominator_value) AS denominator_upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.numerator_lower_bound, entity_metrics.numerator_value), percentiles.numerator_upper_bound) AS numerator_value,
-            least(greatest(percentiles.denominator_lower_bound, entity_metrics.denominator_value), percentiles.denominator_upper_bound) AS denominator_value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(min(entity_metrics.numerator_value) OVER (), entity_metrics.numerator_value), quantileExact(0.9)(entity_metrics.numerator_value) OVER ()) AS numerator_value,
+            least(greatest(min(entity_metrics.denominator_value) OVER (), entity_metrics.denominator_value), max(entity_metrics.denominator_value) OVER ()) AS denominator_value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.numerator_value) AS total_sum,
@@ -768,19 +747,12 @@
      LEFT JOIN denominator_agg ON equals(exposures.entity_id, denominator_agg.entity_id)
      GROUP BY exposures.variant,
               exposures.entity_id),
-       percentiles AS
-    (SELECT min(entity_metrics.numerator_value) AS numerator_lower_bound,
-            quantileExact(0.9)(entity_metrics.numerator_value) AS numerator_upper_bound,
-            min(entity_metrics.denominator_value) AS denominator_lower_bound,
-            max(entity_metrics.denominator_value) AS denominator_upper_bound
-     FROM entity_metrics),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.numerator_lower_bound, entity_metrics.numerator_value), percentiles.numerator_upper_bound) AS numerator_value,
-            least(greatest(percentiles.denominator_lower_bound, entity_metrics.denominator_value), percentiles.denominator_upper_bound) AS denominator_value
-     FROM entity_metrics
-     CROSS JOIN percentiles)
+            least(greatest(min(entity_metrics.numerator_value) OVER (), entity_metrics.numerator_value), quantileExact(0.9)(entity_metrics.numerator_value) OVER ()) AS numerator_value,
+            least(greatest(min(entity_metrics.denominator_value) OVER (), entity_metrics.denominator_value), max(entity_metrics.denominator_value) OVER ()) AS denominator_value
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          count(winsorized_entity_metrics.entity_id) AS num_users,
          sum(winsorized_entity_metrics.numerator_value) AS total_sum,
@@ -887,22 +859,13 @@
      GROUP BY exposures.variant,
               exposures.entity_id,
               exposures.breakdown_value_1),
-       percentiles AS
-    (SELECT min(entity_metrics.numerator_value) AS numerator_lower_bound,
-            quantileExact(0.95)(entity_metrics.numerator_value) AS numerator_upper_bound,
-            min(entity_metrics.denominator_value) AS denominator_lower_bound,
-            max(entity_metrics.denominator_value) AS denominator_upper_bound,
-            entity_metrics.breakdown_value_1 AS breakdown_value_1
-     FROM entity_metrics
-     GROUP BY entity_metrics.breakdown_value_1),
        winsorized_entity_metrics AS
     (SELECT entity_metrics.entity_id AS entity_id,
             entity_metrics.variant AS variant,
-            least(greatest(percentiles.numerator_lower_bound, entity_metrics.numerator_value), percentiles.numerator_upper_bound) AS numerator_value,
-            least(greatest(percentiles.denominator_lower_bound, entity_metrics.denominator_value), percentiles.denominator_upper_bound) AS denominator_value,
+            least(greatest(min(entity_metrics.numerator_value) OVER (PARTITION BY entity_metrics.breakdown_value_1), entity_metrics.numerator_value), quantileExact(0.95)(entity_metrics.numerator_value) OVER (PARTITION BY entity_metrics.breakdown_value_1)) AS numerator_value,
+            least(greatest(min(entity_metrics.denominator_value) OVER (PARTITION BY entity_metrics.breakdown_value_1), entity_metrics.denominator_value), max(entity_metrics.denominator_value) OVER (PARTITION BY entity_metrics.breakdown_value_1)) AS denominator_value,
             entity_metrics.breakdown_value_1 AS breakdown_value_1
-     FROM entity_metrics
-     JOIN percentiles ON equals(percentiles.breakdown_value_1, entity_metrics.breakdown_value_1))
+     FROM entity_metrics)
   SELECT winsorized_entity_metrics.variant AS variant,
          winsorized_entity_metrics.breakdown_value_1 AS breakdown_value_1,
          count(winsorized_entity_metrics.entity_id) AS num_users,

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_retention_metric.ambr
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/__snapshots__/test_retention_metric.ambr
@@ -30,6 +30,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -41,7 +42,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -55,14 +57,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -101,6 +102,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -112,7 +114,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -126,14 +129,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -190,6 +192,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -201,7 +204,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(259200))), equals(events.event, 'signup')), and(greaterOrEquals(events.timestamp, exposures.first_exposure_time), lessOrEquals(events.timestamp, plus(exposures.first_exposure_time, toIntervalSecond(259200)))))
-     GROUP BY exposures.entity_id
+     GROUP BY exposures.entity_id,
+              exposures.variant
      HAVING lessOrEquals(plus(min(toTimeZone(events.timestamp, 'UTC')), toIntervalSecond(604800)), parseDateTime64BestEffortOrNull('2020-01-25 12:00:00', 6, 'UTC'))),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -216,14 +220,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(864000))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -262,6 +265,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -273,7 +277,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(259200))), equals(events.event, 'signup')), and(greaterOrEquals(events.timestamp, exposures.first_exposure_time), lessOrEquals(events.timestamp, plus(exposures.first_exposure_time, toIntervalSecond(259200)))))
-     GROUP BY exposures.entity_id
+     GROUP BY exposures.entity_id,
+              exposures.variant
      HAVING lessOrEquals(plus(min(toTimeZone(events.timestamp, 'UTC')), toIntervalSecond(604800)), parseDateTime64BestEffortOrNull('2020-01-25 12:00:00', 6, 'UTC'))),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -288,14 +293,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(864000))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -352,6 +356,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -363,7 +368,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id
+     GROUP BY exposures.entity_id,
+              exposures.variant
      HAVING lessOrEquals(plus(min(toTimeZone(events.timestamp, 'UTC')), toIntervalSecond(604800)), parseDateTime64BestEffortOrNull('2020-01-25 12:00:00', 6, 'UTC'))),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -378,14 +384,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -424,6 +429,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -435,7 +441,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id
+     GROUP BY exposures.entity_id,
+              exposures.variant
      HAVING lessOrEquals(plus(min(toTimeZone(events.timestamp, 'UTC')), toIntervalSecond(604800)), parseDateTime64BestEffortOrNull('2020-01-25 12:00:00', 6, 'UTC'))),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -450,14 +457,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -514,6 +520,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -525,7 +532,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id
+     GROUP BY exposures.entity_id,
+              exposures.variant
      HAVING lessOrEquals(plus(min(toTimeZone(events.timestamp, 'UTC')), toIntervalSecond(604800)), parseDateTime64BestEffortOrNull('2020-01-25 12:00:00', 6, 'UTC'))),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -540,14 +548,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -586,6 +593,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -597,7 +605,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id
+     GROUP BY exposures.entity_id,
+              exposures.variant
      HAVING lessOrEquals(plus(min(toTimeZone(events.timestamp, 'UTC')), toIntervalSecond(604800)), parseDateTime64BestEffortOrNull('2020-01-25 12:00:00', 6, 'UTC'))),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -612,14 +621,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-25 00:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -676,6 +684,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -687,7 +696,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -701,14 +711,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'first_action'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(0))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(0))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(86400)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(86400)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -747,6 +756,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -758,7 +768,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -772,14 +783,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'first_action'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(0))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(0))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(86400)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(86400)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -836,6 +846,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -847,7 +858,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -861,14 +873,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -924,6 +935,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             max(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -935,7 +947,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -949,14 +962,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1012,6 +1024,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1023,7 +1036,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1037,14 +1051,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1100,6 +1113,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             max(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1111,7 +1125,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1125,14 +1140,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1188,6 +1202,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1199,7 +1214,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'session_start')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1213,14 +1229,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'key_action'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfHour(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfHour(start_events.start_timestamp), toIntervalHour(0))), 0), ifNull(lessOrEquals(toStartOfHour(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfHour(start_events.start_timestamp), toIntervalHour(0))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(3600)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(3600)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1259,6 +1274,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1270,7 +1286,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'session_start')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1284,14 +1301,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'key_action'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfHour(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfHour(start_events.start_timestamp), toIntervalHour(0))), 0), ifNull(lessOrEquals(toStartOfHour(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfHour(start_events.start_timestamp), toIntervalHour(0))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(3600)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(3600)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1348,6 +1364,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1359,7 +1376,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1373,14 +1391,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1419,6 +1436,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1430,7 +1448,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1444,14 +1463,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1508,6 +1526,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1519,7 +1538,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'app_open')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1533,14 +1553,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'feature_used'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1579,6 +1598,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1590,7 +1610,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'app_open')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1604,14 +1625,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'feature_used'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1668,6 +1688,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1679,7 +1700,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1693,14 +1715,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1739,6 +1760,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1750,7 +1772,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1764,14 +1787,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'purchase'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1828,6 +1850,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1839,7 +1862,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1853,14 +1877,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -1916,6 +1939,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -1927,7 +1951,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -1941,14 +1966,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'login'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -2004,6 +2028,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -2015,7 +2040,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'action_performed')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -2029,14 +2055,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'action_performed'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -2075,6 +2100,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -2086,7 +2112,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'action_performed')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -2100,14 +2127,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2020-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC')), toIntervalSecond(604800))), equals(events.event, 'action_performed'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(691200)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -2164,6 +2190,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -2175,7 +2202,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -2189,14 +2217,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(1209600))), equals(events.event, 'return_visit'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(14))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(1296000)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(1296000)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -2235,6 +2262,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -2246,7 +2274,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(0))), equals(events.event, 'signup')), greaterOrEquals(events.timestamp, exposures.first_exposure_time))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -2260,14 +2289,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(1209600))), equals(events.event, 'return_visit'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(7))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(14))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(1296000)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(1296000)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -2324,6 +2352,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -2335,7 +2364,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(7200))), equals(events.event, 'signup')), and(greaterOrEquals(events.timestamp, exposures.first_exposure_time), lessOrEquals(events.timestamp, plus(exposures.first_exposure_time, toIntervalSecond(7200)))))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -2349,14 +2379,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 12:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(266400))), equals(events.event, 'return_visit'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(3))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(345600)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(345600)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,
@@ -2395,6 +2424,7 @@
      GROUP BY entity_id),
        start_events AS
     (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
             min(toTimeZone(events.timestamp, 'UTC')) AS start_timestamp
      FROM events
      LEFT OUTER JOIN
@@ -2406,7 +2436,8 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      INNER JOIN exposures ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposures.entity_id)
      WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(7200))), equals(events.event, 'signup')), and(greaterOrEquals(events.timestamp, exposures.first_exposure_time), lessOrEquals(events.timestamp, plus(exposures.first_exposure_time, toIntervalSecond(7200)))))
-     GROUP BY exposures.entity_id),
+     GROUP BY exposures.entity_id,
+              exposures.variant),
        completion_events AS
     (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
             toTimeZone(events.timestamp, 'UTC') AS completion_timestamp
@@ -2420,14 +2451,13 @@
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
      WHERE and(equals(events.team_id, 99999), greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), less(events.timestamp, plus(assumeNotNull(toDateTime('2024-01-15 12:00:00', 'UTC')), toIntervalSecond(266400))), equals(events.event, 'return_visit'))),
        entity_metrics AS
-    (SELECT exposures.entity_id AS entity_id,
-            exposures.variant AS variant,
+    (SELECT start_events.entity_id AS entity_id,
+            start_events.variant AS variant,
             max(if(and(isNotNull(toTimeZone(completion_events.completion_timestamp, 'UTC')), ifNull(greaterOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(1))), 0), ifNull(lessOrEquals(toStartOfDay(toTimeZone(completion_events.completion_timestamp, 'UTC')), plus(toStartOfDay(start_events.start_timestamp), toIntervalDay(3))), 0)), 1, 0)) AS value
-     FROM exposures
-     INNER JOIN start_events ON equals(exposures.entity_id, start_events.entity_id)
-     LEFT JOIN completion_events ON and(equals(exposures.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(345600)))))
-     GROUP BY exposures.entity_id,
-              exposures.variant)
+     FROM start_events
+     LEFT JOIN completion_events ON and(equals(start_events.entity_id, completion_events.entity_id), and(greaterOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), start_events.start_timestamp), lessOrEquals(toTimeZone(completion_events.completion_timestamp, 'UTC'), plus(start_events.start_timestamp, toIntervalSecond(345600)))))
+     GROUP BY start_events.entity_id,
+              start_events.variant)
   SELECT entity_metrics.variant AS variant,
          count(entity_metrics.entity_id) AS num_users,
          sum(entity_metrics.value) AS total_sum,


### PR DESCRIPTION
_This PR results from running the optimizing-clickhouse-and-hogql-queries skill as requested here: [posthog.slack.com/archives/C02E3BKC78F/p1780996999377719](https://posthog.slack.com/archives/C02E3BKC78F/p1780996999377719)_

## Problem

ClickHouse executes a CTE once per reference, and several experiment query builders reference scan-heavy CTEs more than once — a winsorized ratio metric executed 10 events scans per query. Each duplicated exposure scan also repeats its `person_distinct_id_overrides` join, plus the `person` join when test-account filters use person properties.

## Changes

- Winsorization bounds are window aggregates computed in the same pass (`quantileExact(p)(value) OVER ()`, partitioned by breakdown columns when breakdowns are configured), replacing the `percentiles` CTE + `CROSS JOIN` that re-ran the whole `entity_metrics` chain
- Retention carries `variant` and breakdown columns through `start_events`, so `exposures` is referenced once
- Unordered/CUPED funnels build `first_exposures` from an exposure-only events scan instead of re-reading `base_events` (`base_events WHERE step_0 = 1` is by construction `events WHERE exposure_predicate`)
- Adds a learnings entry to the `optimizing-clickhouse-and-hogql-queries` skill

Events scans per query:

| Query | Before | After |
| --- | --- | --- |
| Funnel optimized, ordered | 1 | 1 |
| Funnel optimized, unordered or CUPED | 2× full OR-scan | 1× OR-scan + 1× exposure-only scan |
| Mean | 2 | 2 |
| Retention | 4 | 3 |
| Ratio | 5 | 5 (follow-up PR: 2–3) |
| Mean, winsorized | 4 | 2 |
| Ratio, winsorized | 10 | 5 |

## How did you test this code?

Agent-authored; automated tests only. Old vs new shapes return identical results on local ClickHouse, with winsorized read rows/bytes exactly halved (median of 5, `use_uncompressed_cache=0`). All experiment query-runner suites pass — 295 tests including numeric result assertions — and snapshot diffs were reviewed. mypy and ruff clean. 8 pre-existing failures in `test_experiment_actors_query.py` reproduce on a clean tree (local personhog environment issue, path untouched).

At-scale memory of the winsorized window aggregate (buffers the full partition) hasn't been measured on a large team yet — pending Test Cluster validation.

Follow-ups:

- Combine ratio numerator + denominator into one conditional-aggregation scan (5 → 2–3 scans), measured locally at 38–58% fewer read rows, pending Test Cluster validation

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code ran the `optimizing-clickhouse-and-hogql-queries` skill over `products/experiments/backend/hogql_queries/`. CTE re-execution was verified with EXPLAIN (5 `ReadFromMergeTree` nodes for the ratio shape) before changing anything; each rewrite was measured against the original shape on local ClickHouse with identical results. Deferred: the ratio combined-scan restructure (needs Test Cluster validation and a design for mixed data-warehouse sources) and a single-scan unordered funnel via `arrayFilter` (memory trade-off unmeasured).
