### PR TITLE
fix(intercom): walk companies via scroll API to avoid 10k page limit

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/intercom.py
@@ -260,23 +260,25 @@ def _conversation_parts_generator(
 
 
 def _iter_companies(session: Session) -> Iterator[dict[str, Any]]:
-    """Walk `POST /companies/list` page by page (no server-side timestamp
-    filter — full refresh)."""
-    body: dict[str, Any] = {"per_page": INTERCOM_ENDPOINTS["companies"].page_size}
-    next_url: str | None = None
+    """Walk every company via `GET /companies/scroll` (full refresh).
+
+    `POST /companies/list` is hard-capped at 10,000 companies — paging past
+    that ceiling makes Intercom return `400 bad_request: page limit reached,
+    please use scroll API`. The Scroll API has no such ceiling: each response
+    carries a `scroll_param` to feed into the next request, and the walk ends
+    when `data` comes back empty (the scroll param then expires). Only one
+    scroll can be open per workspace at a time — fine here, since this is the
+    sole scroll user and a schema never syncs concurrently with itself."""
+    scroll_param: str | None = None
     while True:
-        if next_url is None:
-            payload = _intercom_post(session, "/companies/list", body)
-        else:
-            # `pages.next` is a full URL carrying the page cursor in its query
-            # string. `/companies/list` is POST-only — a GET against it 404s —
-            # so we re-POST the same body to the next-page URL, mirroring how
-            # the REST next-URL paginator advances the other list endpoints
-            # (it preserves the POST method + body and only swaps the URL).
-            payload = _intercom_post(session, next_url, body)
-        yield from (payload.get("data") or [])
-        next_url = (payload.get("pages") or {}).get("next")
-        if not next_url:
+        params = {"scroll_param": scroll_param} if scroll_param else None
+        payload = _intercom_get(session, "/companies/scroll", params=params)
+        data = payload.get("data") or []
+        if not data:
+            return
+        yield from data
+        scroll_param = payload.get("scroll_param")
+        if not scroll_param:
             return
 
 

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
@@ -300,13 +300,15 @@ class TestSubstreamGenerators:
             list(_conversation_parts_generator(mock_session, "updated_at", None))
 
     def test_company_segments_skips_404_parent(self):
+        # The parent companies walk (scroll) and the per-company segments fetch
+        # both go through GET, so the calls interleave on `session.get` in order:
+        # scroll page -> segments(co1) -> segments(co2) -> empty scroll page.
         mock_session = mock.MagicMock()
-        mock_session.post.side_effect = [
-            _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "pages": {}}),
-        ]
         mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "scroll_param": "s1"}),
             _make_response(None, status_code=404, text="Not Found"),
             _make_response({"data": [{"id": "s2"}]}),
+            _make_response({"data": [], "scroll_param": "s2"}),
         ]
 
         segments = list(_company_segments_generator(mock_session))
@@ -316,10 +318,8 @@ class TestSubstreamGenerators:
 
     def test_company_segments_reraises_non_404(self):
         mock_session = mock.MagicMock()
-        mock_session.post.side_effect = [
-            _make_response({"data": [{"id": "co1"}], "pages": {}}),
-        ]
         mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
             _make_response(None, status_code=500, text="Server Error"),
         ]
 
@@ -328,12 +328,11 @@ class TestSubstreamGenerators:
 
     def test_company_segments_injects_company_id(self):
         mock_session = mock.MagicMock()
-        mock_session.post.side_effect = [
-            _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "pages": {}}),
-        ]
         mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}, {"id": "co2"}], "scroll_param": "s1"}),
             _make_response({"data": [{"id": "s1"}]}),
             _make_response({"data": [{"id": "s2"}, {"id": "s3"}]}),
+            _make_response({"data": [], "scroll_param": "s2"}),
         ]
 
         segments = list(_company_segments_generator(mock_session))
@@ -342,28 +341,38 @@ class TestSubstreamGenerators:
         assert segments[0]["company_id"] == "co1"
         assert segments[1]["company_id"] == "co2"
 
-    def test_iter_companies_follows_next_url_with_post(self):
-        # `/companies/list` is POST-only; its `pages.next` URL carries the page
-        # cursor in the query string. Following it with GET 404s in production,
-        # so every page — including subsequent ones — must be a POST carrying
-        # the same body.
-        next_url = f"{INTERCOM_API_BASE}/companies/list?per_page=60&page=2"
+    def test_iter_companies_walks_scroll(self):
+        # `POST /companies/list` is capped at 10,000 companies (60 * 167 page
+        # crosses the ceiling and Intercom 400s). The Scroll API has no ceiling:
+        # the first GET carries no param, subsequent GETs feed `scroll_param`
+        # back, and the walk ends when `data` comes back empty.
         mock_session = mock.MagicMock()
