### PR TITLE
fix(postgres): treat offset-chunking statement timeout as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -175,6 +175,30 @@ def _connect_with_dropped_retry(
             time.sleep(min(2 * attempt, 30))
 
 
+def _statement_timeout_as_non_retryable(
+    error: BaseException,
+    *,
+    should_use_incremental_field: bool,
+    incremental_field: str | None,
+) -> QueryTimeoutException | None:
+    """Classify a statement_timeout (QueryCanceled) hit while streaming rows.
+
+    A chunk/fetch that exhausts the 10-min statement_timeout cannot complete in
+    time — usually a missing index on the incremental field or a deep OFFSET scan —
+    so retrying is futile. On incremental syncs, map it to the same non-retryable
+    QueryTimeoutException the server-cursor and windowed read paths already raise,
+    with an actionable message. Returns None when the error is not a statement
+    timeout, or the sync is non-incremental (the caller should re-raise the original
+    error so a full re-sync can reorder rows safely).
+    """
+    if not isinstance(error, psycopg.errors.QueryCanceled) or not should_use_incremental_field:
+        return None
+    return QueryTimeoutException(
+        f"10 min timeout statement reached. Please ensure your incremental field "
+        f"({incremental_field}) has an appropriate index created"
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class PostgresDiscoveredSchema:
     source_catalog: str | None
@@ -2106,6 +2130,22 @@ def postgres_source(
                         else:
                             # Linear backoff on successive errors to make sure we give the read replica time to catch up
                             time.sleep(2 * successive_errors)
+                    except psycopg.errors.QueryCanceled as e:
+                        # A chunk hit the 10-min statement_timeout. QueryCanceled
+                        # subclasses OperationalError, so this clause must precede the
+                        # connection-dropped handler below. Retrying won't help, so map
+                        # it to the same non-retryable QueryTimeoutException the
+                        # server-cursor and windowed paths raise instead of leaking a
+                        # raw, retryable QueryCanceled that Temporal keeps re-attempting.
+                        _safe_close_connection(connection)
+                        timeout_error = _statement_timeout_as_non_retryable(
+                            e,
+                            should_use_incremental_field=should_use_incremental_field,
+                            incremental_field=incremental_field,
+                        )
+                        if timeout_error is not None:
+                            raise timeout_error from e
+                        raise
                     except (psycopg.errors.ProtocolViolation, psycopg.OperationalError) as e:
                         if not _is_connection_dropped_error(e):
                             _safe_close_connection(connection)

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -62,6 +62,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _normalize_function_names,
     _rls_active_from_conn,
     _role_subject_to_rls,
+    _statement_timeout_as_non_retryable,
     filter_postgres_incremental_fields,
     get_foreign_keys,
     get_leading_index_columns,
@@ -282,6 +283,46 @@ class TestConnectWithDroppedRetry:
                 _connect_with_dropped_retry(connect, logger, max_attempts=3)
 
         assert connect.call_count == 3
+
+
+class TestStatementTimeoutAsNonRetryable:
+    def test_incremental_statement_timeout_maps_to_query_timeout(self):
+        result = _statement_timeout_as_non_retryable(
+            psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
+            should_use_incremental_field=True,
+            incremental_field="updated_at",
+        )
+        assert isinstance(result, QueryTimeoutException)
+        assert "updated_at" in str(result)
+
+    def test_non_incremental_statement_timeout_is_not_mapped(self):
+        # Full-table syncs must re-raise the raw QueryCanceled so a fresh re-sync can
+        # reorder rows; we only short-circuit incremental reads.
+        result = _statement_timeout_as_non_retryable(
+            psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
+            should_use_incremental_field=False,
+            incremental_field=None,
+        )
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            psycopg.errors.ProtocolViolation("server conn crashed?"),
+            psycopg.OperationalError("server closed the connection unexpectedly"),
+            psycopg.errors.SerializationFailure("due to conflict with recovery"),
+            Exception("canceling statement due to statement timeout"),
+        ],
+    )
+    def test_non_statement_timeout_errors_are_not_mapped(self, error):
+        assert (
+            _statement_timeout_as_non_retryable(
+                error,
+                should_use_incremental_field=True,
+                incremental_field="updated_at",
+            )
+            is None
+        )
 
 
 class TestPostgresSourceForPipelineSchemaResolution:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -286,24 +286,27 @@ class TestConnectWithDroppedRetry:
 
 
 class TestStatementTimeoutAsNonRetryable:
-    def test_incremental_statement_timeout_maps_to_query_timeout(self):
+    @pytest.mark.parametrize(
+        "should_use_incremental_field,incremental_field,expected_substr",
+        [
+            # Incremental syncs map the timeout to a non-retryable QueryTimeoutException.
+            (True, "updated_at", "updated_at"),
+            # Full-table syncs must re-raise the raw QueryCanceled so a fresh re-sync can
+            # reorder rows; we only short-circuit incremental reads.
+            (False, None, None),
+        ],
+    )
+    def test_statement_timeout_mapping(self, should_use_incremental_field, incremental_field, expected_substr):
         result = _statement_timeout_as_non_retryable(
             psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
-            should_use_incremental_field=True,
-            incremental_field="updated_at",
+            should_use_incremental_field=should_use_incremental_field,
+            incremental_field=incremental_field,
         )
-        assert isinstance(result, QueryTimeoutException)
-        assert "updated_at" in str(result)
-
-    def test_non_incremental_statement_timeout_is_not_mapped(self):
-        # Full-table syncs must re-raise the raw QueryCanceled so a fresh re-sync can
-        # reorder rows; we only short-circuit incremental reads.
-        result = _statement_timeout_as_non_retryable(
-            psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
-            should_use_incremental_field=False,
-            incremental_field=None,
-        )
-        assert result is None
+        if expected_substr is None:
+            assert result is None
+        else:
+            assert isinstance(result, QueryTimeoutException)
+            assert expected_substr in str(result)
 
     @pytest.mark.parametrize(
         "error",


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring failure on the Postgres data-warehouse import source: [`ProtocolViolation: server conn crashed?`](https://us.posthog.com/project/2/error_tracking/019eb5b3-b38a-7e01-b6c0-dc5eedd36fe2), top in-app frame `offset_chunking` in `posthog/temporal/data_imports/sources/postgres/postgres.py`.

Reading the captured exception chain end to end, the `ProtocolViolation: server conn crashed?` is actually the *handled* cause — the server-cursor read hit a pooler connection drop and correctly fell back to `offset_chunking`. The exception that then *escaped* the activity is a chained `QueryCanceled: canceling statement due to statement timeout` raised inside `offset_chunking` on an incremental read.

That `QueryCanceled` was caught by the generic `(ProtocolViolation, OperationalError)` handler, found not to be a connection drop, and re-raised raw. A raw `QueryCanceled` is not in the source's non-retryable list, so Temporal kept retrying (the failing event was on activity attempt 6) a chunk query that cannot complete within the 10-minute `statement_timeout` — typically because the incremental field lacks an appropriate index, or because a deep `OFFSET` scan is inherently slow. Retrying that is futile and just generates noise.

## Changes

The server-cursor read path (`postgres.py`) and the windowed read path (`partitioned_tables.py`) already classify this exact condition as a **non-retryable** `QueryTimeoutException` with an actionable "ensure your incremental field has an index" message. This brings the `offset_chunking` fallback in line with that established convention:

- Add a small module-level classifier `_statement_timeout_as_non_retryable(...)` (mirroring the existing `_is_connection_dropped_error` helper) that maps a `QueryCanceled` on an incremental sync to `QueryTimeoutException`, and returns `None` otherwise (non-incremental syncs re-raise the raw error so a fresh re-sync can reorder rows safely).
- Add an `except psycopg.errors.QueryCanceled` clause in `offset_chunking` that uses it. It is placed **before** the generic `OperationalError` clause because `QueryCanceled` subclasses `OperationalError`. Recovery-conflict cancels (SQLSTATE 40001 → `SerializationFailure`) are still handled by the existing clause above, so they remain retryable.

`QueryTimeoutException` is already listed in `PostgresSource.get_non_retryable_errors`, so the escaping error now stops the futile retry loop and shows the user an actionable message instead.

### Decision: fixable bug, not a NonRetryableErrors entry

This is not a credentials/config user error, and the underlying statement timeout is not something to add verbatim to `NonRetryableErrors` (that would also catch transient cancels). The bug is that `offset_chunking` failed to apply the codebase's own already-established classification, leaking a raw retryable error. The fix re-uses the existing non-retryable `QueryTimeoutException` path rather than introducing new retry policy.

## How did you test this code?

I'm an agent. I added and ran automated unit tests; I did not perform manual end-to-end testing.

- New `TestStatementTimeoutAsNonRetryable` covering: incremental `QueryCanceled` → `QueryTimeoutException` (message references the incremental field), non-incremental → `None` (re-raise), and non-`QueryCanceled` errors (`ProtocolViolation`, `OperationalError`, `SerializationFailure`, plain `Exception`) → `None`.
- Ran the new class plus the related `TestIsConnectionDroppedError`, `TestIterateDateWindowsFake`, and `TestPostgresSourceNonRetryableErrors` (41 passed). `ruff check` / `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the Postgres import source. Pulled the issue's single sampled event via the error-tracking MCP tools and traced the exception chain: confirmed the `ProtocolViolation` is already handled (it triggers the `offset_chunking` fallback) and that the real escaping error is a chained statement-timeout `QueryCanceled` leaking from `offset_chunking`.

Considered three options: (1) no change — rejected because the residual statement timeout escapes as retryable and loops; (2) add to `NonRetryableErrors` — rejected as too broad and not the right layer; (3) mirror the existing `QueryTimeoutException` convention already used by the server-cursor and windowed paths — chosen, since it reuses an already-non-retryable, actionable error and keeps the three read strategies consistent. Kept the diff scoped to `offset_chunking` (the observed frame) and matched the file's `_is_connection_dropped_error` helper-plus-direct-test pattern for the regression test.
