### PR TITLE
feat(posthog-ai): typed wire definitions for the sandbox stream

### DIFF
--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -13,7 +13,7 @@ import {
     sandboxStreamLogic,
     SSE_RECONNECT_MAX_DELAY_MS,
 } from './sandboxStreamLogic'
-import type { StoredLogEntry } from './types/sandboxStreamTypes'
+import type { StoredLogEntry } from './types/sandboxWireTypes'
 
 function notification(method: string, params: Record<string, unknown>): StoredLogEntry {
     return { type: 'notification', notification: { method, params } }
@@ -668,6 +668,113 @@ describe('sandboxStreamLogic', () => {
 
             expect(logic.values.currentRunStatus).toEqual('completed')
             expect(MockEventSource.instances.length).toEqual(0)
+        })
+    })
+
+    describe('wire frame parsing through onmessage', () => {
+        it('reads the snake_case error_message off task_run_state frames', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            const source = MockEventSource.latest()
+            source.emitOpen()
+
+            await expectLogic(logic, () => {
+                source.onmessage?.({
+                    data: JSON.stringify({
+                        type: 'task_run_state',
+                        run_id: 'run-1',
+                        task_id: 'task-1',
+                        status: 'failed',
+                        error_message: 'sandbox exploded',
+                    }),
+                } as MessageEvent<string>)
+            }).toDispatchActions([
+                (action) =>
+                    action.type === logic.actionTypes.handleTerminalStatus &&
+                    action.payload.status === 'failed' &&
+                    action.payload.errorMessage === 'sandbox exploded',
+            ])
+
+            expect(logic.values.currentRunStatus).toEqual('failed')
+            expect(source.closed).toEqual(true)
+        })
+
+        it('keeps the stream open for non-terminal task_run_state frames', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            const source = MockEventSource.latest()
+            source.emitOpen()
+
+            await expectLogic(logic, () => {
+                source.onmessage?.({
+                    data: JSON.stringify({ type: 'task_run_state', status: 'in_progress', error_message: null }),
+                } as MessageEvent<string>)
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentRunStatus).toEqual('in_progress')
+            expect(source.closed).toEqual(false)
+        })
+
+        it('ignores unrecognized frame types', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            const source = MockEventSource.latest()
+            source.emitOpen()
+
+            source.onmessage?.({
+                data: JSON.stringify({ type: 'telemetry_v2', payload: { value: 1 } }),
+            } as MessageEvent<string>)
+
+            expect(logic.values.threadItems).toEqual([])
+            expect(logic.values.ingestedEntryHashes.size).toEqual(0)
+        })
+    })
+
+    describe('_posthog/progress handling', () => {
+        it('renders the emitter label as current progress', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/progress', {
+                        sessionId: 's',
+                        step: 'clone_repository',
+                        status: 'in_progress',
+                        label: 'Cloning repository',
+                        group: 'setup',
+                    })
+                )
+            }).toMatchValues({ currentProgress: 'Cloning repository' })
+        })
+
+        it('falls back to detail when label is absent', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/progress', { sessionId: 's', detail: 'PostHog/posthog @ master' })
+                )
+            }).toMatchValues({ currentProgress: 'PostHog/posthog @ master' })
+        })
+    })
+
+    describe('mixed notification replay', () => {
+        it('ingests known, unknown, and degenerate notifications without throwing, hashing each once', async () => {
+            const corpus: StoredLogEntry[] = [
+                notification('_posthog/run_started', { runId: 'run-1' }),
+                notification('_posthog/usage_update', { used: { inputTokens: 1 }, cost: null }),
+                notification('_posthog/hologram_sync', { shards: 3 }),
+                { type: 'notification', notification: { method: '_posthog/turn_complete' } },
+                { type: 'notification', notification: { method: '_posthog/console', params: 'not-an-object' as any } },
+                sessionUpdate({ sessionUpdate: 'plan_delta', entries: [] }),
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', text: 'hi' }),
+            ]
+
+            await expectLogic(logic, () => {
+                corpus.forEach((entry) => logic.actions.ingestAcpFrame(entry))
+            }).toFinishAllListeners()
+
+            // Dedup hashing operates on the raw entries — every distinct frame hashes exactly once.
+            expect(logic.values.ingestedEntryHashes.size).toEqual(corpus.length)
         })
     })
 })

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -6,11 +6,20 @@ import { projectLogic } from 'scenes/projectLogic'
 import type { sandboxStreamLogicType } from './sandboxStreamLogicType'
 import type {
     PermissionRequestRecord,
-    StoredLogEntry,
     ThreadItem,
     ToolInvocation,
     ToolInvocationStatus,
 } from './types/sandboxStreamTypes'
+import {
+    type PosthogErrorParams,
+    type PosthogProgressParams,
+    type SseErrorFrameData,
+    type StoredLogEntry,
+    isKnownSessionUpdate,
+    isNotificationFrame,
+    isSessionUpdateNotification,
+    isTaskRunStateFrame,
+} from './types/sandboxWireTypes'
 
 export type SandboxSseStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
 export type SandboxRunStatus = 'queued' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
@@ -391,7 +400,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             }
 
             // Existing run: replay the assembled resume-chain log, then refetch the run to decide on SSE.
