### PR TITLE
feat(replay): serve capture diagnostics from a backend endpoint

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4402,6 +4402,11 @@ const api = {
         async getMatchingEvents(params: string): Promise<MatchingEventsResponse> {
             return await new ApiRequest().recordingMatchingEvents().withQueryString(params).get()
         },
+        async getCaptureDiagnostics(
+            recordingId: SessionRecordingType['id']
+        ): Promise<{ properties: Record<string, any> | null }> {
+            return await new ApiRequest().recording(recordingId).withAction('capture_diagnostics').get()
+        },
         async get(
             recordingId: SessionRecordingType['id'],
             params: Record<string, any> = {},

--- a/frontend/src/scenes/session-recordings/SessionsRecordings-player-failure.stories.tsx
+++ b/frontend/src/scenes/session-recordings/SessionsRecordings-player-failure.stories.tsx
@@ -121,6 +121,7 @@ const meta: Meta = {
             },
             post: {
                 '/api/environments/:team_id/query/:kind': recordingEventsJson,
+                '/api/environments/:team_id/session_recordings/:id/capture_diagnostics': { properties: null },
             },
         }),
     ],

--- a/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayCaptureDiagnosticsPanelLogic.ts
@@ -3,8 +3,6 @@ import { lazyLoaders } from 'kea-loaders'
 
 import api from 'lib/api'
 
