### PR TITLE
feat(capture-logs): add bytes_uncompressed_records kafka header

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -1,5 +1,5 @@
 use crate::avro_schema::AVRO_SCHEMA;
-use crate::log_record::KafkaLogRow;
+use crate::log_record::{sum_kafka_log_row_bytes, KafkaLogRow};
 use crate::metric_record::KafkaMetricRow;
 use crate::metrics_avro_schema::METRICS_AVRO_SCHEMA;
 use crate::trace_record::KafkaTraceRow;
@@ -342,6 +342,7 @@ impl KafkaSink {
         token: &str,
         rows: &[T],
         uncompressed_bytes: u64,
+        records_uncompressed_bytes: Option<u64>,
         timestamps_overridden: u64,
     ) -> Result<(), anyhow::Error> {
         let schema = Schema::parse_str(avro_schema_str)?;
@@ -365,7 +366,7 @@ impl KafkaSink {
             timestamp: None,
             headers: Some({
                 let created_at = Utc::now().to_rfc3339();
-                OwnedHeaders::new()
+                let mut headers = OwnedHeaders::new()
                     .insert(Header {
                         key: "token",
                         value: Some(&token.to_string()),
@@ -373,7 +374,16 @@ impl KafkaSink {
                     .insert(Header {
                         key: "bytes_uncompressed",
                         value: Some(&uncompressed_bytes.to_string()),
-                    })
+                    });
+                // Records-based size next to the payload-based `bytes_uncompressed`, so
+                // billing can compare the two before switching to the records-based value.
+                if let Some(records_bytes) = records_uncompressed_bytes {
+                    headers = headers.insert(Header {
+                        key: "bytes_uncompressed_records",
+                        value: Some(&records_bytes.to_string()),
+                    });
+                }
+                headers
                     .insert(Header {
                         key: "bytes_compressed",
                         value: Some(&payload.len().to_string()),
@@ -420,6 +430,15 @@ impl KafkaSink {
             counter!("capture_logs_timestamps_overridden").increment(timestamps_overridden);
         }
 
+        let records_uncompressed_bytes = sum_kafka_log_row_bytes(&rows);
+        counter!("capture_logs_bytes_uncompressed_payload").increment(uncompressed_bytes);
+        counter!("capture_logs_bytes_uncompressed_records").increment(records_uncompressed_bytes);
+        if records_uncompressed_bytes > uncompressed_bytes {
+            // Records sum should stay below the payload size (it excludes transport overhead);
+            // billing can only switch to it if that invariant holds.
+            counter!("capture_logs_records_bytes_exceed_payload").increment(1);
+        }
+
         self.write_avro_batch(
             &self.logs_producer,
             &self.logs_topic,
@@ -427,6 +446,7 @@ impl KafkaSink {
             token,
             &rows,
             uncompressed_bytes,
+            Some(records_uncompressed_bytes),
             timestamps_overridden,
         )
         .await?;
@@ -456,6 +476,7 @@ impl KafkaSink {
             token,
             &rows,
             uncompressed_bytes,
+            None,
             timestamps_overridden,
         )
         .await?;
@@ -485,6 +506,7 @@ impl KafkaSink {
             token,
             &rows,
             uncompressed_bytes,
+            None,
             timestamps_overridden,
         )
         .await?;

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -399,24 +399,35 @@ mod tests {
         assert_eq!(compute_kafka_log_row_bytes(&row), 57);
     }
 
-    #[test]
-    fn test_sum_kafka_log_row_bytes_sums_rows_and_treats_missing_as_zero() {
-        let with_bytes = sample_row().with_computed_bytes();
-        let per_row = with_bytes.bytes_uncompressed.unwrap() as u64;
-        let without_bytes = sample_row(); // bytes_uncompressed: None
+    fn sample_row_bytes() -> u64 {
+        sample_row()
+            .with_computed_bytes()
+            .bytes_uncompressed
+            .unwrap() as u64
+    }
 
+    #[test]
+    fn test_sum_kafka_log_row_bytes_empty_slice_is_zero() {
         assert_eq!(sum_kafka_log_row_bytes(&[]), 0);
+    }
+
+    #[test]
+    fn test_sum_kafka_log_row_bytes_treats_missing_field_as_zero() {
+        let with_bytes = sample_row().with_computed_bytes();
+        let without_bytes = sample_row(); // bytes_uncompressed: None
         assert_eq!(
             sum_kafka_log_row_bytes(&[with_bytes, without_bytes]),
-            per_row
+            sample_row_bytes()
         );
-        assert_eq!(
-            sum_kafka_log_row_bytes(&[
-                sample_row().with_computed_bytes(),
-                sample_row().with_computed_bytes()
-            ]),
-            per_row * 2
-        );
+    }
+
+    #[test]
+    fn test_sum_kafka_log_row_bytes_sums_all_rows() {
+        let rows = [
+            sample_row().with_computed_bytes(),
+            sample_row().with_computed_bytes(),
+        ];
+        assert_eq!(sum_kafka_log_row_bytes(&rows), sample_row_bytes() * 2);
     }
 
     #[test]

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -64,6 +64,16 @@ pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
     i64::try_from(total).unwrap_or(i64::MAX)
 }
 
+/// Sum of per-row `bytes_uncompressed` across a batch; rows without the field count as zero.
+/// Feeds the `bytes_uncompressed_records` Kafka header — the records-based counterpart to the
+/// payload-sized `bytes_uncompressed` header — so the two can be compared before billing
+/// switches to the records-based value.
+pub fn sum_kafka_log_row_bytes(rows: &[KafkaLogRow]) -> u64 {
+    rows.iter()
+        .map(|row| row.bytes_uncompressed.unwrap_or(0).max(0) as u64)
+        .sum()
+}
+
 impl KafkaLogRow {
     /// Set `bytes_uncompressed` from the row's variable-length content. Consuming
     /// builder; the `mut self` is encapsulated and never escapes.
@@ -387,6 +397,26 @@ mod tests {
         // maps: resource_attributes "host.name"(9)+"localhost"(9)=18; attributes "k"(1)+"v"(1)=2
         // total = 37 + 18 + 2 = 57
         assert_eq!(compute_kafka_log_row_bytes(&row), 57);
+    }
+
+    #[test]
+    fn test_sum_kafka_log_row_bytes_sums_rows_and_treats_missing_as_zero() {
+        let with_bytes = sample_row().with_computed_bytes();
+        let per_row = with_bytes.bytes_uncompressed.unwrap() as u64;
+        let without_bytes = sample_row(); // bytes_uncompressed: None
+
+        assert_eq!(sum_kafka_log_row_bytes(&[]), 0);
+        assert_eq!(
+            sum_kafka_log_row_bytes(&[with_bytes, without_bytes]),
+            per_row
+        );
+        assert_eq!(
+            sum_kafka_log_row_bytes(&[
+                sample_row().with_computed_bytes(),
+                sample_row().with_computed_bytes()
+            ]),
+            per_row * 2
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `bytes_uncompressed` kafka header on logs batches is the size of the full accepted HTTP payload, including transport/encoding overhead. Logs billing is derived from it, but the more accurate basis is the sum of per-record content sizes, which capture already computes into each record's Avro `bytes_uncompressed` field. Billing can only switch to the records-based value once we've verified it is consistently less than or equal to the payload-based value — otherwise the change would effectively increase pricing.

## Changes

- Capture now emits a second kafka header on logs batches, `bytes_uncompressed_records`, containing the sum of per-record `bytes_uncompressed` values. The existing `bytes_uncompressed` header is unchanged.
- New `sum_kafka_log_row_bytes` helper next to `compute_kafka_log_row_bytes`; rows without the field count as zero.
- Capture-side prometheus counters for both values, plus `capture_logs_records_bytes_exceed_payload` which fires when the records sum exceeds the payload size (the invariant that must hold before billing can switch).
- Traces and metrics batches keep the payload-based header only for now.

A companion PR (#63115) parses the new header in the logs ingestion consumer and emits a parallel `bytes_ingested_records` usage metric for the comparison.

## How did you test this code?

Agent-authored. Automated tests only: `cargo test -p capture-logs --lib` (38 passed, including a new unit test for the batch sum helper) and `cargo clippy -p capture-logs` (clean). No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Direction from the logs/APM team: keep the existing payload-based header untouched and add the records-based sum as a separate header so downstream billing can compare both for a validation window before switching. The header is logs-only because traces/metrics billing comparison is out of scope for now; the generic Avro batch writer takes the records sum as an `Option` so those paths simply omit the header.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*