### PR TITLE
chore(ci): narrow hogli path filters to db-setup modules

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -163,10 +163,20 @@ jobs:
                         - rust/feature-flags/src/properties/property_models.rs
                         - frontend/src/products.json # Loaded at runtime by posthog/products.py
                         - 'products/*/manifest.tsx' # Generates products.json
-                        # hogli db commands used for test database setup
-                        - 'tools/hogli-commands/hogli_commands/**'
+                        # hogli setup commands this workflow runs: db:restore-test-db
+                        # and product:bootstrap/lint. Scoped to the modules those
+                        # commands actually import — framework, manifest, boot
+                        # modules, db_schema, product — so unrelated hogli commands
+                        # (doctor, devbox, ...) don't trigger this suite.
                         - 'tools/hogli/**'
                         - hogli.yaml
+                        - 'tools/hogli-commands/hogli_commands/db_schema.py'
+                        - 'tools/hogli-commands/hogli_commands/prechecks.py'
+                        - 'tools/hogli-commands/hogli_commands/telemetry_props.py'
+                        - 'tools/hogli-commands/hogli_commands/hint_hook.py'
+                        - 'tools/hogli-commands/hogli_commands/hints.py'
+                        - 'tools/hogli-commands/hogli_commands/product/**'
+                        - 'tools/hogli-commands/hogli_commands/product_structure.yaml'
                         # Make sure we run if someone is explicitly changing the workflow
                         - .github/workflows/ci-backend.yml
                         - .github/clickhouse-versions.json

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -165,10 +165,17 @@ jobs:
                         - pytest.ini
                         - pyproject.toml
                         - uv.lock
-                        # hogli db commands used for test database setup
-                        - 'tools/hogli-commands/hogli_commands/**'
+                        # hogli db setup (db:restore-schema-fresh). Scoped to the
+                        # modules that command actually imports — framework,
+                        # manifest, boot modules, db_schema — so unrelated hogli
+                        # commands (doctor, devbox, ...) don't trigger this suite.
                         - 'tools/hogli/**'
                         - hogli.yaml
+                        - 'tools/hogli-commands/hogli_commands/db_schema.py'
+                        - 'tools/hogli-commands/hogli_commands/prechecks.py'
+                        - 'tools/hogli-commands/hogli_commands/telemetry_props.py'
+                        - 'tools/hogli-commands/hogli_commands/hint_hook.py'
+                        - 'tools/hogli-commands/hogli_commands/hints.py'
 
             - name: Read ClickHouse versions from JSON
               id: read-versions

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -86,10 +86,17 @@ jobs:
                         - 'posthog/user_scripts/latest_user_defined_function.xml'
                         # Composite actions used by the workflow
                         - '.github/actions/commit-snapshots/**'
-                        # hogli db commands used to restore test database
-                        - 'tools/hogli-commands/hogli_commands/**'
+                        # hogli db setup (db:restore-test-db). Scoped to the
+                        # modules that command actually imports — framework,
+                        # manifest, boot modules, db_schema — so unrelated hogli
+                        # commands (doctor, devbox, ...) don't trigger this suite.
                         - 'tools/hogli/**'
                         - 'hogli.yaml'
+                        - 'tools/hogli-commands/hogli_commands/db_schema.py'
+                        - 'tools/hogli-commands/hogli_commands/prechecks.py'
+                        - 'tools/hogli-commands/hogli_commands/telemetry_props.py'
+                        - 'tools/hogli-commands/hogli_commands/hint_hook.py'
+                        - 'tools/hogli-commands/hogli_commands/hints.py'
                         # CI config
                         - '.github/workflows/ci-mcp.yml'
                         - '.github/workflows/mcp-publish.yml'


### PR DESCRIPTION
## Problem

`ci-backend`, `ci-dagster`, and `ci-mcp` trigger on the whole `tools/hogli-commands/hogli_commands/**` glob, but only invoke a couple of hogli commands (`db:restore-*`, and on ci-backend `product:*`). hogli imports command modules lazily, so an unrelated change (e.g. `doctor.py`) can't affect those steps — yet it currently runs the full Dagster/backend/MCP suites.

## Changes

Scope each filter to the modules its hogli invocations actually import:

- **ci-dagster / ci-mcp** (`db:restore-*`): `tools/hogli/**`, `hogli.yaml`, boot modules, `db_schema.py`.
- **ci-backend** (+ `product:*`): also `product/**`, `product_structure.yaml`.

Unchanged: **ci-python** (runs the full hogli-commands test suite — broad glob is correct) and **ci-lint-workflows** (already scoped).

## How did you test this code?

Agent (Claude Code), human-directed. `hogli lint:workflows` green; YAML valid; verified lazy dispatch + traced the import graph to confirm the allowlist is complete.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused from "why is a hogli `doctor` PR running Dagster?" — the over-broad glob. Chose an explicit allowlist over dorny `!`-negation for auditability, matching the existing precise dagster filter.
