### PR TITLE
fix(hogli): don't execvp wrap when embedded

### DIFF
--- a/tools/hogli/src/hogli/__main__.py
+++ b/tools/hogli/src/hogli/__main__.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-from .cli import cli
-
-
-def main() -> None:
-    """Execute the Click application."""
-
-    cli()
-
+# Route through cli.main (not cli directly) so `python -m hogli` marks itself
+# as the process entrypoint, matching the `hogli` console script.
+from .cli import main
 
 if __name__ == "__main__":  # pragma: no cover - module entry point
     main()

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -283,6 +283,15 @@ _WRAP_FILE_PLACEHOLDER = "{file}"
 # `hogli run`). Manifest commands opt in via `needs_secrets: true`.
 _BUILTIN_COMMANDS_NEEDING_SECRETS = frozenset({"run"})
 
+# True only while hogli runs as the process entrypoint — the `hogli` console
+# script or `python -m hogli`, both of which route through `main`. The secret
+# wrap replaces the process image via os.execvp: that is the whole point when
+# hogli *is* the process, but fatal when hogli is embedded in-process (a click
+# CliRunner test, or any library that imports and invokes the group), where
+# execvp would replace and silently kill the host. Gating the re-exec on this
+# keeps embedders alive without weakening the wrap for real CLI runs.
+_is_process_entrypoint = False
+
 
 def _load_env_file(
     path: os.PathLike[str],
@@ -381,7 +390,14 @@ def _maybe_reexec_via_wrap(secrets: dict[str, Any], env_files: list[Path]) -> No
 
     Returns normally if no re-exec is needed (caller falls through to direct
     file loading). Otherwise replaces the current process via ``os.execvp``.
+
+    Only ever re-execs when hogli owns the process (``_is_process_entrypoint``).
+    Embedded in-process callers (CliRunner tests, library use) fall through to
+    direct file loading so execvp can't replace and kill the host process.
     """
+    if not _is_process_entrypoint:
+        return
+
     secrets_file: Path = secrets["file"]
     marker: str = secrets["marker"]
     wrap: list[str] | None = secrets["wrap"]
@@ -594,7 +610,9 @@ def _fire_post_command_hooks(command: str | None, exit_code: int) -> None:
 
 
 def main() -> None:
-    """Main entry point."""
+    """Main entry point — the only path allowed to re-exec via the secret wrap."""
+    global _is_process_entrypoint
+    _is_process_entrypoint = True
     cli()
 
 

--- a/tools/hogli/src/hogli/cli.py
+++ b/tools/hogli/src/hogli/cli.py
@@ -283,13 +283,9 @@ _WRAP_FILE_PLACEHOLDER = "{file}"
 # `hogli run`). Manifest commands opt in via `needs_secrets: true`.
 _BUILTIN_COMMANDS_NEEDING_SECRETS = frozenset({"run"})
 
-# True only while hogli runs as the process entrypoint — the `hogli` console
-# script or `python -m hogli`, both of which route through `main`. The secret
-# wrap replaces the process image via os.execvp: that is the whole point when
-# hogli *is* the process, but fatal when hogli is embedded in-process (a click
-# CliRunner test, or any library that imports and invokes the group), where
-# execvp would replace and silently kill the host. Gating the re-exec on this
-# keeps embedders alive without weakening the wrap for real CLI runs.
+# False until `main()` flips it (the only path the `hogli` script and
+# `python -m hogli` both take). The secret-wrap re-exec is gated on it; see
+# `_maybe_reexec_via_wrap` for why embedded callers must not execvp.
 _is_process_entrypoint = False
 
 

--- a/tools/hogli/tests/test_cli.py
+++ b/tools/hogli/tests/test_cli.py
@@ -493,6 +493,8 @@ class TestApplyEnvConfig:
         )
         for k in ("PRELOADED", "HOGLI_SECRETS_WRAPPED"):
             monkeypatch.delenv(k, raising=False)
+        # Re-exec only fires when hogli owns the process (real CLI entrypoint).
+        monkeypatch.setattr("hogli.cli._is_process_entrypoint", True)
 
         with (
             patch("shutil.which", return_value="/usr/local/bin/op"),
@@ -513,6 +515,46 @@ class TestApplyEnvConfig:
         assert os.environ["PRELOADED"] == "yes"
         # sentinel set to prevent infinite re-exec loop
         assert os.environ["HOGLI_SECRETS_WRAPPED"] == "1"
+
+    def test_embedded_invocation_never_reexecs(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When hogli is invoked in-process (not the process entrypoint), the
+        wrap must never os.execvp — even with the marker present and the wrap
+        binary installed. execvp would replace and silently kill the host
+        process (e.g. a click CliRunner test runner). Instead it falls through
+        to direct file loading, skipping unresolved refs.
+
+        This is the regression guard for the silent-death bug: any pytest run
+        that drives the CLI through CliRunner on a machine with the wrap binary
+        installed and marker refs in the secrets file would otherwise exec away
+        the test process mid-run.
+        """
+        from hogli.cli import _apply_env_config
+
+        secrets_file = tmp_path / ".env.local"
+        secrets_file.write_text("API_KEY=op://vault/item/credential\nLITERAL=keep_me\n")
+        secrets = {
+            "file": secrets_file,
+            "marker": "op://",
+            "wrap": ["op", "run", "--env-file", "{file}", "--"],
+        }
+        monkeypatch.setattr(
+            "hogli.cli.get_manifest",
+            lambda: self._make_manifest(secrets_config=secrets, needs_secrets_commands={"start"}),
+        )
+        # Embedded, not a real entrypoint: this is what CliRunner / library use sees.
+        monkeypatch.setattr("hogli.cli._is_process_entrypoint", False)
+        for k in ("API_KEY", "LITERAL", "HOGLI_SECRETS_WRAPPED"):
+            monkeypatch.delenv(k, raising=False)
+
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/op"),
+            patch("os.execvp") as mock_exec,
+        ):
+            _apply_env_config("start")
+
+        mock_exec.assert_not_called()
+        assert "API_KEY" not in os.environ  # op:// ref skipped, not leaked as a literal
+        assert os.environ["LITERAL"] == "keep_me"
 
     def test_marker_hit_but_wrap_binary_missing_falls_back_with_warning(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -542,6 +584,9 @@ class TestApplyEnvConfig:
         )
         for k in ("OPENAI_API_KEY", "LITERAL", "HOGLI_SECRETS_WRAPPED"):
             monkeypatch.delenv(k, raising=False)
