### PR TITLE
feat(data-warehouse): promote Meta Ads source to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -130,7 +131,7 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
                     ),
                 ],
             ),
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             suggestedTables=[
                 SuggestedTable(
                     table="campaigns",


### PR DESCRIPTION
## Problem

The Meta Ads (`MetaAds`) data warehouse source has been in **Beta**, but it now meets the bar for general availability based on current 7-day metrics:

- **Adoption:** 2303 teams · live 8.8 months (threshold: 100 teams **or** 3 months).
- **Reliability:** 0.6% error rate over the last 7 days (threshold: < 2.5%).

## Changes

Promote the Meta Ads source's `releaseStatus` from `beta` to `ga` in `posthog/temporal/data_imports/sources/meta_ads/source.py`. The value now uses the `ReleaseStatus.GA` enum rather than a bare string literal, matching the convention for the field.

This status is surfaced by the `/api/public_source_configs/` endpoint and drives the release badge in the setup UI (the `Beta` tag stops rendering once the source is GA).

This is a **status promotion only** — no changes to the connector's behavior, schemas, sync logic, or gating. The source has no `featureFlag` or `unreleasedSource` gate, so nothing else needed to change.

## How did you test this code?

I'm an agent. I ran `ruff check` and `ruff format --check` on the modified file (both pass). No automated tests assert the source's release status, and I did not perform manual testing. The change is a single enum-value update; CI mypy/lint will validate the import and type.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel Carletti directed this promotion. I used the `implementing-warehouse-sources` skill to confirm where release status lives and the field conventions, then located the `MetaAdsSource.get_source_config` definition. The skill notes GA can be expressed either by omitting `releaseStatus` or setting `ReleaseStatus.GA`; I chose the explicit enum so the `/api/public_source_configs/` response surfaces `ga` (as requested) while satisfying the "use the enum, never a string literal" convention. I verified no duplicated beta status or feature-flag gating exists elsewhere for this source.
