### PR TITLE
fix(replay): stop summary dock force-opening over the user's choice

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -103,10 +103,10 @@ export function PlayerSummaryDock(): JSX.Element | null {
     const summaryId = summaryIdBySessionId[sessionRecordingId] ?? null
     const hasRenderedSummary = hasSummary && !sessionSummaryError
     const setIsOpen = (open: boolean): void => setSummaryOpen(sessionRecordingId, open)
-    const expandedHeight = Math.max(
-        MIN_EXPANDED_HEIGHT,
-        Math.min(MAX_EXPANDED_HEIGHT, desiredSize ?? DEFAULT_EXPANDED_HEIGHT)
-    )
+    // Cap the default height to the viewport so the dock can't crush the player.
+    const expandedMaxHeight = desiredSize
+        ? `${Math.max(MIN_EXPANDED_HEIGHT, Math.min(MAX_EXPANDED_HEIGHT, desiredSize))}px`
+        : `min(${DEFAULT_EXPANDED_HEIGHT}px, 45vh)`
 
     // `isOpen` flips multiple times per summary, so dedupe to one capture per render.
     const capturedKeyRef = useRef<string | null>(null)
@@ -136,7 +136,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
                 'relative border-t bg-surface-primary overflow-hidden flex flex-col',
                 !isResizeInProgress && 'transition-[max-height] duration-300 ease-out'
             )}