-import { hogql } from '~/queries/utils'
-
 import type { replayCaptureDiagnosticsPanelLogicType } from './replayCaptureDiagnosticsPanelLogicType'
 
 export interface ReplayCaptureDiagnosticsPanelLogicProps {
@@ -21,24 +19,9 @@ export const replayCaptureDiagnosticsPanelLogic = kea<replayCaptureDiagnosticsPa
     lazyLoaders(({ props }) => ({
         sessionEventProperties: {
             loadSessionEventProperties: async (_, breakpoint): Promise<Record<string, any> | null> => {
-                const query = hogql`
-SELECT properties
-FROM events
-WHERE $session_id = ${props.sessionId}
-ORDER BY timestamp DESC
-LIMIT 1`
-                const result = await api.queryHogQL(query, {
-                    scene: 'ReplayCaptureDiagnostics',
-                    productKey: 'session_replay',
-                })
-
+                const result = await api.recordings.getCaptureDiagnostics(props.sessionId)
                 breakpoint()
-
-                const row = result?.results?.[0]?.[0]
-                if (!row) {
-                    return null
-                }
-                return typeof row === 'string' ? JSON.parse(row) : row
+                return result.properties ?? null
             },
         },
     })),

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -59,8 +59,9 @@ def uuidv7_session_lower_bound(session_id: str, now: datetime | None = None) -> 
 
 
 # Wide window for capture diagnostics when the session id carries no usable
-# timestamp: covers any session whose recording could still be within retention.
-CAPTURE_DIAGNOSTICS_FALLBACK_LOOKBACK = timedelta(days=90)
+# timestamp (or the bounded window missed): covers the longest replay retention
+# plan plus slack, so any recording that can still be played can be diagnosed.
+CAPTURE_DIAGNOSTICS_FALLBACK_LOOKBACK = timedelta(days=370)
 
 
 def get_latest_session_event_properties(session_id: str, team: Team) -> Optional[dict]:
@@ -69,7 +70,9 @@ def get_latest_session_event_properties(session_id: str, team: Team) -> Optional
     Bounded by a window derived from the UUIDv7 session id so the events sort key
     can prune the scan; misses (or ids that don't parse) fall back to a
     retention-wide window so a skewed client clock degrades to a slower lookup
-    rather than missing diagnostics.
+    rather than missing diagnostics. Deliberate trade-off: when a session has
+    events both inside and outside the bounded window, the in-window latest wins
+    without consulting the fallback.
     """
     lower_bound = uuidv7_session_lower_bound(session_id)
     if lower_bound is not None:
@@ -88,7 +91,9 @@ def get_latest_session_event_properties(session_id: str, team: Team) -> Optional
 def _latest_session_event_properties_between(
     session_id: str, team: Team, date_from: datetime, date_to: datetime
 ) -> Optional[dict]:
-    from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+    from posthog.hogql_queries.hogql_query_runner import (
+        HogQLQueryRunner,  # noqa: PLC0415 — breaks a circular import, matching this file's other HogQLQueryRunner imports
+    )
 
     query = HogQLQuery(
         query="""

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -1,4 +1,5 @@
 import re
+import json
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -55,6 +56,60 @@ def uuidv7_session_lower_bound(session_id: str, now: datetime | None = None) -> 
     if embedded_start < _EARLIEST_PLAUSIBLE_SESSION_START:
         return None
     return embedded_start - SESSION_ID_CLOCK_SKEW_SLACK
+
+
+# Wide window for capture diagnostics when the session id carries no usable
+# timestamp: covers any session whose recording could still be within retention.
+CAPTURE_DIAGNOSTICS_FALLBACK_LOOKBACK = timedelta(days=90)
+
+
+def get_latest_session_event_properties(session_id: str, team: Team) -> Optional[dict]:
+    """The most recent event's properties for a session, for the replay capture diagnostics panel.
+
+    Bounded by a window derived from the UUIDv7 session id so the events sort key
+    can prune the scan; misses (or ids that don't parse) fall back to a
+    retention-wide window so a skewed client clock degrades to a slower lookup
+    rather than missing diagnostics.
+    """
+    lower_bound = uuidv7_session_lower_bound(session_id)
+    if lower_bound is not None:
+        # lower_bound is embedded_start - slack; sessions last at most a day,
+        # so embedded_start + 1d + slack closes the window symmetrically.
+        upper_bound = lower_bound + 2 * SESSION_ID_CLOCK_SKEW_SLACK + timedelta(days=1)
+        properties = _latest_session_event_properties_between(session_id, team, lower_bound, upper_bound)
+        if properties is not None:
+            return properties
+    now = datetime.now(pytz.UTC)
+    return _latest_session_event_properties_between(
+        session_id, team, now - CAPTURE_DIAGNOSTICS_FALLBACK_LOOKBACK, now + timedelta(days=1)
+    )
+
+
+def _latest_session_event_properties_between(
+    session_id: str, team: Team, date_from: datetime, date_to: datetime
+) -> Optional[dict]:
+    from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+
+    query = HogQLQuery(
+        query="""
+            SELECT properties
+            FROM events
+            WHERE $session_id = {session_id}
+                AND timestamp >= {date_from}
+                AND timestamp <= {date_to}
+            ORDER BY timestamp DESC
+            LIMIT 1
+        """,
+        values={"session_id": session_id, "date_from": date_from, "date_to": date_to},
+    )
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
+    result = HogQLQueryRunner(team=team, query=query).calculate()
+    if not result.results:
+        return None
+    row = result.results[0][0]
+    if not row:
+        return None
+    return json.loads(row) if isinstance(row, str) else row
 
 
 def seconds_until_midnight():

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -418,39 +418,47 @@ class TestGetLatestSessionEventProperties(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": session_id, "$recording_status": marker},
         )
 
-    def test_finds_event_within_uuidv7_window(self) -> None:
+    @parameterized.expand(
+        [
+            ("event_within_uuidv7_window", True, relativedelta(minutes=0), "bounded"),
+            ("event_outside_uuidv7_window_via_fallback", True, relativedelta(days=10), "fallback"),
+            ("non_uuid_session_id_via_fallback", False, relativedelta(minutes=0), "custom"),
+        ]
+    )
+    def test_finds_event(self, _name: str, uuidv7_id: bool, event_age_before_start, marker: str) -> None:
         session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)
-        session_id = _uuidv7_session_id_for(session_start)
-        self._seed_event(session_id, session_start, "bounded")
+        session_id = _uuidv7_session_id_for(session_start) if uuidv7_id else "my-custom-session-id"
+        self._seed_event(session_id, session_start - event_age_before_start, marker)
 
         properties = get_latest_session_event_properties(session_id, self.team)
 
         assert properties is not None
-        assert properties["$recording_status"] == "bounded"
-
-    def test_finds_event_outside_uuidv7_window_via_fallback(self) -> None:
-        session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)
-        session_id = _uuidv7_session_id_for(session_start)
-        self._seed_event(session_id, session_start - relativedelta(days=10), "fallback")
-
-        properties = get_latest_session_event_properties(session_id, self.team)
-
-        assert properties is not None
-        assert properties["$recording_status"] == "fallback"
-
-    def test_finds_event_for_non_uuid_session_id(self) -> None:
-        session_id = "my-custom-session-id"
-        self._seed_event(session_id, (now() - relativedelta(minutes=10)).replace(microsecond=0), "custom")
-
-        properties = get_latest_session_event_properties(session_id, self.team)
-
-        assert properties is not None
-        assert properties["$recording_status"] == "custom"
+        assert properties["$recording_status"] == marker
 
     def test_returns_none_when_session_has_no_events(self) -> None:
         session_id = _uuidv7_session_id_for(now() - relativedelta(minutes=10))
 
         assert get_latest_session_event_properties(session_id, self.team) is None
