### PR TITLE
feat(data-warehouse): implement deel import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -75,6 +75,7 @@ the row lists both.
 | crunchbase       | HTTP                        | requests                                                        | ✅                          |
 | customer_io      | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
 | datadog          | HTTP                        | requests                                                        | ✅                          |
+| deel             | HTTP                        | requests                                                        | ✅                          |
 | delighted        | HTTP                        | requests                                                        | ✅                          |
 | doit             | HTTP                        | requests                                                        | ✅                          |
 | drip             | HTTP                        | requests                                                        | ✅                          |
@@ -235,7 +236,6 @@ doesn't conflict with concurrent PRs.
 - culture_amp
 - databricks
 - db2
-- deel
 - display_video_360
 - dixa
 - docusign

--- a/posthog/temporal/data_imports/sources/deel/deel.py
+++ b/posthog/temporal/data_imports/sources/deel/deel.py
@@ -1,0 +1,155 @@
+import time
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.deel.settings import DEEL_ENDPOINTS
+
+DEEL_BASE_URL = "https://api.letsdeel.com/rest/v2"
+# Several Deel endpoints cap `limit` below 100, so stay safely under every cap.
+PAGE_SIZE = 50
+REQUEST_TIMEOUT_SECONDS = 60
+# Deel enforces a hard 5 req/s limit org-wide (shared across ALL tokens, 429
+# with no rate-limit headers), so requests are proactively spaced out.
+REQUEST_INTERVAL_SECONDS = 0.25
+MAX_RETRY_ATTEMPTS = 5
+
+
+class DeelRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class DeelResumeConfig:
+    # Offset-paginated endpoints persist the offset; the contracts keyset walk
+    # persists Deel's opaque `after_cursor` instead.
+    offset: Optional[int] = None
+    cursor: Optional[str] = None
+
+
+def _get_session(api_token: str) -> requests.Session:
+    return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
+
+
+def validate_credentials(api_token: str) -> bool:
+    """Confirm the API token is valid with a cheap one-person listing probe.
+
+    Scoped tokens may lack individual resource scopes (403); only 401 means the
+    token itself is bad."""
+    try:
+        response = _get_session(api_token).get(
+            f"{DEEL_BASE_URL}/people?{urlencode({'limit': 1})}",
+            timeout=10,
+        )
+        return response.status_code != 401
+    except Exception:
+        return False
+
+
+def get_rows(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DeelResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = DEEL_ENDPOINTS[endpoint]
+    session = _get_session(api_token)
+
+    @retry(
+        retry=retry_if_exception_type((DeelRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=2, max=60),
+        reraise=True,
+    )
+    def fetch(params: dict[str, Any]) -> dict[str, Any]:
+        # Proactive spacing keeps us under the org-wide 5 req/s budget.
+        time.sleep(REQUEST_INTERVAL_SECONDS)
+        url = f"{DEEL_BASE_URL}{config.path}?{urlencode(params)}"
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise DeelRetryableError(f"Deel API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"Deel API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if config.pagination == "cursor":
+        cursor: Optional[str] = resume_config.cursor if resume_config is not None else None
+        if cursor is not None:
+            logger.debug(f"Deel: resuming {endpoint} from cursor {cursor}")
+
+        while True:
+            params: dict[str, Any] = {"limit": PAGE_SIZE}
+            if cursor is not None:
+                params["after_cursor"] = cursor
+            body = fetch(params)
+            items = body.get("data", []) or []
+
+            if items:
+                yield items
+
+            next_cursor = (body.get("page") or {}).get("cursor")
+            if not next_cursor or not items:
+                break
+
+            cursor = next_cursor
+            # Save state AFTER yielding the page so a crash re-yields the last
+            # page (merge dedupes on primary key) rather than skipping it.
+            resumable_source_manager.save_state(DeelResumeConfig(cursor=cursor))
+        return
+
+    offset = resume_config.offset if resume_config is not None and resume_config.offset is not None else 0
+    if resume_config is not None:
+        logger.debug(f"Deel: resuming {endpoint} from offset {offset}")
+
+    while True:
+        body = fetch({"limit": PAGE_SIZE, "offset": offset})
+        items = body.get("data", []) or []
+
+        if items:
+            yield items
+
+        if len(items) < PAGE_SIZE:
+            break
+
+        offset += PAGE_SIZE
+        resumable_source_manager.save_state(DeelResumeConfig(offset=offset))
+
+
+def deel_source(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DeelResumeConfig],
+) -> SourceResponse:
+    config = DEEL_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_token=api_token,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        sort_mode="asc",
+    )

--- a/posthog/temporal/data_imports/sources/deel/deel.py
+++ b/posthog/temporal/data_imports/sources/deel/deel.py
@@ -39,19 +39,23 @@ def _get_session(api_token: str) -> requests.Session:
     return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
 
 
-def validate_credentials(api_token: str) -> bool:
+def validate_credentials(api_token: str) -> tuple[bool, str | None]:
     """Confirm the API token is valid with a cheap one-person listing probe.
 
     Scoped tokens may lack individual resource scopes (403); only 401 means the
-    token itself is bad."""
+    token itself is bad. A transient network failure surfaces as a distinct
+    "could not reach Deel" error so it isn't mistaken for a bad token."""
     try:
         response = _get_session(api_token).get(
             f"{DEEL_BASE_URL}/people?{urlencode({'limit': 1})}",
             timeout=10,
         )
-        return response.status_code != 401
-    except Exception:
-        return False
+    except requests.RequestException as e:
+        return False, f"Could not reach Deel: {e}"
+
+    if response.status_code == 401:
+        return False, "Invalid Deel API token"
+    return True, None
 
 
 def get_rows(

--- a/posthog/temporal/data_imports/sources/deel/settings.py
+++ b/posthog/temporal/data_imports/sources/deel/settings.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+
+@dataclass
+class DeelEndpointConfig:
+    name: str
+    path: str
+    # Deel mixes pagination styles per endpoint: limit/offset with `page`
+    # metadata on most endpoints, `after_cursor` keyset on contracts.
+    pagination: Literal["offset", "cursor"]
+    primary_key: str = "id"
+    # Stable creation-time field used for datetime partitioning.
+    partition_key: Optional[str] = None
+
+
+# Core HR objects expose no updated-since filter and invoices change status
+# after issuing, so every stream is an honest full refresh (matching Fivetran's
+# Lite connector). Date-range incremental on invoices/timesheets is a possible
+# follow-up once the filter behavior is verified against a live account.
+DEEL_ENDPOINTS: dict[str, DeelEndpointConfig] = {
+    "people": DeelEndpointConfig(
+        name="people",
+        path="/people",
+        pagination="offset",
+    ),
+    "contracts": DeelEndpointConfig(
+        name="contracts",
+        path="/contracts",
+        pagination="cursor",
+        partition_key="created_at",
+    ),
+    "invoices": DeelEndpointConfig(
+        name="invoices",
+        path="/invoices",
+        pagination="offset",
+    ),
+    "invoice_adjustments": DeelEndpointConfig(
+        name="invoice_adjustments",
+        path="/invoice-adjustments",
+        pagination="offset",
+    ),
+}
+
+ENDPOINTS = tuple(DEEL_ENDPOINTS.keys())

--- a/posthog/temporal/data_imports/sources/deel/source.py
+++ b/posthog/temporal/data_imports/sources/deel/source.py
@@ -91,10 +91,7 @@ Create an organization token in [Deel](https://app.deel.com/developer-center) un
     def validate_credentials(
         self, config: DeelSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        if validate_deel_credentials(config.api_token):
-            return True, None
-
-        return False, "Invalid Deel API token"
+        return validate_deel_credentials(config.api_token)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[DeelResumeConfig]:
         return ResumableSourceManager[DeelResumeConfig](inputs, DeelResumeConfig)

--- a/posthog/temporal/data_imports/sources/deel/source.py
+++ b/posthog/temporal/data_imports/sources/deel/source.py
@@ -1,29 +1,113 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.deel.deel import (
+    DeelResumeConfig,
+    deel_source,
+    validate_credentials as validate_deel_credentials,
+)
+from posthog.temporal.data_imports.sources.deel.settings import ENDPOINTS
 from posthog.temporal.data_imports.sources.generated_configs import DeelSourceConfig
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class DeelSource(SimpleSource[DeelSourceConfig]):
+class DeelSource(ResumableSource[DeelSourceConfig, DeelResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.DEEL
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.letsdeel.com": "Deel authentication failed. Please check your API token.",
+            "403 Client Error: Forbidden for url: https://api.letsdeel.com": "Deel denied access. Please check that your API token has the read scope for this dataset.",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.DEEL,
             label="Deel",
+            caption="""Enter your Deel API token to pull your Deel workforce and payroll data into the PostHog Data warehouse.
+
+Create an organization token in [Deel](https://app.deel.com/developer-center) under More > Developer with read scopes for the data you want to sync (e.g. `people:read`, `contracts:read`, `accounting:read`). Prefer an organization token over a personal token — personal tokens stop working when the user leaves the organization.""",
             iconPath="/static/services/deel.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/deel",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_token",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: DeelSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Core Deel objects have no updated-since filter, so every stream is an
+        # honest full refresh.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: DeelSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_deel_credentials(config.api_token):
+            return True, None
+
+        return False, "Invalid Deel API token"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[DeelResumeConfig]:
+        return ResumableSourceManager[DeelResumeConfig](inputs, DeelResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: DeelSourceConfig,
+        resumable_source_manager: ResumableSourceManager[DeelResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return deel_source(
+            api_token=config.api_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/posthog/temporal/data_imports/sources/deel/tests/test_deel.py
+++ b/posthog/temporal/data_imports/sources/deel/tests/test_deel.py
@@ -1,0 +1,163 @@
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.deel.deel import (
+    PAGE_SIZE,
+    DeelResumeConfig,
+    deel_source,
+    get_rows,
+    validate_credentials,
+)
+from posthog.temporal.data_imports.sources.deel.settings import DEEL_ENDPOINTS, ENDPOINTS
+
+
+def _make_manager(resume_state: DeelResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _response(items: list[dict[str, Any]], cursor: str | None = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    body: dict[str, Any] = {"data": items, "page": {"total_rows": len(items)}}
+    if cursor is not None:
+        body["page"]["cursor"] = cursor
+    resp.json.return_value = body
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with mock.patch("posthog.temporal.data_imports.sources.deel.deel.time.sleep"):
+        yield
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, True),
+            # A valid token without people:read still 403s; only 401 means the
+            # token itself is bad.
+            (403, True),
+            (401, False),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials("token") is expected
+
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_validate_credentials_swallows_exceptions(self, mock_session):
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("token") is False
+
+
+class TestGetRowsOffsetPagination:
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_paginates_until_short_page(self, mock_session):
+        full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
+        mock_session.return_value.get.side_effect = [
+            _response(full_page),
+            _response([{"id": "last"}]),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "people", mock.MagicMock(), manager))
+
+        assert len(batches) == 2
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0].offset == PAGE_SIZE
+        second_url = mock_session.return_value.get.call_args_list[1].args[0]
+        assert parse_qs(urlparse(second_url).query)["offset"] == [str(PAGE_SIZE)]
+
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_resumes_from_saved_offset(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        manager = _make_manager(DeelResumeConfig(offset=150))
+        list(get_rows("token", "people", mock.MagicMock(), manager))
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert parse_qs(urlparse(url).query)["offset"] == ["150"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_empty_response_stops_without_saving_state(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "people", mock.MagicMock(), manager))
+
+        assert batches == []
+        manager.save_state.assert_not_called()
+
+
+class TestGetRowsCursorPagination:
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_paginates_via_after_cursor(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "1"}], cursor="cur_abc"),
+            _response([{"id": "2"}]),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "contracts", mock.MagicMock(), manager))
+
+        assert [item["id"] for batch in batches for item in batch] == ["1", "2"]
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0].cursor == "cur_abc"
+        second_url = mock_session.return_value.get.call_args_list[1].args[0]
+        assert parse_qs(urlparse(second_url).query)["after_cursor"] == ["cur_abc"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_resumes_from_saved_cursor(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        manager = _make_manager(DeelResumeConfig(cursor="cur_resume"))
+        list(get_rows("token", "contracts", mock.MagicMock(), manager))
+
+        url = mock_session.return_value.get.call_args.args[0]
+        assert parse_qs(urlparse(url).query)["after_cursor"] == ["cur_resume"]
+
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_empty_page_with_cursor_stops(self, mock_session):
+        mock_session.return_value.get.return_value = _response([], cursor="cur_loop")
+
+        manager = _make_manager()
+        batches = list(get_rows("token", "contracts", mock.MagicMock(), manager))
+
+        assert batches == []
+        assert mock_session.return_value.get.call_count == 1
+        manager.save_state.assert_not_called()
+
+
+class TestDeelSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint):
+        config = DEEL_ENDPOINTS[endpoint]
+        response = deel_source("token", endpoint, mock.MagicMock(), _make_manager())
+
+        assert response.name == endpoint
+        assert response.primary_keys == [config.primary_key]
+        assert response.sort_mode == "asc"
+        if config.partition_key:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == [config.partition_key]
+        else:
+            assert response.partition_mode is None
+            assert response.partition_keys is None
+
+    @pytest.mark.parametrize("config", list(DEEL_ENDPOINTS.values()))
+    def test_partition_keys_are_stable_creation_fields(self, config):
+        if config.partition_key:
+            assert config.partition_key == "created_at"

--- a/posthog/temporal/data_imports/sources/deel/tests/test_deel.py
+++ b/posthog/temporal/data_imports/sources/deel/tests/test_deel.py
@@ -4,6 +4,8 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from unittest import mock
 
+import requests
+
 from posthog.temporal.data_imports.sources.deel.deel import (
     PAGE_SIZE,
     DeelResumeConfig,
@@ -23,10 +25,10 @@ def _make_manager(resume_state: DeelResumeConfig | None = None) -> mock.MagicMoc
 
 def _response(items: list[dict[str, Any]], cursor: str | None = None) -> mock.MagicMock:
     resp = mock.MagicMock()
-    body: dict[str, Any] = {"data": items, "page": {"total_rows": len(items)}}
+    page: dict[str, Any] = {"total_rows": len(items)}
     if cursor is not None:
-        body["page"]["cursor"] = cursor
-    resp.json.return_value = body
+        page["cursor"] = cursor
+    resp.json.return_value = {"data": items, "page": page}
     resp.status_code = 200
     resp.ok = True
     return resp
@@ -42,11 +44,11 @@ class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
         [
-            (200, True),
+            (200, (True, None)),
             # A valid token without people:read still 403s; only 401 means the
             # token itself is bad.
-            (403, True),
-            (401, False),
+            (403, (True, None)),
+            (401, (False, "Invalid Deel API token")),
         ],
     )
     @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
@@ -55,12 +57,15 @@ class TestValidateCredentials:
         response.status_code = status_code
         mock_session.return_value.get.return_value = response
 
-        assert validate_credentials("token") is expected
+        assert validate_credentials("token") == expected
 
     @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
-    def test_validate_credentials_swallows_exceptions(self, mock_session):
-        mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("token") is False
+    def test_validate_credentials_reports_network_error_distinctly(self, mock_session):
+        # A transient network failure must not masquerade as a bad token.
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+        valid, error = validate_credentials("token")
+        assert valid is False
+        assert error is not None and error.startswith("Could not reach Deel")
 
 
 class TestGetRowsOffsetPagination:
@@ -118,6 +123,22 @@ class TestGetRowsCursorPagination:
         assert manager.save_state.call_args.args[0].cursor == "cur_abc"
         second_url = mock_session.return_value.get.call_args_list[1].args[0]
         assert parse_qs(urlparse(second_url).query)["after_cursor"] == ["cur_abc"]
+
+    @pytest.mark.parametrize("num_pages", [2, 3])
+    @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
+    def test_saves_state_after_each_non_terminal_page(self, mock_session, num_pages):
+        # Pages 1..n-1 carry a cursor; the terminal page has none, so state is
+        # saved exactly n - 1 times — once after every page that advances.
+        responses = [_response([{"id": str(i)}], cursor=f"cur_{i}") for i in range(1, num_pages)]
+        responses.append(_response([{"id": str(num_pages)}]))
+        mock_session.return_value.get.side_effect = responses
+
+        manager = _make_manager()
+        list(get_rows("token", "contracts", mock.MagicMock(), manager))
+
+        assert manager.save_state.call_count == num_pages - 1
+        saved_cursors = [call.args[0].cursor for call in manager.save_state.call_args_list]
+        assert saved_cursors == [f"cur_{i}" for i in range(1, num_pages)]
 
     @mock.patch("posthog.temporal.data_imports.sources.deel.deel.make_tracked_session")
     def test_resumes_from_saved_cursor(self, mock_session):

--- a/posthog/temporal/data_imports/sources/deel/tests/test_deel_source.py
+++ b/posthog/temporal/data_imports/sources/deel/tests/test_deel_source.py
@@ -1,0 +1,118 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.deel.deel import DeelResumeConfig
+from posthog.temporal.data_imports.sources.deel.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.deel.source import DeelSource
+from posthog.temporal.data_imports.sources.generated_configs import DeelSourceConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestDeelSource:
+    def setup_method(self):
+        self.source = DeelSource()
+        self.team_id = 123
+        self.config = DeelSourceConfig(api_token="api-token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.DEEL
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Deel"
+        assert config.label == "Deel"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/deel.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_token"]
+
+    def test_api_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_token")
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.letsdeel.com/rest/v2/people?limit=50",
+            "403 Client Error: Forbidden for url: https://api.letsdeel.com/rest/v2/contracts",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_vendor_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "500 Server Error for url: https://api.letsdeel.com/rest/v2/people",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_unrelated(self, other_vendor_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_vendor_error for key in non_retryable_errors)
+
+    def test_get_schemas_are_full_refresh_only(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+        # No Deel core object exposes an updated-since filter; full refresh only.
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+        assert all(schema.incremental_fields == [] for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["people"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "people"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid Deel API token"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.deel.source.validate_deel_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.api_token)
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        inputs = mock.MagicMock()
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is DeelResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.deel.source.deel_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_deel_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "people"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_deel_source.assert_called_once()
+        kwargs = mock_deel_source.call_args.kwargs
+        assert kwargs["api_token"] == "api-token"
+        assert kwargs["endpoint"] == "people"
+        assert kwargs["resumable_source_manager"] is manager

--- a/posthog/temporal/data_imports/sources/deel/tests/test_deel_source.py
+++ b/posthog/temporal/data_imports/sources/deel/tests/test_deel_source.py
@@ -80,20 +80,20 @@ class TestDeelSource:
         assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
 
     @pytest.mark.parametrize(
-        "mock_return, expected_valid, expected_message",
+        "mock_return",
         [
-            (True, True, None),
-            (False, False, "Invalid Deel API token"),
+            (True, None),
+            (False, "Invalid Deel API token"),
+            (False, "Could not reach Deel: boom"),
         ],
     )
     @mock.patch("posthog.temporal.data_imports.sources.deel.source.validate_deel_credentials")
-    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+    def test_validate_credentials(self, mock_validate, mock_return):
         mock_validate.return_value = mock_return
 
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+        result = self.source.validate_credentials(self.config, self.team_id)
 
-        assert is_valid is expected_valid
-        assert error_message == expected_message
+        assert result == mock_return
         mock_validate.assert_called_once_with(self.config.api_token)
 
     def test_get_resumable_source_manager_binds_resume_config(self):

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -482,7 +482,7 @@ class Db2SourceConfig(config.Config):
 
 @config.config
 class DeelSourceConfig(config.Config):
-    pass
+    api_token: str
 
 
 @config.config


### PR DESCRIPTION
## Problem

The Deel data warehouse source was scaffolded (registered with `unreleasedSource=True` and an empty stub) but had no sync logic, so users couldn't pull their Deel workforce and payroll data into PostHog.

## Changes

Implements the Deel import source end-to-end following the warehouse source architecture (`source.py` / `settings.py` / `deel.py` split):

- **Endpoints:** `people`, `contracts`, `invoices`, `invoice_adjustments` against `api.letsdeel.com/rest/v2` with Bearer org-token auth. Deel mixes pagination styles per endpoint, handled via config: limit/offset on most endpoints, opaque `after_cursor` keyset (from `page.cursor`) on contracts. Page size stays at 50 since several Deel endpoints cap `limit` below 100.
- **Rate limiting:** Deel enforces a hard 5 req/s org-wide limit shared across all tokens, returning 429 with no rate-limit headers — the transport proactively spaces requests (250ms) and backs off on 429.
- **Auth/validation:** probes the people list and treats only 401 as invalid — a scoped token without `people:read` 403s but is still a valid credential. Sync-time 403s surface a per-dataset scope message via non-retryable errors.
- **Sync mode:** honest full refresh on every stream — Deel's core objects (people, contracts) expose no updated-since filter, and invoices change status after issuing. Date-range incremental on invoices/timesheets is a possible follow-up once filter behavior is verified against a live account.
- **Resumable:** `ResumableSource` persisting the offset or the contracts cursor, saved after each yielded batch.
- **Partitioning:** contracts partition on `created_at` (month format).
- Removes `unreleasedSource` and ships as `releaseStatus=ALPHA`; regenerates `DeelSourceConfig`; moves deel to the Implemented table in `SOURCES.md`. The caption recommends an organization token (personal tokens die when the user leaves) and lists the read scopes.

Deel webhooks are fully API-manageable (HMAC-signed) and could augment change capture in a follow-up — this PR is pull-only.

## How did you test this code?

Automated tests only (no live Deel credentials):

- `posthog/temporal/data_imports/sources/deel/tests/test_deel.py` — transport: offset pagination with short-page termination, `after_cursor` keyset pagination with empty-page guard, resume from saved offset/cursor, credential validation status mapping (incl. 403-is-valid), per-endpoint `SourceResponse` metadata. Request spacing is patched out in tests.
- `posthog/temporal/data_imports/sources/deel/tests/test_deel_source.py` — source class: config fields, full-refresh-only schemas, non-retryable error matching, argument plumbing.
- Registry-level tests in `posthog/temporal/data_imports/sources/tests/` pass (56 tests total).

Endpoint behavior (paths, mixed pagination shapes, `page.cursor` contract, rate-limit semantics) was verified against Deel's developer docs; live-API smoke testing wasn't possible without credentials, hence the alpha release status.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
