### PR TITLE
fix(tasks): rewrite enricher workspace dep in local sandbox image build

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -9,10 +9,14 @@ COPY local-git /local-git
 COPY local-enricher /local-enricher
 COPY local-agent /local-agent
 
-# Pack shared and enricher first (no workspace deps), then git (depends on shared),
-# then agent (depends on shared, git, and enricher).
+# Pack shared first (no workspace deps), then enricher and git (both depend on
+# shared), then agent (depends on shared, git, and enricher). Every package with
+# a "workspace:*" dependency must have it rewritten to the packed tgz before
+# `pnpm pack`, otherwise pnpm fails with ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL.
 RUN cd /local-shared && pnpm pack && \
-    cd /local-enricher && pnpm pack && \
+    cd /local-enricher && \
+    sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
+    pnpm pack && \
     cd /local-git && \
     sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
     pnpm pack && \

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -63,6 +63,20 @@ NOTEBOOK_IMAGE_NAME = "posthog-sandbox-notebook"
 PI_IMAGE_NAME = "posthog-sandbox-pi"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
 
+# A failing `docker build` can emit megabytes of output. Stuffing all of it into a
+# Temporal ApplicationError's details overflows the failure-payload size limit, and
+# Temporal then discards the real error in favor of an opaque "Failure exceeds size
+# limit." Keep the tail — Docker prints the failing step and error there.
+_MAX_CAPTURED_OUTPUT_CHARS = 8000
+
+
+def _truncate_output(output: str | None) -> str:
+    if not output:
+        return ""
+    if len(output) <= _MAX_CAPTURED_OUTPUT_CHARS:
+        return output
+    return f"...[truncated {len(output) - _MAX_CAPTURED_OUTPUT_CHARS} chars]...\n{output[-_MAX_CAPTURED_OUTPUT_CHARS:]}"
+
 
 class DockerSandbox(SandboxBase):
     """
@@ -372,14 +386,14 @@ class DockerSandbox(SandboxBase):
             logger.exception(f"Failed to create Docker sandbox: {e.stderr}")
             raise SandboxProvisionError(
                 "Failed to create Docker sandbox",
-                {"config_name": config.name, "error": e.stderr},
+                {"config_name": config.name, "error": _truncate_output(e.stderr)},
                 cause=e,
             )
         except Exception as e:
             logger.exception(f"Failed to create Docker sandbox: {e}")
             raise SandboxProvisionError(
                 "Failed to create Docker sandbox",
-                {"config_name": config.name, "error": str(e)},
+                {"config_name": config.name, "error": _truncate_output(str(e))},
                 cause=e,
             )
 


### PR DESCRIPTION
## Problem

local dev sandboxes (`SANDBOX_PROVIDER=docker` with `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` set) stopped building. Sandbox creation failed, and the underlying error was masked by the generic temporal failures

this is local-dev only. Production and Modal images install the agent from the npm registry (`npm install @posthog/agent@latest`) and never pack from the workspace, so they are unaffected.

## Changes

- `Dockerfile.sandbox-local`: rewrite `enricher`'s `@posthog/shared` `workspace:*` dependency to the packed `.tgz` before `pnpm pack`,
