### PR TITLE
fix(error-tracking): break circular import in query runners

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -1,14 +1,14 @@
 name: Agent Skills
 
+# No paths filter on master pushes (matching the other ci-* workflows): the skills build
+# imports product code whose import graph any Python change can affect, so a filtered
+# master trigger lets unrelated commits break the build invisibly until the next
+# skills-path commit takes the blame. PR runs stay filtered via the changes job below.
 on:
     pull_request:
     push:
         branches:
             - master
-        paths:
-            - 'products/*/skills/**'
-            - 'products/posthog_ai/scripts/**'
-            - '.github/workflows/ci-agent-skills.yml'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/products/error_tracking/backend/api/issues.py
+++ b/products/error_tracking/backend/api/issues.py
@@ -24,6 +24,7 @@ from posthog.tasks.email import send_error_tracking_issue_assigned
 
 from products.cohorts.backend.models.cohort import Cohort
 from products.error_tracking.backend.facade import api as facade_api
+from products.error_tracking.backend.issue_serializers import ErrorTrackingIssueAssignmentSerializer
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -33,7 +34,6 @@ from products.error_tracking.backend.models import (
 from products.error_tracking.backend.notifications import dispatch_issue_assigned_realtime
 
 from .external_references import ErrorTrackingExternalReferenceSerializer
-from .utils import ErrorTrackingIssueAssignmentSerializer
 
 IssueNotFoundError = facade_api.IssueNotFoundError
 
@@ -65,15 +65,6 @@ class ErrorTrackingIssueReadSerializer(serializers.Serializer):
     assignee = ErrorTrackingIssueAssigneeReadSerializer(allow_null=True)
     external_issues = ErrorTrackingExternalReferenceSerializer(many=True)
     cohort = ErrorTrackingIssueCohortReadSerializer(allow_null=True)
-
-
-class ErrorTrackingIssuePreviewSerializer(serializers.ModelSerializer):
-    first_seen = serializers.DateTimeField()
-    assignee = ErrorTrackingIssueAssignmentSerializer(source="assignment")
-
-    class Meta:
-        model = ErrorTrackingIssue
-        fields = ["id", "status", "name", "description", "first_seen", "assignee"]
 
 
 DEPRECATED_ISSUE_STATUSES = frozenset({ErrorTrackingIssue.Status.ARCHIVED, ErrorTrackingIssue.Status.PENDING_RELEASE})

--- a/products/error_tracking/backend/api/utils.py
+++ b/products/error_tracking/backend/api/utils.py
@@ -1,8 +1,7 @@
 from typing import Any, Protocol, TypeVar
 
 import structlog
-from drf_spectacular.utils import extend_schema_field
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
@@ -16,28 +15,10 @@ from posthog.api.utils import action
 from posthog.models.team.team import Team
 
 from products.error_tracking.backend.hogvm_stl import RUST_HOGVM_STL
-from products.error_tracking.backend.models import ErrorTrackingIssueAssignment
 
 from common.hogvm.python.operation import Operation
 
 logger = structlog.get_logger(__name__)
-
-
-class ErrorTrackingIssueAssignmentSerializer(serializers.ModelSerializer):
-    id = serializers.SerializerMethodField()
-    type = serializers.SerializerMethodField()
-
-    class Meta:
-        model = ErrorTrackingIssueAssignment
-        fields = ["id", "type"]
-
-    @extend_schema_field({"oneOf": [{"type": "integer"}, {"type": "string"}], "nullable": True})
-    def get_id(self, obj):
-        return obj.user_id if obj.user_id else str(obj.role_id) if obj.role_id else None
-
-    @extend_schema_field(serializers.CharField())
-    def get_type(self, obj):
-        return "role" if obj.role else "user"
 
 
 class HasGetQueryset(Protocol):

--- a/products/error_tracking/backend/hogql_queries/error_tracking_issue_correlation_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_issue_correlation_query_runner.py
@@ -20,7 +20,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
-from products.error_tracking.backend.api.issues import ErrorTrackingIssuePreviewSerializer
+from products.error_tracking.backend.issue_serializers import ErrorTrackingIssuePreviewSerializer
 from products.error_tracking.backend.models import ErrorTrackingIssue
 
 logger = structlog.get_logger(__name__)

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_v1.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner_v1.py
@@ -15,7 +15,6 @@ from posthog.hogql.property import property_to_expr
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.property.util import property_to_django_filter
 
-from products.error_tracking.backend.api.issues import ErrorTrackingIssuePreviewSerializer
 from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_utils import (
     build_event_where_exprs,
     build_select_expressions,
@@ -23,6 +22,7 @@ from products.error_tracking.backend.hogql_queries.error_tracking_query_runner_u
     extract_event,
     order_direction,
 )
+from products.error_tracking.backend.issue_serializers import ErrorTrackingIssuePreviewSerializer
 from products.error_tracking.backend.models import ErrorTrackingIssue
 
 

--- a/products/error_tracking/backend/issue_serializers.py
+++ b/products/error_tracking/backend/issue_serializers.py
@@ -1,0 +1,33 @@
+# These serializers live outside api/ on purpose: the hogql_queries runners need them,
+# and any `api.*` import executes api/__init__.py, whose viewset imports circle back into
+# the runners (api/query.py imports ErrorTrackingQueryRunner).
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueAssignment
+
+
+class ErrorTrackingIssueAssignmentSerializer(serializers.ModelSerializer):
+    id = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ErrorTrackingIssueAssignment
+        fields = ["id", "type"]
+
+    @extend_schema_field({"oneOf": [{"type": "integer"}, {"type": "string"}], "nullable": True})
+    def get_id(self, obj):
+        return obj.user_id if obj.user_id else str(obj.role_id) if obj.role_id else None
+
+    @extend_schema_field(serializers.CharField())
+    def get_type(self, obj):
+        return "role" if obj.role else "user"
+
+
+class ErrorTrackingIssuePreviewSerializer(serializers.ModelSerializer):
+    first_seen = serializers.DateTimeField()
+    assignee = ErrorTrackingIssueAssignmentSerializer(source="assignment")
+
+    class Meta:
+        model = ErrorTrackingIssue
+        fields = ["id", "status", "name", "description", "first_seen", "assignee"]

--- a/products/error_tracking/backend/test/test_import_cycles.py
+++ b/products/error_tracking/backend/test/test_import_cycles.py
@@ -1,0 +1,28 @@
+import sys
+import subprocess
+
+# The skills build (products/posthog_ai/scripts/build_skills.py) imports the query runners
+# in a cold interpreter, before anything has touched the error_tracking api package. If a
+# runner imports from api.*, that executes api/__init__.py, whose viewsets import the
+# runners right back (api/query.py -> ErrorTrackingQueryRunner) and the import blows up
+# with "partially initialized module". Pytest cannot reproduce this in-process — by the
+# time tests run, the modules are already cached — so boot a clean interpreter and import
+# the runners first, like build_skills does.
+_COLD_IMPORT = """
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+import django
+django.setup()
+import products.error_tracking.backend.hogql_queries.error_tracking_query_runner
+import products.error_tracking.backend.hogql_queries.error_tracking_issue_correlation_query_runner
+"""
+
+
+def test_query_runners_import_in_cold_interpreter() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _COLD_IMPORT],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, f"cold import of error_tracking query runners failed:\n{result.stderr[-2000:]}"

