### PR TITLE
feat(query): tag query endpoint and hogql executor spans with team_id

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -198,6 +198,7 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 limit_context = None
 
             with tracer.start_as_current_span("posthog.query.process_query_model") as process_span:
+                process_span.set_attribute("team_id", self.team.pk)
                 process_span.set_attribute("query.kind", getattr(query, "kind", "Other"))
                 process_span.set_attribute(
                     "query.is_query_service", get_query_tag_value("access_method") == "personal_api_key"

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -890,6 +890,7 @@ class HogQLQueryExecutor:
 
     @tracer.start_as_current_span("HogQLQueryExecutor.execute")
     def execute(self) -> HogQLQueryResponse:
+        trace.get_current_span().set_attribute("team_id", self.team.pk)
         try:
             if self.send_raw_query and self.connection_id is not None:
                 self._execute_raw_direct_postgres_query()


### PR DESCRIPTION
## Problem

Query traces in APM are hard to attribute to a team. `create_hogql_database` spans carry a `team_id` attribute and ClickHouse client spans carry `clickhouse.team_id`, but the spans one level up have none:

- `posthog.query.process_query_model` (the query endpoint's main span) only records `query.kind`, `query.is_query_service`, and `query.limit_context`.
- `HogQLQueryExecutor.execute`, which is the root span of most query traces in practice, has no attributes at all.

So filtering traces by team means digging into descendant spans instead of the span you actually land on.

## Changes

Two one-line additions, no behavior change:

- Set `team_id` on the `posthog.query.process_query_model` span in `posthog/api/query.py`.
- Set `team_id` on the `HogQLQueryExecutor.execute` span in `posthog/hogql/query.py`.

The attribute key matches the existing `team_id` convention used by `create_hogql_database` and most hand-instrumented endpoints (recordings, persons, events, sessions).

## How did you test this code?

Authored by an agent; no manual testing was performed. `ruff` and `mypy` pass on both changed files. The change is two `set_attribute` calls on already-existing spans; with no tracer provider configured (tests, local dev) these are no-ops on a non-recording span. Verified against live APM data that the target spans exist and currently lack the attribute.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie via a Claude Code session. The session first verified (via code reading and APM span queries) that `create_hogql_database` already emits a `team_id`-tagged span, then established that the endpoint-level and executor-level spans above it carry no team attribution. These two spans were chosen because `process_query_model` is the query endpoint's main span and `HogQLQueryExecutor.execute` is the de facto trace root while Django request spans aren't being recorded. A broader fix for the missing request-level root span was deliberately left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
