### PR TITLE
chore(signals): document config-create flow and description field in scout skills

### DIFF
--- a/products/signals/skills/authoring-signals-scouts/SKILL.md
+++ b/products/signals/skills/authoring-signals-scouts/SKILL.md
@@ -42,8 +42,10 @@ only as good as its fit to the data it watches.
    specific event, confirm it exists and check its shape with `posthog:read-data-schema`.
    A scout for an event the project doesn't capture is dead on arrival.
 2. **See what already runs.** `posthog:signals-scout-config-list` lists every existing
-   scout on the project with its schedule, `enabled`, and `emit` posture. Don't duplicate
-   a surface a canonical scout already covers — adapt that one instead.
+   scout on the project with its schedule, `enabled`, and `emit` posture, plus each scout's
+   `description` (pulled from the skill's frontmatter) so you can tell what a scout watches
+   without loading its body. Don't duplicate a surface a canonical scout already covers —
+   adapt that one instead.
 3. **Read the closest canonical scout.** It's your template and your reference shape. Pull
    it with `posthog:llma-skill-get {"skill_name": "signals-scout-<x>"}` (per-team rows) or
    read it from the repo at `products/signals/skills/signals-scout-*/`. The generalist
@@ -69,10 +71,10 @@ There are two independent decisions: **what** you're building, and **where** it 
 
 ### Where
 
-| Path                                 | Mechanism                                                                                                                                  | Use when                                                                                                                              |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **Per-team** (the common user path)  | Create/edit a `signals-scout-*` `LLMSkill` row in the project's skills store via `posthog:llma-skill-create` / `-update` / `-file-create`. | Customizing for one project. The harness globs the row in on the next tick; canonical sync leaves your edited ("diverged") row alone. |
-| **Canonical** (PostHog contributors) | Edit disk under `products/signals/skills/signals-scout-*/`, lint/build, open a PR.                                                         | Improving a scout for _every_ enrolled project. `lazy_seed` mirrors it onto all enrolled teams on the next tick.                      |
+| Path                                 | Mechanism                                                                                                                                                                                                                  | Use when                                                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Per-team** (the common user path)  | Create/edit a `signals-scout-*` `LLMSkill` row in the project's skills store via `posthog:llma-skill-create` / `-update` / `-file-create`, then register its config immediately via `posthog:signals-scout-config-create`. | Customizing for one project. The harness globs the row in on the next tick; canonical sync leaves your edited ("diverged") row alone. |
+| **Canonical** (PostHog contributors) | Edit disk under `products/signals/skills/signals-scout-*/`, lint/build, open a PR.                                                                                                                                         | Improving a scout for _every_ enrolled project. `lazy_seed` mirrors it onto all enrolled teams on the next tick.                      |
 
 **Adapting-in-place tradeoff:** editing a canonical scout's row for your team marks it
 **diverged** — you stop receiving upstream improvements to that scout. If you only need an
@@ -119,8 +121,13 @@ body so every run anchors on it.
 ## Run posture (config)
 
 A scout's schedule and emit behavior live on its `SignalScoutConfig`, separate from the
-skill body. Tune with `posthog:signals-scout-config-update` (find the `id` via
-`-config-list`):
+skill body. For a **brand-new scout**, register the config immediately after creating the
+skill with `posthog:signals-scout-config-create {"skill_name": "signals-scout-<scope>", ...}`,
+setting any of the fields below in the same call — including creating it disabled or in
+dry-run **before it ever runs**. (It's an upsert: if the coordinator already auto-registered
+the row, your fields are applied to it.) Otherwise the coordinator auto-registers an enabled
+hourly default on its next tick (up to ~30 min). For an **existing scout**, tune with
+`posthog:signals-scout-config-update` (find the `id` via `-config-list`):
 
 - `run_interval_minutes` — 10 to 43200. Default 60 (hourly). Slow a chatty or expensive
   scout by raising this.
@@ -139,7 +146,10 @@ loop is **emit + inspect**: ship the scout live, let it emit, and calibrate agai
 actually lands.
 
 1. Ship the scout (the default `emit=true`) with a short `run_interval_minutes` so it fires
-   soon.
+   soon — set it at creation via
+   `posthog:signals-scout-config-create {"skill_name": ..., "run_interval_minutes": 10}`
+   right after `llma-skill-create`, rather than waiting for the coordinator to
+   auto-register an hourly default.
 2. After a tick, read what it did: `posthog:inbox-reports-list` (the findings it actually
    emitted), `posthog:signals-scout-runs-list` (run summaries), `-runs-retrieve` (full
    reasoning for one run), and `-scratchpad-search` (the durable memory it wrote).
@@ -148,7 +158,8 @@ actually lands.
 4. Once it's landing the right findings, restore the interval to something sustainable
    (hourly+).
 
-**Want to be extra careful?** Set `emit=false` to dry-run first — the scout runs and logs
+**Want to be extra careful?** Set `emit=false` to dry-run first — create the config with
+`emit=false` via `-config-create` so the scout never has a live first run; it runs and logs
 what it _would_ have emitted (visible via `-runs-list` / `-runs-retrieve`) without writing to
 the inbox. Inspect, refine, then flip `emit=true`. Worth it for a scout you expect to be
 chatty, expensive, or high-stakes; otherwise just emitting and watching the inbox is the

--- a/products/signals/skills/authoring-signals-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-signals-scouts/references/lifecycle-and-testing.md
@@ -14,7 +14,8 @@ exact mechanics; and how to test a scout in each.
   scout immediately (instead of waiting for the tick), register the config yourself with
   `posthog:signals-scout-config-create`, setting the schedule / emit posture in the same
   call; until one of those happens, the scout has no config row and won't show in
-  `-config-list`.
+  `-config-list`. Config responses also carry the scout's `description`, read live from the
+  skill's frontmatter — not a config field you set.
 - **Coordinator.** A periodic Temporal workflow ticks (~every 30 min). Each tick it bounds
   candidates to projects enrolled via the `signals-scout` feature-flag allowlist, then
   dispatches every **enabled** scout whose schedule is **due** (`last_run_at is None`, or

--- a/products/signals/skills/authoring-signals-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-signals-scouts/references/scout-anatomy.md
@@ -48,6 +48,11 @@ metadata:
 `metadata` are optional but conventional — `compatibility` documents the scopes/tools the
 scout assumes; `metadata.scope` gives downstream tooling a short label.
 
+The `description` does double duty: beyond skill discovery, it is surfaced verbatim as the
+scout's `description` on the config API (`signals-scout-config-list` / `-create` / `-update`
+responses) — it's how the fleet roster reads to agents and the UI without opening each
+scout's body. Write it to stand alone in that listing.
+
 ## Body structure
 
 The canonical body is a workflow, not a script — it reads like how an experienced analyst

--- a/products/signals/skills/exploring-signals-scouts/SKILL.md
+++ b/products/signals/skills/exploring-signals-scouts/SKILL.md
@@ -25,7 +25,9 @@ logs, AI observability, experiments, feature flags, session replay, web analytic
 more). A project may also have **custom scouts** beyond the canonical fleet — any
 `signals-scout-*` skill a team authored (e.g. `-brand-mentions`, `-mcp-feedback`) shows up here
 too, so don't assume a fixed roster: `signals-scout-config-list` is the authoritative roster for
