### PR TITLE
feat(data-warehouse): promote Sentry source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/sentry/source.py
+++ b/posthog/temporal/data_imports/sources/sentry/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -87,7 +88,7 @@ Create a token in Sentry and make sure it includes the scopes below if you want 
                     ),
                 ],
             ),
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
         )
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:


### PR DESCRIPTION
## Problem

The Sentry data-warehouse source has been live long enough and is healthy enough to graduate from Beta to general availability. Current 7-day metrics clear the GA bar:

- **Adoption:** 149 teams · live 3.0 months (bar: 100+ teams _or_ live 3+ months).
- **Error rate:** 0.1% (bar: < 2.5%).

## Changes

Set the Sentry source's `releaseStatus` from `"beta"` to `ReleaseStatus.GA`. This is a status-only promotion — no connector behavior, schemas, or sync logic change.

While here, the bare string literal was swapped for the `ReleaseStatus` enum, per the data-warehouse source conventions.

## How did you test this code?

I'm an agent. No manual testing. Ran `ruff check` on the modified file (passes). The change only flips a soft release-status label surfaced by `/api/public_source_configs/`; there is no behavioral path to exercise.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Promotion requested by a human; carried out by an agent (Claude Code). The work was scoped via the `implementing-warehouse-sources` skill, which documents the release-status conventions: a single `releaseStatus` field on the source's `get_source_config`, set via the `ReleaseStatus` enum rather than a string literal. Located the Sentry source under `posthog/temporal/data_imports/sources/sentry/source.py`, confirmed no test or `SOURCES.md` references encode the prior beta status, and made the minimal edit plus the enum import.
