### PR TITLE
feat(data-warehouse): promote Reddit Ads source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -42,7 +43,7 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
             name=SchemaExternalDataSourceType.REDDIT_ADS,
             label="Reddit Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Reddit Ads. Ensure you have granted PostHog access to your Reddit Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/reddit-ads).",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/reddit.png",
             docsUrl="https://posthog.com/docs/cdp/sources/reddit-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -44,7 +44,7 @@ class TestRedditAdsSource:
 
         assert config.name.value == "RedditAds"
         assert config.label == "Reddit Ads"
-        assert config.releaseStatus == "ga"
+        assert config.releaseStatus == ReleaseStatus.GA
         assert len(config.fields) == 2
 
         # Check account_id field

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from requests import Response
 
-from posthog.schema import SourceFieldInputConfig, SourceFieldOauthConfig
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldOauthConfig
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import RedditAdsSourceConfig

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -44,7 +44,7 @@ class TestRedditAdsSource:
 
         assert config.name.value == "RedditAds"
         assert config.label == "Reddit Ads"
-        assert config.releaseStatus == "beta"
+        assert config.releaseStatus == "ga"
         assert len(config.fields) == 2
 
         # Check account_id field


### PR DESCRIPTION
## Problem

The Reddit Ads (`RedditAds`) data-warehouse source has been in **Beta** for a while and now clears our general-availability bar. It's surfaced as `releaseStatus` by the `/api/public_source_configs/` endpoint, so it should report `ga`.

Qualifying metrics (7-day window):

| Criterion | Threshold | Current |
| --- | --- | --- |
| Adoption | 100+ teams **or** live 3+ months | 389 teams · live 8.8 months |
| Error rate | < 2.5% | 2.3% |

## Changes

- Set the Reddit Ads source `releaseStatus` from `beta` to `ga` in `posthog/temporal/data_imports/sources/reddit_ads/source.py`.
- Switch the bare string literal to the `ReleaseStatus` enum (`ReleaseStatus.GA`), matching the warehouse-sources convention.
- Update the corresponding source-config test assertion.

This is a status promotion only — no connector behavior, schema, or sync-logic changes. The source has no `unreleasedSource` flag or `featureFlag` gate, so there is no gating to remove.

## How did you test this code?

I'm an agent (Claude Code). I ran the affected automated test:

```
pytest posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py::TestRedditAdsSource::test_get_source_config
# 1 passed
```

Also ran `ruff check` and `ruff format` on the modified files (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of a human driver to promote the Reddit Ads warehouse source from Beta to GA. Followed the `implementing-warehouse-sources` skill conventions: the skill calls for `releaseStatus` to use the `ReleaseStatus` enum rather than a string literal, so the change also swaps `"beta"` for `ReleaseStatus.GA`. Confirmed there is no `unreleasedSource` flag or feature-flag gate on the source, so no gating was touched.