-a project.
+a project. (One caveat: a just-authored scout has no config row until the coordinator's next
+tick auto-registers one — or until someone registers it via the write-side
+`signals-scout-config-create` — so a brand-new scout may briefly be missing from the list.)
 
 This skill helps you **understand and explore what a project's scouts are doing and how they're
 performing** — entirely through read-only MCP tools. It is the observability counterpart to
@@ -36,7 +38,7 @@ There are five things you can observe about the fleet, each with its own tool:
 
 | What you want to know                        | Tool                                     | What it tells you                                                               |
 | -------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------- |
-| Which scouts run, how often, in what posture | `signals-scout-config-list`              | One row per scout: schedule, `enabled`, `emit`, `last_run_at`                   |
+| Which scouts run, how often, in what posture | `signals-scout-config-list`              | One row per scout: schedule, `enabled`, `emit`, `last_run_at`, `description`    |
 | What the scouts actually did, run by run     | `signals-scout-runs-list` / `-retrieve`  | Per-run status, timing, end-of-run summary, `emitted_count`, deep-link          |
 | What the fleet has learned across runs       | `signals-scout-scratchpad-search`        | Durable per-team memory (baselines, noise, allowlists)                          |
 | What the scouts actually **emitted**         | `execute-sql` over `document_embeddings` | The authoritative per-finding record (weight, severity, confidence) — see below |


### PR DESCRIPTION
## Problem

Two recent scout-platform changes left the meta skills (`authoring-signals-scouts`, `exploring-signals-scouts`) partially stale:

- #62860 added the `signals-scout-config-create` endpoint/MCP tool, making the two-call flow (`llma-skill-create` → `signals-scout-config-create`) the canonical way to ship a scout with its schedule and emit posture set immediately. It updated the skill's `references/lifecycle-and-testing.md` but not the main `SKILL.md`, which still read as if config-update-after-the-coordinator-tick was the only lever.
- #62853 surfaced the scout skill's frontmatter `description` on the config API responses, but neither skill mentioned it.

Agents following the skill body verbatim would still author a scout and wait for the tick rather than registering and tuning the config up front.

## Changes

`authoring-signals-scouts/SKILL.md`:

- "Run posture" now leads with `-config-create` for brand-new scouts (upsert semantics, can create disabled or in dry-run before the first run), keeping `-config-update` for existing scouts.
- The test loop and dry-run guidance reference `-config-create` for setting a short interval / `emit=false` at creation time.
- The per-team path in the "Where" table includes the config-create call; the config-list orientation step mentions the surfaced `description`.

References:

- `scout-anatomy.md` — notes the frontmatter `description` is surfaced verbatim on the config API, so it should be written to stand alone in the fleet roster.
- `lifecycle-and-testing.md` — clarifies `description` on config responses is read live from the skill frontmatter, not a config field.

`exploring-signals-scouts/SKILL.md`:

- Caveat that a just-authored scout has no config row (and is missing from `-config-list`) until the coordinator tick or a `-config-create` call.
- `description` added to the config-list field summary.

## How did you test this code?

I'm an agent; documentation-only change. `hogli lint:skills` (77 skills pass) and `hogli build:skills` both run clean.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed — the skills themselves are the documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code, directed by @andrewm4894 (assignee/DRI). The agent audited the two meta skills against the merged #62860 and #62853 changes, identified the passages still describing the wait-for-the-tick flow, and applied the updates; lint/build verified with hogli.