-            style={{ maxHeight: isOpen ? expandedHeight : COLLAPSED_HEIGHT }}
+            style={{ maxHeight: isOpen ? expandedMaxHeight : COLLAPSED_HEIGHT }}
             data-attr="player-summary-dock"
         >
             {isOpen && <Resizer {...resizerProps} />}

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.test.ts
@@ -26,6 +26,7 @@ describe('sessionSummaryProgressLogic', () => {
     let logic: ReturnType<typeof sessionSummaryProgressLogic.build>
 
     beforeEach(() => {
+        localStorage.clear() // the persisted autoExpandSummary reducer must not leak between tests
         initKeaTests()
         logic = sessionSummaryProgressLogic()
         logic.mount()
@@ -68,22 +69,38 @@ describe('sessionSummaryProgressLogic', () => {
             })
         })
 
-        it('re-opens via setSummary after user closed, only if summary is non-null', async () => {
+        it('does not re-open via setSummary after the user closed', async () => {
             logic.actions.startSummarization(SESSION_ID)
             logic.actions.setSummaryOpen(SESSION_ID, false)
 
-            // Null summary should not reopen
-            await expectLogic(logic, () => {
-                logic.actions.setSummary(SESSION_ID, null)
-            }).toMatchValues({
-                openBySessionId: expect.objectContaining({ [SESSION_ID]: false }),
-            })
-
-            // Non-null summary should reopen
             await expectLogic(logic, () => {
                 logic.actions.setSummary(SESSION_ID, { segments: [] } as any)
             }).toMatchValues({
-                openBySessionId: expect.objectContaining({ [SESSION_ID]: true }),
+                openBySessionId: expect.objectContaining({ [SESSION_ID]: false }),
+            })
+        })
+
+        it('does not auto-open when the user collapsed the dock for another session', async () => {
+            logic.actions.setSummaryOpen('session-a', false)
+
+            await expectLogic(logic, () => {
+                logic.actions.startSummarization('session-b')
+                logic.actions.setSummary('session-c', { segments: [] } as any)
+            }).toMatchValues({
+                autoExpandSummary: false,
+                openBySessionId: { 'session-a': false },
+            })
+        })
+
+        it('expanding the dock re-enables auto-open for future sessions', async () => {
+            logic.actions.setSummaryOpen('session-a', false)
+            logic.actions.setSummaryOpen('session-a', true)
+
+            await expectLogic(logic, () => {
+                logic.actions.startSummarization('session-b')
+            }).toMatchValues({
+                autoExpandSummary: true,
+                openBySessionId: expect.objectContaining({ 'session-b': true }),
             })
         })
 

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
@@ -131,13 +131,28 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
             {} as Record<string, boolean>,
             {
                 setSummaryOpen: (state, { sessionId, open }) => ({ ...state, [sessionId]: open }),
-                startSummarization: (state, { sessionId }) => ({ ...state, [sessionId]: true }),
-                setSummary: (state, { sessionId, summary }) => (summary ? { ...state, [sessionId]: true } : state),
+            },
+        ],
+        // The user's last expand/collapse choice, used as the default for future recordings.
+        autoExpandSummary: [
+            true,
+            { persist: true },
+            {
+                setSummaryOpen: (_, { open }) => open,
             },
         ],
     }),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
+        // Auto-expand unless the user collapsed the dock, in this session or a previous one.
+        setSummary: ({ sessionId, summary }) => {
+            if (summary && values.openBySessionId[sessionId] === undefined && values.autoExpandSummary) {
+                actions.setSummaryOpen(sessionId, true)
+            }
+        },
         startSummarization: async ({ sessionId }) => {
+            if (values.openBySessionId[sessionId] === undefined && values.autoExpandSummary) {
+                actions.setSummaryOpen(sessionId, true)
+            }
             if (inFlightSessionIds.has(sessionId)) {
                 return
             }


### PR DESCRIPTION
## Problem

When a recording has an AI summary, the summary dock force-expands on every open of the recording, and closing it doesn't stick: `sessionSummaryProgressLogic` set the dock open on `startSummarization` *and* on every `setSummary`, so the dock re-opened when the summary arrived mid-stream after the user had collapsed it, re-expanded on every revisit, and again in every new tab. The fixed 480px default expansion also crushes the player on short windows.

Reported via a support ticket as "the AI summary panel automatically opens and causes the video player to shrink — when I close it, the player does not restore". The "does not restore / buffers indefinitely" half of that report is a separate playback bug (no renderable FullSnapshot at the playhead, rrweb clock freezes, `skipPlayerForward` watchdog loops forever) addressed by #62709; this PR fixes the dock behavior that made it so much worse.

## Changes

- The dock only auto-expands when the user hasn't made an explicit choice: an explicit per-session open/close always wins, so a summary arriving after the user collapsed the dock no longer re-opens it.
- The last explicit expand/collapse is persisted (`autoExpandSummary`, kea-localstorage) and used as the auto-expand default for future recordings — collapse the dock once and summarized recordings stop auto-expanding it (including in new tabs); expanding it again re-enables auto-expand. The 44px dock header stays visible either way, so the summary stays discoverable.
- The auto-open moved from the `openBySessionId` reducer into listeners, since the decision now depends on other state.
- The default expanded height is capped at `min(480px, 45vh)` so auto-expansion can't crush the player on short windows; an explicit resize is honored as-is.

Note for reviewers: one existing test asserted that `setSummary` re-opens the dock after the user closed it — that assertion codified the bug and is inverted here.

## How did you test this code?

I'm an agent; no manual testing claimed. Automated coverage:

- `sessionSummaryProgressLogic.test.ts` — updated for the new behavior plus new cases: no re-open after explicit close, persisted preference disables auto-open for other sessions, re-expanding re-enables it (12/12 pass).
- Full `player-meta` suite passes (26 tests); oxlint and kea typegen clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @arnohillen, starting from a support ticket root-cause analysis. The RCA split the report in two: the permanent buffering matched the missing-FullSnapshot stall already being fixed in #62709 (confirmed via the stuck-player `skipPlayerForward` telemetry pattern), while the dock force-open was unowned — this PR. Chosen design: "last explicit choice wins" persisted preference over a one-shot dismissal flag, so the behavior is self-healing and reversible by the user; the height cap applies only to the default expansion so the manual resizer keeps full range.
