### PR TITLE
feat(dashboards): capture dashboard tile removed analytics event

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard_delete_tile.py
+++ b/posthog/api/test/dashboards/test_dashboard_delete_tile.py
@@ -1,4 +1,5 @@
 from posthog.test.base import APIBaseTest
+from unittest.mock import ANY, patch
 
 from django.test import override_settings
 
@@ -53,6 +54,40 @@ class TestDashboardDeleteTile(APIBaseTest):
         assert self.dashboard_api.get_dashboard(dashboard_id)["tiles"] == []
         insight_response = self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}")
         assert insight_response.status_code == status.HTTP_200_OK
+
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    def test_delete_text_tile_fires_tile_removed_event(self, mock_report_user_action) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="hello world")
+        tile_id = dashboard_json["tiles"][0]["id"]
+        mock_report_user_action.reset_mock()
+
+        self._delete_tile(dashboard_id, tile_id)
+
+        mock_report_user_action.assert_any_call(
+            self.user,
+            "dashboard tile removed",
+            {"tile_type": "text", "insight_type": None, "dashboard_id": dashboard_id},
+            team=ANY,
+            request=ANY,
+        )
+
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    def test_delete_insight_tile_fires_tile_removed_event(self, mock_report_user_action) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        self.dashboard_api.create_insight({"name": "insight", "dashboards": [dashboard_id]})
+        tile_id = self.dashboard_api.get_dashboard(dashboard_id)["tiles"][0]["id"]
+        mock_report_user_action.reset_mock()
+
+        self._delete_tile(dashboard_id, tile_id)
+
+        mock_report_user_action.assert_any_call(
+            self.user,
+            "dashboard tile removed",
+            {"tile_type": "insight", "insight_type": None, "dashboard_id": dashboard_id},
+            team=ANY,
+            request=ANY,
+        )
 
     def _setup_unknown_tile_id(self) -> tuple[int, int]:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})

--- a/posthog/api/test/dashboards/test_dashboard_delete_tile.py
+++ b/posthog/api/test/dashboards/test_dashboard_delete_tile.py
@@ -55,28 +55,26 @@ class TestDashboardDeleteTile(APIBaseTest):
         insight_response = self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}")
         assert insight_response.status_code == status.HTTP_200_OK
 
-    @patch("products.dashboards.backend.api.dashboard.report_user_action")
-    def test_delete_text_tile_fires_tile_removed_event(self, mock_report_user_action) -> None:
-        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+    def _create_text_tile_for_removal(self, dashboard_id: int) -> int:
         _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="hello world")
-        tile_id = dashboard_json["tiles"][0]["id"]
-        mock_report_user_action.reset_mock()
+        return dashboard_json["tiles"][0]["id"]
 
-        self._delete_tile(dashboard_id, tile_id)
-
-        mock_report_user_action.assert_any_call(
-            self.user,
-            "dashboard tile removed",
-            {"tile_type": "text", "insight_type": None, "dashboard_id": dashboard_id},
-            team=ANY,
-            request=ANY,
-        )
-
-    @patch("products.dashboards.backend.api.dashboard.report_user_action")
-    def test_delete_insight_tile_fires_tile_removed_event(self, mock_report_user_action) -> None:
-        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+    def _create_insight_tile_for_removal(self, dashboard_id: int) -> int:
         self.dashboard_api.create_insight({"name": "insight", "dashboards": [dashboard_id]})
-        tile_id = self.dashboard_api.get_dashboard(dashboard_id)["tiles"][0]["id"]
+        return self.dashboard_api.get_dashboard(dashboard_id)["tiles"][0]["id"]
+
+    @parameterized.expand(
+        [
+            ("text", _create_text_tile_for_removal, {"tile_type": "text", "insight_type": None}),
+            ("insight", _create_insight_tile_for_removal, {"tile_type": "insight", "insight_type": "trends"}),
+        ]
+    )
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    def test_delete_tile_fires_tile_removed_event(
+        self, _name, create_tile, expected_properties, mock_report_user_action
+    ) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        tile_id = create_tile(self, dashboard_id)
         mock_report_user_action.reset_mock()
 
         self._delete_tile(dashboard_id, tile_id)
@@ -84,7 +82,7 @@ class TestDashboardDeleteTile(APIBaseTest):
         mock_report_user_action.assert_any_call(
             self.user,
             "dashboard tile removed",
-            {"tile_type": "insight", "insight_type": None, "dashboard_id": dashboard_id},
+            {**expected_properties, "dashboard_id": dashboard_id},
             team=ANY,
             request=ANY,
         )

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -956,6 +956,19 @@ def _check_dashboard_widget_count_limit(*, dashboard: Dashboard, user: User) -> 
     )
 
 
