### PR TITLE
fix(replay): surface summary workflow failures and calm retry banner

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -222,7 +222,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
                             {sessionSummaryHasRetried && (
                                 <LemonBanner type="warning" className="mb-2">
                                     <div className="text-sm font-normal">
-                                        Transient error generating the summary. Retrying...
+                                        Hit a temporary error — retrying automatically...
                                     </div>
                                 </LemonBanner>
                             )}

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.test.ts
@@ -134,6 +134,73 @@ describe('sessionSummaryProgressLogic', () => {
         })
     })
 
+    describe('retryStateBySessionId', () => {
+        const progress = (step: number): any => ({
+            phase: 'phase',
+            step,
+            total_steps: 8,
+            rasterizer_workflow_id: null,
+            segments_total: 0,
+            segments_completed: 0,
+            rasterizer: null,
+        })
+
+        it('flags a retry when the step regresses and clears it once caught back up', async () => {
+            logic.actions.setProgress(SESSION_ID, progress(3))
+            await expectLogic(logic).toMatchValues({
+                retryStateBySessionId: expect.objectContaining({
+                    [SESSION_ID]: { maxStep: 3, hasRetried: false },
+                }),
+            })
+
+            // Backend workflow restarted: step goes backwards
+            logic.actions.setProgress(SESSION_ID, progress(0))
+            await expectLogic(logic).toMatchValues({
+                retryStateBySessionId: expect.objectContaining({
+                    [SESSION_ID]: { maxStep: 3, hasRetried: true },
+                }),
+            })
+
+            // Still behind the previous max: warning stays
+            logic.actions.setProgress(SESSION_ID, progress(2))
+            await expectLogic(logic).toMatchValues({
+                retryStateBySessionId: expect.objectContaining({
+                    [SESSION_ID]: { maxStep: 3, hasRetried: true },
+                }),
+            })
+
+            // Caught back up: warning clears
+            logic.actions.setProgress(SESSION_ID, progress(3))
+            await expectLogic(logic).toMatchValues({
+                retryStateBySessionId: expect.objectContaining({
+                    [SESSION_ID]: { maxStep: 3, hasRetried: false },
+                }),
+            })
+        })
+
+        it('resets on a new summarization run and on summary arrival', async () => {
+            logic.actions.setProgress(SESSION_ID, progress(5))
+            logic.actions.setProgress(SESSION_ID, progress(1))
+            await expectLogic(logic, () => {
+                logic.actions.startSummarization(SESSION_ID)
+            }).toMatchValues({
+                retryStateBySessionId: expect.objectContaining({
+                    [SESSION_ID]: { maxStep: 0, hasRetried: false },
+                }),
+            })
+
+            logic.actions.setProgress(SESSION_ID, progress(4))
+            logic.actions.setProgress(SESSION_ID, progress(2))
+            await expectLogic(logic, () => {
+                logic.actions.setSummary(SESSION_ID, { segments: [] } as any)
+            }).toMatchValues({
+                retryStateBySessionId: expect.objectContaining({
+                    [SESSION_ID]: { maxStep: 0, hasRetried: false },
+                }),
+            })
+        })
+    })
+
     describe('forceRestart flag', () => {
         // The cancel-tracking + in-flight maps in the logic file are module
         // singletons, so each test uses a fresh session id to avoid leaking

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
@@ -115,7 +115,10 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
                         ...state,
                         [sessionId]: {
                             maxStep: Math.max(existing.maxStep, progress.step),
-                            hasRetried: existing.hasRetried || progress.step < existing.maxStep,
+                            // A step below the max seen means the backend workflow restarted.
+                            // Cleared once the retry catches back up, so the warning only
+                            // shows while the run is actually behind.
+                            hasRetried: progress.step < existing.maxStep,
                         },
                     }
                 },

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/block-proxy.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/block-proxy.test.ts
@@ -86,6 +86,23 @@ describe('BlockProxy', () => {
             })
         })
 
