### PR TITLE
fix(postgres): stop reporting advisory RLS-check statement timeouts

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -565,6 +565,11 @@ def _rls_active_from_conn(
                 if display_name is not None:
                     result[display_name] = bool(rls_active)
             return result
+    except psycopg.errors.QueryCanceled:
+        # Advisory-only check: a statement timeout (slow/loaded source DB, or a low server-side
+        # `statement_timeout` on a pooler) just means we skip the RLS warning. It's expected and
+        # already handled by returning {}, so don't report it to error tracking as a spurious issue.
+        return {}
     except Exception as e:
         capture_exception(e)
         return {}

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2722,3 +2722,36 @@ class TestRlsDetectionRealDb:
             dj_cursor.execute("CREATE TABLE test_rls_noschema (id SERIAL PRIMARY KEY)")
             result = _rls_active_from_conn(cast(Any, _DjangoBackedConnection(dj_cursor)), "", None)
             assert "public.test_rls_noschema" in result
+
+    def test_rls_active_from_conn_swallows_statement_timeout_without_capturing(self):
+        # The RLS check is advisory: a statement timeout during discovery (seen on slow/loaded
+        # source DBs and poolers with a low server-side `statement_timeout`) must degrade to "no
+        # warning" without surfacing a spurious error-tracking issue.
+        class _TimingOutCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def execute(self, query, *args, **kwargs):
+                # Let `SET LOCAL statement_timeout` succeed; time out on the `SELECT version()`
+                # probe, mirroring the observed stack (_is_duckdb_connection).
+                if "version()" in str(query):
+                    raise psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+
+            def fetchone(self):
+                return None
+
+            def fetchall(self):
+                return []
+
+        class _TimingOutConnection:
+            def cursor(self, *args, **kwargs):
+                return _TimingOutCursor()
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
+            result = _rls_active_from_conn(cast(Any, _TimingOutConnection()), "public", ["test_rls_param"])
+
+        assert result == {}
+        mock_capture.assert_not_called()


### PR DESCRIPTION
## Problem

Error tracking surfaced a `QueryCanceled: canceling statement due to statement timeout` for the Postgres data-warehouse import source.

The stack originates in this source's discovery code:

```
_rls_active_from_conn  (postgres.py:537)
  └─ _get_discovered_tables  (postgres.py:380)
       └─ _is_duckdb_connection  (postgres.py:157)  ← SELECT version() times out
```

`_rls_active_from_conn` is the **advisory** row-level-security check that powers the "RLS is active on this table" warning in the source table picker. It runs a cheap `SELECT version()` probe during schema discovery. On a slow/loaded source database — or a connection pooler with a low server-side `statement_timeout` — that probe can be cancelled by the server.

The check is best-effort and **already degrades gracefully**: it catches the failure and returns `{}`, so discovery continues and the warning is simply omitted. The exception is `handled` — it never fails the import and never reaches the retry layer. The only problem is that its catch-all `except Exception` block unconditionally calls `capture_exception`, so an expected, non-actionable timeout shows up as a spurious error-tracking issue.

## Changes

Special-case `psycopg.errors.QueryCanceled` in `_rls_active_from_conn` to skip `capture_exception` and quietly return `{}`, while still capturing genuinely unexpected exceptions.

This is deliberately **not** added to `NonRetryableErrors`:

- The exception is swallowed inside the advisory check and never reaches the pipeline retry classifier, so a `NonRetryableErrors` entry would have no effect on this issue.
- A statement timeout is a transient/configuration condition. In the **sync** path it must remain retryable, and the sibling helpers (`_get_rows_to_sync`, `_role_subject_to_rls`, `_get_partition_settings`, etc.) deliberately re-raise `QueryCanceled` for exactly that reason. This change does not touch that path.

## How did you test this code?

I'm an agent. I added a regression test (`test_rls_active_from_conn_swallows_statement_timeout_without_capturing`) that drives `_rls_active_from_conn` with a fake connection whose `SELECT version()` probe raises `QueryCanceled`, and asserts the function returns `{}` **and** does not call `capture_exception`. It fails against the old behavior and passes with the fix.

Automated tests I ran locally (the new test needs no database and passes; the pre-existing real-DB tests in the class error out only because this sandbox has no Postgres host):

```
python -m pytest "posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestRlsDetectionRealDb::test_rls_active_from_conn_swallows_statement_timeout_without_capturing"
# 1 passed
```

`ruff check` and `ruff format` pass on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres import source. Pulled the full stack trace and a representative event via the PostHog error-tracking tools, confirmed the failure genuinely originates under `posthog/temporal/data_imports/sources/postgres/`, and read the implementation end to end.

Decision: the event is `handled` (already caught and degraded to `return {}`), so this is noisy reporting rather than a pipeline failure — a fixable bug, not a `NonRetryableErrors` case. Scoped the fix to suppressing `capture_exception` for `QueryCanceled` in the advisory check only, leaving the retryable sync-path behavior untouched. Added a regression test at the same layer as the fix.
