### PR TITLE
fix(ingestion-consumer): export worker health state as state-set gauge

### DIFF
--- a/nodejs/tests/service-e2e/rust-ingestion-consumer.test.ts
+++ b/nodejs/tests/service-e2e/rust-ingestion-consumer.test.ts
@@ -290,7 +290,7 @@ describe('Rust ingestion consumer with Node ingestion API workers', () => {
             expect(worker1RoutedAfterHealthyBatch).toBeGreaterThan(0)
 
             await workers[0].service.stop()
-            await waitForWorkerHealthState(rustConsumer, rustMetricsPort, workers[0].url, 2)
+            await waitForWorkerHealthState(rustConsumer, rustMetricsPort, workers[0].url, 'unhealthy')
             const failoverEvents = buildSingleBatchEvents(
                 team,
                 'rust node e2e failover event',
@@ -333,7 +333,7 @@ describe('Rust ingestion consumer with Node ingestion API workers', () => {
             })
 
             workers[0] = await restartNodeIngestionApiWorker(services, workers[0], 'node-worker-1-recovered')
-            await waitForWorkerHealthState(rustConsumer, rustMetricsPort, workers[0].url, 0)
+            await waitForWorkerHealthState(rustConsumer, rustMetricsPort, workers[0].url, 'healthy')
 
             const recoveryEvents = buildSingleBatchEvents(
                 team,
@@ -383,7 +383,9 @@ describe('Rust ingestion consumer with Node ingestion API workers', () => {
         try {
             await Promise.all(workers.map((worker) => worker.service.stop()))
             await Promise.all(
-                workers.map((worker) => waitForWorkerHealthState(rustConsumer, rustMetricsPort, worker.url, 2))
+                workers.map((worker) =>
+                    waitForWorkerHealthState(rustConsumer, rustMetricsPort, worker.url, 'unhealthy')
+                )
             )
 
             const events = buildSingleBatchEvents(
@@ -1010,16 +1012,16 @@ async function waitForWorkerHealthState(
     rustConsumer: ServiceProcess,
     rustMetricsPort: number,
     worker: string,
-    state: number
+    state: 'healthy' | 'degraded' | 'unhealthy'
 ): Promise<void> {
     await waitForExpect(async () => {
         const metrics = await fetchMetrics(rustConsumer, rustMetricsPort)
         expect(
             getPrometheusSample(metrics, {
                 name: 'ingestion_consumer_worker_health_state',
-                labels: { worker },
+                labels: { worker, state },
             })
-        ).toBe(state)
+        ).toBe(1)
     }, 30_000)
 }
 

--- a/rust/ingestion-consumer/src/worker_registry.rs
+++ b/rust/ingestion-consumer/src/worker_registry.rs
@@ -18,6 +18,12 @@ pub enum WorkerState {
 }
 
 impl WorkerState {
+    const ALL: [WorkerState; 3] = [
+        WorkerState::Healthy,
+        WorkerState::Degraded,
+        WorkerState::Unhealthy,
+    ];
+
     pub fn as_str(self) -> &'static str {
         match self {
             WorkerState::Healthy => "healthy",
@@ -25,13 +31,20 @@ impl WorkerState {
             WorkerState::Unhealthy => "unhealthy",
         }
     }
+}
 
-    fn as_gauge_value(self) -> f64 {
-        match self {
-            WorkerState::Healthy => 0.0,
-            WorkerState::Degraded => 1.0,
-            WorkerState::Unhealthy => 2.0,
-        }
+/// Emit the worker health state as a state-set gauge: one series per state
+/// labeled `state`, with the current state at 1 and all others at 0 (same
+/// pattern as `kube_pod_status_phase`). Operators can alert on a state by
+/// name without decoding magic numbers.
+fn set_state_gauge(worker_url: &str, current: WorkerState) {
+    for state in WorkerState::ALL {
+        gauge!(
+            "ingestion_consumer_worker_health_state",
+            "worker" => worker_url.to_string(),
+            "state" => state.as_str(),
+        )
+        .set(if state == current { 1.0 } else { 0.0 });
     }
 }
 
@@ -106,14 +119,7 @@ impl WorkerHealth {
             "to" => new_state.as_str(),
         )
         .increment(1);
-        // Numeric gauge so operators can alert directly on state without
-        // reconstructing it from cumulative transition counters.
-        // 0 = Healthy, 1 = Degraded, 2 = Unhealthy.
-        gauge!(
-            "ingestion_consumer_worker_health_state",
-            "worker" => worker_url.to_string(),
-        )
-        .set(new_state.as_gauge_value());
+        set_state_gauge(worker_url, new_state);
 
         true
     }
@@ -207,10 +213,16 @@ impl WorkerRegistry {
             .build()
             .expect("failed to create probe HTTP client");
 
-        let workers = worker_urls
+        let workers: Vec<(String, Mutex<WorkerHealth>)> = worker_urls
             .iter()
             .map(|url| (url.clone(), Mutex::new(WorkerHealth::new())))
             .collect();
+
+        // Emit the initial state for every worker so the gauge exists from
+        // startup rather than only after the first transition.
+        for (url, _) in &workers {
+            set_state_gauge(url, WorkerState::Healthy);
+        }
 
         Self {
             workers,


### PR DESCRIPTION
## Problem

The worker health section of the ingestion-consumer Grafana dashboard is hard to read because `ingestion_consumer_worker_health_state` encodes the worker state as a magic number (0 = healthy, 1 = degraded, 2 = unhealthy). Panels need value mappings to decode it, and a freshly started worker exports no health metric at all until its first state transition, so healthy workers are simply absent from the dashboard.

## Changes

- Replace the numeric gauge with the standard Prometheus state-set pattern (same as `kube_pod_status_phase`): one series per state with a `state` label, where the current state is `1` and the others are `0`.
- Emit the gauge for every worker at registry construction, so healthy workers are visible from startup.
- Update the service e2e test helper to assert on the labeled series by state name instead of a numeric value.

## How did you test this code?

I'm an agent. Automated tests run: `cargo test -p ingestion-consumer --lib` (40 tests pass), plus `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings`. The service e2e suite (`nodejs/tests/service-e2e/rust-ingestion-consumer.test.ts`) was updated but not run locally; it runs in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The state-set gauge pattern was chosen over keeping a numeric gauge with value mappings so dashboards and alerts can reference states by name (`state="unhealthy"` == 1). The startup emission was added after noticing the gauge was only set inside `try_transition`, leaving healthy workers invisible until their first transition.
