### PR TITLE
fix(data-warehouse): surface dropped-connection cause in postgres sch…

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1305,6 +1305,8 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
     except psycopg.errors.QueryCanceled:
         raise
     except Exception as e:
+        if cursor.connection.broken:
+            raise
         logger.debug(f"_get_table_chunk_size: Error: {e}. Using DEFAULT_CHUNK_SIZE={DEFAULT_CHUNK_SIZE}", exc_info=e)
 
         return DEFAULT_CHUNK_SIZE
@@ -1325,6 +1327,8 @@ def _role_subject_to_rls(cursor: psycopg.Cursor, schema: str, table_name: str, l
     except psycopg.errors.QueryCanceled:
         raise
     except Exception as e:
+        if cursor.connection.broken:
+            raise
         logger.debug(f"_role_subject_to_rls: Error: {e}", exc_info=e)
         return False
 
@@ -1349,6 +1353,8 @@ def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger:
     except psycopg.errors.QueryCanceled:
         raise
     except Exception as e:
+        if cursor.connection.broken:
+            raise
         # This COUNT(*) is a best-effort estimate for progress reporting and partition sizing.
         # It shares its FROM/WHERE with the real extraction query, so any genuine problem
         # (missing column, unpopulated materialized view, permissions, bad incremental field)
@@ -1657,6 +1663,8 @@ def _get_table(
                         probed_scales[col_name] = row[2 * i]
                         probed_int_digits[col_name] = row[2 * i + 1]
         except Exception as e:
+            if cursor.connection.broken:
+                raise
             # Probe is best-effort. Fall back to DEFAULT_NUMERIC_SCALE and let the downstream
             # `_process_batch` fallback chain infer the right type at row-fetching time.
             logger.warning(
@@ -1977,6 +1985,16 @@ def postgres_source(
                         logger.debug("Checking duplicate primary keys...")
                         has_duplicate_primary_keys = _has_duplicate_primary_keys(
                             cursor, schema, table_name, primary_keys, logger
+                        )
+
+                    # A probe whose connection was culled mid-savepoint leaves psycopg's transaction
+                    # counter leaked (Transaction.__exit__ early-returns without decrementing when
+                    # pgconn.status != OK). The implicit commit on `with connection:` exit then raises
+                    # the misleading "Explicit commit() forbidden within a Transaction context". Surface
+                    # the real, retryable cause instead.
+                    if connection.broken:
+                        raise psycopg.OperationalError(
+                            f"connection to server was lost during schema discovery for {schema}.{table_name}"
                         )
                 except psycopg.errors.QueryCanceled:
                     if should_use_incremental_field:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -209,6 +209,9 @@ class TestIsConnectionDroppedError:
             psycopg.errors.ProtocolViolation("server conn crashed?"),
             psycopg.OperationalError("server closed the connection unexpectedly"),
             psycopg.OperationalError("connection to server was lost"),
+            # Change 1's synthesized message — must stay classified as retryable so the
+            # culled-mid-discovery case retries instead of surfacing as a hard failure.
+            psycopg.OperationalError("connection to server was lost during schema discovery for public.events"),
             psycopg.OperationalError("connection to server was closed unexpectedly"),
             psycopg.OperationalError("consuming input failed: EOF detected"),
             psycopg.OperationalError("terminating connection due to administrator command"),
@@ -1365,6 +1368,7 @@ class TestGetRowsToSync:
         logger = structlog.get_logger()
 
         cursor = mock.MagicMock()
+        cursor.connection.broken = False
         cursor.execute.side_effect = Exception("temporary file size exceeds temp_file_limit (1048576kB)")
         count_query = _build_count_query("public", "users", False, None, None, None)
 
@@ -1374,6 +1378,61 @@ class TestGetRowsToSync:
 
         # The temp-file signal is actionable, so it propagates rather than being swallowed.
         mock_capture.assert_not_called()
+
+
+class TestProbesReraiseOnBrokenConnection:
+    def _mock_cursor(self, *, broken: bool, error: Exception):
+        cursor = mock.MagicMock()
+        cursor.connection.broken = broken
+        cursor.execute.side_effect = error
+        return cursor
+
+    # Each probe has a different signature — wrap them so the test only varies the cursor.
+    @pytest.fixture(
+        params=[
+            (
+                "_get_table_chunk_size",
+                lambda cursor, logger: _get_table_chunk_size(cursor, sql.SQL("SELECT 1").format(), logger),
+                DEFAULT_CHUNK_SIZE,
+            ),
+            (
+                "_get_rows_to_sync",
+                lambda cursor, logger: _get_rows_to_sync(cursor, sql.SQL("SELECT COUNT(*)").format(), logger),
+                0,
+            ),
+            (
+                "_role_subject_to_rls",
+                lambda cursor, logger: _role_subject_to_rls(cursor, "public", "events", logger),
+                False,
+            ),
+        ],
+        ids=["chunk_size", "rows_to_sync", "rls"],
+    )
+    def probe(self, request):
+        return request.param
+
+    def test_reraises_when_connection_broken(self, probe):
+        _name, run_probe, _default = probe
+        logger = structlog.get_logger()
+        cursor = self._mock_cursor(
+            broken=True,
+            error=psycopg.OperationalError("server closed the connection unexpectedly"),
+        )
+
+        # The broken path must re-raise before reaching any best-effort fallback (logging,
+        # capture_exception, etc.).
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture:
+            with pytest.raises(psycopg.OperationalError, match="server closed the connection unexpectedly"):
+                run_probe(cast(Any, cursor), logger)
+            capture.assert_not_called()
+
+    def test_returns_default_when_connection_healthy(self, probe):
+        _name, run_probe, default = probe
+        logger = structlog.get_logger()
+        cursor = self._mock_cursor(broken=False, error=Exception("some unrelated probe failure"))
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception"):
+            assert run_probe(cast(Any, cursor), logger) == default
 
 
 class TestPartitionedTableChunkSizing:


### PR DESCRIPTION
## Problem

Postgres (incl. Supabase) data-warehouse syncs can get permanently stuck on certain
tables with a misleading error:

```
ProgrammingError: Explicit commit() forbidden within a Transaction context.
```

The error is a **symptom that masks the real failure** — a source connection dropped
during schema-discovery probing — so it reads like a double-commit bug in the connector
when the underlying cause is a culled connection.

Root cause: in `postgres_source()`, schema-discovery probes run inside savepoints
(`with cursor.connection.transaction(...)`) within an outer `with connection:` block.
If the source connection is culled mid-probe (e.g. an idle-in-transaction / PgBouncer
cull on a large table), psycopg3's `Transaction.__exit__` early-returns without
decrementing its internal transaction counter when the connection is no longer `OK`,
leaking the counter. The probe helpers' defensive `except Exception: return <default>`
handlers then swallow the real `OperationalError`, so discovery limps to a clean end of
the `with connection:` block — whose implicit auto-commit trips the leaked-counter guard
and raises the misleading `ProgrammingError`. Because that guard runs before any I/O, the
genuine dropped-connection cause never surfaces, and the failure recurs every sync (the
leak is fresh each run), so manual reloads don't help.

## Changes

Surface the real, retryable cause instead of the masked commit error, in
`posthog/temporal/data_imports/sources/postgres/postgres.py`:

- **Stop swallowing a dead connection.** The four schema-discovery probe helpers
  (`_get_table_chunk_size`, `_role_subject_to_rls`, `_get_rows_to_sync`, and the
  numeric-scale probe in `_get_table`) now re-raise when `cursor.connection.broken`,
  rather than returning their best-effort default — so a dropped connection fails fast at
  the culprit probe instead of limping on.
- **Backstop guard.** At the end of the metadata phase, before the `with connection:`
  block auto-commits, raise a clear `psycopg.OperationalError` if the connection is broken.
  Its message reuses the existing dropped-connection wording so `_is_connection_dropped_error`
  classifies it as **transient/retryable** — the Temporal activity then retries the whole
  sync, which resumes cleanly.

No change to transaction semantics or the connection lifecycle — the fix only converts a
masked, non-actionable error into an honest, retryable one.

## How did you test this code?

I'm an agent (PostHog Code); I did not perform manual testing. Automated tests only, run
locally via `hogli test`:

- Added `TestProbesReraiseOnBrokenConnection` (mock-based, parametrized over the three
  signature-varying probes): asserts each probe re-raises the real `OperationalError` when
  `cursor.connection.broken` is `True` (and never reaches `capture_exception` on that path),
  and still returns its default on a healthy connection with an unrelated error.
- Added a case to `TestIsConnectionDroppedError` locking in that the backstop guard's
  synthesized message stays classified as retryable.
- **Verified the new tests fail against the pre-change source** (the probe re-raise
  assertions error with `DID NOT RAISE` before the fix), then pass after — confirming they
  guard the new behavior rather than tautologically passing.
- Full `test_postgres.py` suite green after the change; ruff + ty checks clean.

These are unit tests at the helper boundary (consistent with the file's existing
per-helper test classes); they verify the fix's mechanism, not an end-to-end reproduction
of the psycopg counter leak, which is timing-dependent and only faithfully reproducible
against a live backend culled mid-savepoint.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal pipeline reliability fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and implemented with PostHog Code (Claude Opus). The reported error pointed at
SQLAlchemy/dlt, but tracing it through the installed psycopg3 source showed the Postgres
source uses raw psycopg3, and the error string only originates from psycopg's `_commit_gen`
guard on a leaked transaction counter. Confirmed the leak path (`Transaction.__exit__`
skipping the decrement when the connection isn't `OK`) and the swallow-to-clean-exit chain
that lets it reach the outer auto-commit.

Considered a deeper refactor (a shared probe wrapper, or replacing `with connection:` with
explicit transaction handling) but chose the minimal guard approach: it addresses the
observed failure at the points where the leak is created and reaches the commit, without
touching connection-lifecycle semantics or functions outside this fix's scope. A `/simplify`
pass trimmed a redundant test docstring; a noted follow-up for `/code-review` is whether
`_explain_query`'s own savepoint swallow warrants the same guard (currently backstopped by
the final broken-connection check).