--- a/products/error_tracking/backend/test/test_import_cycles.py
+++ b/products/error_tracking/backend/test/test_import_cycles.py
@@ -1,5 +1,11 @@
 import sys
 import subprocess
+from pathlib import Path
+
+# The product-level turbo test task runs pytest from the product directory, and
+# `python -c` puts cwd on sys.path — the subprocess needs the repo root there to
+# find the posthog package.
+_REPO_ROOT = Path(__file__).parents[4]
 
 # The skills build (products/posthog_ai/scripts/build_skills.py) imports the query runners
 # in a cold interpreter, before anything has touched the error_tracking api package. If a
@@ -24,5 +30,6 @@ def test_query_runners_import_in_cold_interpreter() -> None:
         capture_output=True,
         text=True,
         timeout=180,
+        cwd=_REPO_ROOT,
     )
     assert result.returncode == 0, f"cold import of error_tracking query runners failed:\n{result.stderr[-2000:]}"


### PR DESCRIPTION
## Problem

The agent skills build on master crashes with `ImportError: cannot import name 'ErrorTrackingQueryRunner' from partially initialized module` (Check agent skills / Build agent skills / Sandbox base image jobs).

The cycle: a query runner imports `ErrorTrackingIssuePreviewSerializer` from `api.issues`, which executes `api/__init__.py`, whose `api/query.py` viewset imports the query runner right back. The cycle was always there, but eager route registration during `django.setup()` used to fully initialize the api package before anything else touched the runners, masking it. Since #60849 made route registration lazy, `build_skills.py` imports the runners in a cold interpreter where the cycle is live.

## Changes

Instead of papering over it with a function-local import, fix the layering: the shared serializers move to `issue_serializers.py` outside the `api/` package (`ErrorTrackingIssuePreviewSerializer` wasn't even used inside `api/` — only the two query runners consume it). The query layer no longer imports the viewset layer, in both `error_tracking_query_runner_v1` and the correlation runner, which carried the same latent cycle.

Adds a cold-interpreter regression test that imports the runners first, the way `build_skills.py` does. Pytest alone can't catch this class of bug because the modules are already cached by the time tests run.

Also removes the paths filter from the master push trigger in ci-agent-skills.yml — it was the only ci-* workflow filtering master pushes, which is exactly why this breakage sat invisible on master until an unrelated skills-path commit triggered a run and got blamed. PR runs keep their filter via the changes job.

## How did you test this code?

I'm an agent. Automated: new `test_import_cycles.py` passes (and the identical import sequence reproduced the failure before the fix); ruff clean. Manual: verified both import orders (runner-first and api-first) succeed in a fresh interpreter, and `build_skills.py` gets past all imports locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by @webjunkie. Diagnosis confirmed Mendral's incident analysis (circular import exposed by the lazy router change in #60849). Chose a structural fix (move serializers out of `api/`) over Mendral's suggested deferred import, since repo conventions treat inline imports as a last resort and the runner→viewset import edge was backwards anyway.


