### PR TITLE
feat(vision): polish scanner overview actions and enable toggle

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -4,7 +4,6 @@ import { LemonBanner, LemonButton, LemonSwitch } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { dayjs } from 'lib/dayjs'
-import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -39,7 +38,27 @@ export function ReplayScannerSceneComponent(): JSX.Element {
     useAttachedLogic(scannerLogic, replayScannerSceneLogic)
 
     const { scanner, scannerLoading, togglingEnabled } = useValues(scannerLogic)
-    const { deleteScanner, toggleEnabled } = useActions(scannerLogic)
+    const { toggleEnabled } = useActions(scannerLogic)
+
+    const handleToggleEnabledClick = (): void => {
+        if (!scanner) {
+            return
+        }
+        LemonDialog.open({
+            title: scanner.enabled ? 'Disable scanner?' : 'Enable scanner?',
+            description: scanner.enabled
+                ? 'This will stop the scanner from analyzing new session recordings. Are you sure?'
+                : 'The scanner will begin analyzing new session recordings that match its triggers',
+            primaryButton: {
+                children: scanner.enabled ? 'Disable' : 'Enable',
+                status: scanner.enabled ? 'danger' : 'default',
+                onClick: () => toggleEnabled(),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
 
     if (scannerLoading || !scanner) {
         return (
@@ -57,24 +76,7 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                 resourceType={{ type: 'replay_vision' }}
                 actions={
                     <>
-                        <div className="flex items-center gap-2">
-                            <AccessControlAction
-                                resourceType={AccessControlResourceType.SessionRecording}
-                                minAccessLevel={AccessControlLevel.Editor}
-                            >
-                                <LemonSwitch
-                                    checked={scanner.enabled}
-                                    onChange={() => toggleEnabled()}
-                                    disabled={togglingEnabled}
-                                    size="small"
-                                    data-attr="vision-scanner-toggle-enabled"
-                                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                                />
-                            </AccessControlAction>
-                            <span className={scanner.enabled ? 'text-success' : 'text-muted'}>
-                                {scanner.enabled ? 'Enabled' : 'Disabled'}
-                            </span>
-                        </div>
+                        <ReplayVisionFeedbackButton />
                         <AccessControlAction
                             resourceType={AccessControlResourceType.SessionRecording}
                             minAccessLevel={AccessControlLevel.Editor}
@@ -89,37 +91,29 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                                 Edit scanner
                             </LemonButton>
                         </AccessControlAction>
-                        <ReplayVisionFeedbackButton />
-                        <More
-                            size="small"
-                            overlay={
-                                <LemonButton
-                                    status="danger"
-                                    fullWidth
-                                    onClick={() =>
-                                        LemonDialog.open({
-                                            title: `Delete "${scanner.name || 'Untitled scanner'}"?`,
-                                            description: 'This cannot be undone.',
-                                            primaryButton: {
-                                                children: 'Delete',
-                                                status: 'danger',
-                                                onClick: () => deleteScanner(),
-                                            },
-                                            secondaryButton: { children: 'Cancel' },
-                                        })
-                                    }
-                                    data-attr="vision-scanner-delete"
-                                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                                >
-                                    Delete
-                                </LemonButton>
-                            }
-                        />
                     </>
                 }
             />
 
             <QuotaBanner />
+
+            <div className="w-full max-w-xs">
+                <AccessControlAction
+                    resourceType={AccessControlResourceType.SessionRecording}
+                    minAccessLevel={AccessControlLevel.Editor}
+                >
+                    <LemonSwitch
+                        checked={scanner.enabled}
+                        onChange={handleToggleEnabledClick}
+                        loading={togglingEnabled}
+                        label="Enable scanner"
+                        bordered
+                        fullWidth
+                        data-attr="vision-scanner-toggle-enabled"
+                        data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+                    />
+                </AccessControlAction>
+            </div>
 
             <ScannerOverview scannerId={scannerId} />
 

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -248,7 +248,9 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
                                 onClick={() => loadObservations()}
                                 loading={observationsLoading}
                                 data-attr="vision-observations-refresh"
-                            />
+                            >
+                                Refresh
+                            </LemonButton>
                         </Tooltip>
                     </div>
                     {observationStats.total > 0 && (


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

bad ui -> make slightly better

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![Screenshot 2026-06-11 at 10.57.35 AM.png](https://app.graphite.com/user-attachments/assets/e9c849f5-b776-4282-858f-f789541231af.png)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->