### PR TITLE
fix(notion): honor full Retry-After on rate limits

### DIFF
--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -34,12 +34,14 @@ MAX_CHILD_PAGES_PER_PARENT = 50
 
 MAX_RETRY_WAIT_SECONDS = 30.0
 
-# Upper bound for honoring Notion's server-provided Retry-After on 429s. Notion can ask us to wait
-# several minutes when a workspace is heavily throttled; capping below the requested value just
-# guarantees the retry fires while still rate limited and burns the attempt. Waiting it out in-process
-# is safe: the source generator runs on a worker thread while the activity's heartbeater keeps ticking
-# in the event loop, and the activity's start_to_close_timeout is far larger than this bound.
-MAX_RETRY_AFTER_WAIT_SECONDS = 900.0
+# Notion returns large Retry-After values (we've observed ~460s) when an integration is sustained
+# rate limited. Honor them up to this bound rather than clipping to the 30s exponential-backoff cap:
+# the import activity heartbeats from an independent background task, so a long wait in the request
+# thread does not risk the activity's heartbeat timeout. Clipping to 30s meant we retried while
+# Notion was still rate limiting — exhausting the retries, failing the sync, and hammering an API
+# that asked us to back off (which only prolongs the limit). Honoring the full Retry-After lets the
+# window clear so the next attempt succeeds.
+MAX_RETRY_AFTER_WAIT_SECONDS = 600.0
 
 
 class NotionRetryableError(Exception):
@@ -80,7 +82,8 @@ _wait_exponential = wait_exponential_jitter(initial=1, max=MAX_RETRY_WAIT_SECOND
 
 
 def _wait_strategy(retry_state: RetryCallState) -> float:
-    # Honor Notion's Retry-After on 429s; fall back to exponential backoff otherwise.
+    # Honor Notion's Retry-After on 429s (bounded by MAX_RETRY_AFTER_WAIT_SECONDS); fall back to
+    # exponential backoff otherwise.
     exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
     if isinstance(exc, NotionRetryableError) and exc.retry_after is not None:
         return min(exc.retry_after, MAX_RETRY_AFTER_WAIT_SECONDS)

--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -33,14 +33,13 @@ MAX_BLOCK_DEPTH = 2
 MAX_CHILD_PAGES_PER_PARENT = 50
 
 MAX_RETRY_WAIT_SECONDS = 30.0
-# Notion's Retry-After on a 429 tells us exactly when its rate-limit window reopens, and under
-# sustained load it is frequently well above the exponential-backoff cap (hundreds of seconds).
-# Honor it up to a generous bound instead of retrying early into a window we know is still closed
-# — capping it at MAX_RETRY_WAIT_SECONDS burned every attempt and surfaced the 429 as a failed
-# sync. The activity's liveness heartbeat runs on its own ~4s timer (independent of this thread),
-# so a long in-request sleep does not risk a heartbeat timeout, and the resumable import activity
-# has a week-long start-to-close timeout.
-MAX_RETRY_AFTER_WAIT_SECONDS = 300.0
+
+# Upper bound for honoring Notion's server-provided Retry-After on 429s. Notion can ask us to wait
+# several minutes when a workspace is heavily throttled; capping below the requested value just
+# guarantees the retry fires while still rate limited and burns the attempt. Waiting it out in-process
+# is safe: the source generator runs on a worker thread while the activity's heartbeater keeps ticking
+# in the event loop, and the activity's start_to_close_timeout is far larger than this bound.
+MAX_RETRY_AFTER_WAIT_SECONDS = 900.0
 
 
 class NotionRetryableError(Exception):

--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -33,6 +33,14 @@ MAX_BLOCK_DEPTH = 2
 MAX_CHILD_PAGES_PER_PARENT = 50
 
 MAX_RETRY_WAIT_SECONDS = 30.0
+# Notion's Retry-After on a 429 tells us exactly when its rate-limit window reopens, and under
+# sustained load it is frequently well above the exponential-backoff cap (hundreds of seconds).
+# Honor it up to a generous bound instead of retrying early into a window we know is still closed
+# — capping it at MAX_RETRY_WAIT_SECONDS burned every attempt and surfaced the 429 as a failed
+# sync. The activity's liveness heartbeat runs on its own ~4s timer (independent of this thread),
+# so a long in-request sleep does not risk a heartbeat timeout, and the resumable import activity
+# has a week-long start-to-close timeout.
+MAX_RETRY_AFTER_WAIT_SECONDS = 300.0
 
 
 class NotionRetryableError(Exception):
@@ -76,7 +84,7 @@ def _wait_strategy(retry_state: RetryCallState) -> float:
     # Honor Notion's Retry-After on 429s; fall back to exponential backoff otherwise.
     exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
     if isinstance(exc, NotionRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_WAIT_SECONDS)
+        return min(exc.retry_after, MAX_RETRY_AFTER_WAIT_SECONDS)
     return _wait_exponential(retry_state)
 
 

--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -33,15 +33,13 @@ MAX_BLOCK_DEPTH = 2
 MAX_CHILD_PAGES_PER_PARENT = 50
 
 MAX_RETRY_WAIT_SECONDS = 30.0
-
-# Notion returns large Retry-After values (we've observed ~460s) when an integration is sustained
-# rate limited. Honor them up to this bound rather than clipping to the 30s exponential-backoff cap:
-# the import activity heartbeats from an independent background task, so a long wait in the request
-# thread does not risk the activity's heartbeat timeout. Clipping to 30s meant we retried while
-# Notion was still rate limiting — exhausting the retries, failing the sync, and hammering an API
-# that asked us to back off (which only prolongs the limit). Honoring the full Retry-After lets the
-# window clear so the next attempt succeeds.
-MAX_RETRY_AFTER_WAIT_SECONDS = 600.0
+# Notion can ask us to back off for several minutes via Retry-After under sustained load (values
+# of 5+ minutes are common). Honor that instruction up to this bound instead of retrying early and
+# getting throttled again — retrying inside the penalty window just burns attempts and can extend
+# the penalty. Blocking this long is safe: the import activity has a week-long timeout and
+# heartbeats on an independent timer, so a waiting request won't trip the heartbeat. The bound is a
+# backstop against a pathologically large Retry-After.
+MAX_RETRY_AFTER_SECONDS = 600.0
 
 
 class NotionRetryableError(Exception):
@@ -82,11 +80,10 @@ _wait_exponential = wait_exponential_jitter(initial=1, max=MAX_RETRY_WAIT_SECOND
 
 
 def _wait_strategy(retry_state: RetryCallState) -> float:
-    # Honor Notion's Retry-After on 429s (bounded by MAX_RETRY_AFTER_WAIT_SECONDS); fall back to
-    # exponential backoff otherwise.
+    # Honor Notion's Retry-After on 429s; fall back to exponential backoff otherwise.
     exc = retry_state.outcome.exception() if retry_state.outcome is not None else None
     if isinstance(exc, NotionRetryableError) and exc.retry_after is not None:
-        return min(exc.retry_after, MAX_RETRY_AFTER_WAIT_SECONDS)
+        return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS)
     return _wait_exponential(retry_state)
 
 

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -193,12 +193,11 @@ class TestNotion:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=3.0))
         assert _wait_strategy(cast(RetryCallState, state)) == 3.0
 