+def _tile_type_and_widget_type(tile: DashboardTile) -> tuple[str, str | None]:
+    if tile.text_id is not None:
+        return "text", None
+    if tile.button_tile_id is not None:
+        return "button", None
+    if tile.widget_id is not None:
+        widget_type = tile.widget.widget_type if tile.widget is not None else None
+        return "widget", widget_type
+    if tile.insight_id is not None:
+        return "insight", None
+    raise ValueError("Dashboard tile has no related content for analytics")
+
+
 def _report_dashboard_tile_added(
     *,
     user: User,
@@ -996,6 +1009,50 @@ def _report_dashboard_tile_added(
     report_user_action(
         user,
         "dashboard widget added",
+        widget_properties,
+        team=dashboard.team,
+        request=request,
+    )
+
+
+def _report_dashboard_tile_removed(
+    *,
+    user: User,
+    dashboard: Dashboard,
+    tile: DashboardTile,
+    request: Request | None = None,
+) -> None:
+    tile_type, widget_type = _tile_type_and_widget_type(tile)
+    properties: dict[str, Any] = {
+        "tile_type": tile_type,
+        "insight_type": None,
+        "dashboard_id": dashboard.id,
+    }
+    if widget_type is not None:
+        properties["widget_type"] = widget_type
+
+    report_user_action(
+        user,
+        "dashboard tile removed",
+        properties,
+        team=dashboard.team,
+        request=request,
+    )
+
+    if widget_type is None:
+        return
+
+    widget_properties: dict[str, Any] = {
+        "widget_type": widget_type,
+        "dashboard_id": dashboard.id,
+        "tile_id": tile.id,
+    }
+    if tile.widget_id is not None:
+        widget_properties["widget_id"] = str(tile.widget_id)
+
+    report_user_action(
+        user,
+        "dashboard widget removed",
         widget_properties,
         team=dashboard.team,
         request=request,
@@ -1469,16 +1526,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
     @staticmethod
     def _tile_added_analytics_fields(tile: DashboardTile) -> tuple[str, str | None]:
-        if tile.text_id is not None:
-            return "text", None
-        if tile.button_tile_id is not None:
-            return "button", None
-        if tile.widget_id is not None:
-            widget_type = tile.widget.widget_type if tile.widget is not None else None
-            return "widget", widget_type
-        if tile.insight_id is not None:
-            return "insight", None
-        raise ValueError("Dashboard tile has no related content for analytics")
+        return _tile_type_and_widget_type(tile)
 
     @staticmethod
     def _update_tiles(instance: Dashboard, tile_data: dict, user: User) -> tuple[DashboardTile | None, bool]:
@@ -2373,6 +2421,13 @@ class DashboardsViewSet(
                     [remaining_tile for remaining_tile in remaining if remaining_tile.id in changed_ids],
                     ["layouts"],
                 )
+
+        _report_dashboard_tile_removed(
+            user=cast(User, request.user),
+            dashboard=dashboard,
+            tile=tile,
+            request=request,
+        )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1024,7 +1024,7 @@ def _report_dashboard_tile_removed(
     request: Request | None = None,
 ) -> None:
     tile_type, widget_type = _tile_type_and_widget_type(tile)
-    insight_type = _get_insight_type(tile.insight) if tile.insight_id is not None else None
+    insight_type = _get_insight_type(tile.insight) if tile.insight is not None else None
     properties: dict[str, Any] = {
         "tile_type": tile_type,
         "insight_type": insight_type,

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -105,6 +105,7 @@ from products.product_analytics.backend.api.insight import (
     DashboardTileBasicSerializer,
     InsightSerializer,
     InsightViewSet,
+    _get_insight_type,
 )
 from products.product_analytics.backend.models.insight import Insight
 from products.product_analytics.backend.models.insight_variable import InsightVariable
@@ -1023,9 +1024,10 @@ def _report_dashboard_tile_removed(
     request: Request | None = None,
 ) -> None:
     tile_type, widget_type = _tile_type_and_widget_type(tile)
+    insight_type = _get_insight_type(tile.insight) if tile.insight_id is not None else None
     properties: dict[str, Any] = {
         "tile_type": tile_type,
-        "insight_type": None,
+        "insight_type": insight_type,
         "dashboard_id": dashboard.id,
     }
     if widget_type is not None:

--- a/products/dashboards/backend/api/test/test_dashboard_widgets.py
+++ b/products/dashboards/backend/api/test/test_dashboard_widgets.py
@@ -725,6 +725,44 @@ class TestDashboardWidgets(APIBaseTest):
         assert widget_added_calls[0][0][2]["widget_type"] == "session_replay_list"
 
     @override_settings(IN_UNIT_TESTING=True)
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    def test_delete_widget_tile_fires_tile_removed_and_widget_removed_events(self, mock_report_user_action) -> None:
+        dashboard_id, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id=self.dashboard_api.create_dashboard({"name": "dashboard"})[0],
+            widget_type="error_tracking_list",
+            config={"limit": 10},
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+        mock_report_user_action.reset_mock()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/delete_tile",
+            {"tile_id": tile_id},
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        mock_report_user_action.assert_any_call(
+            self.user,
+            "dashboard tile removed",
+            {
+                "tile_type": "widget",
+                "insight_type": None,
+                "dashboard_id": dashboard_id,
+                "widget_type": "error_tracking_list",
+            },
+            team=ANY,
+            request=ANY,
+        )
+        widget_removed_calls = [
+            call for call in mock_report_user_action.call_args_list if call[0][1] == "dashboard widget removed"
+        ]
+        assert len(widget_removed_calls) == 1
+        assert widget_removed_calls[0][0][2]["widget_type"] == "error_tracking_list"
+        assert widget_removed_calls[0][0][2]["dashboard_id"] == dashboard_id
+        assert widget_removed_calls[0][0][2]["tile_id"] == tile_id
+        assert "widget_id" in widget_removed_calls[0][0][2]
+
+    @override_settings(IN_UNIT_TESTING=True)
     def test_can_batch_create_widget_tiles(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -823,7 +823,23 @@ class InsightSerializer(InsightBasicSerializer):
                         f"You don't have permission to remove insights from dashboard: {dashboard.id}"
                     )
 
+            # Capture the still-active tiles before soft-deleting so we report one
+            # "dashboard tile removed" per tile that is actually removed.
+            tiles_to_remove = list(DashboardTile.objects.filter(dashboard_id__in=ids_to_remove, insight=instance))
             DashboardTile.objects.filter(dashboard_id__in=ids_to_remove, insight=instance).update(deleted=True)
+
+            for tile in tiles_to_remove:
+                report_user_action(
+                    self.context["request"].user,
+                    "dashboard tile removed",
+                    {
+                        "tile_type": "insight",
+                        "insight_type": _get_insight_type(instance),
+                        "dashboard_id": tile.dashboard_id,
+                    },
+                    team=instance.team,
+                    request=self.context["request"],
+                )
 
         self.context["after_dashboard_changes"] = [describe_change(d) for d in dashboards if not d.deleted]
 

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -1492,6 +1492,24 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             request=ANY,
         )
 
+    @patch("products.product_analytics.backend.api.insight.report_user_action")
+    def test_removing_insight_from_dashboard_fires_tile_removed_event(self, mock_report_user_action: mock.Mock) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "test"})
+        insight_id, _ = self.dashboard_api.create_insight(
+            {"filters": {"insight": "STICKINESS"}, "dashboards": [dashboard_id]}
+        )
+        mock_report_user_action.reset_mock()
+
+        self.dashboard_api.update_insight(insight_id, {"dashboards": []})
+
+        mock_report_user_action.assert_any_call(
+            self.user,
+            "dashboard tile removed",
+            {"tile_type": "insight", "insight_type": "stickiness", "dashboard_id": dashboard_id},
+            team=ANY,
+            request=ANY,
+        )
+
     def test_can_update_insight_dashboards_without_deleting_tiles(self) -> None:
         dashboard_one_id, _ = self.dashboard_api.create_dashboard({})
         dashboard_two_id, _ = self.dashboard_api.create_dashboard({})


### PR DESCRIPTION
## Problem

We track `dashboard tile added` (a backend event covering every tile type — insight, text, button, widget), but the only removal signal is the frontend `removed insight from dashboard`, which fires for insights only. That asymmetry makes "added vs removed" funnels unreliable: text/button/widget removals aren't captured at all, and the two sides are captured through different paths.

## Changes

Adds a backend `dashboard tile removed` event mirroring `dashboard tile added`, with the same `tile_type` / `widget_type` properties so add↔remove funnels line up 1:1 and can break down by tile type.

- Fired from `DashboardViewSet.delete_tile()` (single-tile removal), after the soft-delete commits.
- Fired from the insight serializer when an insight is unlinked from a dashboard (one event per tile actually removed).
- Widget tiles additionally emit `dashboard widget removed`, mirroring `dashboard widget added`.
- The whole-dashboard delete cascade is intentionally **not** instrumented — that's "deleted a dashboard", not "removed a widget", and would emit one event per tile.
- Extracted the tile-type derivation into a shared `_tile_type_and_widget_type` helper used by both the add and remove paths.

No serializer fields or action signatures changed, so generated types / MCP schemas are unaffected.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** run the Django suite — this environment has no Postgres/Django available. I added automated tests mirroring the existing `dashboard tile added` coverage and verified `ruff check` and `ruff format` pass on all changed files; CI will run the suite. New tests:

- `test_dashboard_delete_tile.py` — `dashboard tile removed` fires for text and insight tiles.
- `test_dashboard_widgets.py` — deleting a widget tile fires both `dashboard tile removed` and `dashboard widget removed`.
- `test_insight.py` — unlinking an insight from a dashboard fires `dashboard tile removed`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code), directed by Matt Pua. The work started from a request to build an "added a widget → removed a widget same day, by type" funnel; while building it we found there was no generic tile-removal event (only `removed insight from dashboard`, frontend, insight-only). We confirmed `dashboard tile added` is already a backend event covering all tile types, so the chosen fix is a symmetric backend `dashboard tile removed` rather than a frontend one — same capture path and `distinct_id`, reusing the existing tile-type derivation so the funnel breakdown matches the add side exactly. We deliberately scoped out the whole-dashboard delete cascade to avoid event spam.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B70P3KWLW/p1781184641952139)*
