### PR TITLE
fix(replay): stop category dropdown collapsing the filter popover

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.test.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { CLICK_OUTSIDE_BLOCK_CLASS } from 'lib/hooks/useOutsideClickHandler'
+
+import { Popover } from './Popover'
+
+describe('Popover', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderPopover(extra?: React.ReactNode): { onClickOutside: jest.Mock } {
+        const onClickOutside = jest.fn()
+        render(
+            <div>
+                <Popover visible overlay={<div>overlay content</div>} onClickOutside={onClickOutside}>
+                    <button type="button">reference</button>
+                </Popover>
+                {extra}
+            </div>
+        )
+        return { onClickOutside }
+    }
+
+    it('dismisses when clicking a plain outside element', async () => {
+        const { onClickOutside } = renderPopover(<button type="button">outside</button>)
+
+        await userEvent.click(screen.getByText('outside'))
+
+        expect(onClickOutside).toHaveBeenCalled()
+    })
+
+    // Regression: a nested menu portaled out of a parent popover's *reference* subtree
+    // (e.g. the TaxonomicFilter category pill in the search input suffix) inherits the
+    // wrong overlay level, so the parent can't recognize it as nested. The element opts
+    // out via CLICK_OUTSIDE_BLOCK_CLASS — clicking it must not dismiss the parent.
+    it('does not dismiss when clicking an element marked with CLICK_OUTSIDE_BLOCK_CLASS', async () => {
+        const { onClickOutside } = renderPopover(
+            <button type="button" className={CLICK_OUTSIDE_BLOCK_CLASS}>
+                nested menu item
+            </button>
+        )
+
+        await userEvent.click(screen.getByText('nested menu item'))
+
+        expect(onClickOutside).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -91,6 +91,13 @@ export const PopoverReferenceContext = React.createContext<[boolean, Placement] 
 // Used so a parent popover doesn't treat a click on a deeper-nested popover as an outside click.
 const openPopoverFloatings: Array<{ level: number; element: HTMLElement }> = []
 
+// Whether a click target opted out of outside-dismiss via CLICK_OUTSIDE_BLOCK_CLASS. Mirrors the
+// global exemption the legacy useOutsideClickHandler already applies, so both outside-click paths
+// agree. `Element` (not `HTMLElement`) so a click landing on an SVG icon inside an opted-out
+// element still matches.
+const optedOutOfOutsideDismiss = (target: EventTarget | Node | null): boolean =>
+    target instanceof Element && !!target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)
+
 /** This is a custom popover control that uses `floating-ui` to position DOM nodes.
  *
  * Often used with buttons for various menu. If this is your intention, use `LemonButtonWithDropdown`.
@@ -284,11 +291,11 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
             if (!target) {
                 return true
             }
-            // Honor the block class on the floating-ui dismiss path too, not just onClickInside.
-            // A nested menu living in a parent popover's *reference* subtree (e.g. the
-            // TaxonomicFilter category pill in the search input's suffix) inherits the wrong
-            // overlay level, so the level check below can't recognize it as nested.
-            if (target instanceof HTMLElement && target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)) {
+            // Honor the block class on the floating-ui dismiss path too, not just onClickInside —
+            // a nested menu in a parent popover's *reference* subtree (e.g. the TaxonomicFilter
+            // category pill in the search input's suffix) inherits the wrong overlay level, so the
+            // level check below can't recognize it as nested.
+            if (optedOutOfOutsideDismiss(target)) {
                 return false
             }
             if (additionalRefsRef.current.some((r) => r.current?.contains(target))) {
@@ -333,7 +340,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
     }, []) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const _onClickInside: MouseEventHandler<HTMLDivElement> = (e): void => {
-        if (e.target instanceof HTMLElement && e.target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)) {
+        if (optedOutOfOutsideDismiss(e.target)) {
             return
         }
         onClickInside?.(e)

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -275,13 +275,21 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
 
     const dismiss = useDismiss(context, {
         enabled: visible,
-        // useDismiss only treats the floating + reference elements as "inside". Two things
-        // need explicit exemption: additionalRefs (consumer-registered companion elements)
-        // and deeper-nested popovers (portaled, so DOM-siblings rather than descendants).
+        // useDismiss only treats the floating + reference elements as "inside". Three things
+        // need explicit exemption: elements opting out via CLICK_OUTSIDE_BLOCK_CLASS,
+        // additionalRefs (consumer-registered companion elements), and deeper-nested popovers
+        // (portaled, so DOM-siblings rather than descendants).
         outsidePress: (event) => {
             const target = event.target as Node | null
             if (!target) {
                 return true
+            }
+            // Honor the block class on the floating-ui dismiss path too, not just onClickInside.
+            // A nested menu living in a parent popover's *reference* subtree (e.g. the
+            // TaxonomicFilter category pill in the search input's suffix) inherits the wrong
+            // overlay level, so the level check below can't recognize it as nested.
+            if (target instanceof HTMLElement && target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)) {
+                return false
             }
             if (additionalRefsRef.current.some((r) => r.current?.contains(target))) {
                 return false

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilterAddFilterPopover.test.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilterAddFilterPopover.test.tsx
@@ -1,0 +1,109 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { initKeaTests } from '~/test/init'
+import { mockGetEventDefinitions, mockGetPropertyDefinitions } from '~/test/mocks'
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
+
+import { RecordingsUniversalFilterAddFilterPopover } from './RecordingsUniversalFiltersEmbed'
+
+const DEFAULT_GROUP: UniversalFiltersGroup = {
+    type: FilterLogicalOperator.And,
+    values: [{ type: FilterLogicalOperator.And, values: [] }],
+}
+
+jest.mock('lib/components/AutoSizer', () => ({
+    AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
+        renderProp({ height: 400, width: 400 }),
+}))
+
+describe('RecordingsUniversalFilterAddFilterPopover (pill category dropdown)', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                '/api/environments/:team/persons/properties': [],
+                '/api/environments/:team/events/values': [],
+                '/api/environments/:team/persons/values': [],
+            },
+            post: {
+                '/api/environments/:team/query': { results: [] },
+            },
+        })
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+        propertyDefinitionsModel.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function renderPopover(): void {
+        const taxonomicGroupTypes = [
+            TaxonomicFilterGroupType.Events,
+            TaxonomicFilterGroupType.EventProperties,
+            TaxonomicFilterGroupType.PersonProperties,
+        ]
+        render(
+            <Provider>
+                <UniversalFilters
+                    rootKey="replay-add-filter-pill-test"
+                    group={DEFAULT_GROUP}
+                    onChange={jest.fn()}
+                    taxonomicGroupTypes={taxonomicGroupTypes}
+                >
+                    <RecordingsUniversalFilterAddFilterPopover
+                        categoryDropdownVariant="pill"
+                        taxonomicGroupTypes={taxonomicGroupTypes}
+                    />
+                </UniversalFilters>
+            </Provider>
+        )
+    }
+
+    it('applies the picked category from the pill menu while keeping the filter open', async () => {
+        renderPopover()
+
+        // Open the replay filter — focusing the search input reveals the category pill.
+        const input = screen.getByTestId('replay-filters-add-filter-input')
+        await userEvent.click(input)
+
+        const pillTrigger = await screen.findByTestId('taxonomic-category-dropdown-trigger-pill')
+        // Defaults to the first group.
+        expect(pillTrigger).toHaveTextContent('Events')
+
+        // Type a query so we can prove the surrounding popover is not dismissed by the pick:
+        // the bug routed the menu click through the parent popover's outside-press handler,
+        // which cleared the query and collapsed the filter.
+        await userEvent.type(input, 'email')
+        expect(input).toHaveValue('email')
+
+        // Open the pill menu and select a visible option. Re-query the trigger — typing
+        // re-renders the input suffix, detaching the node captured above.
+        await userEvent.click(screen.getByTestId('taxonomic-category-dropdown-trigger-pill'))
+        const personPropertiesItem = await screen.findByTestId('taxonomic-category-dropdown-item-person_properties')
+        await userEvent.click(personPropertiesItem)
+
+        // The picked category is applied (findByRole waits for the re-render)...
+        expect(
+            await screen.findByRole('button', { name: 'Current category: Person properties. Click to change.' })
+        ).toBeInTheDocument()
+
+        // ...and the main filter stays open with its search query intact.
+        expect(screen.getByTestId('replay-filters-add-filter-input')).toBeInTheDocument()
+        expect(screen.getByTestId('replay-filters-add-filter-input')).toHaveValue('email')
+    })
+})

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -493,7 +493,7 @@ function SavedFilterNameEditor({
     )
 }
 
-function RecordingsUniversalFilterAddFilterPopover({
+export function RecordingsUniversalFilterAddFilterPopover({
     categoryDropdownVariant,
     taxonomicGroupTypes,
 }: {


### PR DESCRIPTION
## Problem

On session replay filtering (the `pill` arm of the `TAXONOMIC_FILTER_CATEGORY_DROPDOWN` flag), the filter **category dropdown glitches out**: opening the pill and selecting a category collapses the entire filter popover, which then immediately reopens. Reported via a support ticket.

**Why:** The category pill (`CategoryDropdown`) renders in the search input's `suffix`, which lives in the surrounding `Popover`'s _reference_ subtree — not its overlay. Popover nesting level comes from `PopoverOverlayContext`, and that context is only provided around the overlay (`Popover.tsx`), so the pill's portaled `LemonMenu` inherits the default level instead of one deeper than its parent. The parent's floating-ui `useDismiss` then fails its `level > currentPopoverLevel` nesting check and treats a click inside the pill menu as an _outside press_, dismissing the whole filter popover. It reopens via the input's `onFocus` handler — the visible "glitch".

`CLICK_OUTSIDE_BLOCK_CLASS` was already meant to opt elements out of outside-click dismissal, and the pill is tagged with it — but it was only honored on the `onClickInside` path, not floating-ui's `outsidePress`. There are two independent outside-click mechanisms and only one respected the class.

This only reproduces in the `pill` variant; `control` (tab pills) is unaffected.

## Changes

Honor `CLICK_OUTSIDE_BLOCK_CLASS` on the `Popover` `outsidePress` (floating-ui `useDismiss`) path too, so the class opts an element out of dismissal across _both_ outside-click mechanisms. Purely additive — it can only make dismissal more lenient, and only for elements that explicitly carry the class.

Touches the shared `Popover` component, so worth a careful look, though the blast radius is bounded by the rarity and intent of the opt-out class.

This is a **deliberate app-wide behaviour change**: every `Popover` now refuses to dismiss on a click inside any `.click-outside-block` element. That's parity with the legacy `useOutsideClickHandler`, which already exempts the class globally — this brings the floating-ui path in line rather than inventing new behaviour. The check is shared with `_onClickInside` via a single `optedOutOfOutsideDismiss` predicate.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — I did not manually exercise the UI.

- Added `frontend/src/lib/lemon-ui/Popover/Popover.test.tsx` with two cases: a plain outside click still dismisses; a click on a `CLICK_OUTSIDE_BLOCK_CLASS` element does not. Verified the regression test **fails on master without the fix** and **passes with it**.
- `oxlint` clean on both changed files; `tsc --noEmit` clean for the Popover files.
- The broader `TaxonomicFilter` jest suite could not run in my sandbox (an unbuilt sibling workspace package, `@posthog/quill`) — left for CI. Per the `modifying-taxonomic-filter` skill, this change touches neither tab rendering nor any of the five telemetry events, so payload shapes are unaffected; a reviewer should still smoke-test both `control` and `pill` variants.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code from a Slack thread, driven by @xljones (debug request on a session-replay filter ticket). I traced the glitch through the Popover nesting-level mechanism: the category pill lives in the parent popover's reference subtree, so it never sees the parent's overlay-level context and floating-ui's `useDismiss` mis-classifies clicks inside it as outside presses. Considered the narrower alternative of wrapping the input suffix in a `PopoverOverlayContext.Provider` at the parent's level, but rejected it — the suffix has no clean access to the parent's internal level, making it more invasive than honoring the existing opt-out class on the dismiss path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781181871613849?thread_ts=1781181871.613849&cid=C0ACRAMJUAG)*

