### PR TITLE
feat(rust): build rdkafka with zstd compression support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8269,6 +8269,7 @@ dependencies = [
  "num_enum",
  "openssl-sys",
  "pkg-config",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -12168,6 +12169,7 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -133,7 +133,7 @@ opentelemetry_sdk = { version = "0.22.1", features = ["trace", "rt-tokio"] }
 public-suffix = "0.1.2"
 prost = "0.13"
 rand = "0.8.5"
-rdkafka = { version = "0.37.0", features = ["tracing", "ssl-vendored"] }
+rdkafka = { version = "0.37.0", features = ["tracing", "ssl-vendored", "zstd"] }
 reqwest = { version = "0.12.3", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = { version = "1.0" }


### PR DESCRIPTION
## Problem

Setting `KAFKA_COMPRESSION_CODEC=zstd` on a Rust service fails at client init with `Unsupported value "zstd" ... libzstd not available at build time`: the vendored librdkafka is built without zstd. The immediate motivation is compressing the `property_vals_intermediate` topic (high-volume small records, currently uncompressed); batch-level zstd is the right mechanism for it, unlike the previously reverted per-record envelope encoding which gained nothing on tiny records.

## Changes

- Add the `zstd` feature to the workspace `rdkafka` dependency so librdkafka builds with libzstd (statically vendored, consistent with the existing `ssl-vendored` setup). No behavior change for any service unless it opts in via `KAFKA_COMPRESSION_CODEC=zstd`.

## How did you test this code?

I'm an agent; no manual testing. Lockfile resolved via cargo (adds zstd-sys to the rdkafka-sys graph); CI builds the workspace and validates the native build. The config knob already exists in `common_kafka`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Root-caused a production config error (zstd codec rejected by rdkafka) to the missing cargo feature; verified the earlier envelope-lz4 revert was a different mechanism (per-record framing) and does not argue against codec-level batch compression.
