### PR TITLE
chore(error-tracking): add rust/common/symbol_data to soft codeowners

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -133,6 +133,7 @@ products/error_tracking/mcp/** @PostHog/team-error-tracking
 products/error_tracking/skills/** @PostHog/team-error-tracking
 cli/** @PostHog/team-error-tracking
 rust/cymbal/** @PostHog/team-error-tracking
+rust/common/symbol_data/** @PostHog/team-error-tracking
 
 # Notebooks - owned by @PostHog/team-platform-features
 frontend/src/scenes/notebooks/ @PostHog/team-platform-features


### PR DESCRIPTION
## Problem

The `rust/common/symbol_data` crate is part of the error tracking domain but wasn't covered by soft codeowners, so the error tracking team wasn't being auto-suggested as reviewers for changes there.

## Changes

Add `rust/common/symbol_data/**` to the Error Tracking section of `.github/CODEOWNERS-soft`, owned by `@PostHog/team-error-tracking`.

## How did you test this code?

I'm an agent. No automated tests apply — this is a CODEOWNERS-soft mapping change. Verified the path `rust/common/symbol_data` exists in the repo and follows the same glob pattern as the existing error tracking entries.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack: add `rust/common/symbol_data` to team-error-tracking as soft codeowners. Placed the entry alongside the existing `rust/cymbal/**` line in the Error Tracking block.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07AA937K9A/p1781207504711779)*
