### PR TITLE
fix(posthog-ai): sandbox message ordering and tool-card rendering

### DIFF
--- a/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.test.ts
+++ b/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.test.ts
@@ -1,0 +1,25 @@
+import { contentBlockText, renderContentBlocks } from './FallbackMcpToolRenderer'
+
+describe('renderContentBlocks', () => {
+    it('unwraps the ACP { type: content, content: { type: text, text } } envelope', () => {
+        const blocks = [{ type: 'content', content: { type: 'text', text: 'hello world' } }]
+        expect(renderContentBlocks(blocks)).toEqual('hello world')
+    })
+
+    it('reads a flat { type: text, text } block directly', () => {
+        expect(contentBlockText({ type: 'text', text: 'done' })).toEqual('done')
+    })
+
+    it('joins multiple blocks with newlines', () => {
+        const blocks = [
+            { type: 'content', content: { type: 'text', text: 'one' } },
+            { type: 'text', text: 'two' },
+        ]
+        expect(renderContentBlocks(blocks)).toEqual('one\ntwo')
+    })
+
+    it('falls back to pretty JSON for a non-text block', () => {
+        const block = { type: 'content', content: { type: 'image', data: 'abc' } }
+        expect(contentBlockText(block)).toEqual(JSON.stringify(block, null, 2))
+    })
+})

--- a/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
+++ b/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
@@ -6,16 +6,28 @@ import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import type { McpToolRendererProps } from '../mcpToolRegistry'
 import { MessageTemplate } from './MessageTemplate'
 
+/**
+ * Extracts displayable text from one ACP tool-call content block. ACP nests the real ContentBlock
+ * under a `{ type: 'content', content: { type: 'text', text } }` envelope, so unwrap that first;
+ * flat `{ type: 'text', text }` blocks are read directly. Non-text blocks fall back to pretty JSON.
+ */
+export function contentBlockText(block: unknown): string {
+    if (!block || typeof block !== 'object') {
+        return JSON.stringify(block, null, 2)
+    }
+    const inner =
+        (block as { type?: unknown }).type === 'content' && 'content' in block
+            ? (block as { content: unknown }).content
+            : block
+    if (inner && typeof inner === 'object' && 'text' in inner) {
+        return String((inner as { text: unknown }).text)
+    }
+    return JSON.stringify(block, null, 2)
+}
+
 /** Pretty-prints accumulated ACP `content[]` — text frames inline, everything else as JSON. */
-function renderContentBlocks(content: unknown[]): string {
-    return content
-        .map((block) => {
-            if (block && typeof block === 'object' && 'text' in block) {
-                return String((block as { text: unknown }).text)
-            }
-            return JSON.stringify(block, null, 2)
-        })
-        .join('\n')
+export function renderContentBlocks(content: unknown[]): string {
+    return content.map(contentBlockText).join('\n')
 }
 
 function statusBadge(status: McpToolRendererProps['message']['status']): JSX.Element {

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -262,6 +262,90 @@ describe('sandboxStreamLogic', () => {
         })
     })
 
+    describe('streamed tool input', () => {
+        it('folds rawInput arriving on a later update into a non-exec tool call', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't1',
+                    toolName: 'ToolSearch',
+                    title: 'ToolSearch',
+                    rawInput: {},
+                    status: 'pending',
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: 't1',
+                    rawInput: { query: 'find recordings', max_results: 10 },
+                    status: 'completed',
+                }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const invocation = logic.values.toolInvocations.get('t1')
+            expect(invocation?.input).toEqual({ query: 'find recordings', max_results: 10 })
+            expect(invocation?.resolvedKey).toEqual('ToolSearch')
+        })
+
+        it('re-resolves the registry key when an exec command streams in after an empty tool_call', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't2',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: {},
+                    status: 'pending',
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: 't2',
+                    rawInput: { command: 'call insight-create {"name":"Signups"}' },
+                    status: 'in_progress',
+                }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const invocation = logic.values.toolInvocations.get('t2')
+            expect(invocation?.resolvedKey).toEqual('insight-create')
+            expect(invocation?.innerToolName).toEqual('insight-create')
+            expect(invocation?.innerInput).toEqual({ name: 'Signups' })
+        })
+
+        it('keeps the resolved input when a later update carries none', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't3',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: { command: 'call execute-sql {"query":"select 1"}' },
+                    status: 'in_progress',
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: 't3',
+                    status: 'completed',
+                    rawOutput: { rows: 1 },
+                }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const invocation = logic.values.toolInvocations.get('t3')
+            expect(invocation?.resolvedKey).toEqual('execute-sql')
+            expect(invocation?.innerInput).toEqual({ query: 'select 1' })
+        })
+    })
+
     describe('pushHumanMessage', () => {
         it('appends a human_message item ordered before subsequently ingested assistant frames', async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -208,6 +208,39 @@ describe('sandboxStreamLogic', () => {
             expect(assistantItems[0].id).not.toEqual(assistantItems[1].id)
         })
 
+        it('keeps text before and after a tool call as separate items in wire order', async () => {
+            // Real wire pattern: streamed text, a tool call, then more streamed text — all in one
+            // turn with no agent_message finalize between them and no messageId on any chunk.
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'Let me ' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'check.' } }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't1',
+                    serverName: 'posthog',
+                    toolName: 'exec',
+                    rawInput: { command: 'tools' },
+                    status: 'in_progress',
+                }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'All ' } }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', content: { text: 'set.' } }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            expect(logic.values.threadItems.map((item) => item.type)).toEqual([
+                'assistant_message',
+                'tool_invocation',
+                'assistant_message',
+            ])
+            const assistantItems = logic.values.threadItems.filter((item) => item.type === 'assistant_message')
+            expect(assistantItems[0].text).toEqual('Let me check.')
+            expect(assistantItems[1].text).toEqual('All set.')
+            expect(assistantItems[0].id).not.toEqual(assistantItems[1].id)
+        })
+
         it('starts a new bubble for a chunk arriving after finalize instead of mutating the finalized one', async () => {
             const frames: StoredLogEntry[] = [
                 sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { text: 'Done' } }),

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -654,6 +654,19 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     const errorMessage =
                         (update.error?.message as string | undefined) ??
                         (status === 'failed' ? notification.error?.message : undefined)
+                    // The tool's args stream in across updates (e.g. an `exec` command or a tool's
+                    // input building up), so fold the latest rawInput in and re-resolve the registry
+                    // key from it rather than freezing the empty input the initial tool_call carried.
+                    const rawInput =
+                        update.rawInput && typeof update.rawInput === 'object'
+                            ? (update.rawInput as Record<string, unknown>)
+                            : update.input && typeof update.input === 'object'
+                              ? (update.input as Record<string, unknown>)
+                              : undefined
+                    const reResolved =
+                        rawInput && existing
+                            ? resolveToolKey(existing.rawServerName, existing.rawToolName, rawInput)
+                            : undefined
                     actions.updateToolInvocation(toolCallId, {
                         status,
                         title: (update.title as string | undefined) ?? existing?.title,
@@ -663,6 +676,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                             (update.locations as { path: string; line?: number }[] | undefined) ?? existing?.locations,
                         contentBlocks: mergedContent,
                         error: errorMessage !== undefined ? { message: errorMessage } : existing?.error,
+                        ...(rawInput ? { input: rawInput } : {}),
+                        ...(reResolved
+                            ? {
+                                  resolvedKey: reResolved.resolvedKey,
+                                  innerToolName: reResolved.innerToolName,
+                                  innerInput: reResolved.innerInput,
+                              }
+                            : {}),
                     })
                     break
                 }

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -289,9 +289,12 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     if (idx === -1) {
                         return [...state, { id, type: 'assistant_message', text: delta, complete: false }]
                     }
