### PR TITLE
fix(postgres): stop capturing best-effort row-count failures to error tracking

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1273,8 +1273,13 @@ def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger:
     except psycopg.errors.QueryCanceled:
         raise
     except Exception as e:
+        # This COUNT(*) is a best-effort estimate for progress reporting and partition sizing.
+        # It shares its FROM/WHERE with the real extraction query, so any genuine problem
+        # (missing column, unpopulated materialized view, permissions, bad incremental field)
+        # resurfaces there and is classified through the normal retryable/non-retryable path.
+        # Capturing it here too would only flood error tracking with handled duplicates of
+        # user/upstream conditions we already tolerate, so we log at debug and fall back to 0.
         logger.debug(f"_get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
-        capture_exception(e)
 
         if "temporary file size exceeds temp_file_limit" in str(e):
             raise TemporaryFileSizeExceedsLimitException(

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -19,6 +19,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     DEFAULT_NUMERIC_SCALE,
     MAX_NUMERIC_SCALE,
     QueryTimeoutException,
+    TemporaryFileSizeExceedsLimitException,
 )
 from posthog.temporal.data_imports.sources.postgres.partitioned_tables import (
     WINDOW_MAX_QUERY_CANCELED_RETRIES,
@@ -48,6 +49,7 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _get_partition_settings,
     _get_partition_settings_for_partitioned_table,
     _get_primary_keys,
+    _get_rows_to_sync,
     _get_sslmode,
     _get_table,
     _get_table_chunk_size,
@@ -1157,6 +1159,41 @@ class TestGetTableChunkSize:
 
             dj_cursor.execute("SELECT 1")
             assert dj_cursor.fetchone()[0] == 1
+
+
+class TestGetRowsToSync:
+    @pytest.mark.django_db
+    def test_failing_count_query_falls_back_to_zero_without_capturing(self):
+        logger = structlog.get_logger()
+
+        # Count query references a column that doesn't exist — mirrors a misconfigured
+        # incremental field (e.g. djstripe_updated on a table that lacks it).
+        count_query = sql.SQL("SELECT COUNT(*) FROM {table} WHERE {col} > 0").format(
+            table=sql.Identifier("information_schema", "tables"),
+            col=sql.Identifier("does_not_exist_count_col"),
+        )
+
+        with django_connection.cursor() as dj_cursor:
+            with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
+                rows = _get_rows_to_sync(cast(Any, dj_cursor), count_query, logger)
+
+        # Best-effort estimate falls back to 0 and never reports the handled failure.
+        assert rows == 0
+        mock_capture.assert_not_called()
+
+    def test_temp_file_limit_error_still_raises(self):
+        logger = structlog.get_logger()
+
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = Exception("temporary file size exceeds temp_file_limit (1048576kB)")
+        count_query = _build_count_query("public", "users", False, None, None, None)
+
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.capture_exception") as mock_capture:
+            with pytest.raises(TemporaryFileSizeExceedsLimitException):
+                _get_rows_to_sync(cast(Any, cursor), count_query, logger)
+
+        # The temp-file signal is actionable, so it propagates rather than being swallowed.
+        mock_capture.assert_not_called()
 
 
 class TestPartitionedTableChunkSizing:


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `UndefinedColumn` issue from the Postgres data-warehouse import source — `column "..." does not exist` raised at `posthog/temporal/data_imports/sources/postgres/postgres.py` in `_get_rows_to_sync` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019eb7e0-e926-7833-bee4-5dc674c94c90)).

Looking at the sampled events, the issue actually **groups several distinct upstream/database conditions** that all surface at the same frame — a missing column on the source table (a misconfigured incremental field), and an unpopulated source materialized view, among others. Every event is a **handled** exception (`mechanism.handled = true`): the function already catches the failure, logs it, and falls back to `0`.

`_get_rows_to_sync` runs a `COUNT(*)` only to estimate progress and partition sizing. That count is best-effort, but the code still called `capture_exception` on every failure, so error tracking (and its webhook alerts) filled up with handled duplicates of user/upstream conditions the pipeline already tolerates.

## Changes

Removed the `capture_exception` call from the count fallback in `_get_rows_to_sync`. The function still logs at debug and returns `0`, and still re-raises `TemporaryFileSizeExceedsLimitException` (an actionable signal that must propagate).

This loses no visibility: the count query shares its `FROM`/`WHERE` with the real extraction query, so any genuine problem resurfaces during the actual read and is classified through the normal retryable/non-retryable path. Notably `"does not exist"` is already in the source's `get_non_retryable_errors`, so the named `UndefinedColumn` case is already handled correctly when it propagates from the real query — the only thing this PR removes is the redundant noise.

This is a code fix rather than a `NonRetryableErrors` change: the captured exception never reaches the retry classifier (it's swallowed in the count path), so adding strings there would be a no-op for this issue.

## How did you test this code?

I'm an agent (Claude Code). I added regression tests and ran the automated suite — I did not perform manual end-to-end testing.

- Added `TestGetRowsToSync`:
  - `test_failing_count_query_falls_back_to_zero_without_capturing` — runs a count query against a non-existent column (mirroring the misconfigured-incremental-field scenario) and asserts the function returns `0` and never calls `capture_exception`. Uses a real Django Postgres cursor, matching the existing `TestGetTableChunkSize` pattern (runs in CI).
  - `test_temp_file_limit_error_still_raises` — asserts the `temp_file_limit` error still raises `TemporaryFileSizeExceedsLimitException` and is not captured. Runs without a DB; passes locally.
- Ran the non-DB suites (`TestBuildCountQuery`, `TestPostgresSourceNonRetryableErrors`) and confirmed the full file collects cleanly (253 tests). `ruff check` and `ruff format` pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged the error-tracking issue with the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), then read the import pipeline in `posthog/temporal/data_imports/sources/postgres/`.

Decision path: the stack frame genuinely originates in the source's code, but the exception is handled (best-effort count fallback), not a crash. The underlying causes are user/upstream (missing column, unpopulated MV). Considered extending `NonRetryableErrors` but rejected it — the exception is swallowed before reaching the retry classifier, and the representative `"does not exist"` string is already non-retryable. Chose to remove the redundant `capture_exception` so error tracking stops alerting on conditions the pipeline already tolerates, while keeping the actionable temp-file re-raise.
