### PR TITLE
chore(deps): clarify posthog-js CDN update comment

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,8 +66,9 @@ catalog:
     concurrently: ^5.3.0
     yaml: ^2.8.2
 
-# posthog-js needs to be excluded because we only update our CDN
-# once a newer posthog-js version is merged onto this repo
+# PostHog packages are released by our own workflows. posthog-js is also
+# uploaded to the browser SDK CDN from the posthog-js release workflow, so
+# dependency automation should not delay these package updates.
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
     - posthog-js


### PR DESCRIPTION
## Problem

`pnpm-workspace.yaml` still said `posthog-js` must bypass `minimumReleaseAge` because the CDN only updates after a newer version is merged into this repo. That no longer matches the release flow: browser SDK CDN assets are uploaded from the `posthog-js` release workflow.

## Changes

- Update the `minimumReleaseAgeExclude` comment to say PostHog packages are released by our own workflows.
- Clarify that `posthog-js` browser SDK CDN upload happens from the `posthog-js` release workflow, so dependency automation should not delay these package updates.

## How did you test this code?

Not run — comment-only change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Comment-only repository maintenance; no docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent updated this comment after checking the `posthog-js` release workflow and the `PostHog/posthog` workflows for S3/CDN-related post-merge behavior. The change keeps the dependency-management comment aligned with the current release pipeline.
