### PR TITLE
chore(ci): add eager graph budget check for frontend bundles

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -221,10 +221,14 @@ jobs:
                   order-by: 'Size:desc'
                   strip-hash: "-[A-Za-z0-9]{8}\\.js$"
 
-            # The eager graph check runs inside build:with-report (no token in that
-            # subprocess); this posts/updates its sticky PR comment from the report it
-            # writes. After compressed-size-action the tree is on the BASE branch, so
-            # guard for the script's absence (also covers branches predating the check).
+            # The eager graph check runs in --report-only mode inside build:with-report
+            # (compressed-size-action runs that for the PR AND base builds — a failing
+            # base build must not abort the action for every open PR). These steps post
+            # the sticky PR comment and enforce the budgets from the PR build's report,
+            # which carries the checkout sha in its filename because the base build
+            # overwrites the plain one. After compressed-size-action the tree is on the
+            # BASE branch, so guard for the scripts' absence (also covers branches
+            # predating the check).
             - name: Post eager graph comment
               if: always() && github.event_name == 'pull_request'
               env:
@@ -235,6 +239,23 @@ jobs:
                   else
                       echo "Skipping eager graph comment — script not present on this checkout"
                   fi
+
+            - name: Enforce eager graph budgets
+              if: always() && github.event_name == 'pull_request'
+              run: |
+                  if [ ! -f frontend/bin/check-eager-graph.mjs ]; then
+                      echo "Skipping eager graph enforcement — script not present on this checkout"
+                      exit 0
+                  fi
+                  REPORT="frontend/eager-graph-report-${GITHUB_SHA}.json"
+                  if [ ! -f "$REPORT" ]; then
+                      REPORT="frontend/eager-graph-report.json"
+                  fi
+                  if [ ! -f "$REPORT" ]; then
+                      echo "Skipping eager graph enforcement — no report found (branch may predate the check)"
+                      exit 0
+                  fi
+                  node frontend/bin/check-eager-graph.mjs --assert-report "$REPORT"
 
             - name: Check toolbar for CSP eval violations
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -265,6 +265,61 @@ jobs:
                         "event_type": ${{ toJSON(github.event_name) }}
                       }
 
+    frontend-eager-graph:
+        name: Frontend eager graph budgets
+        needs: [changes]
+        if: needs.changes.outputs.frontend_code == 'true' && github.event_name != 'merge_group'
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  filter: blob:none
+
+            # Unrebased branches predate the check script — skip everything (including
+            # the build) rather than failing PRs that haven't picked it up yet.
+            - name: Check script availability
+              id: script
+              run: echo "present=$([ -f frontend/bin/check-eager-graph.mjs ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
+            - name: Install pnpm
+              if: steps.script.outputs.present == 'true'
+              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+            - name: Set up Node.js
+              if: steps.script.outputs.present == 'true'
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  token: ${{ github.token }}
+
+            - name: Get pnpm store path
+              if: steps.script.outputs.present == 'true'
+              id: pnpm-store
+              run: echo "path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+            - name: Restore pnpm cache
+              if: steps.script.outputs.present == 'true'
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ steps.pnpm-store.outputs.path }}
+                  key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
+
+            - name: Install package.json dependencies with pnpm
+              if: steps.script.outputs.present == 'true'
+              run: |
+                  pnpm --filter=@posthog/playwright... install --frozen-lockfile
+                  bin/turbo --filter=@posthog/frontend prepare
+
+            - name: Build app
+              if: steps.script.outputs.present == 'true'
+              run: pnpm --filter=@posthog/frontend build
+
+            - name: Check eager graph budgets
+              if: steps.script.outputs.present == 'true'
+              run: node frontend/bin/check-eager-graph.mjs
+
     frontend-typescript-checks:
         name: Frontend typechecking
         needs: [changes]

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -265,61 +265,6 @@ jobs:
                         "event_type": ${{ toJSON(github.event_name) }}
                       }
 
-    frontend-eager-graph:
-        name: Frontend eager graph budgets
-        needs: [changes]
-        if: needs.changes.outputs.frontend_code == 'true' && github.event_name != 'merge_group'
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  filter: blob:none
-
-            # Unrebased branches predate the check script — skip everything (including
-            # the build) rather than failing PRs that haven't picked it up yet.
-            - name: Check script availability
-              id: script
-              run: echo "present=$([ -f frontend/bin/check-eager-graph.mjs ] && echo true || echo false)" >> $GITHUB_OUTPUT
-
-            - name: Install pnpm
-              if: steps.script.outputs.present == 'true'
-              uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-            - name: Set up Node.js
-              if: steps.script.outputs.present == 'true'
-              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-              with:
-                  node-version-file: .nvmrc
-                  token: ${{ github.token }}
-
-            - name: Get pnpm store path
-              if: steps.script.outputs.present == 'true'
-              id: pnpm-store
-              run: echo "path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-            - name: Restore pnpm cache
-              if: steps.script.outputs.present == 'true'
-              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: ${{ steps.pnpm-store.outputs.path }}
-                  key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-                  restore-keys: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
-
-            - name: Install package.json dependencies with pnpm
-              if: steps.script.outputs.present == 'true'
-              run: |
-                  pnpm --filter=@posthog/playwright... install --frozen-lockfile
-                  bin/turbo --filter=@posthog/frontend prepare
-
-            - name: Build app
-              if: steps.script.outputs.present == 'true'
-              run: pnpm --filter=@posthog/frontend build
-
-            - name: Check eager graph budgets
-              if: steps.script.outputs.present == 'true'
-              run: node frontend/bin/check-eager-graph.mjs
-
     frontend-typescript-checks:
         name: Frontend typechecking
         needs: [changes]

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -221,6 +221,21 @@ jobs:
                   order-by: 'Size:desc'
                   strip-hash: "-[A-Za-z0-9]{8}\\.js$"
 
