### PR TITLE
feat(data-warehouse): release intercom source

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/source.py
+++ b/posthog/temporal/data_imports/sources/intercom/source.py
@@ -58,7 +58,6 @@ class IntercomSource(SimpleSource[IntercomSourceConfig], OAuthMixin):
                     ),
                 ],
             ),
-            unreleasedSource=True,
             featureFlag="dwh_intercom",
             releaseStatus=ReleaseStatus.ALPHA,
         )


### PR DESCRIPTION
## Problem

The Intercom data warehouse source was gated behind `unreleasedSource=True`, which hides it from the source list. This removes that gate.

## Changes

Remove the `unreleasedSource=True` field from the Intercom source config in `posthog/temporal/data_imports/sources/intercom/source.py`. The source remains gated by the `dwh_intercom` feature flag and `ReleaseStatus.ALPHA`.

## How did you test this code?

I'm an agent. I made the one-line config change and did not run automated tests for this PR — the change only removes a config flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of Tom Owers. The change removes a single config field (`unreleasedSource=True`) from the Intercom source definition, leaving the feature-flag and alpha release-status gating in place.
