### PR TITLE
feat(devex): openapi provenance tags and kernel type aliasing

### DIFF
--- a/frontend/bin/generate-openapi-types.mjs
+++ b/frontend/bin/generate-openapi-types.mjs
@@ -7,7 +7,10 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import {
+    aliasKernelTypes,
     annotatePureZodExports,
+    buildSchemaSourceIndex,
+    collectKernelComponents,
     collectSchemaRefs,
     fixNullDefaults,
     preprocessSchema,
@@ -384,6 +387,11 @@ const schema = preprocessSchema(JSON.parse(fs.readFileSync(schemaPath, 'utf8')))
 const mappings = loadProductMappings()
 const tmpDir = createTempDir()
 
+// Kernel components (x-schema-source: posthog.schema.*) are projections of
+// schema.ts types; their emitted twins get aliased back to the authored source.
+const kernelComponents = collectKernelComponents(schema)
+const schemaSourceIndex = buildSchemaSourceIndex(repoRoot)
+
 console.log('')
 console.log('┌─────────────────────────────────────────────────────────────────────┐')
 if (generateAll) {
@@ -758,6 +766,15 @@ for (let i = 0; i < results.length; i++) {
             const zodFile = path.join(job.outputDir, 'api.zod.ts')
             fixNullDefaults(zodFile)
             annotatePureZodExports(zodFile)
+        }
+        if (job.kind === 'fetch') {
+            const schemasFile = path.join(job.outputDir, 'api.schemas.ts')
+            if (fs.existsSync(schemasFile)) {
+                const aliasStats = aliasKernelTypes(schemasFile, kernelComponents, schemaSourceIndex)
+                if (aliasStats.aliased > 0) {
+                    console.log(`     ↪ aliased ${aliasStats.aliased} kernel types to their schema.ts source`)
+                }
+            }
         }
         console.log(`   ✓ ${job.label}:${job.kind} → ${path.relative(repoRoot, job.outputDir)}`)
         if (!outputDirs.includes(job.outputDir)) {

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -4,10 +4,11 @@ from typing import Any, get_args
 
 from django.core.exceptions import ImproperlyConfigured
 
+from drf_spectacular.contrib.pydantic import PydanticExtension
 from drf_spectacular.drainage import warn as spectacular_warn
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from drf_spectacular.openapi import AutoSchema
-from drf_spectacular.plumbing import build_basic_type, build_mock_request, build_parameter_type
+from drf_spectacular.plumbing import ResolvedComponent, build_basic_type, build_mock_request, build_parameter_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -19,6 +20,7 @@ from drf_spectacular.utils import (
 from rest_framework import fields, serializers
 from rest_framework.exceptions import PermissionDenied
 
+from posthog.api.openapi_provenance import tag_components_from_model
 from posthog.models.entity import MathType
 from posthog.models.property import OperatorType, PropertyType
 from posthog.permissions import APIScopePermission
@@ -181,6 +183,35 @@ class PersonalAPIKeyScheme(OpenApiAuthenticationExtension):
 
     def get_security_definition(self, auto_schema):
         return {"type": "http", "scheme": "bearer"}
+
+
+class ProvenanceTaggedPydanticExtension(PydanticExtension):
+    """drf-spectacular's PydanticExtension plus ``x-schema-source`` provenance tags.
+
+    Reimplements ``map_serializer`` (rather than wrapping it) because the
+    parent registers ``$defs`` sub-components into the registry mid-call,
+    before there is any chance to tag them.
+    """
+
+    priority = 1  # shadow the contrib extension
+
+    def map_serializer(self, auto_schema: Any, direction: str) -> dict:
+        from pydantic.json_schema import (
+            model_json_schema,  # noqa: PLC0415 — mirrors the contrib extension's lazy import
+        )
+
+        schema = model_json_schema(self.target, ref_template="#/components/schemas/{model}", mode="serialization")
+        defs = schema.pop("$defs", {})
+        tag_components_from_model({**defs, self.target.__name__: schema}, self.target)
+        for sub_name, sub_schema in defs.items():
+            component = ResolvedComponent(
+                name=sub_name,
+                type=ResolvedComponent.SCHEMA,
+                object=sub_name,
+                schema=sub_schema,
+            )
+            auto_schema.registry.register_on_missing(component)
+        return schema
 
 
 class PropertyItemSerializer(serializers.Serializer):

--- a/posthog/api/openapi_provenance.py
+++ b/posthog/api/openapi_provenance.py
@@ -1,0 +1,82 @@
+"""Provenance tags for OpenAPI components generated from Pydantic models.
+
+Components that enter the spec through a Pydantic model carry an
+``x-schema-source`` vendor extension naming the authoring Python class, e.g.
+``posthog.schema.TrendsQuery`` or
+``products.logs.backend.contracts.LogsAlertFilters``.
+
+The tag lets downstream consumers tell the two type pipelines apart without
+name matching: components sourced from ``posthog.schema`` are machine
+projections of frontend-authored schema.ts types (round-trip twins that
+generators may alias back to their TS source), while components sourced from
+product contracts are genuinely backend-authored and should keep generating.
+
+Root models are tagged exactly — the class object is in hand at emission.
+Pydantic only exposes nested ``$defs`` by name, so those are resolved against
+the root model's module and ``posthog.schema`` with a structural sanity check
+(property names for models, member values for enums). When resolution fails or
+is ambiguous the component is left untagged; consumers must treat a missing
+tag as unknown provenance, never as a third state.
+"""
+
+import sys
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+SCHEMA_SOURCE_KEY = "x-schema-source"
+
+
+def schema_source_path(source: type) -> str:
+    return f"{source.__module__}.{source.__qualname__}"
+
+
+def _structurally_matches(candidate: type, def_schema: dict[str, Any]) -> bool:
+    if not isinstance(candidate, type):
+        return False
+    if issubclass(candidate, BaseModel):
+        properties = def_schema.get("properties")
+        if properties is None:
+            return False
+        field_names = {
+            field.serialization_alias or field.alias or name for name, field in candidate.model_fields.items()
+        }
+        return set(properties) == field_names
+    if issubclass(candidate, Enum):
+        enum_values = def_schema.get("enum")
+        if enum_values is None:
+            return False
+        return {member.value for member in candidate} == set(enum_values)
+    return False
+
+
+def resolve_def_class(def_name: str, def_schema: dict[str, Any], root_model: type[BaseModel]) -> type | None:
+    """Resolve a pydantic ``$defs`` entry back to its authoring class.
+
+    Candidates, in priority order: the root model's own module (nested product
+    contract types), then ``posthog.schema`` (the kernel). A candidate only
+    counts when its structure matches the def schema, so a coincidental name
+    collision yields no tag instead of a wrong one.
+    """
+    import posthog.schema as kernel_schema  # noqa: PLC0415 — keeps the 28k-line schema module off this module's import path
+
+    root_module = sys.modules.get(root_model.__module__)
+    for module in (root_module, kernel_schema):
+        if module is None:
+            continue
+        candidate = getattr(module, def_name, None)
+        if candidate is not None and _structurally_matches(candidate, def_schema):
+            return candidate
+    return None
+
+
+def tag_components_from_model(components: dict[str, dict[str, Any]], root_model: type[BaseModel]) -> None:
+    """Stamp ``x-schema-source`` on components hoisted from ``root_model``'s JSON schema."""
+    for name, schema in components.items():
+        if name == root_model.__name__:
+            schema[SCHEMA_SOURCE_KEY] = schema_source_path(root_model)
+            continue
+        resolved = resolve_def_class(name, schema, root_model)
+        if resolved is not None:
+            schema[SCHEMA_SOURCE_KEY] = schema_source_path(resolved)

--- a/posthog/api/test/test_openapi_provenance.py
+++ b/posthog/api/test/test_openapi_provenance.py
@@ -1,0 +1,73 @@
+from enum import StrEnum
+
+from parameterized import parameterized
+from pydantic import BaseModel
+
+from posthog.schema import LogSeverityLevel, PropertyGroupFilter
+
+from posthog.api.openapi_provenance import (
+    SCHEMA_SOURCE_KEY,
+    resolve_def_class,
+    schema_source_path,
+    tag_components_from_model,
+)
+
+
+class _LocalEnum(StrEnum):
+    A = "a"
+    B = "b"
+
+
+class _LocalNested(BaseModel):
+    flag: bool | None = None
+
+
+class _Wrapper(BaseModel):
+    group: PropertyGroupFilter | None = None
+    level: LogSeverityLevel | None = None
+    nested: _LocalNested | None = None
+    choice: _LocalEnum | None = None
+
+
+def _components_for(model: type[BaseModel]) -> dict[str, dict]:
+    raw = model.model_json_schema(mode="serialization")
+    defs = raw.pop("$defs", {})
+    return {**defs, model.__name__: raw}
+
+
+class TestOpenApiProvenance:
+    def test_root_model_tagged_exactly(self):
+        components = _components_for(_Wrapper)
+        tag_components_from_model(components, _Wrapper)
+        assert components["_Wrapper"][SCHEMA_SOURCE_KEY] == schema_source_path(_Wrapper)
+        assert components["_Wrapper"][SCHEMA_SOURCE_KEY].endswith("test_openapi_provenance._Wrapper")
+
+    @parameterized.expand(
+        [
+            ("kernel_model", "PropertyGroupFilter", "posthog.schema.PropertyGroupFilter"),
+            ("kernel_enum", "LogSeverityLevel", "posthog.schema.LogSeverityLevel"),
+        ]
+    )
+    def test_kernel_defs_tagged_with_posthog_schema(self, _name, def_name, expected):
+        components = _components_for(_Wrapper)
+        tag_components_from_model(components, _Wrapper)
+        assert components[def_name][SCHEMA_SOURCE_KEY] == expected
+
+    @parameterized.expand(
+        [
+            ("local_model", "_LocalNested"),
+            ("local_enum", "_LocalEnum"),
+        ]
+    )
+    def test_local_defs_resolved_via_root_module(self, _name, def_name):
+        components = _components_for(_Wrapper)
+        tag_components_from_model(components, _Wrapper)
+        assert components[def_name][SCHEMA_SOURCE_KEY].startswith("posthog.api.test.test_openapi_provenance.")
+
+    def test_structural_mismatch_yields_no_tag(self):
+        wrong_shape = {"type": "object", "properties": {"definitely_not": {}, "the_same": {}}}
+        assert resolve_def_class("PropertyGroupFilter", wrong_shape, _Wrapper) is None
+
+    def test_unresolvable_name_yields_no_tag(self):
+        schema = {"type": "object", "properties": {}}
+        assert resolve_def_class("NoSuchClassAnywhere", schema, _Wrapper) is None

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -1,3 +1,47 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type {
+    AlertCondition,
+    COPODDetectorConfig,
+    DetectorConfig,
+    ECODDetectorConfig,
+    EnsembleDetectorConfig,
+    HBOSDetectorConfig,
+    IQRDetectorConfig,
+    InsightThreshold,
+    InsightsThresholdBounds,
+    IsolationForestDetectorConfig,
+    KNNDetectorConfig,
+    LOFDetectorConfig,
+    MADDetectorConfig,
+    OCSVMDetectorConfig,
+    PCADetectorConfig,
+    PreprocessingConfig,
+    ThresholdDetectorConfig,
+    TrendsAlertConfig,
+    ZScoreDetectorConfig,
+} from '~/queries/schema/schema-general'
+
+export type AlertConditionApi = AlertCondition
+export type COPODDetectorConfigApi = COPODDetectorConfig
+export type DetectorConfigApi = DetectorConfig
+export type ECODDetectorConfigApi = ECODDetectorConfig
+export type EnsembleDetectorConfigApi = EnsembleDetectorConfig
+export type HBOSDetectorConfigApi = HBOSDetectorConfig
+export type IQRDetectorConfigApi = IQRDetectorConfig
+export type InsightThresholdApi = InsightThreshold
+export type InsightsThresholdBoundsApi = InsightsThresholdBounds
+export type IsolationForestDetectorConfigApi = IsolationForestDetectorConfig
+export type KNNDetectorConfigApi = KNNDetectorConfig
+export type LOFDetectorConfigApi = LOFDetectorConfig
+export type MADDetectorConfigApi = MADDetectorConfig
+export type OCSVMDetectorConfigApi = OCSVMDetectorConfig
+export type PCADetectorConfigApi = PCADetectorConfig
+export type PreprocessingConfigApi = PreprocessingConfig
+export type ThresholdDetectorConfigApi = ThresholdDetectorConfig
+export type TrendsAlertConfigApi = TrendsAlertConfig
+export type ZScoreDetectorConfigApi = ZScoreDetectorConfig
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -62,25 +106,12 @@ export interface UserBasicApi {
     role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | null
 }
 
-export interface InsightsThresholdBoundsApi {
-    /** Alert fires when the value drops below this number. */
-    lower?: number | null
-    /** Alert fires when the value exceeds this number. */
-    upper?: number | null
-}
-
 export type InsightThresholdTypeApi = (typeof InsightThresholdTypeApi)[keyof typeof InsightThresholdTypeApi]
 
 export const InsightThresholdTypeApi = {
     Absolute: 'absolute',
     Percentage: 'percentage',
 } as const
-
-export interface InsightThresholdApi {
-    bounds?: InsightsThresholdBoundsApi | null
-    /** Whether bounds are compared as absolute values or as percentage change from the previous interval. */
-    type: InsightThresholdTypeApi
-}
 
 export interface ThresholdApi {
     readonly id: string
@@ -98,10 +129,6 @@ export const AlertConditionTypeApi = {
     RelativeIncrease: 'relative_increase',
     RelativeDecrease: 'relative_decrease',
 } as const
-
-export interface AlertConditionApi {
-    type: AlertConditionTypeApi
-}
 
 /**
  * * `Firing` - Firing
@@ -175,95 +202,6 @@ export interface AlertCheckApi {
     readonly notification_suppressed_by_agent: boolean
 }
 
-export interface TrendsAlertConfigApi {
-    /** When true, evaluate the current (still incomplete) time interval in addition to completed ones. */
-    check_ongoing_interval?: boolean | null
-    /** Zero-based index of the series in the insight's query to monitor. */
-    series_index: number
-    type?: 'TrendsAlertConfig'
-}
-
-export interface PreprocessingConfigApi {
-    /** Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0) */
-    diffs_n?: number | null
-    /** Number of lag features. 0 = none, >0 = include n lagged values (default: 0) */
-    lags_n?: number | null
-    /** Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0) */
-    smooth_n?: number | null
-}
-
-export interface ZScoreDetectorConfigApi {
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9) */
-    threshold?: number | null
-    type?: 'zscore'
-    /** Rolling window size for calculating mean/std (default: 30) */
-    window?: number | null
-}
-
-export interface MADDetectorConfigApi {
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9) */
-    threshold?: number | null
-    type?: 'mad'
-    /** Rolling window size for calculating median/MAD (default: 30) */
-    window?: number | null
-}
-
-export interface IQRDetectorConfigApi {
-    /** IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers) */
-    multiplier?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    type?: 'iqr'
-    /** Rolling window size for calculating quartiles (default: 30) */
-    window?: number | null
-}
-
-export interface ThresholdDetectorConfigApi {
-    /** Lower bound - values below this are anomalies */
-    lower_bound?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    type?: 'threshold'
-    /** Upper bound - values above this are anomalies */
-    upper_bound?: number | null
-}
-
-export interface ECODDetectorConfigApi {
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'ecod'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
-export interface COPODDetectorConfigApi {
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'copod'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
-export interface IsolationForestDetectorConfigApi {
-    /** Number of trees in the forest (default: 100) */
-    n_estimators?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'isolation_forest'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
 export type MethodApi = (typeof MethodApi)[keyof typeof MethodApi]
 
 export const MethodApi = {
@@ -272,113 +210,12 @@ export const MethodApi = {
     Median: 'median',
 } as const
 
-export interface KNNDetectorConfigApi {
-    /** Distance method: 'largest', 'mean', 'median' (default: 'largest') */
-    method?: MethodApi | null
-    /** Number of neighbors to consider (default: 5) */
-    n_neighbors?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'knn'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
-export interface HBOSDetectorConfigApi {
-    /** Number of histogram bins (default: 10) */
-    n_bins?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'hbos'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
-export interface LOFDetectorConfigApi {
-    /** Number of neighbors for LOF (default: 20) */
-    n_neighbors?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'lof'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
-export interface OCSVMDetectorConfigApi {
-    /** SVM kernel type (default: "rbf") */
-    kernel?: string | null
-    /** Upper bound on training errors fraction (default: 0.1) */
-    nu?: number | null
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'ocsvm'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
-export interface PCADetectorConfigApi {
-    /** Preprocessing transforms applied before detection */
-    preprocessing?: PreprocessingConfigApi | null
-    /** Anomaly probability threshold (default: 0.9) */
-    threshold?: number | null
-    type?: 'pca'
-    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
-    window?: number | null
-}
-
 export type EnsembleOperatorApi = (typeof EnsembleOperatorApi)[keyof typeof EnsembleOperatorApi]
 
 export const EnsembleOperatorApi = {
     And: 'and',
     Or: 'or',
 } as const
-
-export interface EnsembleDetectorConfigApi {
-    /** Sub-detector configurations (minimum 2) */
-    detectors: (
-        | ZScoreDetectorConfigApi
-        | MADDetectorConfigApi
-        | IQRDetectorConfigApi
-        | ThresholdDetectorConfigApi
-        | ECODDetectorConfigApi
-        | COPODDetectorConfigApi
-        | IsolationForestDetectorConfigApi
-        | KNNDetectorConfigApi
-        | HBOSDetectorConfigApi
-        | LOFDetectorConfigApi
-        | OCSVMDetectorConfigApi
-        | PCADetectorConfigApi
-    )[]
-    /** How to combine sub-detector results */
-    operator: EnsembleOperatorApi
-    type?: 'ensemble'
-}
-
-/**
- * Detector configuration types
- */
-export type DetectorConfigApi =
-    | EnsembleDetectorConfigApi
-    | ZScoreDetectorConfigApi
-    | MADDetectorConfigApi
-    | IQRDetectorConfigApi
-    | ThresholdDetectorConfigApi
-    | ECODDetectorConfigApi
-    | COPODDetectorConfigApi
-    | IsolationForestDetectorConfigApi
-    | KNNDetectorConfigApi
-    | HBOSDetectorConfigApi
-    | LOFDetectorConfigApi
-    | OCSVMDetectorConfigApi
-    | PCADetectorConfigApi
 
 /**
  * * `every_15_minutes` - every_15_minutes

--- a/products/dashboards/backend/widget_specs/pydantic_openapi.py
+++ b/products/dashboards/backend/widget_specs/pydantic_openapi.py
@@ -8,6 +8,8 @@ from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from pydantic import BaseModel
 from rest_framework import serializers
 
+from posthog.api.openapi_provenance import tag_components_from_model
+
 from products.dashboards.backend.widget_specs.common import WidgetFilterEntry
 from products.dashboards.backend.widget_specs.registry import WIDGET_SPECS
 
@@ -50,6 +52,7 @@ def pydantic_model_to_openapi_components(model: type[BaseModel]) -> dict[str, di
     root_schema = deepcopy(raw_schema)
     root_schema.pop("$defs", None)
     components[model.__name__] = _rewrite_pydantic_refs(root_schema, def_names=def_names)
+    tag_components_from_model(components, model)
     return components
 
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1,3 +1,423 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type {
+    AccountsQuery,
+    AccountsQueryResponse,
+    ActionConversionGoal,
+    ActionsNode,
+    ActorsQuery,
+    ActorsQueryResponse,
+    BoxPlotDatum,
+    Breakdown,
+    BreakdownFilter,
+    CalendarHeatmapFilter,
+    ChartAxis,
+    ChartSettings,
+    ChartSettingsDisplay,
+    ChartSettingsFormatting,
+    ClickhouseQueryProgress,
+    CompareFilter,
+    ConditionalFormattingRule,
+    CustomChannelCondition,
+    CustomChannelRule,
+    CustomEventConversionGoal,
+    DataTableNode,
+    DataTableNodeViewPropsContext,
+    DataVisualizationNode,
+    DataWarehouseEventsModifier,
+    DataWarehouseNode,
+    DataWarehouseSyncWarning,
+    DateRange,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTableQueryResponse,
+    ErrorTrackingCorrelatedIssue,
+    ErrorTrackingExternalReference,
+    ErrorTrackingExternalReferenceIntegration,
+    ErrorTrackingIssue,
+    ErrorTrackingIssueAggregations,
+    ErrorTrackingIssueAssignee,
+    ErrorTrackingIssueCohort,
+    ErrorTrackingIssueCorrelationQuery,
+    ErrorTrackingIssueCorrelationQueryResponse,
+    ErrorTrackingPendingFingerprintIssueStateUpdate,
+    ErrorTrackingQuery,
+    ErrorTrackingQueryResponse,
+    EventDefinition,
+    EventOddsRatioSerialized,
+    EventsNode,
+    EventsQuery,
+    EventsQueryActionStep,
+    EventsQueryResponse,
+    ExperimentActorsQuery,
+    ExperimentBreakdownResult,
+    ExperimentDataWarehouseNode,
+    ExperimentEventExposureConfig,
+    ExperimentFunnelMetric,
+    ExperimentFunnelsQuery,
+    ExperimentFunnelsQueryResponse,
+    ExperimentMeanMetric,
+    ExperimentMetricOutlierHandling,
+    ExperimentQuery,
+    ExperimentQueryResponse,
+    ExperimentRatioMetric,
+    ExperimentRetentionMetric,
+    ExperimentStatsBaseValidated,
+    ExperimentTrendsQuery,
+    ExperimentTrendsQueryResponse,
+    ExperimentVariantFunnelsBaseStats,
+    ExperimentVariantResultBayesian,
+    ExperimentVariantResultFrequentist,
+    ExperimentVariantTrendsBaseStats,
+    FunnelCorrelationActorsQuery,
+    FunnelCorrelationQuery,
+    FunnelCorrelationResponse,
+    FunnelCorrelationResult,
+    FunnelExclusionActionsNode,
+    FunnelExclusionEventsNode,
+    FunnelPathsFilter,
+    FunnelsActorsQuery,
+    FunnelsDataWarehouseNode,
+    FunnelsFilter,
+    FunnelsQuery,
+    FunnelsQueryResponse,
+    GoalLine,
+    GroupNode,
+    GroupsQuery,
+    GroupsQueryResponse,
+    HeatmapGradientStop,
+    HeatmapSettings,
+    HogQLFilters,
+    HogQLMetadataResponse,
+    HogQLNotice,
+    HogQLQuery,
+    HogQLQueryModifiers,
+    HogQLQueryResponse,
+    HogQLVariable,
+    HogQuery,
+    HogQueryResponse,
+    InsightActorsQuery,
+    InsightVizNode,
+    IntegrationFilter,
+    LLMTrace,
+    LLMTraceEvent,
+    LLMTracePerson,
+    LifecycleDataWarehouseNode,
+    LifecycleFilter,
+    LifecycleQuery,
+    LifecycleQueryResponse,
+    MarketingAnalyticsAggregatedQuery,
+    MarketingAnalyticsAggregatedQueryResponse,
+    MarketingAnalyticsItem,
+    MarketingAnalyticsTableQuery,
+    MarketingAnalyticsTableQueryResponse,
+    NonIntegratedConversionsTableQuery,
+    NonIntegratedConversionsTableQueryResponse,
+    PathsFilter,
+    PathsLink,
+    PathsQuery,
+    PathsQueryResponse,
+    PersonsNode,
+    QueryLogTags,
+    QueryStatus,
+    QueryTiming,
+    ResolvedDateRangeResponse,
+    ResultCustomizationByPosition,
+    ResultCustomizationByValue,
+    RetentionFilter,
+    RetentionQuery,
+    RetentionQueryResponse,
+    RetentionResult,
+    RetentionValue,
+    RevenueAnalyticsBreakdown,
+    RevenueAnalyticsGrossRevenueQuery,
+    RevenueAnalyticsGrossRevenueQueryResponse,
+    RevenueAnalyticsMRRQuery,
+    RevenueAnalyticsMRRQueryResponse,
+    RevenueAnalyticsMRRQueryResultItem,
+    RevenueAnalyticsMetricsQuery,
+    RevenueAnalyticsMetricsQueryResponse,
+    RevenueAnalyticsOverviewItem,
+    RevenueAnalyticsOverviewQuery,
+    RevenueAnalyticsOverviewQueryResponse,
+    RevenueAnalyticsTopCustomersQuery,
+    RevenueAnalyticsTopCustomersQueryResponse,
+    RevenueCurrencyPropertyConfig,
+    RevenueExampleDataWarehouseTablesQuery,
+    RevenueExampleDataWarehouseTablesQueryResponse,
+    RevenueExampleEventsQuery,
+    RevenueExampleEventsQueryResponse,
+    SamplingRate,
+    SessionAttributionExplorerQuery,
+    SessionAttributionExplorerQueryResponse,
+    SessionData,
+    SessionsQuery,
+    SessionsQueryResponse,
+    StickinessActorsQuery,
+    StickinessCriteria,
+    StickinessFilter,
+    StickinessQuery,
+    StickinessQueryResponse,
+    TableSettings,
+    TraceQuery,
+    TraceQueryResponse,
+    TracesQuery,
+    TracesQueryResponse,
+    TrendsFilter,
+    TrendsFormulaNode,
+    TrendsQuery,
+    TrendsQueryResponse,
+    VizSpecificOptions,
+    WebAnalyticsSampling,
+    WebExternalClicksTableQuery,
+    WebExternalClicksTableQueryResponse,
+    WebGoalsQuery,
+    WebGoalsQueryResponse,
+    WebOverviewItem,
+    WebOverviewQuery,
+    WebOverviewQueryResponse,
+    WebStatsTableQuery,
+    WebStatsTableQueryResponse,
+    WebVitalsPathBreakdownQuery,
+    WebVitalsPathBreakdownQueryResponse,
+    WebVitalsPathBreakdownResult,
+    WebVitalsPathBreakdownResultItem,
+    WebVitalsQuery,
+    YAxisSettings,
+} from '~/queries/schema/schema-general'
+import type {
+    CohortPropertyFilter,
+    DataWarehousePersonPropertyFilter,
+    DataWarehousePropertyFilter,
+    ElementPropertyFilter,
+    EmptyPropertyFilter,
+    ErrorTrackingIssueFilter,
+    EventMetadataPropertyFilter,
+    EventPropertyFilter,
+    FeaturePropertyFilter,
+    FlagPropertyFilter,
+    GroupPropertyFilter,
+    HogQLPropertyFilter,
+    LogEntryPropertyFilter,
+    LogPropertyFilter,
+    PathCleaningFilter,
+    PersonPropertyFilter,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+    RecordingPropertyFilter,
+    RetentionEntity,
+    RevenueAnalyticsPropertyFilter,
+    SessionPropertyFilter,
+    SpanPropertyFilter,
+    WorkflowVariablePropertyFilter,
+} from '~/types'
+
+export type AccountsQueryApi = AccountsQuery
+export type AccountsQueryResponseApi = AccountsQueryResponse
+export type ActionConversionGoalApi = ActionConversionGoal
+export type ActionsNodeApi = ActionsNode
+export type ActorsQueryApi = ActorsQuery
+export type ActorsQueryResponseApi = ActorsQueryResponse
+export type BoxPlotDatumApi = BoxPlotDatum
+export type BreakdownApi = Breakdown
+export type BreakdownFilterApi = BreakdownFilter
+export type CalendarHeatmapFilterApi = CalendarHeatmapFilter
+export type ChartAxisApi = ChartAxis
+export type ChartSettingsApi = ChartSettings
+export type ChartSettingsDisplayApi = ChartSettingsDisplay
+export type ChartSettingsFormattingApi = ChartSettingsFormatting
+export type ClickhouseQueryProgressApi = ClickhouseQueryProgress
+export type CohortPropertyFilterApi = CohortPropertyFilter
+export type CompareFilterApi = CompareFilter
+export type ConditionalFormattingRuleApi = ConditionalFormattingRule
+export type CustomChannelConditionApi = CustomChannelCondition
+export type CustomChannelRuleApi = CustomChannelRule
+export type CustomEventConversionGoalApi = CustomEventConversionGoal
+export type DataTableNodeApi = DataTableNode
+export type DataTableNodeViewPropsContextApi = DataTableNodeViewPropsContext
+export type DataVisualizationNodeApi = DataVisualizationNode
+export type DataWarehouseEventsModifierApi = DataWarehouseEventsModifier
+export type DataWarehouseNodeApi = DataWarehouseNode
+export type DataWarehousePersonPropertyFilterApi = DataWarehousePersonPropertyFilter
+export type DataWarehousePropertyFilterApi = DataWarehousePropertyFilter
+export type DataWarehouseSyncWarningApi = DataWarehouseSyncWarning
+export type DateRangeApi = DateRange
+export type ElementPropertyFilterApi = ElementPropertyFilter
+export type EmptyPropertyFilterApi = EmptyPropertyFilter
+export type EndpointsUsageTableQueryApi = EndpointsUsageTableQuery
+export type EndpointsUsageTableQueryResponseApi = EndpointsUsageTableQueryResponse
+export type ErrorTrackingCorrelatedIssueApi = ErrorTrackingCorrelatedIssue
+export type ErrorTrackingExternalReferenceApi = ErrorTrackingExternalReference
+export type ErrorTrackingExternalReferenceIntegrationApi = ErrorTrackingExternalReferenceIntegration
+export type ErrorTrackingIssueAggregationsApi = ErrorTrackingIssueAggregations
+export type ErrorTrackingIssueApi = ErrorTrackingIssue
+export type ErrorTrackingIssueAssigneeApi = ErrorTrackingIssueAssignee
+export type ErrorTrackingIssueCohortApi = ErrorTrackingIssueCohort
+export type ErrorTrackingIssueCorrelationQueryApi = ErrorTrackingIssueCorrelationQuery
+export type ErrorTrackingIssueCorrelationQueryResponseApi = ErrorTrackingIssueCorrelationQueryResponse
+export type ErrorTrackingIssueFilterApi = ErrorTrackingIssueFilter
+export type ErrorTrackingPendingFingerprintIssueStateUpdateApi = ErrorTrackingPendingFingerprintIssueStateUpdate
+export type ErrorTrackingQueryApi = ErrorTrackingQuery
+export type ErrorTrackingQueryResponseApi = ErrorTrackingQueryResponse
+export type EventDefinitionApi = EventDefinition
+export type EventMetadataPropertyFilterApi = EventMetadataPropertyFilter
+export type EventOddsRatioSerializedApi = EventOddsRatioSerialized
+export type EventPropertyFilterApi = EventPropertyFilter
+export type EventsNodeApi = EventsNode
+export type EventsQueryActionStepApi = EventsQueryActionStep
+export type EventsQueryApi = EventsQuery
+export type EventsQueryResponseApi = EventsQueryResponse
+export type ExperimentActorsQueryApi = ExperimentActorsQuery
+export type ExperimentBreakdownResultApi = ExperimentBreakdownResult
+export type ExperimentDataWarehouseNodeApi = ExperimentDataWarehouseNode
+export type ExperimentEventExposureConfigApi = ExperimentEventExposureConfig
+export type ExperimentFunnelMetricApi = ExperimentFunnelMetric
+export type ExperimentFunnelsQueryApi = ExperimentFunnelsQuery
+export type ExperimentFunnelsQueryResponseApi = ExperimentFunnelsQueryResponse
+export type ExperimentMeanMetricApi = ExperimentMeanMetric
+export type ExperimentMetricOutlierHandlingApi = ExperimentMetricOutlierHandling
+export type ExperimentQueryApi = ExperimentQuery
+export type ExperimentQueryResponseApi = ExperimentQueryResponse
+export type ExperimentRatioMetricApi = ExperimentRatioMetric
+export type ExperimentRetentionMetricApi = ExperimentRetentionMetric
+export type ExperimentStatsBaseValidatedApi = ExperimentStatsBaseValidated
+export type ExperimentTrendsQueryApi = ExperimentTrendsQuery
+export type ExperimentTrendsQueryResponseApi = ExperimentTrendsQueryResponse
+export type ExperimentVariantFunnelsBaseStatsApi = ExperimentVariantFunnelsBaseStats
+export type ExperimentVariantResultBayesianApi = ExperimentVariantResultBayesian
+export type ExperimentVariantResultFrequentistApi = ExperimentVariantResultFrequentist
+export type ExperimentVariantTrendsBaseStatsApi = ExperimentVariantTrendsBaseStats
+export type FeaturePropertyFilterApi = FeaturePropertyFilter
+export type FlagPropertyFilterApi = FlagPropertyFilter
+export type FunnelCorrelationActorsQueryApi = FunnelCorrelationActorsQuery
+export type FunnelCorrelationQueryApi = FunnelCorrelationQuery
+export type FunnelCorrelationResponseApi = FunnelCorrelationResponse
+export type FunnelCorrelationResultApi = FunnelCorrelationResult
+export type FunnelExclusionActionsNodeApi = FunnelExclusionActionsNode
+export type FunnelExclusionEventsNodeApi = FunnelExclusionEventsNode
+export type FunnelPathsFilterApi = FunnelPathsFilter
+export type FunnelsActorsQueryApi = FunnelsActorsQuery
+export type FunnelsDataWarehouseNodeApi = FunnelsDataWarehouseNode
+export type FunnelsFilterApi = FunnelsFilter
+export type FunnelsQueryApi = FunnelsQuery
+export type FunnelsQueryResponseApi = FunnelsQueryResponse
+export type GoalLineApi = GoalLine
+export type GroupNodeApi = GroupNode
+export type GroupPropertyFilterApi = GroupPropertyFilter
+export type GroupsQueryApi = GroupsQuery
+export type GroupsQueryResponseApi = GroupsQueryResponse
+export type HeatmapGradientStopApi = HeatmapGradientStop
+export type HeatmapSettingsApi = HeatmapSettings
+export type HogQLFiltersApi = HogQLFilters
+export type HogQLMetadataResponseApi = HogQLMetadataResponse
+export type HogQLNoticeApi = HogQLNotice
+export type HogQLPropertyFilterApi = HogQLPropertyFilter
+export type HogQLQueryApi = HogQLQuery
+export type HogQLQueryModifiersApi = HogQLQueryModifiers
+export type HogQLQueryResponseApi = HogQLQueryResponse
+export type HogQLVariableApi = HogQLVariable
+export type HogQueryApi = HogQuery
+export type HogQueryResponseApi = HogQueryResponse
+export type InsightActorsQueryApi = InsightActorsQuery
+export type InsightVizNodeApi = InsightVizNode
+export type IntegrationFilterApi = IntegrationFilter
+export type LLMTraceApi = LLMTrace
+export type LLMTraceEventApi = LLMTraceEvent
+export type LLMTracePersonApi = LLMTracePerson
+export type LifecycleDataWarehouseNodeApi = LifecycleDataWarehouseNode
+export type LifecycleFilterApi = LifecycleFilter
+export type LifecycleQueryApi = LifecycleQuery
+export type LifecycleQueryResponseApi = LifecycleQueryResponse
+export type LogEntryPropertyFilterApi = LogEntryPropertyFilter
+export type LogPropertyFilterApi = LogPropertyFilter
+export type MarketingAnalyticsAggregatedQueryApi = MarketingAnalyticsAggregatedQuery
+export type MarketingAnalyticsAggregatedQueryResponseApi = MarketingAnalyticsAggregatedQueryResponse
+export type MarketingAnalyticsItemApi = MarketingAnalyticsItem
+export type MarketingAnalyticsTableQueryApi = MarketingAnalyticsTableQuery
+export type MarketingAnalyticsTableQueryResponseApi = MarketingAnalyticsTableQueryResponse
+export type NonIntegratedConversionsTableQueryApi = NonIntegratedConversionsTableQuery
+export type NonIntegratedConversionsTableQueryResponseApi = NonIntegratedConversionsTableQueryResponse
+export type PathCleaningFilterApi = PathCleaningFilter
+export type PathsFilterApi = PathsFilter
+export type PathsLinkApi = PathsLink
+export type PathsQueryApi = PathsQuery
+export type PathsQueryResponseApi = PathsQueryResponse
+export type PersonPropertyFilterApi = PersonPropertyFilter
+export type PersonsNodeApi = PersonsNode
+export type PropertyGroupFilterApi = PropertyGroupFilter
+export type PropertyGroupFilterValueApi = PropertyGroupFilterValue
+export type QueryLogTagsApi = QueryLogTags
+export type QueryStatusApi = QueryStatus
+export type QueryTimingApi = QueryTiming
+export type RecordingPropertyFilterApi = RecordingPropertyFilter
+export type ResolvedDateRangeResponseApi = ResolvedDateRangeResponse
+export type ResultCustomizationByPositionApi = ResultCustomizationByPosition
+export type ResultCustomizationByValueApi = ResultCustomizationByValue
+export type RetentionEntityApi = RetentionEntity
+export type RetentionFilterApi = RetentionFilter
+export type RetentionQueryApi = RetentionQuery
+export type RetentionQueryResponseApi = RetentionQueryResponse
+export type RetentionResultApi = RetentionResult
+export type RetentionValueApi = RetentionValue
+export type RevenueAnalyticsBreakdownApi = RevenueAnalyticsBreakdown
+export type RevenueAnalyticsGrossRevenueQueryApi = RevenueAnalyticsGrossRevenueQuery
+export type RevenueAnalyticsGrossRevenueQueryResponseApi = RevenueAnalyticsGrossRevenueQueryResponse
+export type RevenueAnalyticsMRRQueryApi = RevenueAnalyticsMRRQuery
+export type RevenueAnalyticsMRRQueryResponseApi = RevenueAnalyticsMRRQueryResponse
+export type RevenueAnalyticsMRRQueryResultItemApi = RevenueAnalyticsMRRQueryResultItem
+export type RevenueAnalyticsMetricsQueryApi = RevenueAnalyticsMetricsQuery
+export type RevenueAnalyticsMetricsQueryResponseApi = RevenueAnalyticsMetricsQueryResponse
+export type RevenueAnalyticsOverviewItemApi = RevenueAnalyticsOverviewItem
+export type RevenueAnalyticsOverviewQueryApi = RevenueAnalyticsOverviewQuery
+export type RevenueAnalyticsOverviewQueryResponseApi = RevenueAnalyticsOverviewQueryResponse
+export type RevenueAnalyticsPropertyFilterApi = RevenueAnalyticsPropertyFilter
+export type RevenueAnalyticsTopCustomersQueryApi = RevenueAnalyticsTopCustomersQuery
+export type RevenueAnalyticsTopCustomersQueryResponseApi = RevenueAnalyticsTopCustomersQueryResponse
+export type RevenueCurrencyPropertyConfigApi = RevenueCurrencyPropertyConfig
+export type RevenueExampleDataWarehouseTablesQueryApi = RevenueExampleDataWarehouseTablesQuery
+export type RevenueExampleDataWarehouseTablesQueryResponseApi = RevenueExampleDataWarehouseTablesQueryResponse
+export type RevenueExampleEventsQueryApi = RevenueExampleEventsQuery
+export type RevenueExampleEventsQueryResponseApi = RevenueExampleEventsQueryResponse
+export type SamplingRateApi = SamplingRate
+export type SessionAttributionExplorerQueryApi = SessionAttributionExplorerQuery
+export type SessionAttributionExplorerQueryResponseApi = SessionAttributionExplorerQueryResponse
+export type SessionDataApi = SessionData
+export type SessionPropertyFilterApi = SessionPropertyFilter
+export type SessionsQueryApi = SessionsQuery
+export type SessionsQueryResponseApi = SessionsQueryResponse
+export type SpanPropertyFilterApi = SpanPropertyFilter
+export type StickinessActorsQueryApi = StickinessActorsQuery
+export type StickinessCriteriaApi = StickinessCriteria
+export type StickinessFilterApi = StickinessFilter
+export type StickinessQueryApi = StickinessQuery
+export type StickinessQueryResponseApi = StickinessQueryResponse
+export type TableSettingsApi = TableSettings
+export type TraceQueryApi = TraceQuery
+export type TraceQueryResponseApi = TraceQueryResponse
+export type TracesQueryApi = TracesQuery
+export type TracesQueryResponseApi = TracesQueryResponse
+export type TrendsFilterApi = TrendsFilter
+export type TrendsFormulaNodeApi = TrendsFormulaNode
+export type TrendsQueryApi = TrendsQuery
+export type TrendsQueryResponseApi = TrendsQueryResponse
+export type VizSpecificOptionsApi = VizSpecificOptions
+export type WebAnalyticsSamplingApi = WebAnalyticsSampling
+export type WebExternalClicksTableQueryApi = WebExternalClicksTableQuery
+export type WebExternalClicksTableQueryResponseApi = WebExternalClicksTableQueryResponse
+export type WebGoalsQueryApi = WebGoalsQuery
+export type WebGoalsQueryResponseApi = WebGoalsQueryResponse
+export type WebOverviewItemApi = WebOverviewItem
+export type WebOverviewQueryApi = WebOverviewQuery
+export type WebOverviewQueryResponseApi = WebOverviewQueryResponse
+export type WebStatsTableQueryApi = WebStatsTableQuery
+export type WebStatsTableQueryResponseApi = WebStatsTableQueryResponse
+export type WebVitalsPathBreakdownQueryApi = WebVitalsPathBreakdownQuery
+export type WebVitalsPathBreakdownQueryResponseApi = WebVitalsPathBreakdownQueryResponse
+export type WebVitalsPathBreakdownResultApi = WebVitalsPathBreakdownResult
+export type WebVitalsPathBreakdownResultItemApi = WebVitalsPathBreakdownResultItem
+export type WebVitalsQueryApi = WebVitalsQuery
+export type WorkflowVariablePropertyFilterApi = WorkflowVariablePropertyFilter
+export type YAxisSettingsApi = YAxisSettings
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -710,56 +1130,6 @@ export const MultipleBreakdownTypeApi = {
     DataWarehousePersonProperty: 'data_warehouse_person_property',
 } as const
 
-export interface BreakdownApi {
-    group_type_index?: number | null
-    histogram_bin_count?: number | null
-    normalize_url?: boolean | null
-    property: string | number
-    type?: MultipleBreakdownTypeApi | null
-}
-
-export interface BreakdownFilterApi {
-    breakdown?: string | (string | number)[] | number | null
-    breakdown_group_type_index?: number | null
-    breakdown_hide_other_aggregation?: boolean | null
-    breakdown_histogram_bin_count?: number | null
-    breakdown_limit?: number | null
-    breakdown_normalize_url?: boolean | null
-    breakdown_path_cleaning?: boolean | null
-    breakdown_type?: BreakdownTypeApi | null
-    breakdowns?: BreakdownApi[] | null
-}
-
-export interface CalendarHeatmapFilterApi {
-    /** When true and the series math is `dau`/`unique_users`, each user contributes to the (day-of-week, hour) bucket of their session's first event only — matching the web overview session-start attribution. When false (default), the user contributes to every bucket they have any event in. No effect on `total` math (event counts are unchanged either way). */
-    bucketBySessionStart?: boolean | null
-}
-
-export interface CompareFilterApi {
-    /** Whether to compare the current date range to a previous date range. */
-    compare?: boolean | null
-    /** The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago. */
-    compare_to?: string | null
-}
-
-export interface ActionConversionGoalApi {
-    actionId: number
-}
-
-export interface CustomEventConversionGoalApi {
-    customEventName: string
-}
-
-export interface DateRangeApi {
-    /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-     * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
-    date_from?: string | null
-    /** End of the date range. Same format as date_from. Omit or null for "now". */
-    date_to?: string | null
-    /** Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period. */
-    explicitDate?: boolean | null
-}
-
 export type IntervalTypeApi = (typeof IntervalTypeApi)[keyof typeof IntervalTypeApi]
 
 export const IntervalTypeApi = {
@@ -810,27 +1180,6 @@ export const CustomChannelOperatorApi = {
     Regex: 'regex',
     NotRegex: 'not_regex',
 } as const
-
-export interface CustomChannelConditionApi {
-    id: string
-    key: CustomChannelFieldApi
-    op: CustomChannelOperatorApi
-    value?: string | string[] | null
-}
-
-export interface CustomChannelRuleApi {
-    channel_type: string
-    combiner: FilterLogicalOperatorApi
-    id: string
-    items: CustomChannelConditionApi[]
-}
-
-export interface DataWarehouseEventsModifierApi {
-    distinct_id_field: string
-    id_field: string
-    table_name: string
-    timestamp_field: string
-}
 
 export type InCohortViaApi = (typeof InCohortViaApi)[keyof typeof InCohortViaApi]
 
@@ -926,62 +1275,6 @@ export const SessionsV2JoinModeApi = {
     Uuid: 'uuid',
 } as const
 
-export interface HogQLQueryModifiersApi {
-    bounceRateDurationSeconds?: number | null
-    bounceRatePageViewMode?: BounceRatePageViewModeApi | null
-    convertToProjectTimezone?: boolean | null
-    customChannelTypeRules?: CustomChannelRuleApi[] | null
-    dataWarehouseEventsModifiers?: DataWarehouseEventsModifierApi[] | null
-    debug?: boolean | null
-    /** If these are provided, the query will fail if these skip indexes are not used */
-    forceClickhouseDataSkippingIndexes?: string[] | null
-    formatCsvAllowDoubleQuotes?: boolean | null
-    inCohortVia?: InCohortViaApi | null
-    inlineCohortCalculation?: InlineCohortCalculationApi | null
-    materializationMode?: MaterializationModeApi | null
-    materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi | null
-    optimizeJoinedFilters?: boolean | null
-    optimizeProjections?: boolean | null
-    /** HogQL parser backend; absent → `rust_py_with_cpp_shadow` (rust-py is primary, cpp runs as a sampled shadow). `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
-    parserMode?: ParserModeApi | null
-    personsArgMaxVersion?: PersonsArgMaxVersionApi | null
-    personsJoinMode?: PersonsJoinModeApi | null
-    personsOnEventsMode?: PersonsOnEventsModeApi | null
-    propertyGroupsMode?: PropertyGroupsModeApi | null
-    pushDownPredicates?: boolean | null
-    s3TableUseInvalidColumns?: boolean | null
-    /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */
-    sessionIdPushdown?: boolean | null
-    /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
-    sessionPropertyPreAggregation?: boolean | null
-    sessionTableVersion?: SessionTableVersionApi | null
-    sessionsV2JoinMode?: SessionsV2JoinModeApi | null
-    timings?: boolean | null
-    useMaterializedViews?: boolean | null
-    usePreaggregatedIntermediateResults?: boolean | null
-    /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
-    usePreaggregatedTableTransforms?: boolean | null
-    useWebAnalyticsPreAggregatedTables?: boolean | null
-}
-
-export interface EventPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    /** Event properties */
-    type?: 'event'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Person properties */
-    type?: 'person'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
 
 export const Key10Api = {
@@ -991,39 +1284,6 @@ export const Key10Api = {
     Selector: 'selector',
 } as const
 
-export interface ElementPropertyFilterApi {
-    key: Key10Api
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'element'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface EventMetadataPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'event_metadata'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface SessionPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'session'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface CohortPropertyFilterApi {
-    cohort_name?: string | null
-    key?: 'id'
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    type?: 'cohort'
-    value: number
-}
-
 export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
 
 export const DurationTypeApi = {
@@ -1032,91 +1292,11 @@ export const DurationTypeApi = {
     InactiveSeconds: 'inactive_seconds',
 } as const
 
-export interface RecordingPropertyFilterApi {
-    key: DurationTypeApi | string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'recording'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface LogEntryPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'log_entry'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
-
-export interface GroupPropertyFilterApi {
-    group_key_names?: GroupPropertyFilterApiGroupKeyNames
-    group_type_index?: number | null
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'group'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FeaturePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Event property with "$feature/" prepended */
-    type?: 'feature'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FlagPropertyFilterApi {
-    /** The key should be the flag ID */
-    key: string
-    label?: string | null
-    /** Only flag_evaluates_to operator is allowed for flag dependencies */
-    operator?: 'flag_evaluates_to'
-    /** Feature flag dependency */
-    type?: 'flag'
-    /** The value can be true, false, or a variant name */
-    value: boolean | string
-}
-
-export interface HogQLPropertyFilterApi {
-    key: string
-    label?: string | null
-    type?: 'hogql'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export const EmptyPropertyFilterApiValue = {
     type: 'empty',
 } as const
-export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
-
-export interface DataWarehousePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface DataWarehousePersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse_person_property'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface ErrorTrackingIssueFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'error_tracking_issue'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
 
 export const LogPropertyFilterTypeApi = {
@@ -1124,14 +1304,6 @@ export const LogPropertyFilterTypeApi = {
     LogAttribute: 'log_attribute',
     LogResourceAttribute: 'log_resource_attribute',
 } as const
-
-export interface LogPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: LogPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
 
@@ -1141,159 +1313,7 @@ export const SpanPropertyFilterTypeApi = {
     SpanResourceAttribute: 'span_resource_attribute',
 } as const
 
-export interface SpanPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: SpanPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface RevenueAnalyticsPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'revenue_analytics'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface WorkflowVariablePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'workflow_variable'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PropertyGroupFilterValueApi {
-    type: FilterLogicalOperatorApi
-    values: (
-        | PropertyGroupFilterValueApi
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | ElementPropertyFilterApi
-        | EventMetadataPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-        | RecordingPropertyFilterApi
-        | LogEntryPropertyFilterApi
-        | GroupPropertyFilterApi
-        | FeaturePropertyFilterApi
-        | FlagPropertyFilterApi
-        | HogQLPropertyFilterApi
-        | EmptyPropertyFilterApi
-        | DataWarehousePropertyFilterApi
-        | DataWarehousePersonPropertyFilterApi
-        | ErrorTrackingIssueFilterApi
-        | LogPropertyFilterApi
-        | SpanPropertyFilterApi
-        | RevenueAnalyticsPropertyFilterApi
-        | WorkflowVariablePropertyFilterApi
-    )[]
-}
-
-export interface PropertyGroupFilterApi {
-    type: FilterLogicalOperatorApi
-    values: PropertyGroupFilterValueApi[]
-}
-
-export interface BoxPlotDatumApi {
-    day: string
-    label: string
-    max: number
-    mean: number
-    median: number
-    min: number
-    p25: number
-    p75: number
-    series_index?: number | null
-    series_label?: string | null
-}
-
-export interface ClickhouseQueryProgressApi {
-    active_cpu_time: number
-    bytes_read: number
-    estimated_rows_total: number
-    rows_read: number
-    time_elapsed: number
-}
-
-export interface QueryStatusApi {
-    /** Whether the query is still running. Will be true if the query is complete, even if it errored. Either result or error will be set. */
-    complete?: boolean | null
-    dashboard_id?: number | null
-    /** When did the query execution task finish (whether successfully or not). */
-    end_time?: string | null
-    /** If the query failed, this will be set to true. More information can be found in the error_message field. */
-    error?: boolean | null
-    error_message?: string | null
-    expiration_time?: string | null
-    id: string
-    insight_id?: number | null
-    labels?: string[] | null
-    /** When was the query execution task picked up by a worker. */
-    pickup_time?: string | null
-    /** ONLY async queries use QueryStatus. */
-    query_async?: true
-    query_progress?: ClickhouseQueryProgressApi | null
-    results?: unknown
-    /** When was query execution task enqueued. */
-    start_time?: string | null
-    task_id?: string | null
-    team_id: number
-}
-
-export interface ResolvedDateRangeResponseApi {
-    date_from: string
-    date_to: string
-}
-
-export interface QueryTimingApi {
-    /** Key. Shortened to 'k' to save on data. */
-    k: string
-    /** Time in seconds. Shortened to 't' to save on data. */
-    t: number
-}
-
-export interface DataWarehouseSyncWarningApi {
-    /** Human-readable warning shown to the user */
-    message: string
-    /** Name of the ExternalDataSchema responsible for syncing the table */
-    schema_name: string
-    /** ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables. */
-    source_id?: string | null
-    /** Source type, e.g. "Stripe", "Hubspot" */
-    source_type: string
-    /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
-    status: string
-    /** Name of the warehouse table the warning refers to */
-    table_name: string
-}
-
 export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface TrendsQueryResponseApi {
-    boxplot_data?: BoxPlotDatumApi[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Wether more breakdown values are available. */
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: TrendsQueryResponseApiResultsItem[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
 
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
 
@@ -1530,350 +1550,13 @@ export const CurrencyCodeApi = {
     Zmw: 'ZMW',
 } as const
 
-export interface RevenueCurrencyPropertyConfigApi {
-    property?: string | null
-    static?: CurrencyCodeApi | null
-}
-
 export type EventsNodeApiResponse = { [key: string]: unknown } | null
-
-export interface EventsNodeApi {
-    custom_name?: string | null
-    /** The event or `null` for all events. */
-    event?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'EventsNode'
-    limit?: number | null
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: EventsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ActionsNodeApiResponse = { [key: string]: unknown } | null
 
-export interface ActionsNodeApi {
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: number
-    kind?: 'ActionsNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: ActionsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type DataWarehouseNodeApiResponse = { [key: string]: unknown } | null
 
-export interface DataWarehouseNodeApi {
-    custom_name?: string | null
-    distinct_id_field: string
-    dw_source_type?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: string
-    id_field: string
-    kind?: 'DataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: DataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type GroupNodeApiResponse = { [key: string]: unknown } | null
-
-export interface GroupNodeApi {
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'GroupNode'
-    limit?: number | null
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    /** Entities to combine in this group */
-    nodes: (EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
-    /** Group of entities combined with AND/OR operator */
-    operator: FilterLogicalOperatorApi
-    optionalInFunnel?: boolean | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: GroupNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface QueryLogTagsApi {
-    /** Name of the query, preferably unique. For example web_analytics_vitals */
-    name?: string | null
-    /** Product responsible for this query. Use string, there's no need to churn the Schema when we add a new product * */
-    productKey?: string | null
-    /** Scene where this query is shown in the UI. Use string, there's no need to churn the Schema when we add a new Scene * */
-    scene?: string | null
-}
 
 export type AggregationAxisFormatApi = (typeof AggregationAxisFormatApi)[keyof typeof AggregationAxisFormatApi]
 
@@ -1916,27 +1599,12 @@ export const ChartDisplayTypeApi = {
     BoxPlot: 'BoxPlot',
 } as const
 
-export interface TrendsFormulaNodeApi {
-    /** Optional user-defined name for the formula */
-    custom_name?: string | null
-    formula: string
-}
-
 export type PositionApi = (typeof PositionApi)[keyof typeof PositionApi]
 
 export const PositionApi = {
     Start: 'start',
     End: 'end',
 } as const
-
-export interface GoalLineApi {
-    borderColor?: string | null
-    displayIfCrossed?: boolean | null
-    displayLabel?: boolean | null
-    label: string
-    position?: PositionApi | null
-    value: number
-}
 
 export type ResultCustomizationByApi = (typeof ResultCustomizationByApi)[keyof typeof ResultCustomizationByApi]
 
@@ -1965,18 +1633,6 @@ export const DataColorTokenApi = {
     Preset15: 'preset-15',
 } as const
 
-export interface ResultCustomizationByValueApi {
-    assignmentBy?: 'value'
-    color?: DataColorTokenApi | null
-    hidden?: boolean | null
-}
-
-export interface ResultCustomizationByPositionApi {
-    assignmentBy?: 'position'
-    color?: DataColorTokenApi | null
-    hidden?: boolean | null
-}
-
 export type YAxisScaleTypeApi = (typeof YAxisScaleTypeApi)[keyof typeof YAxisScaleTypeApi]
 
 export const YAxisScaleTypeApi = {
@@ -1992,124 +1648,6 @@ export type TrendsFilterApiResultCustomizations =
     | { [key: string]: ResultCustomizationByPositionApi }
     | null
 
-export interface TrendsFilterApi {
-    /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-     *
-     * - `numeric` (default): raw numbers, e.g. `1,234`.
-     * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-     * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-     * - `percentage`: values are already in the 0-100 range; appends `%`.
-     * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-     * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-     * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
-    aggregationAxisFormat?: AggregationAxisFormatApi | null
-    /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
-    aggregationAxisPostfix?: string | null
-    /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
-    aggregationAxisPrefix?: string | null
-    breakdown_histogram_bin_count?: number | null
-    confidenceLevel?: number | null
-    /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
-    decimalPlaces?: number | null
-    /** detailed results table */
-    detailedResultsAggregationType?: DetailedResultsAggregationTypeApi | null
-    display?: ChartDisplayTypeApi | null
-    excludeBoxPlotOutliers?: boolean | null
-    formula?: string | null
-    /** List of formulas with optional custom names. Takes precedence over formula/formulas if set. */
-    formulaNodes?: TrendsFormulaNodeApi[] | null
-    formulas?: string[] | null
-    /** Goal Lines */
-    goalLines?: GoalLineApi[] | null
-    hiddenLegendIndexes?: number[] | null
-    hideWeekends?: boolean | null
-    minDecimalPlaces?: number | null
-    movingAverageIntervals?: number | null
-    /** Wether result datasets are associated by their values or by their order. */
-    resultCustomizationBy?: ResultCustomizationByApi | null
-    /** Customizations for the appearance of result datasets. */
-    resultCustomizations?: TrendsFilterApiResultCustomizations
-    showAlertThresholdLines?: boolean | null
-    showAnnotations?: boolean | null
-    showConfidenceIntervals?: boolean | null
-    showLabelsOnSeries?: boolean | null
-    showLegend?: boolean | null
-    showMovingAverage?: boolean | null
-    showMultipleYAxes?: boolean | null
-    showPercentStackView?: boolean | null
-    showTrendLines?: boolean | null
-    showValuesOnSeries?: boolean | null
-    smoothingIntervals?: number | null
-    /** On the horizontal bar-value chart, stack a series' breakdown values into a single bar instead of rendering one bar per breakdown value. */
-    stackBreakdownValues?: boolean | null
-    /** Custom label rendered under the X axis. */
-    xAxisLabel?: string | null
-    /** Custom label rendered alongside the Y axis. */
-    yAxisLabel?: string | null
-    yAxisScaleType?: YAxisScaleTypeApi | null
-}
-
-export interface TrendsQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Breakdown of the events and actions */
-    breakdownFilter?: BreakdownFilterApi | null
-    /** Properties specific to the calendar heatmap display variant. Only consulted when `trendsFilter.display === ChartDisplayType.CalendarHeatmap`; ignored otherwise. */
-    calendarHeatmapFilter?: CalendarHeatmapFilterApi | null
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    /** Whether we should be comparing against a specific conversion goal */
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    kind?: 'TrendsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: TrendsQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (GroupNodeApi | EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** Properties specific to the trends insight */
-    trendsFilter?: TrendsFilterApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type BreakdownAttributionTypeApi = (typeof BreakdownAttributionTypeApi)[keyof typeof BreakdownAttributionTypeApi]
 
 export const BreakdownAttributionTypeApi = {
@@ -2121,169 +1659,7 @@ export const BreakdownAttributionTypeApi = {
 
 export type FunnelExclusionEventsNodeApiResponse = { [key: string]: unknown } | null
 
-export interface FunnelExclusionEventsNodeApi {
-    custom_name?: string | null
-    /** The event or `null` for all events. */
-    event?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    funnelFromStep: number
-    funnelToStep: number
-    kind?: 'EventsNode'
-    limit?: number | null
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: FunnelExclusionEventsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type FunnelExclusionActionsNodeApiResponse = { [key: string]: unknown } | null
-
-export interface FunnelExclusionActionsNodeApi {
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    funnelFromStep: number
-    funnelToStep: number
-    id: number
-    kind?: 'ActionsNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: FunnelExclusionActionsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type StepOrderValueApi = (typeof StepOrderValueApi)[keyof typeof StepOrderValueApi]
 
@@ -2333,232 +1709,7 @@ export const FunnelLayoutApi = {
  */
 export type FunnelsFilterApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
 
-export interface FunnelsFilterApi {
-    binCount?: number | null
-    breakdownAttributionType?: BreakdownAttributionTypeApi | null
-    breakdownAttributionValue?: number | null
-    /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */
-    breakdownSorting?: string | null
-    /** For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups. */
-    customAggregationTarget?: boolean | null
-    exclusions?: (FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi)[] | null
-    funnelAggregateByHogQL?: string | null
-    funnelFromStep?: number | null
-    funnelOrderType?: StepOrderValueApi | null
-    funnelStepReference?: FunnelStepReferenceApi | null
-    /** To select the range of steps for trends & time to convert funnels, 0-indexed */
-    funnelToStep?: number | null
-    funnelVizType?: FunnelVizTypeApi | null
-    funnelWindowInterval?: number | null
-    funnelWindowIntervalUnit?: FunnelConversionWindowTimeUnitApi | null
-    /** Goal Lines */
-    goalLines?: GoalLineApi[] | null
-    hiddenLegendBreakdowns?: string[] | null
-    /** Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent tail of the trend isn't dragged down by entrants who still have time to convert. */
-    hideIncompleteConversionWindowPeriods?: boolean | null
-    layout?: FunnelLayoutApi | null
-    /** Customizations for the appearance of result datasets. */
-    resultCustomizations?: FunnelsFilterApiResultCustomizations
-    /** Whether to render annotations on the chart. Only applies to historical-trends funnels. */
-    showAnnotations?: boolean | null
-    /** Display linear regression trend lines on the chart (only for historical trends viz) */
-    showTrendLines?: boolean | null
-    showValuesOnSeries?: boolean | null
-    useUdf?: boolean | null
-}
-
-export interface FunnelsQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
 export type FunnelsDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
-
-export interface FunnelsDataWarehouseNodeApi {
-    aggregation_target_field: string
-    custom_name?: string | null
-    dw_source_type?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: string
-    id_field: string
-    kind?: 'FunnelsDataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: FunnelsDataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface FunnelsQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Breakdown of the events and actions */
-    breakdownFilter?: BreakdownFilterApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Properties specific to the funnels insight */
-    funnelsFilter?: FunnelsFilterApi | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    kind?: 'FunnelsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: FunnelsQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (GroupNodeApi | EventsNodeApi | ActionsNodeApi | FunnelsDataWarehouseNodeApi)[]
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RetentionValueApi {
-    aggregation_value?: number | null
-    count: number
-    label?: string | null
-}
-
-export interface RetentionResultApi {
-    /** Optional breakdown value for retention cohorts */
-    breakdown_value?: string | number | null
-    date: string
-    label: string
-    values: RetentionValueApi[]
-}
-
-export interface RetentionQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: RetentionResultApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
 
 export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[keyof typeof AggregationPropertyTypeApi]
 
@@ -2634,138 +1785,12 @@ export const EntityTypeApi = {
     Groups: 'groups',
 } as const
 
-export interface RetentionEntityApi {
-    /** Data warehouse field used as the actor identifier */
-    aggregation_target_field?: string | null
-    custom_name?: string | null
-    id?: string | number | null
-    kind?: RetentionEntityKindApi | null
-    name?: string | null
-    order?: number | null
-    /** filters on the event */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    /** Data warehouse table name */
-    table_name?: string | null
-    /** Data warehouse timestamp field */
-    timestamp_field?: string | null
-    type?: EntityTypeApi | null
-    uuid?: string | null
-}
-
 export type TimeWindowModeApi = (typeof TimeWindowModeApi)[keyof typeof TimeWindowModeApi]
 
 export const TimeWindowModeApi = {
     StrictCalendarDates: 'strict_calendar_dates',
     '24HourWindows': '24_hour_windows',
 } as const
-
-export interface RetentionFilterApi {
-    /** The property to aggregate when aggregationType is sum or avg */
-    aggregationProperty?: string | null
-    /** The type of property to aggregate on (event, person or data_warehouse). Defaults to event. */
-    aggregationPropertyType?: AggregationPropertyTypeApi | null
-    /** The aggregation type to use for retention */
-    aggregationType?: AggregationTypeApi | null
-    /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
-    cohortLabelStartIndex?: number | null
-    cumulative?: boolean | null
-    /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
-    customAggregationTarget?: boolean | null
-    dashboardDisplay?: RetentionDashboardDisplayTypeApi | null
-    /** controls the display of the retention graph */
-    display?: ChartDisplayTypeApi | null
-    goalLines?: GoalLineApi[] | null
-    meanRetentionCalculation?: MeanRetentionCalculationApi | null
-    minimumOccurrences?: number | null
-    period?: RetentionPeriodApi | null
-    /** Custom brackets for retention calculations */
-    retentionCustomBrackets?: number[] | null
-    /** Whether retention is with regard to initial cohort size, or that of the previous period. */
-    retentionReference?: RetentionReferenceApi | null
-    retentionType?: RetentionTypeApi | null
-    returningEntity?: RetentionEntityApi | null
-    /** The selected interval to display across all cohorts (null = show all intervals for each cohort) */
-    selectedInterval?: number | null
-    showTrendLines?: boolean | null
-    targetEntity?: RetentionEntityApi | null
-    /** The time window mode to use for retention calculations */
-    timeWindowMode?: TimeWindowModeApi | null
-    totalIntervals?: number | null
-}
-
-export interface RetentionQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Breakdown of the events and actions */
-    breakdownFilter?: BreakdownFilterApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    kind?: 'RetentionQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: RetentionQueryResponseApi | null
-    /** Properties specific to the retention insight */
-    retentionFilter: RetentionFilterApi
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type FunnelPathTypeApi = (typeof FunnelPathTypeApi)[keyof typeof FunnelPathTypeApi]
 
@@ -2774,12 +1799,6 @@ export const FunnelPathTypeApi = {
     FunnelPathBetweenSteps: 'funnel_path_between_steps',
     FunnelPathAfterStep: 'funnel_path_after_step',
 } as const
-
-export interface FunnelPathsFilterApi {
-    funnelPathType?: FunnelPathTypeApi | null
-    funnelSource: FunnelsQueryApi
-    funnelStep?: number | null
-}
 
 export type PathTypeApi = (typeof PathTypeApi)[keyof typeof PathTypeApi]
 
@@ -2790,133 +1809,7 @@ export const PathTypeApi = {
     Hogql: 'hogql',
 } as const
 
-export interface PathCleaningFilterApi {
-    alias?: string | null
-    order?: number | null
-    regex?: string | null
-}
-
-export interface PathsFilterApi {
-    edgeLimit?: number | null
-    endPoint?: string | null
-    excludeEvents?: string[] | null
-    includeEventTypes?: PathTypeApi[] | null
-    localPathCleaningFilters?: PathCleaningFilterApi[] | null
-    maxEdgeWeight?: number | null
-    minEdgeWeight?: number | null
-    /** Relevant only within actors query */
-    pathDropoffKey?: string | null
-    /** Relevant only within actors query */
-    pathEndKey?: string | null
-    pathGroupings?: string[] | null
-    pathReplacements?: boolean | null
-    /** Relevant only within actors query */
-    pathStartKey?: string | null
-    pathsHogQLExpression?: string | null
-    showFullUrls?: boolean | null
-    startPoint?: string | null
-    stepLimit?: number | null
-}
-
-export interface PathsLinkApi {
-    average_conversion_time: number
-    source: string
-    target: string
-    value: number
-}
-
-export interface PathsQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: PathsLinkApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface PathsQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Used for displaying paths in relation to funnel steps. */
-    funnelPathsFilter?: FunnelPathsFilterApi | null
-    kind?: 'PathsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Properties specific to the paths insight */
-    pathsFilter: PathsFilterApi
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: PathsQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type StickinessQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface StickinessQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: StickinessQueryResponseApiResultsItem[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
 
 export type StickinessComputationModeApi =
     (typeof StickinessComputationModeApi)[keyof typeof StickinessComputationModeApi]
@@ -2934,12 +1827,6 @@ export const StickinessOperatorApi = {
     Exact: 'exact',
 } as const
 
-export interface StickinessCriteriaApi {
-    operator: StickinessOperatorApi
-    /** @minimum 1 */
-    value: number
-}
-
 /**
  * Customizations for the appearance of result datasets.
  */
@@ -2947,75 +1834,6 @@ export type StickinessFilterApiResultCustomizations =
     | { [key: string]: ResultCustomizationByValueApi }
     | { [key: string]: ResultCustomizationByPositionApi }
     | null
-
-export interface StickinessFilterApi {
-    computedAs?: StickinessComputationModeApi | null
-    display?: ChartDisplayTypeApi | null
-    hiddenLegendIndexes?: number[] | null
-    /** Whether result datasets are associated by their values or by their order. */
-    resultCustomizationBy?: ResultCustomizationByApi | null
-    /** Customizations for the appearance of result datasets. */
-    resultCustomizations?: StickinessFilterApiResultCustomizations
-    showLegend?: boolean | null
-    showMultipleYAxes?: boolean | null
-    showValuesOnSeries?: boolean | null
-    stickinessCriteria?: StickinessCriteriaApi | null
-}
-
-export interface StickinessQueryApi {
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    /** How many intervals comprise a period. Only used for cohorts, otherwise default 1. */
-    intervalCount?: number | null
-    kind?: 'StickinessQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: StickinessQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
-    /** Properties specific to the stickiness insight */
-    stickinessFilter?: StickinessFilterApi | null
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type LifecycleToggleApi = (typeof LifecycleToggleApi)[keyof typeof LifecycleToggleApi]
 
@@ -3026,174 +1844,9 @@ export const LifecycleToggleApi = {
     Dormant: 'dormant',
 } as const
 
-export interface LifecycleFilterApi {
-    showLegend?: boolean | null
-    /** Append per-band percentage to each value label (e.g. `580 (42%)`). Requires `showValuesOnSeries` — on its own it has no visible effect. */
-    showPercentagesOnSeries?: boolean | null
-    showValuesOnSeries?: boolean | null
-    stacked?: boolean | null
-    toggledLifecycles?: LifecycleToggleApi[] | null
-}
-
 export type LifecycleQueryResponseApiResultsItem = { [key: string]: unknown }
 
-export interface LifecycleQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: LifecycleQueryResponseApiResultsItem[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
 export type LifecycleDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
-
-export interface LifecycleDataWarehouseNodeApi {
-    aggregation_target_field: string
-    created_at_field: string
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: string
-    kind?: 'LifecycleDataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: LifecycleDataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface LifecycleQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** For data warehouse based lifecycle insights when the aggregation target can't be mapped to persons or groups. */
-    customAggregationTarget?: boolean | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    kind?: 'LifecycleQuery'
-    /** Properties specific to the lifecycle insight */
-    lifecycleFilter?: LifecycleFilterApi | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: LifecycleQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (EventsNodeApi | ActionsNodeApi | LifecycleDataWarehouseNodeApi)[]
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type WebStatsBreakdownApi = (typeof WebStatsBreakdownApi)[keyof typeof WebStatsBreakdownApi]
 
@@ -3253,86 +1906,6 @@ export const WebAnalyticsOrderByDirectionApi = {
     Desc: 'DESC',
 } as const
 
-export interface SamplingRateApi {
-    denominator?: number | null
-    numerator: number
-}
-
-export interface WebStatsTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebAnalyticsSamplingApi {
-    enabled?: boolean | null
-    forceSamplingRate?: SamplingRateApi | null
-}
-
-export interface WebStatsTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    breakdownBy: WebStatsBreakdownApi
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeAvgTimeOnPage?: boolean | null
-    includeBounceRate?: boolean | null
-    includeHost?: boolean | null
-    includeRevenue?: boolean | null
-    includeScrollDepth?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebStatsTableQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebStatsTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web stats table precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type WebAnalyticsItemKindApi = (typeof WebAnalyticsItemKindApi)[keyof typeof WebAnalyticsItemKindApi]
 
 export const WebAnalyticsItemKindApi = {
@@ -3341,76 +1914,6 @@ export const WebAnalyticsItemKindApi = {
     Percentage: 'percentage',
     Currency: 'currency',
 } as const
-
-export interface WebOverviewItemApi {
-    changeFromPreviousPct?: number | null
-    isIncreaseBad?: boolean | null
-    key: string
-    kind: WebAnalyticsItemKindApi
-    previous?: number | null
-    usedPreAggregatedTables?: boolean | null
-    value?: number | null
-}
-
-export interface WebOverviewQueryResponseApi {
-    dateFrom?: string | null
-    dateTo?: string | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: WebOverviewItemApi[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebOverviewQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebOverviewQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebOverviewQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export interface ActionsPieApi {
     disableHoverOffset?: boolean | null
@@ -3423,41 +1926,6 @@ export interface RetentionApi {
     useSmallLayout?: boolean | null
 }
 
-export interface VizSpecificOptionsApi {
-    ActionsPie?: ActionsPieApi | null
-    RETENTION?: RetentionApi | null
-}
-
-export interface InsightVizNodeApi {
-    /** Query is embedded inside another bordered component */
-    embedded?: boolean | null
-    /** Show with most visual options enabled. Used in insight scene. */
-    full?: boolean | null
-    hidePersonsModal?: boolean | null
-    hideTooltipOnScroll?: boolean | null
-    kind: InsightVizNodeApiKind
-    showCorrelationTable?: boolean | null
-    showFilters?: boolean | null
-    showHeader?: boolean | null
-    showLastComputation?: boolean | null
-    showLastComputationRefresh?: boolean | null
-    showResults?: boolean | null
-    showTable?: boolean | null
-    source:
-        | TrendsQueryApi
-        | FunnelsQueryApi
-        | RetentionQueryApi
-        | PathsQueryApi
-        | StickinessQueryApi
-        | LifecycleQueryApi
-        | WebStatsTableQueryApi
-        | WebOverviewQueryApi
-    suppressSessionAnalysisWarning?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    vizSpecificOptions?: VizSpecificOptionsApi | null
-}
-
 export type DataTableNodeViewPropsContextTypeApi =
     (typeof DataTableNodeViewPropsContextTypeApi)[keyof typeof DataTableNodeViewPropsContextTypeApi]
 
@@ -3465,11 +1933,6 @@ export const DataTableNodeViewPropsContextTypeApi = {
     EventDefinition: 'event_definition',
     TeamColumns: 'team_columns',
 } as const
-
-export interface DataTableNodeViewPropsContextApi {
-    eventDefinitionId?: string | null
-    type: DataTableNodeViewPropsContextTypeApi
-}
 
 export type DataTableNodeApiKind = (typeof DataTableNodeApiKind)[keyof typeof DataTableNodeApiKind]
 
@@ -3556,13 +2019,6 @@ export interface Response2Api {
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export interface HogQLNoticeApi {
-    end?: number | null
-    fix?: string | null
-    message: string
-    start?: number | null
-}
-
 export type QueryIndexUsageApi = (typeof QueryIndexUsageApi)[keyof typeof QueryIndexUsageApi]
 
 export const QueryIndexUsageApi = {
@@ -3571,17 +2027,6 @@ export const QueryIndexUsageApi = {
     Partial: 'partial',
     Yes: 'yes',
 } as const
-
-export interface HogQLMetadataResponseApi {
-    ch_table_names?: string[] | null
-    errors: HogQLNoticeApi[]
-    isUsingIndices?: QueryIndexUsageApi | null
-    isValid?: boolean | null
-    notices: HogQLNoticeApi[]
-    query?: string | null
-    table_names?: string[] | null
-    warnings: HogQLNoticeApi[]
-}
 
 export interface Response3Api {
     /** Executed ClickHouse query */
@@ -3727,17 +2172,6 @@ export interface Response7Api {
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export interface WebVitalsPathBreakdownResultItemApi {
-    path: string
-    value: number
-}
-
-export interface WebVitalsPathBreakdownResultApi {
-    good: WebVitalsPathBreakdownResultItemApi[]
-    needs_improvements: WebVitalsPathBreakdownResultItemApi[]
-    poor: WebVitalsPathBreakdownResultItemApi[]
-}
-
 export interface Response8Api {
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
     error?: string | null
@@ -3855,14 +2289,6 @@ export interface Response12Api {
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export interface RevenueAnalyticsMRRQueryResultItemApi {
-    churn: unknown
-    contraction: unknown
-    expansion: unknown
-    new: unknown
-    total: unknown
-}
-
 export interface Response13Api {
     columns?: string[] | null
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -3892,11 +2318,6 @@ export const RevenueAnalyticsOverviewItemKeyApi = {
     PayingCustomerCount: 'paying_customer_count',
     AvgRevenuePerCustomer: 'avg_revenue_per_customer',
 } as const
-
-export interface RevenueAnalyticsOverviewItemApi {
-    key: RevenueAnalyticsOverviewItemKeyApi
-    value: number
-}
 
 export interface Response14Api {
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -3962,16 +2383,6 @@ export interface Response16Api {
     types?: unknown[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface MarketingAnalyticsItemApi {
-    changeFromPreviousPct?: number | null
-    hasComparison?: boolean | null
-    isIncreaseBad?: boolean | null
-    key: string
-    kind: WebAnalyticsItemKindApi
-    previous?: number | string | null
-    value?: number | string | null
 }
 
 export interface Response18Api {
@@ -4054,14 +2465,6 @@ export interface VolumeBucketApi {
     value: number
 }
 
-export interface ErrorTrackingIssueAggregationsApi {
-    occurrences: number
-    sessions: number
-    users: number
-    volumeRange?: number[] | null
-    volume_buckets: VolumeBucketApi[]
-}
-
 export type ErrorTrackingIssueAssigneeTypeApi =
     (typeof ErrorTrackingIssueAssigneeTypeApi)[keyof typeof ErrorTrackingIssueAssigneeTypeApi]
 
@@ -4069,16 +2472,6 @@ export const ErrorTrackingIssueAssigneeTypeApi = {
     User: 'user',
     Role: 'role',
 } as const
-
-export interface ErrorTrackingIssueAssigneeApi {
-    id: string | number
-    type: ErrorTrackingIssueAssigneeTypeApi
-}
-
-export interface ErrorTrackingIssueCohortApi {
-    id: number
-    name: string
-}
 
 export type IntegrationKindApi = (typeof IntegrationKindApi)[keyof typeof IntegrationKindApi]
 
@@ -4117,18 +2510,6 @@ export const IntegrationKindApi = {
     CustomerioTrack: 'customerio-track',
 } as const
 
-export interface ErrorTrackingExternalReferenceIntegrationApi {
-    display_name: string
-    id: number
-    kind: IntegrationKindApi
-}
-
-export interface ErrorTrackingExternalReferenceApi {
-    external_url: string
-    id: string
-    integration: ErrorTrackingExternalReferenceIntegrationApi
-}
-
 export interface FirstEventApi {
     distinct_id: string
     properties: string
@@ -4152,24 +2533,6 @@ export const ErrorTrackingIssueStatusApi = {
     PendingRelease: 'pending_release',
     Suppressed: 'suppressed',
 } as const
-
-export interface ErrorTrackingIssueApi {
-    aggregations?: ErrorTrackingIssueAggregationsApi | null
-    assignee?: ErrorTrackingIssueAssigneeApi | null
-    cohort?: ErrorTrackingIssueCohortApi | null
-    description?: string | null
-    external_issues?: ErrorTrackingExternalReferenceApi[] | null
-    first_event?: FirstEventApi | null
-    first_seen: string
-    function?: string | null
-    id: string
-    last_event?: LastEventApi | null
-    last_seen: string
-    library?: string | null
-    name?: string | null
-    source?: string | null
-    status: ErrorTrackingIssueStatusApi
-}
 
 export interface Response21Api {
     columns?: string[] | null
@@ -4200,22 +2563,6 @@ export interface PopulationApi {
     exception_only: number
     neither: number
     success_only: number
-}
-
-export interface ErrorTrackingCorrelatedIssueApi {
-    assignee?: ErrorTrackingIssueAssigneeApi | null
-    cohort?: ErrorTrackingIssueCohortApi | null
-    description?: string | null
-    event: string
-    external_issues?: ErrorTrackingExternalReferenceApi[] | null
-    first_seen: string
-    id: string
-    last_seen: string
-    library?: string | null
-    name?: string | null
-    odds_ratio: number
-    population: PopulationApi
-    status: ErrorTrackingIssueStatusApi
 }
 
 export interface Response22Api {
@@ -4253,12 +2600,6 @@ export const ExperimentSignificanceCodeApi = {
     HighPValue: 'high_p_value',
 } as const
 
-export interface ExperimentVariantFunnelsBaseStatsApi {
-    failure_count: number
-    key: string
-    success_count: number
-}
-
 export type Response23ApiCredibleIntervals = { [key: string]: number[] }
 
 export type Response23ApiInsightItemItem = { [key: string]: unknown }
@@ -4278,13 +2619,6 @@ export interface Response23Api {
     variants: ExperimentVariantFunnelsBaseStatsApi[]
     /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
     warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentVariantTrendsBaseStatsApi {
-    absolute_exposure: number
-    count: number
-    exposure: number
-    key: string
 }
 
 export type Response24ApiCredibleIntervals = { [key: string]: number[] }
@@ -4328,44 +2662,7 @@ export const AIEventTypeApi = {
 
 export type LLMTraceEventApiProperties = { [key: string]: unknown }
 
-export interface LLMTraceEventApi {
-    createdAt: string
-    event: AIEventTypeApi | string
-    id: string
-    properties: LLMTraceEventApiProperties
-}
-
 export type LLMTracePersonApiProperties = { [key: string]: unknown }
-
-export interface LLMTracePersonApi {
-    created_at: string
-    distinct_id: string
-    properties: LLMTracePersonApiProperties
-    uuid: string
-}
-
-export interface LLMTraceApi {
-    aiSessionId?: string | null
-    createdAt: string
-    distinctId: string
-    errorCount?: number | null
-    events: LLMTraceEventApi[]
-    id: string
-    inputCost?: number | null
-    inputState?: unknown
-    inputTokens?: number | null
-    isSupportTrace?: boolean | null
-    outputCost?: number | null
-    outputState?: unknown
-    outputTokens?: number | null
-    person?: LLMTracePersonApi | null
-    requestCost?: number | null
-    tools?: string[] | null
-    totalCost?: number | null
-    totalLatency?: number | null
-    traceName?: string | null
-    webSearchCost?: number | null
-}
 
 export interface Response25Api {
     columns?: string[] | null
@@ -4528,69 +2825,6 @@ export const UrlMatchingApi = {
     Regex: 'regex',
 } as const
 
-export interface EventsQueryActionStepApi {
-    event?: string | null
-    href?: string | null
-    href_matching?: HrefMatchingApi | null
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    selector?: string | null
-    tag_name?: string | null
-    text?: string | null
-    text_matching?: TextMatchingApi | null
-    url?: string | null
-    url_matching?: UrlMatchingApi | null
-}
-
-export interface EventsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Cursor for fetching the next page of results */
-    nextCursor?: string | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
 export type CompareApi = (typeof CompareApi)[keyof typeof CompareApi]
 
 export const CompareApi = {
@@ -4598,234 +2832,7 @@ export const CompareApi = {
     Previous: 'previous',
 } as const
 
-export interface ActorsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    limit: number
-    missing_actors_count?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset: number
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: string[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface InsightActorsQueryApi {
-    breakdown?: string | string[] | number | null
-    compare?: CompareApi | null
-    day?: string | number | null
-    includeRecordings?: boolean | null
-    /** An interval selected out of available intervals in source query. */
-    interval?: number | null
-    kind?: 'InsightActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ActorsQueryResponseApi | null
-    series?: number | null
-    source:
-        | TrendsQueryApi
-        | FunnelsQueryApi
-        | RetentionQueryApi
-        | PathsQueryApi
-        | StickinessQueryApi
-        | LifecycleQueryApi
-        | WebStatsTableQueryApi
-        | WebOverviewQueryApi
-    status?: string | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface EventsQueryApi {
-    /** Show events matching a given action */
-    actionId?: number | null
-    /** Show events matching action steps directly, used when no actionId is provided (e.g. previewing unsaved actions). Ignored if actionId is set. */
-    actionSteps?: EventsQueryActionStepApi[] | null
-    /** Only fetch events that happened after this timestamp */
-    after?: string | null
-    /** Only fetch events that happened before this timestamp */
-    before?: string | null
-    /** Limit to events matching this string */
-    event?: string | null
-    /** Filter to events matching any of these event names */
-    events?: string[] | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | PropertyGroupFilterApi
-              | PropertyGroupFilterValueApi
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'EventsQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Show events for a given person */
-    personId?: string | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: EventsQueryResponseApi | null
-    /** Return a limited set of data. Required. */
-    select: string[]
-    /** source for querying events for insights */
-    source?: InsightActorsQueryApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    /** HogQL filters to apply on returned data */
-    where?: string[] | null
-}
-
 export type PersonsNodeApiResponse = { [key: string]: unknown } | null
-
-export interface PersonsNodeApi {
-    cohort?: number | null
-    distinctId?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'PersonsNode'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: PersonsNodeApiResponse
-    search?: string | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface FunnelsActorsQueryApi {
-    /** Index of the step for which we want to get the timestamp for, per person. Positive for converted persons, negative for dropped of persons. */
-    funnelStep?: number | null
-    /** The breakdown value for which to get persons for. This is an array for person and event properties, a string for groups and an integer for cohorts. */
-    funnelStepBreakdown?: number | string | (number | string)[] | null
-    funnelTrendsDropOff?: boolean | null
-    /** Used together with `funnelTrendsDropOff` for funnels time conversion date for the persons modal. */
-    funnelTrendsEntrancePeriodStart?: string | null
-    includeRecordings?: boolean | null
-    kind?: 'FunnelsActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ActorsQueryResponseApi | null
-    source: FunnelsQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type FunnelCorrelationResultsTypeApi =
     (typeof FunnelCorrelationResultsTypeApi)[keyof typeof FunnelCorrelationResultsTypeApi]
@@ -4845,133 +2852,7 @@ export const CorrelationTypeApi = {
 
 export type EventDefinitionApiProperties = { [key: string]: unknown }
 
-export interface EventDefinitionApi {
-    elements: unknown[]
-    event: string
-    properties: EventDefinitionApiProperties
-}
-
-export interface EventOddsRatioSerializedApi {
-    correlation_type: CorrelationTypeApi
-    event: EventDefinitionApi
-    failure_count: number
-    odds_ratio: number
-    success_count: number
-}
-
-export interface FunnelCorrelationResultApi {
-    events: EventOddsRatioSerializedApi[]
-    skewed: boolean
-}
-
-export interface FunnelCorrelationResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: FunnelCorrelationResultApi
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface FunnelCorrelationQueryApi {
-    funnelCorrelationEventExcludePropertyNames?: string[] | null
-    funnelCorrelationEventNames?: string[] | null
-    funnelCorrelationExcludeEventNames?: string[] | null
-    funnelCorrelationExcludeNames?: string[] | null
-    funnelCorrelationNames?: string[] | null
-    funnelCorrelationType: FunnelCorrelationResultsTypeApi
-    kind?: 'FunnelCorrelationQuery'
-    response?: FunnelCorrelationResponseApi | null
-    source: FunnelsActorsQueryApi
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface FunnelCorrelationActorsQueryApi {
-    funnelCorrelationPersonConverted?: boolean | null
-    funnelCorrelationPersonEntity?: EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi | null
-    funnelCorrelationPropertyValues?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    includeRecordings?: boolean | null
-    kind?: 'FunnelCorrelationActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ActorsQueryResponseApi | null
-    source: FunnelCorrelationQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentEventExposureConfigApiResponse = { [key: string]: unknown } | null
-
-export interface ExperimentEventExposureConfigApi {
-    event: string
-    kind?: 'ExperimentEventExposureConfig'
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | ElementPropertyFilterApi
-        | EventMetadataPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-        | RecordingPropertyFilterApi
-        | LogEntryPropertyFilterApi
-        | GroupPropertyFilterApi
-        | FeaturePropertyFilterApi
-        | FlagPropertyFilterApi
-        | HogQLPropertyFilterApi
-        | EmptyPropertyFilterApi
-        | DataWarehousePropertyFilterApi
-        | DataWarehousePersonPropertyFilterApi
-        | ErrorTrackingIssueFilterApi
-        | LogPropertyFilterApi
-        | SpanPropertyFilterApi
-        | RevenueAnalyticsPropertyFilterApi
-        | WorkflowVariablePropertyFilterApi
-    )[]
-    response?: ExperimentEventExposureConfigApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type MultipleVariantHandlingApi = (typeof MultipleVariantHandlingApi)[keyof typeof MultipleVariantHandlingApi]
 
@@ -4989,162 +2870,11 @@ export const ExperimentMetricGoalApi = {
 
 export type ExperimentDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
 
-export interface ExperimentDataWarehouseNodeApi {
-    custom_name?: string | null
-    data_warehouse_join_key: string
-    events_join_key: string
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'ExperimentDataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: ExperimentDataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentMeanMetricApiResponse = { [key: string]: unknown } | null
-
-export interface ExperimentMeanMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    fingerprint?: string | null
-    goal?: ExperimentMetricGoalApi | null
-    ignore_zeros?: boolean | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
-    lower_bound_percentile?: number | null
-    metric_type?: 'mean'
-    name?: string | null
-    response?: ExperimentMeanMetricApiResponse
-    sharedMetricId?: number | null
-    source: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
-    upper_bound_percentile?: number | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ExperimentFunnelMetricApiResponse = { [key: string]: unknown } | null
 
-export interface ExperimentFunnelMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    fingerprint?: string | null
-    funnel_order_type?: StepOrderValueApi | null
-    goal?: ExperimentMetricGoalApi | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    metric_type?: 'funnel'
-    name?: string | null
-    response?: ExperimentFunnelMetricApiResponse
-    series: (EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi)[]
-    sharedMetricId?: number | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface ExperimentMetricOutlierHandlingApi {
-    ignore_zeros?: boolean | null
-    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
-    lower_bound_percentile?: number | null
-    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
-    upper_bound_percentile?: number | null
-}
-
 export type ExperimentRatioMetricApiResponse = { [key: string]: unknown } | null
-
-export interface ExperimentRatioMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    denominator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    denominator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
-    fingerprint?: string | null
-    goal?: ExperimentMetricGoalApi | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    metric_type?: 'ratio'
-    name?: string | null
-    numerator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    numerator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
-    response?: ExperimentRatioMetricApiResponse
-    sharedMetricId?: number | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type StartHandlingApi = (typeof StartHandlingApi)[keyof typeof StartHandlingApi]
 
@@ -5155,42 +2885,12 @@ export const StartHandlingApi = {
 
 export type ExperimentRetentionMetricApiResponse = { [key: string]: unknown } | null
 
-export interface ExperimentRetentionMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    completion_event: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    fingerprint?: string | null
-    goal?: ExperimentMetricGoalApi | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    metric_type?: 'retention'
-    name?: string | null
-    response?: ExperimentRetentionMetricApiResponse
-    retention_window_end: number
-    retention_window_start: number
-    retention_window_unit: FunnelConversionWindowTimeUnitApi
-    sharedMetricId?: number | null
-    start_event: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    start_handling: StartHandlingApi
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type PrecomputationModeApi = (typeof PrecomputationModeApi)[keyof typeof PrecomputationModeApi]
 
 export const PrecomputationModeApi = {
     Precomputed: 'precomputed',
     Direct: 'direct',
 } as const
-
-export interface SessionDataApi {
-    event_uuid: string
-    person_id: string
-    session_id: string
-    timestamp: string
-}
 
 export type ExperimentStatsValidationFailureApi =
     (typeof ExperimentStatsValidationFailureApi)[keyof typeof ExperimentStatsValidationFailureApi]
@@ -5201,231 +2901,11 @@ export const ExperimentStatsValidationFailureApi = {
     NotEnoughMetricData: 'not-enough-metric-data',
 } as const
 
-export interface ExperimentStatsBaseValidatedApi {
-    covariate_sum?: number | null
-    covariate_sum_product?: number | null
-    covariate_sum_squares?: number | null
-    denominator_sum?: number | null
-    denominator_sum_squares?: number | null
-    key: string
-    number_of_samples: number
-    numerator_denominator_sum_product?: number | null
-    step_counts?: number[] | null
-    step_sessions?: SessionDataApi[][] | null
-    sum: number
-    sum_squares: number
-    validation_failures?: ExperimentStatsValidationFailureApi[] | null
-}
-
-export interface ExperimentVariantResultFrequentistApi {
-    confidence_interval?: number[] | null
-    covariate_sum?: number | null
-    covariate_sum_product?: number | null
-    covariate_sum_squares?: number | null
-    denominator_sum?: number | null
-    denominator_sum_squares?: number | null
-    key: string
-    method?: 'frequentist'
-    number_of_samples: number
-    numerator_denominator_sum_product?: number | null
-    p_value?: number | null
-    significant?: boolean | null
-    step_counts?: number[] | null
-    step_sessions?: SessionDataApi[][] | null
-    sum: number
-    sum_squares: number
-    validation_failures?: ExperimentStatsValidationFailureApi[] | null
-}
-
-export interface ExperimentVariantResultBayesianApi {
-    chance_to_win?: number | null
-    covariate_sum?: number | null
-    covariate_sum_product?: number | null
-    covariate_sum_squares?: number | null
-    credible_interval?: number[] | null
-    denominator_sum?: number | null
-    denominator_sum_squares?: number | null
-    key: string
-    method?: 'bayesian'
-    number_of_samples: number
-    numerator_denominator_sum_product?: number | null
-    significant?: boolean | null
-    step_counts?: number[] | null
-    step_sessions?: SessionDataApi[][] | null
-    sum: number
-    sum_squares: number
-    validation_failures?: ExperimentStatsValidationFailureApi[] | null
-}
-
-export interface ExperimentBreakdownResultApi {
-    /** Control variant stats for this breakdown */
-    baseline: ExperimentStatsBaseValidatedApi
-    /** The breakdown values as an array (e.g., ["MacOS", "Chrome"] for multi-breakdown, ["Chrome"] for single) Although `BreakdownKeyType` could be an array, we only use the array form for the breakdown_value. The way `BreakdownKeyType` is defined is problematic. It should be treated as a primitive and allow for the types using it to define if it's and array or an optional value. */
-    breakdown_value: (string | number)[]
-    /** Test variant results with statistical comparisons for this breakdown */
-    variants: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[]
-}
-
 export type ExperimentQueryResponseApiCredibleIntervals = { [key: string]: number[] } | null
 
 export type ExperimentQueryResponseApiInsight = { [key: string]: unknown }[] | null
 
 export type ExperimentQueryResponseApiProbability = { [key: string]: number } | null
-
-export interface ExperimentQueryResponseApi {
-    baseline?: ExperimentStatsBaseValidatedApi | null
-    /** Results grouped by breakdown value. When present, baseline and variant_results contain aggregated data. */
-    breakdown_results?: ExperimentBreakdownResultApi[] | null
-    clickhouse_sql?: string | null
-    credible_intervals?: ExperimentQueryResponseApiCredibleIntervals
-    hogql?: string | null
-    insight?: ExperimentQueryResponseApiInsight
-    /** Whether exposures were served from the precomputation system */
-    is_precomputed?: boolean | null
-    kind?: 'ExperimentQuery'
-    metric?:
-        | ExperimentMeanMetricApi
-        | ExperimentFunnelMetricApi
-        | ExperimentRatioMetricApi
-        | ExperimentRetentionMetricApi
-        | null
-    p_value?: number | null
-    probability?: ExperimentQueryResponseApiProbability
-    significance_code?: ExperimentSignificanceCodeApi | null
-    significant?: boolean | null
-    stats_version?: number | null
-    variant_results?: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[] | null
-    variants?: ExperimentVariantTrendsBaseStatsApi[] | ExperimentVariantFunnelsBaseStatsApi[] | null
-    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentQueryApi {
-    experiment_id?: number | null
-    kind?: 'ExperimentQuery'
-    metric:
-        | ExperimentMeanMetricApi
-        | ExperimentFunnelMetricApi
-        | ExperimentRatioMetricApi
-        | ExperimentRetentionMetricApi
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    name?: string | null
-    precomputation_mode?: PrecomputationModeApi | null
-    response?: ExperimentQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface ExperimentActorsQueryApi {
-    /** Exposure configuration for filtering events. Defines when users were first exposed to the experiment. */
-    exposureConfig?: ExperimentEventExposureConfigApi | ActionsNodeApi | null
-    /** Feature flag key for breakdown filtering. */
-    featureFlagKey?: string | null
-    /** Index of the step for which we want to get actors for, per experiment variant. Positive for converted persons, negative for dropped off persons. */
-    funnelStep?: number | null
-    /** The variant key for filtering actors. For experiments, this filters by feature flag variant (e.g., 'control', 'test'). */
-    funnelStepBreakdown?: number | string | (number | string)[] | null
-    includeRecordings?: boolean | null
-    kind?: 'ExperimentActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** How to handle users with multiple variant exposures. */
-    multipleVariantHandling?: MultipleVariantHandlingApi | null
-    response?: ActorsQueryResponseApi | null
-    source: ExperimentQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface StickinessActorsQueryApi {
-    compare?: CompareApi | null
-    day?: string | number | null
-    includeRecordings?: boolean | null
-    kind?: 'StickinessActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    operator?: StickinessOperatorApi | null
-    response?: ActorsQueryResponseApi | null
-    series?: number | null
-    source: StickinessQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface HogQLFiltersApi {
-    dateRange?: DateRangeApi | null
-    filterTestAccounts?: boolean | null
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-}
-
-export interface HogQLQueryResponseApi {
-    /** Executed ClickHouse query */
-    clickhouse?: string | null
-    /** Returned columns */
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Query explanation output */
-    explain?: string[] | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Query metadata output */
-    metadata?: HogQLMetadataResponseApi | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Input query string */
-    query?: string | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Types of returned columns */
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface HogQLVariableApi {
-    code_name: string
-    isNull?: boolean | null
-    value?: unknown
-    variableId: string
-}
 
 /**
  * Constant values that can be referenced with the {placeholder} syntax in the query
@@ -5436,273 +2916,6 @@ export type HogQLQueryApiValues = { [key: string]: unknown } | null
  * Variables to be substituted into the query
  */
 export type HogQLQueryApiVariables = { [key: string]: HogQLVariableApi } | null
-
-export interface HogQLQueryApi {
-    /** Optional id of a direct external data source (access_method='direct') to run against instead of ClickHouse. Warehouse import sources are not valid here. */
-    connectionId?: string | null
-    explain?: boolean | null
-    filters?: HogQLFiltersApi | null
-    kind?: 'HogQLQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Client provided name of the query */
-    name?: string | null
-    query: string
-    response?: HogQLQueryResponseApi | null
-    /** Run the selected connection query directly without translating it through HogQL first */
-    sendRawQuery?: boolean | null
-    tags?: QueryLogTagsApi | null
-    /** Constant values that can be referenced with the {placeholder} syntax in the query */
-    values?: HogQLQueryApiValues
-    /** Variables to be substituted into the query */
-    variables?: HogQLQueryApiVariables
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface ActorsQueryApi {
-    /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-    fixedProperties?:
-        | (PersonPropertyFilterApi | CohortPropertyFilterApi | HogQLPropertyFilterApi | EmptyPropertyFilterApi)[]
-        | null
-    kind?: 'ActorsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: string[] | null
-    /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-    properties?:
-        | (PersonPropertyFilterApi | CohortPropertyFilterApi | HogQLPropertyFilterApi | EmptyPropertyFilterApi)[]
-        | PropertyGroupFilterValueApi
-        | null
-    response?: ActorsQueryResponseApi | null
-    search?: string | null
-    select?: string[] | null
-    source?:
-        | InsightActorsQueryApi
-        | FunnelsActorsQueryApi
-        | FunnelCorrelationActorsQueryApi
-        | ExperimentActorsQueryApi
-        | StickinessActorsQueryApi
-        | HogQLQueryApi
-        | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface GroupsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    kind?: 'GroupsQuery'
-    limit: number
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset: number
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface GroupsQueryApi {
-    group_type_index: number
-    kind?: 'GroupsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: string[] | null
-    properties?: (GroupPropertyFilterApi | HogQLPropertyFilterApi)[] | null
-    response?: GroupsQueryResponseApi | null
-    search?: string | null
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface WebExternalClicksTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebExternalClicksTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebExternalClicksTableQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebExternalClicksTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    stripQueryParams?: boolean | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface WebGoalsQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean | null
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebGoalsQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebGoalsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebGoalsQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web_goals_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface WebVitalsQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebVitalsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebGoalsQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    source:
-        | TrendsQueryApi
-        | FunnelsQueryApi
-        | RetentionQueryApi
-        | PathsQueryApi
-        | StickinessQueryApi
-        | LifecycleQueryApi
-        | WebStatsTableQueryApi
-        | WebOverviewQueryApi
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type WebVitalsMetricApi = (typeof WebVitalsMetricApi)[keyof typeof WebVitalsMetricApi]
 
@@ -5720,73 +2933,6 @@ export const WebVitalsPercentileApi = {
     P90: 'p90',
     P99: 'p99',
 } as const
-
-export interface WebVitalsPathBreakdownQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    /**
-     * @minItems 1
-     * @maxItems 1
-     */
-    results: WebVitalsPathBreakdownResultApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebVitalsPathBreakdownQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebVitalsPathBreakdownQuery'
-    metric: WebVitalsMetricApi
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    percentile: WebVitalsPercentileApi
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebVitalsPathBreakdownQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    /**
-     * @minItems 2
-     * @maxItems 2
-     */
-    thresholds: number[]
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web vitals path breakdown precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export interface FiltersApi {
     dateRange?: DateRangeApi | null
@@ -5806,327 +2952,12 @@ export const SessionAttributionGroupByApi = {
     InitialURL: 'InitialURL',
 } as const
 
-export interface SessionAttributionExplorerQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface SessionAttributionExplorerQueryApi {
-    filters?: FiltersApi | null
-    groupBy: SessionAttributionGroupByApi[]
-    kind?: 'SessionAttributionExplorerQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    response?: SessionAttributionExplorerQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface SessionsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface SessionsQueryApi {
-    /** Filter sessions by action - sessions that contain events matching this action */
-    actionId?: number | null
-    /** Only fetch sessions that started after this timestamp */
-    after?: string | null
-    /** Only fetch sessions that started before this timestamp */
-    before?: string | null
-    /** Filter sessions by event name - sessions that contain this event */
-    event?: string | null
-    /** Event property filters - filters sessions that contain events matching these properties */
-    eventProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | PropertyGroupFilterApi
-              | PropertyGroupFilterValueApi
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'SessionsQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Show sessions for a given person */
-    personId?: string | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: SessionsQueryResponseApi | null
-    /** Return a limited set of data. Required. */
-    select: string[]
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    /** HogQL filters to apply on returned data */
-    where?: string[] | null
-}
-
-export interface RevenueAnalyticsBreakdownApi {
-    property: string
-    type?: 'revenue_analytics'
-}
-
 export type SimpleIntervalTypeApi = (typeof SimpleIntervalTypeApi)[keyof typeof SimpleIntervalTypeApi]
 
 export const SimpleIntervalTypeApi = {
     Day: 'day',
     Month: 'month',
 } as const
-
-export interface RevenueAnalyticsGrossRevenueQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsGrossRevenueQueryApi {
-    breakdown: RevenueAnalyticsBreakdownApi[]
-    dateRange?: DateRangeApi | null
-    interval: SimpleIntervalTypeApi
-    kind?: 'RevenueAnalyticsGrossRevenueQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsGrossRevenueQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueAnalyticsMetricsQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsMetricsQueryApi {
-    breakdown: RevenueAnalyticsBreakdownApi[]
-    dateRange?: DateRangeApi | null
-    interval: SimpleIntervalTypeApi
-    kind?: 'RevenueAnalyticsMetricsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsMetricsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueAnalyticsMRRQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: RevenueAnalyticsMRRQueryResultItemApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsMRRQueryApi {
-    breakdown: RevenueAnalyticsBreakdownApi[]
-    dateRange?: DateRangeApi | null
-    interval: SimpleIntervalTypeApi
-    kind?: 'RevenueAnalyticsMRRQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsMRRQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueAnalyticsOverviewQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: RevenueAnalyticsOverviewItemApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsOverviewQueryApi {
-    dateRange?: DateRangeApi | null
-    kind?: 'RevenueAnalyticsOverviewQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsOverviewQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type RevenueAnalyticsTopCustomersGroupByApi =
     (typeof RevenueAnalyticsTopCustomersGroupByApi)[keyof typeof RevenueAnalyticsTopCustomersGroupByApi]
@@ -6135,114 +2966,6 @@ export const RevenueAnalyticsTopCustomersGroupByApi = {
     Month: 'month',
     All: 'all',
 } as const
-
-export interface RevenueAnalyticsTopCustomersQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsTopCustomersQueryApi {
-    dateRange?: DateRangeApi | null
-    groupBy: RevenueAnalyticsTopCustomersGroupByApi
-    kind?: 'RevenueAnalyticsTopCustomersQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsTopCustomersQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueExampleEventsQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueExampleEventsQueryApi {
-    kind?: 'RevenueExampleEventsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    response?: RevenueExampleEventsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueExampleDataWarehouseTablesQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueExampleDataWarehouseTablesQueryApi {
-    kind?: 'RevenueExampleDataWarehouseTablesQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    response?: RevenueExampleDataWarehouseTablesQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ConversionGoalFilter1ApiResponse = { [key: string]: unknown } | null
 
@@ -6519,11 +3242,6 @@ export const MarketingAnalyticsDrillDownLevelApi = {
     Term: 'term',
 } as const
 
-export interface IntegrationFilterApi {
-    /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
-    integrationSourceIds?: string[] | null
-}
-
 export type MarketingAnalyticsOrderByEnumApi =
     (typeof MarketingAnalyticsOrderByEnumApi)[keyof typeof MarketingAnalyticsOrderByEnumApi]
 
@@ -6532,212 +3250,7 @@ export const MarketingAnalyticsOrderByEnumApi = {
     Desc: 'DESC',
 } as const
 
-export interface MarketingAnalyticsTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: MarketingAnalyticsItemApi[][]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface MarketingAnalyticsTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    /** Draft conversion goal that can be set in the UI without saving */
-    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
-    /** Drill-down hierarchy level: channel, source, or campaign (default) */
-    drillDownLevel?: MarketingAnalyticsDrillDownLevelApi | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Filter by integration type */
-    integrationFilter?: IntegrationFilterApi | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'MarketingAnalyticsTableQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by - similar to EventsQuery format */
-    orderBy?: (string | MarketingAnalyticsOrderByEnumApi)[][] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: MarketingAnalyticsTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Return a limited set of data. Will use default columns if empty. */
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type MarketingAnalyticsAggregatedQueryResponseApiResults = { [key: string]: MarketingAnalyticsItemApi }
-
-export interface MarketingAnalyticsAggregatedQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: MarketingAnalyticsAggregatedQueryResponseApiResults
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface MarketingAnalyticsAggregatedQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    /** Draft conversion goal that can be set in the UI without saving */
-    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
-    /** Drill-down hierarchy level: channel, source, or campaign (default) */
-    drillDownLevel?: MarketingAnalyticsDrillDownLevelApi | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Filter by integration IDs */
-    integrationFilter?: IntegrationFilterApi | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'MarketingAnalyticsAggregatedQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: MarketingAnalyticsAggregatedQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Return a limited set of data. Will use default columns if empty. */
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface NonIntegratedConversionsTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: MarketingAnalyticsItemApi[][]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface NonIntegratedConversionsTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    /** Draft conversion goal that can be set in the UI without saving */
-    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'NonIntegratedConversionsTableQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by */
-    orderBy?: (string | MarketingAnalyticsOrderByEnumApi)[][] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: NonIntegratedConversionsTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Return a limited set of data. Will use default columns if empty. */
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ErrorTrackingOrderByApi = (typeof ErrorTrackingOrderByApi)[keyof typeof ErrorTrackingOrderByApi]
 
@@ -6756,326 +3269,17 @@ export const OrderDirection2Api = {
     Desc: 'DESC',
 } as const
 
-export interface ErrorTrackingPendingFingerprintIssueStateUpdateApi {
-    assigned_role_id?: string | null
-    assigned_user_id?: number | null
-    fingerprint: string
-    /** ISO 8601 datetime string. */
-    first_seen: string
-    is_deleted: number
-    issue_description?: string | null
-    issue_id: string
-    issue_name?: string | null
-    issue_status: string
-    /** Client-stamped monotonic version (`Date.now()` ms at mutation success). */
-    version: number
-}
-
-export interface ErrorTrackingQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: ErrorTrackingIssueApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ErrorTrackingQueryApi {
-    assignee?: ErrorTrackingIssueAssigneeApi | null
-    /** Date range to filter results. */
-    dateRange: DateRangeApi
-    filterGroup?: PropertyGroupFilterApi | null
-    /** Whether to filter out test accounts. */
-    filterTestAccounts?: boolean | null
-    groupKey?: string | null
-    groupTypeIndex?: number | null
-    /** Filter to a specific error tracking issue by ID. */
-    issueId?: string | null
-    kind?: 'ErrorTrackingQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Field to sort results by. */
-    orderBy: ErrorTrackingOrderByApi
-    /** Sort direction. */
-    orderDirection?: OrderDirection2Api | null
-    /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery (V3 only). The backend caps the list at 50 entries; extras are dropped silently. */
-    pendingFingerprintIssueStateUpdates?: ErrorTrackingPendingFingerprintIssueStateUpdateApi[] | null
-    personId?: string | null
-    response?: ErrorTrackingQueryResponseApi | null
-    /** Free-text search across exception type, message, and stack frames. */
-    searchQuery?: string | null
-    /** Filter by issue status. */
-    status?: ErrorTrackingIssueStatusApi | string | null
-    tags?: QueryLogTagsApi | null
-    /** Use V2 query path (ClickHouse postgres connector join instead of separate Postgres queries) */
-    useQueryV2?: boolean | null
-    /** Use V3 query path (denormalized ClickHouse table, no Postgres joins) */
-    useQueryV3?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    volumeResolution: number
-    withAggregations?: boolean | null
-    withFirstEvent?: boolean | null
-    withLastEvent?: boolean | null
-}
-
-export interface ErrorTrackingIssueCorrelationQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: ErrorTrackingCorrelatedIssueApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ErrorTrackingIssueCorrelationQueryApi {
-    events: string[]
-    kind?: 'ErrorTrackingIssueCorrelationQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ErrorTrackingIssueCorrelationQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentFunnelsQueryResponseApiCredibleIntervals = { [key: string]: number[] }
 
 export type ExperimentFunnelsQueryResponseApiInsightItemItem = { [key: string]: unknown }
 
 export type ExperimentFunnelsQueryResponseApiProbability = { [key: string]: number }
 
-export interface ExperimentFunnelsQueryResponseApi {
-    credible_intervals: ExperimentFunnelsQueryResponseApiCredibleIntervals
-    expected_loss: number
-    funnels_query?: FunnelsQueryApi | null
-    insight: ExperimentFunnelsQueryResponseApiInsightItemItem[][]
-    kind?: 'ExperimentFunnelsQuery'
-    probability: ExperimentFunnelsQueryResponseApiProbability
-    significance_code: ExperimentSignificanceCodeApi
-    significant: boolean
-    stats_version?: number | null
-    variants: ExperimentVariantFunnelsBaseStatsApi[]
-    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentFunnelsQueryApi {
-    experiment_id?: number | null
-    fingerprint?: string | null
-    funnels_query: FunnelsQueryApi
-    kind?: 'ExperimentFunnelsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    name?: string | null
-    response?: ExperimentFunnelsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentTrendsQueryResponseApiCredibleIntervals = { [key: string]: number[] }
 
 export type ExperimentTrendsQueryResponseApiInsightItem = { [key: string]: unknown }
 
 export type ExperimentTrendsQueryResponseApiProbability = { [key: string]: number }
-
-export interface ExperimentTrendsQueryResponseApi {
-    count_query?: TrendsQueryApi | null
-    credible_intervals: ExperimentTrendsQueryResponseApiCredibleIntervals
-    exposure_query?: TrendsQueryApi | null
-    insight: ExperimentTrendsQueryResponseApiInsightItem[]
-    kind?: 'ExperimentTrendsQuery'
-    p_value: number
-    probability: ExperimentTrendsQueryResponseApiProbability
-    significance_code: ExperimentSignificanceCodeApi
-    significant: boolean
-    stats_version?: number | null
-    variants: ExperimentVariantTrendsBaseStatsApi[]
-    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentTrendsQueryApi {
-    count_query: TrendsQueryApi
-    experiment_id?: number | null
-    exposure_query?: TrendsQueryApi | null
-    fingerprint?: string | null
-    kind?: 'ExperimentTrendsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    name?: string | null
-    response?: ExperimentTrendsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface TracesQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: LLMTraceApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface TracesQueryApi {
-    dateRange?: DateRangeApi | null
-    filterSupportTraces?: boolean | null
-    filterTestAccounts?: boolean | null
-    groupKey?: string | null
-    groupTypeIndex?: number | null
-    kind?: 'TracesQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Person who performed the event */
-    personId?: string | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    /** Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias. */
-    randomOrder?: boolean | null
-    response?: TracesQueryResponseApi | null
-    showColumnConfigurator?: boolean | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface TraceQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: LLMTraceApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface TraceQueryApi {
-    dateRange?: DateRangeApi | null
-    kind?: 'TraceQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: TraceQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    traceId: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type EndpointsUsageBreakdownApi = (typeof EndpointsUsageBreakdownApi)[keyof typeof EndpointsUsageBreakdownApi]
 
@@ -7112,105 +3316,6 @@ export const EndpointsUsageOrderByDirectionApi = {
     Desc: 'DESC',
 } as const
 
-export interface EndpointsUsageTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface EndpointsUsageTableQueryApi {
-    breakdownBy: EndpointsUsageBreakdownApi
-    dateRange?: DateRangeApi | null
-    /** Filter to specific endpoints by name */
-    endpointNames?: string[] | null
-    kind?: 'EndpointsUsageTableQuery'
-    limit?: number | null
-    /** Filter by materialization type */
-    materializationType?: MaterializationTypeApi | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: (EndpointsUsageOrderByFieldApi | EndpointsUsageOrderByDirectionApi)[] | null
-    response?: EndpointsUsageTableQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface AccountsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    kind?: 'AccountsQuery'
-    limit: number
-    /** When `metrics` is set on the query, the aggregated values in the same order. */
-    metricsResults?: (number | null)[] | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset: number
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface AccountsQueryApi {
-    /** Match accounts whose account executive is any of these user ids (OR semantics). */
-    accountExecutive?: number[] | null
-    /** Match accounts whose account owner is any of these user ids (OR semantics). */
-    accountOwner?: number[] | null
-    allRolesUnassigned?: boolean | null
-    /** Match accounts whose CSM is any of these user ids (OR semantics). */
-    csm?: number[] | null
-    /** Optional HogQL boolean expression AND-ed into the WHERE clause. Used by the overview tile click-to-filter affordance. */
-    filterExpression?: string | null
-    kind?: 'AccountsQuery'
-    limit?: number | null
-    /** Aggregation expressions evaluated against the filtered account set; one value per metric is returned in `metricsResults`. When `metrics` is set without a `select`, the runner skips the regular row fetch and returns only the aggregated values. */
-    metrics?: string[] | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: string[] | null
-    response?: AccountsQueryResponseApi | null
-    search?: string | null
-    select?: string[] | null
-    tagNames?: string[] | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type DataTableNodeApiResponse =
     | { [key: string]: unknown }
     | ResponseApi
@@ -7242,121 +3347,6 @@ export type DataTableNodeApiResponse =
     | Response27Api
     | null
 
-export interface DataTableNodeApi {
-    /** Can the user click on column headers to sort the table? (default: true) */
-    allowSorting?: boolean | null
-    /** Columns shown in the table, unless the `source` provides them. */
-    columns?: string[] | null
-    /** Context for the table, used by components like ColumnConfigurator */
-    context?: DataTableNodeViewPropsContextApi | null
-    /** Context key for universal column configuration (e.g., "survey:123") */
-    contextKey?: string | null
-    /** Default columns to use when resetting column configuration */
-    defaultColumns?: string[] | null
-    /** Uses the embedded version of LemonTable */
-    embedded?: boolean | null
-    /** Can expand row to show raw event data (default: true) */
-    expandable?: boolean | null
-    /** Show with most visual options enabled. Used in scenes. */
-    full?: boolean | null
-    /** Columns that aren't shown in the table, even if in columns or returned data */
-    hiddenColumns?: string[] | null
-    kind: DataTableNodeApiKind
-    /** Columns that are sticky when scrolling horizontally */
-    pinnedColumns?: string[] | null
-    /** Link properties via the URL (default: false) */
-    propertiesViaUrl?: boolean | null
-    response?: DataTableNodeApiResponse
-    /** Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources. */
-    showAbsoluteTime?: boolean | null
-    /** Show the kebab menu at the end of the row */
-    showActions?: boolean | null
-    /** Show a button to configure the table's columns if possible */
-    showColumnConfigurator?: boolean | null
-    /** Show count of total and filtered results */
-    showCount?: boolean | null
-    /** Show date range selector */
-    showDateRange?: boolean | null
-    /** Show the time it takes to run a query */
-    showElapsedTime?: boolean | null
-    /** Include an event filter above the table (EventsNode only) */
-    showEventFilter?: boolean | null
-    /** Include an events filter above the table to filter by multiple events (EventsQuery only) */
-    showEventsFilter?: boolean | null
-    /** Show the export button */
-    showExport?: boolean | null
-    /** Include a HogQL query editor above HogQL tables */
-    showHogQLEditor?: boolean | null
-    /** Show a button to open the current query as a new insight. (default: true) */
-    showOpenEditorButton?: boolean | null
-    /** Show a button to configure and persist the table's default columns if possible */
-    showPersistentColumnConfigurator?: boolean | null
-    /** Include a property filter above the table */
-    showPropertyFilter?: boolean | TaxonomicFilterGroupTypeApi[] | null
-    /** Show a recording column for events with session recordings */
-    showRecordingColumn?: boolean | null
-    /** Show a reload button */
-    showReload?: boolean | null
-    /** Show a results table */
-    showResultsTable?: boolean | null
-    /** Show saved filters feature for this table (requires uniqueKey) */
-    showSavedFilters?: boolean | null
-    /** Shows a list of saved queries */
-    showSavedQueries?: boolean | null
-    /** Include a free text search field (PersonsNode only) */
-    showSearch?: boolean | null
-    /** Show actors query options and back to source */
-    showSourceQueryOptions?: boolean | null
-    /** Show table views feature for this table (requires uniqueKey) */
-    showTableViews?: boolean | null
-    /** Show filter to exclude test accounts */
-    showTestAccountFilters?: boolean | null
-    /** Show a detailed query timing breakdown */
-    showTimings?: boolean | null
-    /** Source of the events */
-    source:
-        | EventsNodeApi
-        | EventsQueryApi
-        | PersonsNodeApi
-        | ActorsQueryApi
-        | GroupsQueryApi
-        | HogQLQueryApi
-        | WebOverviewQueryApi
-        | WebStatsTableQueryApi
-        | WebExternalClicksTableQueryApi
-        | WebGoalsQueryApi
-        | WebVitalsQueryApi
-        | WebVitalsPathBreakdownQueryApi
-        | SessionAttributionExplorerQueryApi
-        | SessionsQueryApi
-        | RevenueAnalyticsGrossRevenueQueryApi
-        | RevenueAnalyticsMetricsQueryApi
-        | RevenueAnalyticsMRRQueryApi
-        | RevenueAnalyticsOverviewQueryApi
-        | RevenueAnalyticsTopCustomersQueryApi
-        | RevenueExampleEventsQueryApi
-        | RevenueExampleDataWarehouseTablesQueryApi
-        | MarketingAnalyticsTableQueryApi
-        | MarketingAnalyticsAggregatedQueryApi
-        | NonIntegratedConversionsTableQueryApi
-        | ErrorTrackingQueryApi
-        | ErrorTrackingIssueCorrelationQueryApi
-        | ExperimentFunnelsQueryApi
-        | ExperimentTrendsQueryApi
-        | TracesQueryApi
-        | TraceQueryApi
-        | EndpointsUsageTableQueryApi
-        | AccountsQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface HeatmapGradientStopApi {
-    color: string
-    value: number
-}
-
 export type GradientScaleModeApi = (typeof GradientScaleModeApi)[keyof typeof GradientScaleModeApi]
 
 export const GradientScaleModeApi = {
@@ -7371,36 +3361,12 @@ export const HeatmapSortOrderApi = {
     Desc: 'desc',
 } as const
 
-export interface HeatmapSettingsApi {
-    gradient?: HeatmapGradientStopApi[] | null
-    gradientPreset?: string | null
-    gradientScaleMode?: GradientScaleModeApi | null
-    nullLabel?: string | null
-    nullValue?: string | null
-    sortColumn?: string | null
-    sortOrder?: HeatmapSortOrderApi | null
-    valueColumn?: string | null
-    xAxisColumn?: string | null
-    xAxisLabel?: string | null
-    yAxisColumn?: string | null
-    yAxisLabel?: string | null
-}
-
 export type ScaleApi = (typeof ScaleApi)[keyof typeof ScaleApi]
 
 export const ScaleApi = {
     Linear: 'linear',
     Logarithmic: 'logarithmic',
 } as const
-
-export interface YAxisSettingsApi {
-    label?: string | null
-    scale?: ScaleApi | null
-    showGridLines?: boolean | null
-    showTicks?: boolean | null
-    /** Whether the Y axis should start at zero */
-    startAtZero?: boolean | null
-}
 
 export type DisplayTypeApi = (typeof DisplayTypeApi)[keyof typeof DisplayTypeApi]
 
@@ -7418,14 +3384,6 @@ export const YAxisPositionApi = {
     Right: 'right',
 } as const
 
-export interface ChartSettingsDisplayApi {
-    color?: string | null
-    displayType?: DisplayTypeApi | null
-    label?: string | null
-    trendLine?: boolean | null
-    yAxisPosition?: YAxisPositionApi | null
-}
-
 export type StyleApi = (typeof StyleApi)[keyof typeof StyleApi]
 
 export const StyleApi = {
@@ -7435,52 +3393,15 @@ export const StyleApi = {
     Percent: 'percent',
 } as const
 
-export interface ChartSettingsFormattingApi {
-    decimalPlaces?: number | null
-    prefix?: string | null
-    style?: StyleApi | null
-    suffix?: string | null
-}
-
 export interface SettingsApi {
     display?: ChartSettingsDisplayApi | null
     formatting?: ChartSettingsFormattingApi | null
-}
-
-export interface ChartAxisApi {
-    column: string
-    settings?: SettingsApi | null
 }
 
 /**
  * Per-breakdown-value color customizations. Keyed by the raw breakdown column value.
  */
 export type ChartSettingsApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
-
-export interface ChartSettingsApi {
-    goalLines?: GoalLineApi[] | null
-    heatmap?: HeatmapSettingsApi | null
-    leftYAxisSettings?: YAxisSettingsApi | null
-    /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
-    resultCustomizations?: ChartSettingsApiResultCustomizations
-    rightYAxisSettings?: YAxisSettingsApi | null
-    seriesBreakdownColumn?: string | null
-    showLegend?: boolean | null
-    showNullsAsZero?: boolean | null
-    showPieTotal?: boolean | null
-    showTotalRow?: boolean | null
-    showValuesOnSeries?: boolean | null
-    showXAxisBorder?: boolean | null
-    showXAxisTicks?: boolean | null
-    showYAxisBorder?: boolean | null
-    /** Whether we fill the bars to 100% in stacked mode */
-    stackBars100?: boolean | null
-    xAxis?: ChartAxisApi | null
-    xAxisLabel?: string | null
-    yAxis?: ChartAxisApi[] | null
-    /** Deprecated: use `[left|right]YAxisSettings`. Whether the Y axis should start at zero */
-    yAxisAtZero?: boolean | null
-}
 
 export type DataVisualizationNodeApiKind =
     (typeof DataVisualizationNodeApiKind)[keyof typeof DataVisualizationNodeApiKind]
@@ -7496,56 +3417,11 @@ export const ColorModeApi = {
     Dark: 'dark',
 } as const
 
-export interface ConditionalFormattingRuleApi {
-    bytecode: unknown[]
-    color: string
-    colorMode?: ColorModeApi | null
-    columnName: string
-    id: string
-    input: string
-    templateId: string
-}
-
-export interface TableSettingsApi {
-    columns?: ChartAxisApi[] | null
-    conditionalFormatting?: ConditionalFormattingRuleApi[] | null
-    pinnedColumns?: string[] | null
-    transpose?: boolean | null
-}
-
-export interface DataVisualizationNodeApi {
-    chartSettings?: ChartSettingsApi | null
-    display?: ChartDisplayTypeApi | null
-    kind: DataVisualizationNodeApiKind
-    source: HogQLQueryApi
-    tableSettings?: TableSettingsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type HogQueryApiKind = (typeof HogQueryApiKind)[keyof typeof HogQueryApiKind]
 
 export const HogQueryApiKind = {
     HogQuery: 'HogQuery',
 } as const
-
-export interface HogQueryResponseApi {
-    bytecode?: unknown[] | null
-    coloredBytecode?: unknown[] | null
-    results: unknown
-    stdout?: string | null
-}
-
-export interface HogQueryApi {
-    code?: string | null
-    kind: HogQueryApiKind
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: HogQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 /**
  * The query definition for this insight. The `kind` field determines the query type:

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -1,3 +1,67 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type {
+    Breakdown,
+    BreakdownFilter,
+    ClickhouseQueryProgress,
+    DashboardFilter,
+    EndpointLastExecutionTimesRequest,
+    EndpointRunRequest,
+    QueryStatus,
+    QueryStatusResponse,
+} from '~/queries/schema/schema-general'
+import type {
+    CohortPropertyFilter,
+    DataWarehousePersonPropertyFilter,
+    DataWarehousePropertyFilter,
+    ElementPropertyFilter,
+    EmptyPropertyFilter,
+    ErrorTrackingIssueFilter,
+    EventMetadataPropertyFilter,
+    EventPropertyFilter,
+    FeaturePropertyFilter,
+    FlagPropertyFilter,
+    GroupPropertyFilter,
+    HogQLPropertyFilter,
+    LogEntryPropertyFilter,
+    LogPropertyFilter,
+    PersonPropertyFilter,
+    RecordingPropertyFilter,
+    RevenueAnalyticsPropertyFilter,
+    SessionPropertyFilter,
+    SpanPropertyFilter,
+    WorkflowVariablePropertyFilter,
+} from '~/types'
+
+export type BreakdownApi = Breakdown
+export type BreakdownFilterApi = BreakdownFilter
+export type ClickhouseQueryProgressApi = ClickhouseQueryProgress
+export type CohortPropertyFilterApi = CohortPropertyFilter
+export type DashboardFilterApi = DashboardFilter
+export type DataWarehousePersonPropertyFilterApi = DataWarehousePersonPropertyFilter
+export type DataWarehousePropertyFilterApi = DataWarehousePropertyFilter
+export type ElementPropertyFilterApi = ElementPropertyFilter
+export type EmptyPropertyFilterApi = EmptyPropertyFilter
+export type EndpointLastExecutionTimesRequestApi = EndpointLastExecutionTimesRequest
+export type EndpointRunRequestApi = EndpointRunRequest
+export type ErrorTrackingIssueFilterApi = ErrorTrackingIssueFilter
+export type EventMetadataPropertyFilterApi = EventMetadataPropertyFilter
+export type EventPropertyFilterApi = EventPropertyFilter
+export type FeaturePropertyFilterApi = FeaturePropertyFilter
+export type FlagPropertyFilterApi = FlagPropertyFilter
+export type GroupPropertyFilterApi = GroupPropertyFilter
+export type HogQLPropertyFilterApi = HogQLPropertyFilter
+export type LogEntryPropertyFilterApi = LogEntryPropertyFilter
+export type LogPropertyFilterApi = LogPropertyFilter
+export type PersonPropertyFilterApi = PersonPropertyFilter
+export type QueryStatusApi = QueryStatus
+export type QueryStatusResponseApi = QueryStatusResponse
+export type RecordingPropertyFilterApi = RecordingPropertyFilter
+export type RevenueAnalyticsPropertyFilterApi = RevenueAnalyticsPropertyFilter
+export type SessionPropertyFilterApi = SessionPropertyFilter
+export type SpanPropertyFilterApi = SpanPropertyFilter
+export type WorkflowVariablePropertyFilterApi = WorkflowVariablePropertyFilter
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -483,26 +547,6 @@ export const MultipleBreakdownTypeApi = {
     DataWarehousePersonProperty: 'data_warehouse_person_property',
 } as const
 
-export interface BreakdownApi {
-    group_type_index?: number | null
-    histogram_bin_count?: number | null
-    normalize_url?: boolean | null
-    property: string | number
-    type?: MultipleBreakdownTypeApi | null
-}
-
-export interface BreakdownFilterApi {
-    breakdown?: string | (string | number)[] | number | null
-    breakdown_group_type_index?: number | null
-    breakdown_hide_other_aggregation?: boolean | null
-    breakdown_histogram_bin_count?: number | null
-    breakdown_limit?: number | null
-    breakdown_normalize_url?: boolean | null
-    breakdown_path_cleaning?: boolean | null
-    breakdown_type?: BreakdownTypeApi | null
-    breakdowns?: BreakdownApi[] | null
-}
-
 export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
 
 export const PropertyOperatorApi = {
@@ -542,24 +586,6 @@ export const PropertyOperatorApi = {
     NotIcontainsMulti: 'not_icontains_multi',
 } as const
 
-export interface EventPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    /** Event properties */
-    type?: 'event'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Person properties */
-    type?: 'person'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
 
 export const Key10Api = {
@@ -569,39 +595,6 @@ export const Key10Api = {
     Selector: 'selector',
 } as const
 
-export interface ElementPropertyFilterApi {
-    key: Key10Api
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'element'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface EventMetadataPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'event_metadata'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface SessionPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'session'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface CohortPropertyFilterApi {
-    cohort_name?: string | null
-    key?: 'id'
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    type?: 'cohort'
-    value: number
-}
-
 export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
 
 export const DurationTypeApi = {
@@ -610,91 +603,11 @@ export const DurationTypeApi = {
     InactiveSeconds: 'inactive_seconds',
 } as const
 
-export interface RecordingPropertyFilterApi {
-    key: DurationTypeApi | string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'recording'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface LogEntryPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'log_entry'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
-
-export interface GroupPropertyFilterApi {
-    group_key_names?: GroupPropertyFilterApiGroupKeyNames
-    group_type_index?: number | null
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'group'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FeaturePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Event property with "$feature/" prepended */
-    type?: 'feature'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FlagPropertyFilterApi {
-    /** The key should be the flag ID */
-    key: string
-    label?: string | null
-    /** Only flag_evaluates_to operator is allowed for flag dependencies */
-    operator?: 'flag_evaluates_to'
-    /** Feature flag dependency */
-    type?: 'flag'
-    /** The value can be true, false, or a variant name */
-    value: boolean | string
-}
-
-export interface HogQLPropertyFilterApi {
-    key: string
-    label?: string | null
-    type?: 'hogql'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export const EmptyPropertyFilterApiValue = {
     type: 'empty',
 } as const
-export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
-
-export interface DataWarehousePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface DataWarehousePersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse_person_property'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface ErrorTrackingIssueFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'error_tracking_issue'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
 
 export const LogPropertyFilterTypeApi = {
@@ -702,14 +615,6 @@ export const LogPropertyFilterTypeApi = {
     LogAttribute: 'log_attribute',
     LogResourceAttribute: 'log_resource_attribute',
 } as const
-
-export interface LogPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: LogPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
 
@@ -719,61 +624,6 @@ export const SpanPropertyFilterTypeApi = {
     SpanResourceAttribute: 'span_resource_attribute',
 } as const
 
-export interface SpanPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: SpanPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface RevenueAnalyticsPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'revenue_analytics'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface WorkflowVariablePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'workflow_variable'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface DashboardFilterApi {
-    breakdown_filter?: BreakdownFilterApi | null
-    date_from?: string | null
-    date_to?: string | null
-    explicitDate?: boolean | null
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-}
-
 export type EndpointRefreshModeApi = (typeof EndpointRefreshModeApi)[keyof typeof EndpointRefreshModeApi]
 
 export const EndpointRefreshModeApi = {
@@ -782,31 +632,6 @@ export const EndpointRefreshModeApi = {
     Direct: 'direct',
 } as const
 
-export interface EndpointRunRequestApi {
-    /** Client provided query ID. Can be used to retrieve the status or cancel the query. */
-    client_query_id?: string | null
-    /** Whether to include debug information (such as the executed HogQL) in the response. */
-    debug?: boolean | null
-    filters_override?: DashboardFilterApi | null
-    /** Maximum number of results to return. If not provided, returns all results. */
-    limit?: number | null
-    /** Number of results to skip. Must be used together with limit. Only supported for HogQL endpoints. */
-    offset?: number | null
-    refresh?: EndpointRefreshModeApi | null
-    /** Variables to parameterize the endpoint query. The key is the variable name and the value is the variable value.
-     *
-     * For HogQL endpoints:   Keys must match a variable `code_name` defined in the query (referenced as `{variables.code_name}`).   Example: `{"event_name": "$pageview"}`
-     *
-     * For non-materialized insight endpoints (e.g. TrendsQuery):   - `date_from` and `date_to` are built-in variables that filter the date range.     Example: `{"date_from": "2024-01-01", "date_to": "2024-01-31"}`
-     *
-     * For materialized insight endpoints:   - Use the breakdown property name as the key to filter by breakdown value.     Example: `{"$browser": "Chrome"}`   - `date_from`/`date_to` are not supported on materialized insight endpoints.
-     *
-     * Unknown variable names will return a 400 error. */
-    variables?: EndpointRunRequestApiVariables
-    /** Specific endpoint version to execute. If not provided, the latest version is used. */
-    version?: number | null
-}
-
 export interface PaginatedEndpointVersionResponseListApi {
     count: number
     /** @nullable */
@@ -814,47 +639,6 @@ export interface PaginatedEndpointVersionResponseListApi {
     /** @nullable */
     previous?: string | null
     results: EndpointVersionResponseApi[]
-}
-
-export interface EndpointLastExecutionTimesRequestApi {
-    names: string[]
-}
-
-export interface ClickhouseQueryProgressApi {
-    active_cpu_time: number
-    bytes_read: number
-    estimated_rows_total: number
-    rows_read: number
-    time_elapsed: number
-}
-
-export interface QueryStatusApi {
-    /** Whether the query is still running. Will be true if the query is complete, even if it errored. Either result or error will be set. */
-    complete?: boolean | null
-    dashboard_id?: number | null
-    /** When did the query execution task finish (whether successfully or not). */
-    end_time?: string | null
-    /** If the query failed, this will be set to true. More information can be found in the error_message field. */
-    error?: boolean | null
-    error_message?: string | null
-    expiration_time?: string | null
-    id: string
-    insight_id?: number | null
-    labels?: string[] | null
-    /** When was the query execution task picked up by a worker. */
-    pickup_time?: string | null
-    /** ONLY async queries use QueryStatus. */
-    query_async?: true
-    query_progress?: ClickhouseQueryProgressApi | null
-    results?: unknown
-    /** When was query execution task enqueued. */
-    start_time?: string | null
-    task_id?: string | null
-    team_id: number
-}
-
-export interface QueryStatusResponseApi {
-    query_status: QueryStatusApi
 }
 
 export type EndpointsListParams = {

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -1,3 +1,51 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type {
+    CohortPropertyFilter,
+    DataWarehousePersonPropertyFilter,
+    DataWarehousePropertyFilter,
+    ElementPropertyFilter,
+    EmptyPropertyFilter,
+    ErrorTrackingIssueFilter,
+    EventMetadataPropertyFilter,
+    EventPropertyFilter,
+    FeaturePropertyFilter,
+    FlagPropertyFilter,
+    GroupPropertyFilter,
+    HogQLPropertyFilter,
+    LogEntryPropertyFilter,
+    LogPropertyFilter,
+    PersonPropertyFilter,
+    PropertyGroupFilterValue,
+    RecordingPropertyFilter,
+    RevenueAnalyticsPropertyFilter,
+    SessionPropertyFilter,
+    SpanPropertyFilter,
+    WorkflowVariablePropertyFilter,
+} from '~/types'
+
+export type CohortPropertyFilterApi = CohortPropertyFilter
+export type DataWarehousePersonPropertyFilterApi = DataWarehousePersonPropertyFilter
+export type DataWarehousePropertyFilterApi = DataWarehousePropertyFilter
+export type ElementPropertyFilterApi = ElementPropertyFilter
+export type EmptyPropertyFilterApi = EmptyPropertyFilter
+export type ErrorTrackingIssueFilterApi = ErrorTrackingIssueFilter
+export type EventMetadataPropertyFilterApi = EventMetadataPropertyFilter
+export type EventPropertyFilterApi = EventPropertyFilter
+export type FeaturePropertyFilterApi = FeaturePropertyFilter
+export type FlagPropertyFilterApi = FlagPropertyFilter
+export type GroupPropertyFilterApi = GroupPropertyFilter
+export type HogQLPropertyFilterApi = HogQLPropertyFilter
+export type LogEntryPropertyFilterApi = LogEntryPropertyFilter
+export type LogPropertyFilterApi = LogPropertyFilter
+export type PersonPropertyFilterApi = PersonPropertyFilter
+export type PropertyGroupFilterValueApi = PropertyGroupFilterValue
+export type RecordingPropertyFilterApi = RecordingPropertyFilter
+export type RevenueAnalyticsPropertyFilterApi = RevenueAnalyticsPropertyFilter
+export type SessionPropertyFilterApi = SessionPropertyFilter
+export type SpanPropertyFilterApi = SpanPropertyFilter
+export type WorkflowVariablePropertyFilterApi = WorkflowVariablePropertyFilter
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -85,24 +133,6 @@ export const PropertyOperatorApi = {
     NotIcontainsMulti: 'not_icontains_multi',
 } as const
 
-export interface EventPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    /** Event properties */
-    type?: 'event'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Person properties */
-    type?: 'person'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
 
 export const Key10Api = {
@@ -112,39 +142,6 @@ export const Key10Api = {
     Selector: 'selector',
 } as const
 
-export interface ElementPropertyFilterApi {
-    key: Key10Api
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'element'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface EventMetadataPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'event_metadata'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface SessionPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'session'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface CohortPropertyFilterApi {
-    cohort_name?: string | null
-    key?: 'id'
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    type?: 'cohort'
-    value: number
-}
-
 export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
 
 export const DurationTypeApi = {
@@ -153,91 +150,11 @@ export const DurationTypeApi = {
     InactiveSeconds: 'inactive_seconds',
 } as const
 
-export interface RecordingPropertyFilterApi {
-    key: DurationTypeApi | string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'recording'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface LogEntryPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'log_entry'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
-
-export interface GroupPropertyFilterApi {
-    group_key_names?: GroupPropertyFilterApiGroupKeyNames
-    group_type_index?: number | null
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'group'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FeaturePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Event property with "$feature/" prepended */
-    type?: 'feature'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FlagPropertyFilterApi {
-    /** The key should be the flag ID */
-    key: string
-    label?: string | null
-    /** Only flag_evaluates_to operator is allowed for flag dependencies */
-    operator?: 'flag_evaluates_to'
-    /** Feature flag dependency */
-    type?: 'flag'
-    /** The value can be true, false, or a variant name */
-    value: boolean | string
-}
-
-export interface HogQLPropertyFilterApi {
-    key: string
-    label?: string | null
-    type?: 'hogql'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export const EmptyPropertyFilterApiValue = {
     type: 'empty',
 } as const
-export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
-
-export interface DataWarehousePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface DataWarehousePersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse_person_property'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface ErrorTrackingIssueFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'error_tracking_issue'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
 
 export const LogPropertyFilterTypeApi = {
@@ -246,14 +163,6 @@ export const LogPropertyFilterTypeApi = {
     LogResourceAttribute: 'log_resource_attribute',
 } as const
 
-export interface LogPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: LogPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
 
 export const SpanPropertyFilterTypeApi = {
@@ -261,57 +170,6 @@ export const SpanPropertyFilterTypeApi = {
     SpanAttribute: 'span_attribute',
     SpanResourceAttribute: 'span_resource_attribute',
 } as const
-
-export interface SpanPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: SpanPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface RevenueAnalyticsPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'revenue_analytics'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface WorkflowVariablePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'workflow_variable'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PropertyGroupFilterValueApi {
-    type: FilterLogicalOperatorApi
-    values: (
-        | PropertyGroupFilterValueApi
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | ElementPropertyFilterApi
-        | EventMetadataPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-        | RecordingPropertyFilterApi
-        | LogEntryPropertyFilterApi
-        | GroupPropertyFilterApi
-        | FeaturePropertyFilterApi
-        | FlagPropertyFilterApi
-        | HogQLPropertyFilterApi
-        | EmptyPropertyFilterApi
-        | DataWarehousePropertyFilterApi
-        | DataWarehousePersonPropertyFilterApi
-        | ErrorTrackingIssueFilterApi
-        | LogPropertyFilterApi
-        | SpanPropertyFilterApi
-        | RevenueAnalyticsPropertyFilterApi
-        | WorkflowVariablePropertyFilterApi
-    )[]
-}
 
 /**
  * * `user` - user

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1,3 +1,25 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type {
+    ExperimentApiEventSource,
+    ExperimentApiExposureConfig,
+    ExperimentApiExposureCriteria,
+    ExperimentApiMetric,
+    ExperimentMetricOutlierHandling,
+    ExperimentParameters,
+    ExperimentVariant,
+} from '~/queries/schema/schema-general'
+import type { EventPropertyFilter } from '~/types'
+
+export type EventPropertyFilterApi = EventPropertyFilter
+export type ExperimentApiEventSourceApi = ExperimentApiEventSource
+export type ExperimentApiExposureConfigApi = ExperimentApiExposureConfig
+export type ExperimentApiExposureCriteriaApi = ExperimentApiExposureCriteria
+export type ExperimentApiMetricApi = ExperimentApiMetric
+export type ExperimentMetricOutlierHandlingApi = ExperimentMetricOutlierHandling
+export type ExperimentParametersApi = ExperimentParameters
+export type ExperimentVariantApi = ExperimentVariant
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -225,27 +247,6 @@ export interface MinimalFeatureFlagApi {
     readonly evaluation_contexts: readonly string[]
 }
 
-export interface ExperimentVariantApi {
-    /** Variant key. Exactly one variant in feature_flag_variants must use key 'control' (lowercase, exactly) — that is the baseline used for analysis and the special key the experiment runtime expects. Other variants use keys like 'test', 'variant_a', 'variant_b'. Map natural-language names ('original', 'A', 'baseline') to 'control'. */
-    key: string
-    /** Human-readable variant name. */
-    name?: string | null
-    rollout_percentage?: number | null
-    /** Percentage of users assigned to this variant (0–100). All variants must sum to 100. One of split_percent (recommended) or rollout_percentage must be provided. */
-    split_percent?: number | null
-}
-
-export interface ExperimentParametersApi {
-    /** Variant keys to exclude from metric result calculations. Excluded variants are still served to users but omitted from statistical analysis. */
-    excluded_variants?: string[] | null
-    /** Experiment variants. If specified, must include a variant with key 'control' (lowercase). Defaults to a 50/50 control/test split when omitted. Minimum 2, maximum 20. */
-    feature_flag_variants?: ExperimentVariantApi[] | null
-    /** Minimum detectable effect as a percentage. Lower values need more users but catch smaller changes. Suggest 20–30% for most experiments. */
-    minimum_detectable_effect?: number | null
-    /** Overall rollout percentage (0-100). Controls what fraction of all users enter the experiment. Users outside the rollout never see any variant and are excluded from analysis. Default: 100. */
-    rollout_percentage?: number | null
-}
-
 export interface ExperimentToSavedMetricApi {
     readonly id: number
     experiment: number
@@ -313,31 +314,6 @@ export const PropertyOperatorApi = {
     NotIcontainsMulti: 'not_icontains_multi',
 } as const
 
-export interface EventPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    /** Event properties */
-    type?: 'event'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface ExperimentApiExposureConfigApi {
-    /** Custom exposure event name. Required when kind is 'ExperimentEventExposureConfig'. */
-    event?: string | null
-    /** Action ID. Required when kind is 'ActionsNode'. */
-    id?: number | null
-    /** Defaults to 'ExperimentEventExposureConfig' when omitted. Pass 'ActionsNode' for an action-based exposure. */
-    kind?: Kind1Api | null
-    /** Event property filters. Pass an empty array if no filters needed. */
-    properties: EventPropertyFilterApi[]
-}
-
-export interface ExperimentApiExposureCriteriaApi {
-    exposure_config?: ExperimentApiExposureConfigApi | null
-    filterTestAccounts?: boolean | null
-}
-
 export type KindApi = (typeof KindApi)[keyof typeof KindApi]
 
 export const KindApi = {
@@ -368,32 +344,6 @@ export const MathGroupTypeIndexApi = {
     Number3: 3,
     Number4: 4,
 } as const
-
-export interface ExperimentApiEventSourceApi {
-    /** Event name, e.g. '$pageview'. Required for EventsNode. */
-    event?: string | null
-    /** Action ID. Required for ActionsNode. */
-    id?: number | null
-    kind: KindApi
-    /** How to aggregate this source. Defaults to 'total' (event count). Use 'sum' together with math_property to aggregate a numeric property — e.g. a ratio numerator of revenue per order. Other options: 'avg', 'min', 'max', 'unique_session', 'dau', 'unique_group', 'hogql'. */
-    math?: ExperimentMetricMathTypeApi | null
-    /** Group type index to aggregate over. Required when math is 'unique_group'. */
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    /** HogQL aggregation expression. Required when math is 'hogql' — without it the metric silently falls back to a plain count/sum. */
-    math_hogql?: string | null
-    /** Numeric event property to aggregate when math is 'sum', 'avg', 'min', or 'max' (e.g. 'revenue'). */
-    math_property?: string | null
-    /** Event property filters to narrow which events are counted. */
-    properties?: EventPropertyFilterApi[] | null
-}
-
-export interface ExperimentMetricOutlierHandlingApi {
-    ignore_zeros?: boolean | null
-    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
-    lower_bound_percentile?: number | null
-    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
-    upper_bound_percentile?: number | null
-}
 
 export type ExperimentMetricGoalApi = (typeof ExperimentMetricGoalApi)[keyof typeof ExperimentMetricGoalApi]
 
@@ -429,45 +379,6 @@ export const StartHandlingApi = {
     FirstSeen: 'first_seen',
     LastSeen: 'last_seen',
 } as const
-
-export interface ExperimentApiMetricApi {
-    /** For retention metrics: completion event. */
-    completion_event?: ExperimentApiEventSourceApi | null
-    /** Conversion window duration. */
-    conversion_window?: number | null
-    /** For ratio metrics: denominator source. */
-    denominator?: ExperimentApiEventSourceApi | null
-    /** For ratio metrics: winsorization applied to the denominator aggregate. Leave unset for a binomial-style denominator, which is never clamped. */
-    denominator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
-    /** Whether higher or lower values indicate success. */
-    goal?: ExperimentMetricGoalApi | null
-    /** For mean metrics: exclude zero values when computing the winsorization percentile thresholds. */
-    ignore_zeros?: boolean | null
-    kind?: 'ExperimentMetric'
-    /** For mean metrics: winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). Per-user values below this percentile are clamped to it before aggregation. */
-    lower_bound_percentile?: number | null
-    metric_type: ExperimentMetricTypeApi
-    /** Human-readable metric name. */
-    name?: string | null
-    /** For ratio metrics: numerator source. */
-    numerator?: ExperimentApiEventSourceApi | null
-    /** For ratio metrics: winsorization applied to the numerator aggregate, independently of the denominator and each with its own percentile thresholds. */
-    numerator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
-    retention_window_end?: number | null
-    retention_window_start?: number | null
-    retention_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    /** For funnel metrics: array of EventsNode/ActionsNode steps. */
-    series?: ExperimentApiEventSourceApi[] | null
-    /** For mean metrics: event source. */
-    source?: ExperimentApiEventSourceApi | null
-    /** For retention metrics: start event. */
-    start_event?: ExperimentApiEventSourceApi | null
-    start_handling?: StartHandlingApi | null
-    /** For mean metrics: winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). Per-user values above this percentile are clamped to it before aggregation. */
-    upper_bound_percentile?: number | null
-    /** Unique identifier. Auto-generated if omitted. */
-    uuid?: string | null
-}
 
 /**
  * List wrapper for OpenAPI schema generation — the field stores an array of metrics.

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1,3 +1,55 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type { LogsAlertFilters } from '~/queries/schema/schema-general'
+import type {
+    CohortPropertyFilter,
+    DataWarehousePersonPropertyFilter,
+    DataWarehousePropertyFilter,
+    ElementPropertyFilter,
+    EmptyPropertyFilter,
+    ErrorTrackingIssueFilter,
+    EventMetadataPropertyFilter,
+    EventPropertyFilter,
+    FeaturePropertyFilter,
+    FlagPropertyFilter,
+    GroupPropertyFilter,
+    HogQLPropertyFilter,
+    LogEntryPropertyFilter,
+    LogPropertyFilter,
+    PersonPropertyFilter,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+    RecordingPropertyFilter,
+    RevenueAnalyticsPropertyFilter,
+    SessionPropertyFilter,
+    SpanPropertyFilter,
+    WorkflowVariablePropertyFilter,
+} from '~/types'
+
+export type CohortPropertyFilterApi = CohortPropertyFilter
+export type DataWarehousePersonPropertyFilterApi = DataWarehousePersonPropertyFilter
+export type DataWarehousePropertyFilterApi = DataWarehousePropertyFilter
+export type ElementPropertyFilterApi = ElementPropertyFilter
+export type EmptyPropertyFilterApi = EmptyPropertyFilter
+export type ErrorTrackingIssueFilterApi = ErrorTrackingIssueFilter
+export type EventMetadataPropertyFilterApi = EventMetadataPropertyFilter
+export type EventPropertyFilterApi = EventPropertyFilter
+export type FeaturePropertyFilterApi = FeaturePropertyFilter
+export type FlagPropertyFilterApi = FlagPropertyFilter
+export type GroupPropertyFilterApi = GroupPropertyFilter
+export type HogQLPropertyFilterApi = HogQLPropertyFilter
+export type LogEntryPropertyFilterApi = LogEntryPropertyFilter
+export type LogPropertyFilterApi = LogPropertyFilter
+export type LogsAlertFiltersApi = LogsAlertFilters
+export type PersonPropertyFilterApi = PersonPropertyFilter
+export type PropertyGroupFilterApi = PropertyGroupFilter
+export type PropertyGroupFilterValueApi = PropertyGroupFilterValue
+export type RecordingPropertyFilterApi = RecordingPropertyFilter
+export type RevenueAnalyticsPropertyFilterApi = RevenueAnalyticsPropertyFilter
+export type SessionPropertyFilterApi = SessionPropertyFilter
+export type SpanPropertyFilterApi = SpanPropertyFilter
+export type WorkflowVariablePropertyFilterApi = WorkflowVariablePropertyFilter
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -53,24 +105,6 @@ export const PropertyOperatorApi = {
     NotIcontainsMulti: 'not_icontains_multi',
 } as const
 
-export interface EventPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    /** Event properties */
-    type?: 'event'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Person properties */
-    type?: 'person'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
 
 export const Key10Api = {
@@ -80,39 +114,6 @@ export const Key10Api = {
     Selector: 'selector',
 } as const
 
-export interface ElementPropertyFilterApi {
-    key: Key10Api
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'element'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface EventMetadataPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'event_metadata'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface SessionPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'session'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface CohortPropertyFilterApi {
-    cohort_name?: string | null
-    key?: 'id'
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    type?: 'cohort'
-    value: number
-}
-
 export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
 
 export const DurationTypeApi = {
@@ -121,91 +122,11 @@ export const DurationTypeApi = {
     InactiveSeconds: 'inactive_seconds',
 } as const
 
-export interface RecordingPropertyFilterApi {
-    key: DurationTypeApi | string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'recording'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface LogEntryPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'log_entry'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
-
-export interface GroupPropertyFilterApi {
-    group_key_names?: GroupPropertyFilterApiGroupKeyNames
-    group_type_index?: number | null
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'group'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FeaturePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Event property with "$feature/" prepended */
-    type?: 'feature'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FlagPropertyFilterApi {
-    /** The key should be the flag ID */
-    key: string
-    label?: string | null
-    /** Only flag_evaluates_to operator is allowed for flag dependencies */
-    operator?: 'flag_evaluates_to'
-    /** Feature flag dependency */
-    type?: 'flag'
-    /** The value can be true, false, or a variant name */
-    value: boolean | string
-}
-
-export interface HogQLPropertyFilterApi {
-    key: string
-    label?: string | null
-    type?: 'hogql'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export const EmptyPropertyFilterApiValue = {
     type: 'empty',
 } as const
-export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
-
-export interface DataWarehousePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface DataWarehousePersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse_person_property'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface ErrorTrackingIssueFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'error_tracking_issue'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
 
 export const LogPropertyFilterTypeApi = {
@@ -214,14 +135,6 @@ export const LogPropertyFilterTypeApi = {
     LogResourceAttribute: 'log_resource_attribute',
 } as const
 
-export interface LogPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: LogPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
 
 export const SpanPropertyFilterTypeApi = {
@@ -229,62 +142,6 @@ export const SpanPropertyFilterTypeApi = {
     SpanAttribute: 'span_attribute',
     SpanResourceAttribute: 'span_resource_attribute',
 } as const
-
-export interface SpanPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: SpanPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface RevenueAnalyticsPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'revenue_analytics'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface WorkflowVariablePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'workflow_variable'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PropertyGroupFilterValueApi {
-    type: FilterLogicalOperatorApi
-    values: (
-        | PropertyGroupFilterValueApi
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | ElementPropertyFilterApi
-        | EventMetadataPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-        | RecordingPropertyFilterApi
-        | LogEntryPropertyFilterApi
-        | GroupPropertyFilterApi
-        | FeaturePropertyFilterApi
-        | FlagPropertyFilterApi
-        | HogQLPropertyFilterApi
-        | EmptyPropertyFilterApi
-        | DataWarehousePropertyFilterApi
-        | DataWarehousePersonPropertyFilterApi
-        | ErrorTrackingIssueFilterApi
-        | LogPropertyFilterApi
-        | SpanPropertyFilterApi
-        | RevenueAnalyticsPropertyFilterApi
-        | WorkflowVariablePropertyFilterApi
-    )[]
-}
-
-export interface PropertyGroupFilterApi {
-    type: FilterLogicalOperatorApi
-    values: PropertyGroupFilterValueApi[]
-}
 
 export type LogSeverityLevelApi = (typeof LogSeverityLevelApi)[keyof typeof LogSeverityLevelApi]
 
@@ -296,12 +153,6 @@ export const LogSeverityLevelApi = {
     Error: 'error',
     Fatal: 'fatal',
 } as const
-
-export interface LogsAlertFiltersApi {
-    filterGroup?: PropertyGroupFilterApi | null
-    serviceNames?: string[] | null
-    severityLevels?: LogSeverityLevelApi[] | null
-}
 
 /**
  * * `above` - Above

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1,3 +1,423 @@
+// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:
+// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.
+import type {
+    AccountsQuery,
+    AccountsQueryResponse,
+    ActionConversionGoal,
+    ActionsNode,
+    ActorsQuery,
+    ActorsQueryResponse,
+    BoxPlotDatum,
+    Breakdown,
+    BreakdownFilter,
+    CalendarHeatmapFilter,
+    ChartAxis,
+    ChartSettings,
+    ChartSettingsDisplay,
+    ChartSettingsFormatting,
+    ClickhouseQueryProgress,
+    CompareFilter,
+    ConditionalFormattingRule,
+    CustomChannelCondition,
+    CustomChannelRule,
+    CustomEventConversionGoal,
+    DataTableNode,
+    DataTableNodeViewPropsContext,
+    DataVisualizationNode,
+    DataWarehouseEventsModifier,
+    DataWarehouseNode,
+    DataWarehouseSyncWarning,
+    DateRange,
+    EndpointsUsageTableQuery,
+    EndpointsUsageTableQueryResponse,
+    ErrorTrackingCorrelatedIssue,
+    ErrorTrackingExternalReference,
+    ErrorTrackingExternalReferenceIntegration,
+    ErrorTrackingIssue,
+    ErrorTrackingIssueAggregations,
+    ErrorTrackingIssueAssignee,
+    ErrorTrackingIssueCohort,
+    ErrorTrackingIssueCorrelationQuery,
+    ErrorTrackingIssueCorrelationQueryResponse,
+    ErrorTrackingPendingFingerprintIssueStateUpdate,
+    ErrorTrackingQuery,
+    ErrorTrackingQueryResponse,
+    EventDefinition,
+    EventOddsRatioSerialized,
+    EventsNode,
+    EventsQuery,
+    EventsQueryActionStep,
+    EventsQueryResponse,
+    ExperimentActorsQuery,
+    ExperimentBreakdownResult,
+    ExperimentDataWarehouseNode,
+    ExperimentEventExposureConfig,
+    ExperimentFunnelMetric,
+    ExperimentFunnelsQuery,
+    ExperimentFunnelsQueryResponse,
+    ExperimentMeanMetric,
+    ExperimentMetricOutlierHandling,
+    ExperimentQuery,
+    ExperimentQueryResponse,
+    ExperimentRatioMetric,
+    ExperimentRetentionMetric,
+    ExperimentStatsBaseValidated,
+    ExperimentTrendsQuery,
+    ExperimentTrendsQueryResponse,
+    ExperimentVariantFunnelsBaseStats,
+    ExperimentVariantResultBayesian,
+    ExperimentVariantResultFrequentist,
+    ExperimentVariantTrendsBaseStats,
+    FunnelCorrelationActorsQuery,
+    FunnelCorrelationQuery,
+    FunnelCorrelationResponse,
+    FunnelCorrelationResult,
+    FunnelExclusionActionsNode,
+    FunnelExclusionEventsNode,
+    FunnelPathsFilter,
+    FunnelsActorsQuery,
+    FunnelsDataWarehouseNode,
+    FunnelsFilter,
+    FunnelsQuery,
+    FunnelsQueryResponse,
+    GoalLine,
+    GroupNode,
+    GroupsQuery,
+    GroupsQueryResponse,
+    HeatmapGradientStop,
+    HeatmapSettings,
+    HogQLFilters,
+    HogQLMetadataResponse,
+    HogQLNotice,
+    HogQLQuery,
+    HogQLQueryModifiers,
+    HogQLQueryResponse,
+    HogQLVariable,
+    HogQuery,
+    HogQueryResponse,
+    InsightActorsQuery,
+    InsightVizNode,
+    IntegrationFilter,
+    LLMTrace,
+    LLMTraceEvent,
+    LLMTracePerson,
+    LifecycleDataWarehouseNode,
+    LifecycleFilter,
+    LifecycleQuery,
+    LifecycleQueryResponse,
+    MarketingAnalyticsAggregatedQuery,
+    MarketingAnalyticsAggregatedQueryResponse,
+    MarketingAnalyticsItem,
+    MarketingAnalyticsTableQuery,
+    MarketingAnalyticsTableQueryResponse,
+    NonIntegratedConversionsTableQuery,
+    NonIntegratedConversionsTableQueryResponse,
+    PathsFilter,
+    PathsLink,
+    PathsQuery,
+    PathsQueryResponse,
+    PersonsNode,
+    QueryLogTags,
+    QueryStatus,
+    QueryTiming,
+    ResolvedDateRangeResponse,
+    ResultCustomizationByPosition,
+    ResultCustomizationByValue,
+    RetentionFilter,
+    RetentionQuery,
+    RetentionQueryResponse,
+    RetentionResult,
+    RetentionValue,
+    RevenueAnalyticsBreakdown,
+    RevenueAnalyticsGrossRevenueQuery,
+    RevenueAnalyticsGrossRevenueQueryResponse,
+    RevenueAnalyticsMRRQuery,
+    RevenueAnalyticsMRRQueryResponse,
+    RevenueAnalyticsMRRQueryResultItem,
+    RevenueAnalyticsMetricsQuery,
+    RevenueAnalyticsMetricsQueryResponse,
+    RevenueAnalyticsOverviewItem,
+    RevenueAnalyticsOverviewQuery,
+    RevenueAnalyticsOverviewQueryResponse,
+    RevenueAnalyticsTopCustomersQuery,
+    RevenueAnalyticsTopCustomersQueryResponse,
+    RevenueCurrencyPropertyConfig,
+    RevenueExampleDataWarehouseTablesQuery,
+    RevenueExampleDataWarehouseTablesQueryResponse,
+    RevenueExampleEventsQuery,
+    RevenueExampleEventsQueryResponse,
+    SamplingRate,
+    SessionAttributionExplorerQuery,
+    SessionAttributionExplorerQueryResponse,
+    SessionData,
+    SessionsQuery,
+    SessionsQueryResponse,
+    StickinessActorsQuery,
+    StickinessCriteria,
+    StickinessFilter,
+    StickinessQuery,
+    StickinessQueryResponse,
+    TableSettings,
+    TraceQuery,
+    TraceQueryResponse,
+    TracesQuery,
+    TracesQueryResponse,
+    TrendsFilter,
+    TrendsFormulaNode,
+    TrendsQuery,
+    TrendsQueryResponse,
+    VizSpecificOptions,
+    WebAnalyticsSampling,
+    WebExternalClicksTableQuery,
+    WebExternalClicksTableQueryResponse,
+    WebGoalsQuery,
+    WebGoalsQueryResponse,
+    WebOverviewItem,
+    WebOverviewQuery,
+    WebOverviewQueryResponse,
+    WebStatsTableQuery,
+    WebStatsTableQueryResponse,
+    WebVitalsPathBreakdownQuery,
+    WebVitalsPathBreakdownQueryResponse,
+    WebVitalsPathBreakdownResult,
+    WebVitalsPathBreakdownResultItem,
+    WebVitalsQuery,
+    YAxisSettings,
+} from '~/queries/schema/schema-general'
+import type {
+    CohortPropertyFilter,
+    DataWarehousePersonPropertyFilter,
+    DataWarehousePropertyFilter,
+    ElementPropertyFilter,
+    EmptyPropertyFilter,
+    ErrorTrackingIssueFilter,
+    EventMetadataPropertyFilter,
+    EventPropertyFilter,
+    FeaturePropertyFilter,
+    FlagPropertyFilter,
+    GroupPropertyFilter,
+    HogQLPropertyFilter,
+    LogEntryPropertyFilter,
+    LogPropertyFilter,
+    PathCleaningFilter,
+    PersonPropertyFilter,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+    RecordingPropertyFilter,
+    RetentionEntity,
+    RevenueAnalyticsPropertyFilter,
+    SessionPropertyFilter,
+    SpanPropertyFilter,
+    WorkflowVariablePropertyFilter,
+} from '~/types'
+
+export type AccountsQueryApi = AccountsQuery
+export type AccountsQueryResponseApi = AccountsQueryResponse
+export type ActionConversionGoalApi = ActionConversionGoal
+export type ActionsNodeApi = ActionsNode
+export type ActorsQueryApi = ActorsQuery
+export type ActorsQueryResponseApi = ActorsQueryResponse
+export type BoxPlotDatumApi = BoxPlotDatum
+export type BreakdownApi = Breakdown
+export type BreakdownFilterApi = BreakdownFilter
+export type CalendarHeatmapFilterApi = CalendarHeatmapFilter
+export type ChartAxisApi = ChartAxis
+export type ChartSettingsApi = ChartSettings
+export type ChartSettingsDisplayApi = ChartSettingsDisplay
+export type ChartSettingsFormattingApi = ChartSettingsFormatting
+export type ClickhouseQueryProgressApi = ClickhouseQueryProgress
+export type CohortPropertyFilterApi = CohortPropertyFilter
+export type CompareFilterApi = CompareFilter
+export type ConditionalFormattingRuleApi = ConditionalFormattingRule
+export type CustomChannelConditionApi = CustomChannelCondition
+export type CustomChannelRuleApi = CustomChannelRule
+export type CustomEventConversionGoalApi = CustomEventConversionGoal
+export type DataTableNodeApi = DataTableNode
+export type DataTableNodeViewPropsContextApi = DataTableNodeViewPropsContext
+export type DataVisualizationNodeApi = DataVisualizationNode
+export type DataWarehouseEventsModifierApi = DataWarehouseEventsModifier
+export type DataWarehouseNodeApi = DataWarehouseNode
+export type DataWarehousePersonPropertyFilterApi = DataWarehousePersonPropertyFilter
+export type DataWarehousePropertyFilterApi = DataWarehousePropertyFilter
+export type DataWarehouseSyncWarningApi = DataWarehouseSyncWarning
+export type DateRangeApi = DateRange
+export type ElementPropertyFilterApi = ElementPropertyFilter
+export type EmptyPropertyFilterApi = EmptyPropertyFilter
+export type EndpointsUsageTableQueryApi = EndpointsUsageTableQuery
+export type EndpointsUsageTableQueryResponseApi = EndpointsUsageTableQueryResponse
+export type ErrorTrackingCorrelatedIssueApi = ErrorTrackingCorrelatedIssue
+export type ErrorTrackingExternalReferenceApi = ErrorTrackingExternalReference
+export type ErrorTrackingExternalReferenceIntegrationApi = ErrorTrackingExternalReferenceIntegration
+export type ErrorTrackingIssueAggregationsApi = ErrorTrackingIssueAggregations
+export type ErrorTrackingIssueApi = ErrorTrackingIssue
+export type ErrorTrackingIssueAssigneeApi = ErrorTrackingIssueAssignee
+export type ErrorTrackingIssueCohortApi = ErrorTrackingIssueCohort
+export type ErrorTrackingIssueCorrelationQueryApi = ErrorTrackingIssueCorrelationQuery
+export type ErrorTrackingIssueCorrelationQueryResponseApi = ErrorTrackingIssueCorrelationQueryResponse
+export type ErrorTrackingIssueFilterApi = ErrorTrackingIssueFilter
+export type ErrorTrackingPendingFingerprintIssueStateUpdateApi = ErrorTrackingPendingFingerprintIssueStateUpdate
+export type ErrorTrackingQueryApi = ErrorTrackingQuery
+export type ErrorTrackingQueryResponseApi = ErrorTrackingQueryResponse
+export type EventDefinitionApi = EventDefinition
+export type EventMetadataPropertyFilterApi = EventMetadataPropertyFilter
+export type EventOddsRatioSerializedApi = EventOddsRatioSerialized
+export type EventPropertyFilterApi = EventPropertyFilter
+export type EventsNodeApi = EventsNode
+export type EventsQueryActionStepApi = EventsQueryActionStep
+export type EventsQueryApi = EventsQuery
+export type EventsQueryResponseApi = EventsQueryResponse
+export type ExperimentActorsQueryApi = ExperimentActorsQuery
+export type ExperimentBreakdownResultApi = ExperimentBreakdownResult
+export type ExperimentDataWarehouseNodeApi = ExperimentDataWarehouseNode
+export type ExperimentEventExposureConfigApi = ExperimentEventExposureConfig
+export type ExperimentFunnelMetricApi = ExperimentFunnelMetric
+export type ExperimentFunnelsQueryApi = ExperimentFunnelsQuery
+export type ExperimentFunnelsQueryResponseApi = ExperimentFunnelsQueryResponse
+export type ExperimentMeanMetricApi = ExperimentMeanMetric
+export type ExperimentMetricOutlierHandlingApi = ExperimentMetricOutlierHandling
+export type ExperimentQueryApi = ExperimentQuery
+export type ExperimentQueryResponseApi = ExperimentQueryResponse
+export type ExperimentRatioMetricApi = ExperimentRatioMetric
+export type ExperimentRetentionMetricApi = ExperimentRetentionMetric
+export type ExperimentStatsBaseValidatedApi = ExperimentStatsBaseValidated
+export type ExperimentTrendsQueryApi = ExperimentTrendsQuery
+export type ExperimentTrendsQueryResponseApi = ExperimentTrendsQueryResponse
+export type ExperimentVariantFunnelsBaseStatsApi = ExperimentVariantFunnelsBaseStats
+export type ExperimentVariantResultBayesianApi = ExperimentVariantResultBayesian
+export type ExperimentVariantResultFrequentistApi = ExperimentVariantResultFrequentist
+export type ExperimentVariantTrendsBaseStatsApi = ExperimentVariantTrendsBaseStats
+export type FeaturePropertyFilterApi = FeaturePropertyFilter
+export type FlagPropertyFilterApi = FlagPropertyFilter
+export type FunnelCorrelationActorsQueryApi = FunnelCorrelationActorsQuery
+export type FunnelCorrelationQueryApi = FunnelCorrelationQuery
+export type FunnelCorrelationResponseApi = FunnelCorrelationResponse
+export type FunnelCorrelationResultApi = FunnelCorrelationResult
+export type FunnelExclusionActionsNodeApi = FunnelExclusionActionsNode
+export type FunnelExclusionEventsNodeApi = FunnelExclusionEventsNode
+export type FunnelPathsFilterApi = FunnelPathsFilter
+export type FunnelsActorsQueryApi = FunnelsActorsQuery
+export type FunnelsDataWarehouseNodeApi = FunnelsDataWarehouseNode
+export type FunnelsFilterApi = FunnelsFilter
+export type FunnelsQueryApi = FunnelsQuery
+export type FunnelsQueryResponseApi = FunnelsQueryResponse
+export type GoalLineApi = GoalLine
+export type GroupNodeApi = GroupNode
+export type GroupPropertyFilterApi = GroupPropertyFilter
+export type GroupsQueryApi = GroupsQuery
+export type GroupsQueryResponseApi = GroupsQueryResponse
+export type HeatmapGradientStopApi = HeatmapGradientStop
+export type HeatmapSettingsApi = HeatmapSettings
+export type HogQLFiltersApi = HogQLFilters
+export type HogQLMetadataResponseApi = HogQLMetadataResponse
+export type HogQLNoticeApi = HogQLNotice
+export type HogQLPropertyFilterApi = HogQLPropertyFilter
+export type HogQLQueryApi = HogQLQuery
+export type HogQLQueryModifiersApi = HogQLQueryModifiers
+export type HogQLQueryResponseApi = HogQLQueryResponse
+export type HogQLVariableApi = HogQLVariable
+export type HogQueryApi = HogQuery
+export type HogQueryResponseApi = HogQueryResponse
+export type InsightActorsQueryApi = InsightActorsQuery
+export type InsightVizNodeApi = InsightVizNode
+export type IntegrationFilterApi = IntegrationFilter
+export type LLMTraceApi = LLMTrace
+export type LLMTraceEventApi = LLMTraceEvent
+export type LLMTracePersonApi = LLMTracePerson
+export type LifecycleDataWarehouseNodeApi = LifecycleDataWarehouseNode
+export type LifecycleFilterApi = LifecycleFilter
+export type LifecycleQueryApi = LifecycleQuery
+export type LifecycleQueryResponseApi = LifecycleQueryResponse
+export type LogEntryPropertyFilterApi = LogEntryPropertyFilter
+export type LogPropertyFilterApi = LogPropertyFilter
+export type MarketingAnalyticsAggregatedQueryApi = MarketingAnalyticsAggregatedQuery
+export type MarketingAnalyticsAggregatedQueryResponseApi = MarketingAnalyticsAggregatedQueryResponse
+export type MarketingAnalyticsItemApi = MarketingAnalyticsItem
+export type MarketingAnalyticsTableQueryApi = MarketingAnalyticsTableQuery
+export type MarketingAnalyticsTableQueryResponseApi = MarketingAnalyticsTableQueryResponse
+export type NonIntegratedConversionsTableQueryApi = NonIntegratedConversionsTableQuery
+export type NonIntegratedConversionsTableQueryResponseApi = NonIntegratedConversionsTableQueryResponse
+export type PathCleaningFilterApi = PathCleaningFilter
+export type PathsFilterApi = PathsFilter
+export type PathsLinkApi = PathsLink
+export type PathsQueryApi = PathsQuery
+export type PathsQueryResponseApi = PathsQueryResponse
+export type PersonPropertyFilterApi = PersonPropertyFilter
+export type PersonsNodeApi = PersonsNode
+export type PropertyGroupFilterApi = PropertyGroupFilter
+export type PropertyGroupFilterValueApi = PropertyGroupFilterValue
+export type QueryLogTagsApi = QueryLogTags
+export type QueryStatusApi = QueryStatus
+export type QueryTimingApi = QueryTiming
+export type RecordingPropertyFilterApi = RecordingPropertyFilter
+export type ResolvedDateRangeResponseApi = ResolvedDateRangeResponse
+export type ResultCustomizationByPositionApi = ResultCustomizationByPosition
+export type ResultCustomizationByValueApi = ResultCustomizationByValue
+export type RetentionEntityApi = RetentionEntity
+export type RetentionFilterApi = RetentionFilter
+export type RetentionQueryApi = RetentionQuery
+export type RetentionQueryResponseApi = RetentionQueryResponse
+export type RetentionResultApi = RetentionResult
+export type RetentionValueApi = RetentionValue
+export type RevenueAnalyticsBreakdownApi = RevenueAnalyticsBreakdown
+export type RevenueAnalyticsGrossRevenueQueryApi = RevenueAnalyticsGrossRevenueQuery
+export type RevenueAnalyticsGrossRevenueQueryResponseApi = RevenueAnalyticsGrossRevenueQueryResponse
+export type RevenueAnalyticsMRRQueryApi = RevenueAnalyticsMRRQuery
+export type RevenueAnalyticsMRRQueryResponseApi = RevenueAnalyticsMRRQueryResponse
+export type RevenueAnalyticsMRRQueryResultItemApi = RevenueAnalyticsMRRQueryResultItem
+export type RevenueAnalyticsMetricsQueryApi = RevenueAnalyticsMetricsQuery
+export type RevenueAnalyticsMetricsQueryResponseApi = RevenueAnalyticsMetricsQueryResponse
+export type RevenueAnalyticsOverviewItemApi = RevenueAnalyticsOverviewItem
+export type RevenueAnalyticsOverviewQueryApi = RevenueAnalyticsOverviewQuery
+export type RevenueAnalyticsOverviewQueryResponseApi = RevenueAnalyticsOverviewQueryResponse
+export type RevenueAnalyticsPropertyFilterApi = RevenueAnalyticsPropertyFilter
+export type RevenueAnalyticsTopCustomersQueryApi = RevenueAnalyticsTopCustomersQuery
+export type RevenueAnalyticsTopCustomersQueryResponseApi = RevenueAnalyticsTopCustomersQueryResponse
+export type RevenueCurrencyPropertyConfigApi = RevenueCurrencyPropertyConfig
+export type RevenueExampleDataWarehouseTablesQueryApi = RevenueExampleDataWarehouseTablesQuery
+export type RevenueExampleDataWarehouseTablesQueryResponseApi = RevenueExampleDataWarehouseTablesQueryResponse
+export type RevenueExampleEventsQueryApi = RevenueExampleEventsQuery
+export type RevenueExampleEventsQueryResponseApi = RevenueExampleEventsQueryResponse
+export type SamplingRateApi = SamplingRate
+export type SessionAttributionExplorerQueryApi = SessionAttributionExplorerQuery
+export type SessionAttributionExplorerQueryResponseApi = SessionAttributionExplorerQueryResponse
+export type SessionDataApi = SessionData
+export type SessionPropertyFilterApi = SessionPropertyFilter
+export type SessionsQueryApi = SessionsQuery
+export type SessionsQueryResponseApi = SessionsQueryResponse
+export type SpanPropertyFilterApi = SpanPropertyFilter
+export type StickinessActorsQueryApi = StickinessActorsQuery
+export type StickinessCriteriaApi = StickinessCriteria
+export type StickinessFilterApi = StickinessFilter
+export type StickinessQueryApi = StickinessQuery
+export type StickinessQueryResponseApi = StickinessQueryResponse
+export type TableSettingsApi = TableSettings
+export type TraceQueryApi = TraceQuery
+export type TraceQueryResponseApi = TraceQueryResponse
+export type TracesQueryApi = TracesQuery
+export type TracesQueryResponseApi = TracesQueryResponse
+export type TrendsFilterApi = TrendsFilter
+export type TrendsFormulaNodeApi = TrendsFormulaNode
+export type TrendsQueryApi = TrendsQuery
+export type TrendsQueryResponseApi = TrendsQueryResponse
+export type VizSpecificOptionsApi = VizSpecificOptions
+export type WebAnalyticsSamplingApi = WebAnalyticsSampling
+export type WebExternalClicksTableQueryApi = WebExternalClicksTableQuery
+export type WebExternalClicksTableQueryResponseApi = WebExternalClicksTableQueryResponse
+export type WebGoalsQueryApi = WebGoalsQuery
+export type WebGoalsQueryResponseApi = WebGoalsQueryResponse
+export type WebOverviewItemApi = WebOverviewItem
+export type WebOverviewQueryApi = WebOverviewQuery
+export type WebOverviewQueryResponseApi = WebOverviewQueryResponse
+export type WebStatsTableQueryApi = WebStatsTableQuery
+export type WebStatsTableQueryResponseApi = WebStatsTableQueryResponse
+export type WebVitalsPathBreakdownQueryApi = WebVitalsPathBreakdownQuery
+export type WebVitalsPathBreakdownQueryResponseApi = WebVitalsPathBreakdownQueryResponse
+export type WebVitalsPathBreakdownResultApi = WebVitalsPathBreakdownResult
+export type WebVitalsPathBreakdownResultItemApi = WebVitalsPathBreakdownResultItem
+export type WebVitalsQueryApi = WebVitalsQuery
+export type WorkflowVariablePropertyFilterApi = WorkflowVariablePropertyFilter
+export type YAxisSettingsApi = YAxisSettings
+
 /**
  * Auto-generated from the Django backend OpenAPI schema.
  * To modify these types, update the Django serializers or views, then run:
@@ -206,56 +626,6 @@ export const MultipleBreakdownTypeApi = {
     DataWarehousePersonProperty: 'data_warehouse_person_property',
 } as const
 
-export interface BreakdownApi {
-    group_type_index?: number | null
-    histogram_bin_count?: number | null
-    normalize_url?: boolean | null
-    property: string | number
-    type?: MultipleBreakdownTypeApi | null
-}
-
-export interface BreakdownFilterApi {
-    breakdown?: string | (string | number)[] | number | null
-    breakdown_group_type_index?: number | null
-    breakdown_hide_other_aggregation?: boolean | null
-    breakdown_histogram_bin_count?: number | null
-    breakdown_limit?: number | null
-    breakdown_normalize_url?: boolean | null
-    breakdown_path_cleaning?: boolean | null
-    breakdown_type?: BreakdownTypeApi | null
-    breakdowns?: BreakdownApi[] | null
-}
-
-export interface CalendarHeatmapFilterApi {
-    /** When true and the series math is `dau`/`unique_users`, each user contributes to the (day-of-week, hour) bucket of their session's first event only — matching the web overview session-start attribution. When false (default), the user contributes to every bucket they have any event in. No effect on `total` math (event counts are unchanged either way). */
-    bucketBySessionStart?: boolean | null
-}
-
-export interface CompareFilterApi {
-    /** Whether to compare the current date range to a previous date range. */
-    compare?: boolean | null
-    /** The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago. */
-    compare_to?: string | null
-}
-
-export interface ActionConversionGoalApi {
-    actionId: number
-}
-
-export interface CustomEventConversionGoalApi {
-    customEventName: string
-}
-
-export interface DateRangeApi {
-    /** Start of the date range. Accepts ISO 8601 timestamps (e.g., 2024-01-15T00:00:00Z) or relative formats: -7d (7 days ago), -2w (2 weeks ago), -1m (1 month ago),
-     * -1h (1 hour ago), -1mStart (start of last month), -1yStart (start of last year). */
-    date_from?: string | null
-    /** End of the date range. Same format as date_from. Omit or null for "now". */
-    date_to?: string | null
-    /** Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period. */
-    explicitDate?: boolean | null
-}
-
 export type IntervalTypeApi = (typeof IntervalTypeApi)[keyof typeof IntervalTypeApi]
 
 export const IntervalTypeApi = {
@@ -306,27 +676,6 @@ export const CustomChannelOperatorApi = {
     Regex: 'regex',
     NotRegex: 'not_regex',
 } as const
-
-export interface CustomChannelConditionApi {
-    id: string
-    key: CustomChannelFieldApi
-    op: CustomChannelOperatorApi
-    value?: string | string[] | null
-}
-
-export interface CustomChannelRuleApi {
-    channel_type: string
-    combiner: FilterLogicalOperatorApi
-    id: string
-    items: CustomChannelConditionApi[]
-}
-
-export interface DataWarehouseEventsModifierApi {
-    distinct_id_field: string
-    id_field: string
-    table_name: string
-    timestamp_field: string
-}
 
 export type InCohortViaApi = (typeof InCohortViaApi)[keyof typeof InCohortViaApi]
 
@@ -422,44 +771,6 @@ export const SessionsV2JoinModeApi = {
     Uuid: 'uuid',
 } as const
 
-export interface HogQLQueryModifiersApi {
-    bounceRateDurationSeconds?: number | null
-    bounceRatePageViewMode?: BounceRatePageViewModeApi | null
-    convertToProjectTimezone?: boolean | null
-    customChannelTypeRules?: CustomChannelRuleApi[] | null
-    dataWarehouseEventsModifiers?: DataWarehouseEventsModifierApi[] | null
-    debug?: boolean | null
-    /** If these are provided, the query will fail if these skip indexes are not used */
-    forceClickhouseDataSkippingIndexes?: string[] | null
-    formatCsvAllowDoubleQuotes?: boolean | null
-    inCohortVia?: InCohortViaApi | null
-    inlineCohortCalculation?: InlineCohortCalculationApi | null
-    materializationMode?: MaterializationModeApi | null
-    materializedColumnsOptimizationMode?: MaterializedColumnsOptimizationModeApi | null
-    optimizeJoinedFilters?: boolean | null
-    optimizeProjections?: boolean | null
-    /** HogQL parser backend; absent → `rust_py_with_cpp_shadow` (rust-py is primary, cpp runs as a sampled shadow). `*_shadow` modes return the primary result and sample-compare against the other parser, reporting divergences without failing the request. The `rust_py_*` modes drive the same hand-rolled Rust parser as `rust_*` but build `posthog.hogql.ast` dataclass instances directly via PyO3, skipping the JSON round-trip. */
-    parserMode?: ParserModeApi | null
-    personsArgMaxVersion?: PersonsArgMaxVersionApi | null
-    personsJoinMode?: PersonsJoinModeApi | null
-    personsOnEventsMode?: PersonsOnEventsModeApi | null
-    propertyGroupsMode?: PropertyGroupsModeApi | null
-    pushDownPredicates?: boolean | null
-    s3TableUseInvalidColumns?: boolean | null
-    /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */
-    sessionIdPushdown?: boolean | null
-    /** Pre-filter raw_sessions aggregation by `session_id_v7 IN (cheap pre-aggregation that only materializes the columns referenced by the outer-WHERE session predicate)`. Useful when the breakdown/SELECT pulls in many session columns (e.g. `$channel_type`) but the filter only references one (e.g. `$entry_current_url`). */
-    sessionPropertyPreAggregation?: boolean | null
-    sessionTableVersion?: SessionTableVersionApi | null
-    sessionsV2JoinMode?: SessionsV2JoinModeApi | null
-    timings?: boolean | null
-    useMaterializedViews?: boolean | null
-    usePreaggregatedIntermediateResults?: boolean | null
-    /** Try to automatically convert HogQL queries to use preaggregated tables at the AST level * */
-    usePreaggregatedTableTransforms?: boolean | null
-    useWebAnalyticsPreAggregatedTables?: boolean | null
-}
-
 export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
 
 export const PropertyOperatorApi = {
@@ -499,24 +810,6 @@ export const PropertyOperatorApi = {
     NotIcontainsMulti: 'not_icontains_multi',
 } as const
 
-export interface EventPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    /** Event properties */
-    type?: 'event'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Person properties */
-    type?: 'person'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
 
 export const Key10Api = {
@@ -526,39 +819,6 @@ export const Key10Api = {
     Selector: 'selector',
 } as const
 
-export interface ElementPropertyFilterApi {
-    key: Key10Api
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'element'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface EventMetadataPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'event_metadata'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface SessionPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'session'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface CohortPropertyFilterApi {
-    cohort_name?: string | null
-    key?: 'id'
-    label?: string | null
-    operator?: PropertyOperatorApi | null
-    type?: 'cohort'
-    value: number
-}
-
 export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
 
 export const DurationTypeApi = {
@@ -567,91 +827,11 @@ export const DurationTypeApi = {
     InactiveSeconds: 'inactive_seconds',
 } as const
 
-export interface RecordingPropertyFilterApi {
-    key: DurationTypeApi | string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'recording'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface LogEntryPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'log_entry'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null
-
-export interface GroupPropertyFilterApi {
-    group_key_names?: GroupPropertyFilterApiGroupKeyNames
-    group_type_index?: number | null
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'group'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FeaturePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    /** Event property with "$feature/" prepended */
-    type?: 'feature'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface FlagPropertyFilterApi {
-    /** The key should be the flag ID */
-    key: string
-    label?: string | null
-    /** Only flag_evaluates_to operator is allowed for flag dependencies */
-    operator?: 'flag_evaluates_to'
-    /** Feature flag dependency */
-    type?: 'flag'
-    /** The value can be true, false, or a variant name */
-    value: boolean | string
-}
-
-export interface HogQLPropertyFilterApi {
-    key: string
-    label?: string | null
-    type?: 'hogql'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export const EmptyPropertyFilterApiValue = {
     type: 'empty',
 } as const
-export type EmptyPropertyFilterApi = typeof EmptyPropertyFilterApiValue
-
-export interface DataWarehousePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface DataWarehousePersonPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'data_warehouse_person_property'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface ErrorTrackingIssueFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'error_tracking_issue'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
 export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
 
 export const LogPropertyFilterTypeApi = {
@@ -659,14 +839,6 @@ export const LogPropertyFilterTypeApi = {
     LogAttribute: 'log_attribute',
     LogResourceAttribute: 'log_resource_attribute',
 } as const
-
-export interface LogPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: LogPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
 
 export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
 
@@ -676,159 +848,7 @@ export const SpanPropertyFilterTypeApi = {
     SpanResourceAttribute: 'span_resource_attribute',
 } as const
 
-export interface SpanPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type: SpanPropertyFilterTypeApi
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface RevenueAnalyticsPropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'revenue_analytics'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface WorkflowVariablePropertyFilterApi {
-    key: string
-    label?: string | null
-    operator: PropertyOperatorApi
-    type?: 'workflow_variable'
-    value?: (string | number | boolean)[] | string | number | boolean | null
-}
-
-export interface PropertyGroupFilterValueApi {
-    type: FilterLogicalOperatorApi
-    values: (
-        | PropertyGroupFilterValueApi
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | ElementPropertyFilterApi
-        | EventMetadataPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-        | RecordingPropertyFilterApi
-        | LogEntryPropertyFilterApi
-        | GroupPropertyFilterApi
-        | FeaturePropertyFilterApi
-        | FlagPropertyFilterApi
-        | HogQLPropertyFilterApi
-        | EmptyPropertyFilterApi
-        | DataWarehousePropertyFilterApi
-        | DataWarehousePersonPropertyFilterApi
-        | ErrorTrackingIssueFilterApi
-        | LogPropertyFilterApi
-        | SpanPropertyFilterApi
-        | RevenueAnalyticsPropertyFilterApi
-        | WorkflowVariablePropertyFilterApi
-    )[]
-}
-
-export interface PropertyGroupFilterApi {
-    type: FilterLogicalOperatorApi
-    values: PropertyGroupFilterValueApi[]
-}
-
-export interface BoxPlotDatumApi {
-    day: string
-    label: string
-    max: number
-    mean: number
-    median: number
-    min: number
-    p25: number
-    p75: number
-    series_index?: number | null
-    series_label?: string | null
-}
-
-export interface ClickhouseQueryProgressApi {
-    active_cpu_time: number
-    bytes_read: number
-    estimated_rows_total: number
-    rows_read: number
-    time_elapsed: number
-}
-
-export interface QueryStatusApi {
-    /** Whether the query is still running. Will be true if the query is complete, even if it errored. Either result or error will be set. */
-    complete?: boolean | null
-    dashboard_id?: number | null
-    /** When did the query execution task finish (whether successfully or not). */
-    end_time?: string | null
-    /** If the query failed, this will be set to true. More information can be found in the error_message field. */
-    error?: boolean | null
-    error_message?: string | null
-    expiration_time?: string | null
-    id: string
-    insight_id?: number | null
-    labels?: string[] | null
-    /** When was the query execution task picked up by a worker. */
-    pickup_time?: string | null
-    /** ONLY async queries use QueryStatus. */
-    query_async?: true
-    query_progress?: ClickhouseQueryProgressApi | null
-    results?: unknown
-    /** When was query execution task enqueued. */
-    start_time?: string | null
-    task_id?: string | null
-    team_id: number
-}
-
-export interface ResolvedDateRangeResponseApi {
-    date_from: string
-    date_to: string
-}
-
-export interface QueryTimingApi {
-    /** Key. Shortened to 'k' to save on data. */
-    k: string
-    /** Time in seconds. Shortened to 't' to save on data. */
-    t: number
-}
-
-export interface DataWarehouseSyncWarningApi {
-    /** Human-readable warning shown to the user */
-    message: string
-    /** Name of the ExternalDataSchema responsible for syncing the table */
-    schema_name: string
-    /** ID of the ExternalDataSource, used to link to its management page. Null for self-managed tables. */
-    source_id?: string | null
-    /** Source type, e.g. "Stripe", "Hubspot" */
-    source_type: string
-    /** Sync status that triggered the warning, e.g. "Failed", "Paused", "BillingLimitReached" */
-    status: string
-    /** Name of the warehouse table the warning refers to */
-    table_name: string
-}
-
 export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface TrendsQueryResponseApi {
-    boxplot_data?: BoxPlotDatumApi[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Wether more breakdown values are available. */
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: TrendsQueryResponseApiResultsItem[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
 
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
 
@@ -1065,350 +1085,13 @@ export const CurrencyCodeApi = {
     Zmw: 'ZMW',
 } as const
 
-export interface RevenueCurrencyPropertyConfigApi {
-    property?: string | null
-    static?: CurrencyCodeApi | null
-}
-
 export type EventsNodeApiResponse = { [key: string]: unknown } | null
-
-export interface EventsNodeApi {
-    custom_name?: string | null
-    /** The event or `null` for all events. */
-    event?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'EventsNode'
-    limit?: number | null
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: EventsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ActionsNodeApiResponse = { [key: string]: unknown } | null
 
-export interface ActionsNodeApi {
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: number
-    kind?: 'ActionsNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: ActionsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type DataWarehouseNodeApiResponse = { [key: string]: unknown } | null
 
-export interface DataWarehouseNodeApi {
-    custom_name?: string | null
-    distinct_id_field: string
-    dw_source_type?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: string
-    id_field: string
-    kind?: 'DataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: DataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type GroupNodeApiResponse = { [key: string]: unknown } | null
-
-export interface GroupNodeApi {
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'GroupNode'
-    limit?: number | null
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    /** Entities to combine in this group */
-    nodes: (EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
-    /** Group of entities combined with AND/OR operator */
-    operator: FilterLogicalOperatorApi
-    optionalInFunnel?: boolean | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: GroupNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface QueryLogTagsApi {
-    /** Name of the query, preferably unique. For example web_analytics_vitals */
-    name?: string | null
-    /** Product responsible for this query. Use string, there's no need to churn the Schema when we add a new product * */
-    productKey?: string | null
-    /** Scene where this query is shown in the UI. Use string, there's no need to churn the Schema when we add a new Scene * */
-    scene?: string | null
-}
 
 export type AggregationAxisFormatApi = (typeof AggregationAxisFormatApi)[keyof typeof AggregationAxisFormatApi]
 
@@ -1451,27 +1134,12 @@ export const ChartDisplayTypeApi = {
     BoxPlot: 'BoxPlot',
 } as const
 
-export interface TrendsFormulaNodeApi {
-    /** Optional user-defined name for the formula */
-    custom_name?: string | null
-    formula: string
-}
-
 export type PositionApi = (typeof PositionApi)[keyof typeof PositionApi]
 
 export const PositionApi = {
     Start: 'start',
     End: 'end',
 } as const
-
-export interface GoalLineApi {
-    borderColor?: string | null
-    displayIfCrossed?: boolean | null
-    displayLabel?: boolean | null
-    label: string
-    position?: PositionApi | null
-    value: number
-}
 
 export type ResultCustomizationByApi = (typeof ResultCustomizationByApi)[keyof typeof ResultCustomizationByApi]
 
@@ -1500,18 +1168,6 @@ export const DataColorTokenApi = {
     Preset15: 'preset-15',
 } as const
 
-export interface ResultCustomizationByValueApi {
-    assignmentBy?: 'value'
-    color?: DataColorTokenApi | null
-    hidden?: boolean | null
-}
-
-export interface ResultCustomizationByPositionApi {
-    assignmentBy?: 'position'
-    color?: DataColorTokenApi | null
-    hidden?: boolean | null
-}
-
 export type YAxisScaleTypeApi = (typeof YAxisScaleTypeApi)[keyof typeof YAxisScaleTypeApi]
 
 export const YAxisScaleTypeApi = {
@@ -1527,124 +1183,6 @@ export type TrendsFilterApiResultCustomizations =
     | { [key: string]: ResultCustomizationByPositionApi }
     | null
 
-export interface TrendsFilterApi {
-    /** Y-axis value formatter. Picks a human-friendly unit per value at render time without changing the underlying series values.
-     *
-     * - `numeric` (default): raw numbers, e.g. `1,234`.
-     * - `duration`: values are in seconds; rendered as friendly units per value (`45s`, `2m 12s`, `1h 4m`). Use this whenever the series is in seconds (latency, session length, time-to-event) instead of dividing in `formula` to force minutes or hours.
-     * - `duration_ms`: values are in milliseconds; rendered as friendly units (`850ms`, `1.5s`, `1m 4s`).
-     * - `percentage`: values are already in the 0-100 range; appends `%`.
-     * - `percentage_scaled`: values are a 0-1 ratio; multiplied and rendered as `%`.
-     * - `currency`: values are in the project's base currency (set in project settings, defaults to USD); rendered with that currency symbol. For values pinned to a specific currency regardless of project base (e.g. `$ai_total_cost_usd` is always USD), use `aggregationAxisPrefix` instead.
-     * - `short`: compact notation for large counts (`1.2K`, `3.4M`). */
-    aggregationAxisFormat?: AggregationAxisFormatApi | null
-    /** Literal suffix applied to every value (e.g. ` req`). Reserve for units that `aggregationAxisFormat` cannot express. Do not use ` mins`, ` s`, ` ms`, `%` etc. — pick the matching `aggregationAxisFormat` instead so the underlying values stay numerically correct for breakdowns, formulas, and alerts. Include any leading space yourself. */
-    aggregationAxisPostfix?: string | null
-    /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
-    aggregationAxisPrefix?: string | null
-    breakdown_histogram_bin_count?: number | null
-    confidenceLevel?: number | null
-    /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
-    decimalPlaces?: number | null
-    /** detailed results table */
-    detailedResultsAggregationType?: DetailedResultsAggregationTypeApi | null
-    display?: ChartDisplayTypeApi | null
-    excludeBoxPlotOutliers?: boolean | null
-    formula?: string | null
-    /** List of formulas with optional custom names. Takes precedence over formula/formulas if set. */
-    formulaNodes?: TrendsFormulaNodeApi[] | null
-    formulas?: string[] | null
-    /** Goal Lines */
-    goalLines?: GoalLineApi[] | null
-    hiddenLegendIndexes?: number[] | null
-    hideWeekends?: boolean | null
-    minDecimalPlaces?: number | null
-    movingAverageIntervals?: number | null
-    /** Wether result datasets are associated by their values or by their order. */
-    resultCustomizationBy?: ResultCustomizationByApi | null
-    /** Customizations for the appearance of result datasets. */
-    resultCustomizations?: TrendsFilterApiResultCustomizations
-    showAlertThresholdLines?: boolean | null
-    showAnnotations?: boolean | null
-    showConfidenceIntervals?: boolean | null
-    showLabelsOnSeries?: boolean | null
-    showLegend?: boolean | null
-    showMovingAverage?: boolean | null
-    showMultipleYAxes?: boolean | null
-    showPercentStackView?: boolean | null
-    showTrendLines?: boolean | null
-    showValuesOnSeries?: boolean | null
-    smoothingIntervals?: number | null
-    /** On the horizontal bar-value chart, stack a series' breakdown values into a single bar instead of rendering one bar per breakdown value. */
-    stackBreakdownValues?: boolean | null
-    /** Custom label rendered under the X axis. */
-    xAxisLabel?: string | null
-    /** Custom label rendered alongside the Y axis. */
-    yAxisLabel?: string | null
-    yAxisScaleType?: YAxisScaleTypeApi | null
-}
-
-export interface TrendsQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Breakdown of the events and actions */
-    breakdownFilter?: BreakdownFilterApi | null
-    /** Properties specific to the calendar heatmap display variant. Only consulted when `trendsFilter.display === ChartDisplayType.CalendarHeatmap`; ignored otherwise. */
-    calendarHeatmapFilter?: CalendarHeatmapFilterApi | null
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    /** Whether we should be comparing against a specific conversion goal */
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    kind?: 'TrendsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: TrendsQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (GroupNodeApi | EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** Properties specific to the trends insight */
-    trendsFilter?: TrendsFilterApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type BreakdownAttributionTypeApi = (typeof BreakdownAttributionTypeApi)[keyof typeof BreakdownAttributionTypeApi]
 
 export const BreakdownAttributionTypeApi = {
@@ -1656,169 +1194,7 @@ export const BreakdownAttributionTypeApi = {
 
 export type FunnelExclusionEventsNodeApiResponse = { [key: string]: unknown } | null
 
-export interface FunnelExclusionEventsNodeApi {
-    custom_name?: string | null
-    /** The event or `null` for all events. */
-    event?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    funnelFromStep: number
-    funnelToStep: number
-    kind?: 'EventsNode'
-    limit?: number | null
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: FunnelExclusionEventsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type FunnelExclusionActionsNodeApiResponse = { [key: string]: unknown } | null
-
-export interface FunnelExclusionActionsNodeApi {
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    funnelFromStep: number
-    funnelToStep: number
-    id: number
-    kind?: 'ActionsNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: FunnelExclusionActionsNodeApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type StepOrderValueApi = (typeof StepOrderValueApi)[keyof typeof StepOrderValueApi]
 
@@ -1868,232 +1244,7 @@ export const FunnelLayoutApi = {
  */
 export type FunnelsFilterApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
 
-export interface FunnelsFilterApi {
-    binCount?: number | null
-    breakdownAttributionType?: BreakdownAttributionTypeApi | null
-    breakdownAttributionValue?: number | null
-    /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */
-    breakdownSorting?: string | null
-    /** For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups. */
-    customAggregationTarget?: boolean | null
-    exclusions?: (FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi)[] | null
-    funnelAggregateByHogQL?: string | null
-    funnelFromStep?: number | null
-    funnelOrderType?: StepOrderValueApi | null
-    funnelStepReference?: FunnelStepReferenceApi | null
-    /** To select the range of steps for trends & time to convert funnels, 0-indexed */
-    funnelToStep?: number | null
-    funnelVizType?: FunnelVizTypeApi | null
-    funnelWindowInterval?: number | null
-    funnelWindowIntervalUnit?: FunnelConversionWindowTimeUnitApi | null
-    /** Goal Lines */
-    goalLines?: GoalLineApi[] | null
-    hiddenLegendBreakdowns?: string[] | null
-    /** Trends only: hide periods whose conversion window has not fully elapsed yet, so the recent tail of the trend isn't dragged down by entrants who still have time to convert. */
-    hideIncompleteConversionWindowPeriods?: boolean | null
-    layout?: FunnelLayoutApi | null
-    /** Customizations for the appearance of result datasets. */
-    resultCustomizations?: FunnelsFilterApiResultCustomizations
-    /** Whether to render annotations on the chart. Only applies to historical-trends funnels. */
-    showAnnotations?: boolean | null
-    /** Display linear regression trend lines on the chart (only for historical trends viz) */
-    showTrendLines?: boolean | null
-    showValuesOnSeries?: boolean | null
-    useUdf?: boolean | null
-}
-
-export interface FunnelsQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
 export type FunnelsDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
-
-export interface FunnelsDataWarehouseNodeApi {
-    aggregation_target_field: string
-    custom_name?: string | null
-    dw_source_type?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: string
-    id_field: string
-    kind?: 'FunnelsDataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: FunnelsDataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface FunnelsQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Breakdown of the events and actions */
-    breakdownFilter?: BreakdownFilterApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Properties specific to the funnels insight */
-    funnelsFilter?: FunnelsFilterApi | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    kind?: 'FunnelsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: FunnelsQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (GroupNodeApi | EventsNodeApi | ActionsNodeApi | FunnelsDataWarehouseNodeApi)[]
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RetentionValueApi {
-    aggregation_value?: number | null
-    count: number
-    label?: string | null
-}
-
-export interface RetentionResultApi {
-    /** Optional breakdown value for retention cohorts */
-    breakdown_value?: string | number | null
-    date: string
-    label: string
-    values: RetentionValueApi[]
-}
-
-export interface RetentionQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: RetentionResultApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
 
 export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[keyof typeof AggregationPropertyTypeApi]
 
@@ -2169,138 +1320,12 @@ export const EntityTypeApi = {
     Groups: 'groups',
 } as const
 
-export interface RetentionEntityApi {
-    /** Data warehouse field used as the actor identifier */
-    aggregation_target_field?: string | null
-    custom_name?: string | null
-    id?: string | number | null
-    kind?: RetentionEntityKindApi | null
-    name?: string | null
-    order?: number | null
-    /** filters on the event */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    /** Data warehouse table name */
-    table_name?: string | null
-    /** Data warehouse timestamp field */
-    timestamp_field?: string | null
-    type?: EntityTypeApi | null
-    uuid?: string | null
-}
-
 export type TimeWindowModeApi = (typeof TimeWindowModeApi)[keyof typeof TimeWindowModeApi]
 
 export const TimeWindowModeApi = {
     StrictCalendarDates: 'strict_calendar_dates',
     '24HourWindows': '24_hour_windows',
 } as const
-
-export interface RetentionFilterApi {
-    /** The property to aggregate when aggregationType is sum or avg */
-    aggregationProperty?: string | null
-    /** The type of property to aggregate on (event, person or data_warehouse). Defaults to event. */
-    aggregationPropertyType?: AggregationPropertyTypeApi | null
-    /** The aggregation type to use for retention */
-    aggregationType?: AggregationTypeApi | null
-    /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
-    cohortLabelStartIndex?: number | null
-    cumulative?: boolean | null
-    /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
-    customAggregationTarget?: boolean | null
-    dashboardDisplay?: RetentionDashboardDisplayTypeApi | null
-    /** controls the display of the retention graph */
-    display?: ChartDisplayTypeApi | null
-    goalLines?: GoalLineApi[] | null
-    meanRetentionCalculation?: MeanRetentionCalculationApi | null
-    minimumOccurrences?: number | null
-    period?: RetentionPeriodApi | null
-    /** Custom brackets for retention calculations */
-    retentionCustomBrackets?: number[] | null
-    /** Whether retention is with regard to initial cohort size, or that of the previous period. */
-    retentionReference?: RetentionReferenceApi | null
-    retentionType?: RetentionTypeApi | null
-    returningEntity?: RetentionEntityApi | null
-    /** The selected interval to display across all cohorts (null = show all intervals for each cohort) */
-    selectedInterval?: number | null
-    showTrendLines?: boolean | null
-    targetEntity?: RetentionEntityApi | null
-    /** The time window mode to use for retention calculations */
-    timeWindowMode?: TimeWindowModeApi | null
-    totalIntervals?: number | null
-}
-
-export interface RetentionQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Breakdown of the events and actions */
-    breakdownFilter?: BreakdownFilterApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    kind?: 'RetentionQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: RetentionQueryResponseApi | null
-    /** Properties specific to the retention insight */
-    retentionFilter: RetentionFilterApi
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type FunnelPathTypeApi = (typeof FunnelPathTypeApi)[keyof typeof FunnelPathTypeApi]
 
@@ -2309,12 +1334,6 @@ export const FunnelPathTypeApi = {
     FunnelPathBetweenSteps: 'funnel_path_between_steps',
     FunnelPathAfterStep: 'funnel_path_after_step',
 } as const
-
-export interface FunnelPathsFilterApi {
-    funnelPathType?: FunnelPathTypeApi | null
-    funnelSource: FunnelsQueryApi
-    funnelStep?: number | null
-}
 
 export type PathTypeApi = (typeof PathTypeApi)[keyof typeof PathTypeApi]
 
@@ -2325,133 +1344,7 @@ export const PathTypeApi = {
     Hogql: 'hogql',
 } as const
 
-export interface PathCleaningFilterApi {
-    alias?: string | null
-    order?: number | null
-    regex?: string | null
-}
-
-export interface PathsFilterApi {
-    edgeLimit?: number | null
-    endPoint?: string | null
-    excludeEvents?: string[] | null
-    includeEventTypes?: PathTypeApi[] | null
-    localPathCleaningFilters?: PathCleaningFilterApi[] | null
-    maxEdgeWeight?: number | null
-    minEdgeWeight?: number | null
-    /** Relevant only within actors query */
-    pathDropoffKey?: string | null
-    /** Relevant only within actors query */
-    pathEndKey?: string | null
-    pathGroupings?: string[] | null
-    pathReplacements?: boolean | null
-    /** Relevant only within actors query */
-    pathStartKey?: string | null
-    pathsHogQLExpression?: string | null
-    showFullUrls?: boolean | null
-    startPoint?: string | null
-    stepLimit?: number | null
-}
-
-export interface PathsLinkApi {
-    average_conversion_time: number
-    source: string
-    target: string
-    value: number
-}
-
-export interface PathsQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: PathsLinkApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface PathsQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Used for displaying paths in relation to funnel steps. */
-    funnelPathsFilter?: FunnelPathsFilterApi | null
-    kind?: 'PathsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Properties specific to the paths insight */
-    pathsFilter: PathsFilterApi
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: PathsQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type StickinessQueryResponseApiResultsItem = { [key: string]: unknown }
-
-export interface StickinessQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: StickinessQueryResponseApiResultsItem[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
 
 export type StickinessComputationModeApi =
     (typeof StickinessComputationModeApi)[keyof typeof StickinessComputationModeApi]
@@ -2469,12 +1362,6 @@ export const StickinessOperatorApi = {
     Exact: 'exact',
 } as const
 
-export interface StickinessCriteriaApi {
-    operator: StickinessOperatorApi
-    /** @minimum 1 */
-    value: number
-}
-
 /**
  * Customizations for the appearance of result datasets.
  */
@@ -2482,75 +1369,6 @@ export type StickinessFilterApiResultCustomizations =
     | { [key: string]: ResultCustomizationByValueApi }
     | { [key: string]: ResultCustomizationByPositionApi }
     | null
-
-export interface StickinessFilterApi {
-    computedAs?: StickinessComputationModeApi | null
-    display?: ChartDisplayTypeApi | null
-    hiddenLegendIndexes?: number[] | null
-    /** Whether result datasets are associated by their values or by their order. */
-    resultCustomizationBy?: ResultCustomizationByApi | null
-    /** Customizations for the appearance of result datasets. */
-    resultCustomizations?: StickinessFilterApiResultCustomizations
-    showLegend?: boolean | null
-    showMultipleYAxes?: boolean | null
-    showValuesOnSeries?: boolean | null
-    stickinessCriteria?: StickinessCriteriaApi | null
-}
-
-export interface StickinessQueryApi {
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    /** How many intervals comprise a period. Only used for cohorts, otherwise default 1. */
-    intervalCount?: number | null
-    kind?: 'StickinessQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: StickinessQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi)[]
-    /** Properties specific to the stickiness insight */
-    stickinessFilter?: StickinessFilterApi | null
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type LifecycleToggleApi = (typeof LifecycleToggleApi)[keyof typeof LifecycleToggleApi]
 
@@ -2561,174 +1379,9 @@ export const LifecycleToggleApi = {
     Dormant: 'dormant',
 } as const
 
-export interface LifecycleFilterApi {
-    showLegend?: boolean | null
-    /** Append per-band percentage to each value label (e.g. `580 (42%)`). Requires `showValuesOnSeries` — on its own it has no visible effect. */
-    showPercentagesOnSeries?: boolean | null
-    showValuesOnSeries?: boolean | null
-    stacked?: boolean | null
-    toggledLifecycles?: LifecycleToggleApi[] | null
-}
-
 export type LifecycleQueryResponseApiResultsItem = { [key: string]: unknown }
 
-export interface LifecycleQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: LifecycleQueryResponseApiResultsItem[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
 export type LifecycleDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
-
-export interface LifecycleDataWarehouseNodeApi {
-    aggregation_target_field: string
-    created_at_field: string
-    custom_name?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    id: string
-    kind?: 'LifecycleDataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: LifecycleDataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface LifecycleQueryApi {
-    /** Groups aggregation */
-    aggregation_group_type_index?: number | null
-    /** For data warehouse based lifecycle insights when the aggregation target can't be mapped to persons or groups. */
-    customAggregationTarget?: boolean | null
-    /** Colors used in the insight's visualization */
-    dataColorTheme?: number | null
-    /** Date range for the query */
-    dateRange?: DateRangeApi | null
-    /** Exclude internal and test users by applying the respective filters */
-    filterTestAccounts?: boolean | null
-    /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
-    interval?: IntervalTypeApi | null
-    kind?: 'LifecycleQuery'
-    /** Properties specific to the lifecycle insight */
-    lifecycleFilter?: LifecycleFilterApi | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Property filters for all series */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | PropertyGroupFilterApi
-        | null
-    response?: LifecycleQueryResponseApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Events and actions to include */
-    series: (EventsNodeApi | ActionsNodeApi | LifecycleDataWarehouseNodeApi)[]
-    /** Tags that will be added to the Query log comment */
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type WebStatsBreakdownApi = (typeof WebStatsBreakdownApi)[keyof typeof WebStatsBreakdownApi]
 
@@ -2788,86 +1441,6 @@ export const WebAnalyticsOrderByDirectionApi = {
     Desc: 'DESC',
 } as const
 
-export interface SamplingRateApi {
-    denominator?: number | null
-    numerator: number
-}
-
-export interface WebStatsTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebAnalyticsSamplingApi {
-    enabled?: boolean | null
-    forceSamplingRate?: SamplingRateApi | null
-}
-
-export interface WebStatsTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    breakdownBy: WebStatsBreakdownApi
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeAvgTimeOnPage?: boolean | null
-    includeBounceRate?: boolean | null
-    includeHost?: boolean | null
-    includeRevenue?: boolean | null
-    includeScrollDepth?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebStatsTableQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebStatsTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web stats table precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type WebAnalyticsItemKindApi = (typeof WebAnalyticsItemKindApi)[keyof typeof WebAnalyticsItemKindApi]
 
 export const WebAnalyticsItemKindApi = {
@@ -2876,76 +1449,6 @@ export const WebAnalyticsItemKindApi = {
     Percentage: 'percentage',
     Currency: 'currency',
 } as const
-
-export interface WebOverviewItemApi {
-    changeFromPreviousPct?: number | null
-    isIncreaseBad?: boolean | null
-    key: string
-    kind: WebAnalyticsItemKindApi
-    previous?: number | null
-    usedPreAggregatedTables?: boolean | null
-    value?: number | null
-}
-
-export interface WebOverviewQueryResponseApi {
-    dateFrom?: string | null
-    dateTo?: string | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: WebOverviewItemApi[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    usedPreAggregatedTables?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebOverviewQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebOverviewQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebOverviewQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web_overview_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export interface ActionsPieApi {
     disableHoverOffset?: boolean | null
@@ -2958,41 +1461,6 @@ export interface RetentionApi {
     useSmallLayout?: boolean | null
 }
 
-export interface VizSpecificOptionsApi {
-    ActionsPie?: ActionsPieApi | null
-    RETENTION?: RetentionApi | null
-}
-
-export interface InsightVizNodeApi {
-    /** Query is embedded inside another bordered component */
-    embedded?: boolean | null
-    /** Show with most visual options enabled. Used in insight scene. */
-    full?: boolean | null
-    hidePersonsModal?: boolean | null
-    hideTooltipOnScroll?: boolean | null
-    kind: InsightVizNodeApiKind
-    showCorrelationTable?: boolean | null
-    showFilters?: boolean | null
-    showHeader?: boolean | null
-    showLastComputation?: boolean | null
-    showLastComputationRefresh?: boolean | null
-    showResults?: boolean | null
-    showTable?: boolean | null
-    source:
-        | TrendsQueryApi
-        | FunnelsQueryApi
-        | RetentionQueryApi
-        | PathsQueryApi
-        | StickinessQueryApi
-        | LifecycleQueryApi
-        | WebStatsTableQueryApi
-        | WebOverviewQueryApi
-    suppressSessionAnalysisWarning?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    vizSpecificOptions?: VizSpecificOptionsApi | null
-}
-
 export type DataTableNodeViewPropsContextTypeApi =
     (typeof DataTableNodeViewPropsContextTypeApi)[keyof typeof DataTableNodeViewPropsContextTypeApi]
 
@@ -3000,11 +1468,6 @@ export const DataTableNodeViewPropsContextTypeApi = {
     EventDefinition: 'event_definition',
     TeamColumns: 'team_columns',
 } as const
-
-export interface DataTableNodeViewPropsContextApi {
-    eventDefinitionId?: string | null
-    type: DataTableNodeViewPropsContextTypeApi
-}
 
 export type DataTableNodeApiKind = (typeof DataTableNodeApiKind)[keyof typeof DataTableNodeApiKind]
 
@@ -3091,13 +1554,6 @@ export interface Response2Api {
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export interface HogQLNoticeApi {
-    end?: number | null
-    fix?: string | null
-    message: string
-    start?: number | null
-}
-
 export type QueryIndexUsageApi = (typeof QueryIndexUsageApi)[keyof typeof QueryIndexUsageApi]
 
 export const QueryIndexUsageApi = {
@@ -3106,17 +1562,6 @@ export const QueryIndexUsageApi = {
     Partial: 'partial',
     Yes: 'yes',
 } as const
-
-export interface HogQLMetadataResponseApi {
-    ch_table_names?: string[] | null
-    errors: HogQLNoticeApi[]
-    isUsingIndices?: QueryIndexUsageApi | null
-    isValid?: boolean | null
-    notices: HogQLNoticeApi[]
-    query?: string | null
-    table_names?: string[] | null
-    warnings: HogQLNoticeApi[]
-}
 
 export interface Response3Api {
     /** Executed ClickHouse query */
@@ -3262,17 +1707,6 @@ export interface Response7Api {
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export interface WebVitalsPathBreakdownResultItemApi {
-    path: string
-    value: number
-}
-
-export interface WebVitalsPathBreakdownResultApi {
-    good: WebVitalsPathBreakdownResultItemApi[]
-    needs_improvements: WebVitalsPathBreakdownResultItemApi[]
-    poor: WebVitalsPathBreakdownResultItemApi[]
-}
-
 export interface Response8Api {
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
     error?: string | null
@@ -3390,14 +1824,6 @@ export interface Response12Api {
     warnings?: DataWarehouseSyncWarningApi[] | null
 }
 
-export interface RevenueAnalyticsMRRQueryResultItemApi {
-    churn: unknown
-    contraction: unknown
-    expansion: unknown
-    new: unknown
-    total: unknown
-}
-
 export interface Response13Api {
     columns?: string[] | null
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -3427,11 +1853,6 @@ export const RevenueAnalyticsOverviewItemKeyApi = {
     PayingCustomerCount: 'paying_customer_count',
     AvgRevenuePerCustomer: 'avg_revenue_per_customer',
 } as const
-
-export interface RevenueAnalyticsOverviewItemApi {
-    key: RevenueAnalyticsOverviewItemKeyApi
-    value: number
-}
 
 export interface Response14Api {
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -3497,16 +1918,6 @@ export interface Response16Api {
     types?: unknown[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
     warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface MarketingAnalyticsItemApi {
-    changeFromPreviousPct?: number | null
-    hasComparison?: boolean | null
-    isIncreaseBad?: boolean | null
-    key: string
-    kind: WebAnalyticsItemKindApi
-    previous?: number | string | null
-    value?: number | string | null
 }
 
 export interface Response18Api {
@@ -3589,14 +2000,6 @@ export interface VolumeBucketApi {
     value: number
 }
 
-export interface ErrorTrackingIssueAggregationsApi {
-    occurrences: number
-    sessions: number
-    users: number
-    volumeRange?: number[] | null
-    volume_buckets: VolumeBucketApi[]
-}
-
 export type ErrorTrackingIssueAssigneeTypeApi =
     (typeof ErrorTrackingIssueAssigneeTypeApi)[keyof typeof ErrorTrackingIssueAssigneeTypeApi]
 
@@ -3604,16 +2007,6 @@ export const ErrorTrackingIssueAssigneeTypeApi = {
     User: 'user',
     Role: 'role',
 } as const
-
-export interface ErrorTrackingIssueAssigneeApi {
-    id: string | number
-    type: ErrorTrackingIssueAssigneeTypeApi
-}
-
-export interface ErrorTrackingIssueCohortApi {
-    id: number
-    name: string
-}
 
 export type IntegrationKindApi = (typeof IntegrationKindApi)[keyof typeof IntegrationKindApi]
 
@@ -3652,18 +2045,6 @@ export const IntegrationKindApi = {
     CustomerioTrack: 'customerio-track',
 } as const
 
-export interface ErrorTrackingExternalReferenceIntegrationApi {
-    display_name: string
-    id: number
-    kind: IntegrationKindApi
-}
-
-export interface ErrorTrackingExternalReferenceApi {
-    external_url: string
-    id: string
-    integration: ErrorTrackingExternalReferenceIntegrationApi
-}
-
 export interface FirstEventApi {
     distinct_id: string
     properties: string
@@ -3687,24 +2068,6 @@ export const ErrorTrackingIssueStatusApi = {
     PendingRelease: 'pending_release',
     Suppressed: 'suppressed',
 } as const
-
-export interface ErrorTrackingIssueApi {
-    aggregations?: ErrorTrackingIssueAggregationsApi | null
-    assignee?: ErrorTrackingIssueAssigneeApi | null
-    cohort?: ErrorTrackingIssueCohortApi | null
-    description?: string | null
-    external_issues?: ErrorTrackingExternalReferenceApi[] | null
-    first_event?: FirstEventApi | null
-    first_seen: string
-    function?: string | null
-    id: string
-    last_event?: LastEventApi | null
-    last_seen: string
-    library?: string | null
-    name?: string | null
-    source?: string | null
-    status: ErrorTrackingIssueStatusApi
-}
 
 export interface Response21Api {
     columns?: string[] | null
@@ -3735,22 +2098,6 @@ export interface PopulationApi {
     exception_only: number
     neither: number
     success_only: number
-}
-
-export interface ErrorTrackingCorrelatedIssueApi {
-    assignee?: ErrorTrackingIssueAssigneeApi | null
-    cohort?: ErrorTrackingIssueCohortApi | null
-    description?: string | null
-    event: string
-    external_issues?: ErrorTrackingExternalReferenceApi[] | null
-    first_seen: string
-    id: string
-    last_seen: string
-    library?: string | null
-    name?: string | null
-    odds_ratio: number
-    population: PopulationApi
-    status: ErrorTrackingIssueStatusApi
 }
 
 export interface Response22Api {
@@ -3788,12 +2135,6 @@ export const ExperimentSignificanceCodeApi = {
     HighPValue: 'high_p_value',
 } as const
 
-export interface ExperimentVariantFunnelsBaseStatsApi {
-    failure_count: number
-    key: string
-    success_count: number
-}
-
 export type Response23ApiCredibleIntervals = { [key: string]: number[] }
 
 export type Response23ApiInsightItemItem = { [key: string]: unknown }
@@ -3813,13 +2154,6 @@ export interface Response23Api {
     variants: ExperimentVariantFunnelsBaseStatsApi[]
     /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
     warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentVariantTrendsBaseStatsApi {
-    absolute_exposure: number
-    count: number
-    exposure: number
-    key: string
 }
 
 export type Response24ApiCredibleIntervals = { [key: string]: number[] }
@@ -3863,44 +2197,7 @@ export const AIEventTypeApi = {
 
 export type LLMTraceEventApiProperties = { [key: string]: unknown }
 
-export interface LLMTraceEventApi {
-    createdAt: string
-    event: AIEventTypeApi | string
-    id: string
-    properties: LLMTraceEventApiProperties
-}
-
 export type LLMTracePersonApiProperties = { [key: string]: unknown }
-
-export interface LLMTracePersonApi {
-    created_at: string
-    distinct_id: string
-    properties: LLMTracePersonApiProperties
-    uuid: string
-}
-
-export interface LLMTraceApi {
-    aiSessionId?: string | null
-    createdAt: string
-    distinctId: string
-    errorCount?: number | null
-    events: LLMTraceEventApi[]
-    id: string
-    inputCost?: number | null
-    inputState?: unknown
-    inputTokens?: number | null
-    isSupportTrace?: boolean | null
-    outputCost?: number | null
-    outputState?: unknown
-    outputTokens?: number | null
-    person?: LLMTracePersonApi | null
-    requestCost?: number | null
-    tools?: string[] | null
-    totalCost?: number | null
-    totalLatency?: number | null
-    traceName?: string | null
-    webSearchCost?: number | null
-}
 
 export interface Response25Api {
     columns?: string[] | null
@@ -4063,69 +2360,6 @@ export const UrlMatchingApi = {
     Regex: 'regex',
 } as const
 
-export interface EventsQueryActionStepApi {
-    event?: string | null
-    href?: string | null
-    href_matching?: HrefMatchingApi | null
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    selector?: string | null
-    tag_name?: string | null
-    text?: string | null
-    text_matching?: TextMatchingApi | null
-    url?: string | null
-    url_matching?: UrlMatchingApi | null
-}
-
-export interface EventsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Cursor for fetching the next page of results */
-    nextCursor?: string | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
 export type CompareApi = (typeof CompareApi)[keyof typeof CompareApi]
 
 export const CompareApi = {
@@ -4133,234 +2367,7 @@ export const CompareApi = {
     Previous: 'previous',
 } as const
 
-export interface ActorsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    limit: number
-    missing_actors_count?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset: number
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: string[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface InsightActorsQueryApi {
-    breakdown?: string | string[] | number | null
-    compare?: CompareApi | null
-    day?: string | number | null
-    includeRecordings?: boolean | null
-    /** An interval selected out of available intervals in source query. */
-    interval?: number | null
-    kind?: 'InsightActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ActorsQueryResponseApi | null
-    series?: number | null
-    source:
-        | TrendsQueryApi
-        | FunnelsQueryApi
-        | RetentionQueryApi
-        | PathsQueryApi
-        | StickinessQueryApi
-        | LifecycleQueryApi
-        | WebStatsTableQueryApi
-        | WebOverviewQueryApi
-    status?: string | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface EventsQueryApi {
-    /** Show events matching a given action */
-    actionId?: number | null
-    /** Show events matching action steps directly, used when no actionId is provided (e.g. previewing unsaved actions). Ignored if actionId is set. */
-    actionSteps?: EventsQueryActionStepApi[] | null
-    /** Only fetch events that happened after this timestamp */
-    after?: string | null
-    /** Only fetch events that happened before this timestamp */
-    before?: string | null
-    /** Limit to events matching this string */
-    event?: string | null
-    /** Filter to events matching any of these event names */
-    events?: string[] | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | PropertyGroupFilterApi
-              | PropertyGroupFilterValueApi
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'EventsQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Show events for a given person */
-    personId?: string | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: EventsQueryResponseApi | null
-    /** Return a limited set of data. Required. */
-    select: string[]
-    /** source for querying events for insights */
-    source?: InsightActorsQueryApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    /** HogQL filters to apply on returned data */
-    where?: string[] | null
-}
-
 export type PersonsNodeApiResponse = { [key: string]: unknown } | null
-
-export interface PersonsNodeApi {
-    cohort?: number | null
-    distinctId?: string | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'PersonsNode'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: PersonsNodeApiResponse
-    search?: string | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface FunnelsActorsQueryApi {
-    /** Index of the step for which we want to get the timestamp for, per person. Positive for converted persons, negative for dropped of persons. */
-    funnelStep?: number | null
-    /** The breakdown value for which to get persons for. This is an array for person and event properties, a string for groups and an integer for cohorts. */
-    funnelStepBreakdown?: number | string | (number | string)[] | null
-    funnelTrendsDropOff?: boolean | null
-    /** Used together with `funnelTrendsDropOff` for funnels time conversion date for the persons modal. */
-    funnelTrendsEntrancePeriodStart?: string | null
-    includeRecordings?: boolean | null
-    kind?: 'FunnelsActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ActorsQueryResponseApi | null
-    source: FunnelsQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type FunnelCorrelationResultsTypeApi =
     (typeof FunnelCorrelationResultsTypeApi)[keyof typeof FunnelCorrelationResultsTypeApi]
@@ -4380,133 +2387,7 @@ export const CorrelationTypeApi = {
 
 export type EventDefinitionApiProperties = { [key: string]: unknown }
 
-export interface EventDefinitionApi {
-    elements: unknown[]
-    event: string
-    properties: EventDefinitionApiProperties
-}
-
-export interface EventOddsRatioSerializedApi {
-    correlation_type: CorrelationTypeApi
-    event: EventDefinitionApi
-    failure_count: number
-    odds_ratio: number
-    success_count: number
-}
-
-export interface FunnelCorrelationResultApi {
-    events: EventOddsRatioSerializedApi[]
-    skewed: boolean
-}
-
-export interface FunnelCorrelationResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: FunnelCorrelationResultApi
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface FunnelCorrelationQueryApi {
-    funnelCorrelationEventExcludePropertyNames?: string[] | null
-    funnelCorrelationEventNames?: string[] | null
-    funnelCorrelationExcludeEventNames?: string[] | null
-    funnelCorrelationExcludeNames?: string[] | null
-    funnelCorrelationNames?: string[] | null
-    funnelCorrelationType: FunnelCorrelationResultsTypeApi
-    kind?: 'FunnelCorrelationQuery'
-    response?: FunnelCorrelationResponseApi | null
-    source: FunnelsActorsQueryApi
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface FunnelCorrelationActorsQueryApi {
-    funnelCorrelationPersonConverted?: boolean | null
-    funnelCorrelationPersonEntity?: EventsNodeApi | ActionsNodeApi | DataWarehouseNodeApi | null
-    funnelCorrelationPropertyValues?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    includeRecordings?: boolean | null
-    kind?: 'FunnelCorrelationActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ActorsQueryResponseApi | null
-    source: FunnelCorrelationQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentEventExposureConfigApiResponse = { [key: string]: unknown } | null
-
-export interface ExperimentEventExposureConfigApi {
-    event: string
-    kind?: 'ExperimentEventExposureConfig'
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | ElementPropertyFilterApi
-        | EventMetadataPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-        | RecordingPropertyFilterApi
-        | LogEntryPropertyFilterApi
-        | GroupPropertyFilterApi
-        | FeaturePropertyFilterApi
-        | FlagPropertyFilterApi
-        | HogQLPropertyFilterApi
-        | EmptyPropertyFilterApi
-        | DataWarehousePropertyFilterApi
-        | DataWarehousePersonPropertyFilterApi
-        | ErrorTrackingIssueFilterApi
-        | LogPropertyFilterApi
-        | SpanPropertyFilterApi
-        | RevenueAnalyticsPropertyFilterApi
-        | WorkflowVariablePropertyFilterApi
-    )[]
-    response?: ExperimentEventExposureConfigApiResponse
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type MultipleVariantHandlingApi = (typeof MultipleVariantHandlingApi)[keyof typeof MultipleVariantHandlingApi]
 
@@ -4524,162 +2405,11 @@ export const ExperimentMetricGoalApi = {
 
 export type ExperimentDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
 
-export interface ExperimentDataWarehouseNodeApi {
-    custom_name?: string | null
-    data_warehouse_join_key: string
-    events_join_key: string
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'ExperimentDataWarehouseNode'
-    math?:
-        | BaseMathTypeApi
-        | FunnelMathTypeApi
-        | PropertyMathTypeApi
-        | CountPerActorMathTypeApi
-        | ExperimentMetricMathTypeApi
-        | CalendarHeatmapMathTypeApi
-        | 'unique_group'
-        | 'hogql'
-        | null
-    math_group_type_index?: MathGroupTypeIndexApi | null
-    math_hogql?: string | null
-    math_multiplier?: number | null
-    math_property?: string | null
-    math_property_revenue_currency?: RevenueCurrencyPropertyConfigApi | null
-    math_property_type?: string | null
-    name?: string | null
-    optionalInFunnel?: boolean | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: ExperimentDataWarehouseNodeApiResponse
-    table_name: string
-    timestamp_field: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentMeanMetricApiResponse = { [key: string]: unknown } | null
-
-export interface ExperimentMeanMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    fingerprint?: string | null
-    goal?: ExperimentMetricGoalApi | null
-    ignore_zeros?: boolean | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
-    lower_bound_percentile?: number | null
-    metric_type?: 'mean'
-    name?: string | null
-    response?: ExperimentMeanMetricApiResponse
-    sharedMetricId?: number | null
-    source: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
-    upper_bound_percentile?: number | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ExperimentFunnelMetricApiResponse = { [key: string]: unknown } | null
 
-export interface ExperimentFunnelMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    fingerprint?: string | null
-    funnel_order_type?: StepOrderValueApi | null
-    goal?: ExperimentMetricGoalApi | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    metric_type?: 'funnel'
-    name?: string | null
-    response?: ExperimentFunnelMetricApiResponse
-    series: (EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi)[]
-    sharedMetricId?: number | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface ExperimentMetricOutlierHandlingApi {
-    ignore_zeros?: boolean | null
-    /** Winsorization lower percentile bound, as a fraction in [0, 1] (e.g. 0.01 for the 1st percentile). */
-    lower_bound_percentile?: number | null
-    /** Winsorization upper percentile bound, as a fraction in [0, 1] (e.g. 0.99 for the 99th percentile). */
-    upper_bound_percentile?: number | null
-}
-
 export type ExperimentRatioMetricApiResponse = { [key: string]: unknown } | null
-
-export interface ExperimentRatioMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    denominator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    denominator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
-    fingerprint?: string | null
-    goal?: ExperimentMetricGoalApi | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    metric_type?: 'ratio'
-    name?: string | null
-    numerator: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    numerator_outlier_handling?: ExperimentMetricOutlierHandlingApi | null
-    response?: ExperimentRatioMetricApiResponse
-    sharedMetricId?: number | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type StartHandlingApi = (typeof StartHandlingApi)[keyof typeof StartHandlingApi]
 
@@ -4690,42 +2420,12 @@ export const StartHandlingApi = {
 
 export type ExperimentRetentionMetricApiResponse = { [key: string]: unknown } | null
 
-export interface ExperimentRetentionMetricApi {
-    breakdownFilter?: BreakdownFilterApi | null
-    completion_event: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    conversion_window?: number | null
-    conversion_window_unit?: FunnelConversionWindowTimeUnitApi | null
-    fingerprint?: string | null
-    goal?: ExperimentMetricGoalApi | null
-    isSharedMetric?: boolean | null
-    kind?: 'ExperimentMetric'
-    metric_type?: 'retention'
-    name?: string | null
-    response?: ExperimentRetentionMetricApiResponse
-    retention_window_end: number
-    retention_window_start: number
-    retention_window_unit: FunnelConversionWindowTimeUnitApi
-    sharedMetricId?: number | null
-    start_event: EventsNodeApi | ActionsNodeApi | ExperimentDataWarehouseNodeApi
-    start_handling: StartHandlingApi
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type PrecomputationModeApi = (typeof PrecomputationModeApi)[keyof typeof PrecomputationModeApi]
 
 export const PrecomputationModeApi = {
     Precomputed: 'precomputed',
     Direct: 'direct',
 } as const
-
-export interface SessionDataApi {
-    event_uuid: string
-    person_id: string
-    session_id: string
-    timestamp: string
-}
 
 export type ExperimentStatsValidationFailureApi =
     (typeof ExperimentStatsValidationFailureApi)[keyof typeof ExperimentStatsValidationFailureApi]
@@ -4736,231 +2436,11 @@ export const ExperimentStatsValidationFailureApi = {
     NotEnoughMetricData: 'not-enough-metric-data',
 } as const
 
-export interface ExperimentStatsBaseValidatedApi {
-    covariate_sum?: number | null
-    covariate_sum_product?: number | null
-    covariate_sum_squares?: number | null
-    denominator_sum?: number | null
-    denominator_sum_squares?: number | null
-    key: string
-    number_of_samples: number
-    numerator_denominator_sum_product?: number | null
-    step_counts?: number[] | null
-    step_sessions?: SessionDataApi[][] | null
-    sum: number
-    sum_squares: number
-    validation_failures?: ExperimentStatsValidationFailureApi[] | null
-}
-
-export interface ExperimentVariantResultFrequentistApi {
-    confidence_interval?: number[] | null
-    covariate_sum?: number | null
-    covariate_sum_product?: number | null
-    covariate_sum_squares?: number | null
-    denominator_sum?: number | null
-    denominator_sum_squares?: number | null
-    key: string
-    method?: 'frequentist'
-    number_of_samples: number
-    numerator_denominator_sum_product?: number | null
-    p_value?: number | null
-    significant?: boolean | null
-    step_counts?: number[] | null
-    step_sessions?: SessionDataApi[][] | null
-    sum: number
-    sum_squares: number
-    validation_failures?: ExperimentStatsValidationFailureApi[] | null
-}
-
-export interface ExperimentVariantResultBayesianApi {
-    chance_to_win?: number | null
-    covariate_sum?: number | null
-    covariate_sum_product?: number | null
-    covariate_sum_squares?: number | null
-    credible_interval?: number[] | null
-    denominator_sum?: number | null
-    denominator_sum_squares?: number | null
-    key: string
-    method?: 'bayesian'
-    number_of_samples: number
-    numerator_denominator_sum_product?: number | null
-    significant?: boolean | null
-    step_counts?: number[] | null
-    step_sessions?: SessionDataApi[][] | null
-    sum: number
-    sum_squares: number
-    validation_failures?: ExperimentStatsValidationFailureApi[] | null
-}
-
-export interface ExperimentBreakdownResultApi {
-    /** Control variant stats for this breakdown */
-    baseline: ExperimentStatsBaseValidatedApi
-    /** The breakdown values as an array (e.g., ["MacOS", "Chrome"] for multi-breakdown, ["Chrome"] for single) Although `BreakdownKeyType` could be an array, we only use the array form for the breakdown_value. The way `BreakdownKeyType` is defined is problematic. It should be treated as a primitive and allow for the types using it to define if it's and array or an optional value. */
-    breakdown_value: (string | number)[]
-    /** Test variant results with statistical comparisons for this breakdown */
-    variants: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[]
-}
-
 export type ExperimentQueryResponseApiCredibleIntervals = { [key: string]: number[] } | null
 
 export type ExperimentQueryResponseApiInsight = { [key: string]: unknown }[] | null
 
 export type ExperimentQueryResponseApiProbability = { [key: string]: number } | null
-
-export interface ExperimentQueryResponseApi {
-    baseline?: ExperimentStatsBaseValidatedApi | null
-    /** Results grouped by breakdown value. When present, baseline and variant_results contain aggregated data. */
-    breakdown_results?: ExperimentBreakdownResultApi[] | null
-    clickhouse_sql?: string | null
-    credible_intervals?: ExperimentQueryResponseApiCredibleIntervals
-    hogql?: string | null
-    insight?: ExperimentQueryResponseApiInsight
-    /** Whether exposures were served from the precomputation system */
-    is_precomputed?: boolean | null
-    kind?: 'ExperimentQuery'
-    metric?:
-        | ExperimentMeanMetricApi
-        | ExperimentFunnelMetricApi
-        | ExperimentRatioMetricApi
-        | ExperimentRetentionMetricApi
-        | null
-    p_value?: number | null
-    probability?: ExperimentQueryResponseApiProbability
-    significance_code?: ExperimentSignificanceCodeApi | null
-    significant?: boolean | null
-    stats_version?: number | null
-    variant_results?: ExperimentVariantResultFrequentistApi[] | ExperimentVariantResultBayesianApi[] | null
-    variants?: ExperimentVariantTrendsBaseStatsApi[] | ExperimentVariantFunnelsBaseStatsApi[] | null
-    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentQueryApi {
-    experiment_id?: number | null
-    kind?: 'ExperimentQuery'
-    metric:
-        | ExperimentMeanMetricApi
-        | ExperimentFunnelMetricApi
-        | ExperimentRatioMetricApi
-        | ExperimentRetentionMetricApi
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    name?: string | null
-    precomputation_mode?: PrecomputationModeApi | null
-    response?: ExperimentQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface ExperimentActorsQueryApi {
-    /** Exposure configuration for filtering events. Defines when users were first exposed to the experiment. */
-    exposureConfig?: ExperimentEventExposureConfigApi | ActionsNodeApi | null
-    /** Feature flag key for breakdown filtering. */
-    featureFlagKey?: string | null
-    /** Index of the step for which we want to get actors for, per experiment variant. Positive for converted persons, negative for dropped off persons. */
-    funnelStep?: number | null
-    /** The variant key for filtering actors. For experiments, this filters by feature flag variant (e.g., 'control', 'test'). */
-    funnelStepBreakdown?: number | string | (number | string)[] | null
-    includeRecordings?: boolean | null
-    kind?: 'ExperimentActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** How to handle users with multiple variant exposures. */
-    multipleVariantHandling?: MultipleVariantHandlingApi | null
-    response?: ActorsQueryResponseApi | null
-    source: ExperimentQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface StickinessActorsQueryApi {
-    compare?: CompareApi | null
-    day?: string | number | null
-    includeRecordings?: boolean | null
-    kind?: 'StickinessActorsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    operator?: StickinessOperatorApi | null
-    response?: ActorsQueryResponseApi | null
-    series?: number | null
-    source: StickinessQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface HogQLFiltersApi {
-    dateRange?: DateRangeApi | null
-    filterTestAccounts?: boolean | null
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-}
-
-export interface HogQLQueryResponseApi {
-    /** Executed ClickHouse query */
-    clickhouse?: string | null
-    /** Returned columns */
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Query explanation output */
-    explain?: string[] | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Query metadata output */
-    metadata?: HogQLMetadataResponseApi | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Input query string */
-    query?: string | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Types of returned columns */
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface HogQLVariableApi {
-    code_name: string
-    isNull?: boolean | null
-    value?: unknown
-    variableId: string
-}
 
 /**
  * Constant values that can be referenced with the {placeholder} syntax in the query
@@ -4971,273 +2451,6 @@ export type HogQLQueryApiValues = { [key: string]: unknown } | null
  * Variables to be substituted into the query
  */
 export type HogQLQueryApiVariables = { [key: string]: HogQLVariableApi } | null
-
-export interface HogQLQueryApi {
-    /** Optional id of a direct external data source (access_method='direct') to run against instead of ClickHouse. Warehouse import sources are not valid here. */
-    connectionId?: string | null
-    explain?: boolean | null
-    filters?: HogQLFiltersApi | null
-    kind?: 'HogQLQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Client provided name of the query */
-    name?: string | null
-    query: string
-    response?: HogQLQueryResponseApi | null
-    /** Run the selected connection query directly without translating it through HogQL first */
-    sendRawQuery?: boolean | null
-    tags?: QueryLogTagsApi | null
-    /** Constant values that can be referenced with the {placeholder} syntax in the query */
-    values?: HogQLQueryApiValues
-    /** Variables to be substituted into the query */
-    variables?: HogQLQueryApiVariables
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface ActorsQueryApi {
-    /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-    fixedProperties?:
-        | (PersonPropertyFilterApi | CohortPropertyFilterApi | HogQLPropertyFilterApi | EmptyPropertyFilterApi)[]
-        | null
-    kind?: 'ActorsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: string[] | null
-    /** Currently only person filters supported. No filters for querying groups. See `filter_conditions()` in actor_strategies.py. */
-    properties?:
-        | (PersonPropertyFilterApi | CohortPropertyFilterApi | HogQLPropertyFilterApi | EmptyPropertyFilterApi)[]
-        | PropertyGroupFilterValueApi
-        | null
-    response?: ActorsQueryResponseApi | null
-    search?: string | null
-    select?: string[] | null
-    source?:
-        | InsightActorsQueryApi
-        | FunnelsActorsQueryApi
-        | FunnelCorrelationActorsQueryApi
-        | ExperimentActorsQueryApi
-        | StickinessActorsQueryApi
-        | HogQLQueryApi
-        | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface GroupsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    kind?: 'GroupsQuery'
-    limit: number
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset: number
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface GroupsQueryApi {
-    group_type_index: number
-    kind?: 'GroupsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: string[] | null
-    properties?: (GroupPropertyFilterApi | HogQLPropertyFilterApi)[] | null
-    response?: GroupsQueryResponseApi | null
-    search?: string | null
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface WebExternalClicksTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebExternalClicksTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebExternalClicksTableQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebExternalClicksTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    stripQueryParams?: boolean | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface WebGoalsQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Whether the response was served from the lazy precompute path. */
-    usedLazyPrecompute?: boolean | null
-    /** Whether the response was served from a precomputed table. */
-    usedPreAggregatedTables?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebGoalsQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebGoalsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebGoalsQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web_goals_query precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface WebVitalsQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebVitalsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebGoalsQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    source:
-        | TrendsQueryApi
-        | FunnelsQueryApi
-        | RetentionQueryApi
-        | PathsQueryApi
-        | StickinessQueryApi
-        | LifecycleQueryApi
-        | WebStatsTableQueryApi
-        | WebOverviewQueryApi
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type WebVitalsMetricApi = (typeof WebVitalsMetricApi)[keyof typeof WebVitalsMetricApi]
 
@@ -5255,73 +2468,6 @@ export const WebVitalsPercentileApi = {
     P90: 'p90',
     P99: 'p99',
 } as const
-
-export interface WebVitalsPathBreakdownQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    /**
-     * @minItems 1
-     * @maxItems 1
-     */
-    results: WebVitalsPathBreakdownResultApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    usedLazyPrecompute?: boolean | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface WebVitalsPathBreakdownQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'WebVitalsPathBreakdownQuery'
-    metric: WebVitalsMetricApi
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    orderBy?: (WebAnalyticsOrderByFieldsApi | WebAnalyticsOrderByDirectionApi)[] | null
-    percentile: WebVitalsPercentileApi
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: WebVitalsPathBreakdownQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    tags?: QueryLogTagsApi | null
-    /**
-     * @minItems 2
-     * @maxItems 2
-     */
-    thresholds: number[]
-    useSessionsTable?: boolean | null
-    /** Opt this specific query into the web vitals path breakdown precompute path. Requires the `web-analytics-precompute-toggle` PostHog feature flag to be on for the team's organization for the gate to pass. * */
-    useWebAnalyticsPrecompute?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export interface FiltersApi {
     dateRange?: DateRangeApi | null
@@ -5341,327 +2487,12 @@ export const SessionAttributionGroupByApi = {
     InitialURL: 'InitialURL',
 } as const
 
-export interface SessionAttributionExplorerQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface SessionAttributionExplorerQueryApi {
-    filters?: FiltersApi | null
-    groupBy: SessionAttributionGroupByApi[]
-    kind?: 'SessionAttributionExplorerQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    response?: SessionAttributionExplorerQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface SessionsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface SessionsQueryApi {
-    /** Filter sessions by action - sessions that contain events matching this action */
-    actionId?: number | null
-    /** Only fetch sessions that started after this timestamp */
-    after?: string | null
-    /** Only fetch sessions that started before this timestamp */
-    before?: string | null
-    /** Filter sessions by event name - sessions that contain this event */
-    event?: string | null
-    /** Event property filters - filters sessions that contain events matching these properties */
-    eventProperties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    /** Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person) */
-    fixedProperties?:
-        | (
-              | PropertyGroupFilterApi
-              | PropertyGroupFilterValueApi
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    kind?: 'SessionsQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by */
-    orderBy?: string[] | null
-    /** Show sessions for a given person */
-    personId?: string | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: SessionsQueryResponseApi | null
-    /** Return a limited set of data. Required. */
-    select: string[]
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    /** HogQL filters to apply on returned data */
-    where?: string[] | null
-}
-
-export interface RevenueAnalyticsBreakdownApi {
-    property: string
-    type?: 'revenue_analytics'
-}
-
 export type SimpleIntervalTypeApi = (typeof SimpleIntervalTypeApi)[keyof typeof SimpleIntervalTypeApi]
 
 export const SimpleIntervalTypeApi = {
     Day: 'day',
     Month: 'month',
 } as const
-
-export interface RevenueAnalyticsGrossRevenueQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsGrossRevenueQueryApi {
-    breakdown: RevenueAnalyticsBreakdownApi[]
-    dateRange?: DateRangeApi | null
-    interval: SimpleIntervalTypeApi
-    kind?: 'RevenueAnalyticsGrossRevenueQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsGrossRevenueQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueAnalyticsMetricsQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsMetricsQueryApi {
-    breakdown: RevenueAnalyticsBreakdownApi[]
-    dateRange?: DateRangeApi | null
-    interval: SimpleIntervalTypeApi
-    kind?: 'RevenueAnalyticsMetricsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsMetricsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueAnalyticsMRRQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: RevenueAnalyticsMRRQueryResultItemApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsMRRQueryApi {
-    breakdown: RevenueAnalyticsBreakdownApi[]
-    dateRange?: DateRangeApi | null
-    interval: SimpleIntervalTypeApi
-    kind?: 'RevenueAnalyticsMRRQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsMRRQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueAnalyticsOverviewQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: RevenueAnalyticsOverviewItemApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsOverviewQueryApi {
-    dateRange?: DateRangeApi | null
-    kind?: 'RevenueAnalyticsOverviewQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsOverviewQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type RevenueAnalyticsTopCustomersGroupByApi =
     (typeof RevenueAnalyticsTopCustomersGroupByApi)[keyof typeof RevenueAnalyticsTopCustomersGroupByApi]
@@ -5670,114 +2501,6 @@ export const RevenueAnalyticsTopCustomersGroupByApi = {
     Month: 'month',
     All: 'all',
 } as const
-
-export interface RevenueAnalyticsTopCustomersQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueAnalyticsTopCustomersQueryApi {
-    dateRange?: DateRangeApi | null
-    groupBy: RevenueAnalyticsTopCustomersGroupByApi
-    kind?: 'RevenueAnalyticsTopCustomersQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: RevenueAnalyticsPropertyFilterApi[]
-    response?: RevenueAnalyticsTopCustomersQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueExampleEventsQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueExampleEventsQueryApi {
-    kind?: 'RevenueExampleEventsQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    response?: RevenueExampleEventsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface RevenueExampleDataWarehouseTablesQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface RevenueExampleDataWarehouseTablesQueryApi {
-    kind?: 'RevenueExampleDataWarehouseTablesQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    response?: RevenueExampleDataWarehouseTablesQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ConversionGoalFilter1ApiResponse = { [key: string]: unknown } | null
 
@@ -6054,11 +2777,6 @@ export const MarketingAnalyticsDrillDownLevelApi = {
     Term: 'term',
 } as const
 
-export interface IntegrationFilterApi {
-    /** Selected integration source IDs to filter by (e.g., table IDs or source map IDs) */
-    integrationSourceIds?: string[] | null
-}
-
 export type MarketingAnalyticsOrderByEnumApi =
     (typeof MarketingAnalyticsOrderByEnumApi)[keyof typeof MarketingAnalyticsOrderByEnumApi]
 
@@ -6067,212 +2785,7 @@ export const MarketingAnalyticsOrderByEnumApi = {
     Desc: 'DESC',
 } as const
 
-export interface MarketingAnalyticsTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: MarketingAnalyticsItemApi[][]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface MarketingAnalyticsTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    /** Draft conversion goal that can be set in the UI without saving */
-    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
-    /** Drill-down hierarchy level: channel, source, or campaign (default) */
-    drillDownLevel?: MarketingAnalyticsDrillDownLevelApi | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Filter by integration type */
-    integrationFilter?: IntegrationFilterApi | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'MarketingAnalyticsTableQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by - similar to EventsQuery format */
-    orderBy?: (string | MarketingAnalyticsOrderByEnumApi)[][] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: MarketingAnalyticsTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Return a limited set of data. Will use default columns if empty. */
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type MarketingAnalyticsAggregatedQueryResponseApiResults = { [key: string]: MarketingAnalyticsItemApi }
-
-export interface MarketingAnalyticsAggregatedQueryResponseApi {
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: MarketingAnalyticsAggregatedQueryResponseApiResults
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface MarketingAnalyticsAggregatedQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    /** Draft conversion goal that can be set in the UI without saving */
-    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
-    /** Drill-down hierarchy level: channel, source, or campaign (default) */
-    drillDownLevel?: MarketingAnalyticsDrillDownLevelApi | null
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Filter by integration IDs */
-    integrationFilter?: IntegrationFilterApi | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'MarketingAnalyticsAggregatedQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: MarketingAnalyticsAggregatedQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Return a limited set of data. Will use default columns if empty. */
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface NonIntegratedConversionsTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: MarketingAnalyticsItemApi[][]
-    samplingRate?: SamplingRateApi | null
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface NonIntegratedConversionsTableQueryApi {
-    /** Groups aggregation - not used in Web Analytics but required for type compatibility */
-    aggregation_group_type_index?: number | null
-    /** Compare to date range */
-    compareFilter?: CompareFilterApi | null
-    conversionGoal?: ActionConversionGoalApi | CustomEventConversionGoalApi | null
-    /** Colors used in the insight's visualization - not used in Web Analytics but required for type compatibility */
-    dataColorTheme?: number | null
-    dateRange?: DateRangeApi | null
-    doPathCleaning?: boolean | null
-    /** Draft conversion goal that can be set in the UI without saving */
-    draftConversionGoal?: ConversionGoalFilter1Api | ConversionGoalFilter2Api | ConversionGoalFilter3Api | null
-    /** Filter test accounts */
-    filterTestAccounts?: boolean | null
-    includeRevenue?: boolean | null
-    /** Interval for date range calculation (affects date_to rounding for hour vs day ranges) */
-    interval?: IntervalTypeApi | null
-    kind?: 'NonIntegratedConversionsTableQuery'
-    /** Number of rows to return */
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Number of rows to skip before returning rows */
-    offset?: number | null
-    /** Columns to order by */
-    orderBy?: (string | MarketingAnalyticsOrderByEnumApi)[][] | null
-    properties: (
-        | EventPropertyFilterApi
-        | PersonPropertyFilterApi
-        | SessionPropertyFilterApi
-        | CohortPropertyFilterApi
-    )[]
-    response?: NonIntegratedConversionsTableQueryResponseApi | null
-    sampling?: WebAnalyticsSamplingApi | null
-    /** Sampling rate */
-    samplingFactor?: number | null
-    /** Return a limited set of data. Will use default columns if empty. */
-    select?: string[] | null
-    tags?: QueryLogTagsApi | null
-    useSessionsTable?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type ErrorTrackingOrderByApi = (typeof ErrorTrackingOrderByApi)[keyof typeof ErrorTrackingOrderByApi]
 
@@ -6291,326 +2804,17 @@ export const OrderDirection2Api = {
     Desc: 'DESC',
 } as const
 
-export interface ErrorTrackingPendingFingerprintIssueStateUpdateApi {
-    assigned_role_id?: string | null
-    assigned_user_id?: number | null
-    fingerprint: string
-    /** ISO 8601 datetime string. */
-    first_seen: string
-    is_deleted: number
-    issue_description?: string | null
-    issue_id: string
-    issue_name?: string | null
-    issue_status: string
-    /** Client-stamped monotonic version (`Date.now()` ms at mutation success). */
-    version: number
-}
-
-export interface ErrorTrackingQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: ErrorTrackingIssueApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ErrorTrackingQueryApi {
-    assignee?: ErrorTrackingIssueAssigneeApi | null
-    /** Date range to filter results. */
-    dateRange: DateRangeApi
-    filterGroup?: PropertyGroupFilterApi | null
-    /** Whether to filter out test accounts. */
-    filterTestAccounts?: boolean | null
-    groupKey?: string | null
-    groupTypeIndex?: number | null
-    /** Filter to a specific error tracking issue by ID. */
-    issueId?: string | null
-    kind?: 'ErrorTrackingQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Field to sort results by. */
-    orderBy: ErrorTrackingOrderByApi
-    /** Sort direction. */
-    orderDirection?: OrderDirection2Api | null
-    /** Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery (V3 only). The backend caps the list at 50 entries; extras are dropped silently. */
-    pendingFingerprintIssueStateUpdates?: ErrorTrackingPendingFingerprintIssueStateUpdateApi[] | null
-    personId?: string | null
-    response?: ErrorTrackingQueryResponseApi | null
-    /** Free-text search across exception type, message, and stack frames. */
-    searchQuery?: string | null
-    /** Filter by issue status. */
-    status?: ErrorTrackingIssueStatusApi | string | null
-    tags?: QueryLogTagsApi | null
-    /** Use V2 query path (ClickHouse postgres connector join instead of separate Postgres queries) */
-    useQueryV2?: boolean | null
-    /** Use V3 query path (denormalized ClickHouse table, no Postgres joins) */
-    useQueryV3?: boolean | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-    volumeResolution: number
-    withAggregations?: boolean | null
-    withFirstEvent?: boolean | null
-    withLastEvent?: boolean | null
-}
-
-export interface ErrorTrackingIssueCorrelationQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: ErrorTrackingCorrelatedIssueApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ErrorTrackingIssueCorrelationQueryApi {
-    events: string[]
-    kind?: 'ErrorTrackingIssueCorrelationQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: ErrorTrackingIssueCorrelationQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentFunnelsQueryResponseApiCredibleIntervals = { [key: string]: number[] }
 
 export type ExperimentFunnelsQueryResponseApiInsightItemItem = { [key: string]: unknown }
 
 export type ExperimentFunnelsQueryResponseApiProbability = { [key: string]: number }
 
-export interface ExperimentFunnelsQueryResponseApi {
-    credible_intervals: ExperimentFunnelsQueryResponseApiCredibleIntervals
-    expected_loss: number
-    funnels_query?: FunnelsQueryApi | null
-    insight: ExperimentFunnelsQueryResponseApiInsightItemItem[][]
-    kind?: 'ExperimentFunnelsQuery'
-    probability: ExperimentFunnelsQueryResponseApiProbability
-    significance_code: ExperimentSignificanceCodeApi
-    significant: boolean
-    stats_version?: number | null
-    variants: ExperimentVariantFunnelsBaseStatsApi[]
-    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentFunnelsQueryApi {
-    experiment_id?: number | null
-    fingerprint?: string | null
-    funnels_query: FunnelsQueryApi
-    kind?: 'ExperimentFunnelsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    name?: string | null
-    response?: ExperimentFunnelsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type ExperimentTrendsQueryResponseApiCredibleIntervals = { [key: string]: number[] }
 
 export type ExperimentTrendsQueryResponseApiInsightItem = { [key: string]: unknown }
 
 export type ExperimentTrendsQueryResponseApiProbability = { [key: string]: number }
-
-export interface ExperimentTrendsQueryResponseApi {
-    count_query?: TrendsQueryApi | null
-    credible_intervals: ExperimentTrendsQueryResponseApiCredibleIntervals
-    exposure_query?: TrendsQueryApi | null
-    insight: ExperimentTrendsQueryResponseApiInsightItem[]
-    kind?: 'ExperimentTrendsQuery'
-    p_value: number
-    probability: ExperimentTrendsQueryResponseApiProbability
-    significance_code: ExperimentSignificanceCodeApi
-    significant: boolean
-    stats_version?: number | null
-    variants: ExperimentVariantTrendsBaseStatsApi[]
-    /** Data warehouse sync warnings — see AnalyticsQueryResponseBase.warnings for semantics. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface ExperimentTrendsQueryApi {
-    count_query: TrendsQueryApi
-    experiment_id?: number | null
-    exposure_query?: TrendsQueryApi | null
-    fingerprint?: string | null
-    kind?: 'ExperimentTrendsQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    name?: string | null
-    response?: ExperimentTrendsQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    uuid?: string | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface TracesQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: LLMTraceApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface TracesQueryApi {
-    dateRange?: DateRangeApi | null
-    filterSupportTraces?: boolean | null
-    filterTestAccounts?: boolean | null
-    groupKey?: string | null
-    groupTypeIndex?: number | null
-    kind?: 'TracesQuery'
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Person who performed the event */
-    personId?: string | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    /** Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias. */
-    randomOrder?: boolean | null
-    response?: TracesQueryResponseApi | null
-    showColumnConfigurator?: boolean | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface TraceQueryResponseApi {
-    columns?: string[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: LLMTraceApi[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface TraceQueryApi {
-    dateRange?: DateRangeApi | null
-    kind?: 'TraceQuery'
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    /** Properties configurable in the interface */
-    properties?:
-        | (
-              | EventPropertyFilterApi
-              | PersonPropertyFilterApi
-              | ElementPropertyFilterApi
-              | EventMetadataPropertyFilterApi
-              | SessionPropertyFilterApi
-              | CohortPropertyFilterApi
-              | RecordingPropertyFilterApi
-              | LogEntryPropertyFilterApi
-              | GroupPropertyFilterApi
-              | FeaturePropertyFilterApi
-              | FlagPropertyFilterApi
-              | HogQLPropertyFilterApi
-              | EmptyPropertyFilterApi
-              | DataWarehousePropertyFilterApi
-              | DataWarehousePersonPropertyFilterApi
-              | ErrorTrackingIssueFilterApi
-              | LogPropertyFilterApi
-              | SpanPropertyFilterApi
-              | RevenueAnalyticsPropertyFilterApi
-              | WorkflowVariablePropertyFilterApi
-          )[]
-        | null
-    response?: TraceQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    traceId: string
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 export type EndpointsUsageBreakdownApi = (typeof EndpointsUsageBreakdownApi)[keyof typeof EndpointsUsageBreakdownApi]
 
@@ -6647,105 +2851,6 @@ export const EndpointsUsageOrderByDirectionApi = {
     Desc: 'DESC',
 } as const
 
-export interface EndpointsUsageTableQueryResponseApi {
-    columns?: unknown[] | null
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql?: string | null
-    limit?: number | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types?: unknown[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface EndpointsUsageTableQueryApi {
-    breakdownBy: EndpointsUsageBreakdownApi
-    dateRange?: DateRangeApi | null
-    /** Filter to specific endpoints by name */
-    endpointNames?: string[] | null
-    kind?: 'EndpointsUsageTableQuery'
-    limit?: number | null
-    /** Filter by materialization type */
-    materializationType?: MaterializationTypeApi | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: (EndpointsUsageOrderByFieldApi | EndpointsUsageOrderByDirectionApi)[] | null
-    response?: EndpointsUsageTableQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface AccountsQueryResponseApi {
-    columns: unknown[]
-    /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
-    error?: string | null
-    hasMore?: boolean | null
-    /** Generated HogQL query. */
-    hogql: string
-    kind?: 'AccountsQuery'
-    limit: number
-    /** When `metrics` is set on the query, the aggregated values in the same order. */
-    metricsResults?: (number | null)[] | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset: number
-    /** Query status indicates whether next to the provided data, a query is still running. */
-    query_status?: QueryStatusApi | null
-    /** The resolved previous/comparison period date range, when comparing against another period */
-    resolved_compare_date_range?: ResolvedDateRangeResponseApi | null
-    /** The date range used for the query */
-    resolved_date_range?: ResolvedDateRangeResponseApi | null
-    results: unknown[][]
-    /** Measured timings for different parts of the query generation process */
-    timings?: QueryTimingApi[] | null
-    types: string[]
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
-    warnings?: DataWarehouseSyncWarningApi[] | null
-}
-
-export interface AccountsQueryApi {
-    /** Match accounts whose account executive is any of these user ids (OR semantics). */
-    accountExecutive?: number[] | null
-    /** Match accounts whose account owner is any of these user ids (OR semantics). */
-    accountOwner?: number[] | null
-    allRolesUnassigned?: boolean | null
-    /** Match accounts whose CSM is any of these user ids (OR semantics). */
-    csm?: number[] | null
-    /** Optional HogQL boolean expression AND-ed into the WHERE clause. Used by the overview tile click-to-filter affordance. */
-    filterExpression?: string | null
-    kind?: 'AccountsQuery'
-    limit?: number | null
-    /** Aggregation expressions evaluated against the filtered account set; one value per metric is returned in `metricsResults`. When `metrics` is set without a `select`, the runner skips the regular row fetch and returns only the aggregated values. */
-    metrics?: string[] | null
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    offset?: number | null
-    orderBy?: string[] | null
-    response?: AccountsQueryResponseApi | null
-    search?: string | null
-    select?: string[] | null
-    tagNames?: string[] | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type DataTableNodeApiResponse =
     | { [key: string]: unknown }
     | ResponseApi
@@ -6777,121 +2882,6 @@ export type DataTableNodeApiResponse =
     | Response27Api
     | null
 
-export interface DataTableNodeApi {
-    /** Can the user click on column headers to sort the table? (default: true) */
-    allowSorting?: boolean | null
-    /** Columns shown in the table, unless the `source` provides them. */
-    columns?: string[] | null
-    /** Context for the table, used by components like ColumnConfigurator */
-    context?: DataTableNodeViewPropsContextApi | null
-    /** Context key for universal column configuration (e.g., "survey:123") */
-    contextKey?: string | null
-    /** Default columns to use when resetting column configuration */
-    defaultColumns?: string[] | null
-    /** Uses the embedded version of LemonTable */
-    embedded?: boolean | null
-    /** Can expand row to show raw event data (default: true) */
-    expandable?: boolean | null
-    /** Show with most visual options enabled. Used in scenes. */
-    full?: boolean | null
-    /** Columns that aren't shown in the table, even if in columns or returned data */
-    hiddenColumns?: string[] | null
-    kind: DataTableNodeApiKind
-    /** Columns that are sticky when scrolling horizontally */
-    pinnedColumns?: string[] | null
-    /** Link properties via the URL (default: false) */
-    propertiesViaUrl?: boolean | null
-    response?: DataTableNodeApiResponse
-    /** Render date-time columns (timestamp, created_at, last_seen, last_seen_at, session_start, session_end) as absolute date+time instead of relative ("X ago"). The toggle is exposed in the column header menu only on EventsQuery / ActorsQuery sources. */
-    showAbsoluteTime?: boolean | null
-    /** Show the kebab menu at the end of the row */
-    showActions?: boolean | null
-    /** Show a button to configure the table's columns if possible */
-    showColumnConfigurator?: boolean | null
-    /** Show count of total and filtered results */
-    showCount?: boolean | null
-    /** Show date range selector */
-    showDateRange?: boolean | null
-    /** Show the time it takes to run a query */
-    showElapsedTime?: boolean | null
-    /** Include an event filter above the table (EventsNode only) */
-    showEventFilter?: boolean | null
-    /** Include an events filter above the table to filter by multiple events (EventsQuery only) */
-    showEventsFilter?: boolean | null
-    /** Show the export button */
-    showExport?: boolean | null
-    /** Include a HogQL query editor above HogQL tables */
-    showHogQLEditor?: boolean | null
-    /** Show a button to open the current query as a new insight. (default: true) */
-    showOpenEditorButton?: boolean | null
-    /** Show a button to configure and persist the table's default columns if possible */
-    showPersistentColumnConfigurator?: boolean | null
-    /** Include a property filter above the table */
-    showPropertyFilter?: boolean | TaxonomicFilterGroupTypeApi[] | null
-    /** Show a recording column for events with session recordings */
-    showRecordingColumn?: boolean | null
-    /** Show a reload button */
-    showReload?: boolean | null
-    /** Show a results table */
-    showResultsTable?: boolean | null
-    /** Show saved filters feature for this table (requires uniqueKey) */
-    showSavedFilters?: boolean | null
-    /** Shows a list of saved queries */
-    showSavedQueries?: boolean | null
-    /** Include a free text search field (PersonsNode only) */
-    showSearch?: boolean | null
-    /** Show actors query options and back to source */
-    showSourceQueryOptions?: boolean | null
-    /** Show table views feature for this table (requires uniqueKey) */
-    showTableViews?: boolean | null
-    /** Show filter to exclude test accounts */
-    showTestAccountFilters?: boolean | null
-    /** Show a detailed query timing breakdown */
-    showTimings?: boolean | null
-    /** Source of the events */
-    source:
-        | EventsNodeApi
-        | EventsQueryApi
-        | PersonsNodeApi
-        | ActorsQueryApi
-        | GroupsQueryApi
-        | HogQLQueryApi
-        | WebOverviewQueryApi
-        | WebStatsTableQueryApi
-        | WebExternalClicksTableQueryApi
-        | WebGoalsQueryApi
-        | WebVitalsQueryApi
-        | WebVitalsPathBreakdownQueryApi
-        | SessionAttributionExplorerQueryApi
-        | SessionsQueryApi
-        | RevenueAnalyticsGrossRevenueQueryApi
-        | RevenueAnalyticsMetricsQueryApi
-        | RevenueAnalyticsMRRQueryApi
-        | RevenueAnalyticsOverviewQueryApi
-        | RevenueAnalyticsTopCustomersQueryApi
-        | RevenueExampleEventsQueryApi
-        | RevenueExampleDataWarehouseTablesQueryApi
-        | MarketingAnalyticsTableQueryApi
-        | MarketingAnalyticsAggregatedQueryApi
-        | NonIntegratedConversionsTableQueryApi
-        | ErrorTrackingQueryApi
-        | ErrorTrackingIssueCorrelationQueryApi
-        | ExperimentFunnelsQueryApi
-        | ExperimentTrendsQueryApi
-        | TracesQueryApi
-        | TraceQueryApi
-        | EndpointsUsageTableQueryApi
-        | AccountsQueryApi
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
-export interface HeatmapGradientStopApi {
-    color: string
-    value: number
-}
-
 export type GradientScaleModeApi = (typeof GradientScaleModeApi)[keyof typeof GradientScaleModeApi]
 
 export const GradientScaleModeApi = {
@@ -6906,36 +2896,12 @@ export const HeatmapSortOrderApi = {
     Desc: 'desc',
 } as const
 
-export interface HeatmapSettingsApi {
-    gradient?: HeatmapGradientStopApi[] | null
-    gradientPreset?: string | null
-    gradientScaleMode?: GradientScaleModeApi | null
-    nullLabel?: string | null
-    nullValue?: string | null
-    sortColumn?: string | null
-    sortOrder?: HeatmapSortOrderApi | null
-    valueColumn?: string | null
-    xAxisColumn?: string | null
-    xAxisLabel?: string | null
-    yAxisColumn?: string | null
-    yAxisLabel?: string | null
-}
-
 export type ScaleApi = (typeof ScaleApi)[keyof typeof ScaleApi]
 
 export const ScaleApi = {
     Linear: 'linear',
     Logarithmic: 'logarithmic',
 } as const
-
-export interface YAxisSettingsApi {
-    label?: string | null
-    scale?: ScaleApi | null
-    showGridLines?: boolean | null
-    showTicks?: boolean | null
-    /** Whether the Y axis should start at zero */
-    startAtZero?: boolean | null
-}
 
 export type DisplayTypeApi = (typeof DisplayTypeApi)[keyof typeof DisplayTypeApi]
 
@@ -6953,14 +2919,6 @@ export const YAxisPositionApi = {
     Right: 'right',
 } as const
 
-export interface ChartSettingsDisplayApi {
-    color?: string | null
-    displayType?: DisplayTypeApi | null
-    label?: string | null
-    trendLine?: boolean | null
-    yAxisPosition?: YAxisPositionApi | null
-}
-
 export type StyleApi = (typeof StyleApi)[keyof typeof StyleApi]
 
 export const StyleApi = {
@@ -6970,52 +2928,15 @@ export const StyleApi = {
     Percent: 'percent',
 } as const
 
-export interface ChartSettingsFormattingApi {
-    decimalPlaces?: number | null
-    prefix?: string | null
-    style?: StyleApi | null
-    suffix?: string | null
-}
-
 export interface SettingsApi {
     display?: ChartSettingsDisplayApi | null
     formatting?: ChartSettingsFormattingApi | null
-}
-
-export interface ChartAxisApi {
-    column: string
-    settings?: SettingsApi | null
 }
 
 /**
  * Per-breakdown-value color customizations. Keyed by the raw breakdown column value.
  */
 export type ChartSettingsApiResultCustomizations = { [key: string]: ResultCustomizationByValueApi } | null
-
-export interface ChartSettingsApi {
-    goalLines?: GoalLineApi[] | null
-    heatmap?: HeatmapSettingsApi | null
-    leftYAxisSettings?: YAxisSettingsApi | null
-    /** Per-breakdown-value color customizations. Keyed by the raw breakdown column value. */
-    resultCustomizations?: ChartSettingsApiResultCustomizations
-    rightYAxisSettings?: YAxisSettingsApi | null
-    seriesBreakdownColumn?: string | null
-    showLegend?: boolean | null
-    showNullsAsZero?: boolean | null
-    showPieTotal?: boolean | null
-    showTotalRow?: boolean | null
-    showValuesOnSeries?: boolean | null
-    showXAxisBorder?: boolean | null
-    showXAxisTicks?: boolean | null
-    showYAxisBorder?: boolean | null
-    /** Whether we fill the bars to 100% in stacked mode */
-    stackBars100?: boolean | null
-    xAxis?: ChartAxisApi | null
-    xAxisLabel?: string | null
-    yAxis?: ChartAxisApi[] | null
-    /** Deprecated: use `[left|right]YAxisSettings`. Whether the Y axis should start at zero */
-    yAxisAtZero?: boolean | null
-}
 
 export type DataVisualizationNodeApiKind =
     (typeof DataVisualizationNodeApiKind)[keyof typeof DataVisualizationNodeApiKind]
@@ -7031,56 +2952,11 @@ export const ColorModeApi = {
     Dark: 'dark',
 } as const
 
-export interface ConditionalFormattingRuleApi {
-    bytecode: unknown[]
-    color: string
-    colorMode?: ColorModeApi | null
-    columnName: string
-    id: string
-    input: string
-    templateId: string
-}
-
-export interface TableSettingsApi {
-    columns?: ChartAxisApi[] | null
-    conditionalFormatting?: ConditionalFormattingRuleApi[] | null
-    pinnedColumns?: string[] | null
-    transpose?: boolean | null
-}
-
-export interface DataVisualizationNodeApi {
-    chartSettings?: ChartSettingsApi | null
-    display?: ChartDisplayTypeApi | null
-    kind: DataVisualizationNodeApiKind
-    source: HogQLQueryApi
-    tableSettings?: TableSettingsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
-
 export type HogQueryApiKind = (typeof HogQueryApiKind)[keyof typeof HogQueryApiKind]
 
 export const HogQueryApiKind = {
     HogQuery: 'HogQuery',
 } as const
-
-export interface HogQueryResponseApi {
-    bytecode?: unknown[] | null
-    coloredBytecode?: unknown[] | null
-    results: unknown
-    stdout?: string | null
-}
-
-export interface HogQueryApi {
-    code?: string | null
-    kind: HogQueryApiKind
-    /** Modifiers used when performing the query */
-    modifiers?: HogQLQueryModifiersApi | null
-    response?: HogQueryResponseApi | null
-    tags?: QueryLogTagsApi | null
-    /** version of the node, used for schema migrations */
-    version?: number | null
-}
 
 /**
  * The query definition for this insight. The `kind` field determines the query type:

--- a/tools/openapi-codegen/index.mjs
+++ b/tools/openapi-codegen/index.mjs
@@ -17,6 +17,7 @@ export {
     stripCollidingInlineEnums,
     stripNullDefaults,
 } from './src/preprocess.mjs'
+export { aliasKernelTypes, buildSchemaSourceIndex, collectKernelComponents } from './src/alias-kernel-types.mjs'
 export { formatJs, formatYaml } from './src/format.mjs'
 export { runOrvalParallel } from './src/orval.mjs'
 export { annotatePureZodExports, fixNullDefaults } from './src/zod-postprocess.mjs'

--- a/tools/openapi-codegen/src/alias-kernel-types.mjs
+++ b/tools/openapi-codegen/src/alias-kernel-types.mjs
@@ -1,0 +1,170 @@
+// Aliases generated *Api types back to their authored schema.ts source.
+//
+// OpenAPI components tagged `x-schema-source: posthog.schema.*` are machine
+// projections of frontend-authored types (schema.ts -> schema.py -> OpenAPI).
+// Re-emitting them through Orval produces a second, lossier TypeScript copy of
+// a type the frontend already has (discriminators degrade, typed unions become
+// `unknown`). This pass removes the emitted copy and re-exports the original:
+//
+//     export type { TrendsQuery as TrendsQueryApi } from '~/queries/schema/schema-general'
+//
+// Provenance comes from the tags, never from name matching. Enum components
+// are skipped: Orval emits them as a const + type pair and code may reference
+// the const values, while schema.ts often models them as bare string-literal
+// unions with no runtime value. Components whose tag has no matching exported
+// TS declaration (e.g. codegen-dedup names like `Foo1`) are skipped too.
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SCHEMA_SOURCE_KEY = 'x-schema-source'
+const KERNEL_SOURCE_PREFIX = 'posthog.schema.'
+const TS_EXPORT_RE = /^export (?:declare )?(interface|type|enum|const enum|class) (\w+)/gm
+
+/** Map exported type name -> { module, kind } for every schema.ts source file. */
+export function buildSchemaSourceIndex(repoRoot) {
+    const index = new Map()
+    const schemaDir = path.join(repoRoot, 'frontend/src/queries/schema')
+    const sources = fs
+        .readdirSync(schemaDir)
+        .filter((f) => f.endsWith('.ts'))
+        .sort()
+        .map((f) => ({
+            file: path.join(schemaDir, f),
+            module: `~/queries/schema/${f.replace(/\.ts$/, '')}`,
+        }))
+    // schema.json generation follows imports into ~/types, so kernel-tagged
+    // components can also originate from handwritten types.ts declarations
+    sources.push({ file: path.join(repoRoot, 'frontend/src/types.ts'), module: '~/types' })
+
+    for (const { file, module } of sources) {
+        const text = fs.readFileSync(file, 'utf8')
+        for (const match of text.matchAll(TS_EXPORT_RE)) {
+            const [, kind, name] = match
+            if (!index.has(name)) {
+                index.set(name, { module, kind })
+            }
+        }
+    }
+    return index
+}
+
+/** Component name -> schema for every kernel-tagged component in the spec. */
+export function collectKernelComponents(spec) {
+    const kernel = new Map()
+    for (const [name, schema] of Object.entries(spec?.components?.schemas ?? {})) {
+        const source = schema?.[SCHEMA_SOURCE_KEY]
+        if (typeof source === 'string' && source.startsWith(KERNEL_SOURCE_PREFIX)) {
+            kernel.set(name, schema)
+        }
+    }
+    return kernel
+}
+
+function findDeclBlock(text, generatedName) {
+    const interfaceNeedle = `export interface ${generatedName} `
+    const typeNeedle = `export type ${generatedName} =`
+    const constNeedle = `export const ${generatedName} `
+
+    if (text.includes(constNeedle)) {
+        return { isValueExport: true }
+    }
+
+    let start = text.indexOf(interfaceNeedle)
+    let end = -1
+    if (start !== -1) {
+        const braceStart = text.indexOf('{', start)
+        let depth = 0
+        for (let i = braceStart; i < text.length; i++) {
+            if (text[i] === '{') {
+                depth++
+            } else if (text[i] === '}') {
+                depth--
+                if (depth === 0) {
+                    end = i + 1
+                    break
+                }
+            }
+        }
+    } else {
+        start = text.indexOf(typeNeedle)
+        if (start === -1) {
+            return null
+        }
+        // a type alias ends where the next top-level statement begins
+        const tail = text.slice(start)
+        const next = tail.slice(1).search(/\n(?:export |\/\*\*|\/\/)/)
+        end = next === -1 ? text.length : start + 1 + next
+    }
+    if (end === -1) {
+        return null
+    }
+
+    // absorb the JSDoc block directly above the declaration
+    let docStart = start
+    const before = text.slice(0, start)
+    const trimmed = before.trimEnd()
+    if (trimmed.endsWith('*/')) {
+        const open = trimmed.lastIndexOf('/**')
+        if (open !== -1) {
+            docStart = open
+        }
+    }
+    // absorb trailing newlines so removal doesn't leave gaps
+    while (end < text.length && text[end] === '\n') {
+        end++
+    }
+    return { start: docStart, end }
+}
+
+/**
+ * Rewrite a generated api.schemas.ts: emitted kernel twins become re-export
+ * aliases of their authored schema.ts declarations. Returns stats.
+ */
+export function aliasKernelTypes(schemasFile, kernelComponents, sourceIndex) {
+    let text = fs.readFileSync(schemasFile, 'utf8')
+    const importsByModule = new Map()
+    const aliasLines = []
+    const stats = { aliased: 0, skippedEnum: 0, skippedNoSource: 0, skippedValueExport: 0 }
+
+    for (const [name, schema] of kernelComponents) {
+        const source = sourceIndex.get(name)
+        if (!source) {
+            stats.skippedNoSource++
+            continue
+        }
+        if (schema.enum !== undefined || schema.const !== undefined || source.kind === 'enum') {
+            stats.skippedEnum++
+            continue
+        }
+        const block = findDeclBlock(text, `${name}Api`)
+        if (!block) {
+            continue // not emitted in this file
+        }
+        if (block.isValueExport) {
+            stats.skippedValueExport++
+            continue
+        }
+        text = text.slice(0, block.start) + text.slice(block.end)
+        if (!importsByModule.has(source.module)) {
+            importsByModule.set(source.module, [])
+        }
+        importsByModule.get(source.module).push(name)
+        // a plain re-export would not create a local binding, and sibling
+        // declarations in this file reference the *Api name — alias locally
+        aliasLines.push(`export type ${name}Api = ${name}`)
+        stats.aliased++
+    }
+
+    if (aliasLines.length > 0) {
+        const importLines = [...importsByModule.entries()]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([module, names]) => `import type { ${names.sort().join(', ')} } from '${module}'`)
+        const banner =
+            '// Kernel types below are authored in frontend/src/queries/schema (x-schema-source:\n' +
+            '// posthog.schema.*) — aliased instead of re-emitting a lossy generated copy.\n'
+        text = `${banner}${importLines.join('\n')}\n\n${aliasLines.sort().join('\n')}\n\n${text}`
+        fs.writeFileSync(schemasFile, text)
+    }
+    return stats
+}


### PR DESCRIPTION
## Problem

PostHog has two type codegen pipelines: schema.ts → schema.py (query types) and serializers → OpenAPI → generated TS. They intersect wherever an API payload embeds a query — widget configs, alert filters, endpoint requests. When a serializer references one of those Pydantic models, drf-spectacular inlines its full schema (plus everything it references) into the spec, and Orval regenerates all of it as `*Api` types.

The result: the frontend gets a second, machine-degraded copy of hundreds of types it already authors in `frontend/src/queries/schema/`. Discriminated unions lose their discriminators, typed query fields become `unknown`, and `products/dashboards` + `products/product_analytics` each carried ~5k lines of re-emitted kernel types. Anyone importing `TrendsQueryApi` got a strictly worse type than the `TrendsQuery` sitting one import away — and telling apart "genuinely backend-authored component" from "round-tripped frontend type" required brittle name matching.

## Changes

Two pieces, deliberately producer-declares-identity rather than consumer-guesses:

**Provenance tags.** Every OpenAPI component that enters the spec through a Pydantic model now carries an `x-schema-source` vendor extension naming the authoring Python class (`posthog/api/openapi_provenance.py`). Stamping happens at both Pydantic ingress points: a priority-override of drf-spectacular's contrib `PydanticExtension` (covers `extend_schema(request=Model)` / `extend_schema_field(Model)`), and the dashboards widget-spec bridge. Root models are tagged exactly; nested `$defs` resolve by name against the root model's module and `posthog.schema` with a structural sanity check, and stay untagged on any mismatch — a coincidental name collision yields a missing tag, never a wrong one.

**Kernel aliasing.** A new pass in `@posthog/openapi-codegen` consumes the tags: components tagged `posthog.schema.*` are projections of schema.ts-authored types, so instead of re-emitting them, the generated `api.schemas.ts` aliases the `*Api` name to the authored declaration (`import type { TrendsQuery } from '~/queries/schema/schema-general'` + `export type TrendsQueryApi = TrendsQuery`). Enum components are skipped (Orval emits const + type pairs that code may reference by value), as are tagged components without a matching exported TS declaration. Components tagged with product modules (contracts, widget configs) keep generating exactly as before.

Net effect: ~500 aliased types, about 10.7k lines of generated code removed, and generated types that reference kernel types now expose the original strict typing instead of a lossy copy. Tags themselves are invisible to Orval/Zod/MCP output.

## How did you test this code?

I'm an agent; only automated checks were run:

- 7 unit tests for provenance resolution (`posthog/api/test/test_openapi_provenance.py`)
- `hogli build:openapi-schema` passes with `--fail-on-warn`; tagging alone produced byte-identical generated output before the alias pass was added
- full `hogli build:openapi` + kea typegen + `tsc --noEmit` across the repo: no errors in any touched file (remaining errors are pre-existing on master in the new `products/skills` frontend and a quill package test)
- dashboards widget schema parity + OpenAPI enum tests pass on a fresh test DB

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @webjunkie as part of a type-system cleanup investigation (usage analysis of both codegen pipelines preceded this). Key decisions: provenance tagging over name/shape matching for identifying round-trip components (name-only matching is brittle in both directions, and aliasing changes compile-time types so it must be deterministic); enums excluded from aliasing because generated const objects are referenced by value while schema.ts models them as string-literal unions; import + local alias instead of a pure re-export because sibling declarations in the generated file reference the `*Api` names and re-exports create no local binding.
