### PR TITLE
fix(postgres): stop reporting advisory RLS-check timeouts as errors

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -565,6 +565,13 @@ def _rls_active_from_conn(
                 if display_name is not None:
                     result[display_name] = bool(rls_active)
             return result
+    except (psycopg.errors.QueryCanceled, psycopg.errors.UndefinedFunction, psycopg.errors.FeatureNotSupported):
+        # Advisory check only — every table just omits the RLS warning. These are expected, benign
+        # outcomes, not failures to report: a statement timeout (the catalog query is bounded to 30s
+        # and can exceed it on a large/slow database) or an engine that doesn't implement
+        # row_security_active() (e.g. CockroachDB raises UndefinedFunction). Capturing them only adds
+        # noise; genuinely unexpected errors still fall through to capture_exception below.
+        return {}
     except Exception as e:
         capture_exception(e)
         return {}

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2713,6 +2713,72 @@ class TestRlsDetectionRealDb:
             finally:
                 dj_cursor.execute("RESET ROLE")
 
+    @pytest.mark.parametrize(
+        "raised",
+        [
+            psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
+            psycopg.errors.UndefinedFunction("unknown function: row_security_active()"),
+            psycopg.errors.FeatureNotSupported("row level security is not supported"),
+        ],
+    )
+    def test_rls_active_from_conn_swallows_expected_errors_without_capturing(self, raised):
+        # The RLS check is advisory: a statement timeout (the catalog query is bounded to 30s) or an
+        # engine that lacks row_security_active() (e.g. CockroachDB -> UndefinedFunction) must not be
+        # reported as an error — it just means "no RLS warning". Regression for noisy capture_exception.
+        discovered = {"public.t": (None, "public", "t")}
+
+        def execute_side_effect(statement, *args, **kwargs):
+            if "row_security_active" in str(statement):
+                raise raised
+
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = execute_side_effect
+        cursor.__enter__.return_value = cursor
+        cursor.__exit__.return_value = False
+
+        connection = mock.MagicMock()
+        connection.cursor.return_value = cursor
+
+        with (
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.postgres._get_discovered_tables",
+                return_value=(discovered, False),
+            ),
+            mock.patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock,
+        ):
+            result = _rls_active_from_conn(cast(Any, connection), "public", ["t"])
+
+        assert result == {}
+        capture_mock.assert_not_called()
+
+    def test_rls_active_from_conn_still_captures_unexpected_errors(self):
+        # Guard against blanket suppression: a genuinely unexpected failure must still be reported.
+        discovered = {"public.t": (None, "public", "t")}
+
+        def execute_side_effect(statement, *args, **kwargs):
+            if "row_security_active" in str(statement):
+                raise psycopg.errors.SyntaxError("syntax error")
+
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = execute_side_effect
+        cursor.__enter__.return_value = cursor
+        cursor.__exit__.return_value = False
+
+        connection = mock.MagicMock()
+        connection.cursor.return_value = cursor
+
+        with (
+            mock.patch(
+                "posthog.temporal.data_imports.sources.postgres.postgres._get_discovered_tables",
+                return_value=(discovered, False),
+            ),
+            mock.patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock,
+        ):
+            result = _rls_active_from_conn(cast(Any, connection), "public", ["t"])
+
+        assert result == {}
+        capture_mock.assert_called_once()
+
     @pytest.mark.django_db
     def test_rls_active_from_conn_runs_without_schema_or_names(self):
         # Regression: an early-return guard used to bail when no schema and no names were given,


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `QueryCanceled` ("canceling statement due to statement timeout") from the Postgres data-warehouse import source, raised in `_rls_active_from_conn` at `posthog/temporal/data_imports/sources/postgres/postgres.py`.

Investigating the issue ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019eb321-84e5-7612-b88a-bd225589ec3d)) showed this is **not** a pipeline failure:

- `_rls_active_from_conn` runs during schema discovery (the table-picker listing), purely to power an advisory row-level-security warning in the UI. It already catches every exception and returns `{}`, so discovery continues regardless of the outcome.
- The exception never reaches the sync pipeline's retry layer — it is swallowed locally. The only thing surfacing it to error tracking was a `capture_exception(e)` call.
- The captured events came from two benign, expected causes: the advisory catalog query hitting its bounded 30s `statement_timeout` (`QueryCanceled`), and target engines that don't implement `row_security_active()` — CockroachDB raises `UndefinedFunction` — observed on hosts connecting over the CockroachDB wire protocol (port 26257).

So this is noise, not a bug in the sync path and not a user/upstream auth error. It does **not** belong in `NonRetryableErrors` (that path is for sync-pipeline failures, and a `QueryCanceled` there must stay retryable).

## Changes

In `_rls_active_from_conn`, swallow `QueryCanceled`, `UndefinedFunction`, and `FeatureNotSupported` without capturing — every table simply omits the RLS warning, which is the existing graceful behavior. Genuinely unexpected errors still fall through to `capture_exception`, so we don't lose signal on real bugs. This mirrors the sibling `_role_subject_to_rls`, which already treats the same `row_security_active` query as best-effort.

No change to retry policy, timeouts, or the sync pipeline.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests (no manual testing):

- `test_rls_active_from_conn_swallows_expected_errors_without_capturing` — parametrized over `QueryCanceled`, `UndefinedFunction`, and `FeatureNotSupported`; asserts `_rls_active_from_conn` returns `{}` and does **not** call `capture_exception`.
- `test_rls_active_from_conn_still_captures_unexpected_errors` — asserts an unexpected error (`SyntaxError`) is still captured, guarding against blanket suppression.

```
python -m pytest posthog/temporal/data_imports/sources/postgres/test_postgres.py \
  -k "swallows_expected_errors or still_captures_unexpected"
# 4 passed
```

`ruff check` and `ruff format` pass on both changed files. The existing `TestRlsDetectionRealDb` tests require a live database and were not runnable in this sandbox (they error on connection), but are unaffected by this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the Postgres import source using the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace, representative events, and frame-local variables.

Key decision: the captured frame variables showed the connection targeting a CockroachDB host and a local `UndefinedFunction('unknown function: row_security_active()')`, with the surfaced exception being a `statement_timeout` `QueryCanceled`. Reading the call path (`get_schemas` → `_rls_active_from_conn`) confirmed the exception is caught and swallowed (returns `{}`) and never reaches retry handling — so this is error-tracking noise from a best-effort advisory check, not a sync failure or a non-retryable auth error. Fixed by not capturing the expected exception classes while preserving capture for unexpected ones, rather than extending `NonRetryableErrors` (which would be the wrong layer and would risk making real timeouts non-retryable).

Tools: Claude Code.
