### PR TITLE
perf(hogql): hoist maximal events-only subexpressions in predicate pushdown

### DIFF
--- a/posthog/hogql/transforms/events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/events_predicate_pushdown.py
@@ -13,13 +13,10 @@ pieces move events work into the subquery:
 
 1. The pushable predicates (`EventsPredicatePushdownExtractor`) move into the subquery WHERE verbatim — they already
    reference the real events table, so the physical pass optimizes them (materialized columns, skip indexes) in place.
-2. Everything the *outer* query still references is handled by `EventsSubexprHoister`: each events column the outer
-   expressions read — a bare column, or the raw blob behind a `JSONFieldAccess` property read — is projected into the
-   subquery under its database column name, and the outer reference is rewritten to read that column. All computation
-   over those columns (JSON extraction, casts, join keys) stays in the outer query. Pushdown itself never inspects
-   physical columns or special-cases particular functions. Because the subquery hides the events table, the physical
-   pass leaves the outer reads as JSON extracts over the projected blob; the predicates pushed into the subquery still
-   get the full materialized-column treatment.
+2. Everything the *outer* query still references is handled by `EventsSubexprHoister`: each maximal subexpression that
+   depends only on the events table is projected into the subquery and replaced by a reference to that column. The
+   physical pass then resolves any `JSONFieldAccess` / property-group form inside the subquery. Pushdown itself never
+   inspects physical columns or special-cases particular functions.
 
 It is a pure optimization: any unexpected error leaves the query untouched (run flat), and every rewrite is
 result-equivalent.
@@ -28,7 +25,7 @@ Two things are built by hand here, on purpose:
 
 - **The subquery's types.** `_build_subquery` constructs the subquery's `SelectQueryType` directly rather than calling
   `resolve_types`. It has to: `resolve_types` runs before lowering, has no handling for `JSONFieldAccess`, and clones
-  with `clear_types=True` — so re-resolving a subquery that already holds lowered `JSONFieldAccess` predicates would
+  with `clear_types=True` — so re-resolving a subquery that already holds lowered `JSONFieldAccess` projections would
   wipe their types and break nullability and printing downstream. Teaching the resolver about lowered nodes would cross
   a layering boundary, so the types are assembled here instead.
 - **Hoisted-column nullability.** The printer reads a hoisted column's nullability from the subquery's projected column
@@ -102,20 +99,69 @@ class SelectAliasInliner(CloningVisitor):
         return super().visit_field(node)
 
 
-class EventsSubexprHoister(CloningVisitor):
-    """Rewrites an events query's outer expressions so every reference to the target events table reads a column
-    projected by the pre-filtering subquery.
+class _StructuralNormalizer(CloningVisitor):
+    """Builds the hoister's structural-identity clone of an events-only expression: type- and location-stripped,
+    with every events column leaf rewritten to its resolved database column name. After lowering, two reads off
+    different blobs can carry the same chain (`properties` vs poe's `person_properties`, where the blob identity
+    lives only in the type), so the chain alone would wrongly identify them; the database name disambiguates.
+    Sets `failed` for an unresolvable column so the caller declines."""
 
-    Only source columns are projected — a bare events column, or the raw blob behind a `JSONFieldAccess` property
-    read — each under its real database column name, so two projections can never collide. Computation over those
-    columns (JSON extraction, function calls, join-key casts) stays in the outer query / join ON, applied to the
-    projected columns. Pushdown itself never inspects physical columns, mimics the events schema, or special-cases
-    particular functions.
+    def __init__(self, hoister: "EventsSubexprHoister"):
+        super().__init__(clear_types=True, clear_locations=True)
+        self.hoister = hoister
+        self.failed = False
+
+    def visit_field(self, node: ast.Field) -> ast.Field:
+        if self.hoister._is_target_field(node.type):
+            assert isinstance(node.type, ast.FieldType)
+            name = self.hoister._database_column_name(node.type)
+            if name is None:
+                self.failed = True
+            return ast.Field(chain=[name or ""])
+        return cast(ast.Field, super().visit_field(node))
+
+
+class _EventsOnlyScan(TraversingVisitor):
+    """Classifies the leaf references in an expression so the hoister can decide whether the whole subtree depends
+    only on the target events table. Counts target-table vs foreign field references (a lazy-join or any other
+    non-events ref is simply foreign) and flags nested subqueries."""
+
+    def __init__(self, hoister: "EventsSubexprHoister"):
+        super().__init__()
+        self.hoister = hoister
+        self.target_refs = 0
+        self.foreign_refs = 0
+        self.has_subquery = False
+
+    def visit_field(self, node: ast.Field) -> None:
+        super().visit_field(node)
+        if self.hoister._is_target_field(node.type):
+            self.target_refs += 1
+        else:
+            self.foreign_refs += 1
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        self.has_subquery = True
+
+    def visit_select_set_query(self, node: ast.SelectSetQuery) -> None:
+        self.has_subquery = True
+
+
+class EventsSubexprHoister(CloningVisitor):
+    """Rewrites an events query's outer expressions so the work that depends only on the events table moves into the
+    pre-filtering subquery.
+
+    For each *maximal* subexpression that references only the target events table (its columns and property reads)
+    plus constants — a property value read, `JSONHas(properties, k)`, `match(uuid, …)`, `upper(properties.x)`, … — the
+    whole subexpression is projected into the subquery under a stable name and the outer occurrence becomes a
+    reference to that column. The ClickHouse physical pass, running afterwards, resolves any `JSONFieldAccess` /
+    property-group form *inside the subquery*; pushdown itself never inspects physical columns, mimics the events
+    schema, or special-cases particular functions — `JSONHas` is just one events-only expression among many.
 
     A hoisted reference carries the projected column's real nullability (see the module docstring), so a non-nullable
