### PR TITLE
fix(mcp-analytics): cap tool error-rate card and match neighbour height

### DIFF
--- a/products/mcp_analytics/frontend/dashboard/NotableSessionsTable.tsx
+++ b/products/mcp_analytics/frontend/dashboard/NotableSessionsTable.tsx
@@ -95,7 +95,7 @@ export function NotableSessionsTable({
     loading: boolean
 }): JSX.Element {
     return (
-        <Card size="sm" className="self-start gap-0">
+        <Card size="sm" className="gap-0">
             <CardHeader className="border-b border-border pb-3">
                 <CardTitle>Sessions flagged for review</CardTitle>
             </CardHeader>

--- a/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
@@ -12,11 +12,11 @@ import {
 
 import { formatPercentage } from 'lib/utils'
 
-import { NOTABLE_SESSION_TARGET, type ToolRow } from '../mcpDashboardOverviewLogic'
+import { type ToolRow } from '../mcpDashboardOverviewLogic'
 import { Card, CardState } from './Card'
 import { ChartTooltip } from './ChartTooltip'
 
-const MAX_TOOLS = NOTABLE_SESSION_TARGET
+const MAX_TOOLS = 8
 
 // Upper bound for the error-rate track: a bit above the worst tool's rate, rounded up to a clean 10 —
 // so the track ends just past the data (a 30% max gives a 50% track) rather than an empty-looking 100%.

--- a/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
@@ -12,13 +12,11 @@ import {
 
 import { formatPercentage } from 'lib/utils'
 
-import { type ToolRow } from '../mcpDashboardOverviewLogic'
+import { NOTABLE_SESSION_TARGET, type ToolRow } from '../mcpDashboardOverviewLogic'
 import { Card, CardState } from './Card'
 import { ChartTooltip } from './ChartTooltip'
 
-// Cap the number of tools shown so the card stays compact and matches its neighbour's height —
-// mirrors NOTABLE_SESSION_TARGET so both cards top out at the same number of rows.
-const MAX_TOOLS = 8
+const MAX_TOOLS = NOTABLE_SESSION_TARGET
 
 // Upper bound for the error-rate track: a bit above the worst tool's rate, rounded up to a clean 10 —
 // so the track ends just past the data (a 30% max gives a 50% track) rather than an empty-looking 100%.

--- a/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx
@@ -16,6 +16,10 @@ import { type ToolRow } from '../mcpDashboardOverviewLogic'
 import { Card, CardState } from './Card'
 import { ChartTooltip } from './ChartTooltip'
 
+// Cap the number of tools shown so the card stays compact and matches its neighbour's height —
+// mirrors NOTABLE_SESSION_TARGET so both cards top out at the same number of rows.
+const MAX_TOOLS = 8
+
 // Upper bound for the error-rate track: a bit above the worst tool's rate, rounded up to a clean 10 —
 // so the track ends just past the data (a 30% max gives a 50% track) rather than an empty-looking 100%.
 function niceErrorAxisMax(maxRate: number): number {
@@ -31,7 +35,10 @@ export function ToolErrorRateChart({
     loading: boolean
     theme: ChartTheme
 }): JSX.Element {
-    const sorted = useMemo(() => [...rows].sort((a, b) => b.error_rate_pct - a.error_rate_pct), [rows])
+    const sorted = useMemo(
+        () => [...rows].sort((a, b) => b.error_rate_pct - a.error_rate_pct).slice(0, MAX_TOOLS),
+        [rows]
+    )
     const labels = useMemo(() => sorted.map((r) => r.tool), [sorted])
     const series = useMemo<Series[]>(
         () => [
@@ -91,7 +98,7 @@ export function ToolErrorRateChart({
                 }
                 empty={<div className="py-6 text-center text-[12px] text-secondary">No tool calls yet.</div>}
             >
-                <div className="flex flex-col">
+                <div className="flex flex-1 flex-col">
                     <BarChart series={series} labels={labels} config={config} theme={theme} tooltip={renderTooltip}>
                         <ValueLabels
                             valueFormatter={(value) => formatPercentage(value, { compact: true })}

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -204,7 +204,7 @@ export interface SessionRow {
 export type NotableRule = 'worst_error_rate' | 'all_fail' | 'most_exploratory' | 'exemplar' | 'high_activity'
 
 // Fill the table out to this many rows: the rule-based picks first, then the busiest remaining sessions.
-export const NOTABLE_SESSION_TARGET = 8
+const NOTABLE_SESSION_TARGET = 8
 
 export interface NotableSession {
     rule: NotableRule

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -204,7 +204,7 @@ export interface SessionRow {
 export type NotableRule = 'worst_error_rate' | 'all_fail' | 'most_exploratory' | 'exemplar' | 'high_activity'
 
 // Fill the table out to this many rows: the rule-based picks first, then the busiest remaining sessions.
-const NOTABLE_SESSION_TARGET = 8
+export const NOTABLE_SESSION_TARGET = 8
 
 export interface NotableSession {
     rule: NotableRule


### PR DESCRIPTION
## Problem

In the MCP analytics dashboard ("Last month's usage" section), the **Tools with the highest error rate** card rendered one horizontal bar per tool (with a 30px minimum band) for up to 50 tools. The card grew to roughly 1500px tall, dwarfing the neighbouring **Sessions flagged for review** card, which is capped at 8 rows. The result was a lopsided two-column row with a huge amount of wasted space.

## Changes

In `products/mcp_analytics/frontend/dashboard/ToolErrorRateChart.tsx`:

- Cap the chart to the 8 worst tools by error rate (`MAX_TOOLS = 8`, mirroring `NOTABLE_SESSION_TARGET` so both cards top out at the same number of rows). The SQL query is untouched — the slice happens client-side after sorting by error rate, so we keep the worst offenders.
- Change the chart wrapper to `flex flex-1 flex-col` so the bar chart fills the grid-stretched card height. The neighbouring card now drives the row height and the two cards align.

## How did you test this code?

I'm an agent. I made the change and confirmed it is type-safe (a `.slice()` on the existing `ToolRow[]` and a className change). I could not run `pnpm typescript:check` to completion in this environment because `node_modules` is not installed — the check fails on unrelated `products/workflows/` files (`Cannot find module 'kea'`), and nothing in the failures touches this file. No automated tests cover this presentational component; visual verification in a running dashboard is still recommended.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tooling: Claude Code (Opus 4.8). The human asked to fix the over-sized error-rate card and make it match the neighbouring card's height. Approach chosen: cap the displayed tools client-side (keeps the worst-by-error-rate selection in one place rather than re-ordering the `LIMIT 50` query, which sorts by call volume) and rely on the grid's default stretch plus `flex-1` to equalise heights — consistent with the existing height-fill pattern in `HarnessDonut.tsx` and `ToolUsageChart.tsx`.
