### PR TITLE
refactor(tracing): rename TraceFlameChart to TraceWaterfallView

### DIFF
--- a/products/tracing/frontend/TraceCompareFlame.tsx
+++ b/products/tracing/frontend/TraceCompareFlame.tsx
@@ -9,7 +9,7 @@ import { humanFriendlyNumber } from 'lib/utils'
 
 import { SpanTreeNode } from '~/queries/schema/schema-general'
 
-import { formatDuration } from './TraceFlameChart'
+import { formatDuration } from './TraceWaterfallView'
 
 interface TreeNode {
     serviceName: string

--- a/products/tracing/frontend/TraceCompareTable.tsx
+++ b/products/tracing/frontend/TraceCompareTable.tsx
@@ -6,7 +6,7 @@ import { humanFriendlyNumber } from 'lib/utils'
 
 import { AggregatedSpanRow } from '~/queries/schema/schema-general'
 
-import { formatDuration } from './TraceFlameChart'
+import { formatDuration } from './TraceWaterfallView'
 
 interface CompareRow {
     service_name: string

--- a/products/tracing/frontend/TraceWaterfallView.tsx
+++ b/products/tracing/frontend/TraceWaterfallView.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { SPAN_KIND_LABELS, STATUS_CODE_LABELS } from './types'
 import type { Span } from './types'
 
-interface TraceFlameChartProps {
+interface TraceWaterfallViewProps {
     spans: Span[]
 }
 
@@ -145,7 +145,7 @@ const LABEL_COLUMN_WIDTH_STORAGE_KEY = 'tracing-trace-label-width'
 const LABEL_SPLITTER_HIT_PX = 8
 const ROW_HEIGHT = 32
 // Cap the windowed list viewport; taller traces scroll inside it instead of growing the modal.
-const MAX_FLAME_HEIGHT = 600
+const MAX_WATERFALL_HEIGHT = 600
 // Rough extra room reserved when a span's detail panel is open, so a selection near the top of a
 // short trace doesn't pop an unexpected scrollbar.
 const SELECTED_DETAIL_RESERVE = 320
@@ -284,7 +284,7 @@ function SpanDetailPanel({ span }: { span: Span }): JSX.Element {
     )
 }
 
-interface FlameRowData {
+interface WaterfallRowData {
     flatSpans: SpanNode[]
     traceStartUs: number
     traceDurationUs: number
@@ -296,7 +296,7 @@ interface FlameRowData {
     dynamicRowHeight: ReturnType<typeof useDynamicRowHeight>
 }
 
-function FlameRow({
+function WaterfallRow({
     node,
     traceStartUs,
     traceDurationUs,
@@ -305,7 +305,7 @@ function FlameRow({
     labelColumnWidth,
     selectedSpanId,
     onSelect,
-}: Omit<FlameRowData, 'flatSpans' | 'dynamicRowHeight'> & { node: SpanNode }): JSX.Element {
+}: Omit<WaterfallRowData, 'flatSpans' | 'dynamicRowHeight'> & { node: SpanNode }): JSX.Element {
     const { span } = node
     const spanStartUs = parseTimestampUs(span.timestamp)
     const spanDurationUs = span.duration_nano / 1_000
@@ -418,7 +418,7 @@ function FlameRow({
     )
 }
 
-function FlameListRow({
+function WaterfallListRow({
     ariaAttributes,
     index,
     style,
@@ -435,7 +435,7 @@ function FlameListRow({
     ariaAttributes: { 'aria-posinset': number; 'aria-setsize': number; role: 'listitem' }
     index: number
     style: CSSProperties
-} & FlameRowData): JSX.Element {
+} & WaterfallRowData): JSX.Element {
     const rowRef = useRef<HTMLDivElement>(null)
     const node = flatSpans[index]
 
@@ -448,7 +448,7 @@ function FlameListRow({
     return (
         // eslint-disable-next-line react/forbid-dom-props
         <div {...ariaAttributes} ref={rowRef} style={style} data-index={index} data-row-key={node.span.uuid}>
-            <FlameRow
+            <WaterfallRow
                 node={node}
                 traceStartUs={traceStartUs}
                 traceDurationUs={traceDurationUs}
@@ -462,7 +462,7 @@ function FlameListRow({
     )
 }
 
-export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
+export function TraceWaterfallView({ spans }: TraceWaterfallViewProps): JSX.Element {
     const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null)
     const [cursorPct, setCursorPct] = useState<number | null>(null)
     const [labelColumnWidth, setLabelColumnWidth] = useState(
@@ -681,18 +681,18 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
             <AutoSizer
                 disableHeight
                 renderProp={({ width }: SizeProps) => (
-                    <List<FlameRowData>
+                    <List<WaterfallRowData>
                         style={{
                             height: Math.min(
                                 flatSpans.length * ROW_HEIGHT + (selectedSpanId ? SELECTED_DETAIL_RESERVE : 0),
-                                MAX_FLAME_HEIGHT
+                                MAX_WATERFALL_HEIGHT
                             ),
                             width,
                         }}
                         overscanCount={10}
                         rowCount={flatSpans.length}
                         rowHeight={dynamicRowHeight}
-                        rowComponent={FlameListRow}
+                        rowComponent={WaterfallListRow}
                         rowProps={{
                             flatSpans,
                             traceStartUs,

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -18,7 +18,7 @@ import { TracingSetupPrompt } from './components/SetupPrompt/SetupPrompt'
 import { VirtualizedSpanList } from './components/VirtualizedSpanList/VirtualizedSpanList'
 import { TraceCompareFlame } from './TraceCompareFlame'
 import { TraceCompareTable } from './TraceCompareTable'
-import { TraceFlameChart } from './TraceFlameChart'
+import { TraceWaterfallView } from './TraceWaterfallView'
 import { tracingDataLogic } from './tracingDataLogic'
 import { TracingFilterBar } from './TracingFilterBar'
 import { tracingFiltersLogic } from './tracingFiltersLogic'
@@ -222,7 +222,7 @@ function TracingSceneContents(): JSX.Element {
             >
                 <div className="relative min-h-32">
                     {isLoadingFullTrace && <SpinnerOverlay />}
-                    <TraceFlameChart spans={modalSpans} />
+                    <TraceWaterfallView spans={modalSpans} />
                 </div>
             </LemonModal>
             <LemonModal

--- a/products/tracing/frontend/components/VirtualizedSpanList/ExpandedSpanContent.tsx
+++ b/products/tracing/frontend/components/VirtualizedSpanList/ExpandedSpanContent.tsx
@@ -1,4 +1,4 @@
-import { formatDuration } from '../../TraceFlameChart'
+import { formatDuration } from '../../TraceWaterfallView'
 import { SPAN_KIND_LABELS, STATUS_CODE_LABELS } from '../../types'
 import type { Span } from '../../types'
 import { SpanAttributes } from './SpanAttributes'

--- a/products/tracing/frontend/components/VirtualizedSpanList/VirtualizedSpanList.tsx
+++ b/products/tracing/frontend/components/VirtualizedSpanList/VirtualizedSpanList.tsx
@@ -9,7 +9,7 @@ import { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
 import { SortingIndicator } from 'lib/lemon-ui/LemonTable/sorting'
 import { cn } from 'lib/utils/css-classes'
 
-import { formatDuration } from '../../TraceFlameChart'
+import { formatDuration } from '../../TraceWaterfallView'
 import type { TracingOrderBy, TracingOrderDirection } from '../../tracingFiltersLogic'
 import { SPAN_KIND_LABELS, STATUS_CODE_LABELS } from '../../types'
 import type { Span } from '../../types'


### PR DESCRIPTION
## Problem

The trace visualization component was named `TraceFlameChart`, which is a misnomer — the visualization is actually a waterfall view, not a flame chart. This naming inconsistency made the codebase harder to navigate and understand.

## Changes

Renames `TraceFlameChart.tsx` to `TraceWaterfallView.tsx` and updates all internal identifiers accordingly:

- `TraceFlameChart` → `TraceWaterfallView`
- `TraceFlameChartProps` → `TraceWaterfallViewProps`
- `FlameRow` → `WaterfallRow`
- `FlameListRow` → `WaterfallListRow`
- `MAX_FLAME_HEIGHT` → `MAX_WATERFALL_HEIGHT`

All import sites that referenced `TraceFlameChart` (including `TraceCompareFlame`, `TraceCompareTable`, `TracingScene`, `ExpandedSpanContent`, and `VirtualizedSpanList`) are updated to import from `TraceWaterfallView`.

## How did you test this code?

This is a pure rename/refactor with no behavioral changes. Verified that all import references are updated consistently and the exported `formatDuration` utility remains accessible to all consumers.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update