-    def test_wait_strategy_honors_retry_after_beyond_exponential_cap(self) -> None:
-        # Notion routinely returns Retry-After windows of hundreds of seconds when throttling.
-        # We must wait the full window rather than retrying early into a window that is still
-        # closed (which previously exhausted every attempt and surfaced the 429 as a failed sync).
-        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=196.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == 196.0
+    def test_wait_strategy_honors_large_retry_after_in_full(self) -> None:
+        # Notion routinely asks for several-minute waits when throttling hard; capping below the
+        # requested value would fire the retry while still rate limited and waste the attempt.
+        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=625.0))
+        assert _wait_strategy(cast(RetryCallState, state)) == 625.0
 
     def test_wait_strategy_caps_retry_after(self) -> None:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=10_000.0))

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -193,11 +193,13 @@ class TestNotion:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=3.0))
         assert _wait_strategy(cast(RetryCallState, state)) == 3.0
 
-    def test_wait_strategy_honors_large_retry_after_in_full(self) -> None:
-        # Notion routinely asks for several-minute waits when throttling hard; capping below the
-        # requested value would fire the retry while still rate limited and waste the attempt.
-        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=625.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == 625.0
+    def test_wait_strategy_honors_large_retry_after(self) -> None:
+        # Regression: a multi-minute Retry-After (as Notion returns under sustained rate limiting,
+        # e.g. the observed 459s on /v1/comments) must be honored in full, not clipped to the 30s
+        # exponential-backoff cap. Clipping made us retry while still rate limited, exhaust attempts,
+        # and fail the sync.
+        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=459.0))
+        assert _wait_strategy(cast(RetryCallState, state)) == 459.0
 
     def test_wait_strategy_caps_retry_after(self) -> None:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=10_000.0))

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -11,7 +11,7 @@ from tenacity import RetryCallState
 from posthog.temporal.data_imports.sources.notion.notion import (
     MAX_BLOCK_DEPTH,
     MAX_CHILD_PAGES_PER_PARENT,
-    MAX_RETRY_WAIT_SECONDS,
+    MAX_RETRY_AFTER_WAIT_SECONDS,
     NOTION_VERSION,
     NotionResumeConfig,
     NotionRetryableError,
@@ -193,9 +193,16 @@ class TestNotion:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=3.0))
         assert _wait_strategy(cast(RetryCallState, state)) == 3.0
 
+    def test_wait_strategy_honors_retry_after_beyond_exponential_cap(self) -> None:
+        # Notion routinely returns Retry-After windows of hundreds of seconds when throttling.
+        # We must wait the full window rather than retrying early into a window that is still
+        # closed (which previously exhausted every attempt and surfaced the 429 as a failed sync).
+        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=196.0))
+        assert _wait_strategy(cast(RetryCallState, state)) == 196.0
+
     def test_wait_strategy_caps_retry_after(self) -> None:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=10_000.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_WAIT_SECONDS
