### PR TITLE
chore(ci): cancel backend run when deterministic checks fail

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -640,6 +640,9 @@ jobs:
         needs: [changes]
         if: needs.changes.outputs.backend == 'true'
         timeout-minutes: 10
+        permissions:
+            contents: read
+            actions: write # to cancel this run when a deterministic check fails
         name: Repo checks (depot-ubuntu-latest)
         runs-on: depot-ubuntu-latest
         steps:
@@ -669,6 +672,13 @@ jobs:
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
+            # Boundary between network-dependent setup (can flake) and the pure
+            # static checks below — the cancel step at the end uses it to avoid
+            # canceling the whole run on a transient setup failure.
+            - name: Mark setup complete
+              id: setup-complete
+              run: echo "Setup complete — any failure below is a deterministic check failure"
+
             - name: Bootstrap scaffold product
               run: ./bin/hogli product:bootstrap spline_reticulator --non-interactive
 
@@ -689,6 +699,23 @@ jobs:
 
             - name: Check product facade enforcement (import-linter)
               run: lint-imports
+
+            # A failure in the static checks above is deterministic — a retry can
+            # never fix it, so the rest of the run (50+ test shards) is wasted spend.
+            # PR-only: master and merge queue runs must complete (deploy gate,
+            # snapshots). Same-repo only: fork PR tokens are read-only.
+            - name: Cancel run on deterministic check failure
+              if: >
+                  failure() &&
+                  steps.setup-complete.outcome == 'success' &&
+                  github.event_name == 'pull_request' &&
+                  github.event.pull_request.head.repo.full_name == github.repository
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  GH_REPO: ${{ github.repository }}
+              run: |
+                  echo "::notice::Repo checks failed deterministically — canceling the remaining jobs in this run. A retry cannot fix this failure; push a fix to start a new run."
+                  gh run cancel ${{ github.run_id }}
 
     # Validates product.yaml owners against PostHog/posthog collaborator teams.
     # Gated on the product_yamls paths filter so we only spend a GitHub API call
@@ -1390,6 +1417,7 @@ jobs:
         timeout-minutes: 20
         permissions:
             contents: read
+            actions: write # to cancel this run when the OpenAPI check fails
 
         name: Validate OpenAPI types
         runs-on: depot-ubuntu-latest
@@ -1584,6 +1612,23 @@ jobs:
                   file_pattern: 'frontend/src/generated/** products/*/frontend/generated/** products/*/mcp/*.yaml services/mcp/definitions/*.yaml services/mcp/src/api/generated.ts services/mcp/src/generated/** services/mcp/schema/generated-tool-definitions.json services/mcp/schema/tool-definitions-all.json services/mcp/src/tools/generated/**'
               env:
                   GITHUB_TOKEN: ${{ steps.openapi-app-token.outputs.token }}
+
+            # Schema generation and type drift failures are deterministic — a retry
+            # can never fix them, so the rest of the run is wasted spend. Keyed on the
+            # check step so transient setup or commit failures don't cancel anything.
+            # PR-only and same-repo only: fork PR tokens are read-only.
+            - name: Cancel run on deterministic check failure
+              if: >
+                  failure() &&
+                  steps.openapi-check.outcome == 'failure' &&
+                  github.event_name == 'pull_request' &&
+                  github.event.pull_request.head.repo.full_name == github.repository
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  GH_REPO: ${{ github.repository }}
+              run: |
+                  echo "::notice::OpenAPI check failed deterministically — canceling the remaining jobs in this run. A retry cannot fix this failure; push a fix to start a new run."
+                  gh run cancel ${{ github.run_id }}
 
     build_django_matrix:
         name: Build Django matrix


### PR DESCRIPTION
## Problem

Backend CI is both our most expensive and most failure-prone workflow, and today nothing stops a doomed run early: every job runs to completion even when an early failure already guarantees the run is red.

All numbers below were queried from the public GitHub Actions API on 2026-06-11.

**Failure rates (last 100 PR-triggered runs per workflow):**

| Workflow | Success | Failure | Cancelled by newer push | Failure rate of completed runs |
| --- | --- | --- | --- | --- |
| Backend CI | 41 | 12 | 47 | **23%** |
| Node CI | 82 | 6 | 7 | 6% |
| Frontend CI | 58 | 3 | 20 | 4% |
| E2E (Playwright) | 52 | 2 | 18 | 3% |
| Rust CI | 90 | 1 | 5 | 1% |

**Where the waste is.** Across the 15 most recent failed Backend CI PR runs, jobs burned **4,918 job-minutes total, of which 1,642 job-minutes (33%) ran after the first job had already failed**:

| Run | First failing job | Total job-min | Job-min after first failure | Wasted |
| --- | --- | --- | --- | --- |
| 27349284415 | Product tests | 276 | 5 | 2% |
| 27348874301 | Product tests | 561 | 293 | 52% |
| 27348871246 | Django shard | 543 | 22 | 4% |
| 27348574291 | Django shard | 557 | 16 | 3% |
| 27348043562 | **Repo checks** | 30 | 24 | 79% |
| 27347923796 | Django shard | 218 | 91 | 42% |
| 27347599459 | Validate migrations | 30 | 1 | 3% |
| 27346503511 | Django shard | 957 | 7 | 1% |
| 27345924708 | **Repo checks** | 23 | 17 | 75% |
| 27345811370 | **Repo checks** | 558 | 552 | **99%** |
| 27344956276 | Django shard | 551 | 20 | 4% |
| 27344440634 | **Repo checks** | 22 | 16 | 74% |
| 27344138229 | **Repo checks** | 30 | 25 | 84% |
| 27343917393 | **Repo checks** | 562 | 554 | **99%** |

