### PR TITLE
feat(data-warehouse): promote MongoDB source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -158,7 +159,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             name=SchemaExternalDataSourceType.MONGO_DB,
             label="MongoDB",
             caption="Enter your MongoDB connection string to automatically pull your MongoDB data into the PostHog Data warehouse.",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/Mongodb.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/mongodb",
             fields=cast(


### PR DESCRIPTION
## Problem

The MongoDB data-warehouse source has been running in Beta and now meets our GA bar (7-day window):

- **Adoption:** 234 teams · live 11.3 months (bar: 100 teams or 3 months)
- **Reliability:** 1.4% error rate (bar: < 2.5%)

It's time to drop the Beta label so the connector is presented as generally available.

## Changes

Promote the `MongoDB` source's `releaseStatus` from `beta` to `ga`.

- `posthog/temporal/data_imports/sources/mongodb/source.py`: `releaseStatus="beta"` → `releaseStatus=ReleaseStatus.GA`, importing the `ReleaseStatus` enum from `posthog.schema` (the convention is to use the enum, not a bare string literal).

`releaseStatus` is a soft, presentational label on an already-visible/connectable source — there is no separate gating flag (`featureFlag` / `unreleasedSource`) on this source, so nothing else changes. No connector behavior, schemas, or sync logic were touched. `SOURCES.md` tracks transport/comm method rather than release stage, so it needs no update.

## How did you test this code?

I'm an agent. This is a one-line status label change with no logic impact. I ran `ruff check` and `ruff format` on the modified file (both clean) and confirmed no existing test asserts the MongoDB release status. CI will run the broader suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code to locate the source definition (`posthog/temporal/data_imports/sources/mongodb/source.py`) and flip its release status. Followed the `implementing-warehouse-sources` skill, which specifies using the `ReleaseStatus` enum over a string literal — so this also corrects the pre-existing `"beta"` literal to the enum form on the way to GA. Verified there were no coupled gating flags (`featureFlag`, `unreleasedSource`) to remove and that `SOURCES.md` doesn't track release stage.
