### PR TITLE
fix(dashboards): consolidate edit-mode filter actions into one button group

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -19,6 +19,7 @@ import { DashboardMode, DashboardPlacement, DashboardType } from '~/types'
 
 import { DashboardEditBar } from './DashboardEditBar'
 import { dashboardFiltersLogic } from './dashboardFiltersLogic'
+import { DashboardEditSaveCancelButtons } from './DashboardHeaderActions'
 import { dashboardLogic } from './dashboardLogic'
 import { DashboardQuickFiltersButton } from './DashboardQuickFiltersButton'
 import { dashboardQuickFiltersSelectionLogic } from './dashboardQuickFiltersSelectionLogic'
@@ -160,15 +161,9 @@ export function DashboardAdvancedOptions(): JSX.Element | null {
  * always safe to skip Apply and go straight to Save.
  */
 function DashboardEditActions(): JSX.Element | null {
-    const {
-        dashboardMode,
-        layoutEditMode,
-        canEditDashboard,
-        dashboardLoading,
-        showApplyFiltersBanner,
-        loadingPreview,
-    } = useValues(dashboardLogic)
-    const { setDashboardMode, cancelEditMode, applyFilters } = useActions(dashboardLogic)
+    const { dashboardMode, layoutEditMode, canEditDashboard, showApplyFiltersBanner, loadingPreview } =
+        useValues(dashboardLogic)
+    const { applyFilters } = useActions(dashboardLogic)
 
     if (dashboardMode !== DashboardMode.Edit || layoutEditMode || !canEditDashboard) {
         return null
@@ -176,63 +171,23 @@ function DashboardEditActions(): JSX.Element | null {
 
     return (
         <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <AppShortcut
-                name="CancelDashboardEdit"
-                keybind={[keyBinds.escape]}
-                intent="Cancel edit mode"
-                interaction="click"
-                scope={Scene.Dashboard}
-            >
-                <LemonButton
-                    data-attr="dashboard-edit-mode-discard"
-                    type="secondary"
-                    size="small"
-                    onClick={() => cancelEditMode()}
-                    tooltip="Discard changes and exit edit mode"
-                >
-                    Cancel
-                </LemonButton>
-            </AppShortcut>
-
-            {showApplyFiltersBanner && (
-                <LemonButton
-                    data-attr="dashboard-apply-filters"
-                    type="secondary"
-                    size="small"
-                    loading={loadingPreview}
-                    onClick={applyFilters}
-                    tooltip="Preview these filters. Large dashboards don't auto-apply — Save will apply and persist them too."
-                >
-                    Apply filters
-                </LemonButton>
-            )}
-
-            <AppShortcut
-                name="SaveDashboard"
-                keybind={[keyBinds.edit, keyBinds.save]}
-                intent="Save dashboard"
-                interaction="click"
-                scope={Scene.Dashboard}
-                disabled={!canEditDashboard}
-            >
-                <LemonButton
-                    data-attr="dashboard-edit-mode-save"
-                    type="primary"
-                    size="small"
-                    onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderSaveDashboard)}
-                    tooltip="Save dashboard"
-                    tooltipPlacement="bottom"
-                    disabledReason={
-                        dashboardLoading
-                            ? 'Wait for dashboard to finish loading'
-                            : canEditDashboard
-                              ? undefined
-                              : 'Not privileged to edit this dashboard'
-                    }
-                >
-                    Save
-                </LemonButton>
-            </AppShortcut>
+            <DashboardEditSaveCancelButtons
+                withShortcuts
+                middle={
+                    showApplyFiltersBanner ? (
+                        <LemonButton
+                            data-attr="dashboard-apply-filters"
+                            type="secondary"
+                            size="small"
+                            loading={loadingPreview}
+                            onClick={applyFilters}
+                            tooltip="Preview these filters. Large dashboards don't auto-apply — Save will apply and persist them too."
+                        >
+                            Apply filters
+                        </LemonButton>
+                    ) : null
+                }
+            />
         </div>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -173,7 +173,7 @@ function DashboardEditActions(): JSX.Element | null {
         <div className="flex shrink-0 flex-wrap items-center gap-2">
             <DashboardEditSaveCancelButtons
                 withShortcuts
-                middle={
+                extraAction={
                     showApplyFiltersBanner ? (
                         <LemonButton
                             data-attr="dashboard-apply-filters"

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -173,7 +173,7 @@ function DashboardEditActions(): JSX.Element | null {
         <div className="flex shrink-0 flex-wrap items-center gap-2">
             <DashboardEditSaveCancelButtons
                 withShortcuts
-                extraAction={
+                applyFiltersButton={
                     showApplyFiltersBanner ? (
                         <LemonButton
                             data-attr="dashboard-apply-filters"

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -19,7 +19,6 @@ import { DashboardMode, DashboardPlacement, DashboardType } from '~/types'
 
 import { DashboardEditBar } from './DashboardEditBar'
 import { dashboardFiltersLogic } from './dashboardFiltersLogic'
-import { DashboardEditSaveCancelButtons } from './DashboardHeaderActions'
 import { dashboardLogic } from './dashboardLogic'
 import { DashboardQuickFiltersButton } from './DashboardQuickFiltersButton'
 import { dashboardQuickFiltersSelectionLogic } from './dashboardQuickFiltersSelectionLogic'
@@ -152,8 +151,24 @@ export function DashboardAdvancedOptions(): JSX.Element | null {
     return <DashboardEditBar showDateFilter={false} className="flex gap-2 items-end flex-wrap border rounded p-2" />
 }
 
-function DashboardFilterEditActions(): JSX.Element | null {
-    const { dashboardMode, layoutEditMode, canEditDashboard } = useValues(dashboardLogic)
+/**
+ * Edit-mode actions for the filter bar.
+ *
+ * One Cancel discards everything. On large dashboards that don't auto-preview, an
+ * "Apply filters" button appears so the user can preview pending filter changes before
+ * committing — Save applies any still-unapplied filters as part of persisting, so it's
+ * always safe to skip Apply and go straight to Save.
+ */
+function DashboardEditActions(): JSX.Element | null {
+    const {
+        dashboardMode,
+        layoutEditMode,
+        canEditDashboard,
+        dashboardLoading,
+        showApplyFiltersBanner,
+        loadingPreview,
+    } = useValues(dashboardLogic)
+    const { setDashboardMode, cancelEditMode, applyFilters } = useActions(dashboardLogic)
 
     if (dashboardMode !== DashboardMode.Edit || layoutEditMode || !canEditDashboard) {
         return null
@@ -161,44 +176,63 @@ function DashboardFilterEditActions(): JSX.Element | null {
 
     return (
         <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <DashboardEditSaveCancelButtons withShortcuts />
-        </div>
-    )
-}
-
-function DashboardApplyFiltersInline(): JSX.Element | null {
-    const { showApplyFiltersBanner, loadingPreview, cancellingPreview, hasUrlFilters, dashboardMode } =
-        useValues(dashboardLogic)
-    const { applyFilters, setDashboardMode } = useActions(dashboardLogic)
-
-    if (!showApplyFiltersBanner) {
-        return null
-    }
-
-    return (
-        <div className="flex flex-wrap gap-2 shrink-0 items-center ml-4">
-            <LemonButton
-                onClick={() =>
-                    setDashboardMode(
-                        hasUrlFilters ? dashboardMode : null,
-                        DashboardEventSource.DashboardHeaderDiscardChanges
-                    )
-                }
-                loading={cancellingPreview}
-                type="secondary"
-                size="small"
+            <AppShortcut
+                name="CancelDashboardEdit"
+                keybind={[keyBinds.escape]}
+                intent="Cancel edit mode"
+                interaction="click"
+                scope={Scene.Dashboard}
             >
-                Cancel
-            </LemonButton>
-            <LemonButton
-                onClick={applyFilters}
-                loading={loadingPreview}
-                type="primary"
-                size="small"
-                tooltip="Filters are not automatically applied on large dashboards."
+                <LemonButton
+                    data-attr="dashboard-edit-mode-discard"
+                    type="secondary"
+                    size="small"
+                    onClick={() => cancelEditMode()}
+                    tooltip="Discard changes and exit edit mode"
+                >
+                    Cancel
+                </LemonButton>
+            </AppShortcut>
+
+            {showApplyFiltersBanner && (
+                <LemonButton
+                    data-attr="dashboard-apply-filters"
+                    type="secondary"
+                    size="small"
+                    loading={loadingPreview}
+                    onClick={applyFilters}
+                    tooltip="Preview these filters. Large dashboards don't auto-apply — Save will apply and persist them too."
+                >
+                    Apply filters
+                </LemonButton>
+            )}
+
+            <AppShortcut
+                name="SaveDashboard"
+                keybind={[keyBinds.edit, keyBinds.save]}
+                intent="Save dashboard"
+                interaction="click"
+                scope={Scene.Dashboard}
+                disabled={!canEditDashboard}
             >
-                Apply filters
-            </LemonButton>
+                <LemonButton
+                    data-attr="dashboard-edit-mode-save"
+                    type="primary"
+                    size="small"
+                    onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderSaveDashboard)}
+                    tooltip="Save dashboard"
+                    tooltipPlacement="bottom"
+                    disabledReason={
+                        dashboardLoading
+                            ? 'Wait for dashboard to finish loading'
+                            : canEditDashboard
+                              ? undefined
+                              : 'Not privileged to edit this dashboard'
+                    }
+                >
+                    Save
+                </LemonButton>
+            </AppShortcut>
         </div>
     )
 }
@@ -225,8 +259,7 @@ export function DashboardFilterBar({ backTo }: DashboardFilterBarProps): JSX.Ele
                         ].includes(placement) &&
                             dashboard &&
                             (dashboardFiltersEnabled ? <DashboardPrimaryFilters /> : <DashboardEditBar />)}
-                        <DashboardFilterEditActions />
-                        <DashboardApplyFiltersInline />
+                        <DashboardEditActions />
                     </div>
                 </div>
                 {![DashboardPlacement.Export, DashboardPlacement.Builtin].includes(placement) && (

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -96,7 +96,14 @@ export function DashboardAddTileButton(): JSX.Element | null {
     )
 }
 
-export function DashboardEditSaveCancelButtons({ withShortcuts = true }: { withShortcuts?: boolean }): JSX.Element {
+export function DashboardEditSaveCancelButtons({
+    withShortcuts = true,
+    middle,
+}: {
+    withShortcuts?: boolean
+    /** Optional action rendered between Cancel and Save (e.g. the large-dashboard "Apply filters" preview). */
+    middle?: JSX.Element | null
+}): JSX.Element {
     const { dashboardLoading, canEditDashboard } = useValues(dashboardLogic)
     const { setDashboardMode, cancelEditMode } = useActions(dashboardLogic)
 
@@ -136,6 +143,7 @@ export function DashboardEditSaveCancelButtons({ withShortcuts = true }: { withS
         return (
             <>
                 {cancelButton}
+                {middle}
                 {saveButton}
             </>
         )
@@ -152,6 +160,7 @@ export function DashboardEditSaveCancelButtons({ withShortcuts = true }: { withS
             >
                 {cancelButton}
             </AppShortcut>
+            {middle}
             <AppShortcut
                 name="SaveDashboard"
                 keybind={[keyBinds.edit, keyBinds.save]}

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -98,11 +98,11 @@ export function DashboardAddTileButton(): JSX.Element | null {
 
 export function DashboardEditSaveCancelButtons({
     withShortcuts = true,
-    extraAction,
+    applyFiltersButton,
 }: {
     withShortcuts?: boolean
-    /** Optional action rendered between Cancel and Save (e.g. the large-dashboard "Apply filters" preview). */
-    extraAction?: JSX.Element | null
+    /** The large-dashboard "Apply filters" preview button, rendered between Cancel and Save. */
+    applyFiltersButton?: JSX.Element | null
 }): JSX.Element {
     const { dashboardLoading, canEditDashboard } = useValues(dashboardLogic)
     const { setDashboardMode, cancelEditMode } = useActions(dashboardLogic)
@@ -143,7 +143,7 @@ export function DashboardEditSaveCancelButtons({
         return (
             <>
                 {cancelButton}
-                {extraAction}
+                {applyFiltersButton}
                 {saveButton}
             </>
         )
@@ -160,7 +160,7 @@ export function DashboardEditSaveCancelButtons({
             >
                 {cancelButton}
             </AppShortcut>
-            {extraAction}
+            {applyFiltersButton}
             <AppShortcut
                 name="SaveDashboard"
                 keybind={[keyBinds.edit, keyBinds.save]}

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -98,11 +98,11 @@ export function DashboardAddTileButton(): JSX.Element | null {
 
 export function DashboardEditSaveCancelButtons({
     withShortcuts = true,
-    middle,
+    extraAction,
 }: {
     withShortcuts?: boolean
     /** Optional action rendered between Cancel and Save (e.g. the large-dashboard "Apply filters" preview). */
-    middle?: JSX.Element | null
+    extraAction?: JSX.Element | null
 }): JSX.Element {
     const { dashboardLoading, canEditDashboard } = useValues(dashboardLogic)
     const { setDashboardMode, cancelEditMode } = useActions(dashboardLogic)
@@ -143,7 +143,7 @@ export function DashboardEditSaveCancelButtons({
         return (
             <>
                 {cancelButton}
-                {middle}
+                {extraAction}
                 {saveButton}
             </>
         )
@@ -160,7 +160,7 @@ export function DashboardEditSaveCancelButtons({
             >
                 {cancelButton}
             </AppShortcut>
-            {middle}
+            {extraAction}
             <AppShortcut
                 name="SaveDashboard"
                 keybind={[keyBinds.edit, keyBinds.save]}

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1342,11 +1342,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
         canAutoPreview: [
-            (s) => [s.dashboard],
-            (dashboard) => {
+            (s) => [s.insightTiles],
+            (insightTiles) => {
                 const payload = getFeatureFlagPayload(FEATURE_FLAGS.DASHBOARD_AUTO_PREVIEW_LIMIT)
                 const limit = typeof payload === 'number' ? payload : DEFAULT_AUTO_PREVIEW_TILE_LIMIT
-                return (dashboard?.tiles.length || 0) < limit
+                // The limit is about the number of insights on a dashboard (per the flag's intent),
+                // so count insight tiles only — not text, button, or widget tiles.
+                return insightTiles.length < limit
             },
         ],
         hasIntermittentFilters: [


### PR DESCRIPTION
## Problem

- Editing a dashboard's filters showed **two `Cancel`/`Save` pairs** in the filter bar — two `Cancel` buttons side by side, and a `Save` next to a competing `Apply filters`.
- Separately, the `Apply filters` preview prompt was appearing on a small dashboard (7 insights) that should auto-preview.

## Changes

- Merged the two pairs into one `DashboardEditActions` cluster: a single `Cancel`, an optional `Apply filters` (only when a large dashboard has unapplied changes), and `Save`.
- `Save` already applies any unapplied filters when persisting, so skipping `Apply` is safe.
- Kept keyboard shortcuts (Esc / E / ⌘S), tooltips, and loading/disabled states.
- Fixed `canAutoPreview` to count **insight tiles** (via the `insightTiles` selector) instead of the raw tile array — text/button/hidden-widget tiles no longer push a small dashboard over the limit.

## How did you test this code?

- Agent (PostHog Code), directed by the assignee.
- `oxlint` on both changed files — clean. `pnpm format` — clean.
- Did not run full `tsc` (OOMs locally) or manual UI testing; CI covers those.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with PostHog Code; human driver flagged the duplicated buttons and the spurious `Apply` prompt.
- Root cause confirmed against the live dashboard's tiles in Postgres (7 insight tiles + 3 hidden widget tiles = count of 10).
- Prototyped the cluster with quill `ButtonGroup`, reverted to `LemonButton` to match the surrounding bar.
- Out of scope: the `dashboard-auto-preview-limit` flag payload being a string `"22"` that the `typeof === 'number'` guard rejects, and widget tiles lingering when the `DASHBOARD_WIDGETS` beta is off.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
