### PR TITLE
feat(data-warehouse): promote Clerk source from beta to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -34,7 +35,7 @@ class ClerkSource(ResumableSource[ClerkSourceConfig, ClerkResumeConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLERK,
             label="Clerk",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Clerk secret key to automatically pull your Clerk data into the PostHog Data warehouse.
 
 You can find your secret key in your [Clerk Dashboard](https://dashboard.clerk.com/) under **API Keys**.

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -24,7 +24,7 @@ class TestClerkSource:
 
         assert config.name.value == "Clerk"
         assert config.label == "Clerk"
-        assert config.releaseStatus == "beta"
+        assert config.releaseStatus == "ga"
         assert config.iconPath == "/static/services/clerk.png"
         assert len(config.fields) == 1
 


### PR DESCRIPTION
## Problem

The Clerk data-warehouse source has been in Beta and now clears the bar for general availability based on the current 7-day window:

- **Adoption:** 418 teams · live 4.4 months (need 100 teams *or* 3 months).
- **Reliability:** 0.0% error rate over the last 7 days (need < 2.5%).

## Changes

Promote the Clerk source's release status from `beta` to `ga` — `releaseStatus=ReleaseStatus.GA` in `posthog/temporal/data_imports/sources/clerk/source.py`. The `/api/public_source_configs/` endpoint now surfaces `ga` for Clerk.

This is a status-only promotion:
- No connector behavior, schemas, or sync logic changed.
- Clerk has no `unreleasedSource` flag or `featureFlag` gating (it's already visible and connectable), so there was nothing else to remove.
- Switched the literal `"beta"` to the `ReleaseStatus` enum per the warehouse-source conventions while touching the line.

## How did you test this code?

I'm an agent. The change is a one-value status flip plus the matching assertion in `tests/test_clerk_source.py` (`config.releaseStatus == "ga"`). The full test stack (pytest/ruff) was not installed in this environment, so I verified syntax via `ast.parse` and confirmed `ReleaseStatus.GA == "ga"` in `posthog/schema.py`. CI runs the source test suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel Carletti requested promoting the Clerk warehouse source to GA. Authored with Claude Code. Located the source definition under `posthog/temporal/data_imports/sources/clerk/`, confirmed there was no beta gating flag to remove, flipped `releaseStatus` to the `ReleaseStatus.GA` enum, and updated the corresponding source-config test assertion.
