### PR TITLE
feat(data-warehouse): promote Supabase source from beta to GA

### DIFF
--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -80,7 +80,7 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                     // featureFlagLogic only exposes truthy flags, so an undefined lookup means the
                     // gate is closed for this user. Without this coercion, getSourceDisplayStatus
                     // falls back to `unreleasedSource` and any flagged-but-not-unreleased source
-                    // (plain, supabase) would render as connectable instead of "Notify me".
+                    // (e.g. plain) would render as connectable instead of "Notify me".
                     const featureFlagValue: boolean | undefined = featureFlagDefined ? !!featureFlagRaw : undefined
                     const unreleasedValue = !!connector.unreleasedSource
                     const { status, descriptionEl } = getSourceDisplayStatus(unreleasedValue, featureFlagValue)

--- a/posthog/temporal/data_imports/sources/supabase/source.py
+++ b/posthog/temporal/data_imports/sources/supabase/source.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldFileUploadConfig,
     SourceFieldInputConfig,
@@ -72,8 +73,7 @@ class SupabaseSource(PostgresSource):
             caption="Enter your Supabase credentials to automatically pull your data into the PostHog Data warehouse",
             docsUrl="https://posthog.com/tutorials/supabase-query",
             fields=fields,
-            releaseStatus="beta",
-            featureFlag="supabase-dwh",
+            releaseStatus=ReleaseStatus.GA,
         )
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/supabase/test_supabase_source.py
+++ b/posthog/temporal/data_imports/sources/supabase/test_supabase_source.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest import mock
 
-from posthog.schema import SourceFieldInputConfig
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig
 
 from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 from posthog.temporal.data_imports.sources.supabase.source import SupabaseSource
@@ -21,6 +21,14 @@ def test_supabase_requires_schema_field():
     assert schema_field.required is True
     assert schema_field.label == "Schema"
     assert schema_field.caption is None
+
+
+def test_supabase_is_generally_available():
+    config = SupabaseSource().get_source_config
+
+    assert config.releaseStatus == ReleaseStatus.GA
+    # GA means generally available — no gating flag should hide the source from users.
+    assert config.featureFlag is None
 
 
 def test_supabase_host_field_points_at_the_pooler():


### PR DESCRIPTION
## Problem

The **Supabase** data-warehouse source has been live and stable long enough to graduate from Beta to GA. It now meets the promotion bar on the current 7-day metrics:

- **Adoption:** 1074 teams · live 6.2 months (bar: 100 teams **or** 3 months)
- **Error rate:** 2.0% over the last 7 days (bar: < 2.5%)

While on Beta the source was also hidden behind the `supabase-dwh` feature flag, so only flagged teams could connect it.

## Changes

- Set `releaseStatus` on the Supabase `SourceConfig` to `ReleaseStatus.GA` (was the `"beta"` string literal; now uses the `ReleaseStatus` enum per repo convention).
- Removed the `featureFlag="supabase-dwh"` gate. The flag was the active rollout gate — non-flagged teams rendered the source as "Notify me" / coming soon rather than connectable (see `nonHogFunctionTemplatesLogic.getSourceDisplayStatus`). Keeping it would make a "GA" source still hidden from most users, so removing it is what makes GA actually general. No other code references the `supabase-dwh` flag.
- Updated a now-stale code comment in `nonHogFunctionTemplatesLogic.tsx` that cited `supabase` as an example of a flagged source.
- Added a source-config test asserting GA status and the absence of a gating flag.

No connector behavior, schema, sync, or credential-validation logic changed — this is a status promotion only.

## How did you test this code?

I'm an agent. I added an automated test (`test_supabase_is_generally_available`) asserting `releaseStatus == ReleaseStatus.GA` and `featureFlag is None`. I could not execute the Python test suite in this sandbox (test dependencies such as `pytest`/`django` aren't installed here), but I verified the files compile (`py_compile`) and confirmed `ReleaseStatus.GA` exists in `posthog/schema.py`. `ruff check` and `ruff format` pass on the changed Python files. CI will run the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Started by reading the `implementing-warehouse-sources` skill to confirm conventions: `releaseStatus` should use the `ReleaseStatus` enum, and `featureFlag` is documented as a controlled-rollout gate used *instead of* releasing to everyone. I traced how the public source config flows to the frontend (`/api/public_source_configs/` → `nonHogFunctionTemplatesLogic`) to confirm the feature flag actively gates visibility, which is why removing it is the convention-aligned step for GA rather than leaving gating untouched.
