### PR TITLE
chore(revenue_analytics): transfer ownership to team-web-analytics

### DIFF
--- a/products/revenue_analytics/product.yaml
+++ b/products/revenue_analytics/product.yaml
@@ -1,3 +1,3 @@
 name: Revenue analytics
 owners:
-    - team-growth
+    - team-web-analytics


### PR DESCRIPTION
Transfers ownership of the Revenue Analytics product from `team-growth` to `team-web-analytics`.