### PR TITLE
feat(data-warehouse): promote Google Sheets source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -6,6 +6,7 @@ import gspread
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -106,7 +107,7 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             name=SchemaExternalDataSourceType.GOOGLE_SHEETS,
             label="Google Sheets",
             caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets)",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/Google_Sheets.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/google-sheets",
             fields=cast(


### PR DESCRIPTION
## Problem

The Google Sheets data warehouse source has been shipping with a **Beta** release tag, but it now clears the bar for general availability. Over the last 7-day window it is used by **1542 teams** and has been live for **11.4 months** (the GA bar is 100 teams *or* 3 months), with an error rate of **1.0%** (the bar is < 2.5%). The Beta badge no longer reflects the connector's maturity.

## Changes

- Set the `GoogleSheets` source `releaseStatus` from `beta` to **GA** in `posthog/temporal/data_imports/sources/google_sheets/source.py`. This is the value surfaced by `/api/public_source_configs/`, which the frontend uses to render the source's release badge — GA renders no badge.
- Switched the bare `"beta"` string literal to the `ReleaseStatus` enum (`ReleaseStatus.GA`), per the warehouse-sources convention that `releaseStatus` must use the `ReleaseStatus` enum rather than a string literal.

This is a status promotion only — no connector behavior, schema, or sync logic changes. Gating was left untouched: `GoogleSheets` uses no `featureFlag` and no `unreleasedSource` flag, so there was nothing else to remove.

## How did you test this code?

I'm an agent. I made a minimal, status-only change and ran `ruff check` on the modified file (passes). I verified the `ReleaseStatus` enum exists in `posthog/schema.py` and confirmed no existing tests assert the previous beta status for this source (checked the source's own tests and `products/data_warehouse/backend/api/test/test_public_source_configs.py`). No manual end-to-end testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of the assignee. The task was a pure release-status promotion. I read the `implementing-warehouse-sources` skill, which calls for using the `ReleaseStatus` enum rather than a string literal — so beyond flipping `beta` → `ga` I also adopted the enum (the source had been using a bare string). I considered the idiomatic alternative of omitting `releaseStatus` entirely (how some GA sources express GA), but chose the explicit `ReleaseStatus.GA` to keep the promotion intent obvious in the diff. Confirmed no gating flags (`featureFlag`, `unreleasedSource`) were present to clean up.
