### PR TITLE
feat(navigation): make left nav resizable to any width

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -41,7 +41,7 @@ export function Navigation({
     const { mobileLayout } = useValues(navigationLogic)
     const { mode } = useValues(navigation3000Logic)
     const mainRef = useRef<HTMLElement>(null)
-    const { mainContentRect, isLayoutNavCollapsed, isLayoutPanelVisible } = useValues(panelLayoutLogic)
+    const { mainContentRect, isLayoutNavCollapsed, isLayoutPanelVisible, navbarWidth } = useValues(panelLayoutLogic)
     const { setMainContentRef, setMainContentRect } = useActions(panelLayoutLogic)
     const { setTabScrollDepth } = useActions(sceneLogic)
     const { activeTabId, activeSceneId } = useValues(sceneLogic)
@@ -139,6 +139,11 @@ export function Navigation({
                             ? 'var(--color-bg-surface-primary)'
                             : 'var(--color-bg-primary)',
                         '--side-panel-width': sidePanelWidth + 'px',
+                        // Live navbar width from the resizer drives both the grid's left column
+                        // (via --left-nav-width below) and the nav element itself, which reads
+                        // --project-navbar-width. Collapsed/mobile fall back to the base default.
+                        '--project-navbar-width':
+                            !mobileLayout && !isLayoutNavCollapsed ? `${navbarWidth}px` : undefined,
                         '--left-nav-width': isLayoutNavCollapsed
                             ? 'var(--project-navbar-width-collapsed)'
                             : 'var(--project-navbar-width)',

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -3,7 +3,7 @@ import { cva } from 'cva'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
-import { lazy, Suspense, useRef } from 'react'
+import { lazy, Suspense, useEffect, useRef } from 'react'
 
 import { IconApps, IconChat, IconChevronRight, IconSearch } from '@posthog/icons'
 
@@ -13,15 +13,21 @@ import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
 import { commandLogic } from 'lib/components/Command/commandLogic'
 import { Resizer } from 'lib/components/Resizer/Resizer'
+import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Collapsible } from 'lib/ui/Collapsible/Collapsible'
 import { Label } from 'lib/ui/Label/Label'
 import { WrappingLoadingSkeleton } from 'lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton'
 import { cn } from 'lib/utils/css-classes'
-import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
-import { NavExperimentTab, PanelLayoutNavIdentifier, panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import {
+    NavExperimentTab,
+    PANEL_NAVBAR_COLLAPSE_THRESHOLD,
+    PANEL_NAVBAR_DEFAULT_WIDTH,
+    PanelLayoutNavIdentifier,
+    panelLayoutLogic,
+} from '~/layout/panel-layout/panelLayoutLogic'
 
 import { navigation3000Logic } from '../../navigation-3000/navigationLogic'
 import { NavBarFooter } from '../NavBarFooter'
@@ -99,12 +105,33 @@ export function Nav(): JSX.Element {
         setActivePanelIdentifier,
         showLayoutPanel,
         clearActivePanelIdentifier,
+        setNavbarWidth,
     } = useActions(panelLayoutLogic)
     const { isLayoutPanelVisible, isLayoutNavCollapsed, navExperimentActiveTab, activePanelIdentifier } =
         useValues(panelLayoutLogic)
     const { mobileLayout: isMobileLayout } = useValues(navigation3000Logic)
-    const { firstTabIsActive } = useValues(sceneLogic)
     const { toggleCommand } = useActions(commandLogic)
+
+    const resizerLogicProps: ResizerLogicProps = {
+        logicKey: 'panel-layout-navbar',
+        placement: 'right',
+        containerRef,
+        persistent: true,
+        closeThreshold: PANEL_NAVBAR_COLLAPSE_THRESHOLD,
+        onToggleClosed: (shouldBeClosed) => toggleLayoutNavCollapsed(shouldBeClosed),
+        onDoubleClick: () => toggleLayoutNavCollapsed(),
+    }
+    const { desiredSize } = useValues(resizerLogic(resizerLogicProps))
+
+    // Grow to any width upward; never render narrower than the collapse snap so the live drag
+    // stays in sync with where onToggleClosed flips to collapsed mode.
+    const openWidth = Math.max(Math.round(desiredSize ?? PANEL_NAVBAR_DEFAULT_WIDTH), PANEL_NAVBAR_COLLAPSE_THRESHOLD)
+
+    useEffect(() => {
+        if (!isLayoutNavCollapsed && !isMobileLayout) {
+            setNavbarWidth(openWidth)
+        }
+    }, [openWidth, isLayoutNavCollapsed, isMobileLayout, setNavbarWidth])
 
     useAppShortcut({
         name: 'ToggleLeftNav',
@@ -296,15 +323,9 @@ export function Nav(): JSX.Element {
                 </Tabs.Root>
                 {!isMobileLayout && (
                     <Resizer
-                        logicKey="panel-layout-navbar"
-                        placement="right"
-                        containerRef={containerRef}
-                        closeThreshold={100}
-                        onToggleClosed={(shouldBeClosed) => toggleLayoutNavCollapsed(shouldBeClosed)}
-                        onDoubleClick={() => toggleLayoutNavCollapsed()}
+                        {...resizerLogicProps}
                         data-attr="tree-navbar-resizer"
-                        className={cn('top-[calc(var(--scene-layout-header-height)+7px)] right-[-1px] bottom-4 z-2', {
-                            'top-[var(--scene-layout-header-height)]': firstTabIsActive,
+                        className={cn('top-3 -right-px bottom-4 z-2', {
                             'top-0': isLayoutPanelVisible,
                         })}
                         offset={0}

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -23,6 +23,11 @@ export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null
 export const PANEL_LAYOUT_DEFAULT_WIDTH: number = 245
 export const PANEL_LAYOUT_MIN_WIDTH: number = 160
 
+// Navbar resize: any width upward, snapping to collapsed below the threshold.
+export const PANEL_NAVBAR_DEFAULT_WIDTH: number = 215
+// Below this the drag snaps to collapsed mode.
+export const PANEL_NAVBAR_COLLAPSE_THRESHOLD: number = 140
+
 export const panelLayoutLogic = kea<panelLayoutLogicType>([
     path(['layout', 'panel-layout', 'panelLayoutLogic']),
     connect(() => ({
@@ -48,6 +53,7 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
         setSidePanelWidth: (width: number) => ({ width }),
         toggleNavSection: (section: string) => ({ section }),
         setNavExperimentTab: (tab: NavExperimentTab) => ({ tab }),
+        setNavbarWidth: (width: number) => ({ width }),
     }),
     reducers({
         isLayoutNavbarVisibleForDesktop: [
@@ -155,6 +161,14 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
             { persist: true },
             {
                 setNavExperimentTab: (_, { tab }) => tab,
+            },
+        ],
+        // Transient: the live open width is restored from the resizer's persisted size on mount,
+        // so persisting here would only duplicate it and thrash localStorage on every drag frame.
+        navbarWidth: [
+            PANEL_NAVBAR_DEFAULT_WIDTH,
+            {
+                setNavbarWidth: (_, { width }) => width,
             },
         ],
         expandedNavSections: [


### PR DESCRIPTION
## Problem

The left navigation could be collapsed or open, but the open width was a fixed `215px` — the resize handle only toggled collapse, it never actually changed the width. Users want to widen the nav to fit longer item names and shrink it back down.

<img width="1518" height="1300" alt="2026-06-11 15 46 58" src="https://github.com/user-attachments/assets/c61b6aaa-8149-4927-8aa0-d1288ecd1db0" />


## Changes

- The navbar resizer's desired size now drives the **live** nav width (any width upward), instead of only firing the collapse toggle.
- Width is published to `panelLayoutLogic` (`navbarWidth`) and applied as `--project-navbar-width` at the `.app-layout` level. From there it cascades to both the layout grid's left column and the nav element itself, so **main content resizes to fit** the nav.
- Dragging below the collapse threshold snaps to collapsed mode (existing `onToggleClosed` path); collapsed/mobile fall back to the base width var.
- `navbarWidth` is transient in the logic (the resizer already persists its size and restores it on mount), avoiding per-frame localStorage writes during a drag.

## How did you test this code?

I'm an agent. Automated checks run locally: `typescript:check` (clean for the touched files), `kea-typegen write`, and the frontend formatter / pre-commit lint-staged hook. I did **not** manually exercise the drag in a running app — worth a quick manual pass on resize, collapse-snap, and main-content fit before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). The user asked for a resizable left nav that snaps to collapsed below a threshold and keeps main content sized to the nav. Initial implementation included a content fade-out band approaching the snap point; the user then asked to remove the fade, so that was reverted, leaving a hard snap. Key decision: drive the width via the existing `--project-navbar-width` CSS var at the `.app-layout` grid level rather than threading a new width var through each component — the grid's left column and the nav both already read it, so a single source keeps them in sync.
