### PR TITLE
feat(data-warehouse): implement lightspeed retail import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -117,6 +117,7 @@ the row lists both.
 | launchdarkly     | HTTP                        | requests                                                        | ✅                          |
 | kustomer         | HTTP                        | requests                                                        | ✅                          |
 | lattice          | HTTP                        | requests                                                        | ✅                          |
+| lightspeed_retail | HTTP                       | requests                                                        | ✅                          |
 | linear           | HTTP                        | requests                                                        | ✅                          |
 | lever            | HTTP                        | requests                                                        | ✅                          |
 | linkedin_ads     | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
@@ -277,7 +278,6 @@ doesn't conflict with concurrent PRs.
 - instagram
 - kafka
 - lever
-- lightspeed_retail
 - marketo
 - microsoft_teams
 - netsuite

--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -42,156 +42,156 @@ the row lists both.
 
 ## Implemented sources
 
-| Source           | Comm method                 | Primary library                                                 | Tracked transport           |
-| ---------------- | --------------------------- | --------------------------------------------------------------- | --------------------------- |
-| adroll           | HTTP                        | requests                                                        | ✅                          |
-| aircall          | HTTP                        | requests                                                        | ✅                          |
-| airtable         | HTTP                        | requests                                                        | ✅                          |
-| amazon_ads       | HTTP                        | requests                                                        | ✅                          |
-| amplitude        | HTTP                        | requests                                                        | ✅                          |
-| apollo           | HTTP                        | requests                                                        | ✅                          |
-| appsflyer        | HTTP (CSV reports)          | requests                                                        | ✅                          |
-| asana            | HTTP                        | requests                                                        | ✅                          |
-| ashby            | HTTP                        | requests                                                        | ✅                          |
-| attentive        | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
-| attio            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| azure_devops     | HTTP                        | requests                                                        | ✅                          |
-| bamboohr         | HTTP                        | requests                                                        | ✅                          |
-| bigquery         | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
-| bing_ads         | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
-| braintree        | HTTP (GraphQL)              | requests                                                        | ✅                          |
-| braze            | HTTP                        | requests                                                        | ✅                          |
-| brevo            | HTTP                        | requests                                                        | ✅                          |
-| brex             | HTTP                        | requests                                                        | ✅                          |
-| buildbetter      | HTTP                        | requests                                                        | ✅                          |
-| calendly         | HTTP                        | requests                                                        | ✅                          |
-| campaign_monitor | HTTP                        | requests                                                        | ✅                          |
-| chargebee        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| coda             | HTTP                        | requests                                                        | ✅                          |
-| commercetools    | HTTP                        | requests                                                        | ✅                          |
-| confluence       | HTTP                        | requests                                                        | ✅                          |
-| chartmogul       | HTTP                        | requests                                                        | ✅                          |
-| circleci         | HTTP                        | requests                                                        | ✅                          |
-| clari            | HTTP                        | requests                                                        | ✅                          |
-| clerk            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| clickhouse       | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
-| clickup          | HTTP                        | requests                                                        | ✅                          |
-| close            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| convertkit       | HTTP                        | requests                                                        | ✅                          |
-| convex           | HTTP                        | requests                                                        | ✅                          |
-| copper           | HTTP                        | requests                                                        | ✅                          |
-| coupa            | HTTP                        | requests                                                        | ✅                          |
-| crunchbase       | HTTP                        | requests                                                        | ✅                          |
-| culture_amp      | HTTP                        | requests                                                        | ✅                          |
-| customer_io      | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
-| datadog          | HTTP                        | requests                                                        | ✅                          |
-| deel             | HTTP                        | requests                                                        | ✅                          |
-| delighted        | HTTP                        | requests                                                        | ✅                          |
-| dixa             | HTTP                        | requests                                                        | ✅                          |
-| doit             | HTTP                        | requests                                                        | ✅                          |
-| drip             | HTTP                        | requests                                                        | ✅                          |
-| freshdesk        | HTTP                        | requests                                                        | ✅                          |
-| freshsales       | HTTP                        | requests                                                        | ✅                          |
-| elasticsearch    | HTTP                        | requests                                                        | ✅                          |
-| eventbrite       | HTTP                        | requests                                                        | ✅                          |
-| front            | HTTP                        | requests                                                        | ✅                          |
-| fullstory        | HTTP                        | requests                                                        | ✅                          |
-| github           | HTTP                        | requests                                                        | ✅                          |
-| gitlab           | HTTP                        | requests                                                        | ✅                          |
-| gladly           | HTTP                        | requests                                                        | ✅                          |
-| gocardless       | HTTP                        | requests                                                        | ✅                          |
-| gong             | HTTP                        | requests                                                        | ✅                          |
-| google_ads       | gRPC                        | google-ads (googleads.client)                                   | ✅                          |
-| google_sheets    | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
-| granola          | HTTP                        | requests                                                        | ✅                          |
-| gorgias          | HTTP                        | requests                                                        | ✅                          |
-| greenhouse       | HTTP                        | requests                                                        | ✅                          |
-| guru             | HTTP                        | requests                                                        | ✅                          |
-| hibob            | HTTP                        | requests                                                        | ✅                          |
-| hubspot          | HTTP                        | requests                                                        | ✅                          |
-| incident_io      | HTTP                        | requests                                                        | ✅                          |
-| intercom         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| iterable         | HTTP                        | requests                                                        | ✅                          |
-| jira             | HTTP                        | requests                                                        | ✅                          |
-| klaviyo          | HTTP                        | requests                                                        | ✅                          |
-| launchdarkly     | HTTP                        | requests                                                        | ✅                          |
-| kustomer         | HTTP                        | requests                                                        | ✅                          |
-| lattice          | HTTP                        | requests                                                        | ✅                          |
-| lightspeed_retail | HTTP                       | requests                                                        | ✅                          |
-| linear           | HTTP                        | requests                                                        | ✅                          |
-| lever            | HTTP                        | requests                                                        | ✅                          |
-| linkedin_ads     | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
-| mailchimp        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| mailerlite       | HTTP                        | requests                                                        | ✅                          |
-| mailgun          | HTTP                        | requests                                                        | ✅                          |
-| mailjet          | HTTP                        | requests                                                        | ✅                          |
-| matomo           | HTTP                        | requests                                                        | ✅                          |
-| meta_ads         | HTTP                        | requests                                                        | ✅                          |
-| mixpanel         | HTTP                        | requests                                                        | ✅                          |
-| mollie           | HTTP                        | requests                                                        | ✅                          |
-| monday           | HTTP (GraphQL)              | requests                                                        | ✅                          |
-| mongodb          | DB protocol                 | pymongo                                                         | ➖                          |
-| mssql            | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
-| mysql            | DB protocol                 | pymysql                                                         | ➖                          |
-| okta             | HTTP                        | requests                                                        | ✅                          |
-| notion           | HTTP                        | requests                                                        | ✅                          |
-| omnisend         | HTTP                        | requests                                                        | ✅                          |
-| ortto            | HTTP                        | requests                                                        | ✅                          |
-| outbrain         | HTTP                        | requests                                                        | ✅                          |
-| paddle           | HTTP                        | requests                                                        | ✅                          |
-| optimizely       | HTTP                        | requests                                                        | ✅                          |
-| pagerduty        | HTTP                        | requests                                                        | ✅                          |
-| pandadoc         | HTTP                        | requests                                                        | ✅                          |
-| pendo            | HTTP                        | requests                                                        | ✅                          |
-| personio         | HTTP                        | requests                                                        | ✅                          |
-| pingdom          | HTTP                        | requests                                                        | ✅                          |
-| pinterest_ads    | HTTP                        | requests                                                        | ✅                          |
-| pipedrive        | HTTP                        | requests                                                        | ✅                          |
-| plain            | HTTP                        | requests                                                        | ✅                          |
-| polar            | HTTP                        | requests                                                        | ✅                          |
-| plaid            | HTTP                        | requests                                                        | ✅                          |
-| postgres         | DB protocol                 | psycopg                                                         | ➖                          |
-| postmark         | HTTP                        | requests                                                        | ✅                          |
-| productboard     | HTTP                        | requests                                                        | ✅                          |
-| recurly          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| ramp             | HTTP                        | requests                                                        | ✅                          |
-| recharge         | HTTP                        | requests                                                        | ✅                          |
-| reddit_ads       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| redshift         | DB protocol                 | psycopg (Postgres-compatible)                                   | ➖                          |
-| resend           | HTTP                        | requests                                                        | ✅                          |
-| revenuecat       | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
-| rippling         | HTTP                        | requests                                                        | ✅                          |
-| rollbar          | HTTP                        | requests                                                        | ✅                          |
-| salesforce       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| salesloft        | HTTP                        | requests                                                        | ✅                          |
-| sendgrid         | HTTP                        | requests                                                        | ✅                          |
-| sentry           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| servicenow       | HTTP                        | requests                                                        | ✅                          |
-| shipstation      | HTTP                        | requests                                                        | ✅                          |
-| shopify          | HTTP                        | requests                                                        | ✅                          |
-| shortcut         | HTTP                        | requests                                                        | ✅                          |
-| slack            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| smartsheet       | HTTP                        | requests                                                        | ✅                          |
-| snapchat_ads     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| snowflake        | DB protocol                 | snowflake-connector-python                                      | ➖                          |
-| square           | HTTP                        | requests                                                        | ✅                          |
-| stripe           | HTTP (vendor SDK) + Webhook | stripe (StripeClient + RequestsClient) + `WebhookSourceManager` | ✅ (pull) / ➖ (webhook)    |
-| supabase         | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
-| surveymonkey     | HTTP                        | requests                                                        | ✅                          |
-| taboola          | HTTP                        | requests                                                        | ✅                          |
-| temporalio       | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
-| tiktok_ads       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| trello           | HTTP                        | requests                                                        | ✅                          |
-| twilio           | HTTP                        | requests                                                        | ✅                          |
-| typeform         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| vitally          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| webflow          | HTTP                        | requests                                                        | ✅                          |
-| woocommerce      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| workos           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| wrike            | HTTP                        | requests                                                        | ✅                          |
-| zendesk          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| zoom             | HTTP                        | requests                                                        | ✅                          |
-| zuora            | HTTP                        | requests                                                        | ✅                          |
+| Source            | Comm method                 | Primary library                                                 | Tracked transport           |
+| ----------------- | --------------------------- | --------------------------------------------------------------- | --------------------------- |
+| adroll            | HTTP                        | requests                                                        | ✅                          |
+| aircall           | HTTP                        | requests                                                        | ✅                          |
+| airtable          | HTTP                        | requests                                                        | ✅                          |
+| amazon_ads        | HTTP                        | requests                                                        | ✅                          |
+| amplitude         | HTTP                        | requests                                                        | ✅                          |
+| apollo            | HTTP                        | requests                                                        | ✅                          |
+| appsflyer         | HTTP (CSV reports)          | requests                                                        | ✅                          |
+| asana             | HTTP                        | requests                                                        | ✅                          |
+| ashby             | HTTP                        | requests                                                        | ✅                          |
+| attentive         | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
+| attio             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| azure_devops      | HTTP                        | requests                                                        | ✅                          |
+| bamboohr          | HTTP                        | requests                                                        | ✅                          |
+| bigquery          | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
+| bing_ads          | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
+| braintree         | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| braze             | HTTP                        | requests                                                        | ✅                          |
+| brevo             | HTTP                        | requests                                                        | ✅                          |
+| brex              | HTTP                        | requests                                                        | ✅                          |
+| buildbetter       | HTTP                        | requests                                                        | ✅                          |
+| calendly          | HTTP                        | requests                                                        | ✅                          |
+| campaign_monitor  | HTTP                        | requests                                                        | ✅                          |
+| chargebee         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| coda              | HTTP                        | requests                                                        | ✅                          |
+| commercetools     | HTTP                        | requests                                                        | ✅                          |
+| confluence        | HTTP                        | requests                                                        | ✅                          |
+| chartmogul        | HTTP                        | requests                                                        | ✅                          |
+| circleci          | HTTP                        | requests                                                        | ✅                          |
+| clari             | HTTP                        | requests                                                        | ✅                          |
+| clerk             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| clickhouse        | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
+| clickup           | HTTP                        | requests                                                        | ✅                          |
+| close             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| convertkit        | HTTP                        | requests                                                        | ✅                          |
+| convex            | HTTP                        | requests                                                        | ✅                          |
+| copper            | HTTP                        | requests                                                        | ✅                          |
+| coupa             | HTTP                        | requests                                                        | ✅                          |
+| crunchbase        | HTTP                        | requests                                                        | ✅                          |
+| culture_amp       | HTTP                        | requests                                                        | ✅                          |
+| customer_io       | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
+| datadog           | HTTP                        | requests                                                        | ✅                          |
+| deel              | HTTP                        | requests                                                        | ✅                          |
+| delighted         | HTTP                        | requests                                                        | ✅                          |
+| dixa              | HTTP                        | requests                                                        | ✅                          |
+| doit              | HTTP                        | requests                                                        | ✅                          |
+| drip              | HTTP                        | requests                                                        | ✅                          |
+| freshdesk         | HTTP                        | requests                                                        | ✅                          |
+| freshsales        | HTTP                        | requests                                                        | ✅                          |
+| elasticsearch     | HTTP                        | requests                                                        | ✅                          |
+| eventbrite        | HTTP                        | requests                                                        | ✅                          |
+| front             | HTTP                        | requests                                                        | ✅                          |
+| fullstory         | HTTP                        | requests                                                        | ✅                          |
+| github            | HTTP                        | requests                                                        | ✅                          |
+| gitlab            | HTTP                        | requests                                                        | ✅                          |
+| gladly            | HTTP                        | requests                                                        | ✅                          |
+| gocardless        | HTTP                        | requests                                                        | ✅                          |
+| gong              | HTTP                        | requests                                                        | ✅                          |
+| google_ads        | gRPC                        | google-ads (googleads.client)                                   | ✅                          |
+| google_sheets     | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
+| granola           | HTTP                        | requests                                                        | ✅                          |
+| gorgias           | HTTP                        | requests                                                        | ✅                          |
+| greenhouse        | HTTP                        | requests                                                        | ✅                          |
+| guru              | HTTP                        | requests                                                        | ✅                          |
+| hibob             | HTTP                        | requests                                                        | ✅                          |
+| hubspot           | HTTP                        | requests                                                        | ✅                          |
+| incident_io       | HTTP                        | requests                                                        | ✅                          |
+| intercom          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| iterable          | HTTP                        | requests                                                        | ✅                          |
+| jira              | HTTP                        | requests                                                        | ✅                          |
+| klaviyo           | HTTP                        | requests                                                        | ✅                          |
+| launchdarkly      | HTTP                        | requests                                                        | ✅                          |
+| kustomer          | HTTP                        | requests                                                        | ✅                          |
+| lattice           | HTTP                        | requests                                                        | ✅                          |
+| lightspeed_retail | HTTP                        | requests                                                        | ✅                          |
+| linear            | HTTP                        | requests                                                        | ✅                          |
+| lever             | HTTP                        | requests                                                        | ✅                          |
+| linkedin_ads      | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
+| mailchimp         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| mailerlite        | HTTP                        | requests                                                        | ✅                          |
+| mailgun           | HTTP                        | requests                                                        | ✅                          |
+| mailjet           | HTTP                        | requests                                                        | ✅                          |
+| matomo            | HTTP                        | requests                                                        | ✅                          |
+| meta_ads          | HTTP                        | requests                                                        | ✅                          |
+| mixpanel          | HTTP                        | requests                                                        | ✅                          |
+| mollie            | HTTP                        | requests                                                        | ✅                          |
+| monday            | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| mongodb           | DB protocol                 | pymongo                                                         | ➖                          |
+| mssql             | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
+| mysql             | DB protocol                 | pymysql                                                         | ➖                          |
+| okta              | HTTP                        | requests                                                        | ✅                          |
+| notion            | HTTP                        | requests                                                        | ✅                          |
+| omnisend          | HTTP                        | requests                                                        | ✅                          |
+| ortto             | HTTP                        | requests                                                        | ✅                          |
+| outbrain          | HTTP                        | requests                                                        | ✅                          |
+| paddle            | HTTP                        | requests                                                        | ✅                          |
+| optimizely        | HTTP                        | requests                                                        | ✅                          |
+| pagerduty         | HTTP                        | requests                                                        | ✅                          |
+| pandadoc          | HTTP                        | requests                                                        | ✅                          |
+| pendo             | HTTP                        | requests                                                        | ✅                          |
+| personio          | HTTP                        | requests                                                        | ✅                          |
+| pingdom           | HTTP                        | requests                                                        | ✅                          |
+| pinterest_ads     | HTTP                        | requests                                                        | ✅                          |
+| pipedrive         | HTTP                        | requests                                                        | ✅                          |
+| plain             | HTTP                        | requests                                                        | ✅                          |
+| polar             | HTTP                        | requests                                                        | ✅                          |
+| plaid             | HTTP                        | requests                                                        | ✅                          |
+| postgres          | DB protocol                 | psycopg                                                         | ➖                          |
+| postmark          | HTTP                        | requests                                                        | ✅                          |
+| productboard      | HTTP                        | requests                                                        | ✅                          |
+| recurly           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| ramp              | HTTP                        | requests                                                        | ✅                          |
+| recharge          | HTTP                        | requests                                                        | ✅                          |
+| reddit_ads        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| redshift          | DB protocol                 | psycopg (Postgres-compatible)                                   | ➖                          |
+| resend            | HTTP                        | requests                                                        | ✅                          |
+| revenuecat        | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
+| rippling          | HTTP                        | requests                                                        | ✅                          |
+| rollbar           | HTTP                        | requests                                                        | ✅                          |
+| salesforce        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| salesloft         | HTTP                        | requests                                                        | ✅                          |
+| sendgrid          | HTTP                        | requests                                                        | ✅                          |
+| sentry            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| servicenow        | HTTP                        | requests                                                        | ✅                          |
+| shipstation       | HTTP                        | requests                                                        | ✅                          |
+| shopify           | HTTP                        | requests                                                        | ✅                          |
+| shortcut          | HTTP                        | requests                                                        | ✅                          |
+| slack             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| smartsheet        | HTTP                        | requests                                                        | ✅                          |
+| snapchat_ads      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| snowflake         | DB protocol                 | snowflake-connector-python                                      | ➖                          |
+| square            | HTTP                        | requests                                                        | ✅                          |
+| stripe            | HTTP (vendor SDK) + Webhook | stripe (StripeClient + RequestsClient) + `WebhookSourceManager` | ✅ (pull) / ➖ (webhook)    |
+| supabase          | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
+| surveymonkey      | HTTP                        | requests                                                        | ✅                          |
+| taboola           | HTTP                        | requests                                                        | ✅                          |
+| temporalio        | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
+| tiktok_ads        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| trello            | HTTP                        | requests                                                        | ✅                          |
+| twilio            | HTTP                        | requests                                                        | ✅                          |
+| typeform          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| vitally           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| webflow           | HTTP                        | requests                                                        | ✅                          |
+| woocommerce       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| workos            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| wrike             | HTTP                        | requests                                                        | ✅                          |
+| zendesk           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| zoom              | HTTP                        | requests                                                        | ✅                          |
+| zuora             | HTTP                        | requests                                                        | ✅                          |
 
 ### Notes on partially-tracked sources
 

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -813,7 +813,8 @@ class LeverSourceConfig(config.Config):
 
 @config.config
 class LightspeedRetailSourceConfig(config.Config):
