### PR TITLE
feat(agent_platform): apply opt-in SSL options to product-DB connections

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -190,6 +190,22 @@ product_routes = load_product_db_routes(Path(__file__).resolve().parents[2])
 configured_product_databases: set[str] = set()
 PRODUCT_DB_WRITER_URLS: dict[str, str] = {}
 
+# Optional SSL settings for product-DB connections. dj_database_url only sets
+# connect_timeout, so without these a direct (non-PgBouncer) product DB connects
+# with libpq's default sslmode=prefer. Aurora's pg_hba requires SSL (hostssl), so
+# direct-mode product DBs (e.g. dedicated clusters) need these set. Left unset for
+# local dev/test (plain Postgres, no SSL) so those are unaffected.
+PRODUCT_DB_SSL_MODE: str | None = os.getenv("PRODUCT_DB_SSL_MODE")
+PRODUCT_DB_SSL_ROOT_CERT: str | None = os.getenv("PRODUCT_DB_SSL_ROOT_CERT")
+
+
+def _apply_product_db_ssl_options(options: dict) -> None:
+    if PRODUCT_DB_SSL_MODE:
+        options["sslmode"] = PRODUCT_DB_SSL_MODE
+    if PRODUCT_DB_SSL_ROOT_CERT:
+        options["sslrootcert"] = PRODUCT_DB_SSL_ROOT_CERT
+
+
 for route in product_routes:
     if route.database in configured_product_databases:
         continue
@@ -212,10 +228,12 @@ for route in product_routes:
     PRODUCT_DB_WRITER_URLS[db] = writer_url
     DATABASES[writer_alias] = dict(dj_database_url.parse(writer_url, conn_max_age=0))
     DATABASES[writer_alias].setdefault("OPTIONS", {})["connect_timeout"] = 3
+    _apply_product_db_ssl_options(DATABASES[writer_alias]["OPTIONS"])
 
     reader_url = os.getenv(reader_env, writer_url)
     DATABASES[reader_alias] = dict(dj_database_url.parse(reader_url, conn_max_age=0))
     DATABASES[reader_alias].setdefault("OPTIONS", {})["connect_timeout"] = 3
+    _apply_product_db_ssl_options(DATABASES[reader_alias]["OPTIONS"])
 
     if TEST:
         # Skip the global migration-graph walk during test DB setup. Without
@@ -250,6 +268,7 @@ for route in product_routes:
         direct_alias = f"{db}_db_direct"
         DATABASES[direct_alias] = dict(dj_database_url.parse(direct_url, conn_max_age=0))
         DATABASES[direct_alias].setdefault("OPTIONS", {})["connect_timeout"] = 10
+        _apply_product_db_ssl_options(DATABASES[direct_alias]["OPTIONS"])
         if DISABLE_SERVER_SIDE_CURSORS:
             DATABASES[direct_alias]["DISABLE_SERVER_SIDE_CURSORS"] = True
 


### PR DESCRIPTION
## Problem

Product-DB `DATABASES` entries (the per-product writer/reader/direct aliases built in `data_stores.py`) only set `connect_timeout` — they never set any SSL option. So a product DB that connects **directly** to its server (no PgBouncer in front) uses libpq's default `sslmode=prefer`. When that server requires SSL (e.g. an Aurora cluster whose `pg_hba` is `hostssl`-only), the connection can't be established. The main PostHog DB doesn't hit this because it goes through an in-cluster PgBouncer that doesn't require SSL; a direct-mode product DB is the first connection in such a deploy to reach the server directly.

## Changes

Add two optional, opt-in env vars, applied to the product-DB writer, reader, and direct aliases:

- `PRODUCT_DB_SSL_MODE` → `OPTIONS["sslmode"]`
- `PRODUCT_DB_SSL_ROOT_CERT` → `OPTIONS["sslrootcert"]`

Mirrors the main DB's existing `SSL_OPTIONS` pattern. Both are skipped when unset, so local dev/test (plain local Postgres, no SSL) and every PgBouncer-routed product DB are unaffected — this only changes behaviour for deployments that explicitly set the vars.

## How did you test this code?

I'm an agent (Claude Code). I ran only the checks below — no manual/UI testing:

- `ruff format` + `ruff check` clean on `posthog/settings/data_stores.py`.
- `python -c "import ast; ast.parse(...)"` parse check on the changed file.
- Confirmed the intended deployment effect by rendering the consuming chart (dev-two) in the charts repo and checking the env vars land; that side is a separate charts PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @benjackwhite.

Authored with Claude Code while debugging a dev-two deploy where the `agent_platform` product DB (direct mode against Aurora) failed its connection on SSL. Root cause: product-DB aliases never carried `sslmode`, so libpq defaulted to `prefer` and the `hostssl`-only server rejected the unencrypted fallback.

Decision: make SSL **opt-in via env** rather than hardcoding it, so the change is inert for local/test and for PgBouncer-routed product DBs, and only the direct-to-Aurora deploy opts in (`PRODUCT_DB_SSL_MODE=require`, set in the charts repo). The same commit also rides on `agent-platform-django-base` (the branch the dev-two image is built from) so the fix reaches that deploy now; this PR lands it durably on master. Companion charts change: PostHog/charts#11999.

Draft for review — opened at the author's request to dig into it before marking ready. Agent-authored; requires human review, no self-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_019A4C9d8iXK9qtneWtE7CH5)_