### PR TITLE
fix(playwright): drain discard-triggered insight re-fetch to deflake trends save test

### DIFF
--- a/playwright/e2e/product-analytics/insights/funnels.spec.ts
+++ b/playwright/e2e/product-analytics/insights/funnels.spec.ts
@@ -409,8 +409,7 @@ test.describe('Funnel insights', () => {
         })
 
         await test.step('cancel edit — conversion window reverts to saved value', async () => {
-            await insight.cancelButton.click()
-            await expect(insight.editButton).toBeVisible()
+            await insight.discard()
             await insight.funnels.waitForChart()
 
             await insight.edit()
@@ -453,8 +452,7 @@ test.describe('Funnel insights', () => {
         })
 
         await test.step('cancel restores original state after discard flow', async () => {
-            await insight.cancelButton.click()
-            await expect(insight.editButton).toBeVisible()
+            await insight.discard()
 
             await insight.edit()
             await expect(insight.funnels.conversionWindowInput).not.toHaveValue('3')

--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -21,6 +21,19 @@ test.describe('Trends insights', () => {
         await playwrightSetup.login(page, workspace!)
     })
 
+    // Changing the date range right after entering edit mode can race the editor's
+    // hydration — a late insight load can revert the edit, leaving the save button stuck
+    // on "No changes". Require the dirty state to stick and re-apply if it was reverted.
+    async function selectDateRangeUntilDirty(insight: InsightPage, label: string): Promise<void> {
+        await expect(async () => {
+            await insight.trends.selectDateRange(label)
+            await expect(insight.saveButton).not.toContainText('No changes', { timeout: 2000 })
+            await insight.page.waitForTimeout(300)
+            await expect(insight.saveButton).not.toContainText('No changes', { timeout: 500 })
+            await expect(insight.saveButton).toBeEnabled({ timeout: 500 })
+        }).toPass({ timeout: 30000 })
+    }
+
     test('View default pageview trends and verify daily totals', async ({ page }) => {
         const insight = new InsightPage(page)
 
@@ -320,7 +333,7 @@ test.describe('Trends insights', () => {
         })
 
         await test.step('change date range then discard and verify revert', async () => {
-            await insight.trends.selectDateRange('Last 30 days')
+            await selectDateRangeUntilDirty(insight, 'Last 30 days')
             await expect(insight.trends.dateRangeButton).toContainText('Last 30 days')
             await expect(insight.saveButton).toBeEnabled()
             await insight.discard()
@@ -333,7 +346,7 @@ test.describe('Trends insights', () => {
 
         await test.step('edit again, make a change, and save', async () => {
             await insight.edit()
-            await insight.trends.selectDateRange('Last 14 days')
+            await selectDateRangeUntilDirty(insight, 'Last 14 days')
             await insight.save()
             await expect(insight.trends.dateRangeButton).toContainText('Last 14 days')
         })

--- a/playwright/page-models/insightPage.ts
+++ b/playwright/page-models/insightPage.ts
@@ -178,8 +178,13 @@ export class InsightPage {
     }
 
     async discard(): Promise<void> {
+        // Discarding switches back to view mode, which re-fetches the insight. Drain that
+        // fetch before returning — left in flight, its response can land after a later
+        // edit and clobber it (see waitForInsightLoad).
+        const insightReloaded = this.waitForInsightLoad()
         await this.page.getByTestId('insight-cancel-edit-button').click()
         await expect(this.editButton).toBeVisible()
+        await insightReloaded
     }
 
     async editName(insightName: string = randomString('insight')): Promise<void> {


### PR DESCRIPTION
## Problem

`trends.spec.ts › Save an insight, make changes, discard them, and save a copy` flakes in CI: the save button gets stuck `aria-disabled` and `save()` times out.

#63019 fixed this class of bug for navigation, edit, and save by draining the insight re-fetch each mode change triggers — discarding edits (Edit → View) was the one transition left un-drained. When a test discards, re-enters edit mode, and changes the date range, the stale discard-triggered response can satisfy `edit()`'s wait, leaving the edit-mode re-fetch in flight; it then lands after the date-range change, reverts the query to the saved state, and the save button sticks on "No changes", so clicking it never produces a PATCH.

Reproduced locally at 1/10 on master: the failure screenshot shows the save button reading "No changes" with the date range visibly reverted to the saved value, in exactly the step that follows `discard()` → `edit()`.

## Changes

- `InsightPage.discard()` now drains the view-mode insight re-fetch, mirroring `goToInsight()`/`edit()`/`save()` from #63019.
- The trends spec re-applies the date-range edit if a residual revert lands (`selectDateRangeUntilDirty`, same pattern as the funnels conversion-window helper), and gives the post-discard save path that protection.
- The funnels spec's two hand-rolled `cancelButton.click()` + wait sequences now use `discard()`, picking up the same drain.

## How did you test this code?

I'm an agent; automated tests only:

- Baseline on master: the target test failed 1/10 (`--repeat-each 10 --workers 3`) with the exact reported signature.
- With the fix: 40/40 green (10 + 30 repeats, `--retries 0 --workers 3`).
- Full `trends.spec.ts` pass: 10/10 relevant tests green. The `Export insight data as CSV and XLSX` test cannot pass on a minimal local stack (exports are processed by a Temporal worker that isn't running locally) — unrelated to this change and covered by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code). Root cause was established in the #63019 investigation: `loadInsightSuccess` → `syncQueryFromProps` applies stale insight re-fetch responses over local unsaved edits.
- Considered fixing the underlying frontend race instead (skipping the sync when the editor is dirty), but the legitimate re-sync case (query updated elsewhere) is indistinguishable by state comparison alone, so the test-level drain was chosen; the product race may deserve a separate look.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
