### PR TITLE
feat(error-tracking): capture event when source maps banner is shown

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
@@ -1,7 +1,11 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 
 import { IconMagicWand } from '@posthog/icons'
 import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
 
 import { isSourceMapsRecommendation, recommendationsTabLogic } from '../recommendations/recommendationsTabLogic'
 import { SourceMapsFixModal } from '../recommendations/SourceMapsFixModal'
@@ -13,17 +17,38 @@ const DISMISS_KEY = 'error-tracking-source-maps-banner'
 
 export function SourceMapsBanner(): JSX.Element | null {
     const { recommendations } = useValues(recommendationsTabLogic)
-    const { openModal } = useActions(sourceMapsFixWizardLogic)
+    const { isDismissed } = useValues(lemonBannerLogic({ dismissKey: DISMISS_KEY }))
 
     const sourceMaps = recommendations.find(isSourceMapsRecommendation)
     // Show only once computed and while there's an actual problem (not completed),
     // regardless of whether the recommendation itself was dismissed.
-    if (!sourceMaps || sourceMaps.computed_at === null || sourceMaps.completed) {
+    if (!sourceMaps || sourceMaps.computed_at === null || sourceMaps.completed || isDismissed) {
         return null
     }
 
     const percent = Math.round((sourceMaps.meta.unresolved_pct ?? 0) * 100)
     const lookbackHours = sourceMaps.meta.lookback_hours
+
+    return <SourceMapsBannerContent percent={percent} lookbackHours={lookbackHours} />
+}
+
+// Inner component so the "shown" event fires exactly when the banner becomes visible —
+// the outer guards (including dismissal) gate the mount, so mounting here means it was seen.
+function SourceMapsBannerContent({
+    percent,
+    lookbackHours,
+}: {
+    percent: number
+    lookbackHours: number
+}): JSX.Element {
+    const { openModal } = useActions(sourceMapsFixWizardLogic)
+
+    useOnMountEffect(() => {
+        posthog.capture('error_tracking_source_maps_banner_shown', {
+            unresolved_pct: percent,
+            lookback_hours: lookbackHours,
+        })
+    })
 
     return (
         <>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
@@ -34,13 +34,7 @@ export function SourceMapsBanner(): JSX.Element | null {
 
 // Inner component so the "shown" event fires exactly when the banner becomes visible —
 // the outer guards (including dismissal) gate the mount, so mounting here means it was seen.
-function SourceMapsBannerContent({
-    percent,
-    lookbackHours,
-}: {
-    percent: number
-    lookbackHours: number
-}): JSX.Element {
+function SourceMapsBannerContent({ percent, lookbackHours }: { percent: number; lookbackHours: number }): JSX.Element {
     const { openModal } = useActions(sourceMapsFixWizardLogic)
 
     useOnMountEffect(() => {


### PR DESCRIPTION
Record event when somebody sees the banner