+        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_AFTER_WAIT_SECONDS
 
     def test_comments_stream_respects_page_cap(self) -> None:
         # First call is the page search (one page, then done); every subsequent /v1/comments

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -11,7 +11,7 @@ from tenacity import RetryCallState
 from posthog.temporal.data_imports.sources.notion.notion import (
     MAX_BLOCK_DEPTH,
     MAX_CHILD_PAGES_PER_PARENT,
-    MAX_RETRY_AFTER_WAIT_SECONDS,
+    MAX_RETRY_AFTER_SECONDS,
     NOTION_VERSION,
     NotionResumeConfig,
     NotionRetryableError,
@@ -193,17 +193,16 @@ class TestNotion:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=3.0))
         assert _wait_strategy(cast(RetryCallState, state)) == 3.0
 
-    def test_wait_strategy_honors_large_retry_after(self) -> None:
-        # Regression: a multi-minute Retry-After (as Notion returns under sustained rate limiting,
-        # e.g. the observed 459s on /v1/comments) must be honored in full, not clipped to the 30s
-        # exponential-backoff cap. Clipping made us retry while still rate limited, exhaust attempts,
-        # and fail the sync.
-        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=459.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == 459.0
+    def test_wait_strategy_honors_multi_minute_retry_after(self) -> None:
+        # Notion routinely asks for several minutes under sustained load. Clamping that to the
+        # exponential ceiling retried inside the penalty window and exhausted attempts, so the
+        # full Retry-After must be honored.
+        state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=336.0))
+        assert _wait_strategy(cast(RetryCallState, state)) == 336.0
 
     def test_wait_strategy_caps_retry_after(self) -> None:
         state = _FakeRetryState(NotionRetryableError("rate limited", retry_after=10_000.0))
-        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_AFTER_WAIT_SECONDS
+        assert _wait_strategy(cast(RetryCallState, state)) == MAX_RETRY_AFTER_SECONDS
 
     def test_comments_stream_respects_page_cap(self) -> None:
         # First call is the page search (one page, then done); every subsequent /v1/comments


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `NotionRetryableError` from the Notion data-warehouse import source:

```
Notion rate limited: url=https://api.notion.com/v1/comments, retry_after=459.0
```

The failure originates in `posthog/temporal/data_imports/sources/notion/notion.py` (`_request`, the 429 handler) and fired repeatedly over a multi-day window.

The root cause is in the retry **backoff**, not in credentials or config — this is a transient/upstream rate limit, so it must stay retryable. When Notion is sustained rate limited it returns a large `Retry-After` (here ~460s). The wait strategy clipped that to the 30s exponential-backoff cap (`MAX_RETRY_WAIT_SECONDS`), so tenacity burned all 5 attempts in roughly 2 minutes **while Notion was still rate limiting**. The result:

- retries are exhausted, `NotionRetryableError` propagates and is captured to error tracking (the noise we observed),
- the import activity fails and Temporal retries the whole activity, re-hitting the same wall and re-capturing the error,
- we keep hammering an API that explicitly asked us to back off, which only prolongs the limit.

## Changes

Honor Notion's `Retry-After` in full, bounded by a new, generous cap (`MAX_RETRY_AFTER_WAIT_SECONDS = 600s`) instead of the 30s exponential-backoff cap. The 30s cap exists to keep waits short, but it is unnecessary for honored `Retry-After` values: the import activity heartbeats from an **independent background task** (`LivenessHeartbeater`, ~every 4s), so a long wait in the source-iterator request thread does **not** risk the activity's 2-minute heartbeat timeout. Honoring the full `Retry-After` lets the rate-limit window clear so the next attempt succeeds, rather than failing the sync.

The exponential-backoff cap for non-rate-limit retryable errors (5xx, read timeouts, connection resets) is unchanged at 30s. Scope is limited to this one wait-strategy decision — no change to global retry policy or which errors are retryable.

**Decision: this is a fixable backoff bug, not a non-retryable error.** Rate limiting is transient and must remain retryable; adding it to `NonRetryableErrors` would permanently stop syncing on a temporary condition.

## How did you test this code?

I am an agent. I ran the source's unit tests (`posthog/temporal/data_imports/sources/notion/tests/`) — 28 + 14 passing — plus ruff lint/format. Added a regression test asserting a 459s `Retry-After` is honored in full (the previous behavior clipped it to 30s), and updated the existing cap test to the new bound.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Notion import source. Investigated the stack (confirmed the raise at `notion.py:103`), then traced how the retryable error flows through the pipeline: tenacity wait strategy → source-iterator thread pool → `import_data_activity_sync` heartbeat (`LivenessHeartbeater`, independent background task) and the activity-level Temporal `RetryPolicy` (resumable source, 15 attempts). Key finding that justified the fix: because heartbeating is decoupled from the request thread, the 30s cap on honored `Retry-After` is unnecessary and actively harmful — it makes us give up before Notion's window clears. Considered and rejected adding the rate-limit string to `NonRetryableErrors` (would wrongly stop syncing on a transient condition) and bumping `MAX_RETRY_WAIT_SECONDS` directly (would also over-extend exponential backoff for 5xx).
