### PR TITLE
fix(notion): honor long Retry-After on rate limits

### DIFF
--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -32,15 +32,13 @@ CHUNK_SIZE_BYTES = 100 * 1024 * 1024
 MAX_BLOCK_DEPTH = 2
 MAX_CHILD_PAGES_PER_PARENT = 50
 
-# Cap for our own exponential backoff (a guess) on 5xx/transient errors.
 MAX_RETRY_WAIT_SECONDS = 30.0
-# Cap for an explicit `Retry-After` from Notion. This is a server instruction, not a guess, so we
-# honor it up to a much higher ceiling: Notion can return windows of several minutes (observed
-# values north of 300s), and capping those at MAX_RETRY_WAIT_SECONDS guaranteed every retry re-hit
-# the 429 before the window cleared, so the error always escaped and failed the sync. The source
-# iterator runs in a thread pool while an independent asyncio heartbeat task keeps the activity
-# alive, so a multi-minute blocking sleep here does not trip the heartbeat timeout.
-MAX_RETRY_AFTER_WAIT_SECONDS = 600.0
+# Notion can ask us to back off for several minutes (observed Retry-After of ~420-460s) when a
+# token is sustained-rate-limited. Honor that header up to this higher ceiling instead of the 30s
+# exponential-backoff cap — otherwise our 5 capped retries (~2 min total) exhaust before the
+# rate-limit window clears, the error escapes, and the non-resumable blocks/comments stream is
+# restarted from scratch only to hit the same wall.
+MAX_RATE_LIMIT_RETRY_AFTER_SECONDS = 600.0
 
 
 class NotionRetryableError(Exception):
@@ -84,7 +82,7 @@ def _wait_strategy(retry_state: RetryCallState) -> float:
     # Honor Notion's Retry-After on 429s; fall back to exponential backoff otherwise.
     exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
     if isinstance(exc, NotionRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_AFTER_WAIT_SECONDS)
+        return min(exc.retry_after, MAX_RATE_LIMIT_RETRY_AFTER_SECONDS)
     return _wait_exponential(retry_state)
 
 

--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -32,7 +32,15 @@ CHUNK_SIZE_BYTES = 100 * 1024 * 1024
 MAX_BLOCK_DEPTH = 2
 MAX_CHILD_PAGES_PER_PARENT = 50
 
+# Cap for our own exponential backoff (a guess) on 5xx/transient errors.
 MAX_RETRY_WAIT_SECONDS = 30.0
+# Cap for an explicit `Retry-After` from Notion. This is a server instruction, not a guess, so we
+# honor it up to a much higher ceiling: Notion can return windows of several minutes (observed
+# values north of 300s), and capping those at MAX_RETRY_WAIT_SECONDS guaranteed every retry re-hit
+# the 429 before the window cleared, so the error always escaped and failed the sync. The source
+# iterator runs in a thread pool while an independent asyncio heartbeat task keeps the activity
+# alive, so a multi-minute blocking sleep here does not trip the heartbeat timeout.
+MAX_RETRY_AFTER_WAIT_SECONDS = 600.0
 
 
 class NotionRetryableError(Exception):
@@ -76,7 +84,7 @@ def _wait_strategy(retry_state: RetryCallState) -> float:
     # Honor Notion's Retry-After on 429s; fall back to exponential backoff otherwise.
     exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
     if isinstance(exc, NotionRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT_SECONDS)
+        return min(exc.retry_after, MAX_RETRY_AFTER_WAIT_SECONDS)
     return _wait_exponential(retry_state)
 
 

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -11,7 +11,7 @@ from tenacity import RetryCallState
 from posthog.temporal.data_imports.sources.notion.notion import (
     MAX_BLOCK_DEPTH,
     MAX_CHILD_PAGES_PER_PARENT,
-    MAX_RETRY_AFTER_WAIT_SECONDS,
+    MAX_RATE_LIMIT_RETRY_AFTER_SECONDS,
     NOTION_VERSION,
     NotionResumeConfig,
     NotionRetryableError,
@@ -194,14 +194,15 @@ class TestNotion:
         assert _wait_strategy(cast(RetryCallState, state)) == 3.0
 
     def test_wait_strategy_honors_long_retry_after(self) -> None:
-        # A multi-minute Retry-After (observed: 336s) must be honored in full, not clamped to the
-        # short exponential-backoff cap - clamping guaranteed every retry re-hit the 429.
-        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=336.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == 336.0
+        # Regression: under sustained rate limiting Notion returns a multi-minute Retry-After
+        # (observed ~460s). It must be waited out, not collapsed to the 30s exponential-backoff
+        # ceiling, or the in-request retries exhaust before the window clears and the sync fails.
+        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=460.0))
+        assert _wait_strategy(cast(RetryCallState, state)) == 460.0
 
     def test_wait_strategy_caps_retry_after(self) -> None:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=10_000.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_AFTER_WAIT_SECONDS