The pattern: `repo-checks` (tach, import-linter, IDOR coverage, version specifiers, product structure — pure static analysis) was the first failure in **6 of 14** runs, and those 6 runs account for **1,188 of the 1,642 wasted job-minutes (72%)**. The mechanics are visible in the timing chain: `repo-checks` fails at ~+2.0 min, the 50–70 Django/product shards start at ~+2.4 min and run for another 11–15 minutes on Depot runners — for a run whose outcome was already decided. In the two worst sampled runs that was **~550 wasted job-minutes each (9+ runner-hours per occurrence)**.

These failures are deterministic: a retry can never turn a tach violation or an OpenAPI enum collision green. The only exit is a fix push — and our `cancel-in-progress` concurrency already cancels the stale run *when that push arrives*. This PR just closes the gap between the failure and that push.

## Changes

Adds a final `Cancel run on deterministic check failure` step to two jobs in `ci-backend.yml`:

- **`repo-checks`** — a `setup-complete` marker step separates network-dependent setup (checkout, uv sync — can flake) from the static checks. The cancel step only fires if the marker succeeded, so a transient setup failure never cancels anything.
- **`check-openapi-types`** — cancel is keyed on `steps.openapi-check.outcome == 'failure'`, so transient setup or auto-commit failures don't cancel. The auto-commit path (drift on same-repo PRs) is unaffected: the check step succeeds there, and the pushed commit supersedes the run via concurrency as before.

Guard rails, deliberately scoped:

- **PR events only** — master pushes keep the per-SHA "check-migrations always completes" invariant (deploy gate), and merge queue runs are untouched.
- **Same-repo PRs only** — fork PR tokens are read-only, the cancel call would fail anyway.
- **Job-level `actions: write`** added only to these two jobs, to call the run-cancel API with the default `github.token`.

Expected effect, applied to the sample: ~1,188 of 1,642 wasted job-minutes recovered, and a Backend CI run that fails repo checks now concludes in ~2–4 minutes instead of ~15–25 — faster definitive red for the author, and 50+ Depot runners freed for other PRs (we saw 100 Backend CI PR runs in a 34-minute window, so runner availability compounds).

Alternatives considered and rejected:

- **`fail-fast: true` on the test matrices** — the data argues against it: when a *test shard* fails first, only 1–4% of job-minutes follow it (shards finish near-simultaneously), and cancelling siblings destroys the complete failure list, pushing people into fix-one-push-discover-the-next loops (more runs, more spend). Flake-driven shard failures are already absorbed by pytest `--reruns 2`.
- **Gating the matrices on `repo-checks` via `needs:`** — p50 latency cost is ~0 (repo-checks ends at +2.0 min, the matrix fan-out starts at +2.4 min), but any slow repo-checks run would delay all shards on the 88% of runs that pass. The cancel approach has zero green-path cost.
- **Including `validate-migrations`** — it exercises live Postgres/ClickHouse for ~12 minutes, so failures *can* be transient, and it finishes within ~2–3 minutes of the shards anyway; little to recover, some misfire risk.

Interaction notes: when a run is cancelled, the `django_tests` aggregate (required check) resolves as cancelled, which branch protection treats as not-success — merging stays blocked. `handle-snapshots` in UPDATE mode is cancelled along with the run; the fix push regenerates and commits snapshots as usual. The change is backwards compatible with open PRs that haven't rebased: it relies only on the preinstalled `gh` CLI and the default token — no companion files, secrets, or variables. Rollback is deleting the added steps.

## How did you test this code?

I'm an agent; no manual run-through of the live workflow was performed. Automated/local verification:

- `./bin/hogli lint:workflows` — all 5 checks pass across 88 workflows.
- `actionlint` v1.7.12 (same pinned version and `SHELLCHECK_OPTS=--severity=error` as `ci-actionlint.yml`) — clean.
- YAML parse check of the modified workflow.

The cancel behavior itself can't be exercised before merge (it requires a same-repo PR run with a failing check); the conditions follow documented GitHub Actions semantics (`failure()`, step `outcome`, `gh run cancel`). A cheap post-merge validation: push a PR with a deliberate tach violation and confirm the run cancels within ~1 minute of repo-checks failing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal CI behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Investigation: read all 90 workflow files, then queried the public GitHub Actions API for run conclusions and per-job timings (last 100 PR runs per workflow; per-job analysis of the 15 most recent failed Backend CI runs) to measure post-failure waste before proposing anything.
- Decisions: chose run-cancellation over matrix `fail-fast` (measured shard-failure waste is 1–4% and sibling signal matters) and over `needs:` gating (avoids green-path latency); scoped to the two jobs whose check steps are purely deterministic; excluded `validate-migrations` (DB-backed, transient-capable, low recovery); restricted to same-repo PR events to protect master/deploy-gate and merge queue invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
