### PR TITLE
feat(metrics): deployment docs, attribute seam, query contracts

### DIFF
--- a/docs/internal/metrics/dashboard-mvp.md
+++ b/docs/internal/metrics/dashboard-mvp.md
@@ -1,0 +1,175 @@
+# Metrics Dashboard MVP — Replacing the Grafana logs.json inside PostHog
+
+**Status:** design — owners @daniel-v, #team-apm (@jonmcwest, @frankh).
+**Sibling docs:** [`docs/internal/prom-compat/design.md`](../prom-compat/design.md) (read plane for Prometheus ecosystem — out of scope here).
+
+## Why
+
+The cluster's `logs.json` Grafana dashboard (≈60 panels, source: `PostHog/grafana-dashboards/logs.json`) is the on-call surface for the logs / traces / metrics ingestion stack.
+We already store metrics natively in `metrics1` on the logs ClickHouse cluster.
+This doc scopes the work to render that exact dashboard inside PostHog (`/dashboard/...`) against `posthog.metrics`, so on-call can leave Grafana behind.
+
+Native PostHog Metrics stays the user-facing product. The Prometheus-ecosystem read plane (`services/prom-compat/`, Track A) is a separate stack reading the same storage.
+
+## Non-goals (deliberately deferred)
+
+1. Schema rewrite to the streams-table pattern (Snuffle benchmarks: ~10× disk on metrics, ~5× on logs).
+   The seam for that rewrite is the `attribute_field()` helper introduced in P0.
+2. PromQL / `prom-compat` service — separate stack, already designed.
+3. SDK swap (replacing `prom-client` in `nodejs/src/...` with OTel SDK).
+4. Deploy-annotation automation from Helm release events.
+
+## What's already in place (do not re-build)
+
+**Ingest data plane** — shipped or in-flight:
+
+- `rust/capture-logs/`: OTLP/HTTP receiver at `/v1/metrics` (and `/i/v1/metrics`), JSON or protobuf, writes to Kafka. `rust/capture-logs/src/main.rs:154-160`, `src/service.rs:703-820`.
+- `nodejs/src/metrics-ingestion/metrics-ingestion-consumer.ts`: drains Kafka into ClickHouse with quota + ratelimit (`MetricsRateLimiterService`).
+- ClickHouse `metrics1` table (OTel-shaped, gauge / sum / histogram / exp-histogram / summary), MVs into `metric_attributes`. `posthog/clickhouse/metrics/metrics1.py`. Registered in `posthog/clickhouse/schema.py:332-333`.
+- `charts` (in-flight `daniel/metrics-prod-rollout`): WarpStream metrics cluster + `kafka.metricsBrokers` on capture-logs + `/i/v1/metrics` Contour ingress + `metrics-ingestion` deployment, prod-us + prod-eu.
+- `posthog-cloud-infra`#8321/8322/8415/8434/8489 (merged): Kafka topics + S3 bucket + IRSA + CH named collection + Postgres app user.
+- `argocd/otel-collector/` (daemonset, already deployed): an existing OTel Collector with `prometheus` + `otlp` receivers and a `metrics` pipeline whose exporter today is `debug`.
+
+**Product surface — alpha (gated by `FEATURE_FLAGS.METRICS`):**
+
+- `products/metrics/backend/facade/api.py`: `team_has_metrics(team)`, `query_metric(team, metric_name, aggregation, date_from, date_to)`, `list_metric_names(team, search, limit)`.
+- `products/metrics/backend/metric_query_runner.py`: single-metric runner, aggregations `sum | avg | count | p95`, auto-bucketed to ~60 points.
+- `products/metrics/frontend/MetricsScene.tsx`: Viewer tab (single-metric) + HogQL SQL editor over `posthog.metrics`.
+
+## Gap to close
+
+|                       | Today                            | Target                                                                               |
+| --------------------- | -------------------------------- | ------------------------------------------------------------------------------------ |
+| Filters               | none (metric name + agg only)    | label / attribute predicates with explicit scope (`resource` / `attribute` / `auto`) |
+| Group-by              | none                             | shared interval grid, multi-series response                                          |
+| Aggregations          | sum / avg / count / p95          | + `rate`, `increase`, `histogram_quantile`                                           |
+| Multi-metric          | one clause                       | N clauses + server-side HogQL formula                                                |
+| Storage seam          | direct `attributes_map_str[...]` | `attribute_field(name)` helper used everywhere                                       |
+| Wire shape            | `[{time, value}]`                | `[{labels, points}]` — stable from PR2                                               |
+| Dashboard widget      | none                             | `metric_timeseries` widget type                                                      |
+| Dashboard variables   | n/a                              | dashboard filters propagate into widget config                                       |
+| Annotations           | n/a                              | PostHog Annotations render as vertical lines on metric widgets                       |
+| Scraped infra metrics | not flowing                      | existing collector's metrics pipeline exports to capture-logs                        |
+| MCP                   | none                             | follow-on, not in this MVP                                                           |
+
+## Architecture (target)
+
+```text
+[ envoy /stats/prometheus       ]                  [ posthog services /metrics ]
+[ kminion /metrics              ]   ──scrape──>    [ otel-collector daemonset  ]   ──OTLP/HTTP──>   capture-logs /i/v1/metrics
+[ kube-state-metrics, cadvisor  ]                  [ prometheus receiver       ]                            │
+[ node-exporter                 ]                  [ otlphttp/posthog exporter ]                            │
+                                                                                                            ▼
+                                                                                                          Kafka
+                                                                                                            │
+                                                                                                            ▼
+                                                                                               metrics-ingestion-consumer
+                                                                                                            │
+                                                                                                            ▼
+                                                                                            ClickHouse metrics1 (logs cluster)
+                                                                                                            │
+                                                ┌───────────────────────────────────────────────────────────┴────────────────────────────────────┐
+                                                ▼                                                                                                ▼
+                                  products/metrics facade                                                                          services/prom-compat (Track A, separate)
+                                  (HogQL on metrics1 — this stack)                                                                 (PromQL on metrics1)
+                                                │                                                                                                ▲
+                                                ▼                                                                                                │
+                              MetricsScene + metric_timeseries widget                                                            Grafana / alertmanager / promtool
+```
+
+## The stack
+
+Twenty-three PRs, each <400 LOC including tests. Each is a separate `gt create` on top of the previous.
+
+### Phase 0 — Foundations (no user-visible change, lock the seams)
+
+| #      | Repo    | PR                                                                                                                                                                                                                           | Notes                                                                        |
+| ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **P0** | posthog | `attribute_field(name) -> ast.Expr` helper + `seed_metric(team, name, points, labels)` pytest fixture                                                                                                                        | Schema-rewrite seam (see Non-goal 1) + deterministic test data.              |
+| **P1** | posthog | `MetricQueryClause`, `MetricQueryRequest`, `MetricSeries`, `Point` frozen dataclasses in `products/metrics/backend/facade/contracts.py`. Facade stub raises NotImplementedError for unimplemented fields.                    | Locks the target wire shape from PR1 onward — no schema churn through P3-P7. |
+| **P2** | posthog | DRF serializer + viewset accepts new request shape, returns `[MetricSeries]` (length-1 today). Regenerate TS types via `hogli build:openapi`. Old single-metric viewer kept on the legacy code path with a deprecation TODO. | After this PR every later backend PR regenerates TS types.                   |
+
+### Phase 1 — Charts infra: turn on the existing collector's metrics pipeline
+
+| #           | Repo    | PR                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Notes                                                                                  |
+| ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **INFRA-A** | charts  | Add `otlphttp/posthog-metrics` exporter and a scoped `scrape_configs` block to the existing `argocd/otel-collector/` daemonset. **Dev cluster only**, scrape only the dashboard's targets (envoy capture-logs cluster, kminion ingestion-(logs\|traces) group, kube-state for capture-logs + logs-ingestion + metrics-ingestion + ingestion-(logs\|traces) deployments). Dual-write with `debug` exporter so the data flow can be inspected on day one. | Per-target list is the cardinality guardrail — no namespace wildcard.                  |
+| **INFRA-B** | posthog | Add an `internal-infra` exemption (or a generous fixed quota) for the project token used by the otel-collector to `posthog/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.ts`.                                                                                                                                                                                                                                                      | Without this the cluster's own metric traffic counts toward customer quota.            |
+| **INFRA-C** | charts  | Cut `otlphttp/posthog-metrics` over from dual-write to single-write (drop `debug`). Dev only.                                                                                                                                                                                                                                                                                                                                                           | Validation gate before prod.                                                           |
+| **INFRA-D** | charts  | Replicate INFRA-A + INFRA-C to `values.prod-us.yaml` and `values.prod-eu.yaml`.                                                                                                                                                                                                                                                                                                                                                                         | Lands after `daniel/metrics-prod-rollout` merges and CH `metrics1` is applied in prod. |
+| **INFRA-E** | charts  | Broaden scrape config to the remaining targets the full dashboard needs (`capture-logs`, `logs-ingestion`, `metrics-ingestion` `/metrics` endpoints once SDK side is verified).                                                                                                                                                                                                                                                                         | Gates on P9 (UI can render) so we can sanity-check live.                               |
+
+### Phase 2 — Query layer (PostHog repo)
+
+| #      | Repo    | PR                                                                                                                                                                              | Notes                                                                        |
+| ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **P3** | posthog | Label filters (`eq`, `neq`, `regex`) on a single clause with explicit `scope: resource \| attribute \| auto`. Uses `attribute_field()` from P0.                                 | First feature flag that requires real data — INFRA-A is the source.          |
+| **P4** | posthog | `group_by` on a single clause, with a fixed interval grid shared by every series in the response.                                                                               | Interval is on `MetricQueryRequest`, not per clause (single-grid invariant). |
+| **P5** | posthog | `rate` + `increase` aggregations. `runningDifference()` + `clamp_min(..., 0)` for counter-reset handling. Consumes `aggregation_temporality` to skip the diff for delta inputs. | Most panels are rate-based — getting this wrong shows up in every dashboard. |
+| **P6** | posthog | `histogram_quantile`. Bounds-equality check inside a group; mismatches drop with a logged warning. Uses `histogram_bounds` / `histogram_counts` arrays from `metrics1`.         | P95 latency panel + every histogram-based SLO.                               |
+| **P7** | posthog | Multi-clause query + server-side HogQL formula. Per-clause result joined on time bucket; formula evaluated against named clauses (`(a - b) / a`).                               | Server-side only — no client-side alignment.                                 |
+
+### Phase 3 — Viewer + widget (PostHog repo)
+
+| #       | Repo    | PR                                                                                                                                                                                                              | Notes                                                                                              |
+| ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **P8**  | posthog | `MetricsViewer` — multi-series chart rendering, label-filter UI (consumes the P2 contract).                                                                                                                     | First UI delivery — every later UI consumes the same code path.                                    |
+| **P9**  | posthog | `MetricsViewer` — group-by selector + formula expression input.                                                                                                                                                 | Full Viewer parity.                                                                                |
+| **P10** | posthog | `metric_timeseries` widget registry entry (`validate_config`, `query_fn`) reusing the metrics facade. Add to `WIDGET_REGISTRY` and `EXPECTED_WIDGET_TYPES` in `products/dashboards/backend/widget_registry.py`. | No new facade method allowed — if the widget reaches for one, the gap is in the viewer's exercise. |
+| **P11** | posthog | `metric_timeseries` widget frontend — WidgetCard + catalog entry + config form.                                                                                                                                 | Widget lives in dashboards UI.                                                                     |
+| **P12** | posthog | Dashboard variables / filters → metric widget filter injection (`$service`-equivalent).                                                                                                                         | Replicates the Grafana variable UX.                                                                |
+| **P13** | posthog | PostHog Annotations rendered as vertical lines on metric widgets.                                                                                                                                               | Replaces Grafana's "Deploys" annotation.                                                           |
+
+### Out of stack (separate plans)
+
+- Streams-table schema rewrite — large project, the `attribute_field()` seam is the entry point.
+- prom-compat (Track A) — see `docs/internal/prom-compat/design.md`.
+- `prom-client` → OTel SDK swap in PostHog services.
+- Deploy annotation automation from Helm release events.
+
+## Sequencing rules
+
+1. **P0 + P1 land before any infra PR.** Real data should not hit `metrics1` at scale before the storage seam (`attribute_field`) and the contract dataclasses are merged — once data exists, you can't undo it cheaply.
+2. **INFRA-A..C land between P2 and P3.** P3+ tests run against dev `metrics1` with real OTLP-ingested rows, not synthetic ones, to catch resource-vs-attribute bugs that fixtures miss.
+3. **INFRA-A and INFRA-E are different PRs on purpose.** Narrow scrape in dev first; broad scrape only after the query layer can handle it. Resist the temptation to merge them "to save a PR" — that's how storage bloats 5-10× before the schema rewrite lands.
+4. **Widget PRs (P10+) must not introduce any new facade method.** If you reach for one, the gap is in the viewer's exercise of the contract — go fix it in P3-P9.
+
+## Local verification path
+
+`hogli dev:setup` → select **`metrics`** intent (`devenv/intent-map.yaml:99-101`). This boots `capture-logs`, `ingestion-metrics`, and the dependencies. `metrics1` is created by the standard CH bootstrap.
+
+Per-PR sanity checks:
+
+- **P0–P2**: `hogli test products/metrics/backend/tests/` + `curl POST /api/projects/2/metrics/query` (new shape). HogQL SQL tab in `/metrics` works against `posthog.metrics` from day one.
+- **P3–P7**: curl + JSON. UI does not show new features until P8/P9.
+- **P8+**: browser at `/metrics` (alpha flag on).
+- **P11+**: browser at `/dashboard/...` — add a `metric_timeseries` tile.
+
+Seeder script for ad-hoc dev data (no PRs needed):
+
+```bash
+clickhouse-client -h localhost --query "
+INSERT INTO metrics1 (uuid, team_id, timestamp, service_name, metric_name, metric_type, value, attributes_map_str, resource_attributes)
+SELECT generateUUIDv4(), 2, now() - INTERVAL number SECOND, 'capture-logs', 'envoy_5xx_total', 'sum',
+       toFloat64(number * 0.1),
+       map('container_str', 'capture-logs', 'envoy_response_code_class_str', '5'),
+       map('namespace', 'posthog')
+FROM numbers(3600)"
+```
+
+## Known footguns the stack pre-empts
+
+- Two-grid formulas → P1's `MetricQueryRequest` enforces a single interval shared by every clause.
+- Naive `rate()` over a pod restart → P5 uses `clamp_min(runningDifference(value), 0)`.
+- Histogram aggregation across mismatched bounds → P6 validates bounds equality within a group.
+- `attributes_map_str['foo']` everywhere → P0's `attribute_field()` helper is the only call site.
+- Two response shapes (single vs multi series) → P2 returns `[MetricSeries]` from day one, length-1 if no group-by.
+- Quota throttling on internal infra traffic → INFRA-B carves an exemption.
+- Scraping the whole namespace → INFRA-A scopes to the exact targets the dashboard needs.
+- Cumulative vs delta confusion → `aggregation_temporality` checked in P5 before applying `runningDifference`.
+
+## Open decisions (need owner input)
+
+1. **Internal-infra project** — which project receives scraped cluster metrics in each environment? Recommend a dedicated `posthog-internal-infra` project with its own `team_id` so `team_has_metrics` doesn't flip on the dogfood project. Cap budget separately from customer billing.
+2. **Naming convention** — keep Prometheus `snake_case_total` for scraped metrics (preserves dashboard expressions) and use OTel dotted (`http.server.duration`) for new SDK-emitted metrics. Document; do not mix.
+3. **Token sensitivity** — existing `argocd/otel-collector/values/values.dev.yaml` exposes `Bearer sTMFPsFhdP1Ssg` in plain YAML for the traces pipeline. Confirm: that's a project public capture token, not a personal API key. Apply the same model to the new `otlphttp/posthog-metrics` exporter.

