### PR TITLE
feat(data-warehouse): implement hibob import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -93,6 +93,7 @@ the row lists both.
 | gorgias          | HTTP                        | requests                                                        | ✅                          |
 | greenhouse       | HTTP                        | requests                                                        | ✅                          |
 | guru             | HTTP                        | requests                                                        | ✅                          |
+| hibob            | HTTP                        | requests                                                        | ✅                          |
 | hubspot          | HTTP                        | requests                                                        | ✅                          |
 | incident_io      | HTTP                        | requests                                                        | ✅                          |
 | intercom         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
@@ -258,6 +259,7 @@ doesn't conflict with concurrent PRs.
 - heap
 - helpscout
 - hibob
+- incident_io
 - instagram
 - kafka
 - lever

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -702,7 +702,8 @@ class HelpScoutSourceConfig(config.Config):
 
 @config.config
 class HiBobSourceConfig(config.Config):
-    pass
+    service_user_id: str
+    service_user_token: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/hibob/hibob.py
+++ b/posthog/temporal/data_imports/sources/hibob/hibob.py
@@ -1,0 +1,103 @@
+from collections.abc import Iterator
+from typing import Any
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.hibob.settings import HIBOB_ENDPOINTS
+
+HIBOB_BASE_URL = "https://api.hibob.com"
+REQUEST_TIMEOUT_SECONDS = 120
+# Rate limits are per endpoint (people/search is 50 req/min); 429s carry
+# X-RateLimit headers but exponential backoff is sufficient. Repeated 401/403s
+# trigger a 5-minute WAF block, so auth errors must never be retried.
+MAX_RETRY_ATTEMPTS = 5
+
+
+class HiBobRetryableError(Exception):
+    pass
+
+
+def _get_session(service_user_id: str, service_user_token: str) -> requests.Session:
+    session = make_tracked_session(redact_values=(service_user_token,))
+    session.auth = (service_user_id, service_user_token)
+    return session
+
+
+def validate_credentials(service_user_id: str, service_user_token: str) -> bool:
+    """Confirm the service user credentials are valid with a cheap tasks probe.
+
+    Service users need explicit per-category permission grants (403); only 401
+    means the credentials themselves are bad."""
+    try:
+        response = _get_session(service_user_id, service_user_token).get(
+            f"{HIBOB_BASE_URL}/v1/tasks",
+            timeout=10,
+        )
+        return response.status_code != 401
+    except Exception:
+        return False
+
+
+def get_rows(
+    service_user_id: str,
+    service_user_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    config = HIBOB_ENDPOINTS[endpoint]
+    session = _get_session(service_user_id, service_user_token)
+    url = f"{HIBOB_BASE_URL}{config.path}"
+
+    @retry(
+        retry=retry_if_exception_type((HiBobRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=2, max=90),
+        reraise=True,
+    )
+    def fetch() -> dict[str, Any]:
+        if config.method == "POST":
+            response = session.post(url, json=config.body or {}, timeout=REQUEST_TIMEOUT_SECONDS)
+        else:
+            response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise HiBobRetryableError(f"HiBob API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"HiBob API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    # Both shipped endpoints return their full result set in one response.
+    data = fetch()
+    items = data.get(config.data_key, []) or []
+    if items:
+        yield items
+
+
+def hibob_source(
+    service_user_id: str,
+    service_user_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> SourceResponse:
+    config = HIBOB_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            service_user_id=service_user_id,
+            service_user_token=service_user_token,
+            endpoint=endpoint,
+            logger=logger,
+        ),
+        primary_keys=[config.primary_key],
+        partition_count=1,
+        partition_size=1,
+        sort_mode="asc",
+    )

--- a/posthog/temporal/data_imports/sources/hibob/hibob.py
+++ b/posthog/temporal/data_imports/sources/hibob/hibob.py
@@ -27,19 +27,22 @@ def _get_session(service_user_id: str, service_user_token: str) -> requests.Sess
     return session
 
 
-def validate_credentials(service_user_id: str, service_user_token: str) -> bool:
+def validate_credentials(service_user_id: str, service_user_token: str) -> tuple[bool, str | None]:
     """Confirm the service user credentials are valid with a cheap tasks probe.
 
     Service users need explicit per-category permission grants (403); only 401
-    means the credentials themselves are bad."""
+    means the credentials themselves are bad. Transport failures surface their
+    real reason rather than masquerading as an auth error."""
+    session = _get_session(service_user_id, service_user_token)
     try:
-        response = _get_session(service_user_id, service_user_token).get(
-            f"{HIBOB_BASE_URL}/v1/tasks",
-            timeout=10,
-        )
-        return response.status_code != 401
-    except Exception:
-        return False
+        response = session.get(f"{HIBOB_BASE_URL}/v1/tasks", timeout=10)
+        if response.status_code == 401:
+            return False, "Invalid HiBob Service User credentials"
+        return True, None
+    except Exception as e:
+        return False, str(e)
+    finally:
+        session.close()
 
 
 def get_rows(
@@ -74,10 +77,13 @@ def get_rows(
         return response.json()
 
     # Both shipped endpoints return their full result set in one response.
-    data = fetch()
-    items = data.get(config.data_key, []) or []
-    if items:
-        yield items
+    try:
+        data = fetch()
+        items = data.get(config.data_key, []) or []
+        if items:
+            yield items
+    finally:
+        session.close()
 
 
 def hibob_source(

--- a/posthog/temporal/data_imports/sources/hibob/settings.py
+++ b/posthog/temporal/data_imports/sources/hibob/settings.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+
+@dataclass
+class HiBobEndpointConfig:
+    name: str
+    path: str
+    # Key the rows live under in the response body.
+    data_key: str
+    # HiBob's primary employee read is a POST-for-read with a JSON body.
+    method: Literal["GET", "POST"] = "GET"
+    body: Optional[dict] = None
+    primary_key: str = "id"
+
+
+# HiBob has no updated-at filter on employees (Airbyte is full-refresh only and
+# Fivetran re-imports most tables every sync), so every stream is an honest
+# full refresh. The time off changes endpoint has a `since` param but its rows
+# carry no verifiable per-change timestamp to use as a watermark — deferred.
+HIBOB_ENDPOINTS: dict[str, HiBobEndpointConfig] = {
+    "employees": HiBobEndpointConfig(
+        name="employees",
+        path="/v1/people/search",
+        data_key="employees",
+        method="POST",
+        # humanReadable=REPLACE flattens list/reference values into readable
+        # strings; showInactive includes offboarded employees.
+        body={"showInactive": True, "humanReadable": "REPLACE"},
+    ),
+    "tasks": HiBobEndpointConfig(
+        name="tasks",
+        path="/v1/tasks",
+        data_key="tasks",
+    ),
+}
+
+ENDPOINTS = tuple(HIBOB_ENDPOINTS.keys())

--- a/posthog/temporal/data_imports/sources/hibob/source.py
+++ b/posthog/temporal/data_imports/sources/hibob/source.py
@@ -98,10 +98,7 @@ Create a Service User in Bob under Settings > Integrations > Automation > Servic
     def validate_credentials(
         self, config: HiBobSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        if validate_hibob_credentials(config.service_user_id, config.service_user_token):
-            return True, None
-
-        return False, "Invalid HiBob Service User credentials"
+        return validate_hibob_credentials(config.service_user_id, config.service_user_token)
 
     def source_for_pipeline(self, config: HiBobSourceConfig, inputs: SourceInputs) -> SourceResponse:
         return hibob_source(

--- a/posthog/temporal/data_imports/sources/hibob/source.py
+++ b/posthog/temporal/data_imports/sources/hibob/source.py
@@ -1,13 +1,23 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import HiBobSourceConfig
+from posthog.temporal.data_imports.sources.hibob.hibob import (
+    hibob_source,
+    validate_credentials as validate_hibob_credentials,
+)
+from posthog.temporal.data_imports.sources.hibob.settings import ENDPOINTS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -18,12 +28,85 @@ class HiBobSource(SimpleSource[HiBobSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.HIBOB
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # Repeated 401/403s trip HiBob's WAF (5-minute IP block), so failing
+        # fast on auth errors matters more than usual here.
+        return {
+            "401 Client Error: Unauthorized for url: https://api.hibob.com": "HiBob authentication failed. Please check your Service User ID and token (legacy API tokens were discontinued — only Service Users work).",
+            "403 Client Error: Forbidden for url: https://api.hibob.com": "HiBob denied access. Please add your Service User to a permission group with access to this data category.",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.HI_BOB,
             label="HiBob",
+            caption="""Enter your HiBob Service User credentials to pull your Bob HR data into the PostHog Data warehouse.
+
+Create a Service User in Bob under Settings > Integrations > Automation > Service Users, then add it to a permission group with read access to the data categories you want to sync (e.g. People). Calls return 403 until permissions are granted.""",
             iconPath="/static/services/hibob.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/hibob",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="service_user_id",
+                        label="Service User ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="service_user_token",
+                        label="Service User token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: HiBobSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # HiBob has no updated-at filters; every stream is full refresh.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: HiBobSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_hibob_credentials(config.service_user_id, config.service_user_token):
+            return True, None
+
+        return False, "Invalid HiBob Service User credentials"
+
+    def source_for_pipeline(self, config: HiBobSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return hibob_source(
+            service_user_id=config.service_user_id,
+            service_user_token=config.service_user_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
         )

--- a/posthog/temporal/data_imports/sources/hibob/tests/test_hibob.py
+++ b/posthog/temporal/data_imports/sources/hibob/tests/test_hibob.py
@@ -17,26 +17,26 @@ def _response(body: dict[str, Any]) -> mock.MagicMock:
 
 class TestValidateCredentials:
     @pytest.mark.parametrize(
-        "status_code, expected",
+        "status_code, expected_valid, expected_error",
         [
-            (200, True),
+            (200, True, None),
             # Service users without category permissions 403 but are valid.
-            (403, True),
-            (401, False),
+            (403, True, None),
+            (401, False, "Invalid HiBob Service User credentials"),
         ],
     )
     @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected_valid, expected_error):
         response = mock.MagicMock()
         response.status_code = status_code
         mock_session.return_value.get.return_value = response
 
-        assert validate_credentials("service-id", "token") is expected
+        assert validate_credentials("service-id", "token") == (expected_valid, expected_error)
 
     @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
-    def test_validate_credentials_swallows_exceptions(self, mock_session):
+    def test_validate_credentials_surfaces_transport_errors(self, mock_session):
         mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("service-id", "token") is False
+        assert validate_credentials("service-id", "token") == (False, "boom")
 
 
 class TestGetRows:

--- a/posthog/temporal/data_imports/sources/hibob/tests/test_hibob.py
+++ b/posthog/temporal/data_imports/sources/hibob/tests/test_hibob.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.hibob.hibob import get_rows, hibob_source, validate_credentials
+from posthog.temporal.data_imports.sources.hibob.settings import ENDPOINTS, HIBOB_ENDPOINTS
+
+
+def _response(body: dict[str, Any]) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.json.return_value = body
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, True),
+            # Service users without category permissions 403 but are valid.
+            (403, True),
+            (401, False),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials("service-id", "token") is expected
+
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_validate_credentials_swallows_exceptions(self, mock_session):
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("service-id", "token") is False
+
+
+class TestGetRows:
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_employees_uses_post_for_read_with_body(self, mock_session):
+        mock_session.return_value.post.return_value = _response({"employees": [{"id": "1"}]})
+
+        batches = list(get_rows("service-id", "token", "employees", mock.MagicMock()))
+
+        assert batches == [[{"id": "1"}]]
+        mock_session.return_value.post.assert_called_once()
+        call = mock_session.return_value.post.call_args
+        assert call.args[0] == "https://api.hibob.com/v1/people/search"
+        assert call.kwargs["json"] == {"showInactive": True, "humanReadable": "REPLACE"}
+        mock_session.return_value.get.assert_not_called()
+
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_tasks_uses_get(self, mock_session):
+        mock_session.return_value.get.return_value = _response({"tasks": [{"id": 1}, {"id": 2}]})
+
+        batches = list(get_rows("service-id", "token", "tasks", mock.MagicMock()))
+
+        assert batches == [[{"id": 1}, {"id": 2}]]
+        mock_session.return_value.get.assert_called_once_with("https://api.hibob.com/v1/tasks", timeout=mock.ANY)
+        mock_session.return_value.post.assert_not_called()
+
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_session_uses_basic_auth(self, mock_session):
+        mock_session.return_value.get.return_value = _response({"tasks": []})
+
+        list(get_rows("service-id", "token", "tasks", mock.MagicMock()))
+
+        assert mock_session.return_value.auth == ("service-id", "token")
+
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_empty_response_yields_nothing(self, mock_session):
+        mock_session.return_value.post.return_value = _response({"employees": []})
+
+        assert list(get_rows("service-id", "token", "employees", mock.MagicMock())) == []
+
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.hibob.make_tracked_session")
+    def test_missing_data_key_yields_nothing(self, mock_session):
+        mock_session.return_value.post.return_value = _response({"unexpected": "shape"})
+
+        assert list(get_rows("service-id", "token", "employees", mock.MagicMock())) == []
+
+
+class TestHiBobSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint):
+        config = HIBOB_ENDPOINTS[endpoint]
+        response = hibob_source("service-id", "token", endpoint, mock.MagicMock())
+
+        assert response.name == endpoint
+        assert response.primary_keys == [config.primary_key]
+        assert response.sort_mode == "asc"
+        assert response.partition_mode is None
+        assert response.partition_keys is None

--- a/posthog/temporal/data_imports/sources/hibob/tests/test_hibob_source.py
+++ b/posthog/temporal/data_imports/sources/hibob/tests/test_hibob_source.py
@@ -82,8 +82,9 @@ class TestHiBobSource:
     @pytest.mark.parametrize(
         "mock_return, expected_valid, expected_message",
         [
-            (True, True, None),
-            (False, False, "Invalid HiBob Service User credentials"),
+            ((True, None), True, None),
+            ((False, "Invalid HiBob Service User credentials"), False, "Invalid HiBob Service User credentials"),
+            ((False, "Connection refused"), False, "Connection refused"),
         ],
     )
     @mock.patch("posthog.temporal.data_imports.sources.hibob.source.validate_hibob_credentials")

--- a/posthog/temporal/data_imports/sources/hibob/tests/test_hibob_source.py
+++ b/posthog/temporal/data_imports/sources/hibob/tests/test_hibob_source.py
@@ -1,0 +1,110 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.generated_configs import HiBobSourceConfig
+from posthog.temporal.data_imports.sources.hibob.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.hibob.source import HiBobSource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestHiBobSource:
+    def setup_method(self):
+        self.source = HiBobSource()
+        self.team_id = 123
+        self.config = HiBobSourceConfig(service_user_id="service-id", service_user_token="service-token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.HIBOB
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "HiBob"
+        assert config.label == "HiBob"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/hibob.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["service_user_id", "service_user_token"]
+
+    def test_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(
+            f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "service_user_token"
+        )
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.hibob.com/v1/people/search",
+            "403 Client Error: Forbidden for url: https://api.hibob.com/v1/tasks",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_vendor_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "500 Server Error for url: https://api.hibob.com/v1/people/search",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_unrelated(self, other_vendor_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_vendor_error for key in non_retryable_errors)
+
+    def test_get_schemas_are_full_refresh_only(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+        # HiBob has no updated-at filters; full refresh only.
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+        assert all(schema.incremental_fields == [] for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["employees"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "employees"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid HiBob Service User credentials"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.source.validate_hibob_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with("service-id", "service-token")
+
+    @mock.patch("posthog.temporal.data_imports.sources.hibob.source.hibob_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_hibob_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "employees"
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        mock_hibob_source.assert_called_once()
+        kwargs = mock_hibob_source.call_args.kwargs
+        assert kwargs["service_user_id"] == "service-id"
+        assert kwargs["service_user_token"] == "service-token"
+        assert kwargs["endpoint"] == "employees"


### PR DESCRIPTION
## Problem

The HiBob data warehouse source was scaffolded (registered with `unreleasedSource=True` and an empty stub) but had no sync logic, so users couldn't pull their Bob HR data into PostHog.

## Changes

Implements the HiBob import source following the warehouse source architecture (`source.py` / `settings.py` / `hibob.py` split):

- **Endpoints:** `employees` (Bob's primary read — `POST /v1/people/search`, a POST-for-read with `showInactive` and `humanReadable=REPLACE` in the body so list/reference values flatten into readable strings) and `tasks` (`GET /v1/tasks`). Both return the full result set in a single response, so this is a `SimpleSource` — there's no pagination state to resume.
- **Auth:** HTTP Basic with a Service User ID + token (legacy API tokens were discontinued by HiBob; only Service Users work — the caption and 401 message both call this out). Validation probes `/v1/tasks` and treats only 401 as invalid — Service Users 403 on every category until added to a permission group.
- **Sync mode:** honest full refresh — HiBob exposes no updated-at filter on employees (Airbyte is full-refresh only; Fivetran re-imports most tables every sync). The one delta endpoint, `/timeoff/requests/changes?since=…`, has no verifiable per-change timestamp in its rows to use as a watermark, so it's deferred rather than shipped with broken incremental semantics.
- Retries via tenacity on 429/5xx/transport errors. Auth errors are never retried — HiBob's WAF blocks an IP for 5 minutes after repeated 401/403s — and are registered as non-retryable with permission-group guidance. All HTTP goes through `make_tracked_session()` with the token redacted.
- Removes `unreleasedSource` and ships as `releaseStatus=ALPHA`; regenerates `HiBobSourceConfig`; moves hibob to the Implemented table in `SOURCES.md`.

Per-employee history fan-outs (employment/payroll/lifecycle), time off, and attendance are follow-ups once their shapes can be verified against a live account. Bob webhooks are UI-configured and metadata-only, so pull is the right model.

## How did you test this code?

Automated tests only (no live HiBob credentials):

- `posthog/temporal/data_imports/sources/hibob/tests/test_hibob.py` — transport: POST-for-read body and URL for employees, GET for tasks, Basic-auth session wiring, empty/malformed response handling, credential validation status mapping (incl. 403-is-valid), per-endpoint `SourceResponse` metadata.
- `posthog/temporal/data_imports/sources/hibob/tests/test_hibob_source.py` — source class: config fields, full-refresh-only schemas, non-retryable error matching, argument plumbing.
- Registry-level tests in `posthog/temporal/data_imports/sources/tests/` pass (48 tests total).

Endpoint behavior (people/search contract, Service User auth, rate limits, WAF behavior) was verified against HiBob's API docs and cross-checked with Airbyte's and Fivetran's connectors; live-API smoke testing wasn't possible without credentials, hence the alpha release status.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
