### PR TITLE
feat(dashboards): continue resize/drag gesture when entering edit mode

### DIFF
--- a/frontend/src/lib/components/Cards/ButtonTileCard/ButtonTileCard.tsx
+++ b/frontend/src/lib/components/Cards/ButtonTileCard/ButtonTileCard.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 
 import { Resizeable } from 'lib/components/Cards/CardMeta'
 import { DashboardResizeHandles } from 'lib/components/Cards/handles'
-import { EditModeEdgeOverlay } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+import { EditModeEdge, EditModeEdgeOverlay } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More, MoreProps } from 'lib/lemon-ui/LemonButton/More'
 
@@ -18,7 +18,7 @@ interface ButtonTileCardProps extends React.HTMLAttributes<HTMLDivElement>, Resi
     placement: DashboardPlacement
     children?: JSX.Element
     canEnterEditModeFromEdge?: boolean
-    onEnterEditModeFromEdge?: () => void
+    onEnterEditModeFromEdge?: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
     moreButtonOverlay?: MoreProps['overlay']
     onDragHandleMouseDown?: React.MouseEventHandler<HTMLDivElement>
     /** Whether editing controls (three-dots menu) should be shown. False hides them on template dashboards in view mode. */

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -19,7 +19,12 @@ describe('EditModeEdgeOverlay', () => {
         })
     })
 
