### PR TITLE
feat(data-warehouse): promote Google Ads source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -136,7 +137,7 @@ class GoogleAdsSource(
             name=SchemaExternalDataSourceType.GOOGLE_ADS,
             label="Google Ads",
             caption="Ensure you have granted PostHog access to your Google Ads account, learn how to do this in [the docs](https://posthog.com/docs/cdp/sources/google-ads).",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/google-ads.png",
             docsUrl="https://posthog.com/docs/cdp/sources/google-ads",
             fields=cast(


### PR DESCRIPTION
## Problem

The Google Ads (`GoogleAds`) data-warehouse source has been live and stable long enough to graduate from Beta to GA. It comfortably clears the GA bar on current 7-day metrics:

- **Adoption:** 2,652 teams · live 11.9 months (bar: 100 teams _or_ 3 months)
- **Reliability:** 0.1% error rate over the last 7 days (bar: < 2.5%)

## Changes

Promotes the source's release status from `beta` to `ga`. This is the value surfaced by `/api/public_source_configs/` and rendered as the soft "GA/Beta" label on a visible, connectable source.

- `releaseStatus="beta"` → `releaseStatus=ReleaseStatus.GA` in `posthog/temporal/data_imports/sources/google_ads/source.py`, using the `ReleaseStatus` enum from `posthog.schema` rather than a bare string literal (per the warehouse-source conventions).

No connector behavior, schemas, or sync logic changed — status promotion only. The source was already visible and connectable (no `unreleasedSource` flag), and there is no alpha/beta feature-flag gate on it, so no gating needed to change.

## How did you test this code?

I'm an agent. The dev environment here has no Python venv, so I couldn't run the suite live. Automated checks I did run:

- `ruff check` and `ruff format --check` on the modified file — both pass.
- Confirmed `ReleaseStatus.GA = "ga"` exists in `posthog/schema.py` and that the import is alphabetically sorted in the existing `from posthog.schema import (...)` block.

The source's test module (`tests/test_google_ads_source.py`) does not assert `get_source_config`/`releaseStatus`, so no test changes were required.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel Carletti directed this promotion. I read the `implementing-warehouse-sources` skill to confirm where release status lives and the convention to use the `ReleaseStatus` enum, located the `GoogleAds` source definition, and made the one-line status change plus the enum import. Tool: Claude Code.
