### PR TITLE
fix(replay): fix three player control papercuts

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryViews.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryViews.tsx
@@ -685,6 +685,9 @@ function SessionSummaryOutcomeBanner({ sessionSummary }: { sessionSummary: Sessi
 function SessionSummarySegments({ sessionSummary }: { sessionSummary: SessionSummaryContent }): JSX.Element | null {
     const { seekToTime } = useActions(sessionRecordingPlayerLogic)
 
+    // "Play from this moment" should start playback even if the player is paused
+    const seekToTimeAndPlay = (time: number): void => seekToTime(time, true)
+
     if (!sessionSummary?.segments) {
         return null
     }
@@ -704,7 +707,7 @@ function SessionSummarySegments({ sessionSummary }: { sessionSummary: SessionSum
                         segment={segment}
                         segmentOutcome={matchingSegmentOutcome}
                         keyActions={matchingKeyActions || []}
-                        onSeekToTime={seekToTime}
+                        onSeekToTime={seekToTimeAndPlay}
                     />
                 )
             })}

--- a/frontend/src/scenes/session-recordings/player/controller/seekbarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/controller/seekbarLogic.ts
@@ -7,7 +7,7 @@ import {
     sessionRecordingPlayerLogic,
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
-import { InteractEvent, ReactInteractEvent, THUMB_OFFSET, THUMB_SIZE, getXPos } from '../utils/playerUtils'
+import { InteractEvent, ReactInteractEvent, THUMB_OFFSET, getXPos } from '../utils/playerUtils'
 import type { seekbarLogicType } from './seekbarLogicType'
 
 export const seekbarLogic = kea<seekbarLogicType>([
@@ -168,7 +168,9 @@ export const seekbarLogic = kea<seekbarLogicType>([
             actions.startScrub()
             const xPos = getXPos(event)
             let diffFromThumb = xPos - values.thumb.getBoundingClientRect().left - THUMB_OFFSET
-            if (Math.abs(diffFromThumb) > THUMB_SIZE) {
+            // Only a press on the thumb itself keeps the grab offset; pressing the bar next to
+            // it seeks to the exact position — otherwise small seeks near the thumb go nowhere
+            if (Math.abs(diffFromThumb) > THUMB_OFFSET) {
                 diffFromThumb = 0
             }
             actions.setCursorDiff(diffFromThumb)

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -541,7 +541,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         setScale: (scale: number) => ({ scale }),
         togglePlayPause: true,
         seekToTimestamp: (timestamp: number, forcePlay: boolean = false) => ({ timestamp, forcePlay }),
-        seekToTime: (timeInMilliseconds: number) => ({ timeInMilliseconds }),
+        seekToTime: (timeInMilliseconds: number, forcePlay: boolean = false) => ({ timeInMilliseconds, forcePlay }),
         seekForward: (amount?: number) => ({ amount }),
         seekBackward: (amount?: number) => ({ amount }),
         seekToStart: true,
@@ -1755,9 +1755,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             const currentTime = values.currentPlayerTime || 0
             let targetTime = currentTime - amount
 
-            // If in a gap > 3s or would land in a gap > 3s: go to end of previous activity - amount
+            // When skipping inactivity, rewinding into a gap > 3s would just bounce forward
+            // to the gap's end again, so land before the gap instead — applying only the
+            // not-yet-rewound part of the jump so the total rewind stays predictable.
             // Otherwise: normal rewind
-            if (values.sessionPlayerData.start && values.currentTimestamp) {
+            if (values.skipInactivitySetting && values.sessionPlayerData.start && values.currentTimestamp) {
                 const startTimestamp = values.sessionPlayerData.start.valueOf()
                 const segments = values.sessionPlayerData.segments
                 const currentSegment = values.segmentForTimestamp(values.currentTimestamp)
@@ -1775,22 +1777,23 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 const findSegmentIndex = (segment: RecordingSegment): number =>
                     segments.findIndex((s) => s.startTimestamp === segment.startTimestamp && s.kind === segment.kind)
 
-                const seekToPrevActivityEnd = (segment: RecordingSegment): void => {
+                const seekToPrevActivityEnd = (segment: RecordingSegment, rewindMs: number): void => {
                     const prevActivity = findPrevActivitySegment(findSegmentIndex(segment))
                     if (prevActivity) {
                         const prevStart = prevActivity.startTimestamp - startTimestamp
                         const prevEnd = prevActivity.endTimestamp - startTimestamp
-                        targetTime = Math.max(prevStart, prevEnd - amount)
+                        targetTime = Math.max(prevStart, prevEnd - rewindMs)
                     }
                 }
 
                 if (currentSegment?.kind === 'gap' && currentSegment.durationMs > minGapDuration) {
-                    seekToPrevActivityEnd(currentSegment)
+                    seekToPrevActivityEnd(currentSegment, amount)
                 } else {
                     const targetTimestamp = startTimestamp + targetTime
                     const targetSegment = values.segmentForTimestamp(targetTimestamp)
                     if (targetSegment?.kind === 'gap' && targetSegment.durationMs > minGapDuration) {
-                        seekToPrevActivityEnd(targetSegment)
+                        const rewoundBeforeGap = currentTime - (targetSegment.endTimestamp - startTimestamp)
+                        seekToPrevActivityEnd(targetSegment, Math.max(amount - rewoundBeforeGap, 0))
                     }
                 }
             }
@@ -1810,7 +1813,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             }, 'seekIndicatorTimer')
         },
 
-        seekToTime: ({ timeInMilliseconds }) => {
+        seekToTime: ({ timeInMilliseconds, forcePlay }) => {
             if (values.currentTimestamp === undefined) {
                 return
             }
@@ -1825,7 +1828,14 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 values.sessionPlayerData.end.valueOf()
             )
 
-            actions.seekToTimestamp(newTimestamp)
+            if (forcePlay && values.playingState === SessionPlayerState.PAUSE) {
+                // setPlay seeks to currentTimestamp, so set the target first — seeking and then
+                // playing would rebuild the replayer twice, which can take seconds on large recordings
+                actions.setCurrentTimestamp(newTimestamp)
+                actions.setPlay()
+            } else {
+                actions.seekToTimestamp(newTimestamp, forcePlay)
+            }
         },
         seekToStart: () => {
             actions.seekToTime(0)

--- a/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
@@ -36,10 +36,10 @@ export function SessionGroupSummaryDetailsModal({ isOpen, onClose, event }: Sess
     const { sessionSummary } = useValues(playerMetaLogic(logicProps))
     // Scrolling to a bit before the moment to better notice it
     const timeToSeekTo = (ms: number): number => Math.max(ms - 4000, 0)
-    // Seek to target event timestamp and start playing when modal opens and player is loaded
+    // Seek to target event timestamp when modal opens and player is loaded
     useEffect(() => {
         if (isOpen && event?.target_event && sessionPlayerData) {
-            seekToTime(timeToSeekTo(event.target_event.milliseconds_since_start), true)
+            seekToTime(timeToSeekTo(event.target_event.milliseconds_since_start))
         }
     }, [isOpen, event, sessionPlayerData, seekToTime])
     useEffect(() => {

--- a/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
+++ b/products/session_summaries/frontend/SessionGroupSummaryDetailsModal.tsx
@@ -36,10 +36,10 @@ export function SessionGroupSummaryDetailsModal({ isOpen, onClose, event }: Sess
     const { sessionSummary } = useValues(playerMetaLogic(logicProps))
     // Scrolling to a bit before the moment to better notice it
     const timeToSeekTo = (ms: number): number => Math.max(ms - 4000, 0)
-    // Seek to target event timestamp when modal opens and player is loaded
+    // Seek to target event timestamp and start playing when modal opens and player is loaded
     useEffect(() => {
         if (isOpen && event?.target_event && sessionPlayerData) {
-            seekToTime(timeToSeekTo(event.target_event.milliseconds_since_start))
+            seekToTime(timeToSeekTo(event.target_event.milliseconds_since_start), true)
         }
     }, [isOpen, event, sessionPlayerData, seekToTime])
     useEffect(() => {


### PR DESCRIPTION
## Problem

Three papercuts in the session replay player controls:

1. "Play from this moment" in the recording summary only seeks — a paused player stays paused.
2. "Back 10 seconds" rewinds an unpredictable amount (12s/16s/30s) when the target lands in an inactivity gap, and the gap handling ran even with skip-inactivity disabled.
3. Small scrubs snap back: pressing within 15px of the thumb's center was treated as grabbing the thumb, so tiny seeks landed where you started.

## Changes

- `seekToTime` gains an optional `forcePlay`, used by the summary's "Play from this moment" buttons. Force-playing from paused sets the timestamp first so the replayer only rebuilds once.
- `seekBackward`'s gap handling is gated on the skip-inactivity setting and applies only the not-yet-rewound remainder before the gap, so "back 10s" always rewinds exactly 10 seconds of watched content. Left alone: `jumpTimeMs` scaling with playback speed (displayed on the button, covered by a test).
- The seekbar's grab dead zone now matches the thumb's actual bounds (`THUMB_OFFSET` instead of `THUMB_SIZE`), so pressing next to the thumb seeks to that exact position.

## How did you test this code?

Agent-authored; no manual testing claimed. `sessionRecordingPlayerLogic.test.ts` passes (68/68); oxlint, typegen, and tsc clean. The test mocks have no gap segments, so the gap-rewind arithmetic has no new unit test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — built with Claude Code from a user report of the three symptoms; root-caused in `sessionRecordingPlayerLogic` and `seekbarLogic`.