-    it.each([0, 1, 2, 3])('calls onEnterEditMode when edge %i is pressed', (edgeIndex) => {
+    it.each([
+        [0, 'n'],
+        [1, 's'],
+        [2, 'w'],
+        [3, 'e'],
+    ])('calls onEnterEditMode with the pressed edge when edge %i is pressed', (edgeIndex, expectedEdge) => {
         const onEnterEditMode = jest.fn()
 
         const { getAllByTitle } = render(<EditModeEdgeOverlay onEnterEditMode={onEnterEditMode} />)
@@ -27,5 +32,6 @@ describe('EditModeEdgeOverlay', () => {
 
         fireEvent.mouseDown(edges[edgeIndex])
         expect(onEnterEditMode).toHaveBeenCalledTimes(1)
+        expect(onEnterEditMode).toHaveBeenCalledWith(expect.anything(), expectedEdge)
     })
 })

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
+export type EditModeEdge = 'n' | 's' | 'w' | 'e'
+
 interface EditModeEdgeOverlayProps {
-    onEnterEditMode: () => void
+    onEnterEditMode: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
 }
 
 const edgeOverlayBaseStyle: React.CSSProperties = {
@@ -13,31 +15,31 @@ const edgeOverlayBaseStyle: React.CSSProperties = {
     background: 'none',
 }
 
-const edges: { style: React.CSSProperties; cursor: React.CSSProperties['cursor'] }[] = [
+const edges: { edge: EditModeEdge; style: React.CSSProperties; cursor: React.CSSProperties['cursor'] }[] = [
     // top – vertical resize cursor
-    { style: { left: 0, right: 0, top: -6, height: 12 }, cursor: 'ns-resize' },
+    { edge: 'n', style: { left: 0, right: 0, top: -6, height: 12 }, cursor: 'ns-resize' },
     // bottom – vertical resize cursor
-    { style: { left: 0, right: 0, bottom: -6, height: 12 }, cursor: 'ns-resize' },
+    { edge: 's', style: { left: 0, right: 0, bottom: -6, height: 12 }, cursor: 'ns-resize' },
     // left – horizontal resize cursor
-    { style: { top: 0, bottom: 0, left: -6, width: 12 }, cursor: 'ew-resize' },
+    { edge: 'w', style: { top: 0, bottom: 0, left: -6, width: 12 }, cursor: 'ew-resize' },
     // right – horizontal resize cursor
-    { style: { top: 0, bottom: 0, right: -6, width: 12 }, cursor: 'ew-resize' },
+    { edge: 'e', style: { top: 0, bottom: 0, right: -6, width: 12 }, cursor: 'ew-resize' },
 ]
 
 export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnterEditMode }) => {
-    const handlePress = (event: React.MouseEvent<HTMLDivElement>): void => {
+    const handlePress = (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge): void => {
         // Treat any press (click or drag attempt) as intent to edit
         event.preventDefault()
         event.stopPropagation()
-        onEnterEditMode()
+        onEnterEditMode(event, edge)
     }
 
     return (
         <>
-            {edges.map(({ style, cursor }, index) => (
+            {edges.map(({ edge, style, cursor }) => (
                 <div
-                    key={index}
-                    onMouseDown={handlePress}
+                    key={edge}
+                    onMouseDown={(event) => handlePress(event, edge)}
                     aria-hidden="true"
                     title="Click to edit layout"
                     data-attr="dashboard-edit-mode-from-card-edge"

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -42,7 +42,7 @@ import {
 } from '~/types'
 
 import { DashboardResizeHandles } from '../handles'
-import { EditModeEdgeOverlay } from './EditModeEdgeOverlay'
+import { EditModeEdge, EditModeEdgeOverlay } from './EditModeEdgeOverlay'
 import { InsightMeta } from './InsightMeta'
 
 const IS_STORYBOOK = inStorybook() || inStorybookTestRunner()
@@ -106,7 +106,7 @@ export interface InsightCardProps extends Resizeable {
     /** Whether hovering near the card edge should hint that edit mode is available. */
     canEnterEditModeFromEdge?: boolean
     /** Called when the user clicks an edge hint to enter edit mode. */
-    onEnterEditModeFromEdge?: () => void
+    onEnterEditModeFromEdge?: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
     /** Called when the user mousedowns on the card (drag handle) in view mode to enter edit mode. */
     onDragHandleMouseDown?: React.MouseEventHandler<HTMLDivElement>
 }

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -8,7 +8,7 @@ import 'lib/components/Cards/CardMeta.scss'
 import 'lib/components/MarkdownEditor/shared/RichMarkdownEditor.scss'
 import { Resizeable } from 'lib/components/Cards/CardMeta'
 import { DashboardResizeHandles } from 'lib/components/Cards/handles'
-import { EditModeEdgeOverlay } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+import { EditModeEdge, EditModeEdgeOverlay } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { useRichContentEditor } from 'lib/components/RichContentEditor'
 import { More, MoreProps } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
@@ -24,7 +24,7 @@ interface TextCardProps extends React.HTMLAttributes<HTMLDivElement>, Resizeable
     /** Whether hovering near the card edge should hint that edit mode is available. */
     canEnterEditModeFromEdge?: boolean
     /** Called when the user clicks an edge hint to enter edit mode. */
-    onEnterEditModeFromEdge?: () => void
+    onEnterEditModeFromEdge?: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
     moreButtonOverlay?: MoreProps['overlay']
     /** Called when the user mousedowns on the card body (drag handle) in view mode to enter edit mode. */
     onDragHandleMouseDown?: React.MouseEventHandler<HTMLDivElement>

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -11,10 +11,12 @@ import { DashboardWidgetItem } from '@posthog/products-dashboards/frontend/compo
 import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboards/frontend/widgets/constants'
 
 import { InsightCard } from 'lib/components/Cards/InsightCard'
+import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { BREAKPOINTS, BREAKPOINT_COLUMN_COUNTS, isWidgetTileVisibleOnPlacement } from 'scenes/dashboard/dashboardUtils'
+import { continueDragGestureInEditMode, continueResizeGestureInEditMode } from 'scenes/dashboard/editLayoutGesture'
 import { useSurveyLinkedInsights } from 'scenes/surveys/hooks/useSurveyLinkedInsights'
 import { getBestSurveyOpportunityFunnel } from 'scenes/surveys/utils/opportunityDetection'
 import { urls } from 'scenes/urls'
@@ -187,7 +189,11 @@ export function DashboardItems(): JSX.Element {
     const onEnterEditModeFromEdge = useMemo(
         () =>
             canEnterEditModeFromEdge
-                ? () => setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardEdgeHover)
+                ? (e: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => {
+                      setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardEdgeHover)
+                      // continue the press into a live resize so the user doesn't have to release and grab again
+                      continueResizeGestureInEditMode(e, edge)
+                  }
                 : undefined,
         [canEnterEditModeFromEdge, setDashboardMode]
     )
@@ -217,6 +223,8 @@ export function DashboardItems(): JSX.Element {
                       e.preventDefault()
                       e.stopPropagation()
                       setDashboardMode(DashboardMode.Edit, DashboardEventSource.CardDragHandle)
+                      // continue the press into a live drag so the user doesn't have to release and grab again
+                      continueDragGestureInEditMode(e)
                   }
                 : undefined,
         [canEnterEditModeFromEdge, setDashboardMode]

--- a/frontend/src/scenes/dashboard/editLayoutGesture.test.ts
+++ b/frontend/src/scenes/dashboard/editLayoutGesture.test.ts
@@ -1,0 +1,138 @@
+import type { MouseEvent as ReactMouseEvent } from 'react'
+
+import {
+    continueDragGestureInEditMode,
+    continueResizeGestureInEditMode,
+    resolveResizeHandleDirection,
+} from 'scenes/dashboard/editLayoutGesture'
+
+describe('editLayoutGesture', () => {
+    const rect = { left: 0, right: 300, top: 0, bottom: 200 }
+
+    describe('resolveResizeHandleDirection', () => {
+        it.each([
+            ['n', 150, 0, 'n'],
+            ['s', 150, 200, 's'],
+            ['w', 0, 100, 'w'],
+            ['e', 300, 100, 'e'],
+            ['n', 10, 0, 'nw'],
+            ['n', 295, 0, 'ne'],
+            ['s', 10, 200, 'sw'],
+            ['s', 295, 200, 'se'],
+            ['w', 0, 10, 'nw'],
+            ['w', 0, 195, 'sw'],
+            ['e', 300, 10, 'ne'],
+            ['e', 300, 195, 'se'],
+        ])('maps edge %s at (%i, %i) to handle %s', (edge, clientX, clientY, expected) => {
+            expect(resolveResizeHandleDirection(edge as 'n' | 's' | 'w' | 'e', rect, clientX, clientY)).toBe(expected)
+        })
+    })
+
+    describe('gesture continuation', () => {
+        let rafQueue: FrameRequestCallback[]
+        let grid: HTMLDivElement
+        let gridItem: HTMLDivElement
+        let cardMeta: HTMLDivElement
+
+        const flushFrames = (count: number = 1): void => {
+            for (let i = 0; i < count; i++) {
+                const callbacks = rafQueue.splice(0)
+                callbacks.forEach((callback) => callback(0))
+            }
+        }
+
+        const pressEvent = (target: Element, clientX: number = 150, clientY: number = 100): ReactMouseEvent =>
+            ({ target, clientX, clientY, button: 0 }) as unknown as ReactMouseEvent
+
+        beforeEach(() => {
+            rafQueue = []
+            jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+                rafQueue.push(callback)
+                return rafQueue.length
+            })
+
+            grid = document.createElement('div')
+            grid.className = 'react-grid-layout dashboard-view-mode'
+            gridItem = document.createElement('div')
+            gridItem.className = 'react-grid-item'
+            gridItem.getBoundingClientRect = () => ({ ...rect, x: 0, y: 0, width: 300, height: 200 }) as DOMRect
+            cardMeta = document.createElement('div')
+            cardMeta.className = 'CardMeta'
+            gridItem.appendChild(cardMeta)
+            grid.appendChild(gridItem)
+            document.body.appendChild(grid)
+        })
+
+        afterEach(() => {
+            document.body.removeChild(grid)
+            jest.restoreAllMocks()
+        })
+
+        const mountResizeHandle = (direction: string): HTMLSpanElement => {
+            const handle = document.createElement('span')
+            handle.className = `react-resizable-handle react-resizable-handle-${direction}`
+            gridItem.appendChild(handle)
+            return handle
+        }
+
+        it('replays the mousedown on the matching resize handle once it renders', () => {
+            const onHandleMouseDown = jest.fn()
+
+            continueResizeGestureInEditMode(pressEvent(gridItem, 150, 0), 'n')
+            flushFrames() // handle not rendered yet — keeps waiting
+
+            const handle = mountResizeHandle('n')
+            handle.addEventListener('mousedown', onHandleMouseDown)
+            flushFrames()
+
+            expect(onHandleMouseDown).toHaveBeenCalledTimes(1)
+            const replayed = onHandleMouseDown.mock.calls[0][0] as MouseEvent
+            expect(replayed.clientX).toBe(150)
+            expect(replayed.clientY).toBe(0)
+            expect(replayed.bubbles).toBe(true)
+        })
+
+        it('does not replay if the mouse button is released before the handle renders', () => {
+            const onHandleMouseDown = jest.fn()
+
+            continueResizeGestureInEditMode(pressEvent(gridItem, 150, 0), 'n')
+            window.dispatchEvent(new MouseEvent('mouseup'))
+
+            const handle = mountResizeHandle('n')
+            handle.addEventListener('mousedown', onHandleMouseDown)
+            flushFrames(3)
+
+            expect(onHandleMouseDown).not.toHaveBeenCalled()
+        })
+
+        it('gives up after the frame budget if edit mode never renders', () => {
+            const onHandleMouseDown = jest.fn()
+
+            continueResizeGestureInEditMode(pressEvent(gridItem, 150, 0), 'n')
+            flushFrames(15)
+
+            const handle = mountResizeHandle('n')
+            handle.addEventListener('mousedown', onHandleMouseDown)
+            flushFrames(3)
+
+            expect(onHandleMouseDown).not.toHaveBeenCalled()
+        })
+
+        it('replays the mousedown on the drag handle once the grid is in edit mode', () => {
+            const onDragHandleMouseDown = jest.fn()
+            cardMeta.addEventListener('mousedown', onDragHandleMouseDown)
+
+            continueDragGestureInEditMode(pressEvent(cardMeta, 50, 20))
+            flushFrames() // grid still in view mode — keeps waiting
+            expect(onDragHandleMouseDown).not.toHaveBeenCalled()
+
+            grid.className = 'react-grid-layout dashboard-edit-mode'
+            flushFrames()
+
+            expect(onDragHandleMouseDown).toHaveBeenCalledTimes(1)
+            const replayed = onDragHandleMouseDown.mock.calls[0][0] as MouseEvent
+            expect(replayed.clientX).toBe(50)
+            expect(replayed.clientY).toBe(20)
+        })
+    })
+})

--- a/frontend/src/scenes/dashboard/editLayoutGesture.ts
+++ b/frontend/src/scenes/dashboard/editLayoutGesture.ts
@@ -1,0 +1,94 @@
+import type { MouseEvent as ReactMouseEvent } from 'react'
+
+import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+
+/** Matches the 2rem corner handle hit areas in DashboardItems.scss, so the replayed press lands on the handle that would be under the cursor. */
+const CORNER_THRESHOLD_PX = 32
+/** How many animation frames to wait for edit mode to render before giving up on continuing the gesture. */
+const MAX_FRAMES_TO_WAIT = 10
+
+/** Pick the resize handle direction for a press on a tile edge, upgrading presses near a corner to the corner handle. */
+export function resolveResizeHandleDirection(
+    edge: EditModeEdge,
+    rect: { left: number; right: number; top: number; bottom: number },
+    clientX: number,
+    clientY: number
+): string {
+    if (edge === 'n' || edge === 's') {
+        if (clientX - rect.left <= CORNER_THRESHOLD_PX) {
+            return `${edge}w`
+        }
+        if (rect.right - clientX <= CORNER_THRESHOLD_PX) {
+            return `${edge}e`
+        }
+        return edge
+    }
+    if (clientY - rect.top <= CORNER_THRESHOLD_PX) {
+        return `n${edge}`
+    }
+    if (rect.bottom - clientY <= CORNER_THRESHOLD_PX) {
+        return `s${edge}`
+    }
+    return edge
+}
+
+/**
+ * Re-dispatch the pressed-down mouse event on `findTarget()` once it becomes available, so a gesture started
+ * before edit mode rendered continues without the user having to release and press again. react-grid-layout
+ * only listens for mousedown while drag/resize is enabled, so the original press never reaches it.
+ */
+function replayMouseDown(event: ReactMouseEvent, findTarget: () => Element | null): void {
+    const { clientX, clientY, button } = event
+    let cancelled = false
+    const cancel = (): void => {
+        cancelled = true
+    }
+    // If the button is released before edit mode renders, replaying would leave a drag/resize stuck "in progress"
+    window.addEventListener('mouseup', cancel, { capture: true, once: true })
+
+    let framesLeft = MAX_FRAMES_TO_WAIT
+    const tryReplay = (): void => {
+        if (cancelled) {
+            return
+        }
+        const target = findTarget()
+        if (!target) {
+            framesLeft -= 1
+            if (framesLeft > 0) {
+                requestAnimationFrame(tryReplay)
+            } else {
+                window.removeEventListener('mouseup', cancel, { capture: true })
+            }
+            return
+        }
+        window.removeEventListener('mouseup', cancel, { capture: true })
+        target.dispatchEvent(
+            new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window, clientX, clientY, button })
+        )
+    }
+    requestAnimationFrame(tryReplay)
+}
+
+/** Continue a press on a tile edge into a live resize once edit mode's resize handles have rendered. */
+export function continueResizeGestureInEditMode(event: ReactMouseEvent, edge: EditModeEdge): void {
+    const gridItem = (event.target as Element | null)?.closest('.react-grid-item')
+    if (!gridItem) {
+        return
+    }
+    const rect = gridItem.getBoundingClientRect()
+    const direction = resolveResizeHandleDirection(edge, rect, event.clientX, event.clientY)
+    replayMouseDown(event, () => gridItem.querySelector(`.react-resizable-handle-${direction}`))
+}
+
+/** Continue a press on a tile's drag handle into a live drag once edit mode has enabled dragging. */
+export function continueDragGestureInEditMode(event: ReactMouseEvent): void {
+    const target = event.target as Element | null
+    const gridItem = target?.closest('.react-grid-item')
+    if (!target || !gridItem) {
+        return
+    }
+    replayMouseDown(event, () =>
+        // the grid signals that dragging is live by swapping to the edit-mode class
+        target.isConnected && gridItem.closest('.react-grid-layout.dashboard-edit-mode') ? target : null
+    )
+}

--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom'
 import { DashboardTileRefreshDataButton } from 'lib/components/Cards/InsightCard/DashboardTileRefreshDataButton'
 import { dashboardWidgetMenusLogic } from 'lib/components/Cards/InsightCard/dashboardWidgetMenusLogic'
 import { DashboardWidgetPlacementMenus } from 'lib/components/Cards/InsightCard/DashboardWidgetPlacementMenus'
+import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 
@@ -66,7 +67,7 @@ type DashboardWidgetItemProps = {
     toggleShowDescription?: () => void
     showResizeHandles?: boolean
     canEnterEditModeFromEdge?: boolean
-    onEnterEditModeFromEdge?: () => void
+    onEnterEditModeFromEdge?: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
     onDragHandleMouseDown?: React.MouseEventHandler<HTMLDivElement>
     showEditingControls?: boolean
     onDuplicate?: () => void

--- a/products/dashboards/frontend/components/WidgetCard/WidgetCard.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/WidgetCard.tsx
@@ -4,12 +4,12 @@ import React from 'react'
 import 'lib/components/Cards/CardMeta.scss'
 import type { Resizeable } from 'lib/components/Cards/CardMeta'
 import { DashboardResizeHandles } from 'lib/components/Cards/handles'
-import { EditModeEdgeOverlay } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+import { EditModeEdge, EditModeEdgeOverlay } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 
 type WidgetCardProps = React.HTMLAttributes<HTMLDivElement> &
     Resizeable & {
         canEnterEditModeFromEdge?: boolean
-        onEnterEditModeFromEdge?: () => void
+        onEnterEditModeFromEdge?: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
         /** RGL-injected resize handle nodes — rendered after decorative handles (see InsightCard). */
         gridChildren?: React.ReactNode
         children?: React.ReactNode


### PR DESCRIPTION
## Problem

Entering edit layout mode by interacting with a tile is a two-step action: pressing a tile edge (or the card's drag-handle area) switches on edit mode, but the press itself is swallowed — the grid's drag/resize is still disabled at the moment of the mousedown. The user has to release the button and grab the now-rendered resize handle a second time, which breaks the flow.


Before

https://github.com/user-attachments/assets/c67e36f5-85c4-432e-a430-39c17e4b5068


After

https://github.com/user-attachments/assets/01ed1544-5eaf-4972-b08b-3f4d9ad56169


## Changes

When a press lands on a tile edge or drag handle in view mode, we still enter edit mode immediately — and now also replay that same mousedown (same cursor coordinates) onto the matching resize/drag handle as soon as edit mode renders, roughly one frame later. The button is still held down, so react-grid-layout picks up the in-flight gesture and the resize or drag continues seamlessly from the original press.

- New `frontend/src/scenes/dashboard/editLayoutGesture.ts` with the gesture-continuation logic:
  - `continueResizeGestureInEditMode` waits (up to 10 frames) for the resize handles to mount, then re-dispatches the press on the right one. Presses near a corner upgrade to the corner handle (32px threshold, matching the handle hit areas in `DashboardItems.scss`), so diagonal pulls work on the first gesture.
  - `continueDragGestureInEditMode` does the same for tile dragging, keyed off the grid switching to its edit-mode class.
  - Safety guard: if the button is released before edit mode renders, the replay is cancelled — otherwise a resize would be left stuck "in progress" with no button held. Plain clicks keep their current behavior (just enter edit mode).
- `EditModeEdgeOverlay` now passes the pressed edge (`n`/`s`/`w`/`e`) and the mouse event to its callback.
- `DashboardItems.tsx` invokes the gesture continuation right after `setDashboardMode(Edit, …)` in both the edge-press and drag-handle paths.
- Prop signature updates in `InsightCard`, `TextCard`, `ButtonTileCard`, `WidgetCard`, and `DashboardWidgetItem`.

## How did you test this code?

I'm an agent — automated tests only, no manual testing claimed:

- New jest suite `editLayoutGesture.test.ts` covering corner/edge handle mapping, replay-on-mount, cancel-on-early-release, and the frame-budget give-up path.
- Updated `EditModeEdgeOverlay.test.tsx` to assert the pressed edge is reported; existing `TextCard.test.tsx` suite passes unchanged.
- `oxlint`/`oxfmt` clean; `tsc --noEmit` shows no errors in any changed file.

Recommended manual check: in view mode, press a tile edge and pull — the tile should resize in one motion as edit mode activates; same for pressing a card header and dragging.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task). The user asked for tile edge/border presses to flow directly into a resize or drag instead of requiring a second grab after edit mode activates. Investigated react-grid-layout v2 (wraps react-draggable/react-resizable, which start gestures from delegated mousedown handlers) and chose to replay the original mousedown onto the real handle after the edit-mode re-render, rather than keeping drag/resize always-enabled in view mode — that alternative would interfere with normal tile interaction (links, scrolling, text selection). The mouseup-cancellation guard exists because replaying after the button is released would leave a phantom gesture armed for the next mouse move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