+        it('wraps network-level failures with the target URL', async () => {
+            const connectError = new Error('Connect Timeout Error')
+            connectError.name = 'ConnectTimeoutError'
+            mockInternalFetch.mockRejectedValue(connectError)
+
+            const proxy = new BlockProxy(testCfg, mockLog)
+            await expect(proxy.fetchBlocks(baseInput())).rejects.toMatchObject({
+                name: 'RasterizationError',
+                retryable: true,
+                code: 'BLOCK_LISTING_UNREACHABLE',
+                message: expect.stringContaining(
+                    'http://localhost:6738/api/projects/1/recordings/test-session-123/blocks'
+                ),
+                cause: connectError,
+            })
+        })
+
         it('throws on invalid blocks response', async () => {
             mockInternalFetch.mockResolvedValue({
                 status: 200,

--- a/nodejs/src/session-replay/recording-rasterizer/capture/block-proxy.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/block-proxy.ts
@@ -31,9 +31,22 @@ export class BlockProxy {
         this.sessionId = input.session_id
 
         const url = `${this.cfg.recordingApiBaseUrl}/api/projects/${input.team_id}/recordings/${input.session_id}/blocks`
-        const resp = await internalFetch(url, {
-            headers: { 'X-Internal-Api-Secret': this.cfg.recordingApiSecret },
-        })
+        let resp: Awaited<ReturnType<typeof internalFetch>>
+        try {
+            resp = await internalFetch(url, {
+                headers: { 'X-Internal-Api-Secret': this.cfg.recordingApiSecret },
+            })
+        } catch (err) {
+            // Network-level failures (connect timeouts, DNS) otherwise surface as bare
+            // undici errors with no hint of which host was unreachable.
+            const reason = err instanceof Error ? err.message || err.name : String(err)
+            throw new RasterizationError(
+                `Failed to reach recording API for block listing: ${url}: ${reason}`,
+                true,
+                'BLOCK_LISTING_UNREACHABLE',
+                err
+            )
+        }
         if (resp.status < 200 || resp.status >= 300) {
             const body = await resp.text()
             throw new RasterizationError(

--- a/posthog/temporal/session_replay/session_summary/workflow.py
+++ b/posthog/temporal/session_replay/session_summary/workflow.py
@@ -785,6 +785,48 @@ async def _get_rasterizer_frame_progress(client: Any, rasterizer_workflow_id: st
         return None
 
 
+async def _record_terminal_workflow_failure(
+    handle: WorkflowHandle,
+    status: WorkflowExecutionStatus,
+    *,
+    team_id: int,
+    session_id: str,
+) -> None:
+    """Record why a summary workflow ended in a terminal failure state.
+
+    The polling loop only sees the terminal status; the failure cause lives in
+    the workflow result. Surface it to logs and error tracking so failures can
+    be diagnosed without Temporal UI access. Best-effort: must never break the
+    user-facing stream.
+    """
+    if status == WorkflowExecutionStatus.CANCELED:
+        # User-initiated; not an error.
+        return
+    try:
+        await handle.result()
+    except Exception as e:
+        cause = getattr(e, "cause", None)
+        logger.exception(
+            "session summary workflow ended in terminal failure state",
+            workflow_id=handle.id,
+            team_id=team_id,
+            session_id=session_id,
+            status=status.name,
+            failure=str(cause) if cause is not None else str(e),
+            signals_type="session-summaries",
+        )
+        capture_exception(
+            e,
+            additional_properties={
+                "team_id": team_id,
+                "session_id": session_id,
+                "workflow_id": handle.id,
+                "workflow_status": status.name,
+                "signals_type": "session-summaries",
+            },
+        )
+
+
 async def _fetch_summary_progress(client: Any, handle: WorkflowHandle) -> dict[str, Any] | None:
     """Returns None when the workflow isn't queryable yet — caller should sleep and retry."""
     try:
@@ -958,6 +1000,7 @@ async def execute_summarize_session_video_stream(
                 WorkflowExecutionStatus.TERMINATED,
                 WorkflowExecutionStatus.TIMED_OUT,
             ):
+                await _record_terminal_workflow_failure(handle, status, team_id=team.id, session_id=session_id)
                 status_messages = {
                     WorkflowExecutionStatus.FAILED: "Something went wrong while generating the summary. Please try again.",
                     WorkflowExecutionStatus.CANCELED: "The summary generation was canceled.",

--- a/posthog/temporal/tests/session_replay/session_summary/test_summarize_session.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_summarize_session.py
@@ -443,6 +443,69 @@ class TestExecuteSummarizeSessionVideoStream:
         handle.query.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "terminal_status,should_capture",
+        [
+            (WorkflowExecutionStatus.FAILED, True),
+            (WorkflowExecutionStatus.TERMINATED, True),
+            (WorkflowExecutionStatus.TIMED_OUT, True),
+            (WorkflowExecutionStatus.CANCELED, False),
+        ],
+    )
+    async def test_terminal_failure_records_workflow_failure_cause(
+        self,
+        terminal_status: WorkflowExecutionStatus,
+        should_capture: bool,
+        mock_session_id: str,
+        mock_user: MagicMock,
+        mock_team: MagicMock,
+    ):
+        handle = self._make_handle([(terminal_status, None)])
+        handle.result = AsyncMock(side_effect=RuntimeError("rasterizer ConnectTimeoutError"))
+
+        with (
+            patch.object(SingleSessionSummary.objects, "get_summary", MagicMock(return_value=None)),
+            patch(
+                "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
+                return_value=(None, None, None, MagicMock(), "workflow-id"),
+            ),
+            patch(
+                "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
+                AsyncMock(return_value=handle),
+            ),
+            patch(
+                "posthog.temporal.session_replay.session_summary.workflow.async_connect",
+                AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "posthog.temporal.session_replay.session_summary.workflow.asyncio.sleep",
+                AsyncMock(),
+            ),
+            patch(
+                "posthog.temporal.session_replay.session_summary.workflow.capture_exception",
+            ) as mock_capture,
+        ):
+            events = await self._collect(
+                execute_summarize_session_video_stream(
+                    session_id=mock_session_id,
+                    user=mock_user,
+                    team=mock_team,
+                )
+            )
+
+        # The user-facing error event is yielded regardless of failure recording
+        assert len(events) == 1
+        if should_capture:
+            mock_capture.assert_called_once()
+            props = mock_capture.call_args.kwargs["additional_properties"]
+            assert props["workflow_status"] == terminal_status.name
+            assert props["session_id"] == mock_session_id
+        else:
+            # User-initiated cancel is not an error and short-circuits before fetching the result
+            mock_capture.assert_not_called()
+            handle.result.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_completed_without_db_row_yields_error_event(
         self,
         mock_session_id: str,


### PR DESCRIPTION
## Problem

When the video-based session summary Temporal workflow fails and retries, users see a "Transient error" warning banner that never goes away — even after the retry recovers — which reads as if summarization is permanently broken. Worse, when the workflow ends in a terminal failure state, the SSE stream yields a generic "Something went wrong" with nothing recorded server-side, so diagnosing *why* requires Temporal UI access and log archaeology.

While investigating one of these reports we also found that when the recording rasterizer can't reach the recording API, the activity fails with a bare `ConnectTimeoutError` that doesn't say which host was unreachable, which made root-causing much slower than it needed to be.

## Changes

- **Frontend**: the retry warning banner now clears once the retried workflow run catches back up to the step where the previous attempt failed, instead of persisting for the rest of the run. Copy softened from "Transient error generating the summary. Retrying..." to "Hit a temporary error — retrying automatically...".
- **Backend (Temporal stream)**: when the summary workflow ends in a terminal failure state (FAILED / TERMINATED / TIMED_OUT), the polling loop now extracts the workflow failure cause and records it via structured logging and error tracking with team/session/workflow context. User-initiated cancels are excluded.
- **Rasterizer (Node.js)**: network-level failures fetching the recording block listing are wrapped in a `RasterizationError` that includes the target URL (`BLOCK_LISTING_UNREACHABLE`), so connect timeouts and DNS failures are diagnosable from the activity failure alone.

## How did you test this code?

I'm an agent; no manual testing was performed. Automated tests:

- `sessionSummaryProgressLogic.test.ts` — new `retryStateBySessionId` cases covering flag-on-regression, clear-on-catch-up, and reset semantics (12/12 pass)
- `test_summarize_session.py` — new parametrized `test_terminal_failure_records_workflow_failure_cause` covering FAILED/TERMINATED/TIMED_OUT capture and CANCELED short-circuit (passed alongside the existing terminal-status tests; the full file later errored at setup only due to a local Docker port-forwarding outage, unrelated to the change)
- `block-proxy.test.ts` — new case asserting network failures wrap to `BLOCK_LISTING_UNREACHABLE` with the target URL (11/11 pass)
- Frontend `typescript:check`, nodejs `tsc --noEmit`, `ruff check`/`format` all clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code. Started from a support report of repeated "Transient error" banners during session summarization; traced the banner to the frontend's progress-step-regression heuristic, the regression to workflow-level Temporal retries, and (via internal log analysis) the underlying failures to the rasterizer being unable to reach the recording API — that infra issue is being escalated separately; this PR is the observability and UX hardening that fell out of the investigation.
- Chose to clear the retry banner on catch-up (step ≥ previous max) rather than a timeout, since "behind the previous attempt" is exactly the window where "retrying" is true.
- Failure-cause recording is best-effort and deliberately excludes CANCELED (user-initiated).
