### PR TITLE
perf(hogql): read access-restricted properties as a constant NULL

### DIFF
--- a/posthog/hogql/printer/test/test_property_access_control.py
+++ b/posthog/hogql/printer/test/test_property_access_control.py
@@ -79,19 +79,20 @@ class TestRestrictPropertiesInHogQL(BaseTest):
         assert "secret_field" in sql
 
     def test_denied_event_property_is_stripped_silently(self):
-        # Restricted properties are removed from the JSON blob via JSONDropKeys rather than
-        # raising an error, so explicit access (``properties.secret_field``) compiles to a
-        # JSON extract over the stripped blob and resolves to an empty string at runtime.
+        # A restricted property reads as NULL rather than raising. Explicit access (``properties.secret_field``)
+        # compiles to a constant NULL — the value is never extracted from the blob, and the key never appears, inline
+        # or as a parameter.
         PropertyAccessControl.objects.create(
             team=self.team,
             property_definition=self.event_prop,
             access_level=PropertyAccessLevel.NONE.value,
         )
         sql, values = self._compile_select_with_values("SELECT properties.secret_field FROM events")
-        assert "JSONDropKeys" in sql
-        # the restricted key only appears as a parameter placeholder — never as an inline literal
+        assert "NULL AS secret_field" in sql
+        assert "JSONExtract" not in sql  # the restricted value is never read from the blob
+        assert "JSONDropKeys" not in sql  # no redundant drop-then-extract
         assert "'secret_field'" not in sql