-    value stays unwrapped and can serve as a join key, while a nullable column still wraps correctly.
+    value stays unwrapped and can serve as a join key, while a nullable property key still wraps correctly.
 
-    Sets `blocked` if a referenced events column is unresolvable, so the caller declines."""
+    Sets `blocked` if a referenced leaf is an unresolvable column, so the caller declines."""
 
     def __init__(
         self,
@@ -133,12 +179,19 @@ class EventsSubexprHoister(CloningVisitor):
         self.projections: dict[str, ast.Expr] = {}
         self.column_types: dict[str, ast.Type] = {}
         self.blocked = False
+        self._counter = 0
+        self._structures: dict[str, ast.Expr] = {}
 
     def visit(self, node: ast.AST | None) -> ast.AST:
-        # Each reference to a target events column — bare, or the blob inside a property read — becomes a reference
-        # to the same column projected from the subquery; any surrounding computation stays in place. A join key
-        # needs no special handling; its nullability rides the projected column's type.
-        if isinstance(node, ast.Field) and self._is_target_field(node.type):
+        # Aliases are transparent: recurse so the inner subexpression is hoisted while the alias — and the output
+        # name it carries — stays in the outer query.
+        if not isinstance(node, ast.Expr) or isinstance(node, ast.Alias):
+            return super().visit(node)
+
+        # The maximal events-only subexpression — a direct column, a property read, or an events-only join key — is
+        # projected whole into the subquery and read back as one column. A join key needs no special handling; its
+        # nullability rides the projected column's type.
+        if self._is_hoistable(node):
             name = self._intern(node)
             if name is not None:
                 return ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=self.subquery_ref))
@@ -147,9 +200,10 @@ class EventsSubexprHoister(CloningVisitor):
 
     def visit_alias(self, node: ast.Alias) -> ast.Alias:
         # The resolver wraps a bare column reference in an alias whose `FieldAliasType` carries the events column's
-        # `FieldType` again. Rewriting only the inner field would leave that wrapper stale, and downstream consumers
-        # that resolve through it (`resolve_field_type`) would treat the outer reference as still reading the real
-        # events table. Re-point the wrapper at the rewritten expression's type (mirrors lowering's `visit_alias`).
+        # `FieldType` again. Hoisting only the inner expression would leave that wrapper stale, and downstream
+        # consumers that resolve through it (`resolve_field_type`) would treat the outer reference as still reading
+        # the real events table. Re-point the wrapper at the rewritten expression's type (mirrors lowering's
+        # `visit_alias`).
         new_node = cast(ast.Alias, super().visit_alias(node))
         unwrapped: ast.Type | None = new_node.type
         while isinstance(unwrapped, ast.FieldAliasType):
@@ -170,24 +224,66 @@ class EventsSubexprHoister(CloningVisitor):
     def visit_select_set_query(self, node: ast.SelectSetQuery) -> ast.SelectSetQuery:
         return cast(ast.SelectSetQuery, clone_expr(node, clear_types=False))
 
