### PR TITLE
fix(flags): make projects picker search input full width

### DIFF
--- a/frontend/src/scenes/feature-flags/projects-grid/ProjectsGridPicker.tsx
+++ b/frontend/src/scenes/feature-flags/projects-grid/ProjectsGridPicker.tsx
@@ -46,13 +46,16 @@ export function ProjectsGridPicker(): JSX.Element {
             closeOnClickInside={false}
             overlay={
                 <div className="w-72 flex flex-col gap-2">
-                    <LemonInput
-                        type="search"
-                        value={search}
-                        onChange={setSearch}
-                        placeholder="Search projects"
-                        autoFocus
-                    />
+                    <div className="-mx-2 px-2 pb-2 border-b border-border">
+                        <LemonInput
+                            type="search"
+                            value={search}
+                            onChange={setSearch}
+                            placeholder="Search projects"
+                            fullWidth
+                            autoFocus
+                        />
+                    </div>
                     <div className="max-h-72 overflow-y-auto -mx-2 px-2 flex flex-col gap-0.5">
                         {filteredProjects.length === 0 ? (
                             <div className="text-tertiary text-center py-4 text-xs">No projects found</div>


### PR DESCRIPTION
## Problem

On the feature flags **Projects** tab, the **+ Projects** dropdown's "Search projects" input was sized to its content instead of filling the dropdown, and the project list ran up against the input with no visual separation.

## Changes

- Add `fullWidth` to the search `LemonInput` so it spans the full `w-72` dropdown.
- Move the input into a dedicated header section separated from the scrollable project list by a bottom border, so the input reads as a distinct control above the list rather than blending into it.

Frontend-only, scoped to `ProjectsGridPicker.tsx`.

## How did you test this code?

I'm an agent (PostHog Slack app). I made a frontend-only Tailwind/layout change and did not run manual UI testing. No automated tests were added for this presentational change. Reviewer should eyeball the dropdown in the feature flags projects tab.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- presentational change; no docs impact -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) at the request of Ruby Childs, with layout feedback from Paul D'Ambra. The original report was that the search input should be full width; follow-up feedback was that the list should not run behind/into the input and the input should be a separate section before the list. Implemented both with a `fullWidth` input and a divider-separated header section.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781193458488159?thread_ts=1781193458.488159&cid=C0ACRAMJUAG)*
