### PR TITLE
feat(dashboards): clarify duplicate vs copy-to-project actions

### DIFF
--- a/frontend/src/lib/components/Scenes/SceneDuplicate.tsx
+++ b/frontend/src/lib/components/Scenes/SceneDuplicate.tsx
@@ -6,18 +6,22 @@ import { SceneDataAttrKeyProps } from './utils'
 
 interface SceneDuplicateProps extends SceneDataAttrKeyProps {
     onClick: () => void
+    label?: string
+    icon?: JSX.Element
+    tooltip?: string
 }
 
-export function SceneDuplicate({ dataAttrKey, onClick }: SceneDuplicateProps): JSX.Element {
+export function SceneDuplicate({
+    dataAttrKey,
+    onClick,
+    label = 'Duplicate',
+    icon = <IconCopy />,
+    tooltip = 'Duplicate resource',
+}: SceneDuplicateProps): JSX.Element {
     return (
-        <ButtonPrimitive
-            menuItem
-            onClick={onClick}
-            data-attr={`${dataAttrKey}-duplicate-button`}
-            tooltip="Duplicate resource"
-        >
-            <IconCopy />
-            Duplicate
+        <ButtonPrimitive menuItem onClick={onClick} data-attr={`${dataAttrKey}-duplicate-button`} tooltip={tooltip}>
+            {icon}
+            {label}
         </ButtonPrimitive>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
+++ b/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCode2, IconCopy, IconGraph, IconNotebook, IconPalette, IconTrash } from '@posthog/icons'
+import { IconCode2, IconCopy, IconGraph, IconNotebook, IconPalette, IconStack, IconTrash } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { SceneExportDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu'
@@ -91,13 +91,16 @@ export function DashboardScenePanel(): JSX.Element | null {
                         <SceneDuplicate
                             dataAttrKey={RESOURCE_TYPE}
                             onClick={() => showDuplicateDashboardModal(dashboard.id, dashboard.name)}
+                            label="Make a copy of this dashboard"
+                            icon={<IconStack />}
+                            tooltip="Creates a duplicate of this dashboard in the current project, with the option to copy its tiles too"
                         />
                         {canCopyToProject && (
                             <ButtonPrimitive
                                 menuItem
                                 onClick={() => push(urls.resourceTransfer('Dashboard', dashboard.id))}
                                 data-attr="dashboard-copy-to-project"
-                                tooltip="Copy this dashboard to another project"
+                                tooltip="Copies this dashboard into a different project you have access to, leaving the original here untouched"
                             >
                                 <IconCopy />
                                 Copy to another project


### PR DESCRIPTION
## Problem

A customer reported that the **Duplicate** and **Copy to another project** actions in the dashboard sidebar are hard to tell apart — they sit side by side with the same icon and near-synonymous verbs. The tooltips also weren't adding any helpful information, just restating the labels.

## Changes

Made the two actions distinct on every axis:

- Relabeled **Duplicate** → **Make a copy of this dashboard**.
- Gave it the `IconStack` icon so it no longer shares `IconCopy` with **Copy to another project**.
- Rewrote both tooltips to explain what each action actually does and how they differ, rather than echoing the label:
  - *Make a copy of this dashboard* → "Creates a duplicate of this dashboard in the current project, with the option to copy its tiles too"
  - *Copy to another project* → "Copies this dashboard into a different project you have access to, leaving the original here untouched"
- Added optional `label`/`icon`/`tooltip` overrides to the shared `SceneDuplicate` component, defaulting to the existing behavior so insights, surveys, and session-recording playlists are unchanged.

## How did you test this code?

I'm an agent. I have not run the app or added automated tests — these are copy/icon-only frontend changes. I did not run typecheck/lint locally because the repo's node modules weren't installed in this session. The shared component's new props default to the prior values, so existing call sites are unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with the PostHog Slack app (Claude Code agent) from a Slack thread where a customer flagged the confusion between the two dashboard actions. The reporter also noted the tooltips weren't helpful, so this addresses both. Chose `IconStack` to break the shared-icon ambiguity, and kept the change scoped to the dashboard by adding optional overrides to `SceneDuplicate` rather than changing the shared default (which would have affected other resource types).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781188680272089?thread_ts=1781188680.272089&cid=C0ACRAMJUAG)*
