### PR TITLE
fix(frontend): release hidden overlay raster backings in replay, homepage, and email templater

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -163,7 +163,9 @@ function DestinationEmailTemplaterForm({
                                 className={clsx(
                                     activeContentTab === 'visual'
                                         ? 'flex flex-col flex-1'
-                                        : 'absolute inset-0 -z-10 opacity-0 pointer-events-none'
+                                        : // invisible releases the hidden editor's raster backing while
+                                          // visibility (unlike display:none) preserves its layout state
+                                          'absolute inset-0 -z-10 opacity-0 pointer-events-none invisible'
                                 )}
                             >
                                 <EmailEditor
@@ -535,7 +537,9 @@ function NativeEmailTemplaterForm({
                                 className={clsx(
                                     activeContentTab === 'visual'
                                         ? 'flex flex-col flex-1'
-                                        : 'absolute inset-0 -z-10 opacity-0 pointer-events-none'
+                                        : // invisible releases the hidden editor's raster backing while
+                                          // visibility (unlike display:none) preserves its layout state
+                                          'absolute inset-0 -z-10 opacity-0 pointer-events-none invisible'
                                 )}
                             >
                                 <EmailEditor

--- a/frontend/src/scenes/project-homepage/ai-first/AiFirstHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/AiFirstHomepage.tsx
@@ -41,10 +41,12 @@ export function AiFirstHomepage(): JSX.Element {
                 {/* Chat header — fixed at top, fades in independently */}
                 <div
                     className={cn(
-                        'absolute top-0 left-0 right-0 z-10 transition-opacity duration-300 ease-out motion-reduce:duration-0',
+                        // visibility joins the transition so the fade still plays but the hidden
+                        // header releases its raster backing (see PanelLayout scrims)
+                        'absolute top-0 left-0 right-0 z-10 transition-[opacity,visibility] duration-300 ease-out motion-reduce:duration-0',
                         isAi && phaseAtLeast(animationPhase, 'separator')
                             ? 'opacity-100'
-                            : 'opacity-0 pointer-events-none'
+                            : 'opacity-0 pointer-events-none invisible'
                     )}
                 >
                     {isAi && (

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -220,7 +220,9 @@ export function PlayerController(): JSX.Element {
                 hoverModeIsEnabled && showPlayerChrome
                     ? 'opacity-100 bg-surface-primary pointer-events-auto'
                     : hoverModeIsEnabled
-                      ? 'opacity-0 pointer-events-none'
+                      ? // invisible releases the hidden overlay's raster backing; transition-all
+                        // already covers visibility so the fade still plays (see PanelLayout scrims)
+                        'opacity-0 pointer-events-none invisible'
                       : 'bg-surface-primary'
             )}
         >

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaTopSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaTopSettings.tsx
@@ -171,7 +171,9 @@ export function PlayerMetaTopSettings(): JSX.Element {
                 hoverModeIsEnabled && showPlayerChrome
                     ? 'opacity-100 pointer-events-auto'
                     : hoverModeIsEnabled
-                      ? 'opacity-0 pointer-events-none'
+                      ? // invisible releases the hidden overlay's raster backing; transition-all
+                        // already covers visibility so the fade still plays (see PanelLayout scrims)
+                        'opacity-0 pointer-events-none invisible'
                       : ''
             )}
         >


### PR DESCRIPTION
## Problem

Follow-up to #62866, part of the per-document memory work for #32479. The same invisible-but-rasterized pattern exists in five more places: always-mounted overlays hidden via `opacity-0` keep their composited layer's raster backing alive, because opacity is applied at composite time. #62866 measured the mechanism on the layout scrims (releasing the hidden layers dropped renderer tile memory by ~37%); these are the remaining scene-local instances — smaller surfaces than the full-viewport scrims, but the replay player overlays sit over the player for the whole playback session and the email templater keeps an entire hidden editor rasterized behind the visible tab.

## Changes

Add `invisible` (visibility: hidden) to each hidden state:

- **`PlayerController.tsx` / `PlayerMetaTopSettings.tsx`** (replay hover-mode chrome): these already use `transition-all`, which covers `visibility`, so the 25ms fade is unchanged — visibility flips after fade-out and immediately on fade-in (CSS visibility animates discretely).
- **`AiFirstHomepage.tsx`** (chat header fade-in): transition extended from `transition-opacity` to `transition-[opacity,visibility]`, same as the scrim fix.
- **`EmailTemplater.tsx`** (×2, visual/plaintext tab switch): no transition involved; the hidden editor is kept mounted to preserve its state, and `visibility: hidden` — unlike `display: none` — preserves its layout, so the editor keeps its dimensions while no longer being rasterized.

All hidden states already carried `pointer-events-none`, so hit-testing semantics are unchanged; `invisible` also removes the hidden overlays from the accessibility tree and tab order, which matches their intent.

## How did you test this code?

I'm an agent; no manual testing claimed. The mechanism (visibility releases composited raster backing; discrete visibility transitions preserve fades) was empirically verified in #62866 via CDP memory-infra tracing and a live browser check of the transition timing. For this PR: oxlint/oxfmt clean on all four files; no tests or stories assert on these class lists.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @pauldambra. These five sites were found by grepping for the `opacity-0 pointer-events-none` always-mounted pattern after the PanelLayout scrim fix; each was checked individually for transition semantics (transition-all vs transition-opacity vs none) and for why the element stays mounted (the email templater deliberately keeps the editor alive across tab switches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
