### PR TITLE
feat(data-warehouse): promote Resend source from alpha to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/resend/source.py
+++ b/posthog/temporal/data_imports/sources/resend/source.py
@@ -35,7 +35,7 @@ class ResendSource(ResumableSource[ResendSourceConfig, ResendResumeConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.RESEND,
             label="Resend",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Resend API key to pull your Resend data into the PostHog Data warehouse.
 
 You can create an API key in your [Resend API keys settings](https://resend.com/api-keys).

--- a/posthog/temporal/data_imports/sources/resend/tests/test_resend_source.py
+++ b/posthog/temporal/data_imports/sources/resend/tests/test_resend_source.py
@@ -25,7 +25,7 @@ class TestResendSource:
 
         assert config.name.value == "Resend"
         assert config.label == "Resend"
-        assert config.releaseStatus == "alpha"
+        assert config.releaseStatus == "ga"
         assert config.iconPath == "/static/services/resend.png"
         assert len(config.fields) == 1
 


### PR DESCRIPTION
## Problem

The Resend data-warehouse source has been running in Alpha. It now clears our promotion bar, so it should be marked GA so the `/api/public_source_configs/` endpoint surfaces it as generally available rather than alpha.

Promotion metrics (7-day window):

| Criterion | Threshold | Current |
| --- | --- | --- |
| Teams using / time live | 100 teams or live 3+ months | 137 teams (live ~1.4 months) ✅ |
| Error rate | < 2.5% | 0.0% ✅ |

## Changes

- Flip `releaseStatus` from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA` in the Resend source config (`posthog/temporal/data_imports/sources/resend/source.py`).
- Update the corresponding assertion in `test_resend_source.py`.

This is a status-only promotion. No connector behavior, schemas, or sync logic changed. The source was already visible and connectable (no `unreleasedSource` flag) and has no feature-flag gate, so nothing else needs to change.

## How did you test this code?

I'm an agent. I ran the affected source-config test:

```
.venv/bin/python -m pytest posthog/temporal/data_imports/sources/resend/tests/test_resend_source.py::TestResendSource::test_get_source_config
```

which passes. No manual testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Daniel Carletti to promote the Resend warehouse source from Alpha to GA based on the metrics above. Per the `implementing-warehouse-sources` skill, `releaseStatus` is a soft label on an already-visible source; the only coupled metadata is the test assertion, which was updated. No gating (`unreleasedSource` / `featureFlag`) was present, so none was touched.
