### PR TITLE
fix(experiments): discard stale search responses to prevent UI race

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -115,15 +115,18 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         sharedMetricsResponse: [
             null as CountedPaginatedResponse<SharedMetric> | null,
             {
-                loadSharedMetrics: async () => {
+                loadSharedMetrics: async (_, breakpoint) => {
                     const params = toParams({
                         limit: MODAL_PAGE_SIZE,
                         offset: 0,
                         search: values.searchTerm || undefined,
                     })
-                    return (await api.get(
+                    const response = (await api.get(
                         `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
                     )) as CountedPaginatedResponse<SharedMetric>
+                    // Discard stale responses that resolve after a newer search has fired
+                    breakpoint()
+                    return response
                 },
                 // Page through every remaining result so the tag filter and tag chip list cover the
                 // whole set of shared metrics, not just the first page rendered in the table.

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricModalLogic.ts
@@ -115,7 +115,7 @@ export const sharedMetricModalLogic = kea<sharedMetricModalLogicType>([
         sharedMetricsResponse: [
             null as CountedPaginatedResponse<SharedMetric> | null,
             {
-                loadSharedMetrics: async (_, breakpoint) => {
+                loadSharedMetrics: async (_: void, breakpoint) => {
                     const params = toParams({
                         limit: MODAL_PAGE_SIZE,
                         offset: 0,

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -58,7 +58,7 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
         sharedMetrics: [
             [] as SharedMetric[],
             {
-                loadSharedMetrics: async (_, breakpoint) => {
+                loadSharedMetrics: async (_: void, breakpoint) => {
                     const params = toParams({
                         limit: PAGE_SIZE,
                         offset: (values.page - 1) * PAGE_SIZE,

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricsLogic.tsx
@@ -58,7 +58,7 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
         sharedMetrics: [
             [] as SharedMetric[],
             {
-                loadSharedMetrics: async () => {
+                loadSharedMetrics: async (_, breakpoint) => {
                     const params = toParams({
                         limit: PAGE_SIZE,
                         offset: (values.page - 1) * PAGE_SIZE,
@@ -67,6 +67,8 @@ export const sharedMetricsLogic = kea<sharedMetricsLogicType>([
                     const response: CountedPaginatedResponse<SharedMetric> = await api.get(
                         `api/projects/${values.currentProjectId}/experiment_saved_metrics?${params}`
                     )
+                    // Discard stale responses that resolve after a newer search has fired
+                    breakpoint()
                     actions.setCount(response.count)
                     return response.results
                 },

--- a/frontend/src/scenes/experiments/experimentsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.test.ts
@@ -273,6 +273,35 @@ describe('experimentsLogic', () => {
             expect(api.get).toHaveBeenCalledWith(expect.stringContaining('archived=true'))
         })
 
+        it('discards a stale search response that resolves after a newer one', async () => {
+            api.get.mockClear()
+
+            const staleExperiment = createMockExperiment({ id: 10, name: 'wat' })
+            const freshExperiment = createMockExperiment({ id: 20, name: 'watermark' })
+
+            let resolveStale: (value: unknown) => void = () => {}
+            api.get.mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveStale = resolve
+                    })
+            )
+            api.get.mockResolvedValueOnce({ results: [freshExperiment], count: 1 })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadExperiments() // slow request, e.g. search for "wat"
+                logic.actions.loadExperiments() // fast request, e.g. search for "watermark"
+            }).toDispatchActions(['loadExperimentsSuccess'])
+
+            expect(logic.values.experiments.results).toEqual([freshExperiment])
+
+            // The slow, stale response arrives after the newer one — it must be discarded
+            resolveStale({ results: [staleExperiment], count: 1 })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.experiments.results).toEqual([freshExperiment])
+        })
+
         it('constructs correct params from filters', () => {
             logic.actions.setExperimentsFilters({
                 search: 'test',

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -269,10 +269,12 @@ export const experimentsLogic = kea<experimentsLogicType>([
         experiments: [
             { results: [], count: 0, filters: DEFAULT_FILTERS, offset: 0 } as ExperimentsResult,
             {
-                loadExperiments: async () => {
+                loadExperiments: async (_, breakpoint) => {
                     const response = await api.get(
                         `api/projects/${values.currentProjectId}/experiments?${toParams(values.paramsFromFilters)}`
                     )
+                    // Discard stale responses that resolve after a newer search has fired
+                    breakpoint()
                     return {
                         ...response,
                         offset: values.paramsFromFilters.offset,
@@ -370,12 +372,14 @@ export const experimentsLogic = kea<experimentsLogicType>([
         featureFlagModalFeatureFlags: [
             { results: [], count: 0 } as { results: FeatureFlagType[]; count: number },
             {
-                loadFeatureFlagModalFeatureFlags: async () => {
+                loadFeatureFlagModalFeatureFlags: async (_, breakpoint) => {
                     const response = await api.get(
                         `api/projects/${values.currentProjectId}/experiments/eligible_feature_flags/?${toParams({
                             ...values.featureFlagModalParamsFromFilters,
                         })}`
                     )
+                    // Discard stale responses that resolve after a newer search has fired
+                    breakpoint()
                     return response
                 },
             },

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -269,7 +269,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
         experiments: [
             { results: [], count: 0, filters: DEFAULT_FILTERS, offset: 0 } as ExperimentsResult,
             {
-                loadExperiments: async (_, breakpoint) => {
+                loadExperiments: async (_: void, breakpoint) => {
                     const response = await api.get(
                         `api/projects/${values.currentProjectId}/experiments?${toParams(values.paramsFromFilters)}`
                     )
@@ -372,7 +372,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
         featureFlagModalFeatureFlags: [
             { results: [], count: 0 } as { results: FeatureFlagType[]; count: number },
             {
-                loadFeatureFlagModalFeatureFlags: async (_, breakpoint) => {
+                loadFeatureFlagModalFeatureFlags: async (_: void, breakpoint) => {
                     const response = await api.get(
                         `api/projects/${values.currentProjectId}/experiments/eligible_feature_flags/?${toParams({
                             ...values.featureFlagModalParamsFromFilters,


### PR DESCRIPTION
## Problem

Searching the experiments list fires one request per debounced keystroke, but responses are applied in arrival order. A slow response for an earlier query (e.g. "wat") can land after the response for a later query ("watermark") and overwrite it — the list refreshes right as the user is about to click a result, so they click the wrong item.

## Changes

Add a kea-loaders `breakpoint()` after each search-driven fetch, so a response is discarded if a newer request was dispatched while it was in flight:

- `experimentsLogic`: `loadExperiments`, `loadFeatureFlagModalFeatureFlags`
- `sharedMetricsLogic`: `loadSharedMetrics`
- `sharedMetricModalLogic`: `loadSharedMetrics` (its `loadAllSharedMetrics` already did this)

## How did you test this code?

Added a regression test that resolves an older `loadExperiments` response after a newer one and asserts the stale result is discarded — verified it fails without the fix. All three affected logic test suites pass (54 tests), plus a full TypeScript check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a customer report of search results flickering. Root cause: search loaders applied responses in arrival order with no staleness check. Fix follows the established breakpoint pattern already used by `loadAllSharedMetrics` in the same scene; no API or behavior changes beyond dropping out-of-date responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
