### PR TITLE
fix(postgres): stop capturing RLS check noise from non-Postgres engines

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -511,6 +511,23 @@ def _row_counts_from_conn(
         return {}
 
 
+def _is_unsupported_function_error(error: Exception, function_name: str) -> bool:
+    """True when `error` says the database doesn't implement `function_name`.
+
+    Real Postgres raises `UndefinedFunction` (SQLSTATE 42883), but Postgres-wire-compatible engines
+    (DuckDB/Flight-SQL-backed proxies, etc.) accept the connection yet lack Postgres-only catalog
+    functions like `row_security_active`, surfacing the failure as a generic error whose SQLSTATE we
+    can't rely on. Match the function name plus a "missing function" signal in the message so callers
+    can degrade quietly instead of alerting on an expected, already-handled shape.
+    """
+    if isinstance(error, psycopg.errors.UndefinedFunction):
+        return True
+    message = str(error).lower()
+    if function_name.lower() not in message:
+        return False
+    return any(marker in message for marker in ("does not exist", "unknown function", "not found", "no function"))
+
+
 def _rls_active_from_conn(
     connection: psycopg.Connection,
     schema: str | None,
@@ -566,7 +583,12 @@ def _rls_active_from_conn(
                     result[display_name] = bool(rls_active)
             return result
     except Exception as e:
-        capture_exception(e)
+        # Postgres-wire-compatible engines (DuckDB/Flight-SQL proxies, etc.) accept our connection
+        # but don't implement `row_security_active`. RLS is a Postgres-only concept there, so a
+        # missing-function error is an expected "no RLS" answer, not a bug — degrade quietly rather
+        # than flooding error tracking. Still capture genuinely unexpected failures.
+        if not _is_unsupported_function_error(e, "row_security_active"):
+            capture_exception(e)
         return {}
 
 

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -55,6 +55,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _is_connection_dropped_error,
     _is_partitioned_table,
     _is_read_replica,
+    _is_unsupported_function_error,
     _normalize_function_names,
     _rls_active_from_conn,
     _role_subject_to_rls,
@@ -2722,3 +2723,55 @@ class TestRlsDetectionRealDb:
             dj_cursor.execute("CREATE TABLE test_rls_noschema (id SERIAL PRIMARY KEY)")
             result = _rls_active_from_conn(cast(Any, _DjangoBackedConnection(dj_cursor)), "", None)
             assert "public.test_rls_noschema" in result
+
+
+# Message a DuckDB/Flight-SQL-backed Postgres-wire engine returns when `row_security_active` is
+# absent — the engine accepts the connection but lacks the Postgres-only catalog function.
+_FLIGHT_MISSING_FUNCTION_MSG = (
+    "flight execute: rpc error: code = InvalidArgument desc = failed to prepare query: "
+    "Catalog Error: Scalar Function with name row_security_active does not exist!"
+)
+
+
+class TestIsUnsupportedFunctionError:
+    @pytest.mark.parametrize(
+        "error,expected",
+        [
+            (psycopg.errors.InternalError(_FLIGHT_MISSING_FUNCTION_MSG), True),
+            (Exception('function "row_security_active" does not exist'), True),
+            (Exception("Unknown function: row_security_active"), True),
+            # Real Postgres raises UndefinedFunction (SQLSTATE 42883) — recognised by type alone.
+            (psycopg.errors.UndefinedFunction("function row_security_active(oid) does not exist"), True),
+            # Different function missing -> not our concern, should still be captured.
+            (Exception("function some_other_func does not exist"), False),
+            # A genuine permission error mentioning the function must NOT be swallowed.
+            (Exception("permission denied for function row_security_active"), False),
+            (Exception("connection reset by peer"), False),
+        ],
+    )
+    def test_recognises_missing_function(self, error, expected):
+        assert _is_unsupported_function_error(error, "row_security_active") is expected
+
+
+class TestRlsActiveFromConnErrorHandling:
+    @staticmethod
+    def _conn_raising(exc: Exception):
+        conn = mock.MagicMock()
+        conn.cursor.return_value.__enter__.return_value.execute.side_effect = exc
+        return conn
+
+    def test_unsupported_function_error_is_not_captured(self):
+        # A Postgres-wire engine without `row_security_active` is an expected shape: degrade to no
+        # RLS warnings without flooding error tracking.
+        conn = self._conn_raising(psycopg.errors.InternalError(_FLIGHT_MISSING_FUNCTION_MSG))
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
+            result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
+        assert result == {}
+        capture_mock.assert_not_called()
+
+    def test_unexpected_error_is_still_captured(self):
+        conn = self._conn_raising(Exception("connection reset by peer"))
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as capture_mock:
+            result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
+        assert result == {}
+        capture_mock.assert_called_once()


### PR DESCRIPTION
## Problem

Error tracking surfaced an `InternalError_` from the Postgres data-warehouse import source:

```
flight execute: rpc error: code = InvalidArgument desc = failed to prepare query:
Catalog Error: Scalar Function with name row_security_active does not exist!
LINE 1: SELECT n.nspname, c.relname, row_security_active(c.oid) FROM memory.main.pg_class ...
```

The failure originates in `_rls_active_from_conn` (`posthog/temporal/data_imports/sources/postgres/postgres.py`), which runs an advisory row-level-security check during schema discovery. Some sources configured as "Postgres" are actually Postgres-wire-compatible engines (the `memory.main` / `flight execute` shape points at a DuckDB / Flight-SQL-backed engine) that accept the connection but don't implement the Postgres-only `row_security_active` catalog function.

Crucially, this is **not** a pipeline failure: `_rls_active_from_conn` already catches the error and degrades to "no RLS warnings", and schema discovery continues normally. The only problem is that it called `capture_exception` on *every* failure, so this expected, already-handled shape was reported to error tracking as noise.

## Changes

- Add `_is_unsupported_function_error(error, function_name)` — recognises both real Postgres `UndefinedFunction` (SQLSTATE 42883) and the generic "missing function" errors that wire-compatible engines return (matched on the function name plus a missing-function signal in the message, since their SQLSTATE isn't reliable).
- In `_rls_active_from_conn`, skip `capture_exception` when the failure is a missing `row_security_active`, while still capturing genuinely unexpected errors (permission denied, connection resets, etc.).

This is a fixable-bug fix (over-eager error capture of an expected condition), not a retry-policy change — the import path was already correct, behaviour for real Postgres is unchanged.

## How did you test this code?

I'm an agent. I added and ran automated unit tests (no manual testing):

- `TestIsUnsupportedFunctionError` — parameterized over the real engine message, real-Postgres `UndefinedFunction`, a different missing function, a permission error that *mentions* the function (must still be captured), and an unrelated transient error.
- `TestRlsActiveFromConnErrorHandling` — asserts `_rls_active_from_conn` returns `{}` and does **not** call `capture_exception` for the unsupported-function case, but still calls it once for an unexpected error.

Both new test classes pass (9 tests). The existing real-DB RLS tests require a live Postgres that isn't available in this sandbox; they were unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed via the error-tracking issue that the top in-app frame is `_rls_active_from_conn` and the exception is captured (handled), not fatal. Considered the `NonRetryableErrors` route and rejected it: the import doesn't fail on this path, so the right fix is to stop reporting an expected, already-handled condition as an error rather than to change retry behaviour. Kept the change scoped to the single capture site; the sibling `_role_subject_to_rls` already returns quietly without capturing, so it needed no change.

Tools used: Claude Code (Read/Grep/Edit/Bash), PostHog error-tracking MCP (`query-error-tracking-issue`).
