### PR TITLE
chore(error-tracking): trigger temporal worker deploy

### DIFF
--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -218,6 +218,7 @@ async def merge_similar_fingerprints_activity(
         query_duration_seconds = time.monotonic() - start
         query_duration_ms = query_duration_seconds * 1000
 
+        # Keep emitting candidate metrics for every run; merging is gated separately by configuration.
         _report_closest_fingerprint_metrics(team, inputs, closest_fingerprints, model_name, query_duration_ms)
 
         return FingerprintEmbeddingMergeResult(


### PR DESCRIPTION
## Problem

Trigger the error tracking Temporal worker deployment with a tiny code-only change.

## Changes

- Add a short clarifying comment near fingerprint embedding result metric reporting.

## How did you test this code?

Not run. This is a comment-only change intended to trigger deployment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed for this comment-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created by pi using the coding-agent tools. The requested approach was a minimal change branched from `master` in the PostHog repo so CI/deployment automation can build a fresh error tracking Temporal worker image.