-        self._assert_value_present(values, "secret_field")
+        assert not any("secret_field" in str(v) for v in values.values())
 
     def test_allowed_property_not_affected(self):
         PropertyAccessControl.objects.create(
@@ -136,8 +137,9 @@ class TestRestrictPropertiesInHogQL(BaseTest):
         assert "secret_field" in sql
 
     def test_denied_person_property_is_stripped_silently(self):
-        # Restricted person properties are removed from ``person.properties`` rather than
-        # raising — so the same query produces consistent (empty) output across PoE modes.
+        # A restricted person property reads as NULL rather than raising. Through the PoE join it resolves to
+        # ``argMax(tuple(NULL), ...)`` inside the subquery, so the value is never extracted and the same query produces
+        # consistent (NULL) output across PoE modes.
         person_prop = PropertyDefinition.objects.create(
             team=self.team,
             name="secret_person_field",
@@ -150,9 +152,10 @@ class TestRestrictPropertiesInHogQL(BaseTest):
             access_level=PropertyAccessLevel.NONE.value,
         )
         sql, values = self._compile_select_with_values("SELECT person.properties.secret_person_field FROM events")
-        assert "JSONDropKeys" in sql
+        assert "JSONExtract" not in sql  # the restricted value is never read from the blob
+        assert "JSONDropKeys" not in sql
         assert "'secret_person_field'" not in sql
-        self._assert_value_present(values, "secret_person_field")
+        assert not any("secret_person_field" in str(v) for v in values.values())
 
     def test_no_user_context_uses_default_rules(self):
         PropertyAccessControl.objects.create(
@@ -168,10 +171,11 @@ class TestRestrictPropertiesInHogQL(BaseTest):
         )
         node = parse_select("SELECT properties.secret_field FROM events")
         sql, _ = prepare_and_print_ast(node, context=context, dialect="clickhouse")
-        # default rules still apply without a user — the restricted key is stripped
-        assert "JSONDropKeys" in sql
+        # default rules still apply without a user — the restricted property reads as NULL
+        assert "NULL AS secret_field" in sql
+        assert "JSONExtract" not in sql
         assert "'secret_field'" not in sql
-        assert "secret_field" in context.values.values()
+        assert not any("secret_field" in str(v) for v in context.values.values())
 
     def test_non_property_fields_not_affected(self):
         PropertyAccessControl.objects.create(
@@ -189,12 +193,14 @@ class TestRestrictPropertiesInHogQL(BaseTest):
             property_definition=self.event_prop,
             access_level=PropertyAccessLevel.NONE.value,
         )
-        # the WHERE clause compiles, but the restricted property is stripped from the JSON,
-        # so the comparison effectively runs against an empty string
+        # the WHERE clause compiles, but the restricted property reads as NULL, so the comparison is against NULL (never
+        # against the column or the blob) and matches no rows
         sql, values = self._compile_select_with_values("SELECT event FROM events WHERE properties.secret_field = 'foo'")
-        assert "JSONDropKeys" in sql
+        assert "equals(NULL," in sql
+        assert "JSONExtract" not in sql
+        assert "JSONDropKeys" not in sql
         assert "'secret_field'" not in sql
-        self._assert_value_present(values, "secret_field")
+        assert not any("secret_field" in str(v) for v in values.values())
 
     def test_select_star_works_with_restrictions(self):
         PropertyAccessControl.objects.create(
@@ -230,22 +236,19 @@ class TestRestrictPropertiesInHogQL(BaseTest):
         assert "secret_field" in sql
 
     def test_silent_strip_does_not_leak_access_control_information(self):
-        # The compiled SQL must not embed the restricted property name as a literal,
-        # error message, or comment — anything an attacker could read off the wire to
-        # tell "this property exists but I can't see it" apart from "this property
-        # doesn't exist". Restricted keys are passed through ``add_sensitive_value`` so
-        # they appear only in the parameter dict, not the SQL string.
+        # The compiled SQL must not reveal that a property was hidden — an attacker must not be able to tell "this
+        # property exists but I can't see it" apart from "this property doesn't exist". The restricted read is a constant
+        # NULL, so the key name appears nowhere: not as an inline literal, not as a parameter.
         PropertyAccessControl.objects.create(
             team=self.team,
             property_definition=self.event_prop,
             access_level=PropertyAccessLevel.NONE.value,
         )
         sql, values = self._compile_select_with_values("SELECT properties.secret_field FROM events")
-        # restricted key never appears as an inline literal in SQL — only as a parameter
         assert "'secret_field'" not in sql
         for forbidden_word in ["restricted", "denied", "permission", "not allowed"]:
             assert forbidden_word not in sql.lower(), f"SQL leaks access control info: '{sql}'"
-        self._assert_value_present(values, "secret_field")
+        assert not any("secret_field" in str(v) for v in values.values())
 
     @parameterized.expand(
         [
@@ -378,17 +381,19 @@ class TestRestrictPropertiesInHogQL(BaseTest):
         self._assert_value_present(values, "secret_field")
 
     def test_column_aliased_explicit_property_access_is_stripped(self):
-        # regression: explicit access ``e.c.secret_field`` (where ``c`` aliases ``properties``)
-        # must be stripped via JSONDropKeys, matching the unaliased case.
+        # regression: explicit access ``e.c.secret_field`` (where ``c`` aliases ``properties``) reads as NULL, matching
+        # the unaliased case.
         PropertyAccessControl.objects.create(
             team=self.team,
             property_definition=self.event_prop,
             access_level=PropertyAccessLevel.NONE.value,
         )
         sql, values = self._compile_select_with_values("SELECT e.c.secret_field FROM events AS e (a, b, c)")
-        assert "JSONDropKeys" in sql
+        assert "NULL AS secret_field" in sql
+        assert "JSONExtract" not in sql
+        assert "JSONDropKeys" not in sql
         assert "'secret_field'" not in sql
-        self._assert_value_present(values, "secret_field")
+        assert not any("secret_field" in str(v) for v in values.values())
 
     @parameterized.expand(
         [
@@ -401,10 +406,9 @@ class TestRestrictPropertiesInHogQL(BaseTest):
     def test_person_property_access_is_consistent_across_poe_modes(
         self, _case_name: str, persons_on_events_mode: PersonsOnEventsMode
     ):
-        # regression: previously, ``person.properties.email`` raised a ResolutionError in joined
-        # mode but silently returned an empty value in PoE mode. The intended behaviour is to
-        # strip restricted keys from the JSON blob (returning empty) in *all* modes, so the same
-        # query produces the same compiled output regardless of how person properties are sourced.
+        # regression: previously, ``person.properties.email`` raised a ResolutionError in joined mode but silently
+        # returned an empty value in PoE mode. The intended behaviour is consistent across modes — a restricted property
+        # reads as NULL regardless of how person properties are sourced.
         person_prop = PropertyDefinition.objects.create(
             team=self.team,
             name="email",
@@ -425,10 +429,11 @@ class TestRestrictPropertiesInHogQL(BaseTest):
         )
         node = parse_select("SELECT uuid, event, person.properties.email FROM events")
         sql, _ = prepare_and_print_ast(node, context=context, dialect="clickhouse")
-        assert "JSONDropKeys" in sql
-        # the restricted key never leaks as an inline literal in any PoE mode
+        # the restricted value is never extracted, in any PoE mode, and the key never leaks
+        assert "JSONExtract" not in sql
+        assert "JSONDropKeys" not in sql
         assert "'email'" not in sql
-        assert "email" in context.values.values()
+        assert not any("email" in str(v) for v in context.values.values())
 
 
 class TestRestrictedPropertyWithMaterializedColumn(ClickhouseTestMixin, BaseTest):

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -119,9 +119,9 @@ def prepare_ast_for_printing(
     context.modifiers = set_default_in_cohort_via(context.modifiers)
 
     # Load property-level access control restrictions onto the context. They are enforced only on the ClickHouse path —
-    # the printer wraps the JSON blob in JSONDropKeys, and property resolution declines backing columns. The warehouse
-    # (Postgres / DuckDB) dialects only compile external data-warehouse sources, which carry no restrictable
-    # event/person properties, so they need no enforcement here.
+    # the printer wraps the JSON blob in JSONDropKeys, and property resolution declines backing columns (and reads a
+    # restricted property as NULL). The warehouse (Postgres / DuckDB) dialects only compile external data-warehouse
+    # sources, which carry no restrictable event/person properties, so they need no enforcement here.
     if context.team_id is not None and context.restricted_properties is None:
         with context.timings.measure("load_restricted_properties"):
             context.restricted_properties = get_restricted_properties_for_team(

--- a/posthog/hogql/transforms/clickhouse_property_resolution.py
+++ b/posthog/hogql/transforms/clickhouse_property_resolution.py
@@ -97,8 +97,9 @@ def resolve_materialized_property_source(
         return None
 
     # Property-level access control: a restricted property must never resolve to a backing column, on any path (value
-    # read, comparison, key-existence). The column holds the raw value and bypasses the printer's JSONDropKeys blob
-    # scrub, so reading or comparing it directly would leak the value. Declining here forces the scrubbed JSON path.
+    # read, comparison, key-existence). The column holds the raw value, so a comparison like `WHERE properties.x = 'y'`
+    # could otherwise read it and probe the value. Declining here makes the comparison optimizers fall back; the read
+    # itself becomes a constant NULL in `_substitute_value_read`.
     if property_name in restricted_property_keys_for_table_type(field_type.table_type, context):
         return None
 
@@ -289,7 +290,8 @@ def _substitute_value_read(node: ast.JSONFieldAccess, context: HogQLContext) -> 
     """The backing-column read for a `JSONFieldAccess`, or None to leave it as the JSON extract.
 
     Picks the column and builds the read (the numeric/boolean cast is not handled here — it already wraps this node).
-    Returns None when the property has no backing column or is access-restricted.
+    Returns a constant NULL for an access-restricted property, or None when the property has no precomputed column
+    (materialized, dmat, or property group) to read from — in which case it stays a raw JSON extract.
     """
     field_type = _blob_field_type_of(node)
     # Lowering builds every JSONFieldAccess with the blob FieldType on `expr` and a non-empty key path. Assert the
@@ -299,10 +301,12 @@ def _substitute_value_read(node: ast.JSONFieldAccess, context: HogQLContext) -> 
     first_key = str(node.keys[0])
     deeper_keys: list[str | int] = list(node.keys[1:])
 
-    # Access control: a restricted property must not be read from its materialized column. Decline, so it stays a JSON
-    # read — which the printer strips the restricted key from, collapsing the value to ''.
+    # Access control: a restricted property reads as NULL. The blob path would compute the same value — the printer's
+    # JSONDropKeys strips the key, so extracting it always yields '' which scrubs to NULL — so return that constant
+    # directly and skip the wasted drop-then-extract. (The column resolvers also decline, so comparisons over a
+    # restricted property never read the backing column either; their operand falls through to this same NULL.)
     if first_key in restricted_property_keys_for_table_type(field_type.table_type, context):
-        return None
+        return ast.Constant(value=None, type=ast.StringType(nullable=True))
 
     source = resolve_materialized_property_source(field_type, first_key, context)
     if source is None:


### PR DESCRIPTION
## Problem

A read of an access-restricted property compiles to a JSON extract over the `JSONDropKeys(...)`-scrubbed blob. The key is always dropped, so the extract always yields `''` and scrubs to NULL — the query pays for a JSON parse whose result is known at compile time.

This optimization was de-scoped from the rearchitecture branch (#62239) so that branch stays at strict master parity; it is tracked here with its own rationale.

## Changes

`_substitute_value_read` compiles a restricted property read to a constant `NULL` instead of the drop-then-extract. The related access-control enforcement (restricted properties never resolve to materialized / dmat / property-group columns) is unchanged and stays on the base branch.

Known trade-off to sign off before landing: "restricted" vs "nonexistent" becomes distinguishable in the compiled SQL returned by query responses (`NULL AS x` vs a JSON extract). The property's value never leaks either way; this discloses only that a restriction exists.

**Status: tracker, not land-ready.** Will be rebased and edited before review.

## How did you test this code?

Agent-authored. Automated tests only: this branch is the exact revert of the de-scope commit on the base branch; `posthog/hogql/printer/test/test_property_access_control.py` covers both shapes (constant-NULL here, scrubbed-extract on the base branch).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by Claude Code during the QA review of #62239. The review classified this as an added optimization (not master parity) with a metadata-disclosure trade-off, so the maintainer de-scoped it from the rearchitecture branch into this tracker for a separate decision.
