### PR TITLE
fix: Clamp last seen time to first seen time

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from '@posthog/lemon-ui'
 import { NotFound } from 'lib/components/NotFound'
 import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 import { TZLabel } from 'lib/components/TZLabel'
+import { dayjs } from 'lib/dayjs'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { compactNumber } from 'lib/utils'
@@ -165,6 +166,19 @@ function FirstSeen({ person }: { person: PersonType }): JSX.Element {
     )
 }
 
+// `last_seen_at` is floored to the hour, so for a person whose first and last activity
+// fall in the same hour it can resolve to *before* `created_at`. Clamp to `created_at` so
+// "Last seen" never appears earlier than "First seen" — the real last activity is within
+// the rounding hour of first seen anyway.
+function clampLastSeenToFirstSeen(lastSeenAt: string, createdAt?: string): dayjs.Dayjs {
+    const lastSeen = dayjs(lastSeenAt)
+    if (!createdAt) {
+        return lastSeen
+    }
+    const firstSeen = dayjs(createdAt)
+    return lastSeen.isBefore(firstSeen) ? firstSeen : lastSeen
+}
+
 function LastSeen(): JSX.Element {
     const { person, personLoading } = useValues(personLogic)
     return (
@@ -173,7 +187,7 @@ function LastSeen(): JSX.Element {
             {personLoading ? (
                 <LemonSkeleton className="h-4 w-24" />
             ) : person?.last_seen_at ? (
-                <TZLabel time={person.last_seen_at} />
+                <TZLabel time={clampLastSeenToFirstSeen(person.last_seen_at, person.created_at)} />
             ) : (
                 'unknown'
             )}


### PR DESCRIPTION
## Problem

Last seen at is floored to the nearest hour, meaning it can appear to be before the created_at time for the person, which is confusing.

<img width="568" height="392" alt="CleanShot 2026-06-11 at 15 28 21@2x" src="https://github.com/user-attachments/assets/c77dfab3-1f78-494c-b0b4-6e84a4ec3d14" />


## Changes

Clamp person's `last_seen_at` to the `created_at`. It's not a perfect solution, but at least it's no less accurate than what we have now!