### PR TITLE
fix(postgres): retry transient drops when reconnecting in offset chunking

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -145,6 +145,36 @@ def _is_connection_dropped_error(error: BaseException) -> bool:
     return False
 
 
+def _connect_with_dropped_retry(
+    connect: Callable[[], psycopg.Connection],
+    logger: FilteringBoundLogger,
+    *,
+    max_attempts: int = 5,
+) -> psycopg.Connection:
+    """Open a connection via `connect`, retrying transient connection-dropped errors.
+
+    The streaming recovery path (offset chunking) is reached precisely because the
+    source just dropped our connection (idle cull, failover, mid-stream SSL EOF), so
+    the very reconnect that bootstraps the recovery can itself hit a still-recovering
+    source and fail with another connection-dropped error. Without this, that
+    transient failure escapes the recovery loop and fails the whole sync. Retry with
+    bounded backoff; permanent errors (auth failures, SSL-required) are re-raised
+    immediately because `_is_connection_dropped_error` only matches transient drops.
+    """
+    attempt = 0
+    while True:
+        try:
+            return connect()
+        except (psycopg.errors.ProtocolViolation, psycopg.OperationalError) as e:
+            if not _is_connection_dropped_error(e):
+                raise
+            attempt += 1
+            if attempt >= max_attempts:
+                raise
+            logger.debug(f"Connection attempt failed ({e}). Retrying (attempt {attempt}/{max_attempts})")
+            time.sleep(min(2 * attempt, 30))
+
+
 @dataclasses.dataclass(frozen=True)
 class PostgresDiscoveredSchema:
     source_catalog: str | None
@@ -1992,7 +2022,7 @@ def postgres_source(
 
                 successive_errors = 0
                 successive_conn_errors = 0
-                connection = get_connection()
+                connection = _connect_with_dropped_retry(get_connection, logger)
                 # Autocommit so each LIMIT/OFFSET query runs as its own statement
                 # and no transaction stays open across the slow delta-merge that
                 # happens between yields. A held transaction is what gets the
@@ -2068,7 +2098,7 @@ def postgres_source(
                             f"(attempt {successive_conn_errors})"
                         )
                         time.sleep(min(2 * successive_conn_errors, 30))
-                        connection = get_connection()
+                        connection = _connect_with_dropped_retry(get_connection, logger)
                         connection.autocommit = True
                     except Exception:
                         _safe_close_connection(connection)

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -44,6 +44,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     SafeDateLoader,
     _build_count_query,
     _build_query,
+    _connect_with_dropped_retry,
     _get_estimated_row_count_for_partitioned_table,
     _get_partition_settings,
     _get_partition_settings_for_partitioned_table,
@@ -203,6 +204,54 @@ class TestIsConnectionDroppedError:
     )
     def test_unrelated_errors_are_not_detected(self, error):
         assert _is_connection_dropped_error(error) is False
+
+
+class TestConnectWithDroppedRetry:
+    @pytest.fixture
+    def logger(self):
+        return structlog.get_logger()
+
+    def test_retries_dropped_connection_then_succeeds(self, logger):
+        good_conn = mock.MagicMock()
+        connect = mock.MagicMock(
+            side_effect=[
+                # The exact error surfaced in production: a mid-stream SSL EOF on
+                # the reconnect that bootstraps offset-chunking recovery.
+                psycopg.OperationalError("consuming input failed: SSL SYSCALL error: EOF detected"),
+                psycopg.OperationalError("server closed the connection unexpectedly"),
+                good_conn,
+            ]
+        )
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+            result = _connect_with_dropped_retry(connect, logger, max_attempts=5)
+
+        assert result is good_conn
+        assert connect.call_count == 3
+
+    def test_permanent_error_is_not_retried(self, logger):
+        connect = mock.MagicMock(
+            side_effect=psycopg.OperationalError(
+                'connection to server at "10.0.0.1" failed: FATAL: password authentication failed'
+            )
+        )
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+            with pytest.raises(psycopg.OperationalError):
+                _connect_with_dropped_retry(connect, logger, max_attempts=5)
+
+        assert connect.call_count == 1
+
+    def test_gives_up_after_max_attempts(self, logger):
+        connect = mock.MagicMock(
+            side_effect=psycopg.OperationalError("consuming input failed: SSL SYSCALL error: EOF detected")
+        )
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+            with pytest.raises(psycopg.OperationalError):
+                _connect_with_dropped_retry(connect, logger, max_attempts=3)
+
+        assert connect.call_count == 3
 
 
 class TestPostgresSourceForPipelineSchemaResolution:


### PR DESCRIPTION
## Problem

Postgres data-warehouse imports surfaced a recurring `OperationalError: consuming input failed: SSL SYSCALL error: EOF detected` (error tracking issue [`019eb2c0-7d14-77d0-bce6-b64ca703d395`](https://us.posthog.com/project/2/error_tracking/019eb2c0-7d14-77d0-bce6-b64ca703d395)).

The raised error is a **transient** connection drop (mid-stream SSL EOF / `server closed the connection unexpectedly`), so it should stay retryable — it is correctly **not** a `NonRetryableError`. The streaming server-cursor path already recognizes it via `_is_connection_dropped_error` and falls back to `offset_chunking` to resume.

The bug is in the recovery path itself. `offset_chunking` is entered precisely because the source just dropped our connection, so the source is frequently still briefly unavailable when offset chunking tries to (re)connect. Both connection acquisition sites in `offset_chunking` were unprotected:

- the initial `connection = get_connection()` that bootstraps the loop, and
- the in-loop reconnect inside the connection-dropped handler.

When the source was still down at that moment, `get_connection()` raised another connection-dropped `OperationalError` that escaped the carefully-built retry loop and failed the whole sync activity. The captured stack confirms this: the surfaced frame is `offset_chunking` → `get_connection`, with a chained `connection failed: ... server closed the connection unexpectedly`.

## Changes

- Add `_connect_with_dropped_retry(connect, logger, max_attempts=...)`: opens a connection via the given callable and retries **transient** connection-dropped errors (matched by the existing `_is_connection_dropped_error`) with bounded backoff. Permanent errors (auth failures, SSL-required) are re-raised immediately, so this never masks a real config problem.
- Use it for both reconnect sites in `offset_chunking`, so a still-recovering source no longer fails the activity before the recovery loop can run.

Scope is deliberately narrow — no change to global retry policy and no new entries in `NonRetryableErrors` (this is transient infrastructure, not a user/upstream error).

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing claimed):

- `TestConnectWithDroppedRetry` covering: retry-then-succeed using the exact production error string, permanent errors not retried, and giving up after `max_attempts`.
- Re-ran the existing `TestIsConnectionDroppedError` suite to confirm no regressions.

```
.venv/bin/pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py \
  -k "TestConnectWithDroppedRetry or TestIsConnectionDroppedError"
# 17 passed, 237 deselected
```

Ruff check + format pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook for the Postgres warehouse source. Pulled the issue + representative events via the PostHog error-tracking MCP tools to confirm the stack genuinely originates in `posthog/temporal/data_imports/sources/postgres/postgres.py`.
- Decision: this is a transient infra drop, so **not** a `NonRetryableErrors` candidate. The existing code already classifies the message as a recoverable drop; the real gap was that the recovery path's own (re)connect attempts weren't covered by the retry loop. Fixed at that layer rather than widening retryability anywhere global.
- Tooling: Claude Code with the PostHog MCP error-tracking tools.
