### PR TITLE
feat(mcp): add display options to trends UI app

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4013,17 +4013,17 @@ snapshots:
     mcp-apps-surveys--stats--light:
         hash: v1.k794b7964.da67b48f277665016d143ea09d4471ca6f01f3b8a6d22e7fe0f3dc51b075e92a.l81wzNlVna0bTrWF2HHg1RkJaB7vXRpAIdMbNylhzCw
     mcp-apps-trends--area-chart--light:
-        hash: v1.k794b7964.a999deccedf5244f57f6566d676aacadc4ef4c94722473c68df6c554bd87ad3e.ZHF5IaBqQ0FqN3hgvVZVeLUVvbFI4-7lpT-kWfJFcow
+        hash: v1.k794b7964.fea141e4555bf7c84c7df7d28f440f1967cf46eed78c9df63daa191b42156569.osoYKiT_8UiEIKvjzLfRzJxA6gY3cT4eD1g66S-kD5Q
     mcp-apps-trends--bar-value-few-series--light:
         hash: v1.k794b7964.17235de255bc7d04240957e537b7bc76027c19471525218a28582af1298cd0b3.aA5Dz0x9KR6knEKP4CvKEtRoVS7z6TeKEtTY4_qoML0
     mcp-apps-trends--bar-value-many-breakdowns--light:
         hash: v1.k794b7964.407f0a6b71b45525e4d45d20e1e6af8f0b7a4345748af552b53df223fbcf576a.GnlWLZvvw78tfb9YT0og22-n8GDKTQs3487BrZiQi_8
     mcp-apps-trends--multi-series--light:
-        hash: v1.k794b7964.b3592fc2ce95288f8ca5aeccf3333734383d51c13e4bd495cac91285b6d894d1.26ymJ354sVR0hF1sQR3_Py4lPCNLBQI-d5qUWoBinvc
+        hash: v1.k794b7964.de9682bc3d1cacf6198fa053c98657bc296202e4e1e800c98208b0922724cc5d.17c9wz8bYgE3_74LEk8BY5z_gkAp4NZ95x1pkMvip-s
     mcp-apps-trends--single-series--light:
-        hash: v1.k794b7964.0237d655cb884729a1b01cd8d4bcbc2300e3bb42a6c6bc3f89c70cd206cc91ba.1vqtb4aI3CDKE_XTPD4SOrHfS57ty28sbg1OwXiLcX8
+        hash: v1.k794b7964.6be4744f9c45242fa0945d4cb820c40248b1cb4ec74634d41c11f24f387e87f4.bFA-jAc2ZyaPqEbXMc3jKI6YB2BXTVkJwNpR2jHeMv4
     mcp-apps-trends--time-series-bar--light:
-        hash: v1.k794b7964.36adcc571f4e889579cad4209857a6f63b5cb350adf7d0ccfeba9510360a689c.Ftkx3aKLXu_zFVXyG3nXcz5Syk9oU3OkOXrDSy2QujE
+        hash: v1.k794b7964.a62cfb1eb173fb526193bf9793266dfcedfec505418b6d168991c01ee3c4fd92.3oRewiRVOH-3Rf4IMK0gYKfvHyLCWoPOt0p6I0CkJ2s
     mcp-apps-workflows--active--light:
         hash: v1.k794b7964.ad71858e2dc5a45e3d81bb38d46ad3bbe2dea9c152b625fbbf93117a27e624ca.Z4AVu3aic8bdKuv98SD1V1ZqQXsxPwGX2mZl3cL31bs
     mcp-apps-workflows--archived--light:

--- a/services/mcp/src/ui-apps/components/ChartSettings.tsx
+++ b/services/mcp/src/ui-apps/components/ChartSettings.tsx
@@ -4,20 +4,16 @@ import { Button, Label, Switch } from '@posthog/quill'
 
 import { type ChartConfig, Y_UNIT_OPTIONS, type YUnit } from './chartSettingsConfig'
 
-// Hand-rolled popover (no Radix/Floating UI portals) for the same reason as `charts/Select.tsx`:
-// the app runs in a sandboxed iframe where portalled content can land in a different stacking
-// context. The click-away listener binds to the iframe's own document, so it stays self-contained.
+// Hand-rolled popover (no portals): Quill's portalled popover mispositions inside the MCP iframe
+// (same reason as `charts/Select.tsx`). The click-away listener binds to the iframe's own document.
 
 interface ChartSettingsProps {
     family: 'line' | 'bar'
     config: ChartConfig
     onChange: (config: ChartConfig) => void
-    /** When true, derived-series toggles (trend line / moving average / CI) are disabled —
-     *  area mode auto-stacks, and overlays drawn at raw per-series values look broken
-     *  against the stacked totals. Mirrors the web trends Options behaviour. */
+    /** Disabled in area mode, where overlays would draw against the stacked totals. */
     derivedSeriesDisabled?: boolean
-    /** When true, the percent stack toggle is disabled — only stacked renderings (area,
-     *  stacked bar) support a 100% view. */
+    /** Disabled for non-stacked types — only area / stacked bar have a 100% view. */
     percentStackDisabled?: boolean
 }
 

