### PR TITLE
fix(snowflake): treat Duo Security MFA denial as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -177,6 +177,10 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             "Your free trial has ended": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",
             "Your account is suspended due to lack of payment method": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",
             "MFA authentication is required": None,
+            # The account enforces Duo Security multi-factor auth for this user, so the
+            # connector's login is rejected (250001 / 08001). An unattended sync can't answer a
+            # Duo push, so retrying never succeeds — surface an actionable message instead.
+            "Duo Security authentication is denied": "Snowflake rejected the login because multi-factor authentication (Duo Security) is enforced for this user. Automated syncs can't answer an MFA prompt — connect with a service user that uses key-pair authentication or is exempt from MFA.",
             "invalid credentials": "Snowflake authentication failed. Please check your username, password, and account details.",
             "authentication failed": "Snowflake authentication failed. Please check your username, password, and account details.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -13,6 +13,7 @@ from posthog.temporal.data_imports.sources.snowflake.snowflake import (
     _parse_clustering_key_leading_column,
     filter_snowflake_incremental_fields,
 )
+from posthog.temporal.data_imports.sources.snowflake.source import SnowflakeSource
 
 from products.data_warehouse.backend.types import IncrementalFieldType
 
@@ -338,6 +339,22 @@ class TestGetRowsToSync:
 # ---------------------------------------------------------------------------
 # build_pipeline end-to-end (mocked driver)
 # ---------------------------------------------------------------------------
+
+
+class TestSnowflakeSourceNonRetryableErrors:
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Duo Security authentication is denied",
+            # The real shape from production: codes + host vary, but the Duo substring is stable.
+            "250001 (08001): None: Failed to connect to DB: wv65496-re80354.snowflakecomputing.com:443. "
+            "Duo Security authentication is denied.",
+        ],
+    )
+    def test_duo_security_denied_is_non_retryable(self, error_msg):
+        non_retryable = SnowflakeSource().get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable
 
 
 class TestBuildPipeline:


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OperationalError` from the Snowflake data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019eb3fe-dce4-7dc2-ae68-882fe900238e)):

```
250001 (08001): None: Failed to connect to DB: <host>.snowflakecomputing.com:443. Duo Security authentication is denied.
```

The failure originates in our code — `SnowflakeImplementation.connect()` (`posthog/temporal/data_imports/sources/snowflake/snowflake.py`) calling `snowflake.connector.connect(...)` — but the root cause is upstream: the customer's Snowflake account enforces Duo Security multi-factor authentication for the connecting user. An unattended sync can't answer a Duo push, so the login is rejected on every attempt (the captured event was already on Temporal attempt 3). Retrying never succeeds, so the job should fail fast with an actionable message instead of burning retries.

This is the same class of error as the existing `"MFA authentication is required"` entry, but it surfaces a different, distinct message string that the current matcher doesn't catch.

## Changes

- Add `"Duo Security authentication is denied"` to `SnowflakeSource.get_non_retryable_errors()`, matched on a stable, low-false-positive substring (the volatile host and error codes are excluded). The user-facing message explains MFA is enforced and points toward a service user with key-pair auth or an MFA exemption.
- Add a parameterized regression test asserting both the bare substring and the full production message are recognized as non-retryable.

## How did you test this code?

I'm an agent. I ran the automated tests I added/touched — no manual testing:

- `pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` — 39 passed, including the new `TestSnowflakeSourceNonRetryableErrors`.
- `ruff check` and `ruff format --check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue's stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the failure frame is in the Snowflake source's `connect()`, and read the chained exception (`Duo Security authentication is denied` wrapped by a retryable login error). Decision: user/upstream config error (account-enforced MFA) — nothing for us to do but stop retrying — so the fix extends `NonRetryableErrors` rather than changing the connection code, mirroring the Stripe/Redshift `get_non_retryable_errors` pattern. Matched on the stable Duo substring to avoid false positives from per-request host/codes.