-    def _intern(self, node: ast.Field) -> str | None:
-        """Record a subquery projection for the column `node` reads and return the name to reference it by. The name
-        is always the real database column name, so two different reads can never collide on one projection; repeated
-        reads of a column share it. Returns None (setting `blocked`) for an unresolvable column."""
-        assert isinstance(node.type, ast.FieldType)
-        name = self._database_column_name(node.type)
+    def _intern(self, expr: ast.Expr) -> str | None:
+        """Record a subquery projection for `expr` and return the column name to reference it by. Structurally
+        identical reads share one projection. The preferred name is *not* injective — `properties.a[1]` (array index)
+        and `properties.a['1']` (object key) both prefer `properties__a__1`, and `properties.a.b` collides with
+        `properties['a__b']` — so a structurally different read whose preferred name is already taken gets a fresh
+        synthetic column instead; collapsing the two would silently return the first read's value for the second.
+        Returns None (setting `blocked`) for an unresolvable column."""
+        # Structural identity compares normalized type-stripped clones (type objects can be cyclic — table types
+        # embed query types — so comparing nodes with types attached is unsafe; see `_StructuralNormalizer` for the
+        # column-name normalization that disambiguates reads off different blobs).
+        normalizer = _StructuralNormalizer(self)
+        structure = cast(ast.Expr, normalizer.visit(expr))
+        if normalizer.failed:
+            self.blocked = True
+            return None
+        for existing_name, existing_structure in self._structures.items():
+            if existing_structure == structure:
+                return existing_name
+        name = self._preferred_name(expr)
         if name is None:
             self.blocked = True
             return None
-        if name not in self.projections:
-            value_type: ast.Type = node.type
-            self.projections[name] = clone_expr(node, clear_types=False)
-            self.column_types[name] = value_type
-            self.subquery_type.columns[name] = value_type
+        if name in self.projections:
+            name = self._synthetic_name()
+        value_type: ast.Type = expr.type or ast.UnknownType()
+        self.projections[name] = clone_expr(expr, clear_types=False)
+        self._structures[name] = structure
+        self.column_types[name] = value_type
+        self.subquery_type.columns[name] = value_type
+        return name
+
+    def _preferred_name(self, node: ast.Expr) -> str | None:
+        # A property read's name is its source blob column joined with its key path, so `properties.x` and the person
+        # blob's `person_properties.x` hoist to separate columns instead of colliding on the bare key `x` (which would
+        # read the wrong blob for one of them). A direct column uses its database name; any other events-only
+        # subexpression a synthetic internal name (its outer output name rides its alias).
+        if isinstance(node, ast.JSONFieldAccess):
+            blob = self._database_column_name(node.expr.type) if isinstance(node.expr.type, ast.FieldType) else None
+            if blob is None:
+                return None
+            return "__".join([blob, *(str(key) for key in node.keys)])
+        if isinstance(node, ast.Field) and isinstance(node.type, ast.FieldType):
+            return self._database_column_name(node.type)
+        return self._synthetic_name()
+
+    def _synthetic_name(self) -> str:
+        name = f"__pd_expr_{self._counter}"
+        self._counter += 1
         return name
 
     def _is_target_field(self, node_type: ast.Type | None) -> bool:
         return isinstance(node_type, ast.FieldType) and self._matches_target_table(node_type.table_type)
+
+    def _is_hoistable(self, node: ast.Expr) -> bool:
+        """True if `node` depends only on the target events table (its columns / property reads) plus constants — no
+        joined-table, lazy, or other foreign reference and no nested subquery — and touches the target at least once
+        (so we never project a pure constant)."""
+        scan = _EventsOnlyScan(self)
+        scan.visit(node)
+        return scan.target_refs > 0 and scan.foreign_refs == 0 and not scan.has_subquery
 
     def _database_column_name(self, field_type: ast.FieldType) -> str | None:
         try:
@@ -505,11 +601,11 @@ class EventsPredicatePushdownTransform(TraversingVisitor):
         alias: str | None,
         limit: ast.Constant | None,
     ) -> ast.SelectQuery | None:
-        """Build `SELECT <hoisted columns> FROM events WHERE <pushed predicates> LIMIT n`.
+        """Build `SELECT <hoisted projections> FROM events WHERE <pushed predicates> LIMIT n`.
 
