### PR TITLE
feat(data-warehouse): implement clari import source

### DIFF
--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -224,8 +224,6 @@ doesn't conflict with concurrent PRs.
 - campaign_manager_360
 - checkout_com
 - chorus
-- circleci
-- clari
 - cloudflare
 - cockroachdb
 - coda

--- a/posthog/temporal/data_imports/sources/SOURCES.md
+++ b/posthog/temporal/data_imports/sources/SOURCES.md
@@ -65,6 +65,7 @@ the row lists both.
 | confluence       | HTTP                        | requests                                                        | ✅                          |
 | chartmogul       | HTTP                        | requests                                                        | ✅                          |
 | circleci         | HTTP                        | requests                                                        | ✅                          |
+| clari            | HTTP                        | requests                                                        | ✅                          |
 | clerk            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | clickhouse       | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
 | clickup          | HTTP                        | requests                                                        | ✅                          |
@@ -223,6 +224,7 @@ doesn't conflict with concurrent PRs.
 - campaign_manager_360
 - checkout_com
 - chorus
+- circleci
 - clari
 - cloudflare
 - cockroachdb

--- a/posthog/temporal/data_imports/sources/clari/clari.py
+++ b/posthog/temporal/data_imports/sources/clari/clari.py
@@ -1,0 +1,224 @@
+import time
+import dataclasses
+from collections.abc import Iterator
+from datetime import UTC, date, datetime
+from typing import Any, Optional
+from urllib.parse import quote, urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.clari.settings import CLARI_BASE_URL
+from posthog.temporal.data_imports.sources.common.http import make_tracked_session
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+REQUEST_TIMEOUT_SECONDS = 120
+# ~10 req/s general limit; back off on 429.
+MAX_RETRY_ATTEMPTS = 5
+AUDIT_PAGE_LIMIT = 1000
+# Export jobs usually finish in minutes; the per-attempt poll budget is capped
+# so a stuck job surfaces as a retryable error instead of hanging the activity.
+EXPORT_POLL_INTERVAL_SECONDS = 15
+EXPORT_POLL_MAX_ATTEMPTS = 60
+
+
+class ClariRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class ClariResumeConfig:
+    # Forecast: the in-flight export job to re-poll instead of creating a new
+    # one (exports are quota-limited to ~1000 per rolling 30 days). Audit
+    # events: the nextLink URL of the next unfetched page.
+    job_id: Optional[str] = None
+    next_link: Optional[str] = None
+
+
+def _get_session(api_key: str) -> requests.Session:
+    return make_tracked_session(headers={"apikey": api_key}, redact_values=(api_key,))
+
+
+def _format_timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=UTC)
+        return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if isinstance(value, date):
+        return value.strftime("%Y-%m-%dT00:00:00Z")
+    return str(value)
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Confirm the API key works with a cheap audit-events probe."""
+    try:
+        response = _get_session(api_key).get(
+            f"{CLARI_BASE_URL}/audit/events?limit=1",
+            timeout=15,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def _make_fetcher(session: requests.Session, logger: FilteringBoundLogger):
+    @retry(
+        retry=retry_if_exception_type((ClariRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=2, max=90),
+        reraise=True,
+    )
+    def fetch(method: str, url: str, json_body: Optional[dict[str, Any]] = None) -> requests.Response:
+        response = session.request(method, url, json=json_body, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise ClariRetryableError(f"Clari API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"Clari API error: status={response.status_code}, body={response.text[:500]}, url={url}")
+            response.raise_for_status()
+
+        return response
+
+    return fetch
+
+
+def get_audit_events(
+    api_key: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[ClariResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> Iterator[list[dict[str, Any]]]:
+    session = _get_session(api_key)
+    fetch = _make_fetcher(session, logger)
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume_config is not None and resume_config.next_link:
+        url: Optional[str] = resume_config.next_link
+        logger.debug("Clari: resuming audit_events from saved nextLink")
+    else:
+        params: dict[str, Any] = {"limit": AUDIT_PAGE_LIMIT}
+        if should_use_incremental_field and db_incremental_field_last_value is not None:
+            params["dateFrom"] = _format_timestamp(db_incremental_field_last_value)
+        url = f"{CLARI_BASE_URL}/audit/events?{urlencode(params)}"
+
+    while url:
+        data = fetch("GET", url).json()
+        items = data.get("items") or data.get("activities") or []
+
+        if items:
+            yield items
+
+        url = data.get("nextLink") or None
+        if url:
+            # Save state AFTER yielding so a crash re-yields the in-flight page.
+            resumable_source_manager.save_state(ClariResumeConfig(next_link=url))
+
+
+def _extract_result_rows(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [row for row in data if isinstance(row, dict)]
+    if isinstance(data, dict):
+        for key in ("data", "rows", "records", "results"):
+            value = data.get(key)
+            if isinstance(value, list):
+                return [row for row in value if isinstance(row, dict)]
+        return [data]
+    return []
+
+
+def get_forecast(
+    api_key: str,
+    forecast_id: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[ClariResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    session = _get_session(api_key)
+    fetch = _make_fetcher(session, logger)
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    job_id = resume_config.job_id if resume_config is not None else None
+    if job_id:
+        logger.debug(f"Clari: re-polling existing forecast export job {job_id}")
+
+    if not job_id:
+        create_body = fetch(
+            "POST",
+            f"{CLARI_BASE_URL}/export/forecast/{quote(forecast_id)}",
+            json_body={"exportFormat": "JSON"},
+        ).json()
+        job_id = create_body.get("jobId") or (create_body.get("job") or {}).get("id")
+        if not job_id:
+            raise ValueError(f"Clari export job creation returned no jobId: {create_body}")
+        # Persist immediately — exports are quota-limited, so a retried
+        # activity must re-poll this job rather than create another.
+        resumable_source_manager.save_state(ClariResumeConfig(job_id=job_id))
+
+    status = None
+    for _attempt in range(EXPORT_POLL_MAX_ATTEMPTS):
+        job_body = fetch("GET", f"{CLARI_BASE_URL}/export/jobs/{quote(job_id)}").json()
+        job = job_body.get("job") if isinstance(job_body.get("job"), dict) else job_body
+        status = job.get("status")
+
+        if status == "DONE":
+            break
+        if status in ("FAILED", "CANCELLED", "ABORTED"):
+            # Don't re-poll a dead job on retry.
+            resumable_source_manager.save_state(ClariResumeConfig(job_id=None))
+            raise ValueError(f"Clari forecast export job {job_id} ended with status {status}")
+
+        time.sleep(EXPORT_POLL_INTERVAL_SECONDS)
+    else:
+        raise ClariRetryableError(f"Clari forecast export job {job_id} still {status} after polling budget")
+
+    results = fetch("GET", f"{CLARI_BASE_URL}/export/jobs/{quote(job_id)}/results").json()
+    rows = _extract_result_rows(results)
+    if rows:
+        yield rows
+
+
+def clari_source(
+    api_key: str,
+    forecast_id: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[ClariResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    if endpoint == "audit_events":
+        return SourceResponse(
+            name=endpoint,
+            items=lambda: get_audit_events(
+                api_key=api_key,
+                logger=logger,
+                resumable_source_manager=resumable_source_manager,
+                should_use_incremental_field=should_use_incremental_field,
+                db_incremental_field_last_value=db_incremental_field_last_value,
+            ),
+            # Audit events carry no unique id — dedupe on the natural composite.
+            primary_keys=["eventTimestamp", "actorId", "sessionId", "event"],
+            partition_count=1,
+            partition_size=1,
+            # Result ordering is undocumented, so only commit the watermark
+            # once a sync completes.
+            sort_mode="desc",
+            has_duplicate_primary_keys=True,
+        )
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_forecast(
+            api_key=api_key,
+            forecast_id=forecast_id,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        # Snapshot-style export rows have no identifier; the table fully
+        # refreshes each sync.
+        primary_keys=None,
+        partition_count=1,
+        partition_size=1,
+    )

--- a/posthog/temporal/data_imports/sources/clari/clari.py
+++ b/posthog/temporal/data_imports/sources/clari/clari.py
@@ -160,7 +160,7 @@ def get_forecast(
     for _attempt in range(EXPORT_POLL_MAX_ATTEMPTS):
         job_body = fetch("GET", f"{CLARI_BASE_URL}/export/jobs/{quote(job_id)}").json()
         job = job_body.get("job") if isinstance(job_body.get("job"), dict) else job_body
-        status = job.get("status")
+        status = job["status"]
 
         if status == "DONE":
             break

--- a/posthog/temporal/data_imports/sources/clari/settings.py
+++ b/posthog/temporal/data_imports/sources/clari/settings.py
@@ -1,0 +1,18 @@
+from products.data_warehouse.backend.types import IncrementalField, IncrementalFieldType
+
+CLARI_BASE_URL = "https://api.clari.com/v4"
+
+ENDPOINTS = ("audit_events", "forecast")
+
+# Audit events accept a server-side dateFrom filter; the forecast export is a
+# quarter-scoped snapshot with no cursor, so it is full refresh only.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    "audit_events": [
+        {
+            "label": "eventTimestamp",
+            "type": IncrementalFieldType.DateTime,
+            "field": "eventTimestamp",
+            "field_type": IncrementalFieldType.DateTime,
+        },
+    ],
+}

--- a/posthog/temporal/data_imports/sources/clari/source.py
+++ b/posthog/temporal/data_imports/sources/clari/source.py
@@ -1,29 +1,125 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
+from posthog.temporal.data_imports.sources.clari.clari import (
+    ClariResumeConfig,
+    clari_source,
+    validate_credentials as validate_clari_credentials,
+)
+from posthog.temporal.data_imports.sources.clari.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import ClariSourceConfig
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class ClariSource(SimpleSource[ClariSourceConfig]):
+class ClariSource(ResumableSource[ClariSourceConfig, ClariResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLARI
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://api.clari.com": "Clari authentication failed. Please check your API key.",
+            "403 Client Error: Forbidden for url: https://api.clari.com": "Clari denied access. Please check your API key's permissions.",
+            "404 Client Error: Not Found for url: https://api.clari.com/v4/export/forecast": "Clari forecast not found. Please check your forecast ID (copy it from the Forecast tab URL in Clari).",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLARI,
             label="Clari",
+            caption="""Connect your Clari account to pull your revenue data into the PostHog Data warehouse.
+
+Generate an API key in Clari under your account's API settings. The forecast ID is in the URL when viewing a forecast tab in Clari (e.g. `app.clari.com/forecast/<forecast-id>`). Note: Clari retains audit events for ~30 days and caps forecast exports at roughly 1,000 per rolling 30 days, so avoid very frequent syncs of the forecast table.""",
             iconPath="/static/services/clari.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/clari",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="forecast_id",
