### PR TITLE
feat(insights): freeze the header on DataTable node insights

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -331,6 +331,13 @@
     border-top: 1px solid var(--color-border-primary);
 }
 
+.LemonTable--sticky-header {
+    .ScrollableShadows__inner {
+        // Only long tables scroll; short ones render unchanged.
+        max-height: var(--lemon-table-sticky-header-max-height, 600px);
+    }
+}
+
 // NOTE: this is outside of the storybook check for 3000 selective styling
 .LemonTable__cell--sticky {
     background: var(--lemon-table-background-color);
@@ -351,6 +358,15 @@
 
 // Stickiness is disabled in snapshots due to flakiness
 body:not(.storybook-test-runner) {
+    .LemonTable--sticky-header .LemonTable__content > table > thead {
+        position: sticky;
+        top: 0;
+
+        // Above tbody rows AND above pinned-column cells (z-index: 6), so the
+        // frozen-corner (sticky header × pinned column) renders correctly.
+        z-index: 7;
+    }
+
     .LemonTable__header--sticky,
     .LemonTable__cell--sticky,
     .LemonTable__header--pinned,

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -89,6 +89,8 @@ export interface LemonTableProps<T extends Record<string, any>, K extends BulkSe
     footer?: React.ReactNode
     /** Whether the first column should always remain visible when scrolling horizontally. */
     firstColumnSticky?: boolean
+    /** Freeze the header — body scrolls vertically within a max-height while the header stays pinned at the top. */
+    stickyHeader?: boolean
     /** Array of column keys to pin (make sticky). Columns won't be pinned in order. */
     pinnedColumns?: string[]
     // Max width for the column headers
@@ -140,6 +142,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
     'data-attr': dataAttr,
     footer,
     firstColumnSticky,
+    stickyHeader = false,
     pinnedColumns,
     maxHeaderWidth,
     hideScrollbar,
@@ -372,6 +375,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                     rowRibbonColor !== undefined && `LemonTable--with-ribbon`,
                     stealth && 'LemonTable--stealth',
                     !uppercaseHeader && 'LemonTable--lowercase-header',
+                    stickyHeader && 'LemonTable--sticky-header',
                     allowContentScroll && 'h-full min-h-0 overflow-hidden',
                     className
                 )}
@@ -381,7 +385,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
             >
                 <ScrollableShadows
                     innerClassName={hideScrollbar ? 'hide-scrollbar' : undefined}
-                    direction={allowContentScroll ? undefined : 'horizontal'}
+                    direction={allowContentScroll || stickyHeader ? undefined : 'horizontal'}
                     scrollRef={scrollRef}
                 >
                     <div className="LemonTable__content">

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -903,6 +903,7 @@ export function DataTable({
                             <LemonTable
                                 data-attr={dataAttr}
                                 className="DataTable"
+                                stickyHeader
                                 loading={responseLoading && !nextDataLoading && !newDataLoading}
                                 columns={lemonColumns}
                                 embedded={embedded}


### PR DESCRIPTION
## Problem

DataTable node insights (the `DataTableNode` query kind — events explorer, persons, web analytics, HogQL result tables, etc.) render their results in a `LemonTable` that expands to full height and relies on the page to scroll. Once a result set is long, the column headers scroll out of view and you lose track of which column is which.

## Changes

Freeze the header so it stays visible while scrolling through rows. Implemented as a reusable `stickyHeader` prop on `LemonTable`, then enabled for the DataTable results table:

- **`LemonTable.tsx`** — new `stickyHeader?: boolean` prop. When on, the scroll viewport is allowed to scroll vertically and the outer element gets a `LemonTable--sticky-header` class.
- **`LemonTable.scss`** — the scroll viewport gets `max-height: var(--lemon-table-sticky-header-max-height, 600px)` and the `<thead>` becomes `position: sticky; top: 0`. Because the trigger is a max-height (not a fixed height), **short tables render exactly as today** — only tables taller than the threshold scroll internally with a frozen header.
- **`DataTable.tsx`** — passes `stickyHeader` to the results `LemonTable`.

A few details that made this self-contained:

- `.LemonTable` and its scroll viewport already set `overflow`, which traps a whole-page `position: sticky`. Making the viewport itself the vertical scroll container side-steps that and also works inside dashboard cards.
- The `<thead>` already carries a background and each `<th>` already uses a `box-shadow` bottom border (the SCSS even notes it "supports sticky headers"), so rows don't bleed through and the divider survives.
- `z-index: 7` on the sticky `<thead>` keeps it above tbody rows and above pinned-column cells (`z-index: 6`), so the freeze-corner (sticky header × pinned column) renders correctly.
- The sticky CSS is gated behind the existing `body:not(.storybook-test-runner)` guard, so Storybook visual snapshots are unaffected.

## How did you test this code?

I'm an agent. The dev tooling (`node_modules`, flox) was not available in my environment, so I could **not** run `typescript:check`, `oxfmt`, or the app locally — CI will run lint/types. The change is small and follows existing patterns. Applying the `hobby-preview` label to spin up a preview droplet for manual verification: open a DataTable insight with many rows and confirm the header stays pinned while the body scrolls; confirm short tables and tables with pinned columns behave correctly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @jovansakovic.

Built with Claude Code. The product shape was decided with the requester: the freeze is **always-on** for DataTable nodes (no per-insight toggle, so no schema/openapi changes) and uses a **scroll-within-the-table** model (max-height + internal scroll) rather than whole-page stickiness. The whole-page approach was rejected because `LemonTable`'s existing `overflow` ancestors trap `position: sticky`; the internal-scroll model is self-contained and also works inside dashboard cards. Implemented as a generic `LemonTable` prop so other tables can opt in later.
