### PR TITLE
fix(frontend): remove fake-lazy GlobalModals require from entry bundle

### DIFF
--- a/frontend/src/layout/GlobalModals.tsx
+++ b/frontend/src/layout/GlobalModals.tsx
@@ -1,4 +1,4 @@
-import { actions, kea, path, reducers, useActions, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { ItemSelectModal } from 'lib/components/FileSystem/ItemSelectModal/ItemSelectModal'
 import { LinkToModal } from 'lib/components/FileSystem/LinkTo/LinkTo'
@@ -9,7 +9,6 @@ import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
 import { TimeSensitiveAuthenticationModal } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
 import { GlobalCustomUnitModal } from 'lib/components/UnitPicker/GlobalCustomUnitModal'
 import { UpgradeModal } from 'lib/components/UpgradeModal/UpgradeModal'
-import { bindModalToUrl } from 'lib/logic/bindModalToUrl'
 import { TwoFactorSetupModal } from 'scenes/authentication/two-factor-setup/TwoFactorSetupModal'
 import { PaymentEntryModal } from 'scenes/billing/PaymentEntryModal'
 import { CreateOrganizationModal } from 'scenes/organization/CreateOrganizationModal'
@@ -25,42 +24,10 @@ import { promotedProductLogic } from '~/layout/panel-layout/ai-first/promotedPro
 import { ComposeTicketModal } from 'products/conversations/frontend/components/ComposeTicket'
 import { LogsViewerModal } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal'
 
-import type { globalModalsLogicType } from './GlobalModalsType'
+import { globalModalsLogic } from './globalModalsLogic'
 import { navigationLogic } from './navigation/navigationLogic'
 import { ConfigureHomeModal } from './scenes/ConfigureHomeModal'
 import { ConfigurePromotedProductModal } from './scenes/ConfigurePromotedProductModal'
-
-export const globalModalsLogic = kea<globalModalsLogicType>([
-    path(['layout', 'navigation', 'globalModalsLogic']),
-    actions({
-        showCreateOrganizationModal: true,
-        hideCreateOrganizationModal: true,
-        showCreateProjectModal: true,
-        hideCreateProjectModal: true,
-    }),
-    reducers({
-        isCreateOrganizationModalShown: [
-            false,
-            {
-                showCreateOrganizationModal: () => true,
-                hideCreateOrganizationModal: () => false,
-            },
-        ],
-        isCreateProjectModalShown: [
-            false,
-            {
-                showCreateProjectModal: () => true,
-                hideCreateProjectModal: () => false,
-            },
-        ],
-    }),
-    bindModalToUrl({
-        urlKey: 'create-organization',
-        openActionKey: 'showCreateOrganizationModal',
-        closeActionKey: 'hideCreateOrganizationModal',
-        isOpenKey: 'isCreateOrganizationModalShown',
-    }),
-])
 
 export function GlobalModals(): JSX.Element {
     const { isCreateOrganizationModalShown, isCreateProjectModalShown } = useValues(globalModalsLogic)

--- a/frontend/src/layout/globalModalsLogic.ts
+++ b/frontend/src/layout/globalModalsLogic.ts
@@ -1,0 +1,37 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import { bindModalToUrl } from 'lib/logic/bindModalToUrl'
+
+import type { globalModalsLogicType } from './globalModalsLogicType'
+
+export const globalModalsLogic = kea<globalModalsLogicType>([
+    path(['layout', 'navigation', 'globalModalsLogic']),
+    actions({
+        showCreateOrganizationModal: true,
+        hideCreateOrganizationModal: true,
+        showCreateProjectModal: true,
+        hideCreateProjectModal: true,
+    }),
+    reducers({
+        isCreateOrganizationModalShown: [
+            false,
+            {
+                showCreateOrganizationModal: () => true,
+                hideCreateOrganizationModal: () => false,
+            },
+        ],
+        isCreateProjectModalShown: [
+            false,
+            {
+                showCreateProjectModal: () => true,
+                hideCreateProjectModal: () => false,
+            },
+        ],
+    }),
+    bindModalToUrl({
+        urlKey: 'create-organization',
+        openActionKey: 'showCreateOrganizationModal',
+        closeActionKey: 'hideCreateOrganizationModal',
+        isOpenKey: 'isCreateOrganizationModalShown',
+    }),
+])

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -30,7 +30,7 @@ import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { globalModalsLogic } from '~/layout/GlobalModals'
+import { globalModalsLogic } from '~/layout/globalModalsLogic'
 import { AvailableFeature } from '~/types'
 
 import { RenderKeybind } from '../AppShortcuts/AppShortcutMenu'

--- a/frontend/src/lib/components/Account/OrgCombobox.tsx
+++ b/frontend/src/lib/components/Account/OrgCombobox.tsx
@@ -12,7 +12,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { globalModalsLogic } from '~/layout/GlobalModals'
+import { globalModalsLogic } from '~/layout/globalModalsLogic'
 import { AccessLevelIndicator } from '~/layout/navigation/AccessLevelIndicator'
 import { AvailableFeature } from '~/types'
 

--- a/frontend/src/lib/components/Account/OrgSwitcher.tsx
+++ b/frontend/src/lib/components/Account/OrgSwitcher.tsx
@@ -14,7 +14,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { globalModalsLogic } from '~/layout/GlobalModals'
+import { globalModalsLogic } from '~/layout/globalModalsLogic'
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { AccessLevelIndicator } from '~/layout/navigation/AccessLevelIndicator'
 import { AvailableFeature, OrganizationBasicType } from '~/types'

--- a/frontend/src/lib/components/Account/ProjectCombobox.tsx
+++ b/frontend/src/lib/components/Account/ProjectCombobox.tsx
@@ -15,7 +15,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { globalModalsLogic } from '~/layout/GlobalModals'
+import { globalModalsLogic } from '~/layout/globalModalsLogic'
 import { AvailableFeature } from '~/types'
 
 import { pendingInvitesLogic } from './pendingInvitesLogic'

--- a/frontend/src/lib/components/Account/ProjectSwitcher.tsx
+++ b/frontend/src/lib/components/Account/ProjectSwitcher.tsx
@@ -15,7 +15,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { globalModalsLogic } from '~/layout/GlobalModals'
+import { globalModalsLogic } from '~/layout/globalModalsLogic'
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { AvailableFeature, TeamBasicType } from '~/types'
 

--- a/frontend/src/lib/components/TimeSensitiveAuthentication/modalInterruptionTrackingLogic.ts
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/modalInterruptionTrackingLogic.ts
@@ -1,5 +1,6 @@
 import { actions, connect, kea, listeners, path, reducers } from 'kea'
 
+import { globalModalsLogic } from '~/layout/globalModalsLogic'
 import { organizationLogic } from '~/scenes/organizationLogic'
 import { projectLogic } from '~/scenes/projectLogic'
 
@@ -7,20 +8,10 @@ import type { modalInterruptionTrackingLogicType } from './modalInterruptionTrac
 
 export const modalInterruptionTrackingLogic = kea<modalInterruptionTrackingLogicType>([
     path(['lib', 'components', 'TimeSensitiveAuthentication', 'modalInterruptionTrackingLogic']),
-    connect(() => {
-        try {
-            // Use lazy require to avoid circular dependencies
-            const { globalModalsLogic } = require('~/layout/GlobalModals')
-
-            return {
-                values: [globalModalsLogic, ['isCreateOrganizationModalShown', 'isCreateProjectModalShown']],
-                actions: [organizationLogic, ['createOrganization'], projectLogic, ['createProject']],
-            }
-        } catch {
-            // Safe fallback for tests
-            return {}
-        }
-    }),
+    connect(() => ({
+        values: [globalModalsLogic, ['isCreateOrganizationModalShown', 'isCreateProjectModalShown']],
+        actions: [organizationLogic, ['createOrganization'], projectLogic, ['createProject']],
+    })),
     actions({
         setInterruptedForm: (form: string | null) => ({ form }),
     }),
@@ -34,13 +25,13 @@ export const modalInterruptionTrackingLogic = kea<modalInterruptionTrackingLogic
     }),
     listeners(({ actions, values }) => ({
         createOrganization: () => {
-            if ((values as any).isCreateOrganizationModalShown) {
+            if (values.isCreateOrganizationModalShown) {
                 actions.setInterruptedForm('create_organization_modal')
             }
         },
 
         createProject: () => {
-            if ((values as any).isCreateProjectModalShown) {
+            if (values.isCreateProjectModalShown) {
                 actions.setInterruptedForm('create_project_modal')
             }
         },


### PR DESCRIPTION
## Problem

The frontend ships far more eager JavaScript than it needs to. Bundle attribution (esbuild metafile + production asset measurement) traced the single biggest cause to one line:

`modalInterruptionTrackingLogic.ts` used `require('~/layout/GlobalModals')` inside `connect()`, commented as a "lazy require to avoid circular dependencies". esbuild bundles `require()` **statically**, so this was never lazy — it pulled `GlobalModals.tsx` and every global modal's dependency graph (monaco, the Max AI / Query stack, tiptap, xyflow, and more) into the eager entry closure, via the chain:

`organizationLogic` (entry graph) -> `timeSensitiveAuthenticationLogic` -> `modalInterruptionTrackingLogic` -> `require('~/layout/GlobalModals')`

This also kept the largest shared chunk near CloudFront's 10 MB per-object cap, and inflates the decoded-script memory cost of every renderer (part of the memory investigation in #32479).

References #32479

## Changes

- Extract `globalModalsLogic` from `GlobalModals.tsx` into its own file, `frontend/src/layout/globalModalsLogic.ts`. The logic depends only on kea and `bindModalToUrl`, so connecting to it no longer drags in any modal components. This resolves the circular dependency properly instead of dodging it.
- `modalInterruptionTrackingLogic` now uses a normal static import of the logic — the `require()`, its try/catch "safe fallback for tests", and the `(values as any)` casts it forced are all gone.
- The five Account components that imported `globalModalsLogic` from `GlobalModals.tsx` now import it from the new file, so they no longer anchor the modal graph either.

No behavior change: `GlobalModals` (the component) is still rendered by `AuthenticatedShell` and still mounts the logic; the logic's path, actions, reducers, and URL binding are unchanged.

Measured on the production build's metafile:

| Metric | Before | After |
| --- | --- | --- |
| Eager entry closure (input source) | 8,200 files / 56.1 MB | 751 files / 15.8 MB |
| Largest output chunk | 8.96 MB | 6.35 MB (now lazy-loaded) |
| Eager output chunks reachable from entry | ~17 MB JS | 9.15 MB incl. image assets, largest JS chunk 1.21 MB |

Logged-out pages (login, signup, shared dashboards) benefit most; the authed app loads the same code but split into cacheable, deferred chunks.

## How did you test this code?

I'm an agent; automated verification only:

- `pnpm --filter=@posthog/frontend typescript:check` passes
- `hogli test frontend/src/lib/components/TimeSensitiveAuthentication/timeSensitiveAuthenticationLogic.test.ts` — 9/9 pass (these tests exercise `modalInterruptionTrackingLogic` mounting, which previously relied on the require's try/catch fallback)
- oxlint clean; kea typegen regenerated cleanly
- Production build succeeds; eager-closure numbers above computed from its metafile by walking static imports from `src/index.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @pauldambra, continuing the bundle-split investigation that branched off the memory work in #32479. The metafile analysis simulated removing this require before any code was changed (predicted eager cut matched the measured result). Considered re-exporting `globalModalsLogic` from `GlobalModals.tsx` for import-compatibility, but rejected it — a re-export would keep every importer of the logic anchored to the modal graph, recreating the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)