### PR TITLE
fix(postgres): don't report unsupported row_security_active() to error tracking

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -565,6 +565,12 @@ def _rls_active_from_conn(
                 if display_name is not None:
                     result[display_name] = bool(rls_active)
             return result
+    except psycopg.errors.UndefinedFunction:
+        # row_security_active() is a Postgres-specific catalog function. Wire-compatible backends
+        # we also support as sources (CockroachDB, DuckDB/Duckgres) don't implement it, so a missing
+        # function here is an expected limitation of the backend, not a bug — skip the RLS warning
+        # rather than reporting it to error tracking on every discovery.
+        return {}
     except Exception as e:
         capture_exception(e)
         return {}

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2617,6 +2617,43 @@ class _DjangoBackedCursorCtx:
         return False
 
 
+class _UnsupportedRlsCursor:
+    """Wraps a real cursor but raises UndefinedFunction for the row_security_active query.
+
+    Mimics CockroachDB / DuckDB, which are wire-compatible but don't implement that catalog
+    function. Discovery queries still run against the real cursor.
+    """
+
+    def __init__(self, dj_cursor):
+        self._dj_cursor = dj_cursor
+
+    def execute(self, query, *args, **kwargs):
+        if "row_security_active" in str(query):
+            raise psycopg.errors.UndefinedFunction("unknown function: row_security_active()")
+        return self._dj_cursor.execute(query, *args, **kwargs)
+
+    def fetchone(self):
+        return self._dj_cursor.fetchone()
+
+    def fetchall(self):
+        return self._dj_cursor.fetchall()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class _UnsupportedRlsConnection:
+    def __init__(self, dj_cursor):
+        self._dj_cursor = dj_cursor
+        self.closed = False
+
+    def cursor(self, *args, **kwargs):
+        return _UnsupportedRlsCursor(self._dj_cursor)
+
+
 class TestIteratePartitionsRealDb:
     @pytest.mark.django_db
     def test_yields_all_rows(self):
@@ -2712,6 +2749,20 @@ class TestRlsDetectionRealDb:
                 assert result == {"test_rls_param": expected}
             finally:
                 dj_cursor.execute("RESET ROLE")
+
+    @pytest.mark.django_db
+    def test_rls_active_from_conn_ignores_unsupported_function(self):
+        # CockroachDB / DuckDB are wire-compatible Postgres backends we support as sources, but
+        # they don't implement row_security_active(). That benign UndefinedFunction must not be
+        # reported to error tracking — discovery proceeds, just without an RLS warning.
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_rls_unsupported (id SERIAL PRIMARY KEY)")
+            with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
+                result = _rls_active_from_conn(
+                    cast(Any, _UnsupportedRlsConnection(dj_cursor)), "public", ["test_rls_unsupported"]
+                )
+            assert result == {}
+            capture_mock.assert_not_called()
 
     @pytest.mark.django_db
     def test_rls_active_from_conn_runs_without_schema_or_names(self):


### PR DESCRIPTION
## Problem

Error tracking surfaced a high-frequency `UndefinedFunction: unknown function: row_security_active()` originating in `posthog/temporal/data_imports/sources/postgres/postgres.py` (`_rls_active_from_conn`, the top in-app frame). The affected source connects to a **CockroachDB** backend over the Postgres wire protocol.

`_rls_active_from_conn` runs a catalog query using `row_security_active()` to power the advisory row-level-security warning in the table picker. That function is Postgres-specific. Wire-compatible backends we also support as Postgres sources — CockroachDB and DuckDB/Duckgres — don't implement it and raise `UndefinedFunction` (SQLSTATE 42883).

The exception was already caught and the function returned `{}`, so schema discovery continued correctly (just without an RLS warning). The bug is that the broad `except Exception` branch called `capture_exception(e)`, reporting this **expected** backend limitation to error tracking on every discovery — dozens of occurrences across many syncs.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019eb1cd-0d6b-7ea3-9cbf-704a0e58402d

## Changes

- In `_rls_active_from_conn`, catch `psycopg.errors.UndefinedFunction` before the generic handler and return `{}` without capturing. This mirrors the sibling `_role_subject_to_rls`, which already handles the same call gracefully (debug-log only, no capture).

This is intentionally **not** a `NonRetryableErrors` change: the error never propagates out of discovery or causes a retry — it was purely noise in error tracking. Genuinely unexpected errors are still captured.

## How did you test this code?

I'm an agent. I added a regression test (`test_rls_active_from_conn_ignores_unsupported_function`) that drives `_rls_active_from_conn` through a connection shim which raises `UndefinedFunction` for the `row_security_active` query (mimicking CockroachDB/DuckDB) and asserts the result is `{}` and `capture_exception` is **not** called.

The RLS tests require a real Postgres (`@pytest.mark.django_db`), which wasn't available in my sandbox, so I could not execute them here — I verified the suite collects cleanly, that `psycopg.errors.UndefinedFunction` is a valid exception subclass, and that `ruff check`/`ruff format` pass. CI runs the DB-backed tests.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the failing frame is `_rls_active_from_conn` at the `row_security_active(...)` query and that the backend is CockroachDB. Decided this is a fixable bug (benign error-reporting noise) rather than a retryability concern, since the error was already handled and discovery proceeds regardless. Scoped the fix to suppressing capture for the one expected-on-this-backend exception, leaving all other failures captured.
