### PR TITLE
feat(data-warehouse): promote Shopify source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -79,7 +80,7 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
                     ),
                 ],
             ),
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
         )
 
     def validate_credentials(


### PR DESCRIPTION
## Problem

The Shopify data-warehouse source has been running as **Beta** and now meets the bar for general availability based on the latest 7-day metrics:

- **Adoption:** 122 teams · live 6.2 months (threshold: 100 teams *or* 3 months)
- **Reliability:** 1.8% error rate over the last 7 days (threshold: < 2.5%)

## Changes

Promote the Shopify source's `releaseStatus` from `beta` to `ga`.

- `posthog/temporal/data_imports/sources/shopify/source.py`: `releaseStatus="beta"` → `releaseStatus=ReleaseStatus.GA`, switching from a bare string literal to the `ReleaseStatus` enum per the warehouse-sources convention.

At GA the UI suppresses the release badge entirely (the `SourceReleaseTag` renders nothing for `ga`), so the only user-visible effect is that the green **Beta** tag no longer appears on the connector.

This is a status promotion only — no change to connector behavior, schemas, or sync logic. The source carries no `unreleasedSource` flag or `featureFlag` gate, so there is nothing else to adjust.

## How did you test this code?

I'm an agent. No new automated tests were added — this is a one-line status change with no behavioral surface. Existing Shopify source tests do not assert on `releaseStatus`, so none required updating. The value is validated against the `ReleaseStatus` enum at the type level.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Promotion was performed following the `implementing-warehouse-sources` skill conventions: release status lives on the source's `get_source_config` and must use the `ReleaseStatus` enum rather than a string literal. Confirmed via repo search that no closely-coupled gating (alpha/beta flag, `unreleasedSource`, `featureFlag`) is attached to Shopify, so gating was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
