### PR TITLE
feat(tracing): highlight active span

### DIFF
--- a/products/tracing/frontend/TraceWaterfallView.tsx
+++ b/products/tracing/frontend/TraceWaterfallView.tsx
@@ -287,8 +287,12 @@ function WaterfallRow({
     return (
         <div>
             <div
-                className={`flex items-stretch cursor-pointer transition-colors ${
-                    isSelected ? 'bg-surface-primary-active' : 'hover:bg-surface-primary-hover'
+                // The 3px left border is always reserved (transparent when unselected) so selecting
+                // a span shows an accent bar without shifting the row content.
+                className={`flex items-stretch cursor-pointer transition-colors border-l-[3px] ${
+                    isSelected
+                        ? 'bg-surface-primary-active border-l-accent'
+                        : 'border-l-transparent hover:bg-surface-primary-hover'
                 }`}
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{ minHeight: ROW_HEIGHT }}
@@ -317,7 +321,9 @@ function WaterfallRow({
                     )}
                     <Tooltip title={span.name}>
                         <span
-                            className={`text-xs truncate ${isError ? 'text-danger font-semibold' : 'font-medium'} ${isUnmatched ? 'opacity-40' : ''}`}
+                            className={`text-xs truncate ${isError ? 'text-danger' : ''} ${
+                                isSelected || isError ? 'font-semibold' : 'font-medium'
+                            } ${isUnmatched ? 'opacity-40' : ''}`}
                         >
                             {span.name}
                         </span>


### PR DESCRIPTION
## Problem

When selecting a span in the trace waterfall, there was no visual accent indicator to distinguish the selected row. Adding one caused the row content to shift because the border space wasn't reserved in the unselected state.

Additionally, error spans and selected spans lacked consistent font weight treatment — error spans used `font-semibold` unconditionally, but selected spans did not get any weight boost.

## Changes

- A 3px left border is now always reserved on each waterfall row, rendered as transparent when unselected and as the accent color when selected. This provides a clear visual selection indicator without shifting row content.
- Span name text is now `font-semibold` when the span is either selected or an error (previously only errors got `font-semibold`).

## How did you test this code?

Manually verified by selecting spans in the trace waterfall view and confirming:
- The accent bar appears on selection without any horizontal content shift.
- The span name becomes bold when selected.
- Unselected, non-error rows retain their normal appearance.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update required.