+            # The eager graph check runs inside build:with-report (no token in that
+            # subprocess); this posts/updates its sticky PR comment from the report it
+            # writes. After compressed-size-action the tree is on the BASE branch, so
+            # guard for the script's absence (also covers branches predating the check).
+            - name: Post eager graph comment
+              if: always() && github.event_name == 'pull_request'
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  if [ -f frontend/bin/post-eager-graph-comment.mjs ]; then
+                      node frontend/bin/post-eager-graph-comment.mjs
+                  else
+                      echo "Skipping eager graph comment — script not present on this checkout"
+                  fi
+
             - name: Check toolbar for CSP eval violations
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval
 

--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ frontend/.cache/
 frontend/@posthog/apps-common/dist/
 frontend/dist/
 frontend/dist-report/
-frontend/eager-graph-report.json
+frontend/eager-graph-report*.json
 frontend/pnpm-error.log
 frontend/public/Matter*.woff*
 frontend/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ frontend/.cache/
 frontend/@posthog/apps-common/dist/
 frontend/dist/
 frontend/dist-report/
+frontend/eager-graph-report.json
 frontend/pnpm-error.log
 frontend/public/Matter*.woff*
 frontend/tmp

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -32,14 +32,14 @@ const ROOTS = [
     {
         root: 'src/index.tsx',
         label: 'entry (logged-out pages, app bootstrap)',
-        // master 2026-06-11: 14.59 MB / 749 files (post #62923)
+        // master 2026-06-11: 14.59 MiB / 749 files (post #62923)
         budgetBytes: 17_000_000,
         forbidden: ['node_modules/monaco-editor/'],
     },
     {
         root: 'src/scenes/AuthenticatedShell.tsx',
         label: 'authenticated shell (every logged-in page)',
-        // master 2026-06-11: 55.51 MB / 8,325 files (ratchet down once #62957 / #62967 land)
+        // master 2026-06-11: 55.51 MiB / 8,325 files (ratchet down once #62957 / #62967 land)
         budgetBytes: 64_000_000,
         forbidden: [],
     },
@@ -62,9 +62,9 @@ function assertReport(reportFilePath) {
     for (const r of reportToAssert.roots) {
         if (r.overBudget) {
             fail(
-                `Eager graph for '${r.root}' is ${formatMB(r.bytes)}, over the ${formatMB(r.budgetBytes)} budget.\n` +
+                `Eager graph for '${r.root}' is ${formatMiB(r.bytes)}, over the ${formatMiB(r.budgetBytes)} budget.\n` +
                     `Largest files in the closure:\n` +
-                    r.largest.map(({ file, bytes }) => `   ${formatMB(bytes).padStart(9)}  ${file}`).join('\n') +
+                    r.largest.map(({ file, bytes }) => `   ${formatMiB(bytes).padStart(9)}  ${file}`).join('\n') +
                     `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
                     `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
             )
@@ -76,7 +76,7 @@ function assertReport(reportFilePath) {
             )
         }
         if (!process.exitCode) {
-            console.info(`✅ ${r.label}: ${formatMB(r.bytes)} within ${formatMB(r.budgetBytes)}`)
+            console.info(`✅ ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
         }
     }
 }
@@ -91,8 +91,8 @@ if (assertReportIndex !== -1) {
     process.exit(process.exitCode ?? 0)
 }
 
-function formatMB(bytes) {
-    return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+function formatMiB(bytes) {
+    return `${(bytes / 1024 / 1024).toFixed(2)} MiB`
 }
 
 function eagerClosure(inputs, root) {
@@ -154,33 +154,35 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
         .slice(0, 15)
 
     const overBudget = totalBytes > budgetBytes
-    const status = overBudget ? '❌' : '✅'
+    const forbiddenHits = []
+    for (const forbiddenSubstr of forbidden) {
+        const hit = [...seen].find((f) => f.includes(forbiddenSubstr))
+        if (hit) {
+            forbiddenHits.push({ module: forbiddenSubstr, chain: chainTo(parentOf, hit) })
+        }
+    }
+
+    const status = overBudget || forbiddenHits.length > 0 ? '❌' : '✅'
     console.info(`${status} ${label}`)
     console.info(`   root: ${root}`)
-    console.info(`   eager closure: ${seen.size} files, ${formatMB(totalBytes)} (budget ${formatMB(budgetBytes)})`)
-    summaryLines.push(`| ${status} \`${root}\` | ${formatMB(totalBytes)} | ${formatMB(budgetBytes)} | ${seen.size} |`)
+    console.info(`   eager closure: ${seen.size} files, ${formatMiB(totalBytes)} (budget ${formatMiB(budgetBytes)})`)
+    summaryLines.push(`| ${status} \`${root}\` | ${formatMiB(totalBytes)} | ${formatMiB(budgetBytes)} | ${seen.size} |`)
 
     if (overBudget) {
         fail(
-            `Eager graph for '${root}' is ${formatMB(totalBytes)}, over the ${formatMB(budgetBytes)} budget.\n` +
+            `Eager graph for '${root}' is ${formatMiB(totalBytes)}, over the ${formatMiB(budgetBytes)} budget.\n` +
                 `Something newly reachable through static imports is inflating it. Largest files in the closure:\n` +
-                largest.map(([f, b]) => `   ${formatMB(b).padStart(9)}  ${f}`).join('\n') +
+                largest.map(([f, b]) => `   ${formatMiB(b).padStart(10)}  ${f}`).join('\n') +
                 `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
                 `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
         )
     }
 
-    const forbiddenHits = []
-    for (const forbiddenSubstr of forbidden) {
-        const hit = [...seen].find((f) => f.includes(forbiddenSubstr))
-        if (hit) {
-            const chain = chainTo(parentOf, hit)
-            forbiddenHits.push({ module: forbiddenSubstr, chain })
-            fail(
-                `'${forbiddenSubstr}' is statically reachable from '${root}' — it must stay behind a dynamic import.\n` +
-                    `Import chain:\n   ${chain.join('\n   -> ')}`
-            )
-        }
+    for (const hit of forbiddenHits) {
+        fail(
+            `'${hit.module}' is statically reachable from '${root}' — it must stay behind a dynamic import.\n` +
+                `Import chain:\n   ${hit.chain.join('\n   -> ')}`
+        )
     }
 
     report.roots.push({

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -76,6 +76,7 @@ if (!fs.existsSync(metaPath)) {
 
 const inputs = JSON.parse(fs.readFileSync(metaPath, 'utf-8')).inputs
 const summaryLines = ['## Eager graph check', '', '| Root | Eager size | Budget | Files |', '| --- | --- | --- | --- |']
+const report = { roots: [] }
 
 for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     if (!inputs[root]) {
@@ -91,6 +92,10 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     for (const file of seen) {
         totalBytes += inputs[file].bytes
     }
+    const largest = [...seen]
+        .map((f) => [f, inputs[f].bytes])
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 15)
 
     const overBudget = totalBytes > budgetBytes
     const status = overBudget ? '❌' : '✅'
@@ -100,10 +105,6 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     summaryLines.push(`| ${status} \`${root}\` | ${formatMB(totalBytes)} | ${formatMB(budgetBytes)} | ${seen.size} |`)
 
     if (overBudget) {
-        const largest = [...seen]
-            .map((f) => [f, inputs[f].bytes])
-            .sort((a, b) => b[1] - a[1])
-            .slice(0, 15)
         fail(
             `Eager graph for '${root}' is ${formatMB(totalBytes)}, over the ${formatMB(budgetBytes)} budget.\n` +
                 `Something newly reachable through static imports is inflating it. Largest files in the closure:\n` +
@@ -113,16 +114,34 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
         )
     }
 
+    const forbiddenHits = []
     for (const forbiddenSubstr of forbidden) {
         const hit = [...seen].find((f) => f.includes(forbiddenSubstr))
         if (hit) {
+            forbiddenHits.push({ module: forbiddenSubstr, chain: chainTo(parentOf, hit) })
             fail(
                 `'${forbiddenSubstr}' is statically reachable from '${root}' — it must stay behind a dynamic import.\n` +
                     `Import chain:\n   ${chainTo(parentOf, hit).join('\n   -> ')}`
             )
         }
     }
+
+    report.roots.push({
+        root,
+        label,
+        bytes: totalBytes,
+        files: seen.size,
+        budgetBytes,
+        overBudget,
+        forbidden,
+        forbiddenHits,
+        largest: largest.map(([f, b]) => ({ file: f, bytes: b })),
+    })
 }
+
+// Consumed by bin/post-eager-graph-comment.mjs in CI; written even on failure so
+// the PR comment can show what went over.
+fs.writeFileSync(path.join(frontendDir, 'eager-graph-report.json'), JSON.stringify(report, null, 2))
 
 if (process.env.GITHUB_STEP_SUMMARY) {
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines.join('\n') + '\n')

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -6,6 +7,16 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const frontendDir = path.resolve(__dirname, '..')
 const metaPath = path.join(frontendDir, 'posthog-app-esbuild-meta.json')
+
+// --report-only: record results without failing the build. Used by build:with-report
+// because compressed-size-action runs that script for BOTH the PR build and the base
+// build — a base-branch budget breach must not abort the action for every open PR.
+// Enforcement happens in the dedicated workflow step via --assert-report.
+const reportOnly = process.argv.includes('--report-only')
+
+// --assert-report <path>: skip measuring; read a previously written report and exit
+// non-zero if it records violations.
+const assertReportIndex = process.argv.indexOf('--assert-report')
 
 // The eager graph is everything reachable from a root through STATIC imports only —
 // the code a browser must download and decode before that surface is interactive,
@@ -21,12 +32,14 @@ const ROOTS = [
     {
         root: 'src/index.tsx',
         label: 'entry (logged-out pages, app bootstrap)',
-        budgetBytes: 16_500_000,
+        // master 2026-06-11: 14.59 MB / 749 files (post #62923)
+        budgetBytes: 17_000_000,
         forbidden: ['node_modules/monaco-editor/'],
     },
     {
         root: 'src/scenes/AuthenticatedShell.tsx',
         label: 'authenticated shell (every logged-in page)',
+        // master 2026-06-11: 55.51 MB / 8,325 files (ratchet down once #62957 / #62967 land)
         budgetBytes: 64_000_000,
         forbidden: [],
     },
@@ -35,6 +48,47 @@ const ROOTS = [
 function fail(message) {
     console.error(`\n❌ ${message}`)
     process.exitCode = 1
+}
+
+function assertReport(reportFilePath) {
+    if (!fs.existsSync(reportFilePath)) {
+        fail(`Report not found at ${reportFilePath} — did the build run the check?`)
+        return
+    }
+    const reportToAssert = JSON.parse(fs.readFileSync(reportFilePath, 'utf-8'))
+    for (const message of reportToAssert.errors ?? []) {
+        fail(message)
+    }
+    for (const r of reportToAssert.roots) {
+        if (r.overBudget) {
+            fail(
+                `Eager graph for '${r.root}' is ${formatMB(r.bytes)}, over the ${formatMB(r.budgetBytes)} budget.\n` +
+                    `Largest files in the closure:\n` +
+                    r.largest.map(({ file, bytes }) => `   ${formatMB(bytes).padStart(9)}  ${file}`).join('\n') +
+                    `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
+                    `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
+            )
+        }
+        for (const hit of r.forbiddenHits) {
+            fail(
+                `'${hit.module}' is statically reachable from '${r.root}' — it must stay behind a dynamic import.\n` +
+                    `Import chain:\n   ${hit.chain.join('\n   -> ')}`
+            )
+        }
+        if (!process.exitCode) {
+            console.info(`✅ ${r.label}: ${formatMB(r.bytes)} within ${formatMB(r.budgetBytes)}`)
+        }
+    }
+}
+
+if (assertReportIndex !== -1) {
+    assertReport(process.argv[assertReportIndex + 1])
+    if (process.exitCode) {
+        console.error('\nEager graph check failed — see above.')
+    } else {
+        console.info('\nAll eager graph budgets respected.')
+    }
+    process.exit(process.exitCode ?? 0)
 }
 
 function formatMB(bytes) {
@@ -76,14 +130,16 @@ if (!fs.existsSync(metaPath)) {
 
 const inputs = JSON.parse(fs.readFileSync(metaPath, 'utf-8')).inputs
 const summaryLines = ['## Eager graph check', '', '| Root | Eager size | Budget | Files |', '| --- | --- | --- | --- |']
-const report = { roots: [] }
+const report = { roots: [], errors: [] }
 
 for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     if (!inputs[root]) {
         const candidates = Object.keys(inputs)
             .filter((k) => k.endsWith(path.basename(root)))
             .slice(0, 5)
-        fail(`Root '${root}' not found in metafile. Was it moved/renamed? Candidates: ${candidates.join(', ')}`)
+        const message = `Root '${root}' not found in metafile. Was it moved/renamed? Candidates: ${candidates.join(', ')}`
+        report.errors.push(message)
+        fail(message)
         continue
     }
 
@@ -118,10 +174,11 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     for (const forbiddenSubstr of forbidden) {
         const hit = [...seen].find((f) => f.includes(forbiddenSubstr))
         if (hit) {
-            forbiddenHits.push({ module: forbiddenSubstr, chain: chainTo(parentOf, hit) })
+            const chain = chainTo(parentOf, hit)
+            forbiddenHits.push({ module: forbiddenSubstr, chain })
             fail(
                 `'${forbiddenSubstr}' is statically reachable from '${root}' — it must stay behind a dynamic import.\n` +
-                    `Import chain:\n   ${chainTo(parentOf, hit).join('\n   -> ')}`
+                    `Import chain:\n   ${chain.join('\n   -> ')}`
             )
         }
     }
@@ -139,9 +196,19 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     })
 }
 
-// Consumed by bin/post-eager-graph-comment.mjs in CI; written even on failure so
-// the PR comment can show what went over.
-fs.writeFileSync(path.join(frontendDir, 'eager-graph-report.json'), JSON.stringify(report, null, 2))
+// Consumed by the workflow's comment + enforcement steps; written even on failure so
+// the PR comment can show what went over. The filename carries the built tree's HEAD
+// sha because compressed-size-action runs this for BOTH the PR build and the base
+// build in the same workspace — a plain filename would be overwritten by the base
+// build, making downstream steps report the wrong branch.
+const serialized = JSON.stringify(report, null, 2)
+fs.writeFileSync(path.join(frontendDir, 'eager-graph-report.json'), serialized)
+try {
+    const headSha = execSync('git rev-parse HEAD', { cwd: frontendDir, encoding: 'utf-8' }).trim()
+    fs.writeFileSync(path.join(frontendDir, `eager-graph-report-${headSha}.json`), serialized)
+} catch (err) {
+    console.error(`Could not write sha-specific report: ${err.message}`)
+}
 
 if (process.env.GITHUB_STEP_SUMMARY) {
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines.join('\n') + '\n')
@@ -149,6 +216,10 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 
 if (process.exitCode) {
     console.error('\nEager graph check failed — see above.')
+    if (reportOnly) {
+        console.error('Running with --report-only: violations recorded in the report, not failing the build.')
+        process.exit(0)
+    }
 } else {
     console.info('\nAll eager graph budgets respected.')
 }

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const frontendDir = path.resolve(__dirname, '..')
+const metaPath = path.join(frontendDir, 'posthog-app-esbuild-meta.json')
+
+// The eager graph is everything reachable from a root through STATIC imports only —
+// the code a browser must download and decode before that surface is interactive,
+// regardless of how the bytes are distributed across chunks. Total dist size can't
+// see regressions here (a fake-lazy require() moves no bytes, but makes them eager),
+// which is why this check exists alongside the compressed-size check.
+//
+// Budgets are input-source bytes (pre-minification): stable across builds and
+// proportional to decoded-script memory cost per renderer (see #32479).
+// Ratchet policy: when a bundle-splitting win lands, lower the budget to lock it in;
+// raise a budget only as a conscious, reviewed decision in the PR that needs it.
+const ROOTS = [
+    {
+        root: 'src/index.tsx',
+        label: 'entry (logged-out pages, app bootstrap)',
+        budgetBytes: 16_500_000,
+        forbidden: ['node_modules/monaco-editor/'],
+    },
+    {
+        root: 'src/scenes/AuthenticatedShell.tsx',
+        label: 'authenticated shell (every logged-in page)',
+        budgetBytes: 64_000_000,
+        forbidden: [],
+    },
+]
+
+function fail(message) {
+    console.error(`\n❌ ${message}`)
+    process.exitCode = 1
+}
+
+function formatMB(bytes) {
+    return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}
+
+function eagerClosure(inputs, root) {
+    const parentOf = new Map()
+    const seen = new Set([root])
+    const queue = [root]
+    while (queue.length) {
+        const file = queue.shift()
+        for (const imp of inputs[file]?.imports || []) {
+            if (imp.kind === 'dynamic-import' || seen.has(imp.path) || !inputs[imp.path]) {
+                continue
+            }
+            seen.add(imp.path)
+            parentOf.set(imp.path, file)
+            queue.push(imp.path)
+        }
+    }
+    return { seen, parentOf }
+}
+
+function chainTo(parentOf, target) {
+    const chain = []
+    let cur = target
+    while (cur !== undefined && chain.length < 50) {
+        chain.unshift(cur)
+        cur = parentOf.get(cur)
+    }
+    return chain
+}
+
+if (!fs.existsSync(metaPath)) {
+    fail(`Metafile not found at ${metaPath} — run \`pnpm --filter=@posthog/frontend build\` first.`)
+    process.exit(1)
+}
+
+const inputs = JSON.parse(fs.readFileSync(metaPath, 'utf-8')).inputs
+const summaryLines = ['## Eager graph check', '', '| Root | Eager size | Budget | Files |', '| --- | --- | --- | --- |']
+
+for (const { root, label, budgetBytes, forbidden } of ROOTS) {
+    if (!inputs[root]) {
+        const candidates = Object.keys(inputs)
+            .filter((k) => k.endsWith(path.basename(root)))
+            .slice(0, 5)
+        fail(`Root '${root}' not found in metafile. Was it moved/renamed? Candidates: ${candidates.join(', ')}`)
+        continue
+    }
+
+    const { seen, parentOf } = eagerClosure(inputs, root)
+    let totalBytes = 0
+    for (const file of seen) {
+        totalBytes += inputs[file].bytes
+    }
+
+    const overBudget = totalBytes > budgetBytes
+    const status = overBudget ? '❌' : '✅'
+    console.info(`${status} ${label}`)
+    console.info(`   root: ${root}`)
+    console.info(`   eager closure: ${seen.size} files, ${formatMB(totalBytes)} (budget ${formatMB(budgetBytes)})`)
+    summaryLines.push(`| ${status} \`${root}\` | ${formatMB(totalBytes)} | ${formatMB(budgetBytes)} | ${seen.size} |`)
+
+    if (overBudget) {
+        const largest = [...seen]
+            .map((f) => [f, inputs[f].bytes])
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 15)
+        fail(
+            `Eager graph for '${root}' is ${formatMB(totalBytes)}, over the ${formatMB(budgetBytes)} budget.\n` +
+                `Something newly reachable through static imports is inflating it. Largest files in the closure:\n` +
+                largest.map(([f, b]) => `   ${formatMB(b).padStart(9)}  ${f}`).join('\n') +
+                `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
+                `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
+        )
+    }
+
+    for (const forbiddenSubstr of forbidden) {
+        const hit = [...seen].find((f) => f.includes(forbiddenSubstr))
+        if (hit) {
+            fail(
+                `'${forbiddenSubstr}' is statically reachable from '${root}' — it must stay behind a dynamic import.\n` +
+                    `Import chain:\n   ${chainTo(parentOf, hit).join('\n   -> ')}`
+            )
+        }
+    }
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines.join('\n') + '\n')
+}
+
+if (process.exitCode) {
+    console.error('\nEager graph check failed — see above.')
+} else {
+    console.info('\nAll eager graph budgets respected.')
+}

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const reportPath = path.resolve(__dirname, '..', 'eager-graph-report.json')
+const frontendDir = path.resolve(__dirname, '..')
 
 const MARKER = '<!-- posthog-eager-graph-check -->'
 
@@ -12,10 +12,6 @@ const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
 const repo = process.env.GITHUB_REPOSITORY
 const eventPath = process.env.GITHUB_EVENT_PATH
 
-if (!fs.existsSync(reportPath)) {
-    console.info('No eager-graph-report.json found — nothing to post (branch may predate the check).')
-    process.exit(0)
-}
 if (!token || !repo || !eventPath) {
     console.info('Missing GitHub environment (token/repository/event) — skipping comment.')
     process.exit(0)
@@ -25,6 +21,27 @@ const prNumber = event.pull_request?.number
 if (!prNumber) {
     console.info('Not a pull request event — skipping comment.')
     process.exit(0)
+}
+
+// compressed-size-action builds the PR branch and then the base branch in the same
+// workspace, so the plain report filename holds the LAST build's (the base's) numbers.
+// The PR build's report carries its checkout sha in the filename — that's the one to
+// post. The PR build checks out the merge ref, so its sha is GITHUB_SHA; the head sha
+// covers non-merge-ref checkouts.
+const shaCandidates = [process.env.GITHUB_SHA, event.pull_request?.head?.sha].filter(Boolean)
+const shaReportPath = shaCandidates
+    .map((sha) => path.join(frontendDir, `eager-graph-report-${sha}.json`))
+    .find((p) => fs.existsSync(p))
+const reportPath = shaReportPath ?? path.join(frontendDir, 'eager-graph-report.json')
+if (!fs.existsSync(reportPath)) {
+    console.info('No eager graph report found — nothing to post (branch may predate the check).')
+    process.exit(0)
+}
+if (!shaReportPath) {
+    console.warn(
+        `No report found for shas [${shaCandidates.join(', ')}]; falling back to ${reportPath} — ` +
+            `its numbers may be from a different checkout.`
+    )
 }
 
 const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8'))
@@ -75,12 +92,18 @@ async function gh(url, options = {}) {
 }
 
 let existing = null
-for (let page = 1; page <= 3 && !existing; page++) {
-    const comments = await gh(`/repos/${repo}/issues/${prNumber}/comments?per_page=100&page=${page}`)
-    existing = comments.find((c) => c.body?.includes(MARKER)) ?? null
-    if (comments.length < 100) {
-        break
+try {
+    for (let page = 1; page <= 50 && !existing; page++) {
+        const comments = await gh(`/repos/${repo}/issues/${prNumber}/comments?per_page=100&page=${page}`)
+        existing = comments.find((c) => c.body?.includes(MARKER)) ?? null
+        if (comments.length < 100) {
+            break
+        }
     }
+} catch (err) {
+    // Fork PRs run with a read-only token — the comment is a nicety, never worth a red job.
+    console.warn(`Could not read PR comments (read-only token on fork PRs?): ${err.message}`)
+    process.exit(0)
 }
 
 const previous = (() => {
@@ -92,7 +115,7 @@ const previous = (() => {
     }
 })()
 
-const anyFailure = report.roots.some((r) => r.overBudget || r.forbiddenHits.length > 0)
+const anyFailure = report.roots.some((r) => r.overBudget || r.forbiddenHits.length > 0) || report.errors?.length > 0
 const lines = [
     MARKER,
     `<!-- posthog-eager-graph-data ${JSON.stringify(Object.fromEntries(report.roots.map((r) => [r.root, r.bytes])))} -->`,
@@ -111,6 +134,10 @@ for (const r of report.roots) {
     )
 }
 lines.push('')
+
+for (const message of report.errors ?? []) {
+    lines.push(`❌ ${message}`, '')
+}
 
 for (const r of report.roots) {
     for (const forbiddenModule of r.forbidden) {
@@ -142,10 +169,15 @@ lines.push(
 )
 
 const body = lines.join('\n')
-if (existing) {
-    await gh(`/repos/${repo}/issues/comments/${existing.id}`, { method: 'PATCH', body: JSON.stringify({ body }) })
-    console.info(`Updated eager graph comment ${existing.id} on PR #${prNumber}.`)
-} else {
-    await gh(`/repos/${repo}/issues/${prNumber}/comments`, { method: 'POST', body: JSON.stringify({ body }) })
-    console.info(`Posted eager graph comment on PR #${prNumber}.`)
+try {
+    if (existing) {
+        await gh(`/repos/${repo}/issues/comments/${existing.id}`, { method: 'PATCH', body: JSON.stringify({ body }) })
+        console.info(`Updated eager graph comment ${existing.id} on PR #${prNumber}.`)
+    } else {
+        await gh(`/repos/${repo}/issues/${prNumber}/comments`, { method: 'POST', body: JSON.stringify({ body }) })
+        console.info(`Posted eager graph comment on PR #${prNumber}.`)
+    }
+} catch (err) {
+    // Fork PRs run with a read-only token — the comment is a nicety, never worth a red job.
+    console.warn(`Could not post eager graph comment (read-only token on fork PRs?): ${err.message}`)
 }

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const reportPath = path.resolve(__dirname, '..', 'eager-graph-report.json')
+
+const MARKER = '<!-- posthog-eager-graph-check -->'
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+const repo = process.env.GITHUB_REPOSITORY
+const eventPath = process.env.GITHUB_EVENT_PATH
+
+if (!fs.existsSync(reportPath)) {
+    console.info('No eager-graph-report.json found — nothing to post (branch may predate the check).')
+    process.exit(0)
+}
+if (!token || !repo || !eventPath) {
+    console.info('Missing GitHub environment (token/repository/event) — skipping comment.')
+    process.exit(0)
+}
+const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'))
+const prNumber = event.pull_request?.number
+if (!prNumber) {
+    console.info('Not a pull request event — skipping comment.')
+    process.exit(0)
+}
+
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8'))
+
+function formatBytes(bytes) {
+    const abs = Math.abs(bytes)
+    if (abs >= 1024 * 1024) {
+        return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+    }
+    if (abs >= 1024) {
+        return `${(bytes / 1024).toFixed(1)} kB`
+    }
+    return `${bytes} B`
+}
+
+function formatDelta(bytes, previousBytes) {
+    if (previousBytes === undefined) {
+        return '_(first run)_'
+    }
+    const delta = bytes - previousBytes
+    if (delta === 0) {
+        return 'no change'
+    }
+    return `${delta > 0 ? '+' : '-'}${formatBytes(Math.abs(delta))}`
+}
+
+function budgetBar(bytes, budgetBytes) {
+    const ratio = Math.min(bytes / budgetBytes, 1)
+    const filled = Math.round(ratio * 10)
+    const bar = '█'.repeat(filled) + '░'.repeat(10 - filled)
+    return `\`${bar}\` ${((bytes / budgetBytes) * 100).toFixed(1)}% of ${formatBytes(budgetBytes)}`
+}
+
+async function gh(url, options = {}) {
+    const response = await fetch(`https://api.github.com${url}`, {
+        ...options,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+            ...options.headers,
+        },
+    })
+    if (!response.ok) {
+        throw new Error(`GitHub API ${options.method || 'GET'} ${url} -> ${response.status}: ${await response.text()}`)
+    }
+    return response.json()
+}
+
+let existing = null
+for (let page = 1; page <= 3 && !existing; page++) {
+    const comments = await gh(`/repos/${repo}/issues/${prNumber}/comments?per_page=100&page=${page}`)
+    existing = comments.find((c) => c.body?.includes(MARKER)) ?? null
+    if (comments.length < 100) {
+        break
+    }
+}
+
+const previous = (() => {
+    const match = existing?.body?.match(/<!-- posthog-eager-graph-data (.*?) -->/s)
+    try {
+        return match ? JSON.parse(match[1]) : {}
+    } catch {
+        return {}
+    }
+})()
+
+const anyFailure = report.roots.some((r) => r.overBudget || r.forbiddenHits.length > 0)
+const lines = [
+    MARKER,
+    `<!-- posthog-eager-graph-data ${JSON.stringify(Object.fromEntries(report.roots.map((r) => [r.root, r.bytes])))} -->`,
+    `## ${anyFailure ? '❌' : '🕸️'} Eager graph`,
+    '',
+    "How much code each root forces the browser to download and decode through *static* imports — the regression class total bundle size can't see.",
+    '',
+    '| Root | Eager closure | Δ this PR run | Budget |',
+    '| --- | --- | --- | --- |',
+]
+
+for (const r of report.roots) {
+    const status = r.overBudget ? '❌ ' : ''
+    lines.push(
+        `| ${status}**${r.label}**<br/>\`${r.root}\` | ${formatBytes(r.bytes)} · ${r.files.toLocaleString()} files | ${formatDelta(r.bytes, previous[r.root])} | ${budgetBar(r.bytes, r.budgetBytes)} |`
+    )
+}
+lines.push('')
+
+for (const r of report.roots) {
+    for (const forbiddenModule of r.forbidden) {
+        const hit = r.forbiddenHits.find((h) => h.module === forbiddenModule)
+        if (hit) {
+            lines.push(`❌ \`${forbiddenModule}\` is statically reachable from \`${r.root}\`:`)
+            lines.push('')
+            lines.push('```')
+            lines.push(hit.chain.join('\n  -> '))
+            lines.push('```')
+        } else {
+            lines.push(`✅ \`${forbiddenModule}\` stays out of \`${r.root}\``)
+        }
+    }
+}
+lines.push('')
+
+for (const r of report.roots) {
+    lines.push(`<details><summary>Largest files eagerly reachable from <code>${r.root}</code></summary>`, '')
+    lines.push('| Size | File |', '| --- | --- |')
+    for (const { file, bytes } of r.largest.slice(0, 10)) {
+        lines.push(`| ${formatBytes(bytes)} | \`${file}\` |`)
+    }
+    lines.push('', '</details>')
+}
+lines.push('')
+lines.push(
+    '<sub>Posted automatically by [check-eager-graph](https://github.com/PostHog/posthog/blob/master/frontend/bin/check-eager-graph.mjs) · sizes are input-source bytes from the esbuild metafile · part of #32479</sub>'
+)
+
+const body = lines.join('\n')
+if (existing) {
+    await gh(`/repos/${repo}/issues/comments/${existing.id}`, { method: 'PATCH', body: JSON.stringify({ body }) })
+    console.info(`Updated eager graph comment ${existing.id} on PR #${prNumber}.`)
+} else {
+    await gh(`/repos/${repo}/issues/${prNumber}/comments`, { method: 'POST', body: JSON.stringify({ body }) })
+    console.info(`Posted eager graph comment on PR #${prNumber}.`)
+}

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -49,10 +49,10 @@ const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8'))
 function formatBytes(bytes) {
     const abs = Math.abs(bytes)
     if (abs >= 1024 * 1024) {
-        return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+        return `${(bytes / 1024 / 1024).toFixed(2)} MiB`
     }
     if (abs >= 1024) {
-        return `${(bytes / 1024).toFixed(1)} kB`
+        return `${(bytes / 1024).toFixed(1)} KiB`
     }
     return `${bytes} B`
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
         "copy-scripts": "mkdir -p dist/ && ./bin/copy-posthog-js",
         "clean": "rm -rf dist && mkdir dist",
         "build": "pnpm copy-scripts && pnpm build:esbuild",
-        "build:with-report": "pnpm build && node ./bin/build-bundle-report.mjs",
+        "build:with-report": "pnpm build && node ./bin/build-bundle-report.mjs && node ./bin/check-eager-graph.mjs",
         "build:esbuild": "DEBUG=0 node ./build.mjs",
         "build:products": "DEBUG=0 node build-products.mjs",
         "build:app-urls": "node bin/build-app-url-manifest.mjs",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
         "copy-scripts": "mkdir -p dist/ && ./bin/copy-posthog-js",
         "clean": "rm -rf dist && mkdir dist",
         "build": "pnpm copy-scripts && pnpm build:esbuild",
-        "build:with-report": "pnpm build && node ./bin/build-bundle-report.mjs && node ./bin/check-eager-graph.mjs",
+        "build:with-report": "pnpm build && node ./bin/build-bundle-report.mjs && node ./bin/check-eager-graph.mjs --report-only",
         "build:esbuild": "DEBUG=0 node ./build.mjs",
         "build:products": "DEBUG=0 node build-products.mjs",
         "build:app-urls": "node bin/build-app-url-manifest.mjs",


### PR DESCRIPTION
## Problem

The frontend bundle-splitting work (#62923, #62957, #62967, part of #32479) showed that our existing bundle size check structurally cannot see the regressions that matter most:

- it measures **total dist bytes**, but a lazy-loading regression moves no bytes — a `require()` that esbuild bundles statically, or a stray static import of a heavy module, makes megabytes *eager* without growing the build
- it excludes `_chunks/chunk*.js` (to avoid hash churn noise), which is exactly where heavy shared code lives

So #62923 cut the entry's eager input from 56 MB to 15 MB and the size check showed nothing; conversely, someone reverting that win would also show nothing.

References #32479

## Changes

**`frontend/bin/check-eager-graph.mjs`** walks static imports in the esbuild metafile (which every prod build already writes) from two roots:

| Root | What it represents | Current | Budget |
| --- | --- | --- | --- |
| `src/index.tsx` | logged-out pages, app bootstrap | 14.59 MB | 15.74 MB |
| `src/scenes/AuthenticatedShell.tsx` | every logged-in page | 55.51 MB | 61.04 MB |

It fails when a closure exceeds its budget (printing the 15 largest files in the closure to guide the fix), and supports per-root **forbidden modules**: monaco is forbidden from the entry graph, and a violation prints the full static import chain from root to the module — the exact thing you need to fix it. Budgets are input-source bytes (stable across builds, proportional to per-renderer decoded-script memory). Ratchet policy is documented in the script: lower budgets when wins land, raise them only as a conscious reviewed decision.

**Zero additional CI cost**: the check is chained onto `build:with-report`, which the existing bundle-size job's compressed-size action already runs — no new job, no second build. When the action builds the base branch for comparison it uses the base's `package.json`, so branches that predate the check are unaffected; the same property makes the change backward compatible with unrebased PRs.

Once #62957 and #62967 merge, the authed-shell budget can ratchet down and `monaco-editor` joins its forbidden list.

## How did you test this code?

I'm an agent; verification was local:

- Ran the check against a fresh master build: both budgets pass; monaco confirmed unreachable from the entry (validating #62923 holds)
- Exercised the over-budget path (budget below current value): fails with the largest-files listing
- Exercised the forbidden-module path (temporarily forbidding chart.js from the shell): fails printing the full 10-hop import chain
- oxlint clean; this PR's own bundle-size job runs the chained check end to end

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @pauldambra, following the bundle-split PRs. First iteration added a dedicated CI job with its own build; reworked to chain onto `build:with-report` after feedback that a second frontend build per PR is too much CI. Considered running the check as a post-action step in the bundle-size job, but `compressed-size-action` leaves the working tree on the base branch after it runs, so the metafile on disk would be the base's — chaining into the build script the action invokes is the only zero-cost placement that sees the PR's build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)