### PR TITLE
feat(tasks): resume VM sandboxes from filesystem snapshots

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -241,11 +241,9 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         has_repo = ctx.repository is not None
         repository = ctx.repository
 
-        snapshot_resume_disabled = ctx.use_modal_vm_sandbox
-
         snapshot = None
         used_snapshot = False
-        if has_repo and ctx.github_integration_id is not None and not snapshot_resume_disabled:
+        if has_repo and ctx.github_integration_id is not None:
             assert repository is not None
             with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
                 snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(ctx.github_integration_id, [repository])
@@ -294,13 +292,12 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         environment_variables = _build_environment_variables(ctx, task, github_token, access_token)
 
         run_state = parse_run_state(ctx.state)
-        # When Modal resume snapshots are disabled, ignore any snapshot_external_id
-        # baked into TaskRun state — resume falls back to the agent server's
-        # git-checkpoint flow (POSTHOG_RESUME_RUN_ID continues to be set above).
+        # VM and gVisor both resume from filesystem snapshots. A run's resume
+        # snapshot is taken from the same task's sandbox, so its base image
+        # matches the runtime provisioned here (the earlier disable was for
+        # gVisor memory snapshots, which cannot restore into the VM runtime).
         resume_snapshot_external_id = (
-            run_state.snapshot_external_id
-            if settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS and not snapshot_resume_disabled
-            else None
+            run_state.snapshot_external_id if settings.TASKS_USE_MODAL_RESUME_SNAPSHOTS else None
         )
         if resume_snapshot_external_id:
             used_snapshot = True


### PR DESCRIPTION
## Problem

A follow-up to a stopped **VM** sandbox didn't restore the sandbox from its snapshot — it re-provisioned from the base image and relied only on the agent-server git-checkpoint. gVisor sandboxes already resume from filesystem snapshots; VM sandboxes were excluded by `snapshot_resume_disabled = use_modal_vm_sandbox` in `prepare_sandbox_for_repository`.

That exclusion was written for gVisor **memory** snapshots, which can't restore into the VM runtime. But the active mechanism is **filesystem** snapshots (`Sandbox.snapshot_filesystem`), created per-run by `create_resume_snapshot` and stored as `snapshot_external_id` on the run state. Filesystem snapshots *do* restore into a VM.

## Changes

Drop the VM exclusion in `prepare_sandbox_for_repository` so VM follow-ups resume from the filesystem snapshot like gVisor (both the per-run resume snapshot and the repository-snapshot lookup). A run's resume snapshot is taken from the **same task's** sandbox, so its base image (`VM_BASE` for VM, `DEFAULT_BASE` for gVisor) matches the runtime provisioned on resume — no cross-runtime mismatch on this path.

**Reviewer note:** the cross-task *repository*-snapshot lookup (`get_latest_snapshot_with_repos`) is base-agnostic, so in principle a VM run could warm-start from a gVisor-created snapshot once that path is active. It's a no-op today (repository-snapshot creation is commented out at `workflow.py:395-397`). When that creation is re-enabled, snapshots should be tagged with their template/runtime and the lookup filtered accordingly so VM↔VM and gVisor↔gVisor — worth a follow-up, not needed for this change.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). No CI-automated test was added (resume requires a live Modal sandbox). Verified the underlying mechanism against **real Modal VM sandboxes**: created a `VM_BASE` sandbox (kernel 6.12.8+), wrote files into the workspace, called `snapshot_filesystem(ttl=None)`, destroyed it, then provisioned a **new VM sandbox from that snapshot** and confirmed the full working tree was restored (committed-staged and uncommitted files). Repeated with an explicit `sync` — same result. So a VM sandbox resumes from a filesystem snapshot correctly, which is exactly the path this change unlocks.

A full Temporal-level e2e (create → resume-snapshot → kill → follow-up → resume through the workflow) still needs local object storage healthy; that's a follow-up once the local SeaweedFS volume is recreated.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Came out of investigating VM-sandbox follow-up failures. Established that VM resume was falling back to git-checkpoint because of a snapshot gate intended for gVisor memory snapshots, then empirically confirmed (real Modal VM sandboxes) that the active `snapshot_filesystem` mechanism restores into a VM. The change just removes the now-obsolete VM exclusion. Tools: Claude Code, Modal (local `MODAL_DOCKER` sandboxes), Grafana/PostHog MCP for the supporting investigation.