+        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RATE_LIMIT_RETRY_AFTER_SECONDS
 
     def test_comments_stream_respects_page_cap(self) -> None:
         # First call is the page search (one page, then done); every subsequent /v1/comments

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -11,7 +11,7 @@ from tenacity import RetryCallState
 from posthog.temporal.data_imports.sources.notion.notion import (
     MAX_BLOCK_DEPTH,
     MAX_CHILD_PAGES_PER_PARENT,
-    MAX_RETRY_WAIT_SECONDS,
+    MAX_RETRY_AFTER_WAIT_SECONDS,
     NOTION_VERSION,
     NotionResumeConfig,
     NotionRetryableError,
@@ -193,9 +193,15 @@ class TestNotion:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=3.0))
         assert _wait_strategy(cast(RetryCallState, state)) == 3.0
 
+    def test_wait_strategy_honors_long_retry_after(self) -> None:
+        # A multi-minute Retry-After (observed: 336s) must be honored in full, not clamped to the
+        # short exponential-backoff cap - clamping guaranteed every retry re-hit the 429.
+        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=336.0))
+        assert _wait_strategy(cast(RetryCallState, state)) == 336.0
+
     def test_wait_strategy_caps_retry_after(self) -> None:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=10_000.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_WAIT_SECONDS
+        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_AFTER_WAIT_SECONDS
 
     def test_comments_stream_respects_page_cap(self) -> None:
         # First call is the page search (one page, then done); every subsequent /v1/comments


### PR DESCRIPTION
## Problem

The Notion data-warehouse import source surfaces a recurring `NotionRetryableError` in error tracking:

```
NotionRetryableError: Notion rate limited: url=https://api.notion.com/v1/blocks/<id>/children, retry_after=460.0
```

Issue: [`019eae7a-839c-7d53-9792-2ddab2b4f903`](https://us.posthog.com/project/2/error_tracking/019eae7a-839c-7d53-9792-2ddab2b4f903) — 51 occurrences across 51 sources over ~2 days, actively firing. Top in-app frame is `_request` at `posthog/temporal/data_imports/sources/notion/notion.py:103`, reached from the blocks stream (`_blocks_stream` → `_iter_block_children` → `_request`).

This is a `429` rate-limit, so it is genuinely transient/upstream and must stay **retryable** — but the retry/backoff handling has a defect that turns a recoverable rate-limit into a hard sync failure:

- `_wait_strategy` honors Notion's `Retry-After` header, but caps the wait at `MAX_RETRY_WAIT_SECONDS = 30` (the exponential-backoff ceiling).
- Under sustained rate limiting Notion returns a multi-minute `Retry-After` (observed 421–460s). With `stop_after_attempt(5)`, the 5 attempts wait ≤30s each (~2 min total) — far short of the cooldown — so every attempt re-hits the 429 and the error escapes `_request`.
- It then propagates to the activity, gets logged to error tracking, and the **non-resumable** blocks/comments stream is restarted from scratch by the activity-level retry, hitting the same wall. Net effect: the sync fails and the issue keeps recurring.

Collapsing a genuine multi-minute cooldown to a 30s cap means it can never be waited out in-request.

## Changes

Honor Notion's `Retry-After` up to a dedicated, higher ceiling (`MAX_RATE_LIMIT_RETRY_AFTER_SECONDS = 600`) for rate-limit (429) responses, instead of the 30s exponential-backoff cap. The exponential-backoff cap still applies to non-rate-limit retryable errors (5xx, read timeouts). After waiting out the window, the next attempt succeeds rather than restarting the whole stream.

A longer in-request wait is safe here:
- The activity heartbeater (`Heartbeater._heartbeat_forever`) runs as an independent `asyncio` task on the activity event loop, while `_request` blocks in a `concurrent.futures` worker thread — so the 2-minute heartbeat timeout is not affected.
- `import_data_activity_sync`'s `start_to_close_timeout` is hours/weeks, so the bounded wait fits comfortably.

Scope is limited to this source's wait strategy — no change to global retry policy, and the error stays retryable (not added to `NonRetryableErrors`).

## How did you test this code?

I'm an agent; I did not perform manual testing. Automated only:

- Updated `posthog/temporal/data_imports/sources/notion/tests/test_notion.py`:
  - Added `test_wait_strategy_honors_long_retry_after` — a 460s `Retry-After` (the observed value) is waited out in full, not collapsed to 30s. This is the regression test that would have caught the bug.
  - Updated `test_wait_strategy_caps_retry_after` to assert the new 600s ceiling.
- Ran the full source test file: `28 passed`.
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Notion source. Investigation:

- Confirmed the issue in error tracking (stack trace, exception type, frequency, affected sources) and verified the failure originates in this source's code, not in serialized log context.
- Read the source and the import pipeline to trace the call path and the activity-level retry/heartbeat/timeout configuration.
- Decision: this is a `429` rate-limit — transient/upstream, so **not** a `NonRetryableErrors` case. The fixable bug is the backoff handling capping `Retry-After` below Notion's real cooldown window. Verified the heartbeater is independent of the blocking worker thread before allowing a longer in-request wait.