+        # The missing-binary warning is only meaningful for a real entrypoint
+        # that would otherwise re-exec; simulate one.
+        monkeypatch.setattr("hogli.cli._is_process_entrypoint", True)
 
         with (
             patch("shutil.which", return_value=None),
@@ -630,6 +675,9 @@ class TestApplyEnvConfig:
             lambda: self._make_manifest(secrets_config=secrets, needs_secrets_commands=opted_in),
         )
         monkeypatch.delenv("HOGLI_SECRETS_WRAPPED", raising=False)
+        # This test exercises the needs_secrets gate, not the entrypoint gate —
+        # run as a real entrypoint so the wrap can fire when the gate opens.
+        monkeypatch.setattr("hogli.cli._is_process_entrypoint", True)
 
         with (
             patch("shutil.which", return_value="/usr/local/bin/op"),


### PR DESCRIPTION
## Problem

Any pytest run that drives the hogli CLI through click's `CliRunner` silently kills the whole pytest process — exit code 2, output stops mid-line, no traceback — on machines with the `op` (1Password) CLI installed. CI never catches it because runners don't have `op`.

Root cause: the group callback runs in-process under `CliRunner`. For a `needs_secrets` command with an `op://` marker in `.env.local` and `op` on PATH, `_maybe_reexec_via_wrap` calls `os.execvp`, which replaces the host (pytest) process image. Reproduced identically on master — not a regression.

## Changes

Gate the wrap re-exec on a new `_is_process_entrypoint` flag, set `True` only in `main()` (the `hogli` console script and `python -m hogli`). Embedded in-process callers (`CliRunner`, any library use) fall through to direct file loading instead of being `execvp`'d away.

Kills the whole bug class, not just the named tests — covers every in-process invocation, `--help` or not. Stays generic per `tools/hogli/CLAUDE.md`: no `op`/`op://`/filename knowledge; the wrap config remains the only consumer-specific input.

## How did you test this code?

Agent-run automated tests on a machine with `op` installed and `op://` refs in `.env.local`:

- Before: `test_start_command_exists` → silent death (zero output, nonzero exit).
- After: full `tools/hogli/tests/` suite **262 passed without `HOGLI_SECRETS_WRAPPED`** (261 + new regression test `test_embedded_invocation_never_reexecs`); also green with the sentinel.
- Real wrap preserved: driving `main()` with the actual `hogli.yaml`/`.env.local` still sets the flag and `execvp`s into `op`.
- ruff (lint + format) and `ty` typecheck clean via lint-staged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Diagnosis was provided and verified against the live repro. Considered three fixes: a test-only conftest setting the sentinel, a `--help`-skip, and the process-entrypoint gate. Chose the entrypoint gate because it kills the entire in-process `execvp` class generically without special-casing consumers, while leaving the real-CLI wrap untouched. Three existing wrap-decision tests now simulate a real entrypoint.