--- a/services/mcp/src/ui-apps/components/ChartSettings.tsx
+++ b/services/mcp/src/ui-apps/components/ChartSettings.tsx
@@ -1,0 +1,142 @@
+import { type ReactElement, useEffect, useRef, useState } from 'react'
+
+import { type ChartConfig, Y_UNIT_OPTIONS, type YUnit } from './chartSettingsConfig'
+
+// Hand-rolled popover (no Radix/Floating UI portals) for the same reason as `charts/Select.tsx`:
+// the app runs in a sandboxed iframe where portalled content can land in a different stacking
+// context. The click-away listener binds to the iframe's own document, so it stays self-contained.
+
+interface ChartSettingsProps {
+    chartMode: 'line' | 'bar'
+    config: ChartConfig
+    onChange: (config: ChartConfig) => void
+    /** When true, derived-series toggles (trend line / moving average / CI) are disabled —
+     *  area mode auto-stacks, and overlays drawn at raw per-series values look broken
+     *  against the stacked totals. Mirrors the web trends Options behaviour. */
+    derivedSeriesDisabled?: boolean
+    /** When true, the percent stack toggle is disabled — only stacked renderings (area,
+     *  stacked bar) support a 100% view. */
+    percentStackDisabled?: boolean
+}
+
+export function ChartSettings({
+    chartMode,
+    config,
+    onChange,
+    derivedSeriesDisabled = false,
+    percentStackDisabled = false,
+}: ChartSettingsProps): ReactElement {
+    const [open, setOpen] = useState(false)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!open) {
+            return
+        }
+        const onDocumentClick = (e: MouseEvent): void => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false)
+            }
+        }
+        document.addEventListener('mousedown', onDocumentClick)
+        return () => document.removeEventListener('mousedown', onDocumentClick)
+    }, [open])
+
+    const update = <K extends keyof ChartConfig>(key: K, value: ChartConfig[K]): void => {
+        onChange({ ...config, [key]: value })
+    }
+
+    return (
+        <div ref={containerRef} className="relative">
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                aria-label="Chart options"
+                aria-expanded={open}
+                className="cursor-pointer rounded-sm border border-input bg-background px-2 py-1 text-xs text-foreground hover:bg-accent"
+            >
+                Options
+            </button>
+            {open && (
+                <div
+                    role="dialog"
+                    className="absolute right-0 top-full z-10 mt-1 w-56 rounded-sm border border-input bg-background p-3 shadow-lg"
+                >
+                    <div className="flex flex-col gap-2 text-xs">
+                        <Toggle
+                            label="Value labels"
+                            checked={config.showValueLabels}
+                            onChange={(v) => update('showValueLabels', v)}
+                        />
+                        {chartMode === 'line' && (
+                            <>
+                                <Toggle
+                                    label="Trend line"
+                                    checked={config.showTrendLine}
+                                    disabled={derivedSeriesDisabled}
+                                    onChange={(v) => update('showTrendLine', v)}
+                                />
+                                <Toggle
+                                    label="Moving average"
+                                    checked={config.showMovingAverage}
+                                    disabled={derivedSeriesDisabled}
+                                    onChange={(v) => update('showMovingAverage', v)}
+                                />
+                                <Toggle
+                                    label="Confidence intervals"
+                                    checked={config.showConfidenceIntervals}
+                                    disabled={derivedSeriesDisabled}
+                                    onChange={(v) => update('showConfidenceIntervals', v)}
+                                />
+                            </>
+                        )}
+                        <Toggle
+                            label="Percent stack"
+                            checked={config.percentStack}
+                            disabled={percentStackDisabled}
+                            onChange={(v) => update('percentStack', v)}
+                        />
+                        <div className="mt-1">
+                            <div className="mb-1 text-muted-foreground">Y-axis unit</div>
+                            <select
+                                value={config.yUnit}
+                                onChange={(e) => update('yUnit', e.target.value as YUnit)}
+                                className="w-full cursor-pointer rounded-sm border border-input bg-background px-2 py-1 text-xs text-foreground"
+                            >
+                                {Y_UNIT_OPTIONS.map((opt) => (
+                                    <option key={opt.value} value={opt.value}>
+                                        {opt.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function Toggle({
+    label,
+    checked,
+    onChange,
+    disabled = false,
+}: {
+    label: string
+    checked: boolean
+    onChange: (next: boolean) => void
+    disabled?: boolean
+}): ReactElement {
+    return (
+        <label className={`inline-flex items-center gap-2 ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}>
+            <input
+                type="checkbox"
+                checked={checked && !disabled}
+                disabled={disabled}
+                onChange={(e) => onChange(e.target.checked)}
+            />
+            {label}
+        </label>
+    )
+}

--- a/services/mcp/src/ui-apps/components/ChartSettings.tsx
+++ b/services/mcp/src/ui-apps/components/ChartSettings.tsx
@@ -4,9 +4,6 @@ import { Button, Label, Switch } from '@posthog/quill'
 
 import { type ChartConfig, Y_UNIT_OPTIONS, type YUnit } from './chartSettingsConfig'
 
-// Hand-rolled popover (no portals): Quill's portalled popover mispositions inside the MCP iframe
-// (same reason as `charts/Select.tsx`). The click-away listener binds to the iframe's own document.
-
 interface ChartSettingsProps {
     family: 'line' | 'bar'
     config: ChartConfig

--- a/services/mcp/src/ui-apps/components/ChartSettings.tsx
+++ b/services/mcp/src/ui-apps/components/ChartSettings.tsx
@@ -9,7 +9,7 @@ import { type ChartConfig, Y_UNIT_OPTIONS, type YUnit } from './chartSettingsCon
 // context. The click-away listener binds to the iframe's own document, so it stays self-contained.
 
 interface ChartSettingsProps {
-    chartMode: 'line' | 'bar'
+    family: 'line' | 'bar'
     config: ChartConfig
     onChange: (config: ChartConfig) => void
     /** When true, derived-series toggles (trend line / moving average / CI) are disabled —
@@ -22,7 +22,7 @@ interface ChartSettingsProps {
 }
 
 export function ChartSettings({
-    chartMode,
+    family,
     config,
     onChange,
     derivedSeriesDisabled = false,
@@ -70,7 +70,7 @@ export function ChartSettings({
                             checked={config.showValueLabels}
                             onChange={(v) => update('showValueLabels', v)}
                         />
-                        {chartMode === 'line' && (
+                        {family === 'line' && (
                             <>
                                 <Toggle
                                     label="Trend line"
@@ -94,6 +94,7 @@ export function ChartSettings({
                         />
                         <div className="mt-1">
                             <div className="mb-1 text-muted-foreground">Y-axis unit</div>
+                            {/* eslint-disable-next-line react/forbid-elements */}
                             <select
                                 value={config.yUnit}
                                 onChange={(e) => update('yUnit', e.target.value as YUnit)}

--- a/services/mcp/src/ui-apps/components/ChartSettings.tsx
+++ b/services/mcp/src/ui-apps/components/ChartSettings.tsx
@@ -1,4 +1,6 @@
-import { type ReactElement, useEffect, useRef, useState } from 'react'
+import { type ReactElement, useEffect, useId, useRef, useState } from 'react'
+
+import { Button, Label, Switch } from '@posthog/quill'
 
 import { type ChartConfig, Y_UNIT_OPTIONS, type YUnit } from './chartSettingsConfig'
 
@@ -48,15 +50,15 @@ export function ChartSettings({
 
     return (
         <div ref={containerRef} className="relative">
-            <button
-                type="button"
+            <Button
+                variant="outline"
+                size="sm"
                 onClick={() => setOpen((o) => !o)}
                 aria-label="Chart options"
                 aria-expanded={open}
-                className="cursor-pointer rounded-sm border border-input bg-background px-2 py-1 text-xs text-foreground hover:bg-accent"
             >
                 Options
-            </button>
+            </Button>
             {open && (
                 <div
                     role="dialog"
@@ -75,12 +77,6 @@ export function ChartSettings({
                                     checked={config.showTrendLine}
                                     disabled={derivedSeriesDisabled}
                                     onChange={(v) => update('showTrendLine', v)}
-                                />
-                                <Toggle
-                                    label="Moving average"
-                                    checked={config.showMovingAverage}
-                                    disabled={derivedSeriesDisabled}
-                                    onChange={(v) => update('showMovingAverage', v)}
                                 />
                                 <Toggle
                                     label="Confidence intervals"
@@ -128,15 +124,19 @@ function Toggle({
     onChange: (next: boolean) => void
     disabled?: boolean
 }): ReactElement {
+    const id = useId()
     return (
-        <label className={`inline-flex items-center gap-2 ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}>
-            <input
-                type="checkbox"
+        <div className={`flex items-center justify-between gap-2 ${disabled ? 'opacity-50' : ''}`}>
+            <Label htmlFor={id} className={disabled ? 'cursor-not-allowed' : 'cursor-pointer'}>
+                {label}
+            </Label>
+            <Switch
+                id={id}
+                size="sm"
                 checked={checked && !disabled}
                 disabled={disabled}
-                onChange={(e) => onChange(e.target.checked)}
+                onCheckedChange={(next) => onChange(next)}
             />
-            {label}
-        </label>
+        </div>
     )
 }

--- a/services/mcp/src/ui-apps/components/Component.tsx
+++ b/services/mcp/src/ui-apps/components/Component.tsx
@@ -64,6 +64,9 @@ export function Component({ data }: ComponentProps): ReactElement {
             case 'trends':
                 return (
                     <TrendsVisualizer
+                        // Re-seed chart type/config from scratch when a new query arrives — the host
+                        // updates `data` in place (ontoolresult) rather than remounting the app.
+                        key={JSON.stringify(payload.query)}
                         query={payload.query as TrendsQuery}
                         results={payload.results as TrendsResult}
                         title={getTitle()}

--- a/services/mcp/src/ui-apps/components/Component.tsx
+++ b/services/mcp/src/ui-apps/components/Component.tsx
@@ -63,7 +63,11 @@ export function Component({ data }: ComponentProps): ReactElement {
         switch (visualizationType) {
             case 'trends':
                 return (
-                    <TrendsVisualizer query={payload.query as TrendsQuery} results={payload.results as TrendsResult} />
+                    <TrendsVisualizer
+                        query={payload.query as TrendsQuery}
+                        results={payload.results as TrendsResult}
+                        title={getTitle()}
+                    />
                 )
 
             case 'funnel':
@@ -120,9 +124,12 @@ export function Component({ data }: ComponentProps): ReactElement {
     return (
         <Card>
             <CardContent>
-                <div className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    {getTitle()}
-                </div>
+                {/* Trends renders its own title inline with the chart controls. */}
+                {visualizationType !== 'trends' && (
+                    <div className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        {getTitle()}
+                    </div>
+                )}
                 {renderVisualization()}
             </CardContent>
         </Card>

--- a/services/mcp/src/ui-apps/components/Component.tsx
+++ b/services/mcp/src/ui-apps/components/Component.tsx
@@ -64,12 +64,10 @@ export function Component({ data }: ComponentProps): ReactElement {
             case 'trends':
                 return (
                     <TrendsVisualizer
-                        // Re-seed chart type/config from scratch when a new query arrives — the host
-                        // updates `data` in place (ontoolresult) rather than remounting the app.
+                        // The host updates `data` in place, so key on the query to re-seed state per result.
                         key={JSON.stringify(payload.query)}
                         query={payload.query as TrendsQuery}
                         results={payload.results as TrendsResult}
-                        title={getTitle()}
                     />
                 )
 
@@ -127,12 +125,9 @@ export function Component({ data }: ComponentProps): ReactElement {
     return (
         <Card>
             <CardContent>
-                {/* Trends renders its own title inline with the chart controls. */}
-                {visualizationType !== 'trends' && (
-                    <div className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                        {getTitle()}
-                    </div>
-                )}
+                <div className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    {getTitle()}
+                </div>
                 {renderVisualization()}
             </CardContent>
         </Card>

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -2,7 +2,13 @@ import { type ReactElement, useState } from 'react'
 
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
-import { BarChart as BarValueChart, ciRanges, SlopeChart, TimeSeriesBarChart, TimeSeriesLineChart } from '@posthog/quill-charts'
+import {
+    BarChart as BarValueChart,
+    ciRanges,
+    SlopeChart,
+    TimeSeriesBarChart,
+    TimeSeriesLineChart,
+} from '@posthog/quill-charts'
 
 import { buildTrendsBarChartModel } from 'products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms'
 import {
@@ -38,7 +44,9 @@ const CHART_TYPE_OPTIONS = [
 // when they ask "how much did X change between A and B?" rather than the path between them.
 const SLOPE_TYPE_OPTION = { value: 'slope' as const, label: 'Slope' }
 
-const TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
+const TOOLTIP_CONFIG = { pinnable: true, placement: 'cursor' as const }
+
+const TITLE_CLASS = 'text-xs font-semibold uppercase tracking-wider text-muted-foreground'
 
 function calculateTotal(results: TrendsResultItem[]): number {
     return results.reduce((sum, item) => {
@@ -55,7 +63,7 @@ function calculateTotal(results: TrendsResultItem[]): number {
     }, 0)
 }
 
-export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): ReactElement {
+export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProps): ReactElement {
     const displayType = getDisplayType(query)
     // Honour the backend slope runner: a SlopeGraph query already comes back as two points per series,
     // so defaultChartType opens straight into slope mode rather than line + a manual toggle.
@@ -64,12 +72,15 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
 
     if (!results || results.length === 0) {
         return (
-            <Empty>
-                <EmptyHeader>
-                    <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
-                    <EmptyDescription>No data available</EmptyDescription>
-                </EmptyHeader>
-            </Empty>
+            <div>
+                {title && <div className={`mb-4 ${TITLE_CLASS}`}>{title}</div>}
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
+                        <EmptyDescription>No data available</EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            </div>
         )
     }
 
@@ -77,7 +88,12 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
     if (displayType === 'BoldNumber') {
         const total = calculateTotal(results)
         const label = results[0] ? getSeriesLabel(results[0], 0) : 'Total'
-        return <BigNumber value={total} label={label} />
+        return (
+            <div>
+                {title && <div className={`mb-4 ${TITLE_CLASS}`}>{title}</div>}
+                <BigNumber value={total} label={label} />
+            </div>
+        )
     }
 
     // ActionsBarValue returns aggregated_value per series (empty data[]/days[]) — render a
@@ -90,13 +106,16 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         const barSeries = buildTrendsBarValueSeries(items, { getColor: colorAt })
         const barConfig = buildTrendsBarValueConfig()
         return (
-            <div className="flex flex-col w-full h-[400px]">
-                <BarValueChart
-                    series={barSeries}
-                    labels={items.map((item) => item.label)}
-                    theme={CHART_THEME}
-                    config={barConfig}
-                />
+            <div>
+                {title && <div className={`mb-4 ${TITLE_CLASS}`}>{title}</div>}
+                <div className="flex flex-col w-full h-[400px]">
+                    <BarValueChart
+                        series={barSeries}
+                        labels={items.map((item) => item.label)}
+                        theme={CHART_THEME}
+                        config={barConfig}
+                    />
+                </div>
             </div>
         )
     }
@@ -109,8 +128,6 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         days: item.days,
         incompleteEnd: !!item.incomplete_end,
     }))
-    const yAxisLabel = results.length === 1 && results[0] ? getSeriesLabel(results[0], 0) : undefined
-
     // A slope needs a start and an end, so only offer it when there are at least two time points.
     const slopeAvailable = labels.length >= 2
     const chartTypeOptions = slopeAvailable ? [...CHART_TYPE_OPTIONS, SLOPE_TYPE_OPTION] : CHART_TYPE_OPTIONS
@@ -157,7 +174,6 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
             const { series, config } = buildTrendsBarChartModel(trendResults, {
                 getColor: (_, index) => colorAt(index),
                 labels,
-                yAxisLabel,
                 trendsFilter: effectiveTrendsFilter,
                 isPercentStackView,
                 isGrouped: effectiveType === 'bar',
@@ -174,11 +190,8 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         const config = buildTrendsLineTimeSeriesConfig({
             results: trendResults,
             trendsFilter: effectiveTrendsFilter,
-            yAxisLabel,
             isPercentStackView,
             showTrendLines: chartConfig.showTrendLine && !derivedSeriesDisabled,
-            showMovingAverage: chartConfig.showMovingAverage && !derivedSeriesDisabled,
-            movingAverageIntervals: chartConfig.movingAverageIntervals,
             showConfidenceIntervals: chartConfig.showConfidenceIntervals && !derivedSeriesDisabled,
             confidenceLevel: chartConfig.confidenceLevel,
             ciRanges,
@@ -192,19 +205,22 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
 
     return (
         <div>
-            <div className="mb-2 flex items-center justify-end gap-2">
-                {/* eslint-disable-next-line react/forbid-elements */}
-                <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
-                {/* Slope bypasses the chart-config pipeline entirely — none of these options apply. */}
-                {effectiveType !== 'slope' && (
-                    <ChartSettings
-                        chartMode={isBarFamily(effectiveType) ? 'bar' : 'line'}
-                        config={chartConfig}
-                        onChange={setChartConfig}
-                        derivedSeriesDisabled={derivedSeriesDisabled}
-                        percentStackDisabled={!supportsPercentStack(effectiveType)}
-                    />
-                )}
+            <div className="mb-2 flex items-center gap-2">
+                {title && <div className={TITLE_CLASS}>{title}</div>}
+                <div className="ml-auto flex items-center gap-2">
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
+                    {/* Slope bypasses the chart-config pipeline entirely — none of these options apply. */}
+                    {effectiveType !== 'slope' && (
+                        <ChartSettings
+                            chartMode={isBarFamily(effectiveType) ? 'bar' : 'line'}
+                            config={chartConfig}
+                            onChange={setChartConfig}
+                            derivedSeriesDisabled={derivedSeriesDisabled}
+                            percentStackDisabled={!supportsPercentStack(effectiveType)}
+                        />
+                    )}
+                </div>
             </div>
             <div className="flex flex-col w-full h-[400px]">{renderChart()}</div>
         </div>

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -43,18 +43,14 @@ const CHART_TYPE_OPTIONS = [
     { value: 'stacked-bar' as const, label: 'Stacked bar' },
 ]
 
-// "Slope" collapses each series to its first and last point — the start-vs-end view a user wants
-// when they ask "how much did X change between A and B?" rather than the path between them.
 const SLOPE_TYPE_OPTION = { value: 'slope' as const, label: 'Slope' }
 
 const TOOLTIP_CONFIG = { pinnable: true, placement: 'cursor' as const }
 
-// The default tooltip shows the raw x label (e.g. `2025-05-28`); format the date like the rest of the UI.
+// DefaultTooltip shows the raw x label; format it like the axis.
 const renderDateTooltip = (ctx: TooltipContext): ReactElement => (
     <DefaultTooltip {...ctx} label={formatTooltipDate(ctx.label)} />
 )
-
-const TITLE_CLASS = 'text-xs font-semibold uppercase tracking-wider text-muted-foreground'
 
 function calculateTotal(results: TrendsResultItem[]): number {
     return results.reduce((sum, item) => {
@@ -71,41 +67,29 @@ function calculateTotal(results: TrendsResultItem[]): number {
     }, 0)
 }
 
-export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProps): ReactElement {
+export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): ReactElement {
     const displayType = getDisplayType(query)
-    // Honour the backend slope runner: a SlopeGraph query already comes back as two points per series,
-    // so defaultChartType opens straight into slope mode rather than line + a manual toggle.
     const [chartType, setChartType] = useState<ChartType>(defaultChartType(displayType))
     const [chartConfig, setChartConfig] = useState(() => chartConfigFromTrendsFilter(query?.trendsFilter))
 
     if (!results || results.length === 0) {
         return (
-            <div>
-                {title && <div className={`mb-4 ${TITLE_CLASS}`}>{title}</div>}
-                <Empty>
-                    <EmptyHeader>
-                        <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
-                        <EmptyDescription>No data available</EmptyDescription>
-                    </EmptyHeader>
-                </Empty>
-            </div>
+            <Empty>
+                <EmptyHeader>
+                    <EmptyMedia>{emptyStateIllustration('chart')}</EmptyMedia>
+                    <EmptyDescription>No data available</EmptyDescription>
+                </EmptyHeader>
+            </Empty>
         )
     }
 
-    // BoldNumber and ActionsBarValue aren't time series — no chart-type select, no options.
     if (displayType === 'BoldNumber') {
         const total = calculateTotal(results)
         const label = results[0] ? getSeriesLabel(results[0], 0) : 'Total'
-        return (
-            <div>
-                {title && <div className={`mb-4 ${TITLE_CLASS}`}>{title}</div>}
-                <BigNumber value={total} label={label} />
-            </div>
-        )
+        return <BigNumber value={total} label={label} />
     }
 
-    // ActionsBarValue returns aggregated_value per series (empty data[]/days[]) — render a
-    // horizontal bar of totals, not a time series.
+    // ActionsBarValue is aggregated totals per series (no days[]) — a horizontal bar, not a time series.
     if (displayType === 'ActionsBarValue') {
         const items = results.map((item, i) => ({
             label: getSeriesLabel(item, i),
@@ -114,16 +98,13 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
         const barSeries = buildTrendsBarValueSeries(items, { getColor: colorAt })
         const barConfig = buildTrendsBarValueConfig()
         return (
-            <div>
-                {title && <div className={`mb-4 ${TITLE_CLASS}`}>{title}</div>}
-                <div className="flex flex-col w-full h-[400px]">
-                    <BarValueChart
-                        series={barSeries}
-                        labels={items.map((item) => item.label)}
-                        theme={CHART_THEME}
-                        config={barConfig}
-                    />
-                </div>
+            <div className="flex flex-col w-full h-[400px]">
+                <BarValueChart
+                    series={barSeries}
+                    labels={items.map((item) => item.label)}
+                    theme={CHART_THEME}
+                    config={barConfig}
+                />
             </div>
         )
     }
@@ -139,23 +120,14 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
     const { slopeAvailable, effectiveType } = resolveChartView(chartType, labels.length)
     const chartTypeOptions = slopeAvailable ? [...CHART_TYPE_OPTIONS, SLOPE_TYPE_OPTION] : CHART_TYPE_OPTIONS
 
-    // Area auto-stacks but derived overlays draw at raw per-series values, so they visually
-    // disconnect from the stacked totals. Mirror the web's pattern: disable those toggles in
-    // Options and force them off when rendering area mode.
+    // Area auto-stacks, so derived overlays would draw against the stacked totals — disable them.
     const derivedSeriesDisabled = effectiveType === 'area'
     const isPercentStackView = chartConfig.percentStack && supportsPercentStack(effectiveType)
-    // The dialog's y-unit choice wins over whatever the saved insight specified.
     const effectiveTrendsFilter = { ...query?.trendsFilter, aggregationAxisFormat: chartConfig.yUnit }
-    // `valueLabels: true` falls back to the y-tick formatter, which already respects the
-    // y-unit and percent-stack view.
     const valueLabels = chartConfig.showValueLabels ? true : undefined
 
-    // Build only the active mode's chart model — toggling shouldn't recompute the hidden one.
     const renderChart = (): ReactElement => {
         if (effectiveType === 'slope') {
-            // Hand quill the full series and labels — it reduces to the first and last point itself,
-            // so the slope shaping lives once in quill, not here. The backend's incomplete_end flag is
-            // forwarded so the provisional end dashes exactly as it does in the insight.
             const slopeSeries = trendResults
                 .filter((item) => item.data.length >= 2)
                 .map((item) => ({
@@ -226,22 +198,18 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
 
     return (
         <div>
-            <div className="mb-2 flex items-center gap-2">
-                {title && <div className={TITLE_CLASS}>{title}</div>}
-                <div className="ml-auto flex items-center gap-2">
-                    {/* eslint-disable-next-line react/forbid-elements */}
-                    <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
-                    {/* Slope bypasses the chart-config pipeline entirely — none of these options apply. */}
-                    {effectiveType !== 'slope' && (
-                        <ChartSettings
-                            family={isBarFamily(effectiveType) ? 'bar' : 'line'}
-                            config={chartConfig}
-                            onChange={setChartConfig}
-                            derivedSeriesDisabled={derivedSeriesDisabled}
-                            percentStackDisabled={!supportsPercentStack(effectiveType)}
-                        />
-                    )}
-                </div>
+            <div className="mb-2 flex items-center justify-end gap-2">
+                {/* eslint-disable-next-line react/forbid-elements */}
+                <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
+                {effectiveType !== 'slope' && (
+                    <ChartSettings
+                        family={isBarFamily(effectiveType) ? 'bar' : 'line'}
+                        config={chartConfig}
+                        onChange={setChartConfig}
+                        derivedSeriesDisabled={derivedSeriesDisabled}
+                        percentStackDisabled={!supportsPercentStack(effectiveType)}
+                    />
+                )}
             </div>
             <div className="flex flex-col w-full h-[400px]">{renderChart()}</div>
         </div>

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -28,6 +28,7 @@ import {
     chartConfigFromTrendsFilter,
     defaultChartType,
     isBarFamily,
+    resolveChartView,
     supportsPercentStack,
 } from './chartSettingsConfig'
 import type { TrendsResultItem, TrendsVisualizerProps } from './types'
@@ -128,11 +129,8 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
         days: item.days,
         incompleteEnd: !!item.incomplete_end,
     }))
-    // A slope needs a start and an end, so only offer it when there are at least two time points.
-    const slopeAvailable = labels.length >= 2
+    const { slopeAvailable, effectiveType } = resolveChartView(chartType, labels.length)
     const chartTypeOptions = slopeAvailable ? [...CHART_TYPE_OPTIONS, SLOPE_TYPE_OPTION] : CHART_TYPE_OPTIONS
-    // Results can shrink below two points after slope was selected; fall back rather than render blank.
-    const effectiveType = chartType === 'slope' && !slopeAvailable ? 'line' : chartType
 
     // Area auto-stacks but derived overlays draw at raw per-series values, so they visually
     // disconnect from the stacked totals. Mirror the web's pattern: disable those toggles in
@@ -213,7 +211,7 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
                     {/* Slope bypasses the chart-config pipeline entirely — none of these options apply. */}
                     {effectiveType !== 'slope' && (
                         <ChartSettings
-                            chartMode={isBarFamily(effectiveType) ? 'bar' : 'line'}
+                            family={isBarFamily(effectiveType) ? 'bar' : 'line'}
                             config={chartConfig}
                             onChange={setChartConfig}
                             derivedSeriesDisabled={derivedSeriesDisabled}

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, useState } from 'react'
 
 import { emptyStateIllustration } from '@posthog/mcp-ui'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill'
-import { BarChart as BarValueChart, SlopeChart, TimeSeriesBarChart, TimeSeriesLineChart } from '@posthog/quill-charts'
+import { BarChart as BarValueChart, ciRanges, SlopeChart, TimeSeriesBarChart, TimeSeriesLineChart } from '@posthog/quill-charts'
 
 import { buildTrendsBarChartModel } from 'products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms'
 import {
@@ -16,19 +16,27 @@ import {
 
 import { BigNumber, Select } from './charts'
 import { CHART_THEME, colorAt } from './charts/theme'
+import { ChartSettings } from './ChartSettings'
+import {
+    type ChartType,
+    chartConfigFromTrendsFilter,
+    defaultChartType,
+    isBarFamily,
+    supportsPercentStack,
+} from './chartSettingsConfig'
 import type { TrendsResultItem, TrendsVisualizerProps } from './types'
-import { formatDate, getDisplayType, getSeriesLabel, isBarChart } from './utils'
+import { formatDate, getDisplayType, getSeriesLabel } from './utils'
 
-type ChartMode = 'line' | 'bar' | 'slope'
-
-const CHART_MODE_OPTIONS = [
+const CHART_TYPE_OPTIONS = [
     { value: 'line' as const, label: 'Line' },
+    { value: 'area' as const, label: 'Area' },
     { value: 'bar' as const, label: 'Bar' },
+    { value: 'stacked-bar' as const, label: 'Stacked bar' },
 ]
 
 // "Slope" collapses each series to its first and last point — the start-vs-end view a user wants
 // when they ask "how much did X change between A and B?" rather than the path between them.
-const SLOPE_MODE_OPTION = { value: 'slope' as const, label: 'Slope' }
+const SLOPE_TYPE_OPTION = { value: 'slope' as const, label: 'Slope' }
 
 const TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
 
@@ -50,10 +58,9 @@ function calculateTotal(results: TrendsResultItem[]): number {
 export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): ReactElement {
     const displayType = getDisplayType(query)
     // Honour the backend slope runner: a SlopeGraph query already comes back as two points per series,
-    // so open straight into slope mode rather than line + a manual toggle.
-    const [chartMode, setChartMode] = useState<ChartMode>(
-        isBarChart(displayType) ? 'bar' : displayType === 'SlopeGraph' ? 'slope' : 'line'
-    )
+    // so defaultChartType opens straight into slope mode rather than line + a manual toggle.
+    const [chartType, setChartType] = useState<ChartType>(defaultChartType(displayType))
+    const [chartConfig, setChartConfig] = useState(() => chartConfigFromTrendsFilter(query?.trendsFilter))
 
     if (!results || results.length === 0) {
         return (
@@ -66,6 +73,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
         )
     }
 
+    // BoldNumber and ActionsBarValue aren't time series — no chart-type select, no options.
     if (displayType === 'BoldNumber') {
         const total = calculateTotal(results)
         const label = results[0] ? getSeriesLabel(results[0], 0) : 'Total'
@@ -73,7 +81,7 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
     }
 
     // ActionsBarValue returns aggregated_value per series (empty data[]/days[]) — render a
-    // horizontal bar of totals, not a time series, so there's no line/bar mode toggle.
+    // horizontal bar of totals, not a time series.
     if (displayType === 'ActionsBarValue') {
         const items = results.map((item, i) => ({
             label: getSeriesLabel(item, i),
@@ -105,13 +113,24 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
 
     // A slope needs a start and an end, so only offer it when there are at least two time points.
     const slopeAvailable = labels.length >= 2
-    const chartModeOptions = slopeAvailable ? [...CHART_MODE_OPTIONS, SLOPE_MODE_OPTION] : CHART_MODE_OPTIONS
+    const chartTypeOptions = slopeAvailable ? [...CHART_TYPE_OPTIONS, SLOPE_TYPE_OPTION] : CHART_TYPE_OPTIONS
     // Results can shrink below two points after slope was selected; fall back rather than render blank.
-    const effectiveMode = chartMode === 'slope' && !slopeAvailable ? 'line' : chartMode
+    const effectiveType = chartType === 'slope' && !slopeAvailable ? 'line' : chartType
+
+    // Area auto-stacks but derived overlays draw at raw per-series values, so they visually
+    // disconnect from the stacked totals. Mirror the web's pattern: disable those toggles in
+    // Options and force them off when rendering area mode.
+    const derivedSeriesDisabled = effectiveType === 'area'
+    const isPercentStackView = chartConfig.percentStack && supportsPercentStack(effectiveType)
+    // The dialog's y-unit choice wins over whatever the saved insight specified.
+    const effectiveTrendsFilter = { ...query?.trendsFilter, aggregationAxisFormat: chartConfig.yUnit }
+    // `valueLabels: true` falls back to the y-tick formatter, which already respects the
+    // y-unit and percent-stack view.
+    const valueLabels = chartConfig.showValueLabels ? true : undefined
 
     // Build only the active mode's chart model — toggling shouldn't recompute the hidden one.
     const renderChart = (): ReactElement => {
-        if (effectiveMode === 'slope') {
+        if (effectiveType === 'slope') {
             // Hand quill the full series and labels — it reduces to the first and last point itself,
             // so the slope shaping lives once in quill, not here. The backend's incomplete_end flag is
             // forwarded so the provisional end dashes exactly as it does in the insight.
@@ -134,38 +153,58 @@ export function TrendsVisualizer({ query, results }: TrendsVisualizerProps): Rea
                 />
             )
         }
-        if (effectiveMode === 'bar') {
+        if (isBarFamily(effectiveType)) {
             const { series, config } = buildTrendsBarChartModel(trendResults, {
                 getColor: (_, index) => colorAt(index),
                 labels,
                 yAxisLabel,
-                isPercentStackView: false,
-                isGrouped: false,
+                trendsFilter: effectiveTrendsFilter,
+                isPercentStackView,
+                isGrouped: effectiveType === 'bar',
+                valueLabels,
                 xAxisTickFormatter: (value) => formatDate(value),
                 tooltip: TOOLTIP_CONFIG,
             })
             return <TimeSeriesBarChart series={series} labels={labels} theme={CHART_THEME} config={config} />
         }
         const series = buildTrendsSeries(trendResults, {
-            isArea: displayType === 'ActionsAreaGraph',
+            isArea: effectiveType === 'area',
             getColor: (_, index) => colorAt(index),
         })
         const config = buildTrendsLineTimeSeriesConfig({
             results: trendResults,
-            trendsFilter: query?.trendsFilter,
+            trendsFilter: effectiveTrendsFilter,
             yAxisLabel,
-            isPercentStackView: false,
+            isPercentStackView,
+            showTrendLines: chartConfig.showTrendLine && !derivedSeriesDisabled,
+            showMovingAverage: chartConfig.showMovingAverage && !derivedSeriesDisabled,
+            movingAverageIntervals: chartConfig.movingAverageIntervals,
+            showConfidenceIntervals: chartConfig.showConfidenceIntervals && !derivedSeriesDisabled,
+            confidenceLevel: chartConfig.confidenceLevel,
+            ciRanges,
+            valueLabels,
             showCrosshair: true,
             xAxisTickFormatter: (value) => formatDate(value),
+            tooltip: TOOLTIP_CONFIG,
         })
         return <TimeSeriesLineChart series={series} labels={labels} theme={CHART_THEME} config={config} />
     }
 
     return (
         <div>
-            <div className="mb-2 flex justify-end">
+            <div className="mb-2 flex items-center justify-end gap-2">
                 {/* eslint-disable-next-line react/forbid-elements */}
-                <Select value={effectiveMode} onChange={setChartMode} options={chartModeOptions} />
+                <Select value={effectiveType} onChange={setChartType} options={chartTypeOptions} />
+                {/* Slope bypasses the chart-config pipeline entirely — none of these options apply. */}
+                {effectiveType !== 'slope' && (
+                    <ChartSettings
+                        chartMode={isBarFamily(effectiveType) ? 'bar' : 'line'}
+                        config={chartConfig}
+                        onChange={setChartConfig}
+                        derivedSeriesDisabled={derivedSeriesDisabled}
+                        percentStackDisabled={!supportsPercentStack(effectiveType)}
+                    />
+                )}
             </div>
             <div className="flex flex-col w-full h-[400px]">{renderChart()}</div>
         </div>

--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -5,9 +5,11 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@posthog/quill
 import {
     BarChart as BarValueChart,
     ciRanges,
+    DefaultTooltip,
     SlopeChart,
     TimeSeriesBarChart,
     TimeSeriesLineChart,
+    type TooltipContext,
 } from '@posthog/quill-charts'
 
 import { buildTrendsBarChartModel } from 'products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms'
@@ -32,7 +34,7 @@ import {
     supportsPercentStack,
 } from './chartSettingsConfig'
 import type { TrendsResultItem, TrendsVisualizerProps } from './types'
-import { formatDate, getDisplayType, getSeriesLabel } from './utils'
+import { formatDate, formatTooltipDate, getDisplayType, getSeriesLabel } from './utils'
 
 const CHART_TYPE_OPTIONS = [
     { value: 'line' as const, label: 'Line' },
@@ -46,6 +48,11 @@ const CHART_TYPE_OPTIONS = [
 const SLOPE_TYPE_OPTION = { value: 'slope' as const, label: 'Slope' }
 
 const TOOLTIP_CONFIG = { pinnable: true, placement: 'cursor' as const }
+
+// The default tooltip shows the raw x label (e.g. `2025-05-28`); format the date like the rest of the UI.
+const renderDateTooltip = (ctx: TooltipContext): ReactElement => (
+    <DefaultTooltip {...ctx} label={formatTooltipDate(ctx.label)} />
+)
 
 const TITLE_CLASS = 'text-xs font-semibold uppercase tracking-wider text-muted-foreground'
 
@@ -179,7 +186,15 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
                 xAxisTickFormatter: (value) => formatDate(value),
                 tooltip: TOOLTIP_CONFIG,
             })
-            return <TimeSeriesBarChart series={series} labels={labels} theme={CHART_THEME} config={config} />
+            return (
+                <TimeSeriesBarChart
+                    series={series}
+                    labels={labels}
+                    theme={CHART_THEME}
+                    config={config}
+                    tooltip={renderDateTooltip}
+                />
+            )
         }
         const series = buildTrendsSeries(trendResults, {
             isArea: effectiveType === 'area',
@@ -198,7 +213,15 @@ export function TrendsVisualizer({ query, results, title }: TrendsVisualizerProp
             xAxisTickFormatter: (value) => formatDate(value),
             tooltip: TOOLTIP_CONFIG,
         })
-        return <TimeSeriesLineChart series={series} labels={labels} theme={CHART_THEME} config={config} />
+        return (
+            <TimeSeriesLineChart
+                series={series}
+                labels={labels}
+                theme={CHART_THEME}
+                config={config}
+                tooltip={renderDateTooltip}
+            />
+        )
     }
 
     return (

--- a/services/mcp/src/ui-apps/components/chartSettingsConfig.ts
+++ b/services/mcp/src/ui-apps/components/chartSettingsConfig.ts
@@ -4,15 +4,13 @@ import type { ChartDisplayType, TrendsFilter } from './types'
 
 export type ChartType = 'line' | 'area' | 'bar' | 'stacked-bar' | 'slope'
 
-// The canonical y-unit union lives in quill-charts; reuse it so the two never drift. `import type`
-// is erased at build time, so this stays runtime-free and unit-testable in the node vitest project.
+// Reuse quill's canonical y-unit union so the two can't drift.
 export type YUnit = YAxisFormat
 
 export interface ChartConfig {
     showValueLabels: boolean
     showTrendLine: boolean
     showConfidenceIntervals: boolean
-    /** Seeded from the query only — not exposed in the options dialog. */
     confidenceLevel: number
     percentStack: boolean
     yUnit: YUnit
@@ -37,7 +35,6 @@ export const Y_UNIT_OPTIONS: { value: YUnit; label: string }[] = [
     { value: 'currency', label: 'Currency' },
 ]
 
-/** Initial options for a chart: the saved insight's trendsFilter where present, defaults otherwise. */
 export function chartConfigFromTrendsFilter(trendsFilter: TrendsFilter | undefined): ChartConfig {
     return {
         showValueLabels: trendsFilter?.showValuesOnSeries ?? DEFAULT_CHART_CONFIG.showValueLabels,
@@ -50,7 +47,6 @@ export function chartConfigFromTrendsFilter(trendsFilter: TrendsFilter | undefin
 }
 
 export function defaultChartType(displayType: ChartDisplayType): ChartType {
-    // The backend slope runner returns two points per series, so open straight into slope mode.
     if (displayType === 'SlopeGraph') {
         return 'slope'
     }
@@ -60,7 +56,7 @@ export function defaultChartType(displayType: ChartDisplayType): ChartType {
     if (displayType === 'ActionsUnstackedBar') {
         return 'bar'
     }
-    // ActionsBar has always rendered stacked (web parity), so it maps to the stacked option.
+    // ActionsBar renders stacked on web, so map it to the stacked option.
     if (displayType === 'ActionsBar' || displayType === 'ActionsStackedBar') {
         return 'stacked-bar'
     }
@@ -71,20 +67,16 @@ export function isBarFamily(chartType: ChartType): boolean {
     return chartType === 'bar' || chartType === 'stacked-bar'
 }
 
-/** Web parity: percent stack is only meaningful for stacked renderings (area auto-stacks, stacked bars). */
 export function supportsPercentStack(chartType: ChartType): boolean {
     return chartType === 'area' || chartType === 'stacked-bar'
 }
 
 export interface ResolvedChartView {
-    /** Whether the slope option should be offered — it needs at least two time points. */
     slopeAvailable: boolean
-    /** Chart type to actually render; slope falls back to line when fewer than two points remain. */
     effectiveType: ChartType
 }
 
-// Slope needs a start and an end, so it's only available with >= 2 time points; a chart that drops
-// below two points after slope was picked falls back to line rather than rendering blank.
+// Slope needs at least two time points; below that it falls back to line.
 export function resolveChartView(chartType: ChartType, labelCount: number): ResolvedChartView {
     const slopeAvailable = labelCount >= 2
     return { slopeAvailable, effectiveType: chartType === 'slope' && !slopeAvailable ? 'line' : chartType }

--- a/services/mcp/src/ui-apps/components/chartSettingsConfig.ts
+++ b/services/mcp/src/ui-apps/components/chartSettingsConfig.ts
@@ -1,0 +1,83 @@
+import type { ChartDisplayType, TrendsFilter } from './types'
+
+export type ChartType = 'line' | 'area' | 'bar' | 'stacked-bar' | 'slope'
+
+// Mirrors quill-charts `YAxisFormat` structurally — declared as literals so this module stays
+// runtime-import-free and unit-testable in the node vitest project.
+export type YUnit = 'numeric' | 'short' | 'percentage' | 'percentage_scaled' | 'duration' | 'duration_ms' | 'currency'
+
+export interface ChartConfig {
+    showValueLabels: boolean
+    showTrendLine: boolean
+    showMovingAverage: boolean
+    /** Seeded from the query only — not exposed in the options dialog. */
+    movingAverageIntervals: number
+    showConfidenceIntervals: boolean
+    /** Seeded from the query only — not exposed in the options dialog. */
+    confidenceLevel: number
+    percentStack: boolean
+    yUnit: YUnit
+}
+
+export const DEFAULT_CHART_CONFIG: ChartConfig = {
+    showValueLabels: false,
+    showTrendLine: false,
+    showMovingAverage: false,
+    movingAverageIntervals: 7,
+    showConfidenceIntervals: false,
+    confidenceLevel: 95,
+    percentStack: false,
+    yUnit: 'numeric',
+}
+
+export const Y_UNIT_OPTIONS: { value: YUnit; label: string }[] = [
+    { value: 'numeric', label: 'Numeric' },
+    { value: 'short', label: 'Compact (1.2K)' },
+    { value: 'percentage', label: 'Percentage (0–100)' },
+    { value: 'percentage_scaled', label: 'Percentage (0–1)' },
+    { value: 'duration', label: 'Duration (s)' },
+    { value: 'duration_ms', label: 'Duration (ms)' },
+    { value: 'currency', label: 'Currency' },
+]
+
+/** Initial options for a chart: the saved insight's trendsFilter where present, defaults otherwise. */
+export function chartConfigFromTrendsFilter(trendsFilter: TrendsFilter | undefined): ChartConfig {
+    return {
+        showValueLabels: trendsFilter?.showValuesOnSeries ?? DEFAULT_CHART_CONFIG.showValueLabels,
+        showTrendLine: trendsFilter?.showTrendLines ?? DEFAULT_CHART_CONFIG.showTrendLine,
+        showMovingAverage: trendsFilter?.showMovingAverage ?? DEFAULT_CHART_CONFIG.showMovingAverage,
+        // `||` (not `??`): a 0 window would make buildDerivedConfigs emit no-op averages.
+        movingAverageIntervals: trendsFilter?.movingAverageIntervals || DEFAULT_CHART_CONFIG.movingAverageIntervals,
+        showConfidenceIntervals: trendsFilter?.showConfidenceIntervals ?? DEFAULT_CHART_CONFIG.showConfidenceIntervals,
+        confidenceLevel: trendsFilter?.confidenceLevel ?? DEFAULT_CHART_CONFIG.confidenceLevel,
+        percentStack: trendsFilter?.showPercentStackView ?? DEFAULT_CHART_CONFIG.percentStack,
+        yUnit: trendsFilter?.aggregationAxisFormat ?? DEFAULT_CHART_CONFIG.yUnit,
+    }
+}
+
+export function defaultChartType(displayType: ChartDisplayType): ChartType {
+    // The backend slope runner returns two points per series, so open straight into slope mode.
+    if (displayType === 'SlopeGraph') {
+        return 'slope'
+    }
+    if (displayType === 'ActionsAreaGraph') {
+        return 'area'
+    }
+    if (displayType === 'ActionsUnstackedBar') {
+        return 'bar'
+    }
+    // ActionsBar has always rendered stacked (web parity), so it maps to the stacked option.
+    if (displayType === 'ActionsBar' || displayType === 'ActionsStackedBar') {
+        return 'stacked-bar'
+    }
+    return 'line'
+}
+
+export function isBarFamily(chartType: ChartType): boolean {
+    return chartType === 'bar' || chartType === 'stacked-bar'
+}
+
+/** Web parity: percent stack is only meaningful for stacked renderings (area auto-stacks, stacked bars). */
+export function supportsPercentStack(chartType: ChartType): boolean {
+    return chartType === 'area' || chartType === 'stacked-bar'
+}

--- a/services/mcp/src/ui-apps/components/chartSettingsConfig.ts
+++ b/services/mcp/src/ui-apps/components/chartSettingsConfig.ts
@@ -1,17 +1,16 @@
+import type { YAxisFormat } from '@posthog/quill-charts'
+
 import type { ChartDisplayType, TrendsFilter } from './types'
 
 export type ChartType = 'line' | 'area' | 'bar' | 'stacked-bar' | 'slope'
 
-// Mirrors quill-charts `YAxisFormat` structurally — declared as literals so this module stays
-// runtime-import-free and unit-testable in the node vitest project.
-export type YUnit = 'numeric' | 'short' | 'percentage' | 'percentage_scaled' | 'duration' | 'duration_ms' | 'currency'
+// The canonical y-unit union lives in quill-charts; reuse it so the two never drift. `import type`
+// is erased at build time, so this stays runtime-free and unit-testable in the node vitest project.
+export type YUnit = YAxisFormat
 
 export interface ChartConfig {
     showValueLabels: boolean
     showTrendLine: boolean
-    showMovingAverage: boolean
-    /** Seeded from the query only — not exposed in the options dialog. */
-    movingAverageIntervals: number
     showConfidenceIntervals: boolean
     /** Seeded from the query only — not exposed in the options dialog. */
     confidenceLevel: number
@@ -22,8 +21,6 @@ export interface ChartConfig {
 export const DEFAULT_CHART_CONFIG: ChartConfig = {
     showValueLabels: false,
     showTrendLine: false,
-    showMovingAverage: false,
-    movingAverageIntervals: 7,
     showConfidenceIntervals: false,
     confidenceLevel: 95,
     percentStack: false,
@@ -45,9 +42,6 @@ export function chartConfigFromTrendsFilter(trendsFilter: TrendsFilter | undefin
     return {
         showValueLabels: trendsFilter?.showValuesOnSeries ?? DEFAULT_CHART_CONFIG.showValueLabels,
         showTrendLine: trendsFilter?.showTrendLines ?? DEFAULT_CHART_CONFIG.showTrendLine,
-        showMovingAverage: trendsFilter?.showMovingAverage ?? DEFAULT_CHART_CONFIG.showMovingAverage,
-        // `||` (not `??`): a 0 window would make buildDerivedConfigs emit no-op averages.
-        movingAverageIntervals: trendsFilter?.movingAverageIntervals || DEFAULT_CHART_CONFIG.movingAverageIntervals,
         showConfidenceIntervals: trendsFilter?.showConfidenceIntervals ?? DEFAULT_CHART_CONFIG.showConfidenceIntervals,
         confidenceLevel: trendsFilter?.confidenceLevel ?? DEFAULT_CHART_CONFIG.confidenceLevel,
         percentStack: trendsFilter?.showPercentStackView ?? DEFAULT_CHART_CONFIG.percentStack,
@@ -80,4 +74,18 @@ export function isBarFamily(chartType: ChartType): boolean {
 /** Web parity: percent stack is only meaningful for stacked renderings (area auto-stacks, stacked bars). */
 export function supportsPercentStack(chartType: ChartType): boolean {
     return chartType === 'area' || chartType === 'stacked-bar'
+}
+
+export interface ResolvedChartView {
+    /** Whether the slope option should be offered — it needs at least two time points. */
+    slopeAvailable: boolean
+    /** Chart type to actually render; slope falls back to line when fewer than two points remain. */
+    effectiveType: ChartType
+}
+
+// Slope needs a start and an end, so it's only available with >= 2 time points; a chart that drops
+// below two points after slope was picked falls back to line rather than rendering blank.
+export function resolveChartView(chartType: ChartType, labelCount: number): ResolvedChartView {
+    const slopeAvailable = labelCount >= 2
+    return { slopeAvailable, effectiveType: chartType === 'slope' && !slopeAvailable ? 'line' : chartType }
 }

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -43,9 +43,6 @@ export const LIFECYCLE_COLORS: Record<LifecycleStatus, string> = {
 export const lifecycleColor = (status: string | undefined): string =>
     LIFECYCLE_COLORS[(status ?? 'new') as LifecycleStatus] ?? LIFECYCLE_COLORS.new
 
-// The canvas is always white (Claude Desktop's iframe doesn't set `prefers-color-scheme`,
-// so we can't detect the host theme and adapt at runtime). axisColor drives both the axis
-// lines/ticks and the tick labels — a mid-gray (gray-500) that reads clearly on the white fill.
 export const CHART_THEME: ChartTheme = {
     colors: CHART_COLORS,
     backgroundColor: '#ffffff',

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -43,6 +43,9 @@ export const LIFECYCLE_COLORS: Record<LifecycleStatus, string> = {
 export const lifecycleColor = (status: string | undefined): string =>
     LIFECYCLE_COLORS[(status ?? 'new') as LifecycleStatus] ?? LIFECYCLE_COLORS.new
 
+// Single mid-gray for axis labels — readable on both light and dark hosts. Claude
+// Desktop's iframe doesn't set `prefers-color-scheme`, so we can't detect the host
+// theme and adapt at runtime.
 export const CHART_THEME: ChartTheme = {
     colors: CHART_COLORS,
     backgroundColor: '#ffffff',

--- a/services/mcp/src/ui-apps/components/charts/theme.ts
+++ b/services/mcp/src/ui-apps/components/charts/theme.ts
@@ -43,13 +43,13 @@ export const LIFECYCLE_COLORS: Record<LifecycleStatus, string> = {
 export const lifecycleColor = (status: string | undefined): string =>
     LIFECYCLE_COLORS[(status ?? 'new') as LifecycleStatus] ?? LIFECYCLE_COLORS.new
 
-// Single mid-gray for axis labels — readable on both light and dark hosts. Claude
-// Desktop's iframe doesn't set `prefers-color-scheme`, so we can't detect the host
-// theme and adapt at runtime.
+// The canvas is always white (Claude Desktop's iframe doesn't set `prefers-color-scheme`,
+// so we can't detect the host theme and adapt at runtime). axisColor drives both the axis
+// lines/ticks and the tick labels — a mid-gray (gray-500) that reads clearly on the white fill.
 export const CHART_THEME: ChartTheme = {
     colors: CHART_COLORS,
     backgroundColor: '#ffffff',
-    axisColor: '#9ca3af',
+    axisColor: '#6b7280',
     gridColor: 'rgba(128, 128, 128, 0.2)',
     crosshairColor: 'rgba(128, 128, 128, 0.5)',
     tooltipBackground: '#ffffff',

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -27,9 +27,6 @@ export type ChartDisplayType =
     | 'WorldMap'
     | 'SlopeGraph'
 
-// Structural subset of the schema `TrendsFilter` (declared rather than imported — the MCP bundle
-// resolves no `~/` schema paths). The display-option fields mirror what saved insights carry via
-// the insight-query tool; ad-hoc tool queries only populate `display`/`showLegend`.
 export interface TrendsFilter {
     display?: ChartDisplayType
     showLegend?: boolean

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -226,8 +226,6 @@ export interface RetentionPayload extends BasePayload {
 export interface TrendsVisualizerProps {
     query: TrendsQuery | undefined
     results: TrendsResult
-    /** Shell title (e.g. "Trends"); rendered inline with the chart controls. */
-    title?: string
 }
 
 export interface FunnelVisualizerProps {

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -15,6 +15,8 @@ export type ChartDisplayType =
     | 'ActionsLineGraph'
     | 'ActionsLineGraphCumulative'
     | 'ActionsBar'
+    | 'ActionsStackedBar'
+    | 'ActionsUnstackedBar'
     | 'ActionsBarValue'
     | 'ActionsAreaGraph'
     | 'BoldNumber'
@@ -23,11 +25,31 @@ export type ChartDisplayType =
     | 'WorldMap'
     | 'SlopeGraph'
 
+// Structural subset of the schema `TrendsFilter` (declared rather than imported — the MCP bundle
+// resolves no `~/` schema paths). The display-option fields mirror what saved insights carry via
+// the insight-query tool; ad-hoc tool queries only populate `display`/`showLegend`.
 export interface TrendsFilter {
     display?: ChartDisplayType
     showLegend?: boolean
     showValuesOnSeries?: boolean
-    aggregationAxisFormat?: 'numeric' | 'duration' | 'duration_ms' | 'percentage'
+    showTrendLines?: boolean
+    showMovingAverage?: boolean
+    movingAverageIntervals?: number
+    showConfidenceIntervals?: boolean
+    confidenceLevel?: number
+    showPercentStackView?: boolean
+    aggregationAxisFormat?:
+        | 'numeric'
+        | 'short'
+        | 'percentage'
+        | 'percentage_scaled'
+        | 'duration'
+        | 'duration_ms'
+        | 'currency'
+    aggregationAxisPrefix?: string
+    aggregationAxisPostfix?: string
+    decimalPlaces?: number
+    minDecimalPlaces?: number
 }
 
 export interface TrendsQuery {

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -1,3 +1,5 @@
+import type { YAxisFormat } from '@posthog/quill-charts'
+
 import type { AnalyticsMetadata } from '../types'
 
 // Base payload that all tool results share
@@ -38,14 +40,7 @@ export interface TrendsFilter {
     showConfidenceIntervals?: boolean
     confidenceLevel?: number
     showPercentStackView?: boolean
-    aggregationAxisFormat?:
-        | 'numeric'
-        | 'short'
-        | 'percentage'
-        | 'percentage_scaled'
-        | 'duration'
-        | 'duration_ms'
-        | 'currency'
+    aggregationAxisFormat?: YAxisFormat
     aggregationAxisPrefix?: string
     aggregationAxisPostfix?: string
     decimalPlaces?: number

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -231,6 +231,8 @@ export interface RetentionPayload extends BasePayload {
 export interface TrendsVisualizerProps {
     query: TrendsQuery | undefined
     results: TrendsResult
+    /** Shell title (e.g. "Trends"); rendered inline with the chart controls. */
+    title?: string
 }
 
 export interface FunnelVisualizerProps {

--- a/services/mcp/src/ui-apps/components/utils.ts
+++ b/services/mcp/src/ui-apps/components/utils.ts
@@ -49,6 +49,18 @@ export function formatDate(dateStr: string): string {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
+// Tooltips have room for the full date incl. year; axis ticks (formatDate) drop the year to stay compact.
+export function formatTooltipDate(dateStr: string): string {
+    if (!ISO_DATE_PREFIX.test(dateStr)) {
+        return dateStr
+    }
+    const date = new Date(dateStr)
+    if (Number.isNaN(date.getTime())) {
+        return dateStr
+    }
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
 export function getSeriesLabel(item: { label?: string; action?: { name?: string } }, index: number): string {
     return item.label || item.action?.name || `Series ${index + 1}`
 }

--- a/services/mcp/src/ui-apps/components/utils.ts
+++ b/services/mcp/src/ui-apps/components/utils.ts
@@ -4,10 +4,6 @@ export function getDisplayType(query: TrendsQuery | undefined): ChartDisplayType
     return query?.trendsFilter?.display || 'ActionsLineGraph'
 }
 
-export function isBarChart(displayType: ChartDisplayType): boolean {
-    return displayType === 'ActionsBar' || displayType === 'ActionsBarValue'
-}
-
 export function formatNumber(value: number): string {
     if (value >= 1_000_000) {
         return `${(value / 1_000_000).toFixed(1)}M`

--- a/services/mcp/src/ui-apps/components/utils.ts
+++ b/services/mcp/src/ui-apps/components/utils.ts
@@ -49,7 +49,6 @@ export function formatDate(dateStr: string): string {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
-// Tooltips have room for the full date incl. year; axis ticks (formatDate) drop the year to stay compact.
 export function formatTooltipDate(dateStr: string): string {
     if (!ISO_DATE_PREFIX.test(dateStr)) {
         return dateStr

--- a/services/mcp/tests/unit/insight-visualizations.test.ts
+++ b/services/mcp/tests/unit/insight-visualizations.test.ts
@@ -16,7 +16,6 @@ import {
     formatPercent,
     getDisplayType,
     getSeriesLabel,
-    isBarChart,
     normalizeFunnelSteps,
 } from '@/ui-apps/components/utils'
 
@@ -236,7 +235,7 @@ describe('insight visualizations', () => {
             })
         })
 
-        describe('getDisplayType / isBarChart', () => {
+        describe('getDisplayType', () => {
             it('defaults to ActionsLineGraph when the query or filter is missing', () => {
                 expect(getDisplayType(undefined)).toBe('ActionsLineGraph')
                 expect(getDisplayType({ kind: 'TrendsQuery' })).toBe('ActionsLineGraph')
@@ -246,15 +245,6 @@ describe('insight visualizations', () => {
                 expect(getDisplayType({ kind: 'TrendsQuery', trendsFilter: { display: 'BoldNumber' } })).toBe(
                     'BoldNumber'
                 )
-            })
-
-            it.each([
-                ['ActionsBar', true],
-                ['ActionsBarValue', true],
-                ['ActionsLineGraph', false],
-                ['BoldNumber', false],
-            ] as const)('isBarChart(%s) is %s', (displayType, expected) => {
-                expect(isBarChart(displayType)).toBe(expected)
             })
         })
 

--- a/services/mcp/tests/unit/trends-chart-settings.test.ts
+++ b/services/mcp/tests/unit/trends-chart-settings.test.ts
@@ -5,6 +5,7 @@ import {
     DEFAULT_CHART_CONFIG,
     defaultChartType,
     isBarFamily,
+    resolveChartView,
     supportsPercentStack,
 } from '../../src/ui-apps/components/chartSettingsConfig'
 import type { ChartDisplayType, TrendsFilter } from '../../src/ui-apps/components/types'
@@ -19,8 +20,6 @@ describe('trends chart settings', () => {
             const trendsFilter: TrendsFilter = {
                 showValuesOnSeries: true,
                 showTrendLines: true,
-                showMovingAverage: true,
-                movingAverageIntervals: 14,
                 showConfidenceIntervals: true,
                 confidenceLevel: 90,
                 showPercentStackView: true,
@@ -29,18 +28,11 @@ describe('trends chart settings', () => {
             expect(chartConfigFromTrendsFilter(trendsFilter)).toEqual({
                 showValueLabels: true,
                 showTrendLine: true,
-                showMovingAverage: true,
-                movingAverageIntervals: 14,
                 showConfidenceIntervals: true,
                 confidenceLevel: 90,
                 percentStack: true,
                 yUnit: 'duration',
             })
-        })
-
-        it.each([[undefined], [0]])('falls back to a 7-interval moving average window for %s', (intervals) => {
-            const config = chartConfigFromTrendsFilter({ movingAverageIntervals: intervals })
-            expect(config.movingAverageIntervals).toBe(7)
         })
 
         it('ignores unrelated trendsFilter fields', () => {
@@ -75,6 +67,30 @@ describe('trends chart settings', () => {
         ] as const)('%s: isBarFamily=%s, supportsPercentStack=%s', (chartType, barFamily, percentStack) => {
             expect(isBarFamily(chartType)).toBe(barFamily)
             expect(supportsPercentStack(chartType)).toBe(percentStack)
+        })
+    })
+
+    describe('resolveChartView', () => {
+        it.each([
+            [0, false],
+            [1, false],
+            [2, true],
+            [7, true],
+        ] as const)('slope is available with %i labels: %s', (labelCount, slopeAvailable) => {
+            expect(resolveChartView('line', labelCount).slopeAvailable).toBe(slopeAvailable)
+        })
+
+        it('falls slope back to line when there are fewer than two points', () => {
+            expect(resolveChartView('slope', 1).effectiveType).toBe('line')
+            expect(resolveChartView('slope', 0).effectiveType).toBe('line')
+        })
+
+        it('keeps slope when there are at least two points', () => {
+            expect(resolveChartView('slope', 2).effectiveType).toBe('slope')
+        })
+
+        it.each(['line', 'area', 'bar', 'stacked-bar'] as const)('passes %s through unchanged', (chartType) => {
+            expect(resolveChartView(chartType, 7).effectiveType).toBe(chartType)
         })
     })
 })

--- a/services/mcp/tests/unit/trends-chart-settings.test.ts
+++ b/services/mcp/tests/unit/trends-chart-settings.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    chartConfigFromTrendsFilter,
+    DEFAULT_CHART_CONFIG,
+    defaultChartType,
+    isBarFamily,
+    supportsPercentStack,
+} from '../../src/ui-apps/components/chartSettingsConfig'
+import type { ChartDisplayType, TrendsFilter } from '../../src/ui-apps/components/types'
+
+describe('trends chart settings', () => {
+    describe('chartConfigFromTrendsFilter', () => {
+        it('returns defaults when there is no trendsFilter', () => {
+            expect(chartConfigFromTrendsFilter(undefined)).toEqual(DEFAULT_CHART_CONFIG)
+        })
+
+        it('seeds every field from a fully populated trendsFilter', () => {
+            const trendsFilter: TrendsFilter = {
+                showValuesOnSeries: true,
+                showTrendLines: true,
+                showMovingAverage: true,
+                movingAverageIntervals: 14,
+                showConfidenceIntervals: true,
+                confidenceLevel: 90,
+                showPercentStackView: true,
+                aggregationAxisFormat: 'duration',
+            }
+            expect(chartConfigFromTrendsFilter(trendsFilter)).toEqual({
+                showValueLabels: true,
+                showTrendLine: true,
+                showMovingAverage: true,
+                movingAverageIntervals: 14,
+                showConfidenceIntervals: true,
+                confidenceLevel: 90,
+                percentStack: true,
+                yUnit: 'duration',
+            })
+        })
+
+        it.each([[undefined], [0]])('falls back to a 7-interval moving average window for %s', (intervals) => {
+            const config = chartConfigFromTrendsFilter({ movingAverageIntervals: intervals })
+            expect(config.movingAverageIntervals).toBe(7)
+        })
+
+        it('ignores unrelated trendsFilter fields', () => {
+            expect(chartConfigFromTrendsFilter({ display: 'ActionsBar', showLegend: true })).toEqual(
+                DEFAULT_CHART_CONFIG
+            )
+        })
+    })
+
+    describe('defaultChartType', () => {
+        it.each([
+            ['ActionsLineGraph', 'line'],
+            ['ActionsLineGraphCumulative', 'line'],
+            ['ActionsAreaGraph', 'area'],
+            ['ActionsBar', 'stacked-bar'],
+            ['ActionsStackedBar', 'stacked-bar'],
+            ['ActionsUnstackedBar', 'bar'],
+            ['ActionsPie', 'line'],
+            ['SlopeGraph', 'slope'],
+        ] as Array<[ChartDisplayType, string]>)('maps %s to %s', (displayType, expected) => {
+            expect(defaultChartType(displayType)).toBe(expected)
+        })
+    })
+
+    describe('chart type predicates', () => {
+        it.each([
+            ['line', false, false],
+            ['area', false, true],
+            ['bar', true, false],
+            ['stacked-bar', true, true],
+            ['slope', false, false],
+        ] as const)('%s: isBarFamily=%s, supportsPercentStack=%s', (chartType, barFamily, percentStack) => {
+            expect(isBarFamily(chartType)).toBe(barFamily)
+            expect(supportsPercentStack(chartType)).toBe(percentStack)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

The MCP trends UI app (`query-results`) renders quill-charts but exposes none of the chart display options the web product has — no value labels, trend lines, moving averages, confidence intervals, percent stack view, or y-axis unit control. PR #58086 added an options dialog, but on the pre-quill architecture; the quill-charts migration (#61807, #61809, #62307) rebuilt `TrendsVisualizer` without it. The quill transform builders already support every one of these options, so this is a wiring + UI port, not a chart-feature re-implementation.

## Changes

- **`chartSettingsConfig.ts` (new)** — pure, dependency-free module holding the `ChartConfig` shape and the decision logic: `chartConfigFromTrendsFilter` (seeds initial options from the query's `trendsFilter`, so saved insights run through `insight-query` render as configured), `defaultChartType`, `isBarFamily`, `supportsPercentStack`. Kept runtime-import-free so it's unit-testable in the node vitest project.
- **`ChartSettings.tsx` (new)** — an "Options" button opening a hand-rolled popover (no Radix/Floating UI portals — the app runs in a sandboxed iframe where portalled content can land in a different stacking context, same reasoning as the existing native `Select`). Toggles for value labels, trend line, moving average, confidence intervals, percent stack, and a y-axis unit select. Derived-series toggles are disabled in area mode (area auto-stacks; overlays drawn at raw per-series values look broken against stacked totals — mirrors the web Options behavior), and percent stack is enabled only for stacked renderings (area, stacked bar — web parity with `PERCENT_STACK_VIEW_DISPLAY_TYPE`).
- **`TrendsVisualizer.tsx`** — chart type select expanded to Line / Area / Bar / Stacked bar, and the config flows into the existing transform builders: `showTrendLines` / `showMovingAverage` / `showConfidenceIntervals` (+ `ciRanges` from `@posthog/quill-charts`) on the line config, `isPercentStackView` on both, `valueLabels: true` (falls back to the y-tick formatter, so labels respect the unit and percent-stack for free), and the dialog's y-unit merged over `trendsFilter.aggregationAxisFormat`. `ActionsBar` now maps to the "Stacked bar" option — rendering is unchanged (it was already stacked via `isGrouped: false`), the label is just honest now; "Bar" renders grouped.
- **`types.ts`** — the `TrendsFilter` stub extended with the display-option fields saved insights carry (structural firewall, no `~/` schema imports — same pattern as `trendsChartDisplayOptions.ts`); `ChartDisplayType` gains `ActionsStackedBar` / `ActionsUnstackedBar`.
- **`utils.ts`** — `isBarChart` removed; its only consumer now uses `defaultChartType`, avoiding two sources of truth for the display→chart-type mapping.

No MCP tool schema changes: ad-hoc tool queries still carry only `display`/`showLegend` (zod strips the rest) and start from defaults; extending the zod `TrendsFilter` so the model can request display options is a possible follow-up.

Supersedes the UI-app portion of #58086.

## How did you test this code?

I'm an agent — no manual browser testing. Automated checks:

- `services/mcp/tests/unit/trends-chart-settings.test.ts` (new) — 16 tests covering seeding from a full/empty/partial `trendsFilter`, the moving-average window fallback, `defaultChartType` for every display type, and the chart-type predicates.
- Full MCP unit suite: 1562 tests pass.
- `pnpm --filter @posthog/mcp typecheck` — no errors in changed files (remaining failures are local-environment react-resolution artifacts in untouched `products/*/mcp/apps` files).
- `pnpm --filter @posthog/mcp build:ui-apps` — all UI apps build.
- oxlint + oxfmt clean on changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed — internal MCP UI app change with no public API surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code (Claude Fable 5), Task-Id `e89bca1a-8086-40f7-8c9b-20d56fdbf113`. Tools: Read/Edit/Write/Grep/Bash, Explore + Plan subagents.
- Directed by @sampennington to port the display options from #58086 onto the current MCP apps. Agreed decisions: seed options from the saved insight's `trendsFilter` (no localStorage — #58086 persisted to localStorage instead), expand the chart type select to 4 types, keep the MCP tool zod schema untouched.
- Verified before reusing rather than reimplementing: `buildTrendsLineTimeSeriesConfig`/`buildTrendsBarChartModel` already accept every option; `valueLabels: true` needs no custom formatter (quill falls back to the y-tick formatter); `barLayout` mapping (`isGrouped: false` → stacked) drove the `ActionsBar` → "Stacked bar" default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
