### PR TITLE
feat(replay): open selected recording even when outside list filters

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -38810,6 +38810,10 @@
                 "keypress_count": {
                     "type": "number"
                 },
+                "matches_filters": {
+                    "description": "False when the recording was included in list results via a direct link despite not matching the filters.",
+                    "type": "boolean"
+                },
                 "matching_events": {
                     "description": "List of matching events. *",
                     "items": {

--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -94,6 +94,7 @@ export function Playlist({
         visiblePinnedRecordings: pinnedRecordings,
         otherRecordings,
         hasNext,
+        selectedRecordingOutsideFilters,
     } = useValues(sessionRecordingsPlaylistLogic)
     const { maybeLoadSessionRecordings, setFilters, setSelectedRecordingId } =
         useActions(sessionRecordingsPlaylistLogic)
@@ -301,6 +302,12 @@ export function Playlist({
                             </DraggableToNotebook>
                             <LemonTableLoader loading={sessionRecordingsResponseLoading} />
                         </div>
+                        {selectedRecordingOutsideFilters && (
+                            <LemonBanner type="info" className="m-2 text-xs">
+                                The selected recording doesn't match the current filters. It's shown because it was
+                                opened from a direct link.
+                            </LemonBanner>
+                        )}
                         <div className="overflow-y-auto flex-1 min-h-0" onScroll={handleScroll} ref={contentRef}>
                             {sectionCount > 1 ? (
                                 <LemonCollapse

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -59,6 +59,17 @@ describe('sessionRecordingsPlaylistLogic', () => {
         viewers: [],
         snapshot_source: 'web' as const,
     }
+    const outsideFiltersRecording = {
+        id: 'outside-filters-rec',
+        viewed: false,
+        recording_duration: 10,
+        start_time: '2023-01-12T16:55:36.404000Z',
+        end_time: '2023-01-12T16:55:46.404000Z',
+        console_error_count: 0,
+        viewers: [],
+        snapshot_source: 'web' as const,
+        matches_filters: false,
+    }
 
     beforeEach(() => {
         useMocks({
@@ -89,6 +100,15 @@ describe('sessionRecordingsPlaylistLogic', () => {
                             200,
                             {
                                 results: ["List of specific user's recordings from server"],
+                            },
+                        ]
+                    } else if (searchParams.get('session_recording_id') === outsideFiltersRecording.id) {
+                        // a recording requested via direct link that doesn't match the filters
+                        // is included in results flagged with matches_filters false
+                        return [
+                            200,
+                            {
+                                results: [outsideFiltersRecording, ...listOfSessionRecordings],
                             },
                         ]
                     } else if (searchParams.get('offset') !== null) {
@@ -211,6 +231,32 @@ describe('sessionRecordingsPlaylistLogic', () => {
                     activeSessionRecording: listOfSessionRecordings[0],
                 })
                 expect(router.values.searchParams).not.toHaveProperty('sessionRecordingId', 'not-in-list')
+            })
+        })
+
+        describe('selectedRecordingOutsideFilters', () => {
+            it('is false when no recording is selected', async () => {
+                await expectLogic(logic).toDispatchActions(['loadSessionRecordingsSuccess']).toMatchValues({
+                    selectedRecordingOutsideFilters: false,
+                })
+            })
+
+            it('is false when the selected recording matches the filters', async () => {
+                await expectLogic(logic, () => logic.actions.setSelectedRecordingId('abc'))
+                    .toDispatchActions(['loadSessionRecordingsSuccess'])
+                    .toMatchValues({
+                        selectedRecordingId: 'abc',
+                        selectedRecordingOutsideFilters: false,
+                    })
+            })
+
+            it('is true when the selected recording is flagged as not matching the filters', async () => {
+                await expectLogic(logic, () => logic.actions.setSelectedRecordingId(outsideFiltersRecording.id))
+                    .toDispatchActions(['loadSessionRecordingsSuccess'])
+                    .toMatchValues({
+                        selectedRecordingId: outsideFiltersRecording.id,
+                        selectedRecordingOutsideFilters: true,
+                    })
             })
         })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1277,6 +1277,16 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             },
         ],
 
+        selectedRecordingOutsideFilters: [
+            (s) => [s.selectedRecordingId, s.recordings],
+            (selectedRecordingId, recordings): boolean => {
+                if (!selectedRecordingId) {
+                    return false
+                }
+                return recordings.find((rec) => rec.id === selectedRecordingId)?.matches_filters === false
+            },
+        ],
+
         nextSessionRecording: [
             (s) => [s.activeSessionRecording, s.recordings, s.autoplayDirection],
             (activeSessionRecording, recordings, autoplayDirection): Partial<SessionRecordingType> | undefined => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1927,6 +1927,8 @@ export interface SessionRecordingType {
     summary_outcome?: { success?: boolean | null; description?: string | null } | null
     /** External references to third party issues. */
     external_references?: SessionRecordingExternalReference[]
+    /** False when the recording was included in list results via a direct link despite not matching the filters. */
+    matches_filters?: boolean
 }
 
 export interface SessionRecordingUpdateType {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -9016,6 +9016,12 @@ class SessionRecordingType(BaseModel):
     id: str
     inactive_seconds: float | None = None
     keypress_count: float | None = None
+    matches_filters: bool | None = Field(
+        default=None,
+        description=(
+            "False when the recording was included in list results via a direct link despite not matching the filters."
+        ),
+    )
     matching_events: list[MatchedRecording] | None = Field(default=None, description="List of matching events. *")
     mouse_activity_count: float | None = Field(
         default=None,

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -92,6 +92,9 @@ class SessionRecording(UUIDTModel):
     summary_outcome: Optional[dict] = None
     expiry_time: Optional[datetime] = None
     recording_ttl: Optional[int] = None
+    # False when this recording was included in listing results via session_recording_id
+    # despite not matching the listing filters
+    matches_filters: Optional[bool] = None
 
     # Metadata can be loaded from Clickhouse or S3
     _metadata: Optional[RecordingMetadata] = None

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -301,6 +301,10 @@ class SessionRecordingSerializer(serializers.ModelSerializer, UserAccessControlS
     activity_score = serializers.SerializerMethodField()
     has_summary = serializers.SerializerMethodField()
     summary_outcome = serializers.SerializerMethodField()
+    matches_filters = serializers.SerializerMethodField(
+        help_text="Whether this recording matched the filters of the listing query that returned it. "
+        "False only when a recording requested via session_recording_id was included despite not matching the filters."
+    )
     # Dynamic attrs set on the model instance — not Django fields, so declare explicitly
     expiry_time = serializers.DateTimeField(read_only=True, allow_null=True)
     recording_ttl = serializers.IntegerField(read_only=True, allow_null=True)
@@ -308,6 +312,11 @@ class SessionRecordingSerializer(serializers.ModelSerializer, UserAccessControlS
     def get_ongoing(self, obj: SessionRecording) -> bool:
         # ongoing is a custom field that we add if loading from ClickHouse
         return getattr(obj, "ongoing", False)
+
+    def get_matches_filters(self, obj: SessionRecording) -> bool:
+        # matches_filters is a custom field set when a recording requested via
+        # session_recording_id is included in listing results despite not matching the filters
+        return getattr(obj, "matches_filters", None) is not False
 
     def get_viewed(self, obj: SessionRecording) -> bool:
         # viewed is a custom field that we load from PG Sql and merge into the model
@@ -400,6 +409,7 @@ class SessionRecordingSerializer(serializers.ModelSerializer, UserAccessControlS
             "has_summary",
             "summary_outcome",
             "external_references",
+            "matches_filters",
         ]
 
         read_only_fields = [
@@ -1958,6 +1968,23 @@ def _load_recording_if_matches_filters(
     return None
 
 
+def _load_selected_recording_ignoring_filters(session_id: str, team: Team) -> SessionRecording | None:
+    """
+    Load a recording directly by session id, ignoring listing filters.
+
+    Used when a recording explicitly requested via session_recording_id (e.g. a shared link)
+    doesn't match the current filters: we still want the link to open it, flagged with
+    matches_filters=False so the UI can explain why it's shown.
+    """
+    recording = SessionRecording.get_or_build(session_id=session_id, team=team)
+    if recording.deleted:
+        return None
+    if not recording.load_metadata():
+        return None
+    recording.matches_filters = False
+    return recording
+
+
 # TODO i guess this becomes the query runner for our _internal_ use of RecordingsQuery
 def list_recordings_from_query(
     query: RecordingsQuery, user: User | None, team: Team, allow_event_property_expansion: bool = False
@@ -1998,6 +2025,10 @@ def list_recordings_from_query(
                     team,
                     allow_event_property_expansion,
                 )
+                if prepend_recording is None:
+                    # The recording was explicitly requested (e.g. a shared link) but doesn't match
+                    # the current filters - include it anyway so the link still opens it
+                    prepend_recording = _load_selected_recording_ignoring_filters(session_recording_id_to_prepend, team)
                 if prepend_recording:
                     recordings.append(prepend_recording)
 

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -442,6 +442,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
                 "has_summary": False,
                 "summary_outcome": None,
                 "external_references": [],
+                "matches_filters": True,
             },
         ]
 
@@ -853,6 +854,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             "has_summary": False,
             "summary_outcome": None,
             "external_references": [],
+            "matches_filters": True,
         }
 
     @freeze_time("2023-01-01T12:00:00.000Z")
@@ -1958,14 +1960,15 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
                     "session_recording_id": "session_5",
                 },
                 # session_5 matches the date filter (-3d) even though it would be on a later page
-                # so it should be prepended to results
-                ["session_5"],  # must be in results
+                # so it should be prepended to results, and marked as matching the filters
+                {"session_5": True},  # must be in results, with expected matches_filters
                 [],  # must NOT be in results
             ),
             (
-                "recording_outside_date_range_is_excluded",
+                "recording_outside_date_range_is_included_but_flagged",
                 # Create a recording from 10 days ago, request with date_from=-3d
-                # The recording doesn't match the date filter, so should NOT be included
+                # The recording doesn't match the date filter, but was explicitly requested
+                # (e.g. a shared link), so it should still be included, flagged as not matching
                 {
                     "recordings": [
                         {"session_id": "recent_session", "days_ago": 1},
@@ -1974,8 +1977,21 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
                     "date_from": "-3d",
                     "session_recording_id": "old_session",
                 },
-                ["recent_session"],  # must be in results
-                ["old_session"],  # must NOT be in results - doesn't match date filter
+                {"recent_session": True, "old_session": False},  # must be in results, with expected matches_filters
+                [],  # must NOT be in results
+            ),
+            (
+                "nonexistent_recording_is_excluded",
+                # Ask for a session_recording_id that was never recorded - nothing to include
+                {
+                    "recordings": [
+                        {"session_id": "recent_session", "days_ago": 1},
+                    ],
+                    "date_from": "-3d",
+                    "session_recording_id": "no_such_session",
+                },
+                {"recent_session": True},  # must be in results, with expected matches_filters
+                ["no_such_session"],  # must NOT be in results
             ),
         ]
     )
@@ -1983,17 +1999,18 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         self,
         _name: str,
         config: dict,
-        must_be_in_results: list[str],
+        must_be_in_results: dict[str, bool],
         must_not_be_in_results: list[str],
     ):
         """
-        Test that session_recording_id only includes recordings that match the current filters.
+        Test how session_recording_id interacts with the current filters.
 
-        A recording should be prepended to results if:
-        - It matches all filters (date range, properties, etc.) but is on a different page
+        A recording requested via session_recording_id should always be included if it exists:
+        - matches_filters=True when it matches all filters (e.g. it's just on a different page)
+        - matches_filters=False when it doesn't match the filters (e.g. outside date range),
+          so the UI can explain why it's shown
 
-        A recording should NOT be included if:
-        - It doesn't match the filters (e.g., outside date range)
+        It should NOT be included only when it doesn't exist at all.
         """
         base_time = now()
 
@@ -2013,10 +2030,15 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
 
-        session_ids = [r["id"] for r in response_data["results"]]
+        recordings_by_id = {r["id"]: r for r in response_data["results"]}
+        session_ids = list(recordings_by_id.keys())
 
-        for expected in must_be_in_results:
+        for expected, expected_matches_filters in must_be_in_results.items():
             assert expected in session_ids, f"Expected {expected} to be in results, but got {session_ids}"
+            assert recordings_by_id[expected]["matches_filters"] == expected_matches_filters, (
+                f"Expected {expected} to have matches_filters={expected_matches_filters}, "
+                f"but got {recordings_by_id[expected]['matches_filters']}"
+            )
 
         for unexpected in must_not_be_in_results:
             assert unexpected not in session_ids, f"Expected {unexpected} to NOT be in results, but got {session_ids}"

--- a/products/replay/frontend/generated/api.schemas.ts
+++ b/products/replay/frontend/generated/api.schemas.ts
@@ -259,6 +259,8 @@ export interface SessionRecordingApi {
     readonly summary_outcome: OutcomeApi | null
     /** Load external references (linked issues) for this recording */
     readonly external_references: readonly SessionRecordingApiExternalReferencesItem[]
+    /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
+    readonly matches_filters: boolean
 }
 
 export interface PaginatedSessionRecordingListApi {
@@ -319,6 +321,8 @@ export interface PatchedSessionRecordingApi {
     readonly summary_outcome?: OutcomeApi | null
     /** Load external references (linked issues) for this recording */
     readonly external_references?: readonly PatchedSessionRecordingApiExternalReferencesItem[]
+    /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
+    readonly matches_filters?: boolean
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21212,6 +21212,8 @@ export namespace Schemas {
       id: string;
       inactive_seconds?: number | null;
       keypress_count?: number | null;
+      /** False when the recording was included in list results via a direct link despite not matching the filters. */
+      matches_filters?: boolean | null;
       /** List of matching events. * */
       matching_events?: MatchedRecording[] | null;
       /** count of all mouse activity in the recording, not just clicks */
@@ -26484,6 +26486,8 @@ export namespace Schemas {
       readonly summary_outcome: Outcome | null;
       /** Load external references (linked issues) for this recording */
       readonly external_references: readonly SessionRecordingExternalReferencesItem[];
+      /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
+      readonly matches_filters: boolean;
     }
 
     export interface PaginatedSessionRecordingList {
@@ -32930,6 +32934,8 @@ export namespace Schemas {
       readonly summary_outcome?: Outcome | null;
       /** Load external references (linked issues) for this recording */
       readonly external_references?: readonly PatchedSessionRecordingExternalReferencesItem[];
+      /** Whether this recording matched the filters of the listing query that returned it. False only when a recording requested via session_recording_id was included despite not matching the filters. */
+      readonly matches_filters?: boolean;
     }
 
     /**


### PR DESCRIPTION
## Problem

Opening a recording via a direct link (`session_recording_id` in the URL) silently fails when that recording doesn't match the active listing filters: the list query excludes it, so the player has nothing to select. Shared links should always open their recording, with the UI explaining when it sits outside the current filters.

## Changes

- When the requested recording doesn't match the listing filters, the API now loads it directly (deleted/metadata-less recordings still excluded) and includes it in the results flagged with a new `matches_filters: false` field on the recording serializer and query schema.
- `sessionRecordingsPlaylistLogic` gains a `selectedRecordingOutsideFilters` selector, and the playlist surfaces when the selected recording is shown despite not matching the filters.
- Recordings returned through the normal filtered path report `matches_filters: true`.

## How did you test this code?

This PR is agent-assisted; no manual testing is claimed. Automated coverage, run locally:

- `test_session_recording_id_respects_filters` (parameterized) in `test_session_recordings.py`, covering: a matching recording stays unflagged, a recording outside the date range is included but flagged `matches_filters=false`, and a nonexistent recording is excluded — 15 tests in the area pass against local Postgres + ClickHouse.
- New jest tests for the `selectedRecordingOutsideFilters` selector (no selection, selection matching filters, selection flagged as outside filters) — playlist suite green (61/61).
- lint-staged hooks (ruff, ty, oxfmt/oxlint) passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

Feature authored by @arnohillen; Claude Code (Fable 5) assisted with finishing touches in the same session that produced #62971 (funnel drop-off → replay filter fixes). The agent found and fixed one bug before submission: `get_matches_filters` used `getattr(obj, "matches_filters", True)`, but the model declares `matches_filters: Optional[bool] = None` as a class attribute, so the default never applied and the API returned `null` for normal listings — now `getattr(obj, "matches_filters", None) is not False`.

Reviewer note: this complements #62971, which stops date-windowing explicit `session_ids` queries in the recordings list — together they make direct-linked recordings reliably openable. Both touch `Playlist.tsx`/`sessionRecordingsPlaylistLogic`, so whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