-            let entries: Record<string, any>[]
+            let entries: unknown[]
             try {
                 entries = await api.tasks.runs.getLogEntries(taskId, runId)
             } catch (error) {
@@ -399,7 +408,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
             breakpoint()
-            entries.forEach((entry) => actions.ingestAcpFrame(entry as unknown as StoredLogEntry))
+            entries.filter(isNotificationFrame).forEach((entry) => actions.ingestAcpFrame(entry))
 
             const result = await fetchRunStatus(taskId, runId)
             breakpoint()
@@ -440,27 +449,21 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
 
                     eventSource.onopen = (): void => actions.sseOpened()
                     eventSource.onmessage = (event: MessageEvent<string>): void => {
-                        let data: { type?: string } & Record<string, unknown>
+                        let data: unknown
                         try {
                             data = JSON.parse(event.data)
                         } catch {
                             return
                         }
-                        switch (data.type) {
-                            case 'notification':
-                                actions.ingestAcpFrame(data as unknown as StoredLogEntry)
-                                break
-                            case 'task_run_state':
-                                actions.handleTerminalStatus({
-                                    status: data.status as SandboxRunStatus,
-                                    errorMessage: (data.errorMessage as string | null) ?? null,
-                                })
-                                break
-                            case 'keepalive':
-                                break
-                            default:
-                                break
+                        if (isNotificationFrame(data)) {
+                            actions.ingestAcpFrame(data)
+                        } else if (isTaskRunStateFrame(data)) {
+                            actions.handleTerminalStatus({
+                                status: data.status as SandboxRunStatus,
+                                errorMessage: data.error_message ?? null,
+                            })
                         }
+                        // keepalive arrives as a named event, never here; unknown frame types are ignored.
                     }
                     // `EventSource` fires `error` both for named `event: error` envelopes (carrying
                     // `data`) and for transient connection drops (no `data`). Surface the former
@@ -468,7 +471,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     eventSource.addEventListener('error', (event: MessageEvent<string>): void => {
                         if (typeof event.data === 'string' && event.data.length > 0) {
                             try {
-                                const envelope = JSON.parse(event.data)
+                                const envelope: SseErrorFrameData = JSON.parse(event.data)
                                 actions.handleStreamError({
                                     errorTitle: envelope.errorTitle ?? 'Cloud stream failed',
                                     errorMessage: envelope.errorMessage,
@@ -572,7 +575,6 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             }
             actions.markEntryIngested(hash)
             const method = notification.method
-            const params = (notification.params ?? {}) as Record<string, any>
 
             // Custom `_posthog/*` notification namespace emitted by the agent-server.
             if (method === '_posthog/run_started') {
@@ -584,11 +586,13 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
             if (method === '_posthog/progress') {
-                actions.setCurrentProgress(String(params.message ?? params.progress ?? ''))
+                const progress = (notification.params ?? {}) as PosthogProgressParams
+                actions.setCurrentProgress(String(progress.label ?? progress.detail ?? ''))
                 return
             }
             if (method === '_posthog/error') {
-                actions.pushErrorItem(String(params.message ?? notification.error?.message ?? 'Agent error'))
+                const error = (notification.params ?? {}) as PosthogErrorParams
+                actions.pushErrorItem(String(error.message ?? notification.error?.message ?? 'Agent error'))
                 return
             }
             if (method?.startsWith('_posthog/')) {
@@ -596,14 +600,16 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                 return
             }
 
-            if (method !== 'session/update') {
+            if (!isSessionUpdateNotification(notification)) {
                 return
             }
 
-            const update = (params.update ?? {}) as Record<string, any>
-            const sessionUpdate = update.sessionUpdate as string | undefined
+            const update = notification.params?.update
+            if (!isKnownSessionUpdate(update)) {
+                return
+            }
 
-            switch (sessionUpdate) {
+            switch (update.sessionUpdate) {
                 case 'agent_message_chunk': {
                     const id = String(update.messageId ?? 'current')
                     actions.appendAssistantChunk(id, String(update.content?.text ?? update.text ?? ''))
@@ -621,7 +627,7 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     }
                     const rawServerName = String(update.serverName ?? 'posthog')
                     const rawToolName = String(update.toolName ?? update.title ?? '')
-                    const input = (update.rawInput ?? update.input ?? {}) as Record<string, unknown>
+                    const input = update.rawInput ?? update.input ?? {}
                     const { resolvedKey, innerToolName, innerInput } = resolveToolKey(rawServerName, rawToolName, input)
                     actions.upsertToolInvocation({
                         toolCallId,
@@ -632,9 +638,9 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         input,
                         innerInput,
                         status: mapAcpStatus(update.status),
-                        title: update.title as string | undefined,
-                        kind: update.kind as string | undefined,
-                        locations: update.locations as { path: string; line?: number }[] | undefined,
+                        title: update.title,
+                        kind: update.kind,
+                        locations: update.locations,
                         contentBlocks: Array.isArray(update.content) ? update.content : [],
                     })
                     break
@@ -652,16 +658,16 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                           : []
                     const status = mapAcpStatus(update.status ?? existing?.status)
                     const errorMessage =
-                        (update.error?.message as string | undefined) ??
-                        (status === 'failed' ? notification.error?.message : undefined)
+                        update.error?.message ?? (status === 'failed' ? notification.error?.message : undefined)
                     // The tool's args stream in across updates (e.g. an `exec` command or a tool's
                     // input building up), so fold the latest rawInput in and re-resolve the registry
                     // key from it rather than freezing the empty input the initial tool_call carried.
+                    // Keep the runtime object checks — the wire payload is typed, not validated.
                     const rawInput =
                         update.rawInput && typeof update.rawInput === 'object'
-                            ? (update.rawInput as Record<string, unknown>)
+                            ? update.rawInput
                             : update.input && typeof update.input === 'object'
-                              ? (update.input as Record<string, unknown>)
+                              ? update.input
                               : undefined
                     const reResolved =
                         rawInput && existing
@@ -669,11 +675,10 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                             : undefined
                     actions.updateToolInvocation(toolCallId, {
                         status,
-                        title: (update.title as string | undefined) ?? existing?.title,
+                        title: update.title ?? existing?.title,
                         progress: update.progress ?? existing?.progress,
                         output: update.rawOutput ?? existing?.output,
-                        locations:
-                            (update.locations as { path: string; line?: number }[] | undefined) ?? existing?.locations,
+                        locations: update.locations ?? existing?.locations,
                         contentBlocks: mergedContent,
                         error: errorMessage !== undefined ? { message: errorMessage } : existing?.error,
                         ...(rawInput ? { input: rawInput } : {}),
@@ -691,8 +696,6 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     actions.setCurrentMode(String(update.currentModeId ?? update.mode ?? ''))
                     break
                 }
-                default:
-                    break
             }
         },
     })),

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -1,29 +1,12 @@
 /**
- * Wire + thread shapes for the sandbox agent runtime (`agent_runtime === 'sandbox'`).
+ * Thread shapes for the sandbox agent runtime (`agent_runtime === 'sandbox'`).
  *
  * The sandbox path consumes the products/tasks SSE endpoint directly (the same endpoint
- * PostHog Code uses). `sandboxStreamLogic` parses the raw ACP frames carried inside
- * `StoredLogEntry` envelopes into the `ToolInvocation` / `ThreadItem` state the renderer
- * consumes.
+ * PostHog Code uses). `sandboxStreamLogic` parses the raw wire frames (typed in
+ * `./sandboxWireTypes`) into the `ToolInvocation` / `ThreadItem` state the renderer consumes.
  */
 
-/** ACP notification body — the JSON-RPC payload carried inside a `StoredLogEntry`. */
-export interface AcpNotification {
-    method?: string
-    params?: Record<string, unknown>
-    result?: unknown
-    error?: { message?: string; code?: number } | null
-}
-
-/**
- * Wire envelope around a single ACP notification. The products/tasks stream emits these as
- * the bulk of `data.type === 'notification'` traffic.
- */
-export interface StoredLogEntry {
-    type: 'notification'
-    timestamp?: string
-    notification: AcpNotification
-}
+import type { PermissionOption } from './sandboxWireTypes'
 
 export type ToolInvocationStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
 
@@ -82,12 +65,6 @@ export interface ThreadItem {
     toolCallId?: string
     /** For `error` items. */
     errorMessage?: string
-}
-
-export interface PermissionOption {
-    optionId: string
-    name: string
-    kind: 'allow_once' | 'allow_always' | 'reject' | 'reject_with_feedback'
 }
 
 /**

--- a/frontend/src/scenes/max/types/sandboxWireTypes.test.ts
+++ b/frontend/src/scenes/max/types/sandboxWireTypes.test.ts
@@ -1,0 +1,335 @@
+import {
+    type AcpNotification,
+    type PosthogNotificationParamsByMethod,
+    type StoredLogEntry,
+    isKeepaliveFrame,
+    isKnownSessionUpdate,
+    isNotificationFrame,
+    isPermissionRequestFrame,
+    isPosthogNotification,
+    isSessionUpdateNotification,
+    isTaskRunStateFrame,
+    isUsageUpdateBreakdownParams,
+    isUsageUpdateUsedParams,
+} from './sandboxWireTypes'
+
+const TIMESTAMP = '2026-06-11T09:00:00.000000+00:00'
+const RUN_ID = '3d2f3e7a-5c1b-4f7e-9d51-0a9b8c7d6e5f'
+const TASK_ID = '9b8a7c6d-5e4f-3a2b-1c0d-e9f8a7b6c5d4'
+
+function notification(method: string, params?: Record<string, unknown>): StoredLogEntry {
+    return {
+        type: 'notification',
+        timestamp: TIMESTAMP,
+        notification: { jsonrpc: '2.0', method, ...(params !== undefined ? { params } : {}) },
+    }
+}
+
+function sessionUpdate(update: Record<string, unknown>): StoredLogEntry {
+    return notification('session/update', { sessionId: 'sess_a1b2c3', update })
+}
+
+// Canonical `_posthog/*` payloads as the emitters produce them (products/tasks for the core
+// methods, the agent adapters for the rest).
+const NOTIFICATION_PARAMS_BY_METHOD: { [M in keyof PosthogNotificationParamsByMethod]: Record<string, unknown>[] } = {
+    '_posthog/console': [{ sessionId: RUN_ID, level: 'info', message: 'Provisioning sandbox' }],
+    '_posthog/progress': [
+        {
+            sessionId: RUN_ID,
+            step: 'clone_repository',
+            status: 'in_progress',
+            label: 'Cloning repository',
+            group: 'setup',
+            detail: 'PostHog/posthog @ master',
+        },
+        { sessionId: RUN_ID, step: 'start_agent', status: 'completed', label: 'Starting agent', group: 'setup' },
+    ],
+    '_posthog/sandbox_output': [{ sessionId: RUN_ID, stdout: 'ok\n', stderr: '', exitCode: 0 }],
+    '_posthog/user_message': [{ content: 'Why did checkout conversion drop last week?' }],
+    '_posthog/usage_update': [
+        {
+            sessionId: 'sess_a1b2c3',
+            used: { inputTokens: 12450, outputTokens: 980, cachedReadTokens: 110200, cachedWriteTokens: 2048 },
+            cost: { amount: 0.42, currency: 'USD' },
+        },
+        {
+            sessionId: 'sess_a1b2c3',
+            used: { inputTokens: 900, outputTokens: 120, cachedReadTokens: 0, cachedWriteTokens: 0 },
+            cost: null,
+        },
+        {
+            sessionId: 'sess_a1b2c3',
+            breakdown: {
+                systemPrompt: 3100,
+                tools: 8200,
+                rules: 450,
+                skills: 0,
+                mcp: 12700,
+                subagents: 0,
+                conversation: 20410,
+            },
+        },
+    ],
+    '_posthog/status': [
+        { sessionId: 'sess_a1b2c3', status: 'compacting' },
+        { sessionId: 'sess_a1b2c3', status: 'compacting', isComplete: true },
+    ],
+    '_posthog/compact_boundary': [{ sessionId: 'sess_a1b2c3', trigger: 'auto', preTokens: 168000, contextSize: 54000 }],
+    '_posthog/task_notification': [
+        {
+            sessionId: 'sess_a1b2c3',
+            taskId: TASK_ID,
+            status: 'completed',
+            summary: 'Analysis written to report.md',
+            outputFile: 'report.md',
+        },
+    ],
+    '_posthog/error': [
+        { message: 'Model request failed after 3 retries', classification: 'provider_error' },
+        { message: 'Tool execution timed out' },
+    ],
+    '_posthog/sdk_session': [{ taskRunId: RUN_ID, sessionId: 'sess_a1b2c3', adapter: 'claude' }],
+    '_posthog/resources_used': [
+        {
+            sessionId: 'sess_a1b2c3',
+            products: [
+                { id: 'product_analytics', label: 'Product analytics' },
+                { id: 'session_replay', label: 'Session replay' },
+            ],
+        },
+    ],
+    '_posthog/permission_request': [
+        {
+            requestId: 'perm-1',
+            toolCallId: 'toolu_01',
+            options: [
+                { optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' },
+                { optionId: 'reject', name: 'Reject', kind: 'reject' },
+            ],
+            toolCall: {
+                toolCallId: 'toolu_01',
+                title: 'Run SQL query',
+                kind: 'execute',
+                rawInput: { command: 'call execute-sql {"query": "SELECT 1"}' },
+            },
+        },
+    ],
+    '_posthog/permission_resolved': [{ requestId: 'perm-1', toolCallId: 'toolu_01', optionId: 'allow_once' }],
+    '_posthog/run_started': [{ sessionId: 'sess_a1b2c3', runId: RUN_ID, taskId: TASK_ID, agentVersion: '1.42.0' }],
+    '_posthog/turn_complete': [{ sessionId: 'sess_a1b2c3', stopReason: 'end_turn' }],
+}
+
+const KNOWN_POSTHOG_METHODS = Object.keys(NOTIFICATION_PARAMS_BY_METHOD) as (keyof PosthogNotificationParamsByMethod)[]
+
+const SESSION_UPDATE_CASES: { kind: string; update: Record<string, unknown> }[] = [
+    {
+        kind: 'agent_message_chunk',
+        update: {
+            sessionUpdate: 'agent_message_chunk',
+            messageId: 'msg_01',
+            content: { type: 'text', text: 'Looking at the funnel' },
+        },
+    },
+    { kind: 'agent_message_chunk', update: { sessionUpdate: 'agent_message_chunk', text: ' now.' } },
+    {
+        kind: 'agent_message',
+        update: {
+            sessionUpdate: 'agent_message',
+            messageId: 'msg_01',
+            content: { type: 'text', text: 'Looking at the funnel now.' },
+        },
+    },
+    {
+        kind: 'tool_call',
+        update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'toolu_02',
+            serverName: 'posthog',
+            toolName: 'exec',
+            title: 'exec',
+            kind: 'execute',
+            status: 'pending',
+            rawInput: { command: 'call insight-create {"name": "Weekly signups"}' },
+        },
+    },
+    {
+        kind: 'tool_call_update',
+        update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'toolu_02',
+            status: 'completed',
+            rawOutput: { short_id: 'abc123', name: 'Weekly signups' },
+            content: [{ type: 'content', content: { type: 'text', text: '{"short_id": "abc123"}' } }],
+        },
+    },
+    {
+        kind: 'tool_call_update',
+        update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'toolu_04',
+            status: 'failed',
+            error: { message: 'Permission denied by user' },
+            _meta: {
+                decision_reason: 'User rejected the permission request',
+                decision_reason_type: 'user_rejection',
+                message: 'Permission denied',
+            },
+        },
+    },
+    { kind: 'current_mode_update', update: { sessionUpdate: 'current_mode_update', currentModeId: 'default' } },
+]
+
+function notificationOf(frame: unknown): AcpNotification {
+    if (!isNotificationFrame(frame)) {
+        throw new Error('expected a notification frame')
+    }
+    return frame.notification
+}
+
+describe('sandboxWireTypes guards', () => {
+    it.each([
+        ['queued', { type: 'task_run_state', run_id: RUN_ID, task_id: TASK_ID, status: 'queued', stage: null }],
+        [
+            'failed',
+            {
+                type: 'task_run_state',
+                run_id: RUN_ID,
+                task_id: TASK_ID,
+                status: 'failed',
+                error_message: 'Agent server crashed: sandbox out of memory',
+                completed_at: TIMESTAMP,
+            },
+        ],
+    ])('classifies a %s task_run_state frame and exposes snake_case fields', (_name, frame) => {
+        expect(isTaskRunStateFrame(frame)).toBe(true)
+        expect(isNotificationFrame(frame)).toBe(false)
+        expect(isKeepaliveFrame(frame)).toBe(false)
+        expect(isPermissionRequestFrame(frame)).toBe(false)
+        if (isTaskRunStateFrame(frame) && frame.status === 'failed') {
+            expect(frame.error_message).toEqual(expect.any(String))
+        }
+    })
+
+    it('classifies keepalive and top-level permission_request frames', () => {
+        const keepalive = { type: 'keepalive' }
+        expect(isKeepaliveFrame(keepalive)).toBe(true)
+        expect(isNotificationFrame(keepalive)).toBe(false)
+
+        const permission = {
+            type: 'permission_request',
+            requestId: 'perm-2',
+            toolCallId: 'toolu_05',
+            options: [{ optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' }],
+            toolCall: { toolCallId: 'toolu_05', title: 'Delete dashboard', kind: 'execute' },
+        }
+        expect(isPermissionRequestFrame(permission)).toBe(true)
+        expect(isNotificationFrame(permission)).toBe(false)
+    })
+
+    it.each([
+        ['unknown type', { type: 'telemetry_v2', payload: { metric: 'boot_time_ms', value: 5120 } }],
+        ['missing type', { status: 'in_progress', note: 'frame with no type discriminant' }],
+        ['notification with non-object body', { type: 'notification', notification: 'oops' }],
+    ])('rejects a frame with %s from every envelope guard', (_name, frame) => {
+        expect(isNotificationFrame(frame)).toBe(false)
+        expect(isTaskRunStateFrame(frame)).toBe(false)
+        expect(isKeepaliveFrame(frame)).toBe(false)
+        expect(isPermissionRequestFrame(frame)).toBe(false)
+    })
+
+    it.each(
+        KNOWN_POSTHOG_METHODS.flatMap((method) =>
+            NOTIFICATION_PARAMS_BY_METHOD[method].map((params) => [method, params] as const)
+        )
+    )('%s notifications pass exactly the matching method guard', (method, params) => {
+        const wireNotification = notificationOf(notification(method, params))
+        for (const known of KNOWN_POSTHOG_METHODS) {
+            expect(isPosthogNotification(wireNotification, known)).toBe(known === method)
+        }
+        expect(isSessionUpdateNotification(wireNotification)).toBe(false)
+    })
+
+    it('narrows the two usage_update forms exclusively', () => {
+        const [used, usedNullCost, breakdown] = NOTIFICATION_PARAMS_BY_METHOD['_posthog/usage_update'].map((params) =>
+            notificationOf(notification('_posthog/usage_update', params))
+        )
+        for (const wireNotification of [used, usedNullCost]) {
+            if (!isPosthogNotification(wireNotification, '_posthog/usage_update')) {
+                throw new Error('expected usage_update notification')
+            }
+            expect(isUsageUpdateUsedParams(wireNotification.params)).toBe(true)
+            expect(isUsageUpdateBreakdownParams(wireNotification.params)).toBe(false)
+            if (isUsageUpdateUsedParams(wireNotification.params)) {
+                expect(wireNotification.params.used.inputTokens).toEqual(expect.any(Number))
+            }
+        }
+        if (!isPosthogNotification(breakdown, '_posthog/usage_update')) {
+            throw new Error('expected usage_update notification')
+        }
+        expect(isUsageUpdateBreakdownParams(breakdown.params)).toBe(true)
+        expect(isUsageUpdateUsedParams(breakdown.params)).toBe(false)
+    })
+
+    it('exposes typed progress params after narrowing', () => {
+        const wireNotification = notificationOf(
+            notification('_posthog/progress', NOTIFICATION_PARAMS_BY_METHOD['_posthog/progress'][0])
+        )
+        if (!isPosthogNotification(wireNotification, '_posthog/progress')) {
+            throw new Error('expected progress notification')
+        }
+        expect(wireNotification.params?.label).toEqual('Cloning repository')
+        expect(wireNotification.params?.detail).toEqual('PostHog/posthog @ master')
+    })
+
+    it.each(SESSION_UPDATE_CASES.map(({ kind, update }) => [kind, update] as const))(
+        'narrows a %s session/update to its kind',
+        (kind, update) => {
+            const wireNotification = notificationOf(sessionUpdate(update))
+            expect(isSessionUpdateNotification(wireNotification)).toBe(true)
+            const body = isSessionUpdateNotification(wireNotification) ? wireNotification.params?.update : undefined
+            expect(isKnownSessionUpdate(body)).toBe(true)
+            if (isKnownSessionUpdate(body)) {
+                expect(body.sessionUpdate).toBe(kind)
+            }
+        }
+    )
+
+    it('carries the v0.42 _meta denial reason on failed tool_call_update frames', () => {
+        const failedCase = SESSION_UPDATE_CASES.find(({ update }) => update.status === 'failed')
+        const wireNotification = notificationOf(sessionUpdate(failedCase!.update))
+        const body = isSessionUpdateNotification(wireNotification) ? wireNotification.params?.update : undefined
+        if (!isKnownSessionUpdate(body) || body.sessionUpdate !== 'tool_call_update') {
+            throw new Error('expected a tool_call_update body')
+        }
+        expect(body._meta?.decision_reason).toEqual(expect.any(String))
+        expect(body.error?.message).toEqual(expect.any(String))
+    })
+
+    it('treats unknown sessionUpdate kinds as session/update of unknown body', () => {
+        const wireNotification = notificationOf(
+            sessionUpdate({ sessionUpdate: 'plan_delta', entries: [{ content: 'Investigate funnel' }] })
+        )
+        expect(isSessionUpdateNotification(wireNotification)).toBe(true)
+        expect(isKnownSessionUpdate(wireNotification.params?.update)).toBe(false)
+    })
+
+    it('matches no known method guard for unknown _posthog methods', () => {
+        const wireNotification = notificationOf(notification('_posthog/hologram_sync', { shards: 3 }))
+        for (const known of KNOWN_POSTHOG_METHODS) {
+            expect(isPosthogNotification(wireNotification, known)).toBe(false)
+        }
+        expect(isSessionUpdateNotification(wireNotification)).toBe(false)
+    })
+
+    it('still classifies degenerate notification bodies as notification frames', () => {
+        // Real methods with missing or malformed params must pass the envelope guard — the
+        // discriminant-only contract leaves payload defensiveness to the consumers.
+        expect(isNotificationFrame(notification('_posthog/turn_complete'))).toBe(true)
+        expect(
+            isNotificationFrame({
+                type: 'notification',
+                notification: { method: '_posthog/console', params: 'not-an-object' },
+            })
+        ).toBe(true)
+    })
+})

--- a/frontend/src/scenes/max/types/sandboxWireTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxWireTypes.ts
@@ -1,0 +1,358 @@
+/**
+ * Wire shapes for the sandbox agent stream (products/tasks SSE frames + persisted log entries).
+ *
+ * Two trust levels, matching who owns each shape: the `type`-discriminated envelope frames are
+ * emitted by products/tasks (or follow JSON-RPC framing) and are guarded at the parse boundary;
+ * everything inside `notification.params` is owned by the external agent adapters and evolves
+ * independently — those shapes are typed but only discriminant-checked, never validated, so an
+ * unknown or extended payload degrades to a no-op instead of an error. Old S3 log entries replay
+ * forever; the parse path must accept the union of all historical formats.
+ *
+ * This file is the authoritative typed view of the contract — the frontend is the only consumer
+ * of live SSE frames. The Python backend types just the slice it reads (persisted log entries)
+ * at `products/posthog_ai/backend/wire_types.py`; keep that slice in sync when it grows.
+ */
+
+/** ACP notification body — the JSON-RPC payload carried inside a `StoredLogEntry`. */
+export interface AcpNotification {
+    jsonrpc?: string
+    method?: string
+    params?: Record<string, unknown>
+    result?: unknown
+    error?: { message?: string; code?: number } | null
+}
+
+/**
+ * Wire envelope around a single ACP notification. The products/tasks stream emits these as
+ * the bulk of `data.type === 'notification'` traffic; the `logs/` endpoint replays them.
+ */
+export interface StoredLogEntry {
+    type: 'notification'
+    timestamp?: string
+    notification: AcpNotification
+}
+
+/**
+ * Run-state frame from `TaskRun.build_stream_state_event` (products/tasks/backend/models.py).
+ * Emitted for non-terminal transitions too (queued → in_progress) — never treat every frame
+ * as terminal. Field names are snake_case on the wire.
+ */
+export interface TaskRunStateFrame {
+    type: 'task_run_state'
+    run_id?: string
+    task_id?: string
+    status?: string
+    stage?: string | null
+    output?: unknown
+    branch?: string | null
+    error_message?: string | null
+    updated_at?: string | null
+    completed_at?: string | null
+}
+
+export interface KeepaliveFrame {
+    type: 'keepalive'
+}
+
+export interface PermissionOption {
+    optionId: string
+    name: string
+    kind: 'allow_once' | 'allow_always' | 'reject' | 'reject_with_feedback'
+}
+
+/** Top-level permission frame hoisted onto the stream by the relay. */
+export interface PermissionRequestFrame {
+    type: 'permission_request'
+    requestId?: string
+    toolCallId?: string
+    options?: PermissionOption[]
+    toolCall?: Record<string, unknown>
+}
+
+export type SandboxWireFrame = StoredLogEntry | TaskRunStateFrame | KeepaliveFrame | PermissionRequestFrame
+
+/**
+ * `event: error` payload. The products/tasks relay emits `{error}`; cloud-agent envelopes carry
+ * `{errorTitle, errorMessage, retryable}` — consumers must tolerate either.
+ */
+export interface SseErrorFrameData {
+    error?: string
+    errorTitle?: string
+    errorMessage?: string
+    retryable?: boolean
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isNotificationFrame(value: unknown): value is StoredLogEntry {
+    return isRecord(value) && value.type === 'notification' && isRecord(value.notification)
+}
+
+export function isTaskRunStateFrame(value: unknown): value is TaskRunStateFrame {
+    return isRecord(value) && value.type === 'task_run_state'
+}
+
+export function isKeepaliveFrame(value: unknown): value is KeepaliveFrame {
+    return isRecord(value) && value.type === 'keepalive'
+}
+
+export function isPermissionRequestFrame(value: unknown): value is PermissionRequestFrame {
+    return isRecord(value) && value.type === 'permission_request'
+}
+
+// --- session/update bodies ---
+
+export interface SessionUpdateText {
+    type?: string
+    text?: string
+}
+
+export interface SessionUpdateAgentMessageChunk {
+    sessionUpdate: 'agent_message_chunk'
+    messageId?: string
+    content?: SessionUpdateText
+    text?: string
+}
+
+export interface SessionUpdateAgentMessage {
+    sessionUpdate: 'agent_message'
+    messageId?: string
+    content?: SessionUpdateText
+    text?: string
+}
+
+export interface SessionUpdateToolCall {
+    sessionUpdate: 'tool_call'
+    toolCallId?: string
+    serverName?: string
+    toolName?: string
+    title?: string
+    kind?: string
+    status?: string
+    rawInput?: Record<string, unknown>
+    input?: Record<string, unknown>
+    locations?: { path: string; line?: number }[]
+    content?: unknown[]
+}
+
+/** Set on failed updates since ACP adapter v0.42 — carries the permission-denial reason. */
+export interface SessionUpdateToolCallMeta {
+    decision_reason?: string
+    decision_reason_type?: string
+    message?: string
+}
+
+export interface SessionUpdateToolCallUpdate {
+    sessionUpdate: 'tool_call_update'
+    toolCallId?: string
+    status?: string
+    title?: string
+    rawInput?: Record<string, unknown>
+    input?: Record<string, unknown>
+    rawOutput?: unknown
+    progress?: unknown
+    error?: { message?: string } | null
+    locations?: { path: string; line?: number }[]
+    content?: unknown[]
+    _meta?: SessionUpdateToolCallMeta
+}
+
+export interface SessionUpdateCurrentMode {
+    sessionUpdate: 'current_mode_update'
+    currentModeId?: string
+    mode?: string
+}
+
+export type SessionUpdateBody =
+    | SessionUpdateAgentMessageChunk
+    | SessionUpdateAgentMessage
+    | SessionUpdateToolCall
+    | SessionUpdateToolCallUpdate
+    | SessionUpdateCurrentMode
+
+export interface SessionUpdateParams {
+    sessionId?: string
+    update?: SessionUpdateBody | Record<string, unknown>
+}
+
+export function isSessionUpdateNotification(
+    notification: AcpNotification
+): notification is AcpNotification & { method: 'session/update'; params?: SessionUpdateParams } {
+    return notification.method === 'session/update'
+}
+
+const KNOWN_SESSION_UPDATES: ReadonlySet<string> = new Set([
+    'agent_message_chunk',
+    'agent_message',
+    'tool_call',
+    'tool_call_update',
+    'current_mode_update',
+])
+
+export function isKnownSessionUpdate(update: unknown): update is SessionUpdateBody {
+    return (
+        isRecord(update) && typeof update.sessionUpdate === 'string' && KNOWN_SESSION_UPDATES.has(update.sessionUpdate)
+    )
+}
+
+// --- `_posthog/*` notification params (adapter-owned; keys are camelCase as on the wire) ---
+
+export interface PosthogConsoleParams {
+    sessionId?: string
+    level?: string
+    message?: string
+}
+
+export interface PosthogProgressParams {
+    sessionId?: string
+    step?: string
+    status?: string
+    label?: string
+    group?: string
+    detail?: string
+}
+
+export interface PosthogSandboxOutputParams {
+    sessionId?: string
+    stdout?: string
+    stderr?: string
+    exitCode?: number
+}
+
+export interface PosthogUserMessageParams {
+    content?: string | unknown[]
+}
+
+export interface PosthogUsageTokens {
+    inputTokens?: number
+    outputTokens?: number
+    cachedReadTokens?: number
+    cachedWriteTokens?: number
+}
+
+/** First of the two `usage_update` forms: cumulative token usage plus optional cost. */
+export interface PosthogUsageUpdateUsedParams {
+    sessionId?: string
+    used: PosthogUsageTokens
+    cost?: { amount?: number; currency?: string } | null
+}
+
+/** Second `usage_update` form: context-window composition breakdown. */
+export interface PosthogUsageUpdateBreakdownParams {
+    sessionId?: string
+    breakdown: {
+        systemPrompt?: number
+        tools?: number
+        rules?: number
+        skills?: number
+        mcp?: number
+        subagents?: number
+        conversation?: number
+    }
+}
+
+export interface PosthogStatusParams {
+    sessionId?: string
+    status?: string
+    isComplete?: boolean
+}
+
+export interface PosthogCompactBoundaryParams {
+    sessionId?: string
+    trigger?: string
+    preTokens?: number
+    contextSize?: number
+}
+
+export interface PosthogTaskNotificationParams {
+    sessionId?: string
+    taskId?: string
+    status?: string
+    summary?: string
+    outputFile?: string
+}
+
+export interface PosthogErrorParams {
+    message?: string
+    classification?: string
+}
+
+export interface PosthogSdkSessionParams {
+    taskRunId?: string
+    sessionId?: string
+    adapter?: string
+}
+
+export interface PosthogResourcesUsedParams {
+    sessionId?: string
+    products?: { id?: string; label?: string }[]
+}
+
+/** Permission lifecycle persisted to the run log — pending approvals are re-derived from these on bootstrap. */
+export interface PosthogPermissionRequestParams {
+    requestId?: string
+    toolCallId?: string
+    options?: PermissionOption[]
+    toolCall?: Record<string, unknown>
+}
+
+export interface PosthogPermissionResolvedParams {
+    requestId?: string
+    toolCallId?: string
+    optionId?: string
+}
+
+export interface PosthogRunStartedParams {
+    sessionId?: string
+    runId?: string
+    taskId?: string
+    agentVersion?: string
+}
+
+export interface PosthogTurnCompleteParams {
+    sessionId?: string
+    stopReason?: string
+}
+
+export interface PosthogNotificationParamsByMethod {
+    '_posthog/console': PosthogConsoleParams
+    '_posthog/progress': PosthogProgressParams
+    '_posthog/sandbox_output': PosthogSandboxOutputParams
+    '_posthog/user_message': PosthogUserMessageParams
+    '_posthog/usage_update': PosthogUsageUpdateUsedParams | PosthogUsageUpdateBreakdownParams
+    '_posthog/status': PosthogStatusParams
+    '_posthog/compact_boundary': PosthogCompactBoundaryParams
+    '_posthog/task_notification': PosthogTaskNotificationParams
+    '_posthog/error': PosthogErrorParams
+    '_posthog/sdk_session': PosthogSdkSessionParams
+    '_posthog/resources_used': PosthogResourcesUsedParams
+    '_posthog/permission_request': PosthogPermissionRequestParams
+    '_posthog/permission_resolved': PosthogPermissionResolvedParams
+    '_posthog/run_started': PosthogRunStartedParams
+    '_posthog/turn_complete': PosthogTurnCompleteParams
+}
+
+/**
+ * Narrows a notification to a known `_posthog/*` method and its params shape. Discriminant-only:
+ * the params contents stay trusted per the module contract.
+ */
+export function isPosthogNotification<M extends keyof PosthogNotificationParamsByMethod>(
+    notification: AcpNotification,
+    method: M
+): notification is AcpNotification & { method: M; params?: PosthogNotificationParamsByMethod[M] } {
+    return notification.method === method
+}
+
+export function isUsageUpdateUsedParams(
+    params: PosthogUsageUpdateUsedParams | PosthogUsageUpdateBreakdownParams | undefined
+): params is PosthogUsageUpdateUsedParams {
+    return !!params && 'used' in params
+}
+
+export function isUsageUpdateBreakdownParams(
+    params: PosthogUsageUpdateUsedParams | PosthogUsageUpdateBreakdownParams | undefined
+): params is PosthogUsageUpdateBreakdownParams {
+    return !!params && 'breakdown' in params
+}

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -26,6 +26,7 @@ from products.posthog_ai.backend.context_wrapper import (
     ContextService,
 )
 from products.posthog_ai.backend.helpers import BaseSandboxService
+from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.system_prompt import PromptService
 from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.client import execute_task_processing_workflow
@@ -100,16 +101,16 @@ class MessageRoutingService(BaseSandboxService):
 
         # Seed the PostHog AI per-Run state keys. `attached_context` keeps the full,
         # undeduped list. These aren't `create_and_run` arguments, so merge them into the
-        # run state here, before the workflow starts and reads it.
-        run_state: dict[str, Any] = dict(task_run.state or {})
-        run_state.update(
-            {
-                "systemPrompt": system_prompt,
-                "attached_context": attached_context,
-                "initial_permission_mode": "default",
-                "pending_user_message": wrapped,
-            }
+        # run state here, before the workflow starts and reads it. `exclude_unset` keeps the
+        # merge limited to exactly these keys — model defaults must not leak into the bag.
+        ph_state = PostHogAIRunState(
+            system_prompt=system_prompt,
+            attached_context=attached_context,
+            initial_permission_mode="default",
+            pending_user_message=wrapped,
         )
+        run_state: dict[str, Any] = dict(task_run.state or {})
+        run_state.update(ph_state.model_dump(mode="json", by_alias=True, exclude_unset=True))
         # Persist the enriched run state and conversation linkage together: a half-write
         # would orphan the run (enriched state, but conversation.task still NULL) and the
         # next retry would look like a fresh first message.

--- a/products/posthog_ai/backend/run_state.py
+++ b/products/posthog_ai/backend/run_state.py
@@ -1,0 +1,23 @@
+"""PostHog AI extension of the products/tasks per-Run state bag.
+
+Lives outside ``wire_types.py`` on purpose: that module stays importable without Django,
+while this one pulls in products/tasks temporal internals (already a transitive dependency
+of ``message_routing.py``).
+"""
+
+from pydantic import ConfigDict, Field
+
+from products.posthog_ai.backend.context_wrapper import AttachedContext
+from products.tasks.backend.temporal.process_task.utils import RunState
+
+
+class PostHogAIRunState(RunState):
+    """The base ``RunState`` already covers ``pending_user_message`` and
+    ``initial_permission_mode``; this adds the PostHog AI-only keys. The bag is persisted
+    with the wire's casing (``systemPrompt``), so dump with ``by_alias=True`` and merge with
+    ``exclude_unset=True`` to write exactly the keys that were set."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    system_prompt: str | None = Field(default=None, alias="systemPrompt")
+    attached_context: list[AttachedContext] | None = None

--- a/products/posthog_ai/backend/test/test_run_state.py
+++ b/products/posthog_ai/backend/test/test_run_state.py
@@ -1,0 +1,42 @@
+import unittest
+
+from products.posthog_ai.backend.run_state import PostHogAIRunState
+
+
+class TestPostHogAIRunState(unittest.TestCase):
+    def test_validate_accepts_wire_alias(self) -> None:
+        state = PostHogAIRunState.model_validate({"systemPrompt": "SYS"})
+        assert state.system_prompt == "SYS"
+
+    def test_dump_emits_wire_alias(self) -> None:
+        state = PostHogAIRunState(system_prompt="SYS")
+        dumped = state.model_dump(mode="json", by_alias=True, exclude_unset=True)
+        assert dumped == {"systemPrompt": "SYS"}
+
+    def test_exclude_unset_dumps_only_set_keys(self) -> None:
+        state = PostHogAIRunState(
+            system_prompt="SYS",
+            attached_context=[{"type": "dashboard", "id": 123, "name": "Funnel"}],
+            initial_permission_mode="default",
+            pending_user_message="wrapped",
+        )
+        dumped = state.model_dump(mode="json", by_alias=True, exclude_unset=True)
+        assert dumped == {
+            "systemPrompt": "SYS",
+            "attached_context": [{"type": "dashboard", "id": 123, "name": "Funnel"}],
+            "initial_permission_mode": "default",
+            "pending_user_message": "wrapped",
+        }
+
+    def test_parent_extra_allow_config_survives_subclassing(self) -> None:
+        state = PostHogAIRunState.model_validate({"systemPrompt": "SYS", "sandbox_quirk": True})
+        dumped = state.model_dump(by_alias=True)
+        assert dumped["sandbox_quirk"] is True
+
+    def test_base_run_state_fields_still_parse(self) -> None:
+        state = PostHogAIRunState.model_validate(
+            {"pending_user_message": "hi", "initial_permission_mode": "default", "resume_from_run_id": "r-1"}
+        )
+        assert state.pending_user_message == "hi"
+        assert state.initial_permission_mode == "default"
+        assert state.resume_from_run_id == "r-1"

--- a/products/posthog_ai/backend/test/test_wire_types.py
+++ b/products/posthog_ai/backend/test/test_wire_types.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+import unittest
+
+from parameterized import parameterized
+from pydantic import TypeAdapter
+
+from products.posthog_ai.backend.wire_types import (
+    METHOD_USER_MESSAGE,
+    NotificationFrame,
+    UnknownFrame,
+    UserMessageParams,
+    is_user_message_params,
+    parse_log_entry,
+)
+
+TIMESTAMP = "2026-06-11T09:00:00.000000+00:00"
+
+
+def _notification(method: str, params: Any = None) -> dict[str, Any]:
+    body: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        body["params"] = params
+    return {"type": "notification", "timestamp": TIMESTAMP, "notification": body}
+
+
+class TestWireTypes(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("plain_string", {"content": "Why did checkout conversion drop last week?"}),
+            ("content_blocks", {"content": [{"type": "text", "text": "Why did checkout conversion drop?"}]}),
+        ]
+    )
+    def test_user_message_entries_classify_guard_and_validate_strictly(
+        self, _name: str, params: dict[str, Any]
+    ) -> None:
+        parsed = parse_log_entry(_notification(METHOD_USER_MESSAGE, params))
+        assert isinstance(parsed, NotificationFrame)
+        assert is_user_message_params(parsed.notification.params, parsed.notification.method)
+        # Strict validation of the adapter-owned payload happens here, never in production code —
+        # a drifted shape fails this suite instead of raising mid-log-walk.
+        TypeAdapter(UserMessageParams).validate_python(parsed.notification.params, strict=True)
+
+    @parameterized.expand(
+        [
+            ("other_method", _notification("_posthog/turn_complete", {"stopReason": "end_turn"})),
+            ("no_params", _notification(METHOD_USER_MESSAGE)),
+            (
+                "string_params",
+                {"type": "notification", "notification": {"method": METHOD_USER_MESSAGE, "params": "not-an-object"}},
+            ),
+        ]
+    )
+    def test_guard_rejects_non_user_message_payloads(self, _name: str, entry: dict[str, Any]) -> None:
+        parsed = parse_log_entry(entry)
+        assert isinstance(parsed, NotificationFrame)
+        assert not is_user_message_params(parsed.notification.params, parsed.notification.method)
+
+    @parameterized.expand(
+        [
+            ("unknown_type", {"type": "telemetry_v2", "payload": {"value": 5120}}),
+            ("missing_type", {"status": "in_progress", "note": "frame with no type discriminant"}),
+            ("task_run_state", {"type": "task_run_state", "status": "in_progress"}),
+            ("non_object_body", {"type": "notification", "notification": "oops"}),
+        ]
+    )
+    def test_unrecognized_entries_classify_as_unknown_without_raising(self, _name: str, entry: dict[str, Any]) -> None:
+        parsed = parse_log_entry(entry)
+        assert isinstance(parsed, UnknownFrame)
+        assert parsed.raw == entry
+
+    def test_extra_envelope_fields_are_tolerated(self) -> None:
+        entry = _notification(METHOD_USER_MESSAGE, {"content": "hi", "futureField": True})
+        entry["futureEnvelopeField"] = "later"
+        parsed = parse_log_entry(entry)
+        assert isinstance(parsed, NotificationFrame)
+        assert is_user_message_params(parsed.notification.params, parsed.notification.method)

--- a/products/posthog_ai/backend/wire_types.py
+++ b/products/posthog_ai/backend/wire_types.py
@@ -1,0 +1,77 @@
+"""Typed views of the slice of the sandbox agent wire format the Python backend consumes.
+
+The backend only ever reads persisted log entries (S3 NDJSON replayed via the products/tasks
+``logs/`` path) — today to walk prior ``_posthog/user_message`` notifications for context
+dedup on follow-ups. Live SSE frames are consumed exclusively by the frontend, where the full
+contract is typed at ``frontend/src/scenes/max/types/sandboxWireTypes.ts``; keep that copy in
+mind when extending this one.
+
+The envelope is validated with tolerant pydantic models (we co-own its shape with
+products/tasks); ``notification.params`` is owned by the external agent adapters, so it is
+typed via TypedDict + TypeGuard and never runtime-validated outside tests — old S3 log entries
+replay forever, and a parse path that raises on a historical or future shape would break
+conversation loads.
+"""
+
+from typing import Any, Literal, NotRequired, TypedDict, TypeGuard
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class AcpError(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    code: int | None = None
+    message: str | None = None
+
+
+class AcpNotificationBody(BaseModel):
+    """JSON-RPC notification carried inside a ``notification`` log entry."""
+
+    model_config = ConfigDict(extra="allow")
+
+    jsonrpc: str | None = None
+    method: str | None = None
+    # Adapter-owned; narrow with the TypeGuards below instead of validating here.
+    params: Any = None
+    result: Any = None
+    error: AcpError | None = None
+
+
+class NotificationFrame(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["notification"]
+    timestamp: str | None = None
+    notification: AcpNotificationBody
+
+
+class UnknownFrame(BaseModel):
+    """Fallback for entries this module doesn't recognize. Carries the raw payload untouched."""
+
+    raw: dict[str, Any]
+
+
+def parse_log_entry(data: dict[str, Any]) -> NotificationFrame | UnknownFrame:
+    """Classify a raw persisted log entry. Never raises — unknown or malformed entries come
+    back as ``UnknownFrame`` so a single bad entry can't abort a log walk."""
+    if data.get("type") != "notification":
+        return UnknownFrame(raw=data)
+    try:
+        return NotificationFrame.model_validate(data)
+    except ValidationError:
+        return UnknownFrame(raw=data)
+
+
+METHOD_USER_MESSAGE = "_posthog/user_message"
+
+
+class UserMessageParams(TypedDict):
+    """Params of a ``_posthog/user_message`` notification — the user's message as the
+    agent-server echoed it into the log (plain string or ACP content blocks)."""
+
+    content: NotRequired[str | list[dict[str, Any]]]
+
+
+def is_user_message_params(params: object, method: str | None) -> TypeGuard[UserMessageParams]:
+    return method == METHOD_USER_MESSAGE and isinstance(params, dict)


### PR DESCRIPTION
## Problem

The sandbox agent wire format (SSE frames and persisted log entries from the tasks backend, ACP payloads from the agent adapters) was consumed untyped: the frontend stream logic dug through `Record<string, any>` with casts, and the backend built the per-run state bag as a plain dict. Half of this contract is owned by an external repo and drifts over time, and the loose access was already hiding two live bugs — terminal `error_message` values were read under the wrong field name (so failure messages were silently dropped), and `_posthog/progress` payloads were read with the wrong keys (so progress text never rendered).

## Changes

Typed wire definitions, scoped to each side's actual consumption:

- **TypeScript** (`frontend/src/scenes/max/types/sandboxWireTypes.ts`) carries the **full contract** — the frontend is the only consumer of live SSE frames. Envelope interfaces + discriminant type guards, a `session/update` discriminated union, and a generic method-keyed guard for every `_posthog/*` notification payload. `sandboxStreamTypes.ts` now holds thread/render shapes only.
- **Python** (`products/posthog_ai/backend/wire_types.py`) types only the **slice the backend reads** (persisted log entries): a tolerant pydantic notification envelope with a `parse_log_entry()` that classifies or returns `UnknownFrame` — never raising, because old S3 log entries replay forever — plus the `_posthog/user_message` params that the upcoming follow-up context-dedup walk consumes. SSE-only shapes deliberately have no Python copy.
- **Tests**: each side carries its own corpus of canonical frames (sourced from the in-repo emitters), covering happy paths and deliberate tolerance cases (unknown frame types/methods, malformed params). Payload shapes are validated strictly via `pydantic.TypeAdapter` in tests only.

Consumers refactored onto the types:

- `sandboxStreamLogic.ts` uses guards at the two trust boundaries (SSE `onmessage` frame discrimination, `sessionUpdate` narrowing) and drops all loose casts, preserving the dedup-hash invariant (raw entries are hashed untouched — pinned by a replay test). This fixes the two bugs above; note **progress text becomes visible UI for the first time** (it previously always rendered as an empty string).
- `message_routing.py` builds the run state through a typed `RunState` subclass dumped with `by_alias` + `exclude_unset`, keeping the persisted keys byte-identical to before.

## How did you test this code?

I'm an agent; automated tests only:

- `products/posthog_ai/backend/test/test_wire_types.py`, `test_run_state.py`, and the pre-existing `test_message_routing.py` (passes unchanged) — 23 tests green.
- `frontend/src/scenes/max/types/sandboxWireTypes.test.ts` and the extended `sandboxStreamLogic.test.ts` (78 tests, incl. new wire-frame parsing, progress, and replay dedup tests) — green.
- kea typegen regenerated; `tsc --noEmit`, oxlint, and ruff all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — the internal migration docs already point to code-level wire types as the authoritative shapes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). The driver asked for Python + TypeScript wire types based on a prior contract audit, then to refactor consumers onto them with frontend guards, and iteratively narrowed scope: a shared fixture directory was built and then removed, and the Python copy was trimmed from a full mirror down to the slice upstream backend work will actually consume.
- Design rationale: TS is authoritative (sole SSE consumer); Python's parse path is tolerant because a validating parser must never raise on historical log replays; strict validation lives exclusively in tests.
- The two wire-reading bug fixes fell out of typing the frames against the actual emitter rather than the spec examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)