### PR TITLE
feat(integrations): request in-review Slack scopes on DEV + local

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -314,6 +314,7 @@ export const FEATURE_FLAGS = {
     HACKATHONS_SUBSCRIPTIONS: 'hackathons_subscriptions', // owner: #team-analytics-platform, gates listing subscription delivery history and AI change summaries
     HEALTH_ALERTS: 'health-alerts', // owner: #team-growth, gates the central /health/alerts scene and per-page Alerts buttons
     HEALTH_ASK_AI: 'health-ask-ai', // owner: @jordanm-posthog #team-web-analytics, gates the "Ask PostHog AI" buttons on the Health overview
+    INSIGHT_SUBSCRIBE_PROMINENT_BUTTON: 'insight-subscribe-prominent-button', // owner: @mattp #team-analytics-platform multivariate=control,test
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features
     JS_SNIPPET_VERSIONING: 'js-snippet-versioning', // owner: #team-client-libraries
     LEGAL_DOCUMENTS: 'legal-documents', // owner: @rafaeelaudibert #team-growth
@@ -463,7 +464,6 @@ export const FEATURE_FLAGS = {
     SCENE_ALERTS_LABEL_EXPERIMENT: 'scene-alerts-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,get-notified,monitor-changes,set-up-alert
     SCENE_MENU_BAR: 'scene-menu-bar', // owner: @adamleithp #team-platform-ux, gates the per-scene MenuBar above SceneTitleSection
     SCENE_SUBSCRIBE_LABEL_EXPERIMENT: 'scene-subscribe-label-experiment', // owner: @mattp #team-analytics-platform multivariate=control,recurring-updates,scheduled-notifications,scheduled-reports
-    INSIGHT_SUBSCRIBE_PROMINENT_BUTTON: 'insight-subscribe-prominent-button', // owner: @mattp #team-analytics-platform multivariate=control,test
     SCHEDULE_FEATURE_FLAG_VARIANTS_UPDATE: 'schedule-feature-flag-variants-update', // owner: @gustavo #team-feature-flags
     SCHEMA_ENFORCEMENT_REJECT: 'schema-enforcement-reject', // owner: @aspicer, gates the ability to set schema enforcement mode to "reject"
     SCHEMA_MANAGEMENT: 'schema-management', // owner: @aspicer
@@ -594,6 +594,7 @@ export const SECURE_URL_REGEX = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w.-]+)+[\w\-._~
 export const CLOUD_HOSTNAMES = {
     [Region.US]: 'us.posthog.com',
     [Region.EU]: 'eu.posthog.com',
+    [Region.DEV]: 'app.dev.posthog.dev',
 }
 
 export const SESSION_RECORDINGS_PLAYLIST_FREE_COUNT = 5

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -39664,6 +39664,10 @@
             ],
             "type": "string"
         },
