### PR TITLE
feat(data-warehouse): promote Intercom source to beta

### DIFF
--- a/posthog/temporal/data_imports/sources/intercom/source.py
+++ b/posthog/temporal/data_imports/sources/intercom/source.py
@@ -59,7 +59,7 @@ class IntercomSource(SimpleSource[IntercomSourceConfig], OAuthMixin):
                 ],
             ),
             featureFlag="dwh_intercom",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
         )
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
+++ b/posthog/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
@@ -25,7 +25,7 @@ class TestIntercomSource:
         config = self.source.get_source_config
 
         assert config.name.value == "Intercom"
-        assert config.releaseStatus == "alpha"
+        assert config.releaseStatus == "beta"
         assert not config.unreleasedSource
 
         oauth_field = config.fields[0]


### PR DESCRIPTION
## Problem

The Intercom data warehouse source has been running in **alpha**. Over the last 7-day window it now clears the bar for promotion to **beta**:

- **Teams using it:** 31 (need ≥ 30)
- **Error rate:** 2.3% (need < 5.0%)

## Changes

Promote the `Intercom` source's `releaseStatus` from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` in its `get_source_config`. This is the field surfaced by `/api/public_source_configs/` and rendered as the soft release-stage label in the warehouse connector UI.

This is a status-only change:
- No connector behavior, schemas, or sync logic touched.
- The existing `featureFlag="dwh_intercom"` gating flag is **left in place** — beta is a soft label on a visible source, not a gate, and there's no codebase convention that a beta promotion should drop the rollout flag (several alpha sources also carry feature flags). Removing the flag would be a separate rollout decision.

## How did you test this code?

I'm an agent (Claude Code). I updated the assertion in `test_intercom_source.py` (`releaseStatus == "beta"`) to match. I was unable to execute the test suite in this environment (Django/flox not bootstrapped), so I did not run it. The change is a one-line enum swap plus its mirroring test assertion; `ReleaseStatus.BETA` resolves to the string `"beta"`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code following the `implementing-warehouse-sources` skill. Located the source config under `posthog/temporal/data_imports/sources/intercom/source.py`, confirmed `releaseStatus` flows through `PublicSourceConfigViewSet` from `get_source_config`, and verified no other definition of the Intercom release status exists. Chose to leave the `dwh_intercom` feature flag untouched because the skill guidance only calls for changing closely-coupled gating metadata when conventions clearly require it — they don't here.
