### PR TITLE
feat(llma): widen AI observability onboarding lookback window

### DIFF
--- a/frontend/src/lib/utils/aiEventsUtils.test.ts
+++ b/frontend/src/lib/utils/aiEventsUtils.test.ts
@@ -69,7 +69,7 @@ describe('aiEventsUtils', () => {
         })
 
         it('falls back to ClickHouse when EventDefinition is stale', async () => {
-            const staleDate = dayjs().subtract(60, 'day').toISOString()
+            const staleDate = dayjs().subtract(120, 'day').toISOString()
 
             useMocks({
                 get: {

--- a/frontend/src/lib/utils/aiEventsUtils.ts
+++ b/frontend/src/lib/utils/aiEventsUtils.ts
@@ -8,6 +8,11 @@ import { isDefinitionStale } from './definitions'
 
 export const AI_EVENT_NAMES = ['$ai_generation', '$ai_trace', '$ai_span', '$ai_embedding']
 
+// AI events are bursty (a single experiment can go quiet for weeks), so we use a longer
+// staleness window than the global default before falling back to the onboarding screen.
+const AI_STALE_EVENT_DAYS = 90
+const AI_STALE_EVENT_SECONDS = AI_STALE_EVENT_DAYS * 24 * 60 * 60
+
 /**
  * Checks if the team has sent any AI events.
  *
@@ -23,7 +28,7 @@ export async function hasRecentAIEvents(): Promise<boolean> {
     })
 
     const validDefinition = aiEventDefinitions.results.find(
-        (r) => AI_EVENT_NAMES.includes(r.name) && !isDefinitionStale(r)
+        (r) => AI_EVENT_NAMES.includes(r.name) && !isDefinitionStale(r, AI_STALE_EVENT_SECONDS)
     )
 
     if (validDefinition) {
@@ -34,7 +39,7 @@ export async function hasRecentAIEvents(): Promise<boolean> {
     const response = await api.query<HogQLQuery>(
         {
             kind: NodeKind.HogQLQuery,
-            query: hogql`SELECT 1 FROM events WHERE event IN ${[...AI_EVENT_NAMES]} AND timestamp > now() - INTERVAL 3 HOUR LIMIT 1`,
+            query: hogql`SELECT 1 FROM events WHERE event IN ${[...AI_EVENT_NAMES]} AND timestamp > now() - INTERVAL 12 HOUR LIMIT 1`,
             tags: { productKey: ProductKey.AI_OBSERVABILITY },
         },
         { refresh: 'force_blocking' }

--- a/frontend/src/lib/utils/aiEventsUtils.ts
+++ b/frontend/src/lib/utils/aiEventsUtils.ts
@@ -8,8 +8,9 @@ import { isDefinitionStale } from './definitions'
 
 export const AI_EVENT_NAMES = ['$ai_generation', '$ai_trace', '$ai_span', '$ai_embedding']
 
-// AI events are bursty (a single experiment can go quiet for weeks), so we use a longer
-// staleness window than the global default before falling back to the onboarding screen.
+// Use a longer staleness window than the global default so orgs that ingested AI events
+// in the past, paused, and have since resumed still land on the dashboard rather than the
+// onboarding screen.
 const AI_STALE_EVENT_DAYS = 90
 const AI_STALE_EVENT_SECONDS = AI_STALE_EVENT_DAYS * 24 * 60 * 60
 

--- a/frontend/src/lib/utils/definitions.ts
+++ b/frontend/src/lib/utils/definitions.ts
@@ -3,7 +3,10 @@ import { dayjs } from 'lib/dayjs'
 
 import { EventDefinition, PropertyDefinition } from '~/types'
 
-export const isDefinitionStale = (definition?: EventDefinition | PropertyDefinition): boolean => {
+export const isDefinitionStale = (
+    definition?: EventDefinition | PropertyDefinition,
+    staleSeconds: number = STALE_EVENT_SECONDS
+): boolean => {
     const parsedLastSeen = definition?.last_seen_at ? dayjs(definition.last_seen_at) : null
-    return !!parsedLastSeen && dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS
+    return !!parsedLastSeen && dayjs().diff(parsedLastSeen, 'seconds') > staleSeconds
 }


### PR DESCRIPTION
## Problem

If a project's most recent AI event was more than 30 days ago, the AI observability dashboard bounces back to the "No LLM events" onboarding screen even though the project has real history. AI traffic is bursty, so 30 days is too short.

## Changes

- Use a **90-day** staleness window (vs the global 30 days) for the AI event-definition check that gates the dashboard. `isDefinitionStale` now takes an optional threshold, so this is scoped to AI observability only — global staleness behavior (taxonomic filter, definitions pages, web analytics) is unchanged.
- Bump the ClickHouse fallback (the cold path for brand-new users whose event definition hasn't propagated yet) from **3h → 12h**.

No performance impact: the Postgres query doesn't filter on `last_seen_at` (staleness is compared client-side), and a wider window means the ClickHouse fallback fires *less* often. The fallback query stays team-scoped with `LIMIT 1`.

## How did you test this code?

I'm an agent. I did not run the frontend test/format tooling (not installed in this clone). Changes are type-safe by construction — the new `isDefinitionStale` parameter is optional and all existing callers use the single-arg form.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with the PostHog Slack app (Claude Code) at the user's direction. The user asked to scope a longer event-definition staleness window to AI observability and to bump the fallback to 12h. Chose 90 days as a 3× bump from the global default; trivial to adjust. Implemented via an optional threshold param on `isDefinitionStale` rather than changing the global constant, to avoid affecting the taxonomic filter and definitions pages.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1781202023205539)*
