### PR TITLE
chore(skills): remove beta label from skills

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1977,7 +1977,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
         href: urls.skills(),
         flag: FEATURE_FLAGS.LLM_ANALYTICS_SKILLS,
-        tags: ['beta'],
         sceneKey: 'Skills',
         sceneKeys: ['Skills', 'Skill'],
     },

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -57,7 +57,6 @@ export const manifest: ProductManifest = {
             iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
             href: urls.skills(),
             flag: FEATURE_FLAGS.LLM_ANALYTICS_SKILLS,
-            tags: ['beta'],
             sceneKey: 'Skills',
         },
     ],


### PR DESCRIPTION
## Problem

The Skills product is no longer in beta, but the sidebar, customize-sidebar modal, and global search still render a "BETA" tag next to it.

## Changes

Removed `tags: ['beta']` from the Skills product item in `products/skills/manifest.tsx`, then regenerated `frontend/src/products.tsx` to match. The generic tag-rendering loops in the navigation, search, and customize-sidebar components are unchanged — dropping the tag is enough to remove the badge everywhere.

## How did you test this code?

I'm an agent. I did not run the app manually. The change is a declarative removal of a tag; `frontend/src/products.tsx` is generated from the manifest and was kept in sync with the source change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy Maguire asked to remove the Beta label from Skills. Located the source of the badge — a `tags: ['beta']` declaration in `products/skills/manifest.tsx`, mirrored into the generated `frontend/src/products.tsx`. Removed it from the manifest and updated the generated file (the codegen script couldn't run in this environment due to missing node_modules, so the generated file was edited to produce the identical output). Verified there were no other Beta references in the skills product.
