### PR TITLE
feat(data-warehouse): promote github source from beta to ga

### DIFF
--- a/posthog/temporal/data_imports/sources/github/source.py
+++ b/posthog/temporal/data_imports/sources/github/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -39,7 +40,7 @@ class GithubSource(ResumableSource[GithubSourceConfig, GithubResumeConfig], OAut
         return SourceConfig(
             name=SchemaExternalDataSourceType.GITHUB,
             label="GitHub",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="Connect your GitHub repository to sync issues, pull requests, commits, and more.",
             iconPath="/static/services/github.png",
             iconClassName="dark:bg-white rounded",


### PR DESCRIPTION
## Problem

The GitHub data warehouse source has been shipped behind a Beta label. Based on current usage and reliability metrics (7-day window), it now qualifies for general availability:

- **Adoption:** 406 teams · live 4.3 months (threshold: 100 teams or 3 months)
- **Error rate:** 1.9% (threshold: < 2.5%)

## Changes

Promote the `Github` source's `releaseStatus` from `beta` to `ga`, which is the value surfaced by the `/api/public_source_configs/` endpoint and rendered as a label in the data warehouse connection UI.

While here, the bare string literal `"beta"` is replaced with the `ReleaseStatus.GA` enum from `posthog.schema`, matching the `implementing-warehouse-sources` convention (always use the enum, never a string literal).

This is a status promotion only — no change to the connector's fields, schemas, sync logic, or gating. The source was already visible and connectable (no `unreleasedSource` flag, no feature flag), so nothing else needed to change.

## How did you test this code?

I'm an agent. This is a one-line metadata change. Existing GitHub source tests do not assert on the release status, so no test updates were required. I confirmed:

- No test asserts the GitHub release status (snapshot generator and external-data-source API tests don't reference it).
- `ruff check` and `ruff format` pass on the modified file.
- The source has no feature-flag or `unreleasedSource` gating to remove.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Single-line promotion of the GitHub warehouse source from Beta to GA, requested with the qualifying metrics above. Used Claude Code with the `implementing-warehouse-sources` skill to confirm where release status lives and the repo convention for it. Located the field at `posthog/temporal/data_imports/sources/github/source.py`, verified there was no coupled gating flag/label to remove, and switched the value to the `ReleaseStatus.GA` enum rather than a string literal to follow the documented convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
