### PR TITLE
chore(dev): allow home-dir node metadata for uv interpreter resolution

### DIFF
--- a/bin/dev-sandbox.sb
+++ b/bin/dev-sandbox.sb
@@ -69,6 +69,13 @@
     ;; cargo during the nodejs service prestart. (crates.io token re-denied below.)
     (subpath (string-append (param "HOME") "/.cargo")))
 
+;; Canonicalization (realpath) lstats every path component, so uv resolving its
+;; managed-interpreter symlinks needs metadata on the dir nodes between $HOME and
+;; ~/.local/share/uv. Metadata only — contents of ~/.local{,/share} stay denied.
+(allow file-read-metadata
+    (literal (string-append (param "HOME") "/.local"))
+    (literal (string-append (param "HOME") "/.local/share")))
+
 ;; Keep the crates.io publish token blocked even though ~/.cargo is allowed above.
 (deny file-read*
     (literal (string-append (param "HOME") "/.cargo/credentials"))


### PR DESCRIPTION
## Problem

With the opt-in dev dependency sandbox (`POSTHOG_DEV_SANDBOX=1`), the llm-gateway crashes at boot: its start script runs `uv sync`, and uv canonicalizes the venv's interpreter path (`services/llm-gateway/.venv/bin/python3` resolves through symlinks into `~/.local/share/uv`). `realpath()` lstats every path component, and the Seatbelt profile allows reads under `~/.local/share/uv` but denies metadata on the intermediate `~/.local` and `~/.local/share` nodes — so canonicalization fails with `Operation not permitted` and uv aborts with "Failed to query Python interpreter".

Same class of issue as the duckdb extension allowance in #62681.

## Changes

Adds a metadata-only allowance (`file-read-metadata`, literal paths) for the two directory nodes between `$HOME` and the already-allowed uv subtree. Their contents stay denied, consistent with the profile's deny-by-default philosophy — only the lstat needed for path traversal is permitted.

## How did you test this code?

I'm an agent; no automated tests cover the Seatbelt profile. Verified manually on macOS with `POSTHOG_DEV_SANDBOX=1`:

- Before: `bin/dev-sandbox 'realpath ~/.local/share/uv/python/cpython-3.13-macos-aarch64-none/bin/python3.13'` → `Operation not permitted`; llm-gateway crashes at boot (exit 2).
- After: the same realpath resolves, and the llm-gateway boots and serves on :3308.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code while debugging a local dev stack where the llm-gateway crashlooped under the dev sandbox. Diagnosed by reproducing the failure inside `bin/dev-sandbox` and bisecting path access per component (subtree reads and exec worked; only canonicalization failed, isolating the missing parent-node metadata). The fix is deliberately metadata-only on two literal paths rather than widening read access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)