### PR TITLE
feat(data-warehouse): implement monday import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -112,6 +112,7 @@ the row lists both.
 | meta_ads         | HTTP                        | requests                                                        | ✅                          |
 | mixpanel         | HTTP                        | requests                                                        | ✅                          |
 | mollie           | HTTP                        | requests                                                        | ✅                          |
+| monday           | HTTP (GraphQL)              | requests                                                        | ✅                          |
 | mongodb          | DB protocol                 | pymongo                                                         | ➖                          |
 | mssql            | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
 | mysql            | DB protocol                 | pymysql                                                         | ➖                          |
@@ -265,7 +266,6 @@ doesn't conflict with concurrent PRs.
 - marketo
 - matomo
 - microsoft_teams
-- monday
 - netsuite
 - onedrive
 - opsgenie

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -858,7 +858,7 @@ class MollieSourceConfig(config.Config):
 
 @config.config
 class MondaySourceConfig(config.Config):
-    pass
+    api_token: str
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/monday/monday.py
+++ b/posthog/temporal/data_imports/sources/monday/monday.py
@@ -17,7 +17,7 @@ PAGE_SIZE = 100
 ITEMS_PAGE_SIZE = 500
 REQUEST_TIMEOUT_SECONDS = 120
 # Rate limiting is complexity-budget based (5-10M points/min by tier) and