-        The hoisted column reads and the pushed predicates already reference the original events table type, so the
+        The hoisted projections and the pushed predicates already reference the original events table type, so the
         subquery reuses it directly as its FROM — no schema mimicry, no synthetic materialized columns. The ClickHouse
-        physical pass optimizes the pushed predicates in place afterwards."""
+        physical pass rewrites the `JSONFieldAccess` projections to their materialized columns afterwards."""
         base_table_type: ast.Type = events_table_type
         if isinstance(base_table_type, ast.TableAliasType):
             base_table_type = base_table_type.table_type

--- a/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
@@ -1,3 +1,4 @@
+import re
 import json
 from typing import Any, cast
 from uuid import uuid4
@@ -358,6 +359,33 @@ class TestEventsPredicatePushdownTransform(BaseTest):
         assert ") AS events LEFT JOIN" in printed, (
             "nested subquery with an explicit LIMIT should be pushed:\n" + printed
         )
+
+    def test_pushdown_array_index_vs_object_key_stay_distinct(self):
+        # `properties.a[1]` (array index) and `properties.a['1']` (object key) are different extractions that share
+        # one preferred name (`properties__a__1`); they must hoist to separate projections, or the second read
+        # silently returns the first's value.
+        printed = self._print_select(
+            "SELECT properties.a[1] AS i, properties.a['1'] AS k, session.$session_duration "
+            "FROM events WHERE timestamp >= '2024-01-01' LIMIT 10"
+        )
+        assert ") AS events LEFT JOIN" in printed, f"expected pushdown to fire:\n{printed}"
+        match_i = re.search(r"SELECT (.*?) AS i,", printed)
+        match_k = re.search(r" AS i, (.*?) AS k,", printed)
+        assert match_i and match_k, printed
+        assert match_i.group(1) != match_k.group(1), f"distinct reads collapsed onto one projection:\n{printed}"
+
+    def test_pushdown_nested_key_vs_flat_double_underscore_key_stay_distinct(self):
+        # Nested `properties.a.b` and a flat property literally named `a__b` share the preferred name
+        # `properties__a__b` but are different reads; they must hoist to separate projections.
+        printed = self._print_select(
+            "SELECT properties.a.b AS x, properties['a__b'] AS y, session.$session_duration "
+            "FROM events WHERE timestamp >= '2024-01-01' LIMIT 10"
+        )
+        assert ") AS events LEFT JOIN" in printed, f"expected pushdown to fire:\n{printed}"
+        match_x = re.search(r"SELECT (.*?) AS x,", printed)
+        match_y = re.search(r" AS x, (.*?) AS y,", printed)
+        assert match_x and match_y, printed
+        assert match_x.group(1) != match_y.group(1), f"distinct reads collapsed onto one projection:\n{printed}"
 
 
 class TestOuterWhereAssignment:
@@ -763,10 +791,9 @@ class TestEventsPredicatePushdownTransformUnit:
 
 
 class TestEventsSubexprHoister(BaseTest):
-    """The hoister rewrites an events query's outer column references into references to the pre-filtering subquery,
-    recording which source columns the subquery must project. It runs on the lowered AST (property value reads are
-    `JSONFieldAccess`, whose blob column gets projected while the extraction stays outer); a lazy-join or other
-    non-events reference is simply left in the outer query."""
+    """The hoister rewrites an events query's outer leaves into references to the pre-filtering subquery, recording
+    which columns / property values the subquery must project. It runs on the lowered AST (property value reads are
+    `JSONFieldAccess`); a lazy-join or other non-events reference is simply left in the outer query."""
 
     def setUp(self):
         super().setUp()
@@ -812,18 +839,18 @@ class TestEventsSubexprHoister(BaseTest):
         assert "event" in hoister.projections
         assert self._references_subquery(rewritten[0], subquery_ref) is True
 
-    def test_property_read_projects_its_blob_column(self):
-        # A property read projects the raw blob column under its database name; the extraction stays outer.
+    def test_property_is_projected_under_its_dunder_name(self):
+        # The name is `<blob column>__<key>`, so reads off different blobs never collide on a bare key.
         hoister, _, _ = self._run("SELECT properties.$browser FROM events")
-        assert "properties" in hoister.projections
+        assert "properties__$browser" in hoister.projections
         assert hoister.blocked is False
 