+
+    def test_does_not_leak_another_teams_session(self) -> None:
+        session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)
+        session_id = _uuidv7_session_id_for(session_start)
+        other_team = Team.objects.create(organization=self.organization, name="other team")
+        _create_event(
+            team=other_team,
+            event="$pageview",
+            distinct_id="d1",
+            timestamp=session_start,
+            properties={"$session_id": session_id, "$recording_status": "secret"},
+        )
+
+        assert get_latest_session_event_properties(session_id, self.team) is None
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/session_recordings/{session_id}/capture_diagnostics"
+        )
+        assert response.status_code == 200
+        assert response.json()["properties"] is None
 
     def test_capture_diagnostics_endpoint_returns_properties(self) -> None:
         session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -1,4 +1,4 @@
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
 
 from django.utils.timezone import now
 
@@ -9,6 +9,7 @@ from posthog.models import Team
 from posthog.session_recordings.queries.session_replay_events import (
     SESSION_ID_CLOCK_SKEW_SLACK,
     SessionReplayEvents,
+    get_latest_session_event_properties,
     uuidv7_session_lower_bound,
 )
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
@@ -405,3 +406,60 @@ class TestSessionLookupUsesUuidv7Bound(ClickhouseTestMixin, APIBaseTest):
         found = SessionReplayEvents()._find_with_timestamps([uuid_id, custom_id], self.team)
 
         assert {session_id for session_id, _, _, _ in found} == {uuid_id, custom_id}
+
+
+class TestGetLatestSessionEventProperties(ClickhouseTestMixin, APIBaseTest):
+    def _seed_event(self, session_id: str, timestamp, marker: str) -> None:
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="d1",
+            timestamp=timestamp,
+            properties={"$session_id": session_id, "$recording_status": marker},
+        )
+
+    def test_finds_event_within_uuidv7_window(self) -> None:
+        session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)
+        session_id = _uuidv7_session_id_for(session_start)
+        self._seed_event(session_id, session_start, "bounded")
+
+        properties = get_latest_session_event_properties(session_id, self.team)
+
+        assert properties is not None
+        assert properties["$recording_status"] == "bounded"
+
+    def test_finds_event_outside_uuidv7_window_via_fallback(self) -> None:
+        session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)
+        session_id = _uuidv7_session_id_for(session_start)
+        self._seed_event(session_id, session_start - relativedelta(days=10), "fallback")
+
+        properties = get_latest_session_event_properties(session_id, self.team)
+
+        assert properties is not None
+        assert properties["$recording_status"] == "fallback"
+
+    def test_finds_event_for_non_uuid_session_id(self) -> None:
+        session_id = "my-custom-session-id"
+        self._seed_event(session_id, (now() - relativedelta(minutes=10)).replace(microsecond=0), "custom")
+
+        properties = get_latest_session_event_properties(session_id, self.team)
+
+        assert properties is not None
+        assert properties["$recording_status"] == "custom"
+
+    def test_returns_none_when_session_has_no_events(self) -> None:
+        session_id = _uuidv7_session_id_for(now() - relativedelta(minutes=10))
+
+        assert get_latest_session_event_properties(session_id, self.team) is None
+
+    def test_capture_diagnostics_endpoint_returns_properties(self) -> None:
+        session_start = (now() - relativedelta(minutes=10)).replace(microsecond=0)
+        session_id = _uuidv7_session_id_for(session_start)
+        self._seed_event(session_id, session_start, "endpoint")
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/session_recordings/{session_id}/capture_diagnostics"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["properties"]["$recording_status"] == "endpoint"

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -95,7 +95,10 @@ from posthog.session_recordings.ai_data.ai_regex_schema import AiRegexSchema
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
-from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
+from posthog.session_recordings.queries.session_replay_events import (
+    SessionReplayEvents,
+    get_latest_session_event_properties,
+)
 from posthog.session_recordings.recordings import recording_s3_client
 from posthog.session_recordings.recordings.errors import BlockFetchError, RecordingDeletedError
 from posthog.session_recordings.recordings.recording_api_client import RecordingApiClient, recording_api_client
