### PR TITLE
fix(data-imports): refresh stale DB connection in google search console credentials

### DIFF
--- a/posthog/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import quote
 
 from django.conf import settings
+from django.db import close_old_connections
 
 import requests
 import structlog
@@ -104,6 +105,13 @@ class GoogleSearchConsoleResumeConfig:
 
 
 def _credentials(integration_id: int, team_id: int) -> OAuthCredentials:
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). The session
+    # is built lazily from inside `get_rows` after the schema fetch, so the
+    # connection has often been idle for minutes by the time we reach this lookup;
+    # without refreshing it first, the query raises
+    # `OperationalError: server closed the connection unexpectedly`.
+    close_old_connections()
     integration = Integration.objects.get(id=integration_id, team_id=team_id)
     return OAuthCredentials(
         token=None,

--- a/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -400,3 +400,39 @@ def test_throttle_spaces_requests_per_site(monkeypatch):
     gsc._throttle("sc-domain:example.com")
 
     assert sleeps == [pytest.approx(gsc._MIN_REQUEST_INTERVAL_SECONDS)]
+
+
+class TestCredentialsStaleConnection:
+    """Regression test for stale Postgres connections inside `_credentials`.
+
+    When an import streams rows for many minutes, the Django connection that the
+    Temporal worker thread holds can be dropped server-side. The next call into
+    `Integration.objects.get(...)` from `get_rows` then raises
+    `OperationalError: server closed the connection unexpectedly`. We close stale
+    connections before the ORM query so the next lookup grabs a fresh one.
+    """
+
+    @mock.patch("posthog.temporal.data_imports.sources.google_search_console.google_search_console.OAuthCredentials")
+    @mock.patch("posthog.temporal.data_imports.sources.google_search_console.google_search_console.Integration")
+    @mock.patch(
+        "posthog.temporal.data_imports.sources.google_search_console.google_search_console.close_old_connections"
+    )
+    def test_credentials_closes_stale_connections_before_integration_lookup(
+        self, mock_close_old_connections, mock_integration_model, mock_oauth_credentials
+    ):
+        manager = mock.MagicMock()
+        manager.attach_mock(mock_close_old_connections, "close_old_connections")
+        manager.attach_mock(mock_integration_model.objects.get, "integration_get")
+
+        mock_integration = mock.MagicMock()
+        mock_integration.refresh_token = "fake-refresh-token"
+        mock_integration_model.objects.get.return_value = mock_integration
+
+        gsc._credentials(integration_id=42, team_id=7)
+
+        mock_close_old_connections.assert_called_once_with()
+        mock_integration_model.objects.get.assert_called_once_with(id=42, team_id=7)
+        # Order matters: closing stale connections AFTER the failing query would
+        # not prevent the OperationalError we are guarding against.
+        call_order = [name for name, _, _ in manager.mock_calls]
+        assert call_order.index("close_old_connections") < call_order.index("integration_get")


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: server closed the connection unexpectedly` originating in the data-warehouse import pipeline ([issue](https://us.posthog.com/project/2/error_tracking/019eb6bd-9879-70e2-991e-cee8681b5d3d)).

Reading the stack trace end to end, the failing query is a Django ORM lookup (`module: django.db.utils`) made from the Google Search Console source:

```
import_data_activity_sync → _run → pipeline.run → async_iterate → get_rows
  → google_search_console_session → _credentials → Integration.objects.get(...)
  → psycopg → OperationalError: server closed the connection unexpectedly
```

`_credentials` builds the authorized session lazily from inside `get_rows`, which runs in a Temporal worker thread. By the time the lookup runs, the Django Postgres connection held by that thread has often been idle for minutes (schema fetch, prior extraction) and has been closed server-side. Reusing that stale connection raises the error.

## Changes

This is **our** bug, not a customer/upstream credential problem, and not an unfixable transient — the connection drop is a consequence of reusing a stale pooled connection in a worker thread, which we control. So it should **not** be added to `get_non_retryable_errors` (that would wrongly mark syncs as permanently failed on a recoverable blip).

The fix mirrors the existing, established pattern in the Google Ads source (`google_ads_client`), which already calls `close_old_connections()` for exactly this reason: refresh the connection right before the `Integration.objects.get(...)` lookup in `_credentials`, so the query grabs a fresh connection. Scoped to the one source whose trace produced the issue; no retry-policy or shared-pipeline changes.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — I did not run a manual sync:

- Added `TestCredentialsStaleConnection`, a regression test asserting `close_old_connections()` is called before `Integration.objects.get(...)` (ordering enforced via a shared mock manager), mirroring the Google Ads regression test.
- Ran the full `test_google_search_console.py` suite: 39 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged an error-tracking issue: pulled the issue, representative event, and full stack trace via the PostHog error-tracking MCP tools, then traced the call path through `posthog/temporal/data_imports/`.
- Decision: transient-looking message, but the root cause is a stale Django connection reused in a worker thread — a fixable bug with an in-repo precedent (Google Ads `close_old_connections()`), not a non-retryable user/upstream error. Chose the minimal per-source fix matching that precedent over a broader shared-pipeline change to keep scope tight.
