### PR TITLE
feat(data-warehouse): implement coda import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -61,6 +61,7 @@ the row lists both.
 | calendly         | HTTP                        | requests                                                        | ✅                          |
 | campaign_monitor | HTTP                        | requests                                                        | ✅                          |
 | chargebee        | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| coda             | HTTP                        | requests                                                        | ✅                          |
 | commercetools    | HTTP                        | requests                                                        | ✅                          |
 | confluence       | HTTP                        | requests                                                        | ✅                          |
 | chartmogul       | HTTP                        | requests                                                        | ✅                          |
@@ -226,7 +227,6 @@ doesn't conflict with concurrent PRs.
 - clari
 - cloudflare
 - cockroachdb
-- coda
 - constant_contact
 - copper
 - cosmosdb

--- a/posthog/temporal/data_imports/sources/coda/coda.py
+++ b/posthog/temporal/data_imports/sources/coda/coda.py
@@ -55,8 +55,7 @@ def get_rows(
         wait=wait_exponential_jitter(initial=5, max=120),
         reraise=True,
     )
-    def fetch(path: str, params: dict[str, Any], interval: float) -> dict[str, Any]:
-        time.sleep(interval)
+    def fetch(path: str, params: dict[str, Any]) -> dict[str, Any]:
         url = f"{CODA_BASE_URL}{path}"
         if params:
             url = f"{url}?{urlencode(params)}"
@@ -80,7 +79,10 @@ def get_rows(
             if token:
                 # pageToken supersedes other params on continuation requests.
                 params = {"pageToken": token}
-            data = fetch(path, params, interval)
+            # Proactive pacing sits outside fetch's @retry boundary so tenacity
+            # backoff isn't compounded by this sleep on every retry attempt.
+            time.sleep(interval)
+            data = fetch(path, params)
             items = data.get("items", []) or []
             if items:
                 yield items
@@ -89,12 +91,9 @@ def get_rows(
                 return
 
     def doc_ids() -> list[str]:
-        return [
-            doc["id"]
-            for page in iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS)
-            for doc in page
-            if doc.get("id")
-        ]
+        # Direct access on the primary key so malformed API data fails fast
+        # rather than silently dropping docs from the sync.
+        return [doc["id"] for page in iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS) for doc in page]
 
     if endpoint == "docs":
         yield from iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS)
