### PR TITLE
fix(tasks): verify agentsh daemon via health check, not exec exit code

### DIFF
--- a/products/tasks/backend/services/agentsh.py
+++ b/products/tasks/backend/services/agentsh.py
@@ -342,6 +342,7 @@ def build_exec_prefix() -> str:
 
 def build_setup_script(workspace_path: str) -> str:
     return (
+        f"rm -f {SESSION_ID_FILE} {SESSION_ID_FILE}.tmp; "
         f"nohup agentsh server --config /etc/agentsh/config.yaml > /var/log/agentsh/agentsh.log 2>&1 & "
         f"AGENTSH_OK=0; "
         f"for i in $(seq 1 30); do "
@@ -354,6 +355,10 @@ def build_setup_script(workspace_path: str) -> str:
         f"  cat /var/log/agentsh/agentsh.log >&2 2>/dev/null; "
         f"  exit 1; "
         f"fi; "
-        f"agentsh session create --workspace {workspace_path} --policy default --json "
-        f"| jq -r .id > {SESSION_ID_FILE}"
+        f"SESSION_ID=$(agentsh session create --workspace {workspace_path} --policy default --json | jq -r .id); "
+        f'if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then '
+        f"  echo 'agentsh session create failed' >&2; "
+        f"  exit 1; "
+        f"fi; "
+        f'printf %s "$SESSION_ID" > {SESSION_ID_FILE}.tmp && mv {SESSION_ID_FILE}.tmp {SESSION_ID_FILE}'
     )

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -797,10 +797,10 @@ class ModalSandbox(SandboxBase):
 
     def _agentsh_daemon_is_healthy(self, max_attempts: int = 30, poll_interval: float = 0.5) -> bool:
         health_script = (
-            f"for _ in $(seq 1 {max_attempts}); do "
+            f"for i in $(seq 1 {max_attempts}); do "
             f"  status=$(curl -s -o /dev/null -w '%{{http_code}}' http://127.0.0.1:{AGENTSH_DAEMON_PORT}/health); "
             f'  [ "$status" = "200" ] && exit 0; '
-            f"  sleep {poll_interval}; "
+            f'  [ "$i" -lt {max_attempts} ] && sleep {poll_interval}; '
             f"done; "
             f"exit 1"
         )

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -755,6 +755,13 @@ class ModalSandbox(SandboxBase):
         result = self.execute(setup_script, timeout_seconds=30)
         if not self._agentsh_daemon_is_healthy():
             agentsh_log = self.execute("cat /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
+            logger.error(
+                "agentsh daemon failed to start in sandbox %s (setup exit_code=%s); stderr=%r agentsh_log=%r",
+                self.id,
+                result.exit_code,
+                result.stderr.strip()[:1000],
+                agentsh_log.stdout.strip()[:2000],
+            )
             raise SandboxExecutionError(
                 "Failed to start agentsh daemon",
                 {
@@ -770,6 +777,12 @@ class ModalSandbox(SandboxBase):
         session_check = self.execute(f"cat {SESSION_ID_FILE}", timeout_seconds=5)
         if session_check.exit_code != 0 or not session_check.stdout.strip():
             agentsh_log = self.execute("cat /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
+            logger.error(
+                "agentsh session creation failed in sandbox %s; stderr=%r agentsh_log=%r",
+                self.id,
+                session_check.stderr.strip()[:1000],
+                agentsh_log.stdout.strip()[:2000],
+            )
             raise SandboxExecutionError(
                 "Failed to create agentsh session",
                 {

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -38,6 +38,7 @@ from products.tasks.backend.exceptions import (
 )
 from products.tasks.backend.models import SandboxSnapshot
 from products.tasks.backend.services.agentsh import (
+    AGENTSH_DAEMON_PORT,
     BASH_ENV_SCRIPT,
     ENV_FILE,
     ENV_WRAPPER_SCRIPT,
@@ -752,7 +753,7 @@ class ModalSandbox(SandboxBase):
 
         setup_script = build_setup_script(workspace_path)
         result = self.execute(setup_script, timeout_seconds=30)
-        if result.exit_code != 0:
+        if not self._agentsh_daemon_is_healthy():
             agentsh_log = self.execute("cat /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
             raise SandboxExecutionError(
                 "Failed to start agentsh daemon",
@@ -760,9 +761,10 @@ class ModalSandbox(SandboxBase):
                     "sandbox_id": self.id,
                     "stderr": result.stderr,
                     "stdout": result.stdout,
+                    "exit_code": result.exit_code,
                     "agentsh_log": agentsh_log.stdout,
                 },
-                cause=RuntimeError(result.stderr),
+                cause=RuntimeError(result.stderr or "agentsh daemon health check failed"),
             )
 
         session_check = self.execute(f"cat {SESSION_ID_FILE}", timeout_seconds=5)
@@ -779,6 +781,18 @@ class ModalSandbox(SandboxBase):
             )
 
         logger.info("agentsh daemon started and session created in sandbox %s", self.id)
+
+    def _agentsh_daemon_is_healthy(self, max_attempts: int = 30, poll_interval: float = 0.5) -> bool:
+        health_script = (
+            f"for _ in $(seq 1 {max_attempts}); do "
+            f"  status=$(curl -s -o /dev/null -w '%{{http_code}}' http://127.0.0.1:{AGENTSH_DAEMON_PORT}/health); "
+            f'  [ "$status" = "200" ] && exit 0; '
+            f"  sleep {poll_interval}; "
+            f"done; "
+            f"exit 1"
+        )
+        result = self.execute(health_script, timeout_seconds=max(30, int(max_attempts * poll_interval) + 5))
+        return result.exit_code == 0
 
     def _wait_for_health_check(
         self, max_attempts: int = AGENT_SERVER_HEALTH_MAX_ATTEMPTS, poll_interval: float = 0.5


### PR DESCRIPTION
## Problem

VM sandbox runs that enforce a network allowlist (the agentsh egress firewall) were failing at `start_agent_server` but the root cause is a false negative. On the Modal VM runtime, the `exec` that launches the backgrounded `agentsh server` daemon is reaped by the runtime and returns exit code `-1` even on success, lol