+        "SlackIntegrationScopeInReview": {
+            "enum": ["assistant:write", "im:history", "mpim:read"],
+            "type": "string"
+        },
         "SlashCommandName": {
             "enum": ["/init", "/remember", "/usage", "/feedback", "/ticket"],
             "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -54,6 +54,7 @@ import {
     SessionRecordingType,
     SimpleIntervalType,
     SlackIntegrationScope,
+    SlackIntegrationScopeInReview,
     StepOrderValue,
     StickinessFilterType,
     TrendsFilterType,
@@ -62,9 +63,10 @@ import {
 import { integer, numerical_key, positive_integer } from './type-utils'
 
 export { ChartDisplayCategory }
-// Re-exported so the codegen picks it up and emits `class SlackIntegrationScope(StrEnum)` in
-// posthog/schema.py. The matching runtime const lives in `~/types` as `SLACK_INTEGRATION_SCOPES`.
-export { SlackIntegrationScope }
+// Re-exported so the codegen picks them up and emits matching `StrEnum`s in posthog/schema.py.
+// The runtime consts live in `~/types` as `SLACK_INTEGRATION_SCOPES` (always-on) and
+// `SLACK_INTEGRATION_SCOPES_IN_REVIEW` (DEV-instance only until Slack approves them).
+export { SlackIntegrationScope, SlackIntegrationScopeInReview }
 
 /**
  * PostHog Query Schema definition.

--- a/frontend/src/scenes/settings/environment/SlackIntegration.tsx
+++ b/frontend/src/scenes/settings/environment/SlackIntegration.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
@@ -9,10 +9,11 @@ import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedAr
 import { TeamMembershipLevel } from 'lib/constants'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IntegrationView } from 'lib/integrations/IntegrationView'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { SLACK_INTEGRATION_SCOPES } from '~/types'
+import { Region, SLACK_INTEGRATION_SCOPES, SLACK_INTEGRATION_SCOPES_IN_REVIEW } from '~/types'
 
 // Modified version of https://app.slack.com/app-settings/TSS5W8YQZ/A03KWE2FJJ2/app-manifest to match current instance.
 const getSlackAppManifest = (): any => ({
@@ -52,12 +53,25 @@ const getSlackAppManifest = (): any => ({
 
 export function SlackIntegration(): JSX.Element {
     const { slackIntegrations, slackAvailable } = useValues(integrationsLogic)
+    const { preflight, isDev } = useValues(preflightLogic)
     const [showSlackInstructions, setShowSlackInstructions] = useState(false)
     const { user } = useValues(userLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
+
+    // On the DEV instance and local dev (DEBUG=True) the PostHog Slack app manifest lists the
+    // in-review scopes, so we both request them at install and compare against them in the
+    // scope-mismatch banner. On US/EU/self-hosted they'd be rejected by Slack as invalid_scope,
+    // so we stay on the always-on list.
+    const requiredScopes = useMemo(() => {
+        const scopes =
+            isDev || preflight?.region === Region.DEV
+                ? [...SLACK_INTEGRATION_SCOPES, ...SLACK_INTEGRATION_SCOPES_IN_REVIEW]
+                : SLACK_INTEGRATION_SCOPES
+        return scopes.join(' ')
+    }, [isDev, preflight?.region])
 
     if (restrictedReason) {
         return <p>{restrictedReason}</p>
@@ -67,11 +81,7 @@ export function SlackIntegration(): JSX.Element {
         <div>
             <div className="deprecated-space-y-2">
                 {slackIntegrations?.map((integration) => (
-                    <IntegrationView
-                        key={integration.id}
-                        integration={integration}
-                        schema={{ requiredScopes: SLACK_INTEGRATION_SCOPES.join(' ') }}
-                    />
+                    <IntegrationView key={integration.id} integration={integration} schema={{ requiredScopes }} />
                 ))}
 
                 <div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -247,6 +247,7 @@ export enum Realm {
 export enum Region {
     US = 'US',
     EU = 'EU',
+    DEV = 'DEV',
 }
 
 export type SSOProvider = 'google-oauth2' | 'github' | 'gitlab' | 'saml'
@@ -5256,15 +5257,21 @@ export enum SlackIntegrationScope {
     TEAM_READ = 'team:read',
     USERS_READ = 'users:read',
     USERS_READ_EMAIL = 'users:read.email',
-    // Pending Slack app-directory submission review — uncomment once approved. Until then we cannot
-    // request these in the OAuth install URL without Slack returning `invalid_scope`. Keeping the
-    // entries here so the next person widening the scope set has the full target list in one place.
-    // ASSISTANT_WRITE = 'assistant:write',
-    // IM_HISTORY = 'im:history',
-    // MPIM_READ = 'mpim:read',
 }
 
 export const SLACK_INTEGRATION_SCOPES = Object.values(SlackIntegrationScope)
+
+// Scopes still pending Slack app-directory review. Requested only on the internal DEV instance
+// (settings.CLOUD_DEPLOYMENT == "DEV", surfaced as `preflight.region === Region.DEV`) where the
+// PostHog Slack app manifest already lists them; requesting them anywhere else fails with
+// `invalid_scope`. Move entries into SlackIntegrationScope once Slack approves the public app.
+export enum SlackIntegrationScopeInReview {
+    ASSISTANT_WRITE = 'assistant:write',
+    IM_HISTORY = 'im:history',
+    MPIM_READ = 'mpim:read',
+}
+
+export const SLACK_INTEGRATION_SCOPES_IN_REVIEW = Object.values(SlackIntegrationScopeInReview)
 
 export interface IntegrationType {
     id: number

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -37,7 +37,7 @@ from rest_framework.request import Request
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from posthog.schema import SlackIntegrationScope
+from posthog.schema import SlackIntegrationScope, SlackIntegrationScopeInReview
 
 from posthog.cache_utils import cache_for
 from posthog.exceptions_capture import capture_exception
@@ -276,7 +276,20 @@ class OauthConfig:
 # Slack accepts comma-separated scopes on the OAuth authorize URL. The canonical list is the
 # StrEnum declared in posthog/schema.py (generated from the SlackIntegrationScope enum in
 # frontend/src/types.ts via `hogli build:schema`), so widening it on either side stays in sync.
-POSTHOG_SLACK_SCOPE = ",".join(scope.value for scope in SlackIntegrationScope)
+#
+# On the internal DEV instance (CLOUD_DEPLOYMENT="DEV") and local development (settings.DEBUG)
+# we also request the in-review scopes — the Slack app manifest in those setups can list them.
+# US/EU/self-hosted would fail with `invalid_scope` until Slack approves the public Cloud app.
+# Evaluated at module import; tests that need a different value should
+# `@override_settings(...)` *before* importing this module (or `importlib.reload` it after).
+def _build_posthog_slack_scope() -> str:
+    scopes = [scope.value for scope in SlackIntegrationScope]
+    if settings.DEBUG or get_instance_region() == "DEV":
+        scopes.extend(scope.value for scope in SlackIntegrationScopeInReview)
+    return ",".join(scopes)
+
+
+POSTHOG_SLACK_SCOPE = _build_posthog_slack_scope()
 
 
 class OauthIntegration:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4867,6 +4867,12 @@ class SlackIntegrationScope(StrEnum):
     USERS_READ_EMAIL = "users:read.email"
 
 
+class SlackIntegrationScopeInReview(StrEnum):
+    ASSISTANT_WRITE = "assistant:write"
+    IM_HISTORY = "im:history"
+    MPIM_READ = "mpim:read"
+
+
 class SlashCommandName(StrEnum):
     FIELD_INIT = "/init"
     FIELD_REMEMBER = "/remember"


### PR DESCRIPTION
## Problem

Three Slack OAuth scopes (`assistant:write`, `im:history`, `mpim:read`) are still in app-directory review. We want to exercise the install + scope-mismatch flow against them on the DEV instance and locally before they're approved for the public app.

## Changes

- New `SlackIntegrationScopeInReview` enum in `frontend/src/types.ts` codegens to `posthog/schema.py`.
- Both sides extend `POSTHOG_SLACK_SCOPE` / `IntegrationView.schema.requiredScopes` with the in-review scopes only when `settings.DEBUG` / `isDev` or region is DEV.
- `Region` enum gains `Dev = 'DEV'`.

## How did you test this code?

Tested locally.

## 🤖 Agent context

Claude Opus 4.7.