-    def test_nested_property_projects_the_same_blob_column(self):
+    def test_nested_property_uses_dunder_joined_name(self):
         hoister, _, _ = self._run("SELECT properties.a.b FROM events")
-        assert set(hoister.projections) == {"properties"}
+        assert "properties__a__b" in hoister.projections
 
     def test_property_reference_is_rewritten_to_subquery(self):
-        # The outer property read keeps its extraction but its blob argument now references the subquery column.
+        # The outer occurrence of a property read becomes a reference to the subquery column the physical pass fills.
         _, rewritten, subquery_ref = self._run("SELECT properties.$browser FROM events")
         assert self._references_subquery(rewritten[0], subquery_ref) is True
 
@@ -872,11 +899,25 @@ class TestEventsSubexprHoister(BaseTest):
 
     def test_poe_property_and_event_property_same_key_project_separately(self):
         # `properties.url` reads the event blob; `poe.properties.url` reads `person_properties`. They share the key
-        # `url` but must project separate blob columns — collapsing them onto one would read the wrong blob for one.
+        # `url` but must hoist to separate columns — collapsing them onto one silently read the wrong blob for one.
         hoister, _, _ = self._run("SELECT properties.url, poe.properties.url FROM events")
-        assert "properties" in hoister.projections
-        assert "person_properties" in hoister.projections
+        assert "properties__url" in hoister.projections
+        assert "person_properties__url" in hoister.projections
         assert hoister.blocked is False
+
+    def test_different_reads_colliding_on_preferred_name_get_separate_projections(self):
+        # `properties.a.b` and `properties['a__b']` both prefer the name `properties__a__b` but are different reads;
+        # the second must get a fresh synthetic column instead of silently reusing the first's projection.
+        hoister, _, _ = self._run("SELECT properties.a.b, properties['a__b'] FROM events")
+        assert "properties__a__b" in hoister.projections
+        assert "__pd_expr_0" in hoister.projections
+        assert hoister.projections["properties__a__b"] != hoister.projections["__pd_expr_0"]
+
+    def test_identical_computed_expressions_share_one_projection(self):
+        # Structurally identical non-leaf expressions dedupe onto a single synthetic projection.
+        hoister, _, _ = self._run("SELECT upper(event), upper(event) FROM events")
+        synthetic = [name for name in hoister.projections if name.startswith("__pd_expr_")]
+        assert len(synthetic) == 1
 
 
 class TestSavedQueryWithLazyJoins(BaseTest):