-        mock_session.post.side_effect = [
-            _make_response({"data": [{"id": "co1"}], "pages": {"next": next_url}}),
-            _make_response({"data": [{"id": "co2"}], "pages": {}}),
+        mock_session.get.side_effect = [
+            _make_response({"data": [{"id": "co1"}], "scroll_param": "s1"}),
+            _make_response({"data": [{"id": "co2"}], "scroll_param": "s2"}),
+            _make_response({"data": [], "scroll_param": "s3"}),
         ]
 
         companies = list(_iter_companies(mock_session))
 
         assert [c["id"] for c in companies] == ["co1", "co2"]
-        # Second page is POSTed to the next-page URL with the same body — not
-        # GET (the production 404 this guards against).
-        assert mock_session.post.call_args_list[1].args[0] == next_url
-        assert mock_session.post.call_args_list[1].kwargs["json"] == {
-            "per_page": INTERCOM_ENDPOINTS["companies"].page_size
-        }
-        assert mock_session.get.call_count == 0
+        calls = mock_session.get.call_args_list
+        assert calls[0].kwargs["params"] is None
+        assert calls[1].kwargs["params"] == {"scroll_param": "s1"}
+        assert calls[2].kwargs["params"] == {"scroll_param": "s2"}
+        # Every call hits the un-capped scroll endpoint, never the 10k-capped
+        # `/companies/list` (POST) path that produced the 400.
+        assert all(call.args[0].endswith("/companies/scroll") for call in calls)
+        assert mock_session.post.call_count == 0
+
+    def test_iter_companies_stops_on_empty_first_page(self):
+        # A workspace with no companies returns empty data on the first scroll
+        # request — the walk must terminate without a second call.
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [_make_response({"data": [], "scroll_param": "s1"})]
+
+        assert list(_iter_companies(mock_session)) == []
+        assert mock_session.get.call_count == 1
 
 
 class TestSubstreamSessionRetries:


### PR DESCRIPTION
## Problem

Error tracking surfaced an active, recurring failure on the Intercom data-warehouse import source:

```
HTTPError: 400 Client Error: Bad Request for url:
https://api.intercom.io/companies/list?per_page=60&page=167
```

- Issue: https://us.posthog.com/project/2/error_tracking/019eaeb6-a15c-7c60-8e58-a0052b080e08
- Failing function: `_company_segments_generator` → top in-app frame `_intercom_post` (`intercom.py`, `response.raise_for_status()`)
- 36 occurrences across 36 distinct workspaces, ongoing.

**Root cause:** Intercom's `POST /companies/list` is hard-capped at **10,000 companies** (`per_page=60 × page=167 ≈ 10,020` crosses the ceiling). Past it, Intercom returns `400 bad_request: "page limit reached, please use scroll API"`. Our company walk (`_iter_companies`) used offset-based list pagination, so it cannot complete for any workspace with more than 10k companies — the whole `company_segments` sync crashes.

This is a **fixable bug in our pagination**, not a credential/upstream condition, so adding it to `NonRetryableErrors` would be wrong: that would permanently drop company data for large workspaces instead of fetching it. The correct fix is to use Intercom's Scroll API, which has no pagination ceiling.

## Changes

- `_iter_companies` now walks `GET /companies/scroll` instead of `POST /companies/list`. Each response carries a `scroll_param` fed into the next request; the walk ends when `data` comes back empty (the scroll param then expires). This is the same full-refresh walk used by the `company_segments` substream — the failing path in the issue.
- Scope is kept to the reported path. The Scroll API allows one open scroll per workspace at a time, which is fine here: this is the only scroll user and a schema never syncs concurrently with itself. Transient 500s (Intercom's documented "internal network error" on scroll) remain retryable via the existing session retry policy.

## How did you test this code?

I'm an agent. I ran the existing + updated unit suite for the source:

```
python -m pytest posthog/temporal/data_imports/sources/intercom/tests/test_intercom.py
# 63 passed
```

Updated/added tests:
- `test_iter_companies_walks_scroll` — asserts the walk uses `/companies/scroll` (never the 10k-capped `/companies/list` POST), with no param on the first call and `scroll_param` fed back on subsequent calls.
- `test_iter_companies_stops_on_empty_first_page` — empty-data workspace terminates after one call.
- `test_company_segments_*` — updated for the interleaved parent-scroll / child-segment GET ordering; 404-skip and non-404-reraise behavior preserved.

`ruff check` / `ruff format` pass.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog's error-tracking MCP tools to confirm the issue (stack trace, frequency, affected workspaces) and Intercom's REST API docs to confirm the 10,000-company ceiling on the list endpoint and the Scroll API as the supported alternative. Considered and rejected extending `NonRetryableErrors` (would swallow recoverable data for large workspaces). Kept the change scoped to `_iter_companies` — the exact failing path — rather than also rerouting the top-level `companies` table endpoint (which runs through the shared REST framework and would change write-disposition semantics).