+                        label="Forecast ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="net_bookings",
+                        secret=False,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: ClariSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=INCREMENTAL_FIELDS.get(endpoint) is not None,
+                supports_append=INCREMENTAL_FIELDS.get(endpoint) is not None,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: ClariSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_clari_credentials(config.api_key):
+            return True, None
+
+        return False, "Invalid Clari credentials"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ClariResumeConfig]:
+        return ResumableSourceManager[ClariResumeConfig](inputs, ClariResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: ClariSourceConfig,
+        resumable_source_manager: ResumableSourceManager[ClariResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return clari_source(
+            api_key=config.api_key,
+            forecast_id=config.forecast_id,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/posthog/temporal/data_imports/sources/clari/tests/test_clari.py
+++ b/posthog/temporal/data_imports/sources/clari/tests/test_clari.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 import pytest
@@ -39,6 +39,7 @@ class TestFormatTimestamp:
         [
             (datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), "2024-01-02T03:04:05Z"),
             (datetime(2024, 1, 2, 3, 4, 5), "2024-01-02T03:04:05Z"),
+            (date(2024, 1, 2), "2024-01-02T00:00:00Z"),
             ("2024-01-02T03:04:05Z", "2024-01-02T03:04:05Z"),
         ],
     )

--- a/posthog/temporal/data_imports/sources/clari/tests/test_clari.py
+++ b/posthog/temporal/data_imports/sources/clari/tests/test_clari.py
@@ -1,0 +1,223 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.clari.clari import (
+    ClariResumeConfig,
+    ClariRetryableError,
+    _extract_result_rows,
+    _format_timestamp,
+    clari_source,
+    get_audit_events,
+    get_forecast,
+    validate_credentials,
+)
+
+_MODULE = "posthog.temporal.data_imports.sources.clari.clari"
+
+
+def _make_manager(resume_state: ClariResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _response(body: Any) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.json.return_value = body
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+class TestFormatTimestamp:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), "2024-01-02T03:04:05Z"),
+            (datetime(2024, 1, 2, 3, 4, 5), "2024-01-02T03:04:05Z"),
+            ("2024-01-02T03:04:05Z", "2024-01-02T03:04:05Z"),
+        ],
+    )
+    def test_formats(self, value, expected):
+        assert _format_timestamp(value) == expected
+
+
+class TestExtractResultRows:
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            ([{"a": 1}, {"b": 2}], [{"a": 1}, {"b": 2}]),
+            ([{"a": 1}, "junk"], [{"a": 1}]),
+            ({"data": [{"a": 1}]}, [{"a": 1}]),
+            ({"rows": [{"a": 1}]}, [{"a": 1}]),
+            ({"unknown_key": "x"}, [{"unknown_key": "x"}]),
+            ("junk", []),
+        ],
+    )
+    def test_extracts_rows(self, data, expected):
+        assert _extract_result_rows(data) == expected
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status_code, expected",
+        [
+            (200, True),
+            (401, False),
+            (403, False),
+        ],
+    )
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        assert validate_credentials("key") is expected
+
+
+class TestGetAuditEvents:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_follows_next_link_until_absent(self, mock_session):
+        mock_session.return_value.request.side_effect = [
+            _response({"items": [{"event": "login"}], "nextLink": "https://api.clari.com/v4/audit/events?skip=1000"}),
+            _response({"items": [{"event": "logout"}]}),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_audit_events("key", mock.MagicMock(), manager))
+
+        assert [row["event"] for batch in batches for row in batch] == ["login", "logout"]
+        # State saved once, after the first page yielded, pointing at the next page.
+        saved = manager.save_state.call_args_list
+        assert [call.args[0].next_link for call in saved] == ["https://api.clari.com/v4/audit/events?skip=1000"]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_incremental_passes_date_from(self, mock_session):
+        mock_session.return_value.request.side_effect = [_response({"items": []})]
+
+        list(
+            get_audit_events(
+                "key",
+                mock.MagicMock(),
+                _make_manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC),
+            )
+        )
+
+        url = mock_session.return_value.request.call_args.args[1]
+        assert "dateFrom=2024-01-02T03%3A04%3A05Z" in url
+        assert "limit=1000" in url
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_resumes_from_saved_next_link(self, mock_session):
+        mock_session.return_value.request.side_effect = [_response({"items": [{"event": "x"}]})]
+
+        manager = _make_manager(ClariResumeConfig(next_link="https://api.clari.com/v4/audit/events?skip=2000"))
+        batches = list(get_audit_events("key", mock.MagicMock(), manager))
+
+        assert len(batches) == 1
+        url = mock_session.return_value.request.call_args.args[1]
+        assert url == "https://api.clari.com/v4/audit/events?skip=2000"
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_accepts_activities_response_key(self, mock_session):
+        mock_session.return_value.request.side_effect = [_response({"activities": [{"event": "x"}]})]
+
+        batches = list(get_audit_events("key", mock.MagicMock(), _make_manager()))
+
+        assert batches == [[{"event": "x"}]]
+
+
+class TestGetForecast:
+    @mock.patch(f"{_MODULE}.time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_creates_job_polls_and_downloads_results(self, mock_session, mock_sleep):
+        mock_session.return_value.request.side_effect = [
+            _response({"jobId": "job-1"}),
+            _response({"job": {"id": "job-1", "status": "STARTED"}}),
+            _response({"job": {"id": "job-1", "status": "DONE"}}),
+            _response([{"Field": "forecast", "Data Value": 100}]),
+        ]
+
+        manager = _make_manager()
+        batches = list(get_forecast("key", "fc-1", mock.MagicMock(), manager))
+
+        assert batches == [[{"Field": "forecast", "Data Value": 100}]]
+        create_call = mock_session.return_value.request.call_args_list[0]
+        assert create_call.args == ("POST", "https://api.clari.com/v4/export/forecast/fc-1")
+        assert create_call.kwargs["json"] == {"exportFormat": "JSON"}
+        # Job id persisted immediately after creation — exports are quota-limited.
+        assert manager.save_state.call_args_list[0].args[0].job_id == "job-1"
+
+    @mock.patch(f"{_MODULE}.time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_resumes_existing_job_without_creating_a_new_one(self, mock_session, mock_sleep):
+        mock_session.return_value.request.side_effect = [
+            _response({"job": {"id": "job-9", "status": "DONE"}}),
+            _response([{"Field": "quota"}]),
+        ]
+
+        manager = _make_manager(ClariResumeConfig(job_id="job-9"))
+        batches = list(get_forecast("key", "fc-1", mock.MagicMock(), manager))
+
+        assert batches == [[{"Field": "quota"}]]
+        methods = [call.args[0] for call in mock_session.return_value.request.call_args_list]
+        assert "POST" not in methods
+
+    @pytest.mark.parametrize("terminal_status", ["FAILED", "CANCELLED", "ABORTED"])
+    @mock.patch(f"{_MODULE}.time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_dead_job_raises_and_clears_resume_state(self, mock_session, mock_sleep, terminal_status):
+        mock_session.return_value.request.side_effect = [
+            _response({"jobId": "job-1"}),
+            _response({"job": {"id": "job-1", "status": terminal_status}}),
+        ]
+
+        manager = _make_manager()
+        with pytest.raises(ValueError, match=terminal_status):
+            list(get_forecast("key", "fc-1", mock.MagicMock(), manager))
+
+        assert manager.save_state.call_args_list[-1].args[0].job_id is None
+
+    @mock.patch(f"{_MODULE}.EXPORT_POLL_MAX_ATTEMPTS", 2)
+    @mock.patch(f"{_MODULE}.time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_exhausted_poll_budget_raises_retryable(self, mock_session, mock_sleep):
+        mock_session.return_value.request.side_effect = [
+            _response({"jobId": "job-1"}),
+            _response({"job": {"id": "job-1", "status": "STARTED"}}),
+            _response({"job": {"id": "job-1", "status": "STARTED"}}),
+        ]
+
+        with pytest.raises(ClariRetryableError):
+            list(get_forecast("key", "fc-1", mock.MagicMock(), _make_manager()))
+
+    @mock.patch(f"{_MODULE}.time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_missing_job_id_in_create_response_raises(self, mock_session, mock_sleep):
+        mock_session.return_value.request.side_effect = [_response({"unexpected": True})]
+
+        with pytest.raises(ValueError, match="no jobId"):
+            list(get_forecast("key", "fc-1", mock.MagicMock(), _make_manager()))
+
+
+class TestClariSourceResponse:
+    def test_audit_events_metadata(self):
+        response = clari_source("key", "fc-1", "audit_events", mock.MagicMock(), _make_manager())
+
+        assert response.name == "audit_events"
+        assert response.primary_keys == ["eventTimestamp", "actorId", "sessionId", "event"]
+        assert response.sort_mode == "desc"
+        assert response.has_duplicate_primary_keys is True
+
+    def test_forecast_metadata(self):
+        response = clari_source("key", "fc-1", "forecast", mock.MagicMock(), _make_manager())
+
+        assert response.name == "forecast"
+        assert response.primary_keys is None

--- a/posthog/temporal/data_imports/sources/clari/tests/test_clari_source.py
+++ b/posthog/temporal/data_imports/sources/clari/tests/test_clari_source.py
@@ -1,0 +1,132 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from posthog.temporal.data_imports.sources.clari.clari import ClariResumeConfig
+from posthog.temporal.data_imports.sources.clari.settings import ENDPOINTS, INCREMENTAL_FIELDS
+from posthog.temporal.data_imports.sources.clari.source import ClariSource
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.generated_configs import ClariSourceConfig
+
+from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+class TestClariSource:
+    def setup_method(self):
+        self.source = ClariSource()
+        self.team_id = 123
+        self.config = ClariSourceConfig(api_key="key", forecast_id="fc-1")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.CLARI
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Clari"
+        assert config.label == "Clari"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/clari.png"
+
+        field_names = [f.name for f in config.fields]
+        assert field_names == ["api_key", "forecast_id"]
+
+    def test_api_key_field_is_secret_password(self):
+        config = self.source.get_source_config
+        key_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_key")
+        assert key_field.type == SourceFieldInputConfigType.PASSWORD
+        assert key_field.secret is True
+        assert key_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.clari.com/v4/audit/events",
+            "403 Client Error: Forbidden for url: https://api.clari.com/v4/export/jobs/123",
+            "404 Client Error: Not Found for url: https://api.clari.com/v4/export/forecast/bad-id",
+        ],
+    )
+    def test_non_retryable_errors_match_known_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    def test_non_retryable_errors_does_not_match_server_errors(self):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        error = "500 Server Error for url: https://api.clari.com/v4/audit/events"
+        assert not any(key in error for key in non_retryable_errors)
+
+    def test_get_schemas(self):
+        schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, self.team_id)}
+
+        assert set(schemas) == set(ENDPOINTS)
+        # Only audit events expose a server-side date filter.
+        assert schemas["audit_events"].supports_incremental is True
+        assert schemas["audit_events"].incremental_fields == INCREMENTAL_FIELDS["audit_events"]
+        assert [f["field"] for f in schemas["audit_events"].incremental_fields] == ["eventTimestamp"]
+        assert schemas["forecast"].supports_incremental is False
+        assert schemas["forecast"].incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["forecast"])
+        assert len(schemas) == 1
+        assert schemas[0].name == "forecast"
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    @mock.patch("posthog.temporal.data_imports.sources.clari.source.validate_clari_credentials")
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        if not expected_valid:
+            assert error_message == "Invalid Clari credentials"
+        mock_validate.assert_called_once_with("key")
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        inputs = mock.MagicMock()
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is ClariResumeConfig
+
+    @mock.patch("posthog.temporal.data_imports.sources.clari.source.clari_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_clari_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "audit_events"
+        inputs.should_use_incremental_field = True
+        inputs.db_incremental_field_last_value = "2024-01-02T03:04:05Z"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_clari_source.assert_called_once()
+        kwargs = mock_clari_source.call_args.kwargs
+        assert kwargs["api_key"] == "key"
+        assert kwargs["forecast_id"] == "fc-1"
+        assert kwargs["endpoint"] == "audit_events"
+        assert kwargs["resumable_source_manager"] is manager
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == "2024-01-02T03:04:05Z"
+
+    @mock.patch("posthog.temporal.data_imports.sources.clari.source.clari_source")
+    def test_source_for_pipeline_omits_last_value_on_full_refresh(self, mock_clari_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "forecast"
+        inputs.should_use_incremental_field = False
+        inputs.db_incremental_field_last_value = "2024-01-02T03:04:05Z"
+
+        self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
+
+        assert mock_clari_source.call_args.kwargs["db_incremental_field_last_value"] is None

--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -336,7 +336,8 @@ class CircleCISourceConfig(config.Config):
 
 @config.config
 class ClariSourceConfig(config.Config):
-    pass
+    api_key: str
+    forecast_id: str
 
 
 @config.config


### PR DESCRIPTION
## Problem

The Clari data warehouse source was scaffolded but unimplemented (`unreleasedSource=True` stub).

## Changes

Implements the Clari import source against Clari's v4 REST API (`apikey` header auth):

- **Streams**:
  - `audit_events` — plain paginated `GET /audit/events` (1000-row pages, `nextLink` follow), with honest incremental via the server-side `dateFrom` filter on `eventTimestamp`. Events carry no unique id, so the composite primary key (`eventTimestamp`, `actorId`, `sessionId`, `event`) is marked `has_duplicate_primary_keys`, and `sort_mode="desc"` defers the watermark to sync completion since result ordering is undocumented.
  - `forecast` — Clari's async export pipeline: `POST /export/forecast/{forecastId}` → poll `GET /export/jobs/{jobId}` (SCHEDULED/STARTED/DONE/FAILED/CANCELLED/ABORTED) → download `/export/jobs/{jobId}/results` as JSON. Snapshot-style full refresh (no cursor exists).
- **Quota protection**: Clari caps exports at ~1000 per rolling 30 days and 3 concurrent jobs, so the created `jobId` is persisted in resume state immediately — a retried activity re-polls the existing job instead of creating another. Dead jobs clear the state; an exhausted poll budget raises a retryable error so Temporal resumes against the same job.
- **Resumable**: audit events also persist the `nextLink` of the next unfetched page after each yielded page.
- **Config**: API key + forecast ID (copied from the Forecast tab URL in Clari — same config surface as Fivetran's connector). The caption warns about the ~30-day audit event retention and the export quota.
- **Retries**: tenacity with exponential jitter on 429/5xx/timeouts; 401/403/404 mapped to friendly non-retryable errors.

Ships as `ALPHA`. Behavior verified against Clari's public API reference (endpoint paths, export job status enum, audit event schema, pagination); no live credentials were available for an end-to-end sync.

## How did you test this code?

40 unit tests covering timestamp formatting, result-row extraction across response shapes, credential validation, nextLink pagination with resume, incremental `dateFrom` plumbing, the full export job lifecycle (create → poll → download, resume of in-flight jobs, terminal-status state clearing, poll-budget exhaustion), and the full `ClariSource` registration surface.

## 🤖 Agent context

Part of the ongoing effort to implement scaffolded data warehouse sources. Follows the established source patterns (`ResumableSource`, `make_tracked_session`, honest incremental support).