-    pass
+    domain_prefix: str
+    api_token: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
@@ -1,0 +1,178 @@
+import re
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.lightspeed_retail.settings import LIGHTSPEED_RETAIL_ENDPOINTS
+
+# X-Series v2.0 list pages cap at 200 items.
+PAGE_SIZE = 200
+REQUEST_TIMEOUT_SECONDS = 60
+# Rate limit is 300 × registers + 50 requests per 5-minute window (429 with a
+# Retry-After HTTP date); generous exponential backoff keeps us under it.
+MAX_RETRY_ATTEMPTS = 6
+
+
+class LightspeedRetailRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class LightspeedRetailResumeConfig:
+    # X-Series keyset pagination: `after=<version>` where version is the max
+    # record version of the previous page — one integer fully describes where
+    # to pick back up.
+    after: int
+
+
+def _get_session(api_token: str) -> requests.Session:
+    return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
+
+
+def _clean_domain_prefix(domain_prefix: str) -> str:
+    """Accept either the bare store subdomain or a pasted full domain/URL."""
+    prefix = domain_prefix.strip().removeprefix("https://").removeprefix("http://")
+    prefix = prefix.split(".")[0].split("/")[0]
+    if not re.fullmatch(r"[a-zA-Z0-9-]+", prefix):
+        raise ValueError(f"Invalid Lightspeed domain prefix: {domain_prefix}")
+    return prefix
+
+
+def _base_url(domain_prefix: str) -> str:
+    return f"https://{_clean_domain_prefix(domain_prefix)}.retail.lightspeed.app/api/2.0"
+
+
+def _to_version(value: Any) -> Optional[int]:
+    """Coerce an incremental cursor value to an integer record version."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_url(domain_prefix: str, path: str, after: Optional[int]) -> str:
+    params: dict[str, Any] = {"page_size": PAGE_SIZE}
+    if after is not None:
+        params["after"] = after
+    return f"{_base_url(domain_prefix)}{path}?{urlencode(params)}"
+
+
+def validate_credentials(domain_prefix: str, api_token: str) -> bool:
+    """Confirm the token and store subdomain are valid with a cheap outlets probe."""
+    try:
+        response = _get_session(api_token).get(
+            _build_url(domain_prefix, "/outlets", None),
+            timeout=10,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def get_rows(
+    domain_prefix: str,
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[LightspeedRetailResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = LIGHTSPEED_RETAIL_ENDPOINTS[endpoint]
+    session = _get_session(api_token)
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume_config is not None:
+        after: Optional[int] = resume_config.after
+        logger.debug(f"Lightspeed Retail: resuming {endpoint} from version {after}")
+    elif should_use_incremental_field:
+        after = _to_version(db_incremental_field_last_value)
+    else:
+        after = None
+
+    @retry(
+        retry=retry_if_exception_type((LightspeedRetailRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=2, max=120),
+        reraise=True,
+    )
+    def fetch_page(page_url: str) -> dict[str, Any]:
+        response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise LightspeedRetailRetryableError(
+                f"Lightspeed Retail API error (retryable): status={response.status_code}, url={page_url}"
+            )
+
+        if not response.ok:
+            logger.error(
+                f"Lightspeed Retail API error: status={response.status_code}, body={response.text}, url={page_url}"
+            )
+            response.raise_for_status()
+
+        return response.json()
+
+    while True:
+        data = fetch_page(_build_url(domain_prefix, config.path, after))
+        items = data.get("data", []) or []
+
+        if not items:
+            break
+
+        yield items
+
+        next_after = (data.get("version") or {}).get("max")
+        if next_after is None:
+            # Defensive: without the keyset cursor we can't advance; recompute
+            # from the page to avoid refetching the same window forever.
+            next_after = max((item.get("version") or 0) for item in items)
+            if next_after <= (after or 0):
+                break
+
+        after = int(next_after)
+        # Save state AFTER yielding the page so a crash re-yields the last page
+        # (merge dedupes on primary key) rather than skipping it.
+        resumable_source_manager.save_state(LightspeedRetailResumeConfig(after=after))
+
+
+def lightspeed_retail_source(
+    domain_prefix: str,
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[LightspeedRetailResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = LIGHTSPEED_RETAIL_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            domain_prefix=domain_prefix,
+            api_token=api_token,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        # Keyset pagination on the monotonic version yields ascending version order.
+        sort_mode="asc",
+    )

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
@@ -60,8 +60,8 @@ def _to_version(value: Any) -> Optional[int]:
         return None
 
 
-def _build_url(domain_prefix: str, path: str, after: Optional[int]) -> str:
-    params: dict[str, Any] = {"page_size": PAGE_SIZE}
+def _build_url(domain_prefix: str, path: str, after: Optional[int], page_size: int = PAGE_SIZE) -> str:
+    params: dict[str, Any] = {"page_size": page_size}
     if after is not None:
         params["after"] = after
     return f"{_base_url(domain_prefix)}{path}?{urlencode(params)}"
@@ -71,7 +71,7 @@ def validate_credentials(domain_prefix: str, api_token: str) -> bool:
     """Confirm the token and store subdomain are valid with a cheap outlets probe."""
     try:
         response = _get_session(api_token).get(
-            _build_url(domain_prefix, "/outlets", None),
+            _build_url(domain_prefix, "/outlets", None, page_size=1),
             timeout=10,
         )
         return response.status_code == 200

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/lightspeed_retail.py
@@ -136,7 +136,7 @@ def get_rows(
             # Defensive: without the keyset cursor we can't advance; recompute
             # from the page to avoid refetching the same window forever.
             next_after = max((item.get("version") or 0) for item in items)
-            if next_after <= (after or 0):
+            if after is not None and next_after <= after:
                 break
 
         after = int(next_after)

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/settings.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/settings.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+# Every X-Series v2.0 record carries a monotonically increasing integer
+# `version`; the same `after=<version>` param used for keyset pagination doubles
+# as a lossless incremental cursor, so the menu is shared across endpoints.
+_VERSION_INCREMENTAL_FIELDS: list[IncrementalField] = [
+    {
+        "label": "version",
+        "type": IncrementalFieldType.Integer,
+        "field": "version",
+        "field_type": IncrementalFieldType.Integer,
+    },
+]
+
+
+@dataclass
+class LightspeedRetailEndpointConfig:
+    name: str
+    path: str
+    primary_key: str = "id"
+    incremental_fields: list[IncrementalField] = field(default_factory=lambda: list(_VERSION_INCREMENTAL_FIELDS))
+    # Stable creation-time field used for datetime partitioning. Never a
+    # version/updated-style field, which would rewrite partitions on every sync.
+    partition_key: Optional[str] = None
+
+
+LIGHTSPEED_RETAIL_ENDPOINTS: dict[str, LightspeedRetailEndpointConfig] = {
+    "sales": LightspeedRetailEndpointConfig(
+        name="sales",
+        path="/sales",
+        partition_key="sale_date",
+    ),
+    "customers": LightspeedRetailEndpointConfig(
+        name="customers",
+        path="/customers",
+        partition_key="created_at",
+    ),
+    "products": LightspeedRetailEndpointConfig(
+        name="products",
+        path="/products",
+        partition_key="created_at",
+    ),
+    "inventory": LightspeedRetailEndpointConfig(
+        name="inventory",
+        path="/inventory",
+    ),
+    "outlets": LightspeedRetailEndpointConfig(
+        name="outlets",
+        path="/outlets",
+    ),
+    "registers": LightspeedRetailEndpointConfig(
+        name="registers",
+        path="/registers",
+    ),
+    "users": LightspeedRetailEndpointConfig(
+        name="users",
+        path="/users",
+    ),
+    "taxes": LightspeedRetailEndpointConfig(
+        name="taxes",
+        path="/taxes",
+    ),
+}
+
+ENDPOINTS = tuple(LIGHTSPEED_RETAIL_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in LIGHTSPEED_RETAIL_ENDPOINTS.items() if config.incremental_fields
+}

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/source.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/source.py
@@ -1,29 +1,132 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import LightspeedRetailSourceConfig
+from posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
+    LightspeedRetailResumeConfig,
+    lightspeed_retail_source,
+    validate_credentials as validate_lightspeed_credentials,
+)
+from posthog.temporal.data_imports.sources.lightspeed_retail.settings import ENDPOINTS, INCREMENTAL_FIELDS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class LightspeedRetailSource(SimpleSource[LightspeedRetailSourceConfig]):
+class LightspeedRetailSource(ResumableSource[LightspeedRetailSourceConfig, LightspeedRetailResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.LIGHTSPEEDRETAIL
+
+    @property
+    def connection_host_fields(self) -> list[str]:
+        # `domain_prefix` determines the host the stored personal token is sent
+        # to; retargeting it must re-require the token.
+        return ["domain_prefix"]
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url": "Lightspeed Retail authentication failed. Please check your personal token and store domain prefix.",
+            "403 Client Error: Forbidden for url": "Lightspeed Retail denied access. Please check that your personal token has the required permissions.",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.LIGHTSPEED_RETAIL,
             label="Lightspeed Retail",
+            caption="""Enter your Lightspeed Retail (X-Series) credentials to pull your point-of-sale data into the PostHog Data warehouse.
+
+Your domain prefix is the first part of your store URL — for `mystore.retail.lightspeed.app` enter `mystore`. An admin can create a personal token in Setup > Personal Tokens (available on the Plus plan and above).""",
             iconPath="/static/services/lightspeed_retail.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/lightspeed-retail",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="domain_prefix",
+                        label="Domain prefix",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="mystore",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="api_token",
+                        label="Personal token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: LightspeedRetailSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None,
+                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: LightspeedRetailSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_lightspeed_credentials(config.domain_prefix, config.api_token):
+            return True, None
+
+        return False, "Invalid Lightspeed Retail credentials"
+
+    def get_resumable_source_manager(
+        self, inputs: SourceInputs
+    ) -> ResumableSourceManager[LightspeedRetailResumeConfig]:
+        return ResumableSourceManager[LightspeedRetailResumeConfig](inputs, LightspeedRetailResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: LightspeedRetailSourceConfig,
+        resumable_source_manager: ResumableSourceManager[LightspeedRetailResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return lightspeed_retail_source(
+            domain_prefix=config.domain_prefix,
+            api_token=config.api_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
@@ -1,0 +1,219 @@
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import (
+    LightspeedRetailResumeConfig,
+    _base_url,
+    _build_url,
+    _clean_domain_prefix,
+    _to_version,
+    get_rows,
+    lightspeed_retail_source,
+    validate_credentials,
+)
+from posthog.temporal.data_imports.sources.lightspeed_retail.settings import ENDPOINTS, LIGHTSPEED_RETAIL_ENDPOINTS
+
+
+def _make_manager(resume_state: LightspeedRetailResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _response(items: list[dict[str, Any]], max_version: int | None = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    body: dict[str, Any] = {"data": items}
+    if max_version is not None:
+        body["version"] = {"min": 0, "max": max_version}
+    resp.json.return_value = body
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+class TestCleanDomainPrefix:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("mystore", "mystore"),
+            (" mystore ", "mystore"),
+            ("https://mystore.retail.lightspeed.app", "mystore"),
+            ("mystore.retail.lightspeed.app/api/2.0", "mystore"),
+            ("my-store", "my-store"),
+        ],
+    )
+    def test_valid_prefixes(self, value, expected):
+        assert _clean_domain_prefix(value) == expected
+
+    @pytest.mark.parametrize("value", ["", "my store", "store?x=1", "../evil"])
+    def test_invalid_prefixes_raise(self, value):
+        with pytest.raises(ValueError):
+            _clean_domain_prefix(value)
+
+    def test_base_url(self):
+        assert _base_url("mystore") == "https://mystore.retail.lightspeed.app/api/2.0"
+
+
+class TestToVersion:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, None),
+            (12345, 12345),
+            ("12345", 12345),
+            (123.9, 123),
+            ("not-a-number", None),
+            (True, None),
+        ],
+    )
+    def test_to_version_values(self, value, expected):
+        assert _to_version(value) == expected
+
+
+class TestBuildUrl:
+    def test_without_after(self):
+        url = _build_url("mystore", "/sales", None)
+        assert url == "https://mystore.retail.lightspeed.app/api/2.0/sales?page_size=200"
+
+    def test_with_after(self):
+        url = _build_url("mystore", "/sales", 999)
+        query = parse_qs(urlparse(url).query)
+        assert query["after"] == ["999"]
+        assert query["page_size"] == ["200"]
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, True),
+            (401, False),
+            (403, False),
+            (500, False),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials("mystore", "token") is expected
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_validate_credentials_rejects_bad_prefix_without_request(self, mock_session):
+        assert validate_credentials("my store!", "token") is False
+        mock_session.return_value.get.assert_not_called()
+
+
+class TestGetRows:
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_paginates_via_version_keyset(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "1", "version": 10}, {"id": "2", "version": 20}], max_version=20),
+            _response([{"id": "3", "version": 30}], max_version=30),
+            _response([]),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("mystore", "token", "sales", mock.MagicMock(), manager))
+
+        assert [item["id"] for batch in batches for item in batch] == ["1", "2", "3"]
+        # State saved after each non-final page with the next keyset cursor.
+        assert [call.args[0].after for call in manager.save_state.call_args_list] == [20, 30]
+        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
+        assert "after" not in parse_qs(urlparse(urls[0]).query)
+        assert parse_qs(urlparse(urls[1]).query)["after"] == ["20"]
+        assert parse_qs(urlparse(urls[2]).query)["after"] == ["30"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_resumes_from_saved_version(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        manager = _make_manager(LightspeedRetailResumeConfig(after=555))
+        list(get_rows("mystore", "token", "sales", mock.MagicMock(), manager))
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert parse_qs(urlparse(url).query)["after"] == ["555"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_incremental_starts_from_watermark_version(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        manager = _make_manager()
+        list(
+            get_rows(
+                "mystore",
+                "token",
+                "sales",
+                mock.MagicMock(),
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=777,
+            )
+        )
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert parse_qs(urlparse(url).query)["after"] == ["777"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_full_refresh_starts_without_after(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        manager = _make_manager()
+        list(get_rows("mystore", "token", "sales", mock.MagicMock(), manager))
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert "after" not in parse_qs(urlparse(url).query)
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_missing_version_block_falls_back_to_page_max(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "1", "version": 10}]),
+            _response([]),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("mystore", "token", "sales", mock.MagicMock(), manager))
+
+        assert len(batches) == 1
+        second_url = mock_session.return_value.get.call_args_list[1].args[0]
+        assert parse_qs(urlparse(second_url).query)["after"] == ["10"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_non_advancing_cursor_stops_instead_of_looping(self, mock_session):
+        # Page with no version block and versions <= the current cursor must
+        # terminate rather than refetch the same window forever.
+        mock_session.return_value.get.return_value = _response([{"id": "1", "version": 5}])
+
+        manager = _make_manager(LightspeedRetailResumeConfig(after=5))
+        batches = list(get_rows("mystore", "token", "sales", mock.MagicMock(), manager))
+
+        assert len(batches) == 1
+        assert mock_session.return_value.get.call_count == 1
+
+
+class TestLightspeedRetailSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint):
+        config = LIGHTSPEED_RETAIL_ENDPOINTS[endpoint]
+        response = lightspeed_retail_source("mystore", "token", endpoint, mock.MagicMock(), _make_manager())
+
+        assert response.name == endpoint
+        assert response.primary_keys == [config.primary_key]
+        assert response.sort_mode == "asc"
+        if config.partition_key:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == [config.partition_key]
+        else:
+            assert response.partition_mode is None
+            assert response.partition_keys is None
+
+    @pytest.mark.parametrize("config", list(LIGHTSPEED_RETAIL_ENDPOINTS.values()))
+    def test_partition_keys_are_stable_creation_fields(self, config):
+        if config.partition_key:
+            assert config.partition_key in {"sale_date", "created_at"}

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py
@@ -196,6 +196,23 @@ class TestGetRows:
         assert len(batches) == 1
         assert mock_session.return_value.get.call_count == 1
 
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail.make_tracked_session")
+    def test_first_page_advances_when_fallback_version_is_zero(self, mock_session):
+        # First page (no saved cursor) with no version block and page max of 0
+        # must still advance: the `after or 0` floor used to break prematurely.
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "1", "version": 0}]),
+            _response([]),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("mystore", "token", "sales", mock.MagicMock(), manager))
+
+        assert len(batches) == 1
+        assert mock_session.return_value.get.call_count == 2
+        second_url = mock_session.return_value.get.call_args_list[1].args[0]
+        assert parse_qs(urlparse(second_url).query)["after"] == ["0"]
+
 
 class TestLightspeedRetailSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))

--- a/posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py
+++ b/posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py
@@ -1,0 +1,140 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import LightspeedRetailSourceConfig
+from posthog.temporal.data_imports.sources.lightspeed_retail.lightspeed_retail import LightspeedRetailResumeConfig
+from posthog.temporal.data_imports.sources.lightspeed_retail.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.lightspeed_retail.source import LightspeedRetailSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestLightspeedRetailSource:
+    def setup_method(self):
+        self.source = LightspeedRetailSource()
+        self.team_id = 123
+        self.config = LightspeedRetailSourceConfig(domain_prefix="mystore", api_token="api-token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.LIGHTSPEEDRETAIL
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "LightspeedRetail"
+        assert config.label == "Lightspeed Retail"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/lightspeed_retail.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["domain_prefix", "api_token"]
+
+    def test_api_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_token")
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    def test_domain_prefix_is_a_connection_host_field(self):
+        # The stored token is sent to the host derived from domain_prefix, so
+        # retargeting it must force re-entry of the secret.
+        assert self.source.connection_host_fields == ["domain_prefix"]
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://mystore.retail.lightspeed.app/api/2.0/sales",
+            "403 Client Error: Forbidden for url: https://mystore.retail.lightspeed.app/api/2.0/customers",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    def test_non_retryable_errors_does_not_match_server_errors(self):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(
+            key in "500 Server Error for url: https://mystore.retail.lightspeed.app/api/2.0/sales"
+            for key in non_retryable_errors
+        )
+
+    def test_get_schemas(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+        # Every v2.0 collection supports the version keyset cursor.
+        assert all(schema.supports_incremental for schema in schemas)
+        assert all(schema.supports_append for schema in schemas)
+
+    def test_schemas_advertise_version_cursor(self):
+        schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, self.team_id)}
+
+        assert schemas["sales"].incremental_fields == INCREMENTAL_FIELDS["sales"]
+        assert [f["field"] for f in schemas["sales"].incremental_fields] == ["version"]
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["sales"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "sales"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid Lightspeed Retail credentials"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.source.validate_lightspeed_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.domain_prefix, self.config.api_token)
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        inputs = mock.MagicMock()
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is LightspeedRetailResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.source.lightspeed_retail_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_lightspeed_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "sales"
+        inputs.should_use_incremental_field = True
+        inputs.db_incremental_field_last_value = 999
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_lightspeed_source.assert_called_once()
+        kwargs = mock_lightspeed_source.call_args.kwargs
+        assert kwargs["domain_prefix"] == "mystore"
+        assert kwargs["api_token"] == "api-token"
+        assert kwargs["endpoint"] == "sales"
+        assert kwargs["resumable_source_manager"] is manager
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == 999
+
+    @mock.patch("posthog.temporal.data_imports.sources.lightspeed_retail.source.lightspeed_retail_source")
+    def test_source_for_pipeline_omits_last_value_on_full_refresh(self, mock_lightspeed_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "outlets"
+        inputs.should_use_incremental_field = False
+        inputs.db_incremental_field_last_value = 999
+
+        self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
+
+        assert mock_lightspeed_source.call_args.kwargs["db_incremental_field_last_value"] is None


### PR DESCRIPTION
## Problem

The Lightspeed Retail data warehouse source was scaffolded (registered with `unreleasedSource=True` and an empty stub) but had no sync logic, so users couldn't pull their Lightspeed Retail (X-Series) point-of-sale data into PostHog.

## Changes

Implements the Lightspeed Retail (X-Series) import source end-to-end following the warehouse source architecture (`source.py` / `settings.py` / `lightspeed_retail.py` split):

- **Endpoints:** `sales`, `customers`, `products`, `inventory`, `outlets`, `registers`, `users`, `taxes` against the per-retailer v2.0 API (`https://{domain_prefix}.retail.lightspeed.app/api/2.0`).
- **Auth:** Bearer personal token (admin-created, Plus plan and above). The user also supplies their store's domain prefix, which is normalized (accepts a pasted full URL) and validated against a safe charset before building the host. Because the token is sent to a host derived from `domain_prefix`, the field is declared in `connection_host_fields` so retargeting it forces re-entry of the secret.
- **Incremental sync = pagination:** every v2.0 record carries a monotonically increasing integer `version`, and the `after=<version>` keyset-pagination param doubles as a lossless incremental cursor. All schemas advertise `version` as the cursor; incremental runs start `after` the persisted watermark, and each page advances via the response's `version.max` (with a defensive fallback to the page max plus a non-advancing-cursor guard against infinite loops).
- **Resumable:** `ResumableSource` persisting the `after` cursor, saved after each yielded page.
- **Partitioning:** sales partition on `sale_date`, customers/products on `created_at` (month format).
- Retries via tenacity with generous backoff (X-Series allows 300 × registers + 50 requests per 5-minute window, 429 on exceed); 401/403 registered as non-retryable with friendly messages. All HTTP goes through `make_tracked_session()` with the token redacted.
- Removes `unreleasedSource` and ships as `releaseStatus=ALPHA`; regenerates `LightspeedRetailSourceConfig`; moves lightspeed_retail to the Implemented table in `SOURCES.md`.

Webhooks (sale.update etc.) are creatable via the API but largely redundant given the lossless version cursor, so this ships pull-only.

## How did you test this code?

Automated tests only (no live Lightspeed credentials):

- `posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail.py` — transport: version-keyset pagination, resume-from-saved-cursor, incremental start from watermark, missing-version-block fallback and non-advancing-cursor termination, domain-prefix normalization/rejection, credential validation, per-endpoint `SourceResponse` metadata.
- `posthog/temporal/data_imports/sources/lightspeed_retail/tests/test_lightspeed_retail_source.py` — source class: config fields, `connection_host_fields`, schemas, non-retryable error matching, argument plumbing.
- Registry-level tests in `posthog/temporal/data_imports/sources/tests/` pass (85 tests total).

Endpoint behavior (per-retailer host, `after`/`page_size` keyset pagination, version semantics, rate limits) was verified against the X-Series API docs and cross-checked with Airbyte's source-lightspeed-retail; live-API smoke testing wasn't possible without credentials, hence the alpha release status.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