-# surfaces as 429s; exponential backoff rides out the minute window.
+# surfaces as a GraphQL error (not a 429); exponential backoff rides out the minute window.
 MAX_RETRY_ATTEMPTS = 5
 
 _BOARDS_QUERY = """

--- a/posthog/temporal/data_imports/sources/monday/monday.py
+++ b/posthog/temporal/data_imports/sources/monday/monday.py
@@ -1,0 +1,255 @@
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.monday.settings import MONDAY_ENDPOINTS
+
+MONDAY_API_URL = "https://api.monday.com/v2"
+# Pinned GA API version (monday releases quarterly versions).
+MONDAY_API_VERSION = "2024-10"
+# Boards/users page size; items_page caps at 500.
+PAGE_SIZE = 100
+ITEMS_PAGE_SIZE = 500
+REQUEST_TIMEOUT_SECONDS = 120
+# Rate limiting is complexity-budget based (5-10M points/min by tier) and
+# surfaces as 429s; exponential backoff rides out the minute window.
+MAX_RETRY_ATTEMPTS = 5
+
+_BOARDS_QUERY = """
+query ($limit: Int!, $page: Int!) {
+  boards (limit: $limit, page: $page) {
+    id
+    name
+    board_kind
+    state
+    description
+    workspace_id
+    item_terminology
+    items_count
+    permissions
+    updated_at
+  }
+}
+"""
+
+_USERS_QUERY = """
+query ($limit: Int!, $page: Int!) {
+  users (limit: $limit, page: $page) {
+    id
+    name
+    email
+    enabled
+    is_admin
+    is_guest
+    is_pending
+    title
+    location
+    created_at
+    last_activity
+  }
+}
+"""
+
+_WORKSPACES_QUERY = """
+query ($limit: Int!, $page: Int!) {
+  workspaces (limit: $limit, page: $page) {
+    id
+    name
+    kind
+    description
+    state
+    created_at
+  }
+}
+"""
+
+_ITEM_FIELDS = """
+      id
+      name
+      state
+      created_at
+      updated_at
+      group { id title }
+      creator_id
+      column_values { id type text value }
+"""
+
+_BOARD_IDS_QUERY = """
+query ($limit: Int!, $page: Int!) {
+  boards (limit: $limit, page: $page) { id }
+}
+"""
+
+_ITEMS_PAGE_QUERY = f"""
+query ($boardId: [ID!], $limit: Int!) {{
+  boards (ids: $boardId) {{
+    items_page (limit: $limit) {{
+      cursor
+      items {{
+{_ITEM_FIELDS}
+      }}
+    }}
+  }}
+}}
+"""
+
+_NEXT_ITEMS_PAGE_QUERY = f"""
+query ($cursor: String!, $limit: Int!) {{
+  next_items_page (cursor: $cursor, limit: $limit) {{
+    cursor
+    items {{
+{_ITEM_FIELDS}
+    }}
+  }}
+}}
+"""
+
+
+class MondayRetryableError(Exception):
+    pass
+
+
+class MondayGraphQLError(Exception):
+    pass
+
+
+def _get_session(api_token: str) -> requests.Session:
+    return make_tracked_session(
+        headers={"Authorization": api_token, "API-Version": MONDAY_API_VERSION},
+        redact_values=(api_token,),
+    )
+
+
+def _execute(
+    session: requests.Session,
+    query: str,
+    variables: dict[str, Any],
+    logger: FilteringBoundLogger,
+) -> dict[str, Any]:
+    response = session.post(
+        MONDAY_API_URL,
+        json={"query": query, "variables": variables},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise MondayRetryableError(f"monday.com API error (retryable): status={response.status_code}")
+
+    if not response.ok:
+        logger.error(f"monday.com API error: status={response.status_code}, body={response.text}")
+        response.raise_for_status()
+
+    body = response.json()
+    errors = body.get("errors")
+    if errors:
+        message = "; ".join(str(error.get("message", error)) for error in errors)
+        # Complexity-budget exhaustion comes back as a GraphQL error, not a 429.
+        if "complexity" in message.lower():
+            raise MondayRetryableError(f"monday.com complexity budget exhausted: {message}")
+        raise MondayGraphQLError(f"monday.com GraphQL error: {message}")
+
+    return body.get("data") or {}
+
+
+class _NoopLogger:
+    def error(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def debug(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def validate_credentials(api_token: str) -> bool:
+    """Confirm the API token is valid with a cheap `me` query."""
+    try:
+        session = _get_session(api_token)
+        data = _execute(session, "query { me { id } }", {}, _NoopLogger())  # type: ignore[arg-type]
+        return bool((data.get("me") or {}).get("id"))
+    except Exception:
+        return False
+
+
+def get_rows(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    session = _get_session(api_token)
+
+    @retry(
+        retry=retry_if_exception_type((MondayRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=5, max=120),
+        reraise=True,
+    )
+    def execute(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        return _execute(session, query, variables, logger)
+
+    def iterate_paged(query: str, data_key: str) -> Iterator[list[dict[str, Any]]]:
+        page = 1
+        while True:
+            data = execute(query, {"limit": PAGE_SIZE, "page": page})
+            items = data.get(data_key) or []
+            if items:
+                yield items
+            if len(items) < PAGE_SIZE:
+                return
+            page += 1
+
+    if endpoint == "boards":
+        yield from iterate_paged(_BOARDS_QUERY, "boards")
+        return
+
+    if endpoint == "users":
+        yield from iterate_paged(_USERS_QUERY, "users")
+        return
+
+    if endpoint == "workspaces":
+        yield from iterate_paged(_WORKSPACES_QUERY, "workspaces")
+        return
+
+    # items: fan out over every board, then walk its items_page cursor chain.
+    board_ids = [board["id"] for page in iterate_paged(_BOARD_IDS_QUERY, "boards") for board in page]
+
+    for board_id in board_ids:
+        data = execute(_ITEMS_PAGE_QUERY, {"boardId": [board_id], "limit": ITEMS_PAGE_SIZE})
+        boards = data.get("boards") or []
+        items_page = (boards[0].get("items_page") if boards else None) or {}
+
+        while True:
+            items = [{**item, "_board_id": board_id} for item in (items_page.get("items") or [])]
+            if items:
+                yield items
+
+            cursor: Optional[str] = items_page.get("cursor")
+            if not cursor or not items:
+                break
+
+            data = execute(_NEXT_ITEMS_PAGE_QUERY, {"cursor": cursor, "limit": ITEMS_PAGE_SIZE})
+            items_page = data.get("next_items_page") or {}
+
+
+def monday_source(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> SourceResponse:
+    config = MONDAY_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_token=api_token,
+            endpoint=endpoint,
+            logger=logger,
+        ),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        sort_mode="asc",
+    )

--- a/posthog/temporal/data_imports/sources/monday/settings.py
+++ b/posthog/temporal/data_imports/sources/monday/settings.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MondayEndpointConfig:
+    name: str
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+
+
+# monday.com is GraphQL-only. List queries have no honest updated-since
+# filtering (incremental would need the activity log, whose retention window is
+# plan-dependent), so every stream is a full refresh. Items use cursor paging
+# whose cursors expire after 60 minutes, so nothing is persisted across runs.
+MONDAY_ENDPOINTS: dict[str, MondayEndpointConfig] = {
+    "boards": MondayEndpointConfig(
+        name="boards",
+    ),
+    "items": MondayEndpointConfig(
+        name="items",
+        # Item ids are globally unique, but keep the board linkage in the key
+        # so re-parented items can't collide.
+        primary_keys=["_board_id", "id"],
+    ),
+    "users": MondayEndpointConfig(
+        name="users",
+    ),
+    "workspaces": MondayEndpointConfig(
+        name="workspaces",
+    ),
+}
+
+ENDPOINTS = tuple(MONDAY_ENDPOINTS.keys())

--- a/posthog/temporal/data_imports/sources/monday/source.py
+++ b/posthog/temporal/data_imports/sources/monday/source.py
@@ -29,9 +29,12 @@ class MondaySource(SimpleSource[MondaySourceConfig]):
         return ExternalDataSourceType.MONDAY
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # Scope GraphQL matches to auth/permission failures only — a broad "monday.com GraphQL error"
+        # key would also catch transient server-side errors and permanently disable the sync.
         return {
             "401 Client Error: Unauthorized for url: https://api.monday.com": "monday.com authentication failed. Please check your API token.",
-            "monday.com GraphQL error": "monday.com rejected the request. Please check that your API token has access to the requested data.",
+            "monday.com GraphQL error: Not authenticated": "monday.com authentication failed. Please check your API token.",
+            "monday.com GraphQL error: User unauthorized": "monday.com rejected the request. Please check that your API token has access to the requested data.",
         }
 
     @property

--- a/posthog/temporal/data_imports/sources/monday/source.py
+++ b/posthog/temporal/data_imports/sources/monday/source.py
@@ -1,13 +1,23 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import MondaySourceConfig
+from posthog.temporal.data_imports.sources.monday.monday import (
+    monday_source,
+    validate_credentials as validate_monday_credentials,
+)
+from posthog.temporal.data_imports.sources.monday.settings import ENDPOINTS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -18,12 +28,75 @@ class MondaySource(SimpleSource[MondaySourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.MONDAY
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.monday.com": "monday.com authentication failed. Please check your API token.",
+            "monday.com GraphQL error": "monday.com rejected the request. Please check that your API token has access to the requested data.",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.MONDAY,
-            label="Monday",
+            label="monday.com",
+            caption="""Enter your monday.com API token to pull your boards and items into the PostHog Data warehouse.
+
+You can find your personal API token in monday.com under your avatar > Developers > My access tokens (admins can also use the account API token). Items are synced from every board the token can access.""",
             iconPath="/static/services/monday.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/monday",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_token",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: MondaySourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # GraphQL list queries have no honest updated-since filter (incremental
+        # would need the plan-limited activity log), so full refresh only.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: MondaySourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_monday_credentials(config.api_token):
+            return True, None
+
+        return False, "Invalid monday.com API token"
+
+    def source_for_pipeline(self, config: MondaySourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return monday_source(
+            api_token=config.api_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
         )

--- a/posthog/temporal/data_imports/sources/monday/tests/test_monday.py
+++ b/posthog/temporal/data_imports/sources/monday/tests/test_monday.py
@@ -1,0 +1,141 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.monday.monday import (
+    ITEMS_PAGE_SIZE,
+    PAGE_SIZE,
+    MondayGraphQLError,
+    get_rows,
+    monday_source,
+    validate_credentials,
+)
+from posthog.temporal.data_imports.sources.monday.settings import ENDPOINTS, MONDAY_ENDPOINTS
+
+_MODULE = "posthog.temporal.data_imports.sources.monday.monday"
+
+
+def _response(data: dict[str, Any], errors: list[dict[str, Any]] | None = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    body: dict[str, Any] = {"data": data}
+    if errors is not None:
+        body["errors"] = errors
+    resp.json.return_value = body
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+class TestValidateCredentials:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_valid_when_me_returns_id(self, mock_session):
+        mock_session.return_value.post.return_value = _response({"me": {"id": "user-1"}})
+        assert validate_credentials("token") is True
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_invalid_when_me_is_empty(self, mock_session):
+        mock_session.return_value.post.return_value = _response({"me": None})
+        assert validate_credentials("token") is False
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_invalid_on_graphql_errors(self, mock_session):
+        mock_session.return_value.post.return_value = _response({}, errors=[{"message": "Not Authenticated"}])
+        assert validate_credentials("token") is False
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_invalid_on_exception(self, mock_session):
+        mock_session.return_value.post.side_effect = Exception("boom")
+        assert validate_credentials("token") is False
+
+
+class TestGetRowsPaged:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_boards_paginate_until_short_page(self, mock_session):
+        full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
+        mock_session.return_value.post.side_effect = [
+            _response({"boards": full_page}),
+            _response({"boards": [{"id": "last"}]}),
+        ]
+
+        batches = list(get_rows("token", "boards", mock.MagicMock()))
+
+        assert len(batches) == 2
+        first_vars = mock_session.return_value.post.call_args_list[0].kwargs["json"]["variables"]
+        second_vars = mock_session.return_value.post.call_args_list[1].kwargs["json"]["variables"]
+        assert first_vars == {"limit": PAGE_SIZE, "page": 1}
+        assert second_vars == {"limit": PAGE_SIZE, "page": 2}
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_graphql_error_raises(self, mock_session):
+        mock_session.return_value.post.return_value = _response({}, errors=[{"message": "Field not found"}])
+
+        with pytest.raises(MondayGraphQLError):
+            list(get_rows("token", "users", mock.MagicMock()))
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_requests_carry_token_and_api_version(self, mock_session):
+        mock_session.return_value.post.return_value = _response({"users": []})
+
+        list(get_rows("token", "users", mock.MagicMock()))
+
+        headers = mock_session.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "token"
+        assert headers["API-Version"]
+
+
+class TestGetRowsItems:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_items_fan_out_over_boards_and_walk_cursors(self, mock_session):
+        full_items = [{"id": str(i)} for i in range(ITEMS_PAGE_SIZE)]
+        mock_session.return_value.post.side_effect = [
+            _response({"boards": [{"id": "b1"}]}),  # board ids page
+            _response({"boards": [{"items_page": {"cursor": "cur1", "items": full_items}}]}),
+            _response({"next_items_page": {"cursor": None, "items": [{"id": "tail"}]}}),
+        ]
+
+        batches = list(get_rows("token", "items", mock.MagicMock()))
+
+        flat = [item for batch in batches for item in batch]
+        assert len(flat) == ITEMS_PAGE_SIZE + 1
+        assert all(item["_board_id"] == "b1" for item in flat)
+        next_vars = mock_session.return_value.post.call_args_list[2].kwargs["json"]["variables"]
+        assert next_vars == {"cursor": "cur1", "limit": ITEMS_PAGE_SIZE}
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_items_stop_when_cursor_absent(self, mock_session):
+        mock_session.return_value.post.side_effect = [
+            _response({"boards": [{"id": "b1"}]}),
+            _response({"boards": [{"items_page": {"cursor": None, "items": [{"id": "only"}]}}]}),
+        ]
+
+        batches = list(get_rows("token", "items", mock.MagicMock()))
+
+        assert [item["id"] for batch in batches for item in batch] == ["only"]
+        assert mock_session.return_value.post.call_count == 2
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_items_handle_board_without_items_page(self, mock_session):
+        mock_session.return_value.post.side_effect = [
+            _response({"boards": [{"id": "b1"}]}),
+            _response({"boards": []}),
+        ]
+
+        assert list(get_rows("token", "items", mock.MagicMock())) == []
+
+
+class TestMondaySourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint):
+        config = MONDAY_ENDPOINTS[endpoint]
+        response = monday_source("token", endpoint, mock.MagicMock())
+
+        assert response.name == endpoint
+        assert response.primary_keys == config.primary_keys
+        assert response.sort_mode == "asc"
+        assert response.partition_mode is None
+        assert response.partition_keys is None
+
+    def test_items_have_composite_primary_key(self):
+        response = monday_source("token", "items", mock.MagicMock())
+        assert response.primary_keys == ["_board_id", "id"]

--- a/posthog/temporal/data_imports/sources/monday/tests/test_monday_source.py
+++ b/posthog/temporal/data_imports/sources/monday/tests/test_monday_source.py
@@ -1,0 +1,107 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.generated_configs import MondaySourceConfig
+from posthog.temporal.data_imports.sources.monday.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.monday.source import MondaySource
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestMondaySource:
+    def setup_method(self):
+        self.source = MondaySource()
+        self.team_id = 123
+        self.config = MondaySourceConfig(api_token="api-token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.MONDAY
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Monday"
+        assert config.label == "monday.com"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/monday.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_token"]
+
+    def test_api_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_token")
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.monday.com/v2",
+            "monday.com GraphQL error: User unauthorized to perform action",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "500 Server Error for url: https://api.monday.com/v2",
+            "monday.com complexity budget exhausted: budget left 0",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)
+
+    def test_get_schemas_are_full_refresh_only(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+        assert all(schema.incremental_fields == [] for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["items"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "items"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid monday.com API token"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.monday.source.validate_monday_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.api_token)
+
+    @mock.patch("posthog.temporal.data_imports.sources.monday.source.monday_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_monday_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "items"
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        mock_monday_source.assert_called_once()
+        kwargs = mock_monday_source.call_args.kwargs
+        assert kwargs["api_token"] == "api-token"
+        assert kwargs["endpoint"] == "items"


### PR DESCRIPTION
## Problem

The monday.com data warehouse source was scaffolded (registered with `unreleasedSource=True` and an empty stub) but had no sync logic, so users couldn't pull their monday.com boards and items into PostHog.

## Changes

Implements the monday.com import source following the warehouse source architecture (`source.py` / `settings.py` / `monday.py` split). monday.com is **GraphQL-only** (no REST alternative), so the transport is a small GraphQL client over `POST /v2` with all values passed as GraphQL variables (never interpolated into query strings) and a pinned `API-Version` header:

- **Endpoints:** `boards`, `users`, `workspaces` (limit/page pagination terminated on a short page) and `items` — fanned out over every board via `items_page` and continued with `next_items_page` cursor chains (500 items/page; cursors expire after 60 minutes, so nothing is persisted across runs → `SimpleSource`). Item rows carry `_board_id` with composite pk `(_board_id, id)`.
- **Error handling:** GraphQL errors arrive in a 200 body — the client raises on the `errors` key, with **complexity-budget exhaustion** (monday's rate limiting is complexity-points-per-minute, reported as a GraphQL error rather than a 429) classified as retryable with backoff that rides out the minute window. Other GraphQL errors map to a non-retryable entry so bad scopes don't retry forever.
- **Auth:** API token in the `Authorization` header. Validation runs a cheap `{ me { id } }` query.
- **Sync mode:** honest full refresh — list queries have no updated-since filter; real incremental would need the activity log, whose retention window is plan-dependent.
- Removes `unreleasedSource` and ships as `releaseStatus=ALPHA`; regenerates `MondaySourceConfig`; moves monday to the Implemented table in `SOURCES.md` (comm method noted as HTTP/GraphQL).

monday.com webhooks are manageable via GraphQL mutations and could augment change capture in a follow-up.

## How did you test this code?

Automated tests only (no live monday.com credentials):

- `posthog/temporal/data_imports/sources/monday/tests/test_monday.py` — transport: page pagination with variables, items board fan-out and cursor-chain walking with `_board_id` injection, cursor-absent and missing-items_page guards, GraphQL error raising, token/API-Version headers, `me`-query credential validation.
- `posthog/temporal/data_imports/sources/monday/tests/test_monday_source.py` — source class: config fields, full-refresh-only schemas, non-retryable error matching (complexity errors deliberately NOT matched — they're retryable), argument plumbing.
- Registry-level tests in `posthog/temporal/data_imports/sources/tests/` pass (53 tests total).

Query shapes (boards/users/workspaces fields, items_page/next_items_page contract) were verified against monday.com's GraphQL API docs; live smoke testing wasn't possible without credentials, hence the alpha release status.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
