### PR TITLE
fix(tasks): title inbox report tasks with the report title

### DIFF
--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -222,6 +222,15 @@ class TaskSerializer(serializers.ModelSerializer):
             )
         return attrs
 
+    @staticmethod
+    def _signal_report_title(validated_data: dict) -> str | None:
+        """The linked report's own title for a report-scoped task, capped to the title field length."""
+        if validated_data.get("origin_product") != Task.OriginProduct.SIGNAL_REPORT:
+            return None
+        report = validated_data.get("signal_report")
+        report_title = (getattr(report, "title", None) or "").strip()
+        return report_title[:255] or None
+
     def create(self, validated_data):
         validated_data["team"] = self.context["team"]
         validated_data.setdefault("origin_product", Task.OriginProduct.USER_CREATED)
@@ -257,11 +266,19 @@ class TaskSerializer(serializers.ModelSerializer):
                 validated_data["github_user_integration"] = github_user_integration.integration
 
         title = validated_data.get("title", "").strip()
-        if not title and validated_data.get("description"):
+        report_title = self._signal_report_title(validated_data)
+        if title:
+            validated_data.setdefault("title_manually_set", True)
+        elif report_title:
+            # Report tasks run a deliberately generic prompt ("Act on PostHog inbox
+            # report …") whose summary makes a useless title. Use the report's own
+            # title and lock it so client-side title generation doesn't re-summarize
+            # the prompt over it.
+            validated_data["title"] = report_title
+            validated_data.setdefault("title_manually_set", True)
+        elif validated_data.get("description"):
             validated_data["title"] = generate_task_title(validated_data["description"])
             validated_data.setdefault("title_manually_set", False)
-        elif title:
-            validated_data.setdefault("title_manually_set", True)
 
         # Inbox / PostHog Code: tasks created via this API with a signal report use the same
         # origin_product as server-side flows, but only those flows previously called

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -950,6 +950,62 @@ class TestTaskAPI(BaseTaskAPITest):
         )
         self.assertEqual(str(link.task_id), data["id"])
 
+    def test_signal_report_task_uses_report_title_when_no_title_given(self):
+        from products.signals.backend.models import SignalReport
+
+        report = SignalReport.objects.create(team=self.team, title="Checkout flow throws on empty cart")
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "description": "Act on PostHog inbox report abc. Use the inbox MCP tools to fetch the report...",
+                "origin_product": "signal_report",
+                "signal_report": str(report.id),
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task = Task.objects.get(id=response.json()["id"])
+        self.assertEqual(task.title, "Checkout flow throws on empty cart")
+        self.assertTrue(task.title_manually_set)
+
+    def test_signal_report_task_explicit_title_wins_over_report_title(self):
+        from products.signals.backend.models import SignalReport
+
+        report = SignalReport.objects.create(team=self.team, title="Report title")
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Explicit title",
+                "description": "Act on PostHog inbox report abc...",
+                "origin_product": "signal_report",
+                "signal_report": str(report.id),
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task = Task.objects.get(id=response.json()["id"])
+        self.assertEqual(task.title, "Explicit title")
+
+    @patch("products.tasks.backend.serializers.generate_task_title", return_value="Generated title")
+    def test_signal_report_task_without_report_title_falls_back_to_generation(self, mock_generate):
+        from products.signals.backend.models import SignalReport
+
+        report = SignalReport.objects.create(team=self.team)  # no title
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "description": "Act on PostHog inbox report abc...",
+                "origin_product": "signal_report",
+                "signal_report": str(report.id),
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task = Task.objects.get(id=response.json()["id"])
+        self.assertEqual(task.title, "Generated title")
+        self.assertFalse(task.title_manually_set)
+        mock_generate.assert_called_once()
+
     def test_create_task_with_signal_report_different_team_rejected(self):
         from products.signals.backend.models import SignalReport
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -985,6 +985,7 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         task = Task.objects.get(id=response.json()["id"])
         self.assertEqual(task.title, "Explicit title")
+        self.assertTrue(task.title_manually_set)
 
     @patch("products.tasks.backend.serializers.generate_task_title", return_value="Generated title")
     def test_signal_report_task_without_report_title_falls_back_to_generation(self, mock_generate):


### PR DESCRIPTION
## Problem

Tasks created from an inbox report — the **Act on** / Create PR action — were titled with a useless generic string like *"Act on PostHog inbox report"*.

The cause: those tasks run a deliberately generic prompt (`buildCreatePrReportPrompt` in PostHog/code — *"Act on PostHog inbox report `<id>`… use the inbox MCP tools to fetch the report…"*). The report content is fetched lazily via MCP, so the prompt itself carries nothing report-specific. The task is created via the API with no title, so `TaskSerializer.create` runs `generate_task_title()` over that generic prompt — and the best short title an LLM can make from it is "Act on PostHog inbox report".

The report's own title was right there on the `SignalReport` the whole time.

## Changes

In `TaskSerializer.create`, when creating a `signal_report`-origin task whose linked report has a title, use the report's title instead of generating one, and mark it `title_manually_set` so the desktop client's title generator (`useChatTitleGenerator`) leaves it alone rather than re-summarizing the generic prompt over it.

- An explicit title in the request still wins.
- Falls back to the existing `generate_task_title()` generator when the report has no title.

## How did you test this code?

I'm an agent. I added and rely on automated tests in `products/tasks/backend/tests/test_api.py` (report title used when no title is given; explicit title wins; fallback to generation when the report has no title). I could not run the Django DB-backed suite in my sandbox (no Postgres/Docker available), so these run in CI. I verified the changed files compile and pass `ruff check` / `ruff format --check` locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Slack report that inbox "Act on" tasks get dumb titles. Traced the title through both repos: the generic create-PR prompt originates in PostHog/code, but the title is set by the backend's `generate_task_title` (and re-applied client-side by `useChatTitleGenerator`). An initial attempt plumbed the report title through the PostHog/code client; on reviewer steer it was moved to the backend instead, since `SignalReport.title` is already available at task creation — a single authoritative fix that works for every client. `title_manually_set` is reused as the existing "don't auto-regenerate" lock so the client generator respects it.