### PR TITLE
fix(postgres): treat exhausted recovery-conflict retries as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -188,6 +188,22 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "SSLRequiredError": None,
             "SSL/TLS connection is required": None,
             "Could not establish session to SSH gateway": None,
+            # `offset_chunking` retries a Postgres standby recovery conflict ("canceling statement
+            # due to conflict with recovery") 30 times in-process with backoff + chunk-size
+            # reduction before raising this. The conflict comes from the customer's read replica
+            # applying WAL that removes row versions our long-running read still needs
+            # (max_standby_streaming_delay exceeded). Once those in-process retries are exhausted the
+            # condition is sustained, not a transient blip — retrying the whole activity just
+            # re-reads from offset 0 into the same wall, so stop and surface an actionable message.
+            # Matched substring excludes the volatile retry count and is distinct from the
+            # connection-dropped abort ("successive connection-dropped errors"), which stays retryable.
+            "successive SerializationFailure errors. Aborting.": (
+                "PostHog repeatedly hit Postgres recovery conflicts while reading from your read replica "
+                '("canceling statement due to conflict with recovery"). This happens when the replica must '
+                "apply changes from the primary that remove rows the sync is still reading. Increase "
+                "max_standby_streaming_delay on the replica, enable hot_standby_feedback, or point the "
+                "connection at the primary database, then re-enable the sync."
+            ),
             "DiskFull": "Source database ran out of disk space. Free up disk space on your database server or add an index on your incremental field to reduce temp file usage.",
             "No space left on device": "Source database ran out of disk space. Free up disk space on your database server or add an index on your incremental field to reduce temp file usage.",
             # Raised when a Postgres numeric value cannot be represented in any Delta-compatible

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -168,6 +168,33 @@ class TestPostgresSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Widened integer column error should be non-retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Hit 30 successive SerializationFailure errors. Aborting.",
+            "Exception: Hit 30 successive SerializationFailure errors. Aborting.",
+        ],
+    )
+    def test_exhausted_recovery_conflict_retries_are_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Exhausted recovery-conflict error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # A single recovery conflict is retried in-process; on its own it must stay retryable.
+            "canceling statement due to conflict with recovery",
+            "could not serialize access due to conflict with recovery",
+            # The connection-dropped abort is a separate, genuinely transient condition.
+            "Hit 10 successive connection-dropped errors. Aborting.",
+        ],
+    )
+    def test_recovery_conflict_related_transients_stay_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Transient error should remain retryable: {error_msg}"
+
 
 class TestIsConnectionDroppedError:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring failure in the Postgres data-warehouse import source: [ProtocolViolation / "canceling statement due to conflict with recovery"](https://us.posthog.com/project/2/error_tracking/019eb1ed-cf90-7373-9e00-0f4a44587e43).

Reading the full exception chain, the real terminating error is `Exception("Hit 30 successive SerializationFailure errors. Aborting.")`, raised by our own `offset_chunking` loop in `posthog/temporal/data_imports/sources/postgres/postgres.py`.

The underlying cause is a Postgres **standby recovery conflict** — `canceling statement due to conflict with recovery / User query might have needed to see row versions that must be removed`. This happens when a read replica has to apply WAL from the primary that removes row versions our long-running read still needs (`max_standby_streaming_delay` exceeded, `hot_standby_feedback` off). It is a condition on the **customer's read replica**, not our code.

`offset_chunking` already handles the transient case: it retries the conflicting chunk up to 30 times with escalating backoff and chunk-size reduction. Only after those in-process retries are exhausted does it raise the terminal `Exception`. That terminal error was **not** in the source's `NonRetryableErrors`, so Temporal kept retrying the whole activity (the captured failure was on attempt 6), each retry re-reading the table from offset 0 straight back into the same upstream wall.

## Changes

- Add the terminal abort message to `PostgresSource.get_non_retryable_errors()` with an actionable, public-safe message telling the user how to fix their replica (`max_standby_streaming_delay` / `hot_standby_feedback` / point at the primary), then re-enable the sync.
- Match on the stable substring `"successive SerializationFailure errors. Aborting."`, which:
  - excludes the volatile retry-count number, and
  - is distinct from the genuinely-transient connection-dropped abort (`"successive connection-dropped errors"`), which intentionally stays retryable.

### Decision: user/upstream vs. transient

A single recovery conflict is transient and is already retried in-process — it is **not** added to `NonRetryableErrors`. Only the *exhaustion* of those 30 in-process retries is classified non-retryable: by then the condition is sustained, retrying the activity restarts the whole table read into the same failure, and the only real remedy is replica-side configuration. This is the ambiguous-but-upstream case where stopping the retry loop and surfacing an actionable message is the safer, more useful behavior. Scope is limited to this one error; global retry policy is unchanged.

## How did you test this code?

I'm an agent (Claude Code via PostHog Code tools). Automated tests only — no manual testing:

- Extended `TestPostgresSourceNonRetryableErrors` in `test_postgres.py`:
  - `test_exhausted_recovery_conflict_retries_are_non_retryable` — the terminal message is recognised as non-retryable.
  - `test_recovery_conflict_related_transients_stay_retryable` — a bare `conflict with recovery` message and the connection-dropped abort remain retryable (guards against over-widening).
- Ran `pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors` → 19 passed.
- `ruff check` and `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Used the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the full exception chain and confirm the failure originates in `sources/postgres/`, then traced `offset_chunking`'s retry loop.

Decision history: considered (a) leaving it retryable as a transient infra error, (b) reworking the retry/backoff logic, and (c) classifying the exhausted-retry abort as non-retryable. Chose (c): the in-process retries already cover the transient case, and once they are exhausted the upstream replica condition is sustained, so Temporal-level retries only re-read the table into the same wall. Kept the change minimal and mirrored the existing `NonRetryableErrors` pattern (Stripe reference). Verified the matched substring won't catch the sibling connection-dropped abort, which must stay retryable.

Agent-authored — requires human review.
