### PR TITLE
perf(hogql): trust resolved types for subquery column nullability

### DIFF
--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1479,6 +1479,15 @@ class BasePrinter(Visitor[str]):
         elif isinstance(node_type, ast.CallType):
             return node_type.return_type.nullable
         elif isinstance(node_type, ast.FieldType):
+            # A field reading from a subquery (alias) has no database field, so `is_nullable` defaults to True and
+            # over-wraps the column in `ifNull(...)`. Its real nullability is the projected column's constant type —
+            # use that, so a non-nullable value selected from a subquery isn't needlessly null-wrapped (which, for a
+            # join key, ClickHouse can't use). Real-table fields keep `is_nullable` (identical result, no risk).
+            if not isinstance(node_type.table_type, ast.BaseTableType):
+                try:
+                    return node_type.resolve_constant_type(self.context).nullable
+                except Exception:
+                    return True
             return node_type.is_nullable(self.context)
         return None
 

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -272,14 +272,14 @@
   -- ClickHouse
   SELECT e.event AS event, s.session_id AS session_id 
   FROM (
-    SELECT e.event AS event, nullIf(nullIf(e.`$session_id`, ''), 'null') AS `properties__$session_id` 
+    SELECT e.event AS event, e.properties AS properties 
     FROM events AS e 
     WHERE and(equals(e.team_id, 99999), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) 
     LIMIT 10) AS e LEFT JOIN (
     SELECT session_replay_events.session_id AS session_id 
     FROM session_replay_events 
     WHERE equals(session_replay_events.team_id, 99999) 
-    GROUP BY session_replay_events.session_id) AS s ON equals(s.session_id, e.`properties__$session_id`) 
+    GROUP BY session_replay_events.session_id) AS s ON equals(s.session_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '')) 
   LIMIT 10 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, optimize_rewrite_aggregate_function_with_if=0, optimize_min_inequality_conjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
   