@@ -106,11 +105,15 @@ def get_rows(
                 yield [{**table, "_doc_id": doc_id} for table in page]
         return
 
+    if endpoint != "rows":
+        raise ValueError(f"Unknown Coda endpoint: {endpoint!r}")
+
     # rows: fan out docs → tables → rows.
     for doc_id in doc_ids():
         tables: list[str] = []
         for page in iterate_pages(f"/docs/{quote(doc_id)}/tables", PAGE_SIZE, READ_INTERVAL_SECONDS):
-            tables.extend(table["id"] for table in page if table.get("id"))
+            # Direct access on the primary key so malformed API data fails fast.
+            tables.extend(table["id"] for table in page)
 
         for table_id in tables:
             for page in iterate_pages(

--- a/posthog/temporal/data_imports/sources/coda/coda.py
+++ b/posthog/temporal/data_imports/sources/coda/coda.py
@@ -87,7 +87,9 @@ def get_rows(
             if items:
                 yield items
             token = data.get("nextPageToken")
-            if not token or not items:
+            # Continue while Coda hands back a continuation token, even if this
+            # page was empty — intermediate empty pages still precede more data.
+            if not token:
                 return
 
     def doc_ids() -> list[str]:

--- a/posthog/temporal/data_imports/sources/coda/coda.py
+++ b/posthog/temporal/data_imports/sources/coda/coda.py
@@ -1,0 +1,144 @@
+import time
+from collections.abc import Iterator
+from typing import Any, Optional
+from urllib.parse import quote, urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.coda.settings import CODA_ENDPOINTS
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+
+CODA_BASE_URL = "https://coda.io/apis/v1"
+PAGE_SIZE = 100
+ROWS_PAGE_SIZE = 200
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_RETRY_ATTEMPTS = 5
+# Coda's rate limits are per endpoint family: doc listing allows only
+# 4 req/6s, while reads allow 100 req/6s — space requests accordingly.
+DOC_LIST_INTERVAL_SECONDS = 1.6
+READ_INTERVAL_SECONDS = 0.07
+
+
+class CodaRetryableError(Exception):
+    pass
+
+
+def _get_session(api_token: str) -> requests.Session:
+    return make_tracked_session(headers={"Authorization": f"Bearer {api_token}"}, redact_values=(api_token,))
+
+
+def validate_credentials(api_token: str) -> bool:
+    """Confirm the API token is valid with the whoami endpoint."""
+    try:
+        response = _get_session(api_token).get(
+            f"{CODA_BASE_URL}/whoami",
+            timeout=10,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def get_rows(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    session = _get_session(api_token)
+
+    @retry(
+        retry=retry_if_exception_type((CodaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=5, max=120),
+        reraise=True,
+    )
+    def fetch(path: str, params: dict[str, Any], interval: float) -> dict[str, Any]:
+        time.sleep(interval)
+        url = f"{CODA_BASE_URL}{path}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise CodaRetryableError(f"Coda API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"Coda API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    def iterate_pages(
+        path: str, page_size: int, interval: float, extra: dict[str, Any] | None = None
+    ) -> Iterator[list[dict[str, Any]]]:
+        token: Optional[str] = None
+        while True:
+            params: dict[str, Any] = {"limit": page_size, **(extra or {})}
+            if token:
+                # pageToken supersedes other params on continuation requests.
+                params = {"pageToken": token}
+            data = fetch(path, params, interval)
+            items = data.get("items", []) or []
+            if items:
+                yield items
+            token = data.get("nextPageToken")
+            if not token or not items:
+                return
+
+    def doc_ids() -> list[str]:
+        return [
+            doc["id"]
+            for page in iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS)
+            for doc in page
+            if doc.get("id")
+        ]
+
+    if endpoint == "docs":
+        yield from iterate_pages("/docs", PAGE_SIZE, DOC_LIST_INTERVAL_SECONDS)
+        return
+
+    if endpoint == "tables":
+        for doc_id in doc_ids():
+            for page in iterate_pages(f"/docs/{quote(doc_id)}/tables", PAGE_SIZE, READ_INTERVAL_SECONDS):
+                yield [{**table, "_doc_id": doc_id} for table in page]
+        return
+
+    # rows: fan out docs → tables → rows.
+    for doc_id in doc_ids():
+        tables: list[str] = []
+        for page in iterate_pages(f"/docs/{quote(doc_id)}/tables", PAGE_SIZE, READ_INTERVAL_SECONDS):
+            tables.extend(table["id"] for table in page if table.get("id"))
+
+        for table_id in tables:
+            for page in iterate_pages(
+                f"/docs/{quote(doc_id)}/tables/{quote(table_id)}/rows",
+                ROWS_PAGE_SIZE,
+                READ_INTERVAL_SECONDS,
+                # Column names instead of opaque column ids in `values`.
+                extra={"useColumnNames": "true"},
+            ):
+                yield [{**row, "_doc_id": doc_id, "_table_id": table_id} for row in page]
+
+
+def coda_source(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> SourceResponse:
+    config = CODA_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_token=api_token,
+            endpoint=endpoint,
+            logger=logger,
+        ),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        sort_mode="asc",
+    )

--- a/posthog/temporal/data_imports/sources/coda/settings.py
+++ b/posthog/temporal/data_imports/sources/coda/settings.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CodaEndpointConfig:
+    name: str
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+
+
+# Coda's list endpoints have no updated-since filters (rows only sort), so
+# every stream is a full refresh. Rows fan out docs → tables → rows; ids are
+# only unique within their parent, hence the composite keys.
+CODA_ENDPOINTS: dict[str, CodaEndpointConfig] = {
+    "docs": CodaEndpointConfig(
+        name="docs",
+    ),
+    "tables": CodaEndpointConfig(
+        name="tables",
+        primary_keys=["_doc_id", "id"],
+    ),
+    "rows": CodaEndpointConfig(
+        name="rows",
+        primary_keys=["_doc_id", "_table_id", "id"],
+    ),
+}
+
+ENDPOINTS = tuple(CODA_ENDPOINTS.keys())

--- a/posthog/temporal/data_imports/sources/coda/source.py
+++ b/posthog/temporal/data_imports/sources/coda/source.py
@@ -1,12 +1,22 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.coda.coda import (
+    coda_source,
+    validate_credentials as validate_coda_credentials,
+)
+from posthog.temporal.data_imports.sources.coda.settings import ENDPOINTS
 from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import CodaSourceConfig
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
@@ -18,12 +28,74 @@ class CodaSource(SimpleSource[CodaSourceConfig]):
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CODA
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://coda.io": "Coda authentication failed. Please check your API token.",
+            "403 Client Error: Forbidden for url: https://coda.io": "Coda denied access. Please check that your API token can read the requested docs.",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CODA,
             label="Coda",
+            caption="""Enter your Coda API token to pull your docs, tables, and rows into the PostHog Data warehouse.
+
+You can generate an API token in [Coda account settings](https://coda.io/account). The token only sees docs its creator can access. Rows are synced from every table of every doc — note Coda's doc-listing rate limit makes large workspaces slow to sync.""",
             iconPath="/static/services/coda.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/coda",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_token",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: CodaSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Coda's list endpoints have no updated-since filters; full refresh only.
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: CodaSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_coda_credentials(config.api_token):
+            return True, None
+
+        return False, "Invalid Coda API token"
+
+    def source_for_pipeline(self, config: CodaSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return coda_source(
+            api_token=config.api_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
         )

--- a/posthog/temporal/data_imports/sources/coda/tests/test_coda.py
+++ b/posthog/temporal/data_imports/sources/coda/tests/test_coda.py
@@ -1,0 +1,129 @@
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.coda.coda import coda_source, get_rows, validate_credentials
+from posthog.temporal.data_imports.sources.coda.settings import CODA_ENDPOINTS, ENDPOINTS
+
+_MODULE = "posthog.temporal.data_imports.sources.coda.coda"
+
+
+def _response(items: list[dict[str, Any]], next_token: str | None = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    body: dict[str, Any] = {"items": items}
+    if next_token:
+        body["nextPageToken"] = next_token
+    resp.json.return_value = body
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with mock.patch(f"{_MODULE}.time.sleep"):
+        yield
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, True),
+            (401, False),
+            (403, False),
+            (500, False),
+        ],
+    )
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials("token") is expected
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_validate_credentials_swallows_exceptions(self, mock_session):
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("token") is False
+
+
+class TestGetRows:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_docs_paginate_via_page_token(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "doc1"}], next_token="tok1"),
+            _response([{"id": "doc2"}]),
+        ]
+
+        batches = list(get_rows("token", "docs", mock.MagicMock()))
+
+        assert [item["id"] for batch in batches for item in batch] == ["doc1", "doc2"]
+        second_url = mock_session.return_value.get.call_args_list[1].args[0]
+        assert parse_qs(urlparse(second_url).query)["pageToken"] == ["tok1"]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_tables_fan_out_over_docs(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "doc1"}]),
+            _response([{"id": "grid-1", "name": "Tasks"}]),
+        ]
+
+        batches = list(get_rows("token", "tables", mock.MagicMock()))
+
+        flat = [item for batch in batches for item in batch]
+        assert [(t["id"], t["_doc_id"]) for t in flat] == [("grid-1", "doc1")]
+        urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
+        assert urlparse(urls[1]).path == "/apis/v1/docs/doc1/tables"
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_rows_fan_out_docs_tables_rows(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "doc1"}]),  # docs
+            _response([{"id": "grid-1"}]),  # tables for doc1
+            _response([{"id": "i-1", "values": {"Name": "x"}}]),  # rows for grid-1
+        ]
+
+        batches = list(get_rows("token", "rows", mock.MagicMock()))
+
+        flat = [item for batch in batches for item in batch]
+        assert [(r["id"], r["_doc_id"], r["_table_id"]) for r in flat] == [("i-1", "doc1", "grid-1")]
+        rows_url = mock_session.return_value.get.call_args_list[2].args[0]
+        parsed = urlparse(rows_url)
+        assert parsed.path == "/apis/v1/docs/doc1/tables/grid-1/rows"
+        assert parse_qs(parsed.query)["useColumnNames"] == ["true"]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_tables_without_id_are_skipped_in_rows(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "doc1"}]),
+            _response([{"name": "broken"}]),
+        ]
+
+        assert list(get_rows("token", "rows", mock.MagicMock())) == []
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_empty_workspace_yields_nothing(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        assert list(get_rows("token", "rows", mock.MagicMock())) == []
+
+
+class TestCodaSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint):
+        config = CODA_ENDPOINTS[endpoint]
+        response = coda_source("token", endpoint, mock.MagicMock())
+
+        assert response.name == endpoint
+        assert response.primary_keys == config.primary_keys
+        assert response.sort_mode == "asc"
+        assert response.partition_mode is None
+        assert response.partition_keys is None
+
+    def test_rows_have_composite_primary_key(self):
+        response = coda_source("token", "rows", mock.MagicMock())
+        assert response.primary_keys == ["_doc_id", "_table_id", "id"]

