### PR TITLE
fix(notion): fail fast on rate limits longer than the retry budget

### DIFF
--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, Optional
 
 import requests
 from structlog.types import FilteringBoundLogger
-from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from tenacity import RetryCallState, retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 from urllib3.util.retry import Retry
 
 from posthog.temporal.data_imports.pipelines.pipeline.batcher import Batcher
@@ -80,8 +80,25 @@ def _wait_strategy(retry_state: RetryCallState) -> float:
     return _wait_exponential(retry_state)
 
 
+def _should_retry_request(exc: BaseException) -> bool:
+    # Transient network failures are worth a quick in-process retry.
+    if isinstance(exc, requests.ReadTimeout | requests.ConnectionError):
+        return True
+    if isinstance(exc, NotionRetryableError):
+        # A 429 whose Retry-After is longer than we can usefully wait in-process is futile to
+        # retry here: the activity's heartbeat budget (~2 min) is far smaller than Notion's
+        # multi-minute rate-limit window, so retrying would burn that budget on attempts that
+        # are guaranteed to be rate limited again - and risks a heartbeat timeout masking the
+        # real error. Fail fast and let Temporal reschedule the activity, whose backoff far
+        # exceeds anything we can sleep mid-request. 5xx and short 429s stay retryable.
+        if exc.retry_after is not None and exc.retry_after > MAX_RETRY_WAIT_SECONDS:
+            return False
+        return True
+    return False
+
+
 @retry(
-    retry=retry_if_exception_type((NotionRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    retry=retry_if_exception(_should_retry_request),
     stop=stop_after_attempt(5),
     wait=_wait_strategy,
     reraise=True,

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -22,6 +22,7 @@ from posthog.temporal.data_imports.sources.notion.notion import (
     _request,
     _search_body,
     _search_stream,
+    _should_retry_request,
     _wait_strategy,
     validate_credentials,
 )
@@ -176,6 +177,30 @@ class TestNotion:
                 cast(requests.Session, session), "GET", "/v1/users", mock.MagicMock(), params={}
             )
         assert exc_info.value.retry_after == 7.0
+
+    def test_request_fails_fast_when_retry_after_exceeds_cap(self) -> None:
+        # Notion's Retry-After can be many minutes - far longer than the activity heartbeat
+        # budget - so retrying in-process is futile. The request must fail fast after a single
+        # attempt rather than burning the budget on guaranteed-rate-limited retries.
+        long_retry_after = str(MAX_RETRY_WAIT_SECONDS + 100)
+        session = FakeSession([FakeResponse({}, status_code=429, headers={"Retry-After": long_retry_after})])
+        with pytest.raises(NotionRetryableError):
+            _request(cast(requests.Session, session), "GET", "/v1/users", mock.MagicMock(), params={})
+        assert len(session.calls) == 1
+
+    @parameterized.expand(
+        [
+            ("short_429", NotionRetryableError("rate limited", retry_after=5.0), True),
+            ("429_at_cap", NotionRetryableError("rate limited", retry_after=float(MAX_RETRY_WAIT_SECONDS)), True),
+            ("long_429", NotionRetryableError("rate limited", retry_after=MAX_RETRY_WAIT_SECONDS + 1), False),
+            ("5xx_no_retry_after", NotionRetryableError("server error", retry_after=None), True),
+            ("read_timeout", requests.ReadTimeout("timeout"), True),
+            ("connection_error", requests.ConnectionError("reset"), True),
+            ("http_error", requests.HTTPError("401 Client Error"), False),
+        ]
+    )
+    def test_should_retry_request(self, _name: str, exc: BaseException, expected: bool) -> None:
+        assert _should_retry_request(exc) is expected
 
     def test_request_5xx_raises_retryable_without_retry_after(self) -> None:
         session = FakeSession([FakeResponse({}, status_code=503)])


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `NotionRetryableError: Notion rate limited: ... retry_after=435.0` from the Notion data-warehouse import source, raised in `posthog/temporal/data_imports/sources/notion/notion.py` (`_request`, line 103). It originates in the `blocks` stream's recursive child fan-out (`_blocks_stream` → `_iter_block_children` → `_request`), which makes a large number of requests against Notion's ~3 req/s limit and reliably hits 429s with multi-minute `Retry-After` values (392–591s observed across affected teams).

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019eaefd-32cb-7021-9079-ea0f779fd25b

This is a transient rate limit, so it should stay retryable — it does **not** belong in `NonRetryableErrors`. The defect is in the in-process backoff: `_wait_strategy` caps each wait at `MAX_RETRY_WAIT_SECONDS` (30s), but tenacity still fired all 5 attempts. Since Notion has explicitly said the limit won't clear for several minutes, every one of those retries is guaranteed to be rate limited again. Worse, the import activity runs with a 2-minute `heartbeat_timeout`, and ~4 capped 30s waits ≈ 2 minutes — so the futile retries consume the entire heartbeat budget and can trip a heartbeat timeout that masks the clear `NotionRetryableError`, before failing anyway.

## Changes

Replaced the exception-type retry predicate with one that fails fast on a 429 whose `Retry-After` exceeds `MAX_RETRY_WAIT_SECONDS`: there is no point retrying in-process when Notion's backoff is far longer than anything we can sleep within the heartbeat budget. The request raises immediately so Temporal reschedules the activity, whose retry backoff far exceeds our in-request budget and gives the rate-limit window time to clear.

Everything else stays retryable in-process: short 429s (`Retry-After` ≤ cap), 5xx responses (no `Retry-After`), read timeouts, and connection resets. The pipeline/Temporal retry policy is untouched.

## How did you test this code?

I'm an agent. I added and ran automated tests (`bin/hogli test posthog/temporal/data_imports/sources/notion/tests/test_notion.py`, 35 passed) and ran ruff check/format on the changed files:

- `test_request_fails_fast_when_retry_after_exceeds_cap` — a 429 with a long `Retry-After` makes exactly one request and raises (no in-process retries). This would have caught the original wasteful-retry behavior.
- `test_should_retry_request` (parameterized) — short 429, 429 at the cap, long 429, 5xx without `Retry-After`, read timeout, connection error, and a non-retryable HTTP error.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the Notion source. Confirmed the issue in PostHog error tracking via the error-tracking MCP tools (real stack trace rooted in `notion.py`, 11 occurrences across 11 teams), read the source and the import activity's retry/heartbeat configuration, and concluded this is a transient rate limit that should remain retryable rather than a `NonRetryableErrors` candidate. Considered honoring the full `Retry-After` in-process and rejected it: a multi-minute blocking sleep would exceed the 2-minute activity heartbeat timeout. Chose the scoped fail-fast approach so Temporal handles the long backoff.