@@ -304,14 +304,14 @@
   -- ClickHouse
   SELECT e.event AS event, s.session_id AS session_id 
   FROM (
-    SELECT e.event AS event, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS `properties__$$$session_id` 
+    SELECT e.event AS event, e.properties AS properties 
     FROM events AS e 
-    WHERE and(equals(e.team_id, 99999), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''))) 
+    WHERE and(equals(e.team_id, 99999), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''))) 
     LIMIT 10) AS e LEFT JOIN (
     SELECT session_replay_events.session_id AS session_id 
     FROM session_replay_events 
     WHERE equals(session_replay_events.team_id, 99999) 
-    GROUP BY session_replay_events.session_id) AS s ON equals(s.session_id, e.`properties__$$$session_id`) 
+    GROUP BY session_replay_events.session_id) AS s ON equals(s.session_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', '')) 
   LIMIT 10 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, optimize_rewrite_aggregate_function_with_if=0, optimize_min_inequality_conjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
   

--- a/posthog/hogql/transforms/events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/events_predicate_pushdown.py
@@ -15,10 +15,10 @@ pieces move events work into the subquery:
    reference the real events table, so the physical pass optimizes them (materialized columns, skip indexes) in place.
 2. Everything the *outer* query still references is handled by `EventsSubexprHoister`: each events column the outer
    expressions read — a bare column, or the raw blob behind a `JSONFieldAccess` property read — is projected into the
-   subquery under its database column name. All computation over those columns (JSON extraction, casts, join keys)
-   stays in the outer query. Pushdown itself never inspects physical columns or special-cases particular functions.
-   A blob reference is rewritten to read the projected column, which hides the events table from the physical pass:
-   the outer reads stay JSON extracts over the projected blob, while the predicates pushed into the subquery still
+   subquery under its database column name, and the outer reference is rewritten to read that column. All computation
+   over those columns (JSON extraction, casts, join keys) stays in the outer query. Pushdown itself never inspects
+   physical columns or special-cases particular functions. Because the subquery hides the events table, the physical
+   pass leaves the outer reads as JSON extracts over the projected blob; the predicates pushed into the subquery still
    get the full materialized-column treatment.
 
 It is a pure optimization: any unexpected error leaves the query untouched (run flat), and every rewrite is
@@ -31,11 +31,9 @@ Two things are built by hand here, on purpose:
   with `clear_types=True` — so re-resolving a subquery that already holds lowered `JSONFieldAccess` predicates would
   wipe their types and break nullability and printing downstream. Teaching the resolver about lowered nodes would cross
   a layering boundary, so the types are assembled here instead.
-- **Outer reference types.** A rewritten blob reference is re-typed onto the subquery, so the physical pass cannot
-  substitute a materialized / property-group column the subquery does not project. Every other outer events reference
-  keeps its original events-table type and resolves against the subquery alias by name (the subquery projects each
-  column under its database name): the printer then derives its nullability from the real events column, so a
-  non-nullable join key stays unwrapped — an `ifNull(...)`-wrapped equality is not a usable join key for ClickHouse.
+- **Hoisted-column nullability.** The printer reads a hoisted column's nullability from the subquery's projected column
+  type, not as a blanket-nullable subquery column. That is what lets a join key be hoisted like any other column: it
+  wraps in `ifNull(...)` only when the value is genuinely nullable.
 """
 
 from typing import cast
@@ -48,7 +46,7 @@ from posthog.hogql import ast
 from posthog.hogql.base import _T_AST
 from posthog.hogql.constants import LimitContext, get_max_limit_for_context
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.models import DatabaseField, StringJSONDatabaseField
+from posthog.hogql.database.models import DatabaseField
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.util.where_clause_extractor import EventsPredicatePushdownExtractor
 from posthog.hogql.functions.mapping import find_hogql_aggregation
@@ -105,7 +103,8 @@ class SelectAliasInliner(CloningVisitor):
 
 
 class EventsSubexprHoister(CloningVisitor):
-    """Collects every reference to the target events table into a column projected by the pre-filtering subquery.
+    """Rewrites an events query's outer expressions so every reference to the target events table reads a column
+    projected by the pre-filtering subquery.
 
     Only source columns are projected — a bare events column, or the raw blob behind a `JSONFieldAccess` property
     read — each under its real database column name, so two projections can never collide. Computation over those
@@ -113,9 +112,8 @@ class EventsSubexprHoister(CloningVisitor):
     projected columns. Pushdown itself never inspects physical columns, mimics the events schema, or special-cases
     particular functions.
 
-    Only blob references are rewritten onto the subquery; every other reference keeps its original events-table type
-    and resolves against the subquery alias by name, so its real nullability still drives `ifNull(...)` wrapping (see
-    the module docstring).
+    A hoisted reference carries the projected column's real nullability (see the module docstring), so a non-nullable
+    value stays unwrapped and can serve as a join key, while a nullable column still wraps correctly.
 
     Sets `blocked` if a referenced events column is unresolvable, so the caller declines."""
 
@@ -137,25 +135,21 @@ class EventsSubexprHoister(CloningVisitor):
         self.blocked = False
 
     def visit(self, node: ast.AST | None) -> ast.AST:
-        # Each reference to a target events column — bare, or the blob inside a property read — gets the same column
-        # projected from the subquery; any surrounding computation stays in place. Only a blob reference is re-typed
-        # onto the subquery (hiding it from the physical pass); any other reference keeps its original type and
-        # resolves against the subquery alias by name, so its real nullability still applies — a non-nullable join
-        # key must not pick up a blanket-nullable `ifNull(...)` wrap, which ClickHouse rejects as a join key.
+        # Each reference to a target events column — bare, or the blob inside a property read — becomes a reference
+        # to the same column projected from the subquery; any surrounding computation stays in place. A join key
+        # needs no special handling; its nullability rides the projected column's type.
         if isinstance(node, ast.Field) and self._is_target_field(node.type):
-            field = self._intern(node)
-            if isinstance(field, StringJSONDatabaseField):
-                name = field.name
+            name = self._intern(node)
+            if name is not None:
                 return ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=self.subquery_ref))
 
         return super().visit(node)
 
     def visit_alias(self, node: ast.Alias) -> ast.Alias:
         # The resolver wraps a bare column reference in an alias whose `FieldAliasType` carries the events column's
