### PR TITLE
fix(ingestion): pre-create all clickhouse kafka engine topics in person-state-batch test

### DIFF
--- a/nodejs/tests/worker/ingestion/person-state-batch.test.ts
+++ b/nodejs/tests/worker/ingestion/person-state-batch.test.ts
@@ -11,6 +11,7 @@ import { PipelineResultType, isDlqResult, isOkResult, isRedirectResult } from '~
 import { KafkaProducerWrapper } from '~/kafka/producer'
 import { PluginEvent, Properties } from '~/plugin-scaffold'
 import { Clickhouse } from '~/tests/helpers/clickhouse'
+import { ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { fromInternalPerson } from '~/worker/ingestion/persons/person-update-batch'
 import { PersonsStore } from '~/worker/ingestion/persons/persons-store'
 
@@ -169,6 +170,11 @@ describe('PersonState.processEvent()', () => {
         mockProducerObserver.resetKafkaProducer()
 
         clickhouse = Clickhouse.create()
+        // Pre-create every topic ClickHouse's Kafka engine tables subscribe to. Otherwise any
+        // table whose topic is missing keeps retrying "Can't get assignment", which saturates
+        // ClickHouse's background scheduler and intermittently starves the consumers this suite
+        // waits on via delayUntilEventIngested — flaky timeouts in CI.
+        await ensureKafkaTopics(await clickhouse.getKafkaEngineTopics())
         await clickhouse.exec('SYSTEM STOP MERGES')
 
         organizationId = await createOrganization(hub.postgres)


### PR DESCRIPTION
## Problem

The `person-state-batch` ingestion test (`nodejs/tests/worker/ingestion/person-state-batch.test.ts`) is flaky in CI for the same root cause fixed in #62694 and #62839.

ClickHouse's Kafka engine has many tables, each subscribing to its own topic. Any subscribed topic that doesn't exist leaves its consumer endlessly retrying `Can't get assignment`. Those retries saturate ClickHouse's shared background scheduler and intermittently starve the consumers the suite actually depends on — here, the consumers behind the 9 `delayUntilEventIngested` waits (e.g. `person_distinct_id_overrides_mv`, `person`, `person_distinct_id2`) — producing flaky 30s timeouts in CI.

Unlike the postgres-parity suite, this suite never pre-created any Kafka topics at all.

## Changes

In `beforeAll`, pre-create every topic ClickHouse's Kafka engine tables subscribe to, using the `getKafkaEngineTopics()` helper introduced in #62694:

```ts
await ensureKafkaTopics(await clickhouse.getKafkaEngineTopics())
```

## How did you test this code?

I'm an agent. This is a test-only change. The suite requires live Kafka, ClickHouse, and Postgres, so it runs in CI. I verified the file typechecks (`tsc --noEmit` reports no errors for it) and that lint-staged formatting passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @jose-sequeira to check whether the fix from #62839 applies to a flaky timeout in `person-state-batch.test.ts` and apply it. I inspected #62839's diff and the failing test, confirmed the suite waits on ClickHouse Kafka-engine ingestion via `delayUntilEventIngested` but never calls `ensureKafkaTopics`, and applied the minimal equivalent change: pre-create all ClickHouse Kafka-engine topics in `beforeAll`. A warmup probe like postgres-parity's `waitForClickHousePersonConsumer` was considered but deferred unless flakiness persists after the topic fix.

Authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
