### PR TITLE
chore(playwright): make selectDateRange verify the range applied

### DIFF
--- a/playwright/page-models/insights/stickinessInsight.ts
+++ b/playwright/page-models/insights/stickinessInsight.ts
@@ -70,6 +70,9 @@ export class StickinessInsight extends ChartInsightBase {
         await expect(async () => {
             await this.dateRangeButton.click({ timeout: 500 })
             await this.page.getByTestId(dataAttr).click({ timeout: 500 })
+            // Verify the selection actually applied — an edit-mode remount can
+            // swallow the click, leaving the old range. Retry the whole open+click.
+            await expect(this.dateRangeButton).toContainText(text, { timeout: 1000 })
         }).toPass({ timeout: 15000 })
         await this.waitForChart()
     }

--- a/playwright/page-models/insights/trendsInsight.ts
+++ b/playwright/page-models/insights/trendsInsight.ts
@@ -149,6 +149,9 @@ export class TrendsInsight extends ChartInsightBase {
         await expect(async () => {
             await this.dateRangeButton.click({ timeout: 500 })
             await this.page.getByTestId(dataAttr).click({ timeout: 500 })
+            // Verify the selection actually applied — an edit-mode remount can
+            // swallow the click, leaving the old range. Retry the whole open+click.
+            await expect(this.dateRangeButton).toContainText(text, { timeout: 1000 })
         }).toPass({ timeout: 15000 })
         await this.waitForChart()
     }


### PR DESCRIPTION
## Problem

The trends date-range test flakes with `expected "Last 30 days", received "Last 7 days"`. The `selectDateRange` page helper opens the date picker and clicks the option inside a `toPass` retry, but only checks that the *clicks* didn't throw — not that the selection actually took effect. An edit-mode remount can swallow the click, so the helper returns "successfully" while the range is still the old value, and the test then fails (or, with retries, flakes).

## Changes

- In `selectDateRange` for both `trendsInsight.ts` and `stickinessInsight.ts`, add a `toContainText` check on the date-filter button *inside* the existing `toPass` retry. If the selection was swallowed, the whole open+click block retries instead of passing.

## How did you test this code?

I'm an agent. This targets a remount race that only reproduces intermittently under CI load, so I didn't reproduce a green/red locally for it; the fix is a standard self-verifying-retry hardening of an existing `toPass` block and changes no assertions in the specs themselves. The existing Playwright CI run exercises both helpers (trends + stickiness date-range steps).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

While reviewing reported Playwright flakiness with Claude Code, traced a `trends.spec.ts` date-range flake to `selectDateRange` returning before the selection applied (an edit-mode remount swallowed the click). The existing `toPass` only guarded against the clicks throwing, not the outcome. Folded the outcome assertion into the retry. Kept this separate from the related timeout-cap PR (#62894) since it's a distinct fix.