-        # `FieldType` again. When the inner field is rewritten (a blob reference), keeping the old wrapper would leave
-        # it stale, and downstream consumers that resolve through it (`resolve_field_type`) would treat the outer
-        # reference as still reading the real events table. Re-point the wrapper at the rewritten expression's type
-        # (mirrors lowering's `visit_alias`); for an unrewritten reference this rebuilds an identical wrapper.
+        # `FieldType` again. Rewriting only the inner field would leave that wrapper stale, and downstream consumers
+        # that resolve through it (`resolve_field_type`) would treat the outer reference as still reading the real
+        # events table. Re-point the wrapper at the rewritten expression's type (mirrors lowering's `visit_alias`).
         new_node = cast(ast.Alias, super().visit_alias(node))
         unwrapped: ast.Type | None = new_node.type
         while isinstance(unwrapped, ast.FieldAliasType):
@@ -176,31 +170,30 @@ class EventsSubexprHoister(CloningVisitor):
     def visit_select_set_query(self, node: ast.SelectSetQuery) -> ast.SelectSetQuery:
         return cast(ast.SelectSetQuery, clone_expr(node, clear_types=False))
 
-    def _intern(self, node: ast.Field) -> DatabaseField | None:
-        """Record a subquery projection for the column `node` reads and return its resolved database field. The
-        projection name is always the real database column name, so two different reads can never collide on one
-        projection; repeated reads of a column share it. Returns None (setting `blocked`) for an unresolvable column."""
+    def _intern(self, node: ast.Field) -> str | None:
+        """Record a subquery projection for the column `node` reads and return the name to reference it by. The name
+        is always the real database column name, so two different reads can never collide on one projection; repeated
+        reads of a column share it. Returns None (setting `blocked`) for an unresolvable column."""
         assert isinstance(node.type, ast.FieldType)
-        field = self._resolve_database_field(node.type)
-        if field is None:
+        name = self._database_column_name(node.type)
+        if name is None:
             self.blocked = True
             return None
-        name = field.name
         if name not in self.projections:
             value_type: ast.Type = node.type
             self.projections[name] = clone_expr(node, clear_types=False)
             self.column_types[name] = value_type
             self.subquery_type.columns[name] = value_type
-        return field
+        return name
 
     def _is_target_field(self, node_type: ast.Type | None) -> bool:
         return isinstance(node_type, ast.FieldType) and self._matches_target_table(node_type.table_type)
 
-    def _resolve_database_field(self, field_type: ast.FieldType) -> DatabaseField | None:
+    def _database_column_name(self, field_type: ast.FieldType) -> str | None:
         try:
             resolved = field_type.resolve_database_field(self.context)
             if isinstance(resolved, DatabaseField):
-                return resolved
+                return resolved.name
             return None
         except Exception as err:
             # Fail-safe: an unresolvable column blocks pushdown rather than risking a wrong subquery; debug-logged so
@@ -342,10 +335,9 @@ class EventsPredicatePushdownTransform(TraversingVisitor):
         if inner_limit is None:
             return "no_short_circuitable_limit"
 
-        # Hoist the events leaves the outer query still references into the pre-filtering subquery; blob references
-        # are rewritten to read the subquery column, other references resolve against the subquery alias by name.
-        # Build the subquery's type/ref first so the rewritten references can point at it; nothing on `node` is
-        # mutated until every check below passes.
+        # Hoist the events leaves the outer query still references into the pre-filtering subquery, rewriting each
+        # outer reference to read the subquery column. Build the subquery's type/ref first so the rewritten
+        # references can point at it; nothing on `node` is mutated until every check below passes.
         new_alias = node.select_from.alias or "events"
         subquery_type = ast.SelectQueryType(columns={}, tables={new_alias: events_table_type})
         subquery_ref = ast.SelectQueryAliasType(alias=new_alias, select_query_type=subquery_type)

