### PR TITLE
feat(integrations): surface non-destructive Slack reconnect on scope mismatch

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -39644,6 +39644,25 @@
             ],
             "description": "A single (leaf) detector config"
         },
+        "SlackIntegrationScope": {
+            "enum": [
+                "app_mentions:read",
+                "channels:history",
+                "channels:read",
+                "chat:write",
+                "chat:write.customize",
+                "groups:history",
+                "groups:read",
+                "links:read",
+                "links:write",
+                "reactions:read",
+                "reactions:write",
+                "team:read",
+                "users:read",
+                "users:read.email"
+            ],
+            "type": "string"
+        },
         "SlashCommandName": {
             "enum": ["/init", "/remember", "/usage", "/feedback", "/ticket"],
             "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -53,6 +53,7 @@ import {
     SessionPropertyFilter,
     SessionRecordingType,
     SimpleIntervalType,
+    SlackIntegrationScope,
     StepOrderValue,
     StickinessFilterType,
     TrendsFilterType,
@@ -61,6 +62,9 @@ import {
 import { integer, numerical_key, positive_integer } from './type-utils'
 
 export { ChartDisplayCategory }
+// Re-exported so the codegen picks it up and emits `class SlackIntegrationScope(StrEnum)` in
+// posthog/schema.py. The matching runtime const lives in `~/types` as `SLACK_INTEGRATION_SCOPES`.
+export { SlackIntegrationScope }
 
 /**
  * PostHog Query Schema definition.

--- a/frontend/src/scenes/settings/environment/SlackIntegration.tsx
+++ b/frontend/src/scenes/settings/environment/SlackIntegration.tsx
@@ -12,7 +12,9 @@ import { IntegrationView } from 'lib/integrations/IntegrationView'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-// Modified version of https://app.slack.com/app-settings/TSS5W8YQZ/A03KWE2FJJ2/app-manifest to match current instance
+import { SLACK_INTEGRATION_SCOPES } from '~/types'
+
+// Modified version of https://app.slack.com/app-settings/TSS5W8YQZ/A03KWE2FJJ2/app-manifest to match current instance.
 const getSlackAppManifest = (): any => ({
     display_information: {
         name: 'PostHog',
@@ -34,22 +36,7 @@ const getSlackAppManifest = (): any => ({
     oauth_config: {
         redirect_urls: [`${window.location.origin.replace('http://', 'https://')}/integrations/slack/callback`],
         scopes: {
-            bot: [
-                'app_mentions:read',
-                'channels:history',
-                'channels:read',
-                'chat:write',
-                'chat:write.customize',
-                'groups:history',
-                'groups:read',
-                'links:read',
-                'links:write',
-                'reactions:read',
-                'reactions:write',
-                'team:read',
-                'users:read',
-                'users:read.email',
-            ],
+            bot: SLACK_INTEGRATION_SCOPES,
         },
     },
     settings: {
@@ -80,7 +67,11 @@ export function SlackIntegration(): JSX.Element {
         <div>
             <div className="deprecated-space-y-2">
                 {slackIntegrations?.map((integration) => (
-                    <IntegrationView key={integration.id} integration={integration} />
+                    <IntegrationView
+                        key={integration.id}
+                        integration={integration}
+                        schema={{ requiredScopes: SLACK_INTEGRATION_SCOPES.join(' ') }}
+                    />
                 ))}
 
                 <div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5231,6 +5231,41 @@ export const INTEGRATION_KINDS = [
 
 export type IntegrationKind = (typeof INTEGRATION_KINDS)[number]
 
+// Canonical bot scopes PostHog requests during the Slack OAuth install flow. Single source of
+// truth for both the frontend (app-manifest snippet + IntegrationView scope-mismatch banner)
+// and the backend (`POSTHOG_SLACK_SCOPE` in posthog/models/integration.py, via posthog/schema.py).
+// Widening this list will surface the "Required scopes are missing" banner for any workspace
+// authorized before the change.
+//
+// Declared as an enum (not `as const` + derived type) because ts-json-schema-generator prunes
+// type-alias-only re-exports that aren't referenced as a property type — see ChartDisplayCategory
+// in schema-general.ts for the equivalent value+type re-export pattern that flows cleanly to
+// `class SlackIntegrationScope(StrEnum)` in posthog/schema.py.
+export enum SlackIntegrationScope {
+    APP_MENTIONS_READ = 'app_mentions:read',
+    CHANNELS_HISTORY = 'channels:history',
+    CHANNELS_READ = 'channels:read',
+    CHAT_WRITE = 'chat:write',
+    CHAT_WRITE_CUSTOMIZE = 'chat:write.customize',
+    GROUPS_HISTORY = 'groups:history',
+    GROUPS_READ = 'groups:read',
+    LINKS_READ = 'links:read',
+    LINKS_WRITE = 'links:write',
+    REACTIONS_READ = 'reactions:read',
+    REACTIONS_WRITE = 'reactions:write',
+    TEAM_READ = 'team:read',
+    USERS_READ = 'users:read',
+    USERS_READ_EMAIL = 'users:read.email',
+    // Pending Slack app-directory submission review — uncomment once approved. Until then we cannot
+    // request these in the OAuth install URL without Slack returning `invalid_scope`. Keeping the
+    // entries here so the next person widening the scope set has the full target list in one place.
+    // ASSISTANT_WRITE = 'assistant:write',
+    // IM_HISTORY = 'im:history',
+    // MPIM_READ = 'mpim:read',
+}
+
+export const SLACK_INTEGRATION_SCOPES = Object.values(SlackIntegrationScope)
+
 export interface IntegrationType {
     id: number
     kind: IntegrationKind

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -37,6 +37,8 @@ from rest_framework.request import Request
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from posthog.schema import SlackIntegrationScope
+
 from posthog.cache_utils import cache_for
 from posthog.exceptions_capture import capture_exception
 from posthog.helpers.encrypted_fields import EncryptedJSONField
@@ -271,24 +273,10 @@ class OauthConfig:
     additional_authorize_params: dict[str, str] | None = None
 
 
-POSTHOG_SLACK_SCOPE = ",".join(
-    [
-        "channels:read",
-        "groups:read",
-        "chat:write",
-        "chat:write.customize",
-        "app_mentions:read",
-        "channels:history",
-        "groups:history",
-        "links:read",
-        "links:write",
-        "reactions:read",
-        "reactions:write",
-        "team:read",
-        "users:read",
-        "users:read.email",
-    ]
-)
+# Slack accepts comma-separated scopes on the OAuth authorize URL. The canonical list is the
+# StrEnum declared in posthog/schema.py (generated from the SlackIntegrationScope enum in
+# frontend/src/types.ts via `hogli build:schema`), so widening it on either side stays in sync.
+POSTHOG_SLACK_SCOPE = ",".join(scope.value for scope in SlackIntegrationScope)
 
 
 class OauthIntegration:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4849,6 +4849,23 @@ class SimpleIntervalType(StrEnum):
     MONTH = "month"
 
 
+class SlackIntegrationScope(StrEnum):
+    APP_MENTIONS_READ = "app_mentions:read"
+    CHANNELS_HISTORY = "channels:history"
+    CHANNELS_READ = "channels:read"
+    CHAT_WRITE = "chat:write"
+    CHAT_WRITE_CUSTOMIZE = "chat:write.customize"
+    GROUPS_HISTORY = "groups:history"
+    GROUPS_READ = "groups:read"
+    LINKS_READ = "links:read"
+    LINKS_WRITE = "links:write"
+    REACTIONS_READ = "reactions:read"
+    REACTIONS_WRITE = "reactions:write"
+    TEAM_READ = "team:read"
+    USERS_READ = "users:read"
+    USERS_READ_EMAIL = "users:read.email"
+
+
 class SlashCommandName(StrEnum):
     FIELD_INIT = "/init"
     FIELD_REMEMBER = "/remember"


### PR DESCRIPTION
## Problem

The Slack settings page rendered `IntegrationView` without a `schema`, so the existing "Required scopes are missing" banner (and its Reconnect action) never fired even when a workspace's token was behind PostHog's canonical scope list. Users hit it later as runtime 401s from Slack HogFunctions instead of a banner pointing at the safe path.

Re-running OAuth is non-destructive (`Integration.objects.update_or_create` is keyed on `(team_id, kind, integration_id)` and preserves the row's PK), so all that was missing was the banner.

Underneath, the canonical scope list was also duplicated: `POSTHOG_SLACK_SCOPE` in `posthog/models/integration.py` (used as the `scope=` query param at install) and an inline `bot:` array in `SlackIntegration.tsx` (used in the app-manifest snippet). Two copies, easy to drift apart.

## Changes

Declare the scopes once as a TypeScript enum in `frontend/src/types.ts`. Re-export it from `frontend/src/queries/schema/schema-general.ts` so `hogli build:schema` emits a matching `StrEnum` in `posthog/schema.py`. Consume from one place on each side:

- `posthog/models/integration.py` derives `POSTHOG_SLACK_SCOPE = ",".join(scope.value for scope in SlackIntegrationScope)`.
- `SlackIntegration.tsx` imports `SLACK_INTEGRATION_SCOPES` for both the app-manifest snippet and `IntegrationView.schema.requiredScopes`.

With the schema wired in, the orange "Required scopes are missing" banner now fires automatically on the Slack settings page for any workspace whose token is behind the canonical list, and its Reconnect button re-runs OAuth without breaking any downstream references.

Three scopes currently in Slack app-directory review (`assistant:write`, `im:history`, `mpim:read`) are kept commented out in the enum so the next widening has the full target list visible in one place.

## How did you test this code?

Tested locally — verified the Reconnect banner fires on the Slack settings page when granted scopes lag the canonical list, and that the OAuth callback preserves the integration row's PK so downstream references survive.

## Showcase

<img width="1200" height="342" alt="Screenshot 2026-06-11 at 15 07 33" src="https://github.com/user-attachments/assets/2c4173a5-ee7f-488b-9f69-eaf97c34cdcf" />


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal refactor + UX surface.

## 🤖 Agent context

Claude Opus 4.7.