### PR TITLE
feat(mcp-analytics): redirect base path to dashboard

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -420,6 +420,8 @@ export const productRedirects: Record<
         combineUrl('/logs/drop-rules/new', searchParams, hashParams).url,
     '/logs/sampling/:id': (params, searchParams, hashParams) =>
         combineUrl(`/logs/drop-rules/${params.id}`, searchParams, hashParams).url,
+    '/mcp-analytics': (_params, searchParams, hashParams) =>
+        combineUrl(urls.mcpAnalyticsDashboard(), searchParams, hashParams).url,
     '/replay-vision/templates': '/replay-vision/new/template',
     '/prompt-management/skills': (_params, searchParams, hashParams) =>
         combineUrl(urls.skills(), searchParams, hashParams).url,

--- a/products/mcp_analytics/manifest.tsx
+++ b/products/mcp_analytics/manifest.tsx
@@ -3,6 +3,8 @@
  *
  * Defines scenes, routes, URLs, and navigation for this product.
  */
+import { combineUrl } from 'kea-router'
+
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
@@ -39,7 +41,10 @@ export const manifest: ProductManifest = {
         '/mcp-analytics/tool-quality/:toolName': ['MCPAnalyticsToolDetail', 'mcpAnalyticsTool'],
         '/mcp-analytics/intent-clustering': ['MCPAnalytics', 'mcpAnalyticsIntentClustering'],
     },
-    redirects: {},
+    redirects: {
+        '/mcp-analytics': (_params, searchParams, hashParams) =>
+            combineUrl(urls.mcpAnalyticsDashboard(), searchParams, hashParams).url,
+    },
     urls: {
         // Define URL helpers here
         mcpAnalyticsDashboard: (): string => '/mcp-analytics/dashboard',


### PR DESCRIPTION
## Problem

Visiting the MCP analytics base path (`/mcp-analytics`) lands on a blank/unmatched route — there's no scene registered for the bare path, only for the per-tab routes (`/mcp-analytics/dashboard`, `/sessions`, etc.). Users (and any internal links to the base path) need a sensible default landing tab.

## Changes

Add a redirect from `/mcp-analytics` to `/mcp-analytics/dashboard` in the product manifest, preserving any query and hash params. Follows the same pattern `ai_observability` uses for its base-path redirect (`combineUrl(...)` from `kea-router`).

The tabs remain route-based (one named route per tab) — see the discussion in the agent context for why we kept that over a `?tab=` query-param approach.

## How did you test this code?

I'm an agent (PostHog Code). I did not run the app manually. This is a one-line routing config change mirroring an existing, exercised pattern in `ai_observability`. No automated tests were added — the change is declarative manifest routing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: PostHog Code (Claude Opus).
- Paul asked for the base-path redirect, then asked whether the scene should move from route-based tabs to `?tab=`. We reviewed canonical scenes — `endpoints` uses `?tab=`, `workflows` uses `/workflows/:tab` — and concluded there's no mandated convention. Recommendation was to keep the existing route-based approach (distinct breadcrumbs/deep-links, `activeTab` derived from `sceneKey`, natural nesting for the tool-detail route) rather than churn to query params. Paul chose to keep it as-is, so this PR is just the redirect.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