--- a/posthog/hogql/transforms/test/__snapshots__/test_events_predicate_pushdown.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_events_predicate_pushdown.ambr
@@ -4,14 +4,14 @@
   
   SELECT e.event AS event, e__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(e.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, e.event AS event 
+    SELECT e.`$session_id` AS `$session_id`, e.event AS event 
     FROM events AS e 
-    WHERE and(equals(e.team_id, 420), greaterOrEquals(e.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), less(e.timestamp, toDateTime64(%(hogql_val_3)s, 6, %(hogql_val_4)s))) 
+    WHERE and(equals(e.team_id, 420), greaterOrEquals(e.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), less(e.timestamp, toDateTime64(%(hogql_val_2)s, 6, %(hogql_val_3)s))) 
     LIMIT 50) AS e LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_5)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_6)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_7)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_8)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_9)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(e.__pd_expr_0, e__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_8)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, %(hogql_val_9)s)), e__session.session_id_v7) 
   LIMIT 50
   '''
 # ---
@@ -20,30 +20,30 @@
   
   SELECT events.event AS event, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), less(events.timestamp, toDateTime64(%(hogql_val_3)s, 6, %(hogql_val_4)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), less(events.timestamp, toDateTime64(%(hogql_val_2)s, 6, %(hogql_val_3)s))) 
     LIMIT 50) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_5)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_6)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_7)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_8)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_9)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_8)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_9)s)), events__session.session_id_v7) 
   LIMIT 50
   '''
 # ---
 # name: TestEventsPredicatePushdownTransform.test_bare_timestamp_with_select_alias_pushes_down
   '''
   
-  SELECT events.event AS event, events.__pd_expr_0 AS timestamp, events__session.`$session_duration` AS `$session_duration` 
+  SELECT events.event AS event, toTimeZone(toTimeZone(events.timestamp, %(hogql_val_10)s), %(hogql_val_11)s) AS timestamp, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toTimeZone(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s) AS __pd_expr_0, toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_2)s)) AS __pd_expr_1, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event, events.timestamp AS timestamp 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(toTimeZone(events.timestamp, %(hogql_val_3)s), %(hogql_val_4)s), %(hogql_val_5)s), lessOrEquals(toTimeZone(toTimeZone(events.timestamp, %(hogql_val_6)s), %(hogql_val_7)s), today())) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s), %(hogql_val_2)s), lessOrEquals(toTimeZone(toTimeZone(events.timestamp, %(hogql_val_3)s), %(hogql_val_4)s), today())) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_8)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_9)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_10)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_5)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_6)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_7)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_11)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(today(), toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_1, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_8)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(today(), toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_9)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -52,14 +52,14 @@
   
   SELECT e.event AS event, e__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(e.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, e.event AS event 
+    SELECT e.`$session_id` AS `$session_id`, e.event AS event 
     FROM events AS e 
-    WHERE and(equals(e.team_id, 420), greaterOrEquals(e.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s))) 
+    WHERE and(equals(e.team_id, 420), greaterOrEquals(e.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s))) 
     LIMIT 50000) AS e LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_2)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_3)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_4)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_6)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(e.__pd_expr_0, e__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_5)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, %(hogql_val_6)s)), e__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -68,14 +68,14 @@
   
   SELECT events.event AS event, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s))) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_2)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_3)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_4)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_6)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_5)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_6)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -104,16 +104,16 @@
 # name: TestEventsPredicatePushdownTransform.test_multiple_poe_fields_with_session_join
   '''
   