@@ -1611,10 +1652,10 @@ class TestEventsPredicatePushdownMaterializedExecution(_PushdownExecutionTestBas
     """Pushdown must stay a pure optimization on teams that have materialized columns.
 
     The test ClickHouse has no materialized columns by default, so the rest of the suite never prints
-    `events.mat_*`. These tests materialize a property first. Predicates pushed into the subquery sit on the
-    real events table, so the physical pass reads the materialized column there; an outer property reference
-    instead extracts from the `properties` blob the subquery projects (the subquery hides the events table
-    from the physical pass). Every assertion checks pushdown-on == pushdown-off.
+    `events.mat_*`. These tests materialize a property first, so the printer reads the physical column and
+    the pushdown subquery must expose it; without that exposure a property referenced outside the pushed
+    predicate (SELECT / GROUP BY / ORDER BY / HAVING) prints `events.mat_tier` against a subquery alias that
+    doesn't have it → `Unknown identifier`. Every assertion checks pushdown-on == pushdown-off.
     """
 
     def _create_data(self) -> None:
@@ -1643,28 +1684,32 @@ class TestEventsPredicatePushdownMaterializedExecution(_PushdownExecutionTestBas
     _RANGE = "timestamp >= '2024-01-01' AND timestamp < '2024-01-08'"
 
     def test_exec_materialized_property_in_outer_select(self):
-        # A materialized property in the outer SELECT: the subquery projects the source `properties` blob and the
-        # outer query extracts from it. The subquery hides the events table from the physical pass, so the outer
-        # read does not use `mat_tier`; only predicates pushed into the subquery get the materialized column.
-        with materialized("events", "tier"):
+        # The CRITICAL repro: a materialized property in the outer SELECT. The subquery must expose
+        # `mat_tier` or the outer `events.mat_tier` is an Unknown identifier.
+        with materialized("events", "tier") as mat_col:
             self._create_data()
             select = (
                 f"SELECT properties.tier AS t, session.$session_duration AS d FROM events WHERE {self._RANGE} LIMIT 50"
             )
             printed = self._print_pushdown_sql(select)
             subquery = self._events_subquery(printed)
-            assert "properties AS properties" in subquery, (
-                f"expected the raw blob projected for the outer property read:\n{printed}"
-            )
+            assert mat_col.name in subquery, f"expected the materialized column exposed in the subquery:\n{printed}"
             assert "LIMIT" in subquery, f"expected the pushed subquery to carry an inner LIMIT:\n{printed}"
+            # The materialized property must NOT also drag the raw `properties` blob into the subquery
+            # projection (over-projection would force a ~100x-slower full-Map read). Guards drift on the
+            # plain-materialized PropertyType path, mirroring the JSONHas blob-projection guard.
+            assert "properties AS properties" not in subquery, (
+                f"materialized property over-projected the blob:\n{printed}"
+            )
             self._assert_equivalent(select, expected_rows=3)
 
-    def test_exec_materialized_property_as_join_key_projects_blob(self):
-        # A materialized property used as the events-side join key. The key expression stays in the ON, extracting
-        # from the `properties` blob the subquery projects (the subquery hides the events table, so the ON keeps
-        # the JSON extract rather than `mat_tier`). This asserts the projection on the printed SQL; end-to-end
-        # execution of a property join key is covered by test_query.test_join_with_property_materialized.
-        with materialized("events", "tier"):
+    def test_exec_materialized_property_as_join_key_exposes_mat_column(self):
+        # A materialized property used as the events-side join key. The key expression stays in the ON (a subquery
+        # column would read as nullable and break join-key detection), so the physical pass rewrites the ON's
+        # property to `events.mat_tier`, which the subquery must expose — without it the ON references `mat_tier`
+        # against a subquery alias that lacks it (Unknown identifier). This asserts the exposure on the printed SQL;
+        # end-to-end execution of a property join key is covered by test_query.test_join_with_property_materialized.
+        with materialized("events", "tier") as mat_col:
             self._create_data()
             select = (
                 "SELECT events.event AS ae, p.id FROM events "
@@ -1672,8 +1717,8 @@ class TestEventsPredicatePushdownMaterializedExecution(_PushdownExecutionTestBas
                 "WHERE events.timestamp >= '2024-01-01' AND events.timestamp < '2024-01-08' LIMIT 50"
             )
             subquery = self._events_subquery(self._print_pushdown_sql(select))
-            assert "properties AS properties" in subquery, (
-                f"expected the raw blob projected for the property join key:\n{subquery}"
+            assert mat_col.name in subquery, (
+                f"expected the materialized column exposed for the property join key:\n{subquery}"
             )
 
     def test_exec_materialized_property_in_order_by_declines(self):
@@ -1766,10 +1811,10 @@ class TestEventsPredicatePushdownMaterializedExecution(_PushdownExecutionTestBas
 class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestBase):
     """Pushdown must stay a pure optimization under propertyGroupsMode=OPTIMIZED (the PostHog Cloud default).
 
-    In OPTIMIZED mode the physical pass rewrites property reads and `JSONHas(properties, 'k')` into property-group
-    Map column reads — but only on the real events table, i.e. for predicates pushed into the subquery. An outer
-    reference instead reads the `properties` blob the subquery projects, so every shape must stay result-equivalent
-    on vs off.
+    In OPTIMIZED mode the printer rewrites `JSONHas(properties, 'k')` into `has(events.properties_group_*,
+    'k')`, referencing a property-group Map column. JSONHas's argument is the bare `properties` column (not
+    a `properties.k` PropertyType), so the subquery must still expose that Map column or an outer-scope
+    JSONHas resolves against a column the subquery alias doesn't carry → `Unknown identifier`.
     """
 
     _property_groups_mode = PropertyGroupsMode.OPTIMIZED
@@ -1794,18 +1839,18 @@ class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestB
 
     _RANGE = "timestamp >= '2024-01-01' AND timestamp < '2024-01-08'"
 
-    def test_exec_outer_json_has_reads_projected_blob(self):
-        # An outer JSONHas keeps its call form in the outer query, reading the `properties` blob the subquery
-        # projects (the subquery hides the events table, so the group-column rewrite doesn't apply). JSONHas is
-        # in the SELECT (referenced outside the pushed predicate) so the pushdown still fires with an inner LIMIT.
+    def test_exec_outer_json_has_exposes_property_group_column(self):
+        # The reproduced break: an outer JSONHas → printer emits has(events.properties_group_*), which the
+        # subquery must expose. JSONHas is in the SELECT (referenced outside the pushed predicate) so the
+        # pushdown still fires with an inner LIMIT.
         self._create_data()
         select = (
             f"SELECT event, JSONHas(properties, 'tier') AS h, session.$session_duration FROM events "
             f"WHERE {self._RANGE} LIMIT 50"
         )
         printed = self._print_pushdown_sql(select)
-        assert "properties AS properties" in self._events_subquery(printed), (
-            f"expected the raw blob projected for the outer JSONHas:\n{printed}"
+        assert "properties_group" in self._events_subquery(printed), (
+            f"expected the property-group Map column exposed in the subquery:\n{printed}"
         )
         with_pushdown = self._results(select, push_down=True)
         without_pushdown = self._results(select, push_down=False)
@@ -1814,6 +1859,21 @@ class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestB
         )
         assert len(with_pushdown or []) == 3
 
+    def test_exec_json_has_does_not_project_properties_blob(self):
+        # Under OPTIMIZED the printer reads only the property-group Map column for JSONHas, never the
+        # `properties` blob. When JSONHas is the sole `properties` reference, the subquery must expose the
+        # Map column and NOT project the full blob (which would force a ~100x Map read for nothing).
+        self._create_data()
+        select = (
+            f"SELECT event, JSONHas(properties, 'tier') AS h, session.$session_duration FROM events "
+            f"WHERE {self._RANGE} LIMIT 50"
+        )
+        subquery = self._events_subquery(self._print_pushdown_sql(select))
+        assert "properties_group" in subquery, f"expected the group Map column exposed:\n{subquery}"
+        assert "properties AS properties" not in subquery, (
+            f"the raw properties blob must NOT be projected when only JSONHas reads it:\n{subquery}"
+        )
+
     def test_exec_json_has_in_select_stays_equivalent(self):
         self._create_data()
         select = (
@@ -1821,7 +1881,7 @@ class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestB
             f"WHERE {self._RANGE} LIMIT 50"
         )
         printed = self._print_pushdown_sql(select)
-        assert "properties AS properties" in self._events_subquery(printed), printed
+        assert "properties_group" in self._events_subquery(printed), printed
         with_pushdown = self._results(select, push_down=True)
         without_pushdown = self._results(select, push_down=False)
         assert self._sorted(with_pushdown) == self._sorted(without_pushdown), (
@@ -1843,13 +1903,14 @@ class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestB
         )
         assert len(with_pushdown or []) == 2  # only u1's two events have the tier property
 
-    def test_exec_property_type_reads_projected_blob(self):
-        # An outer `properties.tier` value read (lowered to a JSONFieldAccess, distinct path from the JSONHas
-        # call form above) extracts from the `properties` blob the subquery projects.
+    def test_exec_property_type_uses_property_group_column(self):
+        # `properties.tier` (a PropertyType, not JSONHas) under OPTIMIZED is read from the property-group
+        # Map column by the printer; the collector's PropertyType path must expose it too. Distinct code
+        # path from the JSONHas tests above (visit_field/_collect_materialized_column, not visit_call).
         self._create_data()
         select = f"SELECT properties.tier AS t, session.$session_duration AS d FROM events WHERE {self._RANGE} LIMIT 50"
         printed = self._print_pushdown_sql(select)
-        assert "properties AS properties" in self._events_subquery(printed), printed
+        assert "properties_group" in self._events_subquery(printed), printed
         with_pushdown = self._results(select, push_down=True)
         without_pushdown = self._results(select, push_down=False)
         assert self._sorted(with_pushdown) == self._sorted(without_pushdown), (
@@ -1857,16 +1918,17 @@ class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestB
         )
         assert len(with_pushdown or []) == 3  # u1's two tier='pro' events and u2's no-tier event
 
-    def test_exec_is_not_null_reads_projected_blob(self):
-        # An outer isNotNull(properties.tier) keeps its call form over the projected `properties` blob (the
-        # group-column has() rewrite only applies on the real events table, inside the subquery).
+    def test_exec_is_not_null_uses_property_group_column(self):
+        # Under OPTIMIZED the printer rewrites isNull/isNotNull(properties.k) to the property-group has()
+        # expression, so the Map column must be exposed. The arg is a PropertyType (visit_field path), so
+        # the group column is exposed by _collect_materialized_column; pin that equivalence here.
         self._create_data()
         select = (
             f"SELECT isNotNull(properties.tier) AS has_tier, session.$session_duration AS d "
             f"FROM events WHERE {self._RANGE} LIMIT 50"
         )
         printed = self._print_pushdown_sql(select)
-        assert "properties AS properties" in self._events_subquery(printed), printed
+        assert "properties_group" in self._events_subquery(printed), printed
         with_pushdown = self._results(select, push_down=True)
         without_pushdown = self._results(select, push_down=False)
         assert self._sorted(with_pushdown) == self._sorted(without_pushdown), (
@@ -1876,12 +1938,12 @@ class TestEventsPredicatePushdownPropertyGroupsExecution(_PushdownExecutionTestB
 
 
 class TestEventsPredicatePushdownDmatExecution(_PushdownExecutionTestBase):
-    """Pushdown must stay a pure optimization for dmat (dynamic materialized) properties too.
+    """Pushdown must expose dmat (dynamic materialized) columns in the subquery too.
 
-    A property with a READY MaterializedColumnSlot is read from `dmat_string_<n>` on the real events table;
-    after pushdown an outer reference to it extracts from the `properties` blob the subquery projects instead.
-    The test DB has the physical dmat columns but `_create_event` doesn't populate them, so events are inserted
-    with the column pre-filled (same approach as test_property_types_dmat.py).
+    A property with a READY MaterializedColumnSlot is read from `dmat_string_<n>` by the printer, so an
+    outer reference to that property after pushdown must resolve against the subquery alias. The test DB
+    has the physical dmat columns but `_create_event` doesn't populate them, so events are inserted with
+    the column pre-filled (same approach as test_property_types_dmat.py).
     """
 
     _SLOT_INDEX = 0
@@ -1920,6 +1982,6 @@ class TestEventsPredicatePushdownDmatExecution(_PushdownExecutionTestBase):
         self._setup_dmat_events()
         select = "SELECT properties.tier AS t, session.$session_duration AS d FROM events WHERE timestamp >= '2020-01-01' LIMIT 50"
         printed = self._print_pushdown_sql(select)
-        assert "properties AS properties" in self._events_subquery(printed), printed
+        assert f"dmat_string_{self._SLOT_INDEX}" in self._events_subquery(printed), printed
         on = self._assert_results_equivalent(select)
         assert len(on) == 2


### PR DESCRIPTION
## Problem

The events predicate pushdown (base branch) keeps master's strategy: the pre-filtering subquery projects source columns (raw JSON blobs, bare columns) and all computation stays in the outer query. That ships the whole `properties` blob through the join even when only one extracted value is needed, and recomputes join-key expressions per output row.

This optimization was de-scoped from the rearchitecture branch (#62239) so that branch stays at strict master parity; it is tracked here with its own rationale.

## Changes

- The pushdown hoister projects maximal events-only subexpressions (extracted property values, join-key computations) as computed columns inside the LIMIT-bounded subquery, instead of projecting raw blobs.
- Collision-safe projection naming: hoisted reads dedupe by structural equality of the expression, never by name alone — two distinct reads that stringify to the same `__`-joined name (e.g. `properties.a[1]` vs `properties.a['1']`, `properties.a.b` vs `properties['a__b']`) get distinct columns. Regression tests included.

**Status: tracker, not land-ready.** It predates two later de-scope commits on the base branch and needs a rebase (expected conflicts in `events_predicate_pushdown.py`) plus re-review before landing.

## How did you test this code?

Agent-authored. Automated tests only: the pushdown suite (`posthog/hogql/transforms/test/test_events_predicate_pushdown.py`, 146 passed at branch point) including new structural-dedupe regression tests and ClickHouse-backed result-equivalence (`test_exec_*`) tests. Snapshots at the branch point were byte-identical to the pre-de-scope rearchitecture tip.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by Claude Code during the QA review of #62239. The review found that hoisted-projection naming could silently collapse two distinct property reads onto one column; the maintainer chose to de-scope the whole hoisting optimization from the rearchitecture branch and re-introduce it here with the collision fix (structural dedupe, fresh synthetic name on collision) and regression tests.
