### PR TITLE
feat(tracing): add query and raw tabs to the span inspector

### DIFF
--- a/products/tracing/frontend/components/TraceDrawer/TraceDrawer.tsx
+++ b/products/tracing/frontend/components/TraceDrawer/TraceDrawer.tsx
@@ -3,6 +3,8 @@ import { useMemo, useRef, useState } from 'react'
 
 import { LemonButton, LemonTabs, LemonTag, SpinnerOverlay } from '@posthog/lemon-ui'
 
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { JSONViewer } from 'lib/components/JSONViewer'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { type ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { IconLink } from 'lib/lemon-ui/icons'
@@ -11,6 +13,7 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 
 import { useKeepMountedWhileOpen } from '../../hooks/useKeepMountedWhileOpen'
+import { getQueryText } from '../../spanSummary'
 import { absoluteTraceUrl } from '../../traceLinks'
 import { buildServiceColorMap, formatDuration, TraceWaterfallView } from '../../TraceWaterfallView'
 import type { Span } from '../../types'
@@ -18,7 +21,7 @@ import { ExpandedSpanContent } from '../VirtualizedSpanList/ExpandedSpanContent'
 import { SpanLogsTab } from './SpanLogsTab'
 import { SpanSummaryHeader } from './SpanSummaryHeader'
 
-type InspectorTab = 'attributes' | 'logs'
+type InspectorTab = 'attributes' | 'query' | 'logs' | 'raw'
 
 // Below this the inspector's content (the attribute KVP tables) stops being readable; clamp so a
 // drag can't crush it. The max is a flex `max-w` so a too-wide drag can't starve the waterfall.
@@ -73,14 +76,21 @@ export function TraceDrawer({
     // Shared with the waterfall so a service is the same color in the bars and the summary header.
     const serviceColorMap = useMemo(() => buildServiceColorMap(spans), [spans])
 
+    // The inspector always shows something: the selected span, falling back to the root.
+    const inspectedSpan = selectedSpan ?? rootSpan
+
     // Gate mounting so a closed drawer holds no react-modal portal (and its listener surface).
     const shouldRender = useKeepMountedWhileOpen(isOpen)
     if (!shouldRender) {
         return null
     }
 
-    // The inspector always shows something: the selected span, falling back to the root.
-    const inspectedSpan = selectedSpan ?? rootSpan
+    // Only DB spans carry a query; the Query tab appears only when one is present.
+    const queryText = inspectedSpan ? getQueryText(inspectedSpan) : null
+    // The Query tab is conditional, so if it's the active tab and the user selects a span without a
+    // query, fall back to Attributes — otherwise activeKey would point at a tab LemonTabs has dropped
+    // and the inspector body would render blank. (Preference is preserved: a DB span re-shows Query.)
+    const activeInspectorTab: InspectorTab = inspectorTab === 'query' && !queryText ? 'attributes' : inspectorTab
 
     return (
         <LemonDrawer
@@ -138,7 +148,7 @@ export function TraceDrawer({
                         <>
                             <SpanSummaryHeader span={inspectedSpan} serviceColorMap={serviceColorMap} />
                             <LemonTabs
-                                activeKey={inspectorTab}
+                                activeKey={activeInspectorTab}
                                 onChange={setInspectorTab}
                                 data-attr="tracing-inspector-tabs"
                                 tabs={[
@@ -149,6 +159,22 @@ export function TraceDrawer({
                                         // shows only the user attributes (no duplicate details table).
                                         content: <ExpandedSpanContent span={inspectedSpan} showDetails={false} />,
                                     },
+                                    // Conditional (LemonTabs ignores falsy entries): only DB spans have a query.
+                                    queryText
+                                        ? {
+                                              key: 'query',
+                                              label: 'Query',
+                                              content: (
+                                                  <CodeSnippet
+                                                      language={Language.SQL}
+                                                      wrap
+                                                      maxLinesWithoutExpansion={40}
+                                                  >
+                                                      {queryText}
+                                                  </CodeSnippet>
+                                              ),
+                                          }
+                                        : null,
                                     {
                                         key: 'logs',
                                         label: 'Logs',
@@ -156,6 +182,13 @@ export function TraceDrawer({
                                         // pinned filter re-query in place when the selected span changes, so a remount
                                         // would only churn its logics and lose scroll.
                                         content: <SpanLogsTab span={inspectedSpan} />,
+                                    },
+                                    {
+                                        key: 'raw',
+                                        label: 'Raw',
+                                        // Interactive tree, matching the logs viewer's raw view (LogDetailsModal)
+                                        // for cross-pane consistency. The span as the frontend holds it.
+                                        content: <JSONViewer src={inspectedSpan} collapsed={2} sortKeys />,
                                     },
                                 ]}
                             />

--- a/products/tracing/frontend/spanSummary.test.ts
+++ b/products/tracing/frontend/spanSummary.test.ts
@@ -1,4 +1,4 @@
-import { deriveSpanSummary } from './spanSummary'
+import { deriveSpanSummary, getQueryText } from './spanSummary'
 import type { Span } from './types'
 
 function makeSpan(overrides: Partial<Span>): Span {
@@ -91,5 +91,18 @@ describe('deriveSpanSummary', () => {
         [{ 'messaging.system': 'kafka' }, 'Messaging'],
     ])('derives type from the attribute namespace (%j)', (attributes, type) => {
         expect(deriveSpanSummary(makeSpan({ attributes })).type).toBe(type)
+    })
+})
+
+describe('getQueryText', () => {
+    it.each([
+        // legacy spelling
+        [{ 'db.statement': 'SELECT * FROM users WHERE id = ?' }, 'SELECT * FROM users WHERE id = ?'],
+        // both present: the stabilized db.query.text wins over the legacy db.statement
+        [{ 'db.query.text': 'SELECT 1', 'db.statement': 'SELECT 2' }, 'SELECT 1'],
+        // non-DB span
+        [{ 'http.method': 'GET' }, null],
+    ])('resolves the DB query text from %j', (attributes, expected) => {
+        expect(getQueryText(makeSpan({ attributes }))).toBe(expected)
     })
 })

--- a/products/tracing/frontend/spanSummary.ts
+++ b/products/tracing/frontend/spanSummary.ts
@@ -79,6 +79,13 @@ function deriveType(attrs: Record<string, string>): string | null {
     return null
 }
 
+// The query text for a DB span. `db.query.text` is the stabilized OTel DB-semconv key; `db.statement`
+// is the long-standing (pre-rename) spelling most deployed instrumentations still emit — check both.
+// Usually parameterized (literal values stripped to `?`) by the instrumentation. Null for non-DB spans.
+export function getQueryText(span: Span): string | null {
+    return firstAttr(span.attributes ?? {}, ['db.query.text', 'db.statement'])
+}
+
 export function deriveSpanSummary(span: Span): SpanSummary {
     const attrs = span.attributes ?? {}
 


### PR DESCRIPTION
## Problem

When inspecting a database span in the trace drawer, there was no convenient way to view the SQL query associated with that span. Users had to dig through raw attributes to find `db.statement` or `db.query.text`. Additionally, there was no way to view the full raw span data in a structured, interactive format.

## Changes

Two new tabs have been added to the trace drawer's span inspector:

- **Query tab** — appears conditionally, only for DB spans that carry a `db.query.text` or `db.statement` attribute. Renders the SQL with syntax highlighting and wrapping, up to 40 lines before requiring expansion.
- **Raw tab** — always present, renders the full span object as an interactive JSON tree (collapsed to depth 2, keys sorted), consistent with the raw view in the logs inspector.

A `getQueryText` helper was extracted into `spanSummary.ts` to resolve the query text from a span, preferring the stabilized OTel semconv key `db.query.text` over the legacy `db.statement` spelling that most deployed instrumentations still emit.

To handle the conditional Query tab gracefully, if the Query tab is active and the user selects a span without a query, the inspector falls back to the Attributes tab rather than rendering a blank body.

![Screenshot placeholder — add before merging]

## How did you test this code?

Unit tests were added for `getQueryText` covering:
- Reading `db.statement` (legacy spelling)
- Preferring `db.query.text` over `db.statement` when both are present
- Returning `null` for non-DB spans

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent added the `getQueryText` helper, wired up the conditional Query tab and the always-present Raw tab, and handled the tab fallback logic when switching between DB and non-DB spans. The `JSONViewer` component was chosen to match the existing raw view pattern in `LogDetailsModal` for cross-pane consistency. No manual testing was performed by the agent; correctness was verified through the unit tests added in `spanSummary.test.ts`.