-  SELECT events.event AS event, events.person_id AS id, events.person_properties AS properties, events.__pd_expr_0 AS created_at, events__session.`$session_duration` AS `$session_duration` 
+  SELECT events.event AS event, events.person_id AS id, events.person_properties AS properties, toTimeZone(events.person_created_at, %(hogql_val_7)s) AS created_at, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toTimeZone(events.person_created_at, %(hogql_val_0)s) AS __pd_expr_0, toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_1)s)) AS __pd_expr_1, events.event AS event, events.person_id AS person_id, events.person_properties AS person_properties 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event, events.person_created_at AS person_created_at, events.person_id AS person_id, events.person_properties AS person_properties 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_2)s, 6, %(hogql_val_3)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s))) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_2)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_3)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_4)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_1, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_5)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_6)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -122,14 +122,14 @@
   
   SELECT events.event AS event, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), equals(events.event, %(hogql_val_3)s)) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), equals(events.event, %(hogql_val_2)s)) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_6)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_7)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -227,16 +227,16 @@
 # name: TestEventsPredicatePushdownTransform.test_poe_created_at_with_session_join
   '''
   
-  SELECT events.event AS event, events.__pd_expr_0 AS created_at, events__session.`$session_duration` AS `$session_duration` 
+  SELECT events.event AS event, toTimeZone(events.person_created_at, %(hogql_val_7)s) AS created_at, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toTimeZone(events.person_created_at, %(hogql_val_0)s) AS __pd_expr_0, toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_1)s)) AS __pd_expr_1, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event, events.person_created_at AS person_created_at 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_2)s, 6, %(hogql_val_3)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s))) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_2)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_3)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_4)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_1, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_5)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_6)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -245,14 +245,14 @@
   
   SELECT events.person_id AS id, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.person_id AS person_id 
+    SELECT events.`$session_id` AS `$session_id`, events.person_id AS person_id 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s))) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_2)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_3)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_4)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_6)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_5)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_6)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -261,14 +261,14 @@
   
   SELECT events.event AS event, events.person_properties AS properties, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event, events.person_properties AS person_properties 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event, events.person_properties AS person_properties 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s))) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_2)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_3)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_4)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_6)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_5)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_6)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -348,14 +348,14 @@
   FROM (
     SELECT events.event AS event, events__session.`$session_duration` AS `$session_duration` 
     FROM (
-      SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event 
+      SELECT events.`$session_id` AS `$session_id`, events.event AS event 
       FROM events 
-      WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), or(equals(events.event, %(hogql_val_3)s), equals(events.event, %(hogql_val_4)s))) 
+      WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), or(equals(events.event, %(hogql_val_2)s), equals(events.event, %(hogql_val_3)s))) 
       LIMIT 100) AS events LEFT JOIN (
-      SELECT dateDiff(%(hogql_val_5)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_6)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_7)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+      SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
       FROM raw_sessions 
-      WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_8)s, toIntervalDay(3)))) 
-      GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+      WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3)))) 
+      GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_8)s)), events__session.session_id_v7) 
     LIMIT 100) 
   GROUP BY event 
   LIMIT 50000

--- a/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
@@ -4,14 +4,14 @@
   
   SELECT events.event AS event, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), less(events.timestamp, toDateTime64(%(hogql_val_3)s, 6, %(hogql_val_4)s)), equals(events.event, %(hogql_val_5)s), isNotNull(events.`$session_id`)) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), less(events.timestamp, toDateTime64(%(hogql_val_2)s, 6, %(hogql_val_3)s)), equals(events.event, %(hogql_val_4)s), isNotNull(events.`$session_id`)) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_6)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_7)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_8)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_5)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_6)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_7)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_9)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_10)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_8)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_9)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_10)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -33,14 +33,14 @@
   
   SELECT events.event AS event, events__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, events.event AS event 
+    SELECT events.`$session_id` AS `$session_id`, events.event AS event 
     FROM events 
-    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), less(events.timestamp, toDateTime64(%(hogql_val_3)s, 6, %(hogql_val_4)s))) 
+    WHERE and(equals(events.team_id, 420), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), less(events.timestamp, toDateTime64(%(hogql_val_2)s, 6, %(hogql_val_3)s))) 
     LIMIT 50000) AS events LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_5)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_6)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_7)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_8)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_9)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.__pd_expr_0, events__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_8)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, %(hogql_val_9)s)), events__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---
@@ -49,14 +49,14 @@
   
   SELECT e.event AS event, e__session.`$session_duration` AS `$session_duration` 
   FROM (
-    SELECT toUInt128(accurateCastOrNull(e.`$session_id`, %(hogql_val_0)s)) AS __pd_expr_0, e.event AS event 
+    SELECT e.`$session_id` AS `$session_id`, e.event AS event 
     FROM events AS e 
-    WHERE and(equals(e.team_id, 420), greaterOrEquals(e.timestamp, toDateTime64(%(hogql_val_1)s, 6, %(hogql_val_2)s)), equals(e.event, %(hogql_val_3)s)) 
+    WHERE and(equals(e.team_id, 420), greaterOrEquals(e.timestamp, toDateTime64(%(hogql_val_0)s, 6, %(hogql_val_1)s)), equals(e.event, %(hogql_val_2)s)) 
     LIMIT 50000) AS e LEFT JOIN (
-    SELECT dateDiff(%(hogql_val_4)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_5)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_6)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
+    SELECT dateDiff(%(hogql_val_3)s, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_4)s)), max(toTimeZone(raw_sessions.max_timestamp, %(hogql_val_5)s))) AS `$session_duration`, raw_sessions.session_id_v7 AS session_id_v7 
     FROM raw_sessions 
-    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_7)s, toIntervalDay(3)))) 
-    GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(e.__pd_expr_0, e__session.session_id_v7) 
+    WHERE and(equals(raw_sessions.team_id, 420), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_6)s, toIntervalDay(3)))) 
+    GROUP BY raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, %(hogql_val_7)s)), e__session.session_id_v7) 
   LIMIT 50000
   '''
 # ---

