### PR TITLE
fix(error-tracking): reverse ruby pre_context before assigning line offsets

### DIFF
--- a/rust/cymbal/src/langs/ruby.rs
+++ b/rust/cymbal/src/langs/ruby.rs
@@ -74,6 +74,31 @@ impl RawRubyFrame {
     }
 }
 
+impl From<&RawRubyFrame> for Frame {
+    fn from(raw: &RawRubyFrame) -> Self {
+        Frame {
+            frame_id: FrameId::placeholder(),
+            mangled_name: raw.function.clone(),
+            line: raw.lineno,
+            column: None,
+            source: Some(raw.filename.clone()),
+            in_app: raw.meta.in_app,
+            resolved_name: Some(raw.function.clone()),
+            lang: "ruby".to_string(),
+            resolved: true,
+            resolve_failure: None,
+
+            junk_drawer: None,
+            context: raw.get_context(),
+            release: None,
+            synthetic: raw.meta.synthetic,
+            suspicious: false,
+            module: None,
+            code_variables: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -121,30 +146,5 @@ mod test {
                 ContextLine::new(13, "line 13"),
             ]
         );
-    }
-}
-
-impl From<&RawRubyFrame> for Frame {
-    fn from(raw: &RawRubyFrame) -> Self {
-        Frame {
-            frame_id: FrameId::placeholder(),
-            mangled_name: raw.function.clone(),
-            line: raw.lineno,
-            column: None,
-            source: Some(raw.filename.clone()),
-            in_app: raw.meta.in_app,
-            resolved_name: Some(raw.function.clone()),
-            lang: "ruby".to_string(),
-            resolved: true,
-            resolve_failure: None,
-
-            junk_drawer: None,
-            context: raw.get_context(),
-            release: None,
-            synthetic: raw.meta.synthetic,
-            suspicious: false,
-            module: None,
-            code_variables: None,
-        }
     }
 }

--- a/rust/cymbal/src/langs/ruby.rs
+++ b/rust/cymbal/src/langs/ruby.rs
@@ -56,6 +56,7 @@ impl RawRubyFrame {
         let before = self
             .pre_context
             .iter()
+            .rev() // pre_context arrives in file order, newest line last
             .enumerate()
             .map(|(i, line)| ContextLine::new_rel(lineno, -(i as i32) - 1, line.clone()))
             .collect();
@@ -70,6 +71,56 @@ impl RawRubyFrame {
             line,
             after,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_context_preserves_file_order() {
+        // The ruby SDK sends pre/post_context as file-order slices around the
+        // crash line, so line 10 here is preceded by lines 7-9 and followed by 11-13
+        let frame = RawRubyFrame {
+            path: None,
+            context_line: Some("line 10".to_string()),
+            filename: "app.rb".to_string(),
+            function: "call".to_string(),
+            lineno: Some(10),
+            pre_context: vec![
+                "line 7".to_string(),
+                "line 8".to_string(),
+                "line 9".to_string(),
+            ],
+            post_context: vec![
+                "line 11".to_string(),
+                "line 12".to_string(),
+                "line 13".to_string(),
+            ],
+            meta: CommonFrameMetadata::default(),
+        };
+
+        let context = frame.get_context().unwrap();
+
+        assert_eq!(context.line, ContextLine::new(10, "line 10"));
+        // before is emitted nearest-line-first; the frontend sorts by line number
+        assert_eq!(
+            context.before,
+            vec![
+                ContextLine::new(9, "line 9"),
+                ContextLine::new(8, "line 8"),
+                ContextLine::new(7, "line 7"),
+            ]
+        );
+        assert_eq!(
+            context.after,
+            vec![
+                ContextLine::new(11, "line 11"),
+                ContextLine::new(12, "line 12"),
+                ContextLine::new(13, "line 13"),
+            ]
+        );
     }
 }
 

--- a/rust/cymbal/src/langs/ruby.rs
+++ b/rust/cymbal/src/langs/ruby.rs
@@ -103,48 +103,57 @@ impl From<&RawRubyFrame> for Frame {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_get_context_preserves_file_order() {
-        // The ruby SDK sends pre/post_context as file-order slices around the
-        // crash line, so line 10 here is preceded by lines 7-9 and followed by 11-13
-        let frame = RawRubyFrame {
+    fn frame(lineno: u32, pre_context: &[&str], post_context: &[&str]) -> RawRubyFrame {
+        RawRubyFrame {
             path: None,
-            context_line: Some("line 10".to_string()),
+            context_line: Some(format!("line {lineno}")),
             filename: "app.rb".to_string(),
             function: "call".to_string(),
-            lineno: Some(10),
-            pre_context: vec![
-                "line 7".to_string(),
-                "line 8".to_string(),
-                "line 9".to_string(),
-            ],
-            post_context: vec![
-                "line 11".to_string(),
-                "line 12".to_string(),
-                "line 13".to_string(),
-            ],
+            lineno: Some(lineno),
+            pre_context: pre_context.iter().map(|s| s.to_string()).collect(),
+            post_context: post_context.iter().map(|s| s.to_string()).collect(),
             meta: CommonFrameMetadata::default(),
-        };
+        }
+    }
 
-        let context = frame.get_context().unwrap();
+    #[test]
+    fn test_get_context_pairs_lines_with_numbers() {
+        // pre/post_context arrive in file order; before is emitted
+        // nearest-line-first and the frontend sorts by line number
+        type Case = (u32, &'static [&'static str], &'static [(u32, &'static str)]);
+        let cases: &[Case] = &[
+            (
+                10,
+                &["line 7", "line 8", "line 9"],
+                &[(9, "line 9"), (8, "line 8"), (7, "line 7")],
+            ),
+            // SDK omitted context lines entirely
+            (10, &[], &[]),
+            // more pre-context lines than lines above lineno: offsets saturate at 0
+            (2, &["a", "b", "c"], &[(1, "c"), (0, "b"), (0, "a")]),
+        ];
 
-        assert_eq!(context.line, ContextLine::new(10, "line 10"));
-        // before is emitted nearest-line-first; the frontend sorts by line number
-        assert_eq!(
-            context.before,
-            vec![
-                ContextLine::new(9, "line 9"),
-                ContextLine::new(8, "line 8"),
-                ContextLine::new(7, "line 7"),
-            ]
-        );
-        assert_eq!(
-            context.after,
-            vec![
-                ContextLine::new(11, "line 11"),
-                ContextLine::new(12, "line 12"),
-                ContextLine::new(13, "line 13"),
-            ]
-        );
+        for (lineno, pre, expected_before) in cases {
+            let context = frame(*lineno, pre, &["next 1", "next 2"])
+                .get_context()
+                .unwrap();
+
+            assert_eq!(
+                context.line,
+                ContextLine::new(*lineno, format!("line {lineno}"))
+            );
+            let expected: Vec<ContextLine> = expected_before
+                .iter()
+                .map(|(number, line)| ContextLine::new(*number, *line))
+                .collect();
+            assert_eq!(context.before, expected);
+            assert_eq!(
+                context.after,
+                vec![
+                    ContextLine::new(lineno + 1, "next 1"),
+                    ContextLine::new(lineno + 2, "next 2"),
+                ]
+            );
+        }
     }
 }


