### PR TITLE
fix(plain): use Plain's `after` datetime filter for incremental syncs

### DIFF
--- a/posthog/temporal/data_imports/sources/plain/plain.py
+++ b/posthog/temporal/data_imports/sources/plain/plain.py
@@ -37,6 +37,16 @@ def _datetime_to_plain_iso8601(value: datetime) -> str:
     return value.isoformat().replace("+00:00", "Z")
 
 
+def _updated_at_filter(updated_at_gte: datetime) -> dict[str, Any]:
+    """Build Plain's server-side ``updatedAt`` filter for incremental syncs.
+
+    Plain's ``DatetimeFilter`` exposes ``after`` (>= the given timestamp) and ``before`` (< it);
+    it has no ``gte`` field, so sending one is rejected with a 400. ``after`` matches the inclusive
+    lower-bound semantics we want for incremental syncs.
+    """
+    return {"updatedAt": {"after": _datetime_to_plain_iso8601(updated_at_gte)}}
+
+
 def _parse_plain_datetime(value: str | datetime | None) -> datetime | None:
     if value is None:
         return None
@@ -235,7 +245,7 @@ def _fetch_paginated_endpoint(
     variables: dict[str, Any] = {"first": PLAIN_DEFAULT_PAGE_SIZE}
 
     if updated_at_gte is not None:
-        variables["filter"] = {"updatedAt": {"gte": _datetime_to_plain_iso8601(updated_at_gte)}}
+        variables["filter"] = _updated_at_filter(updated_at_gte)
 
     has_next_page = True
     while has_next_page:
@@ -267,7 +277,7 @@ def _fetch_timeline_entries(
     """
     variables: dict[str, Any] = {"first": PLAIN_DEFAULT_PAGE_SIZE}
     if created_at_gte is not None:
-        variables["filter"] = {"updatedAt": {"gte": _datetime_to_plain_iso8601(created_at_gte)}}
+        variables["filter"] = _updated_at_filter(created_at_gte)
 
     has_next_page = True
     while has_next_page:

--- a/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
+++ b/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
@@ -8,6 +8,7 @@ import requests
 from posthog.temporal.data_imports.sources.plain.plain import (
     PlainRetryableError,
     _datetime_to_plain_iso8601,
+    _fetch_paginated_endpoint,
     _fetch_thread_timeline_entries,
     _fetch_timeline_entries,
     _flatten_datetime,
@@ -340,6 +341,51 @@ class TestTimelineEntryIncrementalFilter:
         assert [e["id"] for e in pages[0]] == ["te_null"]
 
 
+class TestFetchPaginatedEndpointIncrementalFilter:
+    def test_sends_after_filter_when_incremental(self):
+        recorded = []
+
+        def execute(query, variables):
+            recorded.append((query, dict(variables)))
+            return {"data": {"customers": {"edges": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+
+        list(
+            _fetch_paginated_endpoint(
+                execute,
+                endpoint_name="customers",
+                query="query PaginatedCustomers { customers { edges { node { id } } } }",
+                logger=mock.MagicMock(),
+                updated_at_gte=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            )
+        )
+
+        assert recorded, "expected customers query to be issued"
+        _, variables = recorded[0]
+        # Plain's DatetimeFilter uses `after` (>=), not `gte` — sending `gte` is rejected with a 400.
+        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00Z"}}
+
+    def test_omits_filter_for_full_sync(self):
+        recorded = []
+
+        def execute(query, variables):
+            recorded.append((query, dict(variables)))
+            return {"data": {"customers": {"edges": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+
+        list(
+            _fetch_paginated_endpoint(
+                execute,
+                endpoint_name="customers",
+                query="query PaginatedCustomers { customers { edges { node { id } } } }",
+                logger=mock.MagicMock(),
+                updated_at_gte=None,
+            )
+        )
+
+        assert recorded
+        _, variables = recorded[0]
+        assert "filter" not in variables
+
+
 class TestFetchTimelineEntriesStreaming:
     def test_sends_updatedat_filter_when_incremental(self):
         recorded = []
@@ -360,7 +406,8 @@ class TestFetchTimelineEntriesStreaming:
 
         assert recorded, "expected threads query to be issued"
         _, variables = recorded[0]
-        assert variables["filter"] == {"updatedAt": {"gte": "2024-01-15T10:30:00Z"}}
+        # Plain's DatetimeFilter uses `after` (>=), not `gte` — sending `gte` is rejected with a 400.
+        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00Z"}}
 
     def test_streams_thread_pages_without_buffering_all_ids(self):
         executed_queries: list[str] = []


### PR DESCRIPTION
## Problem

Incremental syncs for the `plain` data-warehouse import source were failing with a 400 Bad Request from Plain's GraphQL API:

```
400 Client Error: Bad Request (Plain API: Variable "$filter" got invalid value
{ gte: "..." } at "filter.updatedAt"; Field "gte" is not defined by type "DatetimeFilter".)
```

Plain's `DatetimeFilter` input type only defines two fields — `after` (timestamps **greater than or equal**) and `before` (timestamps **less than**). Our incremental sync built the server-side filter as `{updatedAt: {gte: ...}}`, and Plain rejects the unknown `gte` field outright.

This only surfaced on incremental syncs: the initial full sync sends no filter and succeeds, so every subsequent incremental run for a source was the one that broke.

Observed via PostHog error tracking — [issue 019eb306-1ac6-7583-9d91-0db09e171b40](https://us.posthog.com/project/2/error_tracking/019eb306-1ac6-7583-9d91-0db09e171b40). The top in-app frame is `execute` in `posthog/temporal/data_imports/sources/plain/plain.py`, i.e. the request our code constructed was malformed — this is our bug, not a credential/upstream problem, so the right fix is to send a request Plain accepts (rather than adding it to `NonRetryableErrors`).

## Changes

- Build the `updatedAt` filter with Plain's `after` field instead of the non-existent `gte`. `after` has the inclusive lower-bound (`>=`) semantics we want for incremental syncs, so the behavior is unchanged apart from no longer being rejected.
- Extract the filter construction into a single `_updated_at_filter` helper used by both the paginated-endpoint path (customers/threads) and the timeline-entries path, so the two call sites can't diverge again.
- Add regression tests asserting the `after` filter shape on the paginated-endpoint path (which previously had no filter-shape coverage), that full syncs omit the filter, and updated the existing timeline-entries test (which had codified the buggy `gte` shape).

## How did you test this code?

I'm an agent. I ran the source's automated tests locally:

- `posthog/temporal/data_imports/sources/plain/tests/test_plain.py` — 29 passed
- `posthog/temporal/data_imports/sources/plain/tests/test_plain_source.py` — 10 passed
- `ruff check` and `ruff format --check` on the changed files — clean

The `after`/`before` field semantics were confirmed against Plain's published GraphQL schema (`DatetimeFilter`).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `plain` import source. Confirmed the issue in error tracking (35 occurrences, originating in `plain.py`), traced the 400 to the malformed `gte` filter, and verified against Plain's GraphQL schema that `DatetimeFilter` exposes `after`/`before` only. Decision was a code fix (wrong request param) rather than extending `NonRetryableErrors`, since the failure is our request being malformed, not a user/upstream credential or config problem.
