### PR TITLE
fix(linear): retry HTTP 429 rate limits instead of failing the sync

### DIFF
--- a/posthog/temporal/data_imports/sources/linear/linear.py
+++ b/posthog/temporal/data_imports/sources/linear/linear.py
@@ -60,6 +60,13 @@ def _make_paginated_request(
         if response.status_code >= 500:
             raise LinearRetryableError(f"Linear: server error {response.status_code}")
 
+        # Linear answers HTTP-level rate limits with a 429 and an HTML body (not GraphQL JSON),
+        # so this must be caught before the JSON parse below. Otherwise response.json() raises a
+        # JSONDecodeError that escalates to a plain, non-retryable Exception instead of being
+        # retried with backoff like the GraphQL-level RATELIMITED case.
+        if response.status_code == 429:
+            raise LinearRetryableError("Linear: rate limited (429)")
+
         try:
             payload = response.json()
         except Exception:

--- a/posthog/temporal/data_imports/sources/linear/test_linear.py
+++ b/posthog/temporal/data_imports/sources/linear/test_linear.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.linear.linear import (
     LinearResumeConfig,
+    LinearRetryableError,
     _make_paginated_request,
     linear_source,
 )
@@ -26,6 +27,17 @@ def _make_response(nodes: list[dict[str, Any]], has_next_page: bool, end_cursor:
             }
         }
     }
+    return response
+
+
+def _make_rate_limited_response() -> MagicMock:
+    """Mimic Linear's HTTP-level 429: an HTML body that fails JSON parsing."""
+    response = MagicMock()
+    response.status_code = 429
+    response.ok = False
+    response.reason = "Too Many Requests"
+    response.text = "<!DOCTYPE html><html><head><title>Rate limited</title></head></html>"
+    response.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
     return response
 
 
@@ -149,6 +161,57 @@ class TestMakePaginatedRequest:
 
         manager.save_state.assert_not_called()
         assert session.post.call_count == 1
+
+    @patch("time.sleep", return_value=None)
+    @patch("posthog.temporal.data_imports.sources.linear.linear.make_tracked_session")
+    def test_http_429_is_retried_then_succeeds(self, mock_session_cls: MagicMock, _mock_sleep: MagicMock) -> None:
+        # Linear returns an HTML 429 page that fails JSON parsing. It must be retried with backoff,
+        # not surfaced as a non-retryable JSONDecodeError/Exception.
+        session = MagicMock()
+        session.post.side_effect = [
+            _make_rate_limited_response(),
+            _make_response([{"id": "a"}], False, None),
+        ]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager()
+        logger = MagicMock()
+
+        pages = list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert pages == [[{"id": "a"}]]
+        assert session.post.call_count == 2
+
+    @patch("time.sleep", return_value=None)
+    @patch("posthog.temporal.data_imports.sources.linear.linear.make_tracked_session")
+    def test_persistent_http_429_raises_retryable_error(
+        self, mock_session_cls: MagicMock, _mock_sleep: MagicMock
+    ) -> None:
+        session = MagicMock()
+        session.post.side_effect = [_make_rate_limited_response() for _ in range(5)]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager()
+        logger = MagicMock()
+
+        with pytest.raises(LinearRetryableError):
+            list(
+                _make_paginated_request(
+                    access_token="tok",
+                    endpoint_name="issues",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert session.post.call_count == 5
 
 
 class TestLinearSource:


### PR DESCRIPTION
## Problem

The `linear` data-warehouse import source intermittently fails an entire sync run when Linear rate-limits us.

Linear returns HTTP-level rate limits as a **429 with an HTML "Rate limited" page** (not GraphQL JSON). The paginator only treated two cases as retryable:

- `status_code >= 500`
- GraphQL responses carrying an `extensions.code == "RATELIMITED"` (which requires a JSON body)

A raw HTTP 429 matched neither. The flow was: 429 → `status_code >= 500` is false → `response.json()` raises `JSONDecodeError` on the HTML body → `not response.ok` → a plain `Exception` is raised. Because the `@retry` decorator only retries `LinearRetryableError`, this transient rate limit was surfaced as a fatal error and the sync failed instead of backing off.

Observed in error tracking (exception chain `JSONDecodeError` → `Exception: 429 Client Error: Too Many Requests (Linear API: <!DOCTYPE html> … Rate limited …)`), raised at `posthog/temporal/data_imports/sources/linear/linear.py:67`.

## Changes

Classify HTTP `429` as `LinearRetryableError` **before** the JSON parse, so the existing retry/backoff (`wait_exponential_jitter`, 5 attempts) handles it — the same way the GraphQL-level `RATELIMITED` case is already treated. A 429 is a transient rate limit, so it stays retryable rather than being added to `get_non_retryable_errors`.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- `test_http_429_is_retried_then_succeeds` — an HTML 429 followed by a success page is retried and yields data (2 POSTs).
- `test_persistent_http_429_raises_retryable_error` — a persistent 429 reraises `LinearRetryableError` (not a `JSONDecodeError`/plain `Exception`) after exhausting attempts.

`uv run python -m pytest posthog/temporal/data_imports/sources/linear/test_linear.py` → 12 passed. `ruff check` and `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Linear import source. Investigated the captured stack trace and confirmed the failure originates in this source's `execute()` (the chained `JSONDecodeError` → `Exception` at `linear.py:67`). Weighed user/upstream-error (extend `NonRetryableErrors`) vs. fixable bug: a 429 is a transient rate limit that should be retried with backoff, not made terminal — so this is a code fix, not a non-retryable classification. Kept the change minimal: one status-code guard mirroring the existing 5xx and GraphQL-RATELIMITED handling, plus regression tests at the paginator layer.

Tools: Claude Code; PostHog error-tracking MCP (`query-error-tracking-issue`, `query-error-tracking-issue-events`).