-                    if (state[idx].complete) {
-                        // Never reopen a finalized buffer — a post-finalize chunk is a new message
-                        // (the wire may omit messageId), so start a fresh bubble with a unique id.
+                    // Continue the matched buffer only if it is still the thread tail. A finalized
+                    // buffer, or one with another item appended after it (a tool call, separator,
+                    // error), must not absorb the chunk — text resuming after a tool call is its own
+                    // message and has to render in chronological order. The wire often omits
+                    // messageId, so a fresh bubble gets a uniquified id.
+                    if (state[idx].complete || idx !== state.length - 1) {
                         return [
                             ...state,
                             { id: `${id}@${state.length}`, type: 'assistant_message', text: delta, complete: false },


### PR DESCRIPTION
## Problem

The sandbox runtime renders Max's thread from `sandboxStreamLogic.threadItems` and renders tool cards through the MCP tool registry. Three rendering defects surfaced while testing the cloud-agent stream:

- **Text merged across tool calls.** Assistant text that resumed after a tool call folded back into the pre-tool-call buffer, so two text segments rendered as a single bubble with the tool call orphaned after them — losing chronological order. The ACP wire omits `messageId`, so every chunk shares one fallback id and continued the last matching buffer regardless of items appended in between.
- **Tool input shown as `{}`.** A tool's arguments stream in across `tool_call_update` frames, but only the initial `tool_call` input was kept, so the card displayed an empty input. For `exec` tools whose command streams in, this also froze a stale `resolvedKey`, so they never reached their rich widget.
- **Tool output shown as raw JSON.** The content extractor only checked for text at the top level, so it dumped JSON instead of the text — ACP nests the real block under a `{ type: "content", content: { type: "text", text } }` envelope.

## Changes

- `sandboxStreamLogic` `appendAssistantChunk`: continue an assistant buffer only while it is still the thread tail; otherwise start a fresh bubble. Fixes the merge across tool calls, and the same merge across a turn separator when a turn's text is only chunked and never finalized.
- `sandboxStreamLogic` `tool_call_update`: fold the latest `rawInput` into the invocation and re-resolve the registry key from it, so streamed args appear and exec tools resolve to the right widget.
- `FallbackMcpToolRenderer`: unwrap the ACP `content` envelope before reading text; fall back to pretty JSON only for genuinely non-text blocks.

No schema or generated-type changes; the renderer reads `threadItems` in array order.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8) — automated tests only, no manual UI testing claimed.

- `sandboxStreamLogic.test.ts`: added cases for text → tool → text ordering, the streamed-input fold (non-exec input + exec key re-resolution), and input-preserved-when-a-later-update-carries-none. Suite green (33/33).
- `FallbackMcpToolRenderer.test.ts` (new): content-envelope unwrap, flat `{type:'text'}` block, multi-block join, and non-text JSON fallback (4/4).
- oxlint and oxfmt clean on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @skoob13 using Claude Code (Opus 4.8). The bugs were identified from real cloud-agent stream logs shared during the session; each fix was verified against the actual ACP wire shape and the MCP server source rather than the migration spec. A related conversation-fetch race (a pre-commit `GET /conversations/{id}/` returning 404 before the create POST commits) was diagnosed in the same session but intentionally scoped out of this PR.

Tools used: Claude Code (Read, Edit, Bash), `hogli test`, oxlint/oxfmt.