### PR TITLE
fix(notion): retry connection-break ChunkedEncodingError

### DIFF
--- a/posthog/temporal/data_imports/sources/notion/notion.py
+++ b/posthog/temporal/data_imports/sources/notion/notion.py
@@ -81,7 +81,18 @@ def _wait_strategy(retry_state: RetryCallState) -> float:
 
 
 @retry(
-    retry=retry_if_exception_type((NotionRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    # ChunkedEncodingError is a sibling of ConnectionError (both RequestException, not subclasses of
+    # each other): Notion can break the connection mid-response, surfacing as a malformed chunk
+    # ("Connection broken: InvalidChunkLength"). It is a transient connection failure like the others,
+    # so retry it rather than letting it crash the sync.
+    retry=retry_if_exception_type(
+        (
+            NotionRetryableError,
+            requests.ReadTimeout,
+            requests.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        )
+    ),
     stop=stop_after_attempt(5),
     wait=_wait_strategy,
     reraise=True,

--- a/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/posthog/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -185,6 +185,27 @@ class TestNotion:
             )
         assert exc_info.value.retry_after is None
 
+    def test_request_retries_chunked_encoding_error(self) -> None:
+        # Notion can break the connection mid-response, which requests surfaces as a
+        # ChunkedEncodingError ("Connection broken: InvalidChunkLength"). It is transient and must be
+        # retried like other connection failures, not propagated as a fatal sync error.
+        attempts = {"count": 0}
+
+        def request(*_args: Any, **_kwargs: Any) -> FakeResponse:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise requests.exceptions.ChunkedEncodingError("Connection broken: InvalidChunkLength(got length b'')")
+            return FakeResponse({"results": []})
+
+        session = mock.MagicMock()
+        session.request.side_effect = request
+
+        with mock.patch(f"{MODULE}._wait_strategy", return_value=0):
+            result = _request(cast(requests.Session, session), "GET", "/v1/comments", mock.MagicMock(), params={})
+
+        assert result == {"results": []}
+        assert attempts["count"] == 2
+
     @parameterized.expand([("5", 5.0), (None, None), ("not-a-number", None)])
     def test_parse_retry_after(self, value: str | None, expected: float | None) -> None:
         assert _parse_retry_after(value) == expected


### PR DESCRIPTION
## Problem

Error tracking surfaced a crash in the Notion data-warehouse import source: [issue 019eb301-99d7-7bc2-b379-4eb406de60ce](https://us.posthog.com/project/2/error_tracking/019eb301-99d7-7bc2-b379-4eb406de60ce).

The exception chain is `InvalidChunkLength(got length b'', 0 bytes read)` → `ProtocolError("Connection broken: ...")` → `requests.exceptions.ChunkedEncodingError`. It originates in `_request` (`notion.py:99`) while `session.request(...)` streams a paginated `/v1/comments` response body — Notion closed the connection mid-response, so urllib3 read an empty chunk-size line.

This is a **transient connection-level failure**, equivalent to a connection reset. It should be retried — but it wasn't. `_request`'s `@retry` predicate already retries `requests.ReadTimeout` and `requests.ConnectionError`, yet `ChunkedEncodingError` is a *sibling* of `ConnectionError` (both subclass `RequestException`, neither inherits the other), so it slipped past the predicate and crashed the sync on the first occurrence instead of being retried.

## Changes

- Add `requests.exceptions.ChunkedEncodingError` to the `retry_if_exception_type` tuple in `_request`, so connection-break-mid-response is retried like the other transient connection failures (`ReadTimeout`, `ConnectionError`).

This is deliberately **not** a `NonRetryableErrors` change — the failure is transient, not a credential/config/permanent-upstream problem, so suppressing retries would be wrong. The fix keeps it retryable and simply ensures the existing retry layer actually covers it.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — I did not run a live Notion sync.

- Added `test_request_retries_chunked_encoding_error`: a session that raises `ChunkedEncodingError` on the first attempt and succeeds on the second must be retried and return the successful payload.
- Ran the full source test file: `pytest posthog/temporal/data_imports/sources/notion/tests/test_notion.py` — 28 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Investigated with the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the full stack trace and confirm the failure genuinely originates in the Notion source's `_request`, then read `notion.py` and its tests.

Decision: classified the error as a transient connection break (not a user/upstream auth/config error and not something to make non-retryable). Confirmed via the class hierarchy that `ChunkedEncodingError` and `ConnectionError` are siblings, so the existing predicate could not have caught it. Chose the minimal scoped fix (extend the retry predicate) over widening `NonRetryableErrors` or touching global retry policy.