--- a/posthog/temporal/data_imports/sources/coda/tests/test_coda.py
+++ b/posthog/temporal/data_imports/sources/coda/tests/test_coda.py
@@ -66,6 +66,18 @@ class TestGetRows:
         assert parse_qs(urlparse(second_url).query)["pageToken"] == ["tok1"]
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_empty_intermediate_page_does_not_halt_pagination(self, mock_session):
+        mock_session.return_value.get.side_effect = [
+            _response([{"id": "doc1"}], next_token="tok1"),
+            _response([], next_token="tok2"),
+            _response([{"id": "doc2"}]),
+        ]
+
+        batches = list(get_rows("token", "docs", mock.MagicMock()))
+
+        assert [item["id"] for batch in batches for item in batch] == ["doc1", "doc2"]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_tables_fan_out_over_docs(self, mock_session):
         mock_session.return_value.get.side_effect = [
             _response([{"id": "doc1"}]),

--- a/posthog/temporal/data_imports/sources/coda/tests/test_coda.py
+++ b/posthog/temporal/data_imports/sources/coda/tests/test_coda.py
@@ -97,19 +97,27 @@ class TestGetRows:
         assert parse_qs(parsed.query)["useColumnNames"] == ["true"]
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_tables_without_id_are_skipped_in_rows(self, mock_session):
+    def test_table_without_id_fails_fast_in_rows(self, mock_session):
         mock_session.return_value.get.side_effect = [
             _response([{"id": "doc1"}]),
             _response([{"name": "broken"}]),
         ]
 
-        assert list(get_rows("token", "rows", mock.MagicMock())) == []
+        with pytest.raises(KeyError):
+            list(get_rows("token", "rows", mock.MagicMock()))
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_empty_workspace_yields_nothing(self, mock_session):
         mock_session.return_value.get.return_value = _response([])
 
         assert list(get_rows("token", "rows", mock.MagicMock())) == []
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_unknown_endpoint_raises(self, mock_session):
+        mock_session.return_value.get.return_value = _response([])
+
+        with pytest.raises(ValueError, match="Unknown Coda endpoint"):
+            list(get_rows("token", "nonsense", mock.MagicMock()))
 
 
 class TestCodaSourceResponse:

--- a/posthog/temporal/data_imports/sources/coda/tests/test_coda_source.py
+++ b/posthog/temporal/data_imports/sources/coda/tests/test_coda_source.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.coda.settings import ENDPOINTS
+from posthog.temporal.data_imports.sources.coda.source import CodaSource
+from posthog.temporal.data_imports.sources.generated_configs import CodaSourceConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestCodaSource:
+    def setup_method(self):
+        self.source = CodaSource()
+        self.team_id = 123
+        self.config = CodaSourceConfig(api_token="api-token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.CODA
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Coda"
+        assert config.label == "Coda"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/coda.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_token"]
+
+    def test_api_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_token")
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://coda.io/apis/v1/docs",
+            "403 Client Error: Forbidden for url: https://coda.io/apis/v1/docs/doc1/tables",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_vendor_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+            "500 Server Error for url: https://coda.io/apis/v1/docs",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_unrelated(self, other_vendor_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_vendor_error for key in non_retryable_errors)
+
+    def test_get_schemas_are_full_refresh_only(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+        assert all(not schema.supports_incremental for schema in schemas)
+        assert all(not schema.supports_append for schema in schemas)
+        assert all(schema.incremental_fields == [] for schema in schemas)
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["rows"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "rows"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid Coda API token"),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.coda.source.validate_coda_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.api_token)
+
+    @mock.patch("posthog.temporal.data_imports.sources.coda.source.coda_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_coda_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "rows"
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        mock_coda_source.assert_called_once()
+        kwargs = mock_coda_source.call_args.kwargs
+        assert kwargs["api_token"] == "api-token"
+        assert kwargs["endpoint"] == "rows"

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -380,7 +380,7 @@ class CockroachDBSourceConfig(config.Config):
 
 @config.config
 class CodaSourceConfig(config.Config):
-    pass
+    api_token: str
 
 
 @config.config


### PR DESCRIPTION
## Problem

The Coda data warehouse source was scaffolded (registered with `unreleasedSource=True` and an empty stub) but had no sync logic, so users couldn't pull their Coda docs into PostHog.

## Changes

Implements the Coda import source following the warehouse source architecture (`source.py` / `settings.py` / `coda.py` split). Coda's data model is hierarchical, so this is a two-level fan-out under tight rate limits:

- **Endpoints:** `docs` (workspace listing), `tables` (per doc), and `rows` (per doc × table, with `useColumnNames=true` so cell values key by readable column names instead of opaque column ids). Parent linkage is injected (`_doc_id`, `_table_id`) and forms the composite primary keys, since table/row ids are only unique within their parent.
- **Rate limits:** Coda caps doc listing at **4 req/6s** (reads at 100 req/6s) — requests are proactively spaced per endpoint family (1.6s for doc listings, 70ms for reads), with 429 backoff on top. The caption warns that large workspaces sync slowly.
- **Pagination:** opaque `pageToken`/`nextPageToken` cursors per page chain (the token supersedes other params on continuation requests).
- **Auth:** Bearer API token, validated via `/whoami`.
- **Sync mode:** honest full refresh — Coda's list endpoints have no updated-since filters (rows only support sorting), so this is a `SimpleSource`.
- Removes `unreleasedSource` and ships as `releaseStatus=ALPHA`; regenerates `CodaSourceConfig`; moves coda to the Implemented table in `SOURCES.md`. All HTTP goes through `make_tracked_session()` with the token redacted.

## How did you test this code?

Automated tests only (no live Coda credentials):

- `posthog/temporal/data_imports/sources/coda/tests/test_coda.py` — transport: pageToken pagination, docs→tables and docs→tables→rows fan-outs with parent-key injection and `useColumnNames`, id-less table skipping, credential validation status mapping, per-endpoint `SourceResponse` metadata incl. composite keys. Request spacing patched out in tests.
- `posthog/temporal/data_imports/sources/coda/tests/test_coda_source.py` — source class: config fields, full-refresh-only schemas, non-retryable error matching, argument plumbing.
- Registry-level tests in `posthog/temporal/data_imports/sources/tests/` pass (51 tests total).

Endpoint behavior (paths, pagination contract, rate limit families, useColumnNames) was verified against Coda's API docs; live smoke testing wasn't possible without credentials, hence the alpha release status.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