--- a/docs/internal/metrics/deployment-layout.md
+++ b/docs/internal/metrics/deployment-layout.md
@@ -1,0 +1,106 @@
+# Metrics — deployment layout (local / dev / prod-us / prod-eu / charts)
+
+Companion to [`dashboard-mvp.md`](./dashboard-mvp.md). This is the "what has to exist where" checklist for metrics to be fully functional, plus the schema decision.
+
+## Schema decision (settled)
+
+**Alpha ships on the current `metrics1` table.** The streams-table layout (Snuffle's default schema: `metrics_series` id→labels + `metrics_samples` id,ts,value + inverted `metrics_label_index`) is the **post-alpha storage track**, not a blocker.
+
+Why this is safe and correct for a days-to-alpha timeline:
+
+- Snuffle's `create_metrics_posthog_schema.sql` is **our current `metrics1` verbatim** — Rory built his PromQL bridge to read our existing table. So prom-compat works against `metrics1` as-is; we lose nothing by not migrating first.
+- The streams layout is the _eventual_ target (Snuffle benchmarks ~89.5% less disk, ~31→3 bytes/sample) but it changes the ingestion write path + adds a backfill — too much risk to land under an alpha deadline.
+- The `attribute_field()` helper (P0) is the migration seam: when storage moves to streams, only that one function changes, not every query call site.
+
+**Action when we do the storage track:** model `metrics_series` keyed by a full series fingerprint — Snuffle computes it as `cityHash64(metric_name, service_name, mapSort(resource_attributes), mapSort(attributes_map_str))`. We already materialize a partial `resource_fingerprint = cityHash64(resource_attributes)` on `metrics1`; the full series identity adds metric_name + service_name + sorted data-point attributes.
+
+## The full data path (all environments)
+
+```text
+producers ─► capture-logs /i/v1/metrics ─► Kafka (WarpStream "metrics") ─► metrics-ingestion consumer ─► ClickHouse metrics1 (logs cluster)
+   │                                                                                                              │
+   ├─ app SDKs (OTLP, customer traffic)                                                                           ▼
+   └─ infra/service metrics via vmagent ─► otel-collector bridge (prometheusremotewrite→OTLP)         products/metrics (HogQL) + prom-compat (PromQL)
+```
+
+Two producer classes:
+
+1. **Customer OTLP** — apps push OTLP straight to `/i/v1/metrics`. Already works in every env where the ingest path is live.
+2. **Our own infra/service metrics** — vmagent already scrapes them; the otel-collector bridge (INFRA-A) fans a copy into `/i/v1/metrics`. This is the "pipe our logs services through" path.
+
+## Status matrix — what exists where
+
+Legend: ✅ live · ⏳ in-flight (PR) · ➕ this stack adds it · — n/a
+
+| Layer                                                    | local             | dev               | prod-us       | prod-eu       | Where it lives                                 |
+| -------------------------------------------------------- | ----------------- | ----------------- | ------------- | ------------- | ---------------------------------------------- |
+| Kafka topics (`ingestion_metrics`, `clickhouse_metrics`) | ✅ (compose)      | ✅                | ✅            | ✅            | cloud-infra #8321                              |
+| WarpStream metrics cluster + S3 + IRSA                   | —                 | ✅                | ⏳            | ⏳            | charts `warpstream-metrics`; cloud-infra #8322 |
+| CH named collection `warpstream_metrics`                 | —                 | ✅                | ✅            | ✅            | cloud-infra #8415/#8489                        |
+| metrics-ingestion Postgres app user                      | ✅                | ✅                | ✅            | ✅            | cloud-infra #8434                              |
+| capture-logs `kafka.metricsBrokers`/`metricsTopic`       | ✅ (compose)      | ✅                | ⏳            | ⏳            | charts `capture-logs` (global in rollout)      |
+| Contour ingress `/i/v1/metrics`                          | ✅ (caddy)        | ✅                | ⏳            | ⏳            | charts `contour-ingress`                       |
+| metrics-ingestion consumer deploy                        | ✅ (mprocs)       | ✅                | ⏳            | ⏳            | charts `logs/metrics-ingestion`                |
+| ClickHouse `metrics1` + MVs                              | ✅ (CH bootstrap) | ✅                | ⏳ direct SQL | ⏳ direct SQL | `posthog/clickhouse/metrics/`                  |
+| **otel-collector bridge** (infra→metrics1)               | ➕ local recipe   | ➕ INFRA-A #11808 | ➕ INFRA-D    | ➕ INFRA-D    | charts `otel-collector` + `vmagent`            |
+| Rate-limit/quota exemption for internal-infra token      | —                 | ➕ INFRA-B        | ➕ INFRA-D    | ➕ INFRA-D    | `nodejs/.../metrics-rate-limiter.service.ts`   |
+| Feature flag `METRICS` + `metrics:read` scope            | ✅ code           | ✅ code           | ✅ code       | ✅ code       | posthog repo (all envs share)                  |
+| Query layer (filters/group-by/rate/hist/formula)         | ➕ this stack     | ➕                | ➕            | ➕            | `products/metrics/backend`                     |
+
+**Read:** the ingestion data plane is **done in dev**, and **pending in prod** behind `daniel/metrics-prod-rollout` (charts) + the post-merge `metrics1` SQL apply on the prod-us/prod-eu logs CH clusters. cloud-infra scaffolding (topics/S3/IRSA/CH collection/PG user) is **merged in all three envs**.
+
+## What still has to be added, by repo
+
+### posthog (this stack)
+
+- Query layer: `MetricQueryRequest`/`MetricSeries` contracts → endpoint → shared metric-math library (filters, group-by, rate, increase, histogram_quantile, formula). **This is the product gap; nothing else replaces it.**
+- INFRA-B: internal-infra token quota exemption in `MetricsRateLimiterService`.
+- (Post-alpha) Alerting on the shared math library; streams-table storage migration.
+
+### charts
+
+- INFRA-A (#11808, dev): otel-collector `prometheusremotewrite` bridge + vmagent second remote-write. **Draft up.**
+- INFRA-C (dev): drop the `debug` exporter once metrics1 arrival is confirmed.
+- INFRA-D (prod-us + prod-eu): replicate the bridge after `metrics-prod-rollout` merges and prod `metrics1` SQL is applied. Decide internal-infra project here.
+- INFRA-E: broaden the bridge filter beyond the initial dashboard metric set once the query layer can render more.
+- (Merge) `daniel/metrics-prod-rollout`: takes the ingestion data plane to prod-us + prod-eu.
+
+### posthog-cloud-infra
+
+- **Nothing new required** for alpha — topics/S3/IRSA/CH collection/PG user are all merged in every env.
+- Open decision (INFRA-D): provision a dedicated `posthog-internal-infra` project + token per env so scraped infra metrics don't flip `team_has_metrics` on the dogfood team and so internal-infra volume is billed/quota'd separately.
+
+### Per-env "go live" checklist for prod
+
+1. Merge `daniel/metrics-prod-rollout` (charts).
+2. Apply `metrics1` + MV DDL to prod-us and prod-eu logs CH clusters (direct SQL, as in dev).
+3. Point a smoke OTLP producer at the prod `/i/v1/metrics`; confirm rows in `metrics1`.
+4. Land INFRA-D (bridge) per env; confirm vmagent → bridge → metrics1 for the dashboard metric set.
+5. Verify `team_has_metrics` + the query layer against real prod series.
+
+## Local validation (the priority) — fully functional metrics on a laptop
+
+No charts/cloud-infra needed locally. The `metrics` dev intent boots the whole pipe.
+
+1. `hogli dev:setup` → select the **`metrics`** intent (boots `capture-logs`, `ingestion-metrics`, deps; `metrics1` created by CH bootstrap). `hogli start`.
+2. Enable the `metrics` feature flag for your user.
+3. Pipe a real PostHog logs service through (its `prom-client` metrics):
+   - `logs-ingestion` exposes `/_metrics` on `:6743`; `metrics-ingestion` on `:6744`.
+   - Run the local OTel collector recipe (see `bin/`/docker-compose profile added by the "local pipe" task) to scrape `:6743` and push OTLP to `http://localhost:8010/i/v1/metrics` with the project-2 capture token.
+4. Search/validate:
+   - `/metrics` SQL tab: `SELECT metric_name, count() FROM posthog.metrics WHERE metric_name ILIKE '%logs_ingestion%' GROUP BY 1 ORDER BY 2 DESC`
+   - `/metrics` Viewer: the new query layer (filters/group-by/rate/histogram_quantile) against the same data.
+
+Ad-hoc seed without the pipe (no PRs needed):
+
+```bash
+clickhouse-client -h localhost --query "
+INSERT INTO metrics1 (uuid, team_id, timestamp, service_name, metric_name, metric_type, value, attributes_map_str, resource_attributes)
+SELECT generateUUIDv4(), 2, now() - INTERVAL number SECOND, 'logs-ingestion', 'logs_ingestion_bytes_received_total', 'sum',
+       toFloat64(number * 1024),
+       map('container_str','logs-ingestion','team_id_str','2'),
+       map('namespace','posthog')
+FROM numbers(3600)"
+```
+
+(`team_has_metrics` caches for 7 days — after wiping CH, `cache.delete("team:2:has_metrics")`.)

--- a/products/metrics/backend/facade/contracts.py
+++ b/products/metrics/backend/facade/contracts.py
@@ -10,4 +10,106 @@ Characteristics:
 - Used by facade as inputs/outputs
 
 Do NOT depend on Django models, DRF serializers, or request objects.
+
+These define the query wire shape used by the viewer, the dashboard
+widget, and (later) alerting. The response is always a list of
+`MetricSeries` — a single ungrouped query returns one series with empty
+labels, so consumers never branch on "single vs multi series".
 """
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from .enums import AttributeScope, FilterOp, MetricAggregation
+
+
+@dataclass(frozen=True, slots=True)
+class MetricFilter:
+    """A single label predicate on a clause."""
+
+    key: str
+    op: FilterOp
+    value: str
+    scope: AttributeScope = AttributeScope.AUTO
+
+
+@dataclass(frozen=True, slots=True)
+class MetricGroupBy:
+    """One label to split a clause's result into separate series by."""
+
+    key: str
+    scope: AttributeScope = AttributeScope.AUTO
+
+
+@dataclass(frozen=True, slots=True)
+class MetricQueryClause:
+    """One metric selection: a name, an aggregation, and optional
+    filters / group-by. `name` is the alias a formula refers to (e.g. "a").
+    """
+
+    name: str
+    metric_name: str
+    aggregation: MetricAggregation
+    filters: tuple[MetricFilter, ...] = ()
+    group_by: tuple[MetricGroupBy, ...] = ()
+    # Required for QUANTILE / HISTOGRAM_QUANTILE; ignored otherwise.
+    quantile: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.aggregation.needs_quantile:
+            if self.quantile is None:
+                raise ValueError(f"{self.aggregation} requires a quantile")
+            if not 0.0 < self.quantile < 1.0:
+                raise ValueError("quantile must be in (0, 1)")
+        if not self.name:
+            raise ValueError("clause name must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class MetricQueryRequest:
+    """A whole metric query: one or more clauses over a shared time grid,
+    with an optional formula combining them by clause name.
+
+    `interval` is on the request (not per clause) so every series in the
+    response shares one bucket grid — required for a formula like "a / b"
+    to align, and the right default anyway. None means auto-pick from the
+    range.
+    """
+
+    clauses: tuple[MetricQueryClause, ...]
+    date_from: dt.datetime
+    date_to: dt.datetime
+    interval: str | None = None
+    formula: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.clauses:
+            raise ValueError("at least one clause is required")
+        if self.date_to <= self.date_from:
+            raise ValueError("date_to must be after date_from")
+        names = [c.name for c in self.clauses]
+        if len(names) != len(set(names)):
+            raise ValueError("clause names must be unique")
+
+
+@dataclass(frozen=True, slots=True)
+class MetricPoint:
+    """One bucketed datapoint. `time` is the bucket start, ISO 8601."""
+
+    time: str
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSeries:
+    """One line on a chart: the label values that identify it plus its
+    points. `labels` is empty for an ungrouped query. `clause` records
+    which clause produced it (the formula result uses `clause="formula"`).
+    """
+
+    labels: dict[str, str]
+    points: tuple[MetricPoint, ...]
+    metric_name: str | None = None
+    clause: str | None = None

--- a/products/metrics/backend/facade/enums.py
+++ b/products/metrics/backend/facade/enums.py
@@ -1,13 +1,72 @@
 """
 Exported enums and constants for metrics.
 
-Small products can keep enums in contracts.py instead. Split
-into this file when contracts.py gets crowded.
-
-Rule: if an enum appears in a contract dataclass field, it
-belongs here (or in contracts.py). Shared types that other
-products need to interpret contract objects also belong here.
-
-Internal-only constants (DB magic values, feature flags, etc.)
-should stay in the implementation (logic.py, models.py).
+These appear in the contract dataclasses (contracts.py) and are the
+vocabulary other products / the presentation layer use to build metric
+queries. Framework-free: no Django, no DRF.
 """
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class AttributeScope(StrEnum):
+    """Where a label lives on a `metrics1` row.
+
+    - RESOURCE: `resource_attributes` (set once per scrape target, e.g.
+      `service.name`, `k8s.pod.name`).
+    - ATTRIBUTE: per-data-point `attributes` (the alias that strips the
+      5-char `_str` type tag, e.g. `http.method`).
+    - AUTO: resource first, fall back to attribute. ClickHouse map lookups
+      return '' for missing keys, so the fallback compares against '' — you
+      cannot meaningfully match "equals empty string" in AUTO scope; use an
+      explicit scope for that edge case.
+    """
+
+    RESOURCE = "resource"
+    ATTRIBUTE = "attribute"
+    AUTO = "auto"
+
+
+class FilterOp(StrEnum):
+    """Comparison operators for a label filter."""
+
+    EQ = "eq"
+    NEQ = "neq"
+    REGEX = "regex"
+    NOT_REGEX = "not_regex"
+
+
+class MetricAggregation(StrEnum):
+    """How a clause collapses the values in each time bucket into one number.
+
+    Instant aggregations operate on the values that fell in the bucket:
+    SUM, AVG, COUNT, MIN, MAX, QUANTILE.
+
+    Counter functions operate on the change across the bucket (cumulative
+    counters get reset-corrected; deltas are summed): RATE, INCREASE.
+
+    HISTOGRAM_QUANTILE reads the `histogram_bounds`/`histogram_counts`
+    arrays rather than the scalar `value`.
+
+    QUANTILE and HISTOGRAM_QUANTILE require the clause's `quantile` field.
+    """
+
+    SUM = "sum"
+    AVG = "avg"
+    COUNT = "count"
+    MIN = "min"
+    MAX = "max"
+    QUANTILE = "quantile"
+    RATE = "rate"
+    INCREASE = "increase"
+    HISTOGRAM_QUANTILE = "histogram_quantile"
+
+    @property
+    def needs_quantile(self) -> bool:
+        return self in (MetricAggregation.QUANTILE, MetricAggregation.HISTOGRAM_QUANTILE)
+
+    @property
+    def is_counter_function(self) -> bool:
+        return self in (MetricAggregation.RATE, MetricAggregation.INCREASE)

--- a/products/metrics/backend/metric_query_runner.py
+++ b/products/metrics/backend/metric_query_runner.py
@@ -9,14 +9,60 @@ pipeline yet.
 """
 
 import datetime as dt
-from typing import Any
+from typing import Any, Literal
 
 from posthog.hogql import ast
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.models import Team
+
+AttributeScope = Literal["resource", "attribute", "auto"]
+
+_ALLOWED_ATTRIBUTE_SCOPES: frozenset[str] = frozenset({"resource", "attribute", "auto"})
+
+
+def attribute_field(name: str, *, scope: AttributeScope = "auto") -> ast.Expr:
+    """Build the HogQL AST node that accesses a metric attribute by name.
+
+    This is the single seam between the upcoming filter / group-by / rate /
+    histogram-quantile work (PR3-PR6) and the underlying `metrics1` storage
+    shape. When the Snuffle-style streams-table rewrite lands, only this
+    function changes — every call site keeps working.
+
+    `scope` resolves *where* the attribute lives:
+
+    - ``"resource"`` — look in ``resource_attributes`` only (Prometheus-style
+      `service.name`, `k8s.pod.name` — set once per scrape target).
+    - ``"attribute"`` — look in ``attributes`` only (the alias view of
+      ``attributes_map_str`` that strips the 5-char ``__str`` type tag from
+      each key). Per-data-point labels like ``http.method`` live here.
+    - ``"auto"`` (default) — try resource first, fall back to attribute if
+      empty. Map lookups in ClickHouse return ``''`` for missing keys, not
+      NULL, so the fallback compares against the empty string.
+
+    The empty-string fallback is documented behaviour, not a bug: it means
+    callers cannot meaningfully filter for "attribute equals empty string"
+    in auto scope. Use an explicit scope for that edge case.
+    """
+    if scope not in _ALLOWED_ATTRIBUTE_SCOPES:
+        raise ValueError(f"Unknown attribute scope: {scope!r}")
+
+    name_constant = ast.Constant(value=name)
+
+    # arrayElement, not subscript: HogQL prints `field[...]` on a
+    # StringJSONDatabaseField as JSONExtractRaw, which is illegal on the
+    # physical Map columns. arrayElement passes through and is ClickHouse's
+    # native Map accessor ('' for missing keys).
+    if scope == "resource":
+        return parse_expr("arrayElement(resource_attributes, {name})", placeholders={"name": name_constant})
+    if scope == "attribute":
+        return parse_expr("arrayElement(attributes, {name})", placeholders={"name": name_constant})
+    return parse_expr(
+        "if(arrayElement(resource_attributes, {name}) != '', arrayElement(resource_attributes, {name}), arrayElement(attributes, {name}))",
+        placeholders={"name": name_constant},
+    )
 
 
 def _aggregation_expr(name: str) -> ast.Expr:

--- a/products/metrics/backend/tests/_seeder.py
+++ b/products/metrics/backend/tests/_seeder.py
@@ -1,0 +1,91 @@
+"""Test-only metric row seeder for `metrics1`.
+
+Inserts rows directly via `sync_execute` rather than driving the OTLP pipe,
+so tests don't depend on capture-logs + metrics-ingestion-consumer running.
+
+The shape mirrors what `rust/capture-logs/src/metric_record.rs` emits — every
+later query-runner PR (filters, group-by, rate, histogram_quantile) leans on
+this to plant deterministic fixtures with specific labels and timestamps.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+import datetime as dt
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from posthog.clickhouse.client import sync_execute
+
+
+def _attribute_map_str_with_type_tags(labels: Mapping[str, str]) -> dict[str, str]:
+    """`attributes_map_str` stores keys with a trailing 5-char type tag (e.g.
+    `container__str`), matching the Kafka MV's `concat(k, '__str')`. The
+    ClickHouse table exposes a stripped ALIAS column `attributes` via
+    `left(k, -5)`. The seeder accepts user-friendly names (`container`) and
+    appends the `__str` tag so lookups via the ALIAS work as expected.
+    """
+    return {f"{key}__str": value for key, value in labels.items()}
+
+
+def seed_metric(
+    *,
+    team_id: int,
+    metric_name: str,
+    points: Iterable[tuple[dt.datetime, float]],
+    labels: Mapping[str, str] | None = None,
+    resource_labels: Mapping[str, str] | None = None,
+    metric_type: str = "gauge",
+    service_name: str = "test-service",
+    aggregation_temporality: str = "cumulative",
+    is_monotonic: bool = False,
+    histogram_bounds: list[float] | None = None,
+    histogram_counts: list[int] | None = None,
+    unit: str = "",
+) -> None:
+    """Insert one row per `(timestamp, value)` point into `metrics1`.
+
+    `labels` populates the per-data-point `attributes_map_str` map (with the
+    `__str` type-tag suffix the schema expects). `resource_labels` populates
+    `resource_attributes` directly — those are tag-free.
+
+    Histogram inputs (`histogram_bounds`, `histogram_counts`) are passed
+    through verbatim; only relevant when `metric_type='histogram'`.
+    """
+    attributes_map_str = _attribute_map_str_with_type_tags(labels or {})
+    resource_attributes = dict(resource_labels or {})
+
+    rows: list[dict[str, Any]] = []
+    for timestamp, value in points:
+        rows.append(
+            {
+                "uuid": str(uuid.uuid4()),
+                "team_id": team_id,
+                "trace_id": "",
+                "span_id": "",
+                "trace_flags": 0,
+                "timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "observed_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "service_name": service_name,
+                "metric_name": metric_name,
+                "metric_type": metric_type,
+                "value": value,
+                "count": 1,
+                "histogram_bounds": histogram_bounds or [],
+                "histogram_counts": histogram_counts or [],
+                "unit": unit,
+                "aggregation_temporality": aggregation_temporality,
+                "is_monotonic": is_monotonic,
+                "resource_attributes": resource_attributes,
+                "instrumentation_scope": "",
+                "attributes_map_str": attributes_map_str,
+                "attributes_map_float": {},
+            }
+        )
+
+    if not rows:
+        return
+
+    payload = "\n".join(json.dumps(row) for row in rows)
+    sync_execute(f"INSERT INTO metrics1 FORMAT JSONEachRow {payload}")

--- a/products/metrics/backend/tests/test_contracts.py
+++ b/products/metrics/backend/tests/test_contracts.py
@@ -1,0 +1,96 @@
+import datetime as dt
+
+import pytest
+
+from products.metrics.backend.facade.contracts import (
+    MetricFilter,
+    MetricGroupBy,
+    MetricPoint,
+    MetricQueryClause,
+    MetricQueryRequest,
+    MetricSeries,
+)
+from products.metrics.backend.facade.enums import AttributeScope, FilterOp, MetricAggregation
+
+
+def _clause(**overrides) -> MetricQueryClause:
+    base = {"name": "a", "metric_name": "m", "aggregation": MetricAggregation.SUM}
+    return MetricQueryClause(**{**base, **overrides})
+
+
+class TestMetricQueryClause:
+    def test_minimal_clause(self):
+        clause = _clause()
+        assert clause.filters == ()
+        assert clause.group_by == ()
+        assert clause.quantile is None
+
+    def test_quantile_aggregation_requires_quantile(self):
+        with pytest.raises(ValueError):
+            _clause(aggregation=MetricAggregation.QUANTILE)
+        with pytest.raises(ValueError):
+            _clause(aggregation=MetricAggregation.HISTOGRAM_QUANTILE)
+
+    def test_quantile_must_be_in_open_unit_interval(self):
+        for bad in (0.0, 1.0, -0.1, 1.5):
+            with pytest.raises(ValueError):
+                _clause(aggregation=MetricAggregation.QUANTILE, quantile=bad)
+        assert _clause(aggregation=MetricAggregation.QUANTILE, quantile=0.95).quantile == 0.95
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValueError):
+            _clause(name="")
+
+
+class TestMetricQueryRequest:
+    def _req(self, **overrides) -> MetricQueryRequest:
+        now = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        base = {
+            "clauses": (_clause(),),
+            "date_from": now - dt.timedelta(hours=1),
+            "date_to": now,
+        }
+        return MetricQueryRequest(**{**base, **overrides})
+
+    def test_minimal_request(self):
+        req = self._req()
+        assert req.interval is None
+        assert req.formula is None
+
+    def test_requires_at_least_one_clause(self):
+        now = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        with pytest.raises(ValueError):
+            MetricQueryRequest(clauses=(), date_from=now - dt.timedelta(hours=1), date_to=now)
+
+    def test_rejects_inverted_range(self):
+        now = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        with pytest.raises(ValueError):
+            MetricQueryRequest(clauses=(_clause(),), date_from=now, date_to=now - dt.timedelta(hours=1))
+
+    def test_rejects_duplicate_clause_names(self):
+        with pytest.raises(ValueError):
+            self._req(clauses=(_clause(name="a"), _clause(name="a", metric_name="other")))
+
+    def test_allows_distinct_clause_names_for_formula(self):
+        req = self._req(
+            clauses=(_clause(name="a"), _clause(name="b", metric_name="other")),
+            formula="a / b",
+        )
+        assert req.formula == "a / b"
+
+
+class TestFiltersAndGroupBy:
+    def test_filter_defaults_to_auto_scope(self):
+        f = MetricFilter(key="container", op=FilterOp.EQ, value="logs-ingestion")
+        assert f.scope == AttributeScope.AUTO
+
+    def test_group_by_explicit_scope(self):
+        g = MetricGroupBy(key="service_name", scope=AttributeScope.RESOURCE)
+        assert g.scope == AttributeScope.RESOURCE
+
+
+class TestMetricSeries:
+    def test_ungrouped_series_has_empty_labels(self):
+        series = MetricSeries(labels={}, points=(MetricPoint(time="2026-01-01T00:00:00", value=1.0),))
+        assert series.labels == {}
+        assert series.points[0].value == 1.0

--- a/products/metrics/backend/tests/test_metric_names_query_runner.py
+++ b/products/metrics/backend/tests/test_metric_names_query_runner.py
@@ -9,7 +9,18 @@ from rest_framework import status
 from posthog.clickhouse.client import sync_execute
 
 from products.metrics.backend.metric_names_query_runner import MetricNamesQueryRunner
-from products.metrics.backend.tests.test_metric_query_runner import _insert_metric_row
+from products.metrics.backend.tests._seeder import seed_metric
+
+
+def _seed_point(
+    *,
+    team_id: int,
+    metric_name: str,
+    value: float,
+    timestamp: dt.datetime,
+    metric_type: str = "gauge",
+) -> None:
+    seed_metric(team_id=team_id, metric_name=metric_name, points=[(timestamp, value)], metric_type=metric_type)
 
 
 class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
@@ -35,21 +46,21 @@ class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_returns_distinct_names_with_metric_type(self):
         anchor = timezone.now().replace(microsecond=0) - dt.timedelta(minutes=5)
-        _insert_metric_row(
+        _seed_point(
             team_id=self.team.id,
             metric_name="http.server.duration",
             value=1.0,
             timestamp=anchor,
             metric_type="histogram",
         )
-        _insert_metric_row(
+        _seed_point(
             team_id=self.team.id,
             metric_name="http.server.duration",
             value=2.0,
             timestamp=anchor,
             metric_type="histogram",
         )
-        _insert_metric_row(
+        _seed_point(
             team_id=self.team.id,
             metric_name="queue.depth",
             value=12.0,
@@ -69,8 +80,8 @@ class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_search_filters_by_substring(self):
         anchor = timezone.now().replace(microsecond=0) - dt.timedelta(minutes=5)
-        _insert_metric_row(team_id=self.team.id, metric_name="http.server.duration", value=1.0, timestamp=anchor)
-        _insert_metric_row(team_id=self.team.id, metric_name="queue.depth", value=12.0, timestamp=anchor)
+        _seed_point(team_id=self.team.id, metric_name="http.server.duration", value=1.0, timestamp=anchor)
+        _seed_point(team_id=self.team.id, metric_name="queue.depth", value=12.0, timestamp=anchor)
 
         runner = MetricNamesQueryRunner(team=self.team, search="server")
         results = runner.run()
@@ -78,13 +89,13 @@ class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_exact_match_floats_to_top(self):
         anchor = timezone.now().replace(microsecond=0)
-        _insert_metric_row(
+        _seed_point(
             team_id=self.team.id,
             metric_name="foo.bar",
             value=1.0,
             timestamp=anchor - dt.timedelta(minutes=10),
         )
-        _insert_metric_row(
+        _seed_point(
             team_id=self.team.id,
             metric_name="bar",
             value=2.0,
@@ -97,7 +108,7 @@ class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_respects_team_isolation(self):
         anchor = timezone.now().replace(microsecond=0) - dt.timedelta(minutes=5)
-        _insert_metric_row(team_id=99999, metric_name="other.team.metric", value=1.0, timestamp=anchor)
+        _seed_point(team_id=99999, metric_name="other.team.metric", value=1.0, timestamp=anchor)
 
         runner = MetricNamesQueryRunner(team=self.team)
         self.assertEqual(runner.run(), [])
@@ -105,8 +116,8 @@ class TestMetricNamesQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def test_lookback_excludes_old_data(self):
         old = timezone.now().replace(microsecond=0) - dt.timedelta(days=14)
         recent = timezone.now().replace(microsecond=0) - dt.timedelta(hours=1)
-        _insert_metric_row(team_id=self.team.id, metric_name="old.metric", value=1.0, timestamp=old)
-        _insert_metric_row(team_id=self.team.id, metric_name="recent.metric", value=2.0, timestamp=recent)
+        _seed_point(team_id=self.team.id, metric_name="old.metric", value=1.0, timestamp=old)
+        _seed_point(team_id=self.team.id, metric_name="recent.metric", value=2.0, timestamp=recent)
 
         runner = MetricNamesQueryRunner(team=self.team, lookback=dt.timedelta(days=7))
         names = [row["name"] for row in runner.run()]
@@ -133,8 +144,8 @@ class TestMetricsValuesAPI(ClickhouseTestMixin, APIBaseTest):
 
     def test_values_returns_metric_names(self):
         anchor = timezone.now().replace(microsecond=0) - dt.timedelta(minutes=5)
-        _insert_metric_row(team_id=self.team.id, metric_name="m1", value=1.0, timestamp=anchor)
-        _insert_metric_row(team_id=self.team.id, metric_name="m2", value=2.0, timestamp=anchor, metric_type="gauge")
+        _seed_point(team_id=self.team.id, metric_name="m1", value=1.0, timestamp=anchor)
+        _seed_point(team_id=self.team.id, metric_name="m2", value=2.0, timestamp=anchor, metric_type="gauge")
 
         response = self.client.get(f"/api/projects/{self.team.id}/metrics/values")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -144,8 +155,8 @@ class TestMetricsValuesAPI(ClickhouseTestMixin, APIBaseTest):
 
     def test_values_search_param(self):
         anchor = timezone.now().replace(microsecond=0) - dt.timedelta(minutes=5)
-        _insert_metric_row(team_id=self.team.id, metric_name="http.duration", value=1.0, timestamp=anchor)
-        _insert_metric_row(team_id=self.team.id, metric_name="queue.depth", value=2.0, timestamp=anchor)
+        _seed_point(team_id=self.team.id, metric_name="http.duration", value=1.0, timestamp=anchor)
+        _seed_point(team_id=self.team.id, metric_name="queue.depth", value=2.0, timestamp=anchor)
 
         response = self.client.get(f"/api/projects/{self.team.id}/metrics/values?value=http")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/products/metrics/backend/tests/test_metric_query_runner.py
+++ b/products/metrics/backend/tests/test_metric_query_runner.py
@@ -1,4 +1,3 @@
-import json
 import datetime as dt
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -8,48 +7,15 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
 
-from products.metrics.backend.metric_query_runner import MetricQueryRunner, _pick_interval
-
-
-def _insert_metric_row(
-    *,
-    team_id: int,
-    metric_name: str,
-    value: float,
-    timestamp: dt.datetime,
-    metric_type: str = "gauge",
-) -> None:
-    """Insert a single row into the local `metrics1` table.
-
-    Uses the same shape `rust/capture-logs/src/metric_record.rs` emits, with
-    fields the test doesn't care about set to empty/default.
-    """
-    row = {
-        "uuid": "019e6bc4-4897-77d0-ab21-56ba3e2fe535",
-        "team_id": team_id,
-        "trace_id": "",
-        "span_id": "",
-        "trace_flags": 0,
-        "timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
-        "observed_timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S.%f"),
-        "service_name": "test-service",
-        "metric_name": metric_name,
-        "metric_type": metric_type,
-        "value": value,
-        "count": 1,
-        "histogram_bounds": [],
-        "histogram_counts": [],
-        "unit": "",
-        "aggregation_temporality": "cumulative",
-        "is_monotonic": False,
-        "resource_attributes": {},
-        "instrumentation_scope": "",
-        "attributes_map_str": {},
-        "attributes_map_float": {},
-    }
-    sync_execute(f"INSERT INTO metrics1 FORMAT JSONEachRow {json.dumps(row)}")
+from products.metrics.backend.metric_query_runner import MetricQueryRunner, _pick_interval, attribute_field
+from products.metrics.backend.tests._seeder import seed_metric
 
 
 class TestPickInterval:
@@ -108,18 +74,20 @@ class TestMetricQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_aggregates_sum_per_bucket(self):
         anchor = timezone.now().replace(microsecond=0)
-        _insert_metric_row(
-            team_id=self.team.id, metric_name="m1", value=2.0, timestamp=anchor - dt.timedelta(minutes=5)
-        )
-        _insert_metric_row(
-            team_id=self.team.id, metric_name="m1", value=3.0, timestamp=anchor - dt.timedelta(minutes=5)
-        )
-        _insert_metric_row(
-            team_id=self.team.id, metric_name="m1", value=4.0, timestamp=anchor - dt.timedelta(minutes=20)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m1",
+            points=[
+                (anchor - dt.timedelta(minutes=5), 2.0),
+                (anchor - dt.timedelta(minutes=5), 3.0),
+                (anchor - dt.timedelta(minutes=20), 4.0),
+            ],
         )
         # Different metric — should be filtered out.
-        _insert_metric_row(
-            team_id=self.team.id, metric_name="m2", value=99.0, timestamp=anchor - dt.timedelta(minutes=5)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m2",
+            points=[(anchor - dt.timedelta(minutes=5), 99.0)],
         )
 
         runner = MetricQueryRunner(
@@ -136,7 +104,11 @@ class TestMetricQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_respects_team_isolation(self):
         anchor = timezone.now().replace(microsecond=0)
-        _insert_metric_row(team_id=99999, metric_name="m1", value=5.0, timestamp=anchor - dt.timedelta(minutes=5))
+        seed_metric(
+            team_id=99999,
+            metric_name="m1",
+            points=[(anchor - dt.timedelta(minutes=5), 5.0)],
+        )
 
         runner = MetricQueryRunner(
             team=self.team,
@@ -182,11 +154,13 @@ class TestMetricsQueryAPI(ClickhouseTestMixin, APIBaseTest):
 
     def test_query_returns_aggregated_points(self):
         anchor = timezone.now().replace(microsecond=0)
-        _insert_metric_row(
-            team_id=self.team.id, metric_name="m1", value=1.0, timestamp=anchor - dt.timedelta(minutes=10)
-        )
-        _insert_metric_row(
-            team_id=self.team.id, metric_name="m1", value=2.0, timestamp=anchor - dt.timedelta(minutes=10)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m1",
+            points=[
+                (anchor - dt.timedelta(minutes=10), 1.0),
+                (anchor - dt.timedelta(minutes=10), 2.0),
+            ],
         )
 
         response = self.client.post(
@@ -206,3 +180,96 @@ class TestMetricsQueryAPI(ClickhouseTestMixin, APIBaseTest):
         body = response.json()
         self.assertIn("results", body)
         self.assertEqual(sum(point["value"] for point in body["results"]), 3.0)
+
+
+class TestAttributeField(ClickhouseTestMixin, APIBaseTest):
+    """End-to-end tests for the `attribute_field` helper.
+
+    The helper builds an AST node; correctness depends on what ClickHouse
+    actually returns, so we execute a real query against `posthog.metrics`
+    for each scope and assert the resolved value.
+    """
+
+    CLASS_DATA_LEVEL_SETUP = True
+
+    def setUp(self):
+        super().setUp()
+        sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+
+    def _select_attribute(self, expr: ast.Expr, metric_name: str) -> str | None:
+        query = parse_select(
+            """
+                SELECT {expr} AS value FROM posthog.metrics
+                WHERE metric_name = {metric_name} LIMIT 1
+            """,
+            placeholders={"expr": expr, "metric_name": ast.Constant(value=metric_name)},
+        )
+        assert isinstance(query, ast.SelectQuery)
+        response = execute_hogql_query(
+            query_type="AttributeFieldTest",
+            query=query,
+            team=self.team,
+            workload=Workload.LOGS,
+        )
+        if not response.results:
+            return None
+        return response.results[0][0]
+
+    def test_rejects_unknown_scope(self):
+        with self.assertRaises(ValueError):
+            attribute_field("container", scope="bogus")  # type: ignore[arg-type]
+
+    def test_resource_scope_reads_resource_attributes(self):
+        anchor = timezone.now().replace(microsecond=0)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m_resource",
+            points=[(anchor, 1.0)],
+            resource_labels={"service_name": "logs-ingestion"},
+        )
+        value = self._select_attribute(attribute_field("service_name", scope="resource"), "m_resource")
+        self.assertEqual(value, "logs-ingestion")
+
+    def test_attribute_scope_reads_attributes_via_alias(self):
+        anchor = timezone.now().replace(microsecond=0)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m_attribute",
+            points=[(anchor, 1.0)],
+            labels={"http_method": "POST"},
+        )
+        value = self._select_attribute(attribute_field("http_method", scope="attribute"), "m_attribute")
+        self.assertEqual(value, "POST")
+
+    def test_auto_scope_prefers_resource_when_present(self):
+        anchor = timezone.now().replace(microsecond=0)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m_auto_resource",
+            points=[(anchor, 1.0)],
+            resource_labels={"container": "capture-logs"},
+            labels={"container": "should-not-win"},
+        )
+        value = self._select_attribute(attribute_field("container"), "m_auto_resource")
+        self.assertEqual(value, "capture-logs")
+
+    def test_auto_scope_falls_back_to_attribute_when_resource_empty(self):
+        anchor = timezone.now().replace(microsecond=0)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m_auto_attribute",
+            points=[(anchor, 1.0)],
+            labels={"endpoint": "/api/projects/2/metrics/query"},
+        )
+        value = self._select_attribute(attribute_field("endpoint"), "m_auto_attribute")
+        self.assertEqual(value, "/api/projects/2/metrics/query")
+
+    def test_auto_scope_returns_empty_when_neither_present(self):
+        anchor = timezone.now().replace(microsecond=0)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="m_auto_missing",
+            points=[(anchor, 1.0)],
+        )
+        value = self._select_attribute(attribute_field("nonexistent"), "m_auto_missing")
+        self.assertEqual(value, "")


### PR DESCRIPTION
## Problem

The metrics query surface is about to grow (filters, group-by, counter functions, formulas). Locking the request/response contract down as frozen dataclasses *before* the behavior lands means every later PR extends one shape instead of inventing its own.

## Changes

Adds `facade/contracts.py` + `facade/enums.py` (previously empty stubs): `MetricFilter`, `MetricGroupBy`, `MetricQueryClause`, `MetricQueryRequest`, `MetricPoint`, `MetricSeries`, and the `AttributeScope` / `FilterOp` / `MetricAggregation` enums. Framework-free, frozen, validated in `__post_init__` (quantile bounds, unique clause names, window ordering). Design choices worth knowing:

- `interval` lives on the **request**, not per clause — every series in a response shares one bucket grid, which is what makes formulas like `a / b` line up.
- The response is **always** `[MetricSeries]`; a single ungrouped query returns one series with empty labels, so consumers never branch on single-vs-multi.
- `AttributeScope.AUTO` is the default everywhere — explicit `resource`/`attribute` scope stays available but the planned schema-v2 merged-label layout makes `auto` the forward-compatible choice.

Pure types + unit tests; no behavior change.

## How did you test this code?

I'm an agent. Automated: `hogli test products/metrics/backend/tests/test_contracts.py` (12 tests: validation rules, immutability).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @DanielVisca

Contracts were drafted by Daniel; this revision validates them against the implemented stack above it (no shape changes were needed — only the docstring promise that the formula result uses `clause="formula"`, which PR #63129 honors).