### PR TITLE
fix(dev): enable strictPort on vite dev server

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -28,10 +28,11 @@ vite_port_listeners() {
     return 0
 }
 
-# Vite isn't configured with strictPort, so if a stale process from a previous
-# session is still squatting on $VITE_PORT, Vite silently falls back to the next
-# free port — and the app, which hardcodes $VITE_PORT everywhere, fails to load.
-# Reclaim the port up front so we always come up where we're expected.
+# If a stale process from a previous session is still squatting on $VITE_PORT,
+# the app — which hardcodes $VITE_PORT everywhere — fails to load. Reclaim the
+# port up front so we always come up where we're expected; Vite's strictPort
+# turns any reclaim failure into a loud startup error instead of a silent
+# fallback to the next free port.
 free_vite_port() {
     local pids
     pids=$(vite_port_listeners)

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -105,6 +105,10 @@ export default defineConfig(({ mode }) => {
         },
         server: {
             port: 8234,
+            // The rest of the stack hardcodes 8234, so falling back to another port serves a
+            // broken app (the browser keeps talking to whatever squats 8234). Fail loudly instead;
+            // bin/start-frontend reclaims the port from stale processes before launching.
+            strictPort: true,
             host: process.argv.includes('--host') ? '0.0.0.0' : 'localhost',
             allowedHosts: process.env.VITE_ALLOWED_HOSTS?.split(',')
                 .map((s) => s.trim())


### PR DESCRIPTION
## Problem

A stale process squatting the Vite dev port (8234) makes a freshly started Vite silently fall back to 8235+, while the rest of the app hardcodes 8234 — so the browser keeps talking to the stale process. The result is a hard-to-diagnose broken frontend (blank page, `504 Outdated Optimize Dep`) that survives reinstalls and cache cleanup.

#61964 stops `bin/start-frontend` from leaking orphaned vite subtrees, and #62487 reclaims the port before launch. But if reclaiming ever fails (`lsof`/`fuser` unavailable, unkillable process, race), Vite still drifts silently and the failure mode returns.

## Changes

- `strictPort: true` in `frontend/vite.config.mts` — failing to bind 8234 is now a loud startup error (`Port 8234 is already in use`) instead of a silent fallback to a port nothing points at
- Updated the `free_vite_port` comment in `bin/start-frontend` to describe its new role: reclaim for convenience, strictPort as the loud backstop

## How did you test this code?

I'm an agent — no manual UI testing. Verified against the installed Vite 7.3.3:

- With the config change and the port held by another vite, startup exits non-zero with `Error: Port 8246 is already in use`; without it, Vite logs `Port 8246 is in use, trying another one...` and serves on the next port
- With the port free, startup is unchanged (`ready in ~500 ms`)
- `shellcheck bin/start-frontend` passes

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact; dev-environment change only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) at Raúl's direction while re-investigating the recurring branch-switch 504s. Findings that led here: Vite 7 already invalidates a stale optimize-dep cache eagerly at server startup (lockfile-content hash), so cache-clearing fixes like #61732 duplicate built-in behavior; the persistent in-the-wild failures matched stale processes holding the port. This one-liner is the remaining guard the Vite docs recommend when surrounding infra depends on a fixed port.