--- a/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
@@ -763,9 +763,8 @@ class TestEventsPredicatePushdownTransformUnit:
 
 
 class TestEventsSubexprHoister(BaseTest):
-    """The hoister records which source columns the pre-filtering subquery must project for an events query's outer
-    expressions, rewriting only blob references onto the subquery (other references keep their original type and
-    resolve against the subquery alias by name). It runs on the lowered AST (property value reads are
+    """The hoister rewrites an events query's outer column references into references to the pre-filtering subquery,
+    recording which source columns the subquery must project. It runs on the lowered AST (property value reads are
     `JSONFieldAccess`, whose blob column gets projected while the extraction stays outer); a lazy-join or other
     non-events reference is simply left in the outer query."""
 
@@ -807,12 +806,11 @@ class TestEventsSubexprHoister(BaseTest):
         assert hoister.blocked is False
 
     def test_direct_column_is_projected_under_its_database_name(self):
-        # A direct column is hoisted under its database name, but the outer occurrence keeps its original type and
-        # resolves against the subquery alias by name; the printer derives its nullability from the real events
-        # column, so a non-nullable value stays unwrapped and usable as a join key.
+        # A direct column is hoisted under its database name and the outer occurrence reads the subquery column;
+        # the printer resolves its nullability through the subquery column type, so it stays a usable join key.
         hoister, rewritten, subquery_ref = self._run("SELECT event FROM events")
         assert "event" in hoister.projections
-        assert self._references_subquery(rewritten[0], subquery_ref) is False
+        assert self._references_subquery(rewritten[0], subquery_ref) is True
 
     def test_property_read_projects_its_blob_column(self):
         # A property read projects the raw blob column under its database name; the extraction stays outer.


### PR DESCRIPTION
## Problem

The printer treats any field read through a subquery or select alias as nullable, wrapping its comparisons in `ifNull(equals(...), 0)`. For columns whose projected type is provably non-nullable the wrapper is redundant — it bloats the SQL and an ifNull-wrapped equality cannot serve as a ClickHouse join key.

This optimization was de-scoped from the rearchitecture branch (#62239) so that branch stays at strict master parity; it is tracked here with its own rationale.

## Changes

`BasePrinter._is_type_nullable` trusts `resolve_constant_type()` for fields read through a non-base-table type, dropping ~200 redundant `ifNull` wrappers across snapshots.

Correctness relies on two invariants worth pinning before this lands:
- ClickHouse default `join_use_nulls = 0` (LEFT JOIN misses fill type defaults, not NULL) — the dropped wrapper would otherwise change `!=` / `NOT` semantics on joined columns.
- Resolver-declared column types being accurate — a type that under-declares nullability now flips filter semantics instead of producing a redundant wrapper.

**Status: tracker, not land-ready.** Will be rebased and edited before review.

## How did you test this code?

Agent-authored. Automated tests only: this branch is the exact revert of the de-scope commit on the base branch, which was validated by the printer, pushdown, and where-clause-extractor suites at the time of the original implementation. Snapshot churn is regenerated by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by Claude Code during the QA review of #62239. The review flagged that this relaxation makes resolver type accuracy and the `join_use_nulls=0` default load-bearing for WHERE semantics, validated only by a differential harness that was deleted at cutover — so the maintainer de-scoped it from the rearchitecture branch into this tracker. Recommended hardening before landing: pin `join_use_nulls=0` in standard HogQL query settings and log the `except Exception → nullable` fallback.
