### PR TITLE
fix(devex): drop deleted task unfile receivers from setup baseline

### DIFF
--- a/posthog/test/setup_receivers_baseline.txt
+++ b/posthog/test/setup_receivers_baseline.txt
@@ -77,7 +77,6 @@ post_delete:products.feature_flags.backend.local_evaluation.feature_flag_changed
 post_delete:products.feature_flags.backend.models.feature_flag.refresh_flag_cache_on_updates
 post_delete:products.slack_app.backend.signals.invalidate_repo_list_on_user_github_change
 post_delete:products.surveys.backend.models.survey_changed
-post_delete:products.tasks.backend.models._unfile_task_on_hard_delete
 post_init:posthog.storage.team_llm_gateway_policy_signal_handlers._snapshot_loaded_state
 post_save:ee.models.license.license_saved
 post_save:ee.vercel.integration.sync_experiment_experimentation_item
@@ -156,7 +155,6 @@ post_save:products.product_analytics.backend.models.insight_caching_state.sync_i
 post_save:products.product_analytics.backend.models.insight_caching_state.sync_sharing_configuration
 post_save:products.slack_app.backend.signals.invalidate_repo_list_on_user_github_change
 post_save:products.surveys.backend.models.survey_changed
-post_save:products.tasks.backend.models._unfile_task_on_soft_delete
 post_save:products.tasks.backend.models.track_task_run_completion
 post_save:products.workflows.backend.models.hog_flow.hog_flow.action_saved_for_hog_flows
 post_save:products.workflows.backend.models.hog_flow.hog_flow.hog_flow_saved


### PR DESCRIPTION
## Problem

Master is red on `test_setup_receivers_match_baseline`: #62791 deliberately deleted the `_unfile_task_on_soft_delete` / `_unfile_task_on_hard_delete` receivers (replaced by the file-system sync mixin), but its CI last ran before #60849 introduced the receivers-baseline guard, so the stale baseline merged.

## Changes

Regenerated `posthog/test/setup_receivers_baseline.txt` — the diff is exactly the two deleted receiver lines, nothing else changed. This is the sanctioned path for deliberate receiver deletion per the guard's failure message.

## How did you test this code?

I'm an agent: `UPDATE_SETUP_RECEIVERS_BASELINE=1 pytest posthog/test/test_startup_import_budget.py -k receivers_match` to regenerate, then reran the test clean.

## 🤖 Agent context

Authored by Claude Code with Julian. Unblocks master after the #62791 / #60849 stale-CI race.