@@ -969,6 +972,14 @@ class SessionRecordingViewSet(
             recording.viewers = other_viewers.get(str(recording.session_id), [])
 
         return JsonResponse({"viewed": recording.viewed, "other_viewers": len(recording.viewers or [])})
+
+    @extend_schema(exclude=True)
+    @action(methods=["GET"], detail=True, url_path="capture_diagnostics")
+    def capture_diagnostics(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        """Latest event properties for the recording's session, for the capture diagnostics panel."""
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
+        properties = get_latest_session_event_properties(str(kwargs["pk"]), self.team)
+        return Response({"properties": properties})
 
     # Returns metadata about the recording
     def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -977,8 +977,8 @@ class SessionRecordingViewSet(
     @action(methods=["GET"], detail=True, url_path="capture_diagnostics")
     def capture_diagnostics(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         """Latest event properties for the recording's session, for the capture diagnostics panel."""
-        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
-        properties = get_latest_session_event_properties(str(kwargs["pk"]), self.team)
+        recording = self.get_object()
+        properties = get_latest_session_event_properties(str(recording.session_id), self.team)
         return Response({"properties": properties})
 
     # Returns metadata about the recording


### PR DESCRIPTION
## Problem

The replay capture diagnostics panel builds its HogQL lookup client-side. After #62742 and #62770, the UUIDv7 window-derivation logic exists twice — once in TypeScript (`sessionIdTimestampBounds`) and once in Python (`uuidv7_session_lower_bound`) — maintained separately. The client-side fallback retry also costs a second browser round trip when it fires.

## Changes

- New internal `capture_diagnostics` action on `SessionRecordingViewSet`: runs the bounded latest-event-properties lookup server-side via `get_latest_session_event_properties`, reusing the backend's `uuidv7_session_lower_bound`, with a retention-wide fallback window on a miss.
- `replayCaptureDiagnosticsPanelLogic` shrinks to a single `api.recordings.getCaptureDiagnostics` call — the client-side bound derivation is gone, and a skewed-clock retry is one HTTP round trip instead of two.
- Stacked on #62770 (uses its `uuidv7_session_lower_bound`). **Supersedes #62742**, which implemented the same bound client-side.

Part of a 2-PR stack moving replay frontend HogQL behind backend endpoints; #62915 (player events) follows.

## How did you test this code?

Agent-authored; no manual testing claimed. New backend tests cover the bounded path, the fallback path (event outside the UUIDv7 window), non-UUID session ids, the empty case, and the endpoint itself (5 tests). Existing panel component suite passes (13 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session continuing the replay query-optimization work (#62719, #62742, #62770): the author asked for the frontend replay HogQL with backend twins to move behind query runners/endpoints as a Graphite stack. This PR merges the diagnostics bound logic into the backend implementation rather than building a parallel one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