### PR DESCRIPTION
Fix: https://posthoghelp.zendesk.com/agent/tickets/60221 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/62012)

## Problem

Stack traces from the Ruby SDK render their pre-context source lines in reverse order: the line numbers ascend correctly, but the code attached to each number is mirrored around the crash line.

The Ruby SDK sends `pre_context` as a file-order slice (farthest line first, `lineno - 1` last) — the same convention as the python and node SDKs. But Cymbal's Ruby frame `get_context` assigned relative offsets assuming nearest-line-first ordering, so each pre-context line was stamped with a mirrored line number. Since the frontend sorts context lines by number before rendering, the code above the highlighted line displayed bottom-to-top.

## Changes

- Add the missing `.rev()` when enumerating `pre_context` in `RawRubyFrame::get_context`, matching what the python, php, and node resolvers already do. (`custom.rs` intentionally skips `.rev()` — its documented contract is nearest-first.)
- Add a unit test asserting each context line is paired with its correct line number.

`post_context` was already correct (both sides agree on file order), and `frame_id()` hashes the raw input, so fingerprints are unaffected. Frame contexts are persisted at ingestion time, so only newly ingested events pick up the fix. Frame-level ordering was verified separately and is correct end-to-end: the SDK reverses to oldest-first like python/js, the pipeline is order-preserving, and the frontend treats the last frame as the crash site.

## How did you test this code?

I'm an agent. Automated test: `cargo test -p cymbal --lib langs::ruby` — new `test_get_context_preserves_file_order` passes. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Investigation traced the user report ("line numbers in order, source code not") through the Cymbal resolution pipeline: ruled out frame reordering (`Batch::apply_func` uses order-preserving `buffered`), then compared `get_context` across language resolvers and found Ruby was the only SDK-context resolver missing `.rev()` on `pre_context`. Confirmed against the posthog-ruby SDK source (file-order slice, derived from sentry-ruby), cross-checked that the python and node SDKs emit the same ordering, and verified the frontend (`FrameContextLine.tsx`) sorts by line number — explaining the exact symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)