### PR TITLE
feat(metrics): multi-clause queries and server-side formulas (P7)

### DIFF
--- a/products/metrics/backend/facade/api.py
+++ b/products/metrics/backend/facade/api.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from posthog.models import Team
 
-from products.metrics.backend.facade.contracts import MetricPoint, MetricQueryRequest, MetricSeries
+from products.metrics.backend.facade.contracts import MetricPoint, MetricQueryClause, MetricQueryRequest, MetricSeries
 from products.metrics.backend.facade.enums import MetricAggregation
+from products.metrics.backend.formula import evaluate, parse_formula
 from products.metrics.backend.has_metrics_query_runner import team_has_metrics as _team_has_metrics
 from products.metrics.backend.metric_names_query_runner import MetricNamesQueryRunner
 from products.metrics.backend.metric_query_runner import MetricQueryRunner
@@ -60,53 +61,112 @@ def _assemble_series(
     return series[:MAX_SERIES_PER_CLAUSE]
 
 
+def _resolve_runner_aggregation(clause: MetricQueryClause) -> str:
+    if clause.aggregation == MetricAggregation.QUANTILE and clause.quantile == 0.95:
+        return "p95"
+    if clause.aggregation == MetricAggregation.HISTOGRAM_QUANTILE:
+        return "histogram_quantile"
+    if clause.aggregation in _RUNNER_AGGREGATIONS:
+        return _RUNNER_AGGREGATIONS[clause.aggregation]
+    raise ValueError(f"aggregation {clause.aggregation.value!r} is not supported yet")
+
+
+def _evaluate_formula(
+    formula_text: str, series_by_clause: dict[str, list[MetricSeries]], grid: list[str]
+) -> list[MetricSeries]:
+    """Combine clause results point-by-point on the shared grid.
+
+    Series are matched across clauses by exact label-set equality
+    (Prometheus-style one-to-one vector matching); a clause that produced a
+    single ungrouped series is broadcast to every label-set instead. A
+    label-set missing from any non-broadcast clause is dropped.
+    """
+    node = parse_formula(formula_text, frozenset(series_by_clause))
+
+    broadcasts: dict[str, MetricSeries] = {}
+    grouped: dict[str, dict[tuple[tuple[str, str], ...], MetricSeries]] = {}
+    for name, series_list in series_by_clause.items():
+        if len(series_list) == 1 and not series_list[0].labels:
+            broadcasts[name] = series_list[0]
+        else:
+            grouped[name] = {tuple(sorted(s.labels.items())): s for s in series_list}
+
+    if grouped:
+        label_sets: set[tuple[tuple[str, str], ...]] = set.intersection(
+            *(set(by_labels) for by_labels in grouped.values())
+        )
+    else:
+        label_sets = {()}
+
+    result: list[MetricSeries] = []
+    for label_set in sorted(label_sets):
+        per_clause_points: dict[str, tuple[MetricPoint, ...]] = {
+            name: (grouped[name][label_set].points if name in grouped else broadcasts[name].points)
+            for name in series_by_clause
+        }
+        points = tuple(
+            MetricPoint(
+                time=time,
+                value=evaluate(node, {name: pts[index].value for name, pts in per_clause_points.items()}),
+            )
+            for index, time in enumerate(grid)
+        )
+        result.append(MetricSeries(labels=dict(label_set), points=points, metric_name=None, clause="formula"))
+    return result
+
+
 def run_metric_query(*, team: Team, request: MetricQueryRequest) -> list[MetricSeries]:
     """Execute a metric query and return one `MetricSeries` per
     (clause, label-set) pair — a single ungrouped clause yields exactly one
     series with empty labels, so consumers never branch on single-vs-multi.
 
-    All series share one bucket grid (the union of observed buckets,
-    zero-filled), which is what makes cross-series and cross-clause math
-    line up. Series per clause are capped at `MAX_SERIES_PER_CLAUSE`,
-    keeping the largest ones.
+    Every series of every clause shares one bucket grid (the union of
+    observed buckets, zero-filled), which is what makes cross-series and
+    cross-clause math line up. Series per clause are capped at
+    `MAX_SERIES_PER_CLAUSE`, keeping the largest ones.
 
-    Current scope: one clause; multi-clause and formula raise `ValueError`
-    until their PRs land. The presentation layer surfaces `ValueError` as
-    a 400.
+    With `formula` set, only the formula result series are returned
+    (`clause="formula"`); request the clauses separately if you need the
+    inputs too. The presentation layer surfaces `ValueError` as a 400.
     """
-    if len(request.clauses) != 1:
-        raise ValueError("multi-clause queries are not supported yet")
-    if request.formula is not None:
-        raise ValueError("formulas are not supported yet")
+    rows_by_clause: dict[str, list[dict[str, Any]]] = {}
+    for clause in request.clauses:
+        runner_aggregation = _resolve_runner_aggregation(clause)
+        runner = MetricQueryRunner(
+            team=team,
+            metric_name=clause.metric_name,
+            aggregation=runner_aggregation,
+            date_from=request.date_from,
+            date_to=request.date_to,
+            filters=clause.filters,
+            group_by=clause.group_by,
+            interval=request.interval,
+            quantile=clause.quantile if runner_aggregation == "histogram_quantile" else None,
+        )
+        rows_by_clause[clause.name] = runner.run()
 
-    clause = request.clauses[0]
-
-    if clause.aggregation == MetricAggregation.QUANTILE and clause.quantile == 0.95:
-        runner_aggregation = "p95"
-    elif clause.aggregation == MetricAggregation.HISTOGRAM_QUANTILE:
-        runner_aggregation = "histogram_quantile"
-    elif clause.aggregation in _RUNNER_AGGREGATIONS:
-        runner_aggregation = _RUNNER_AGGREGATIONS[clause.aggregation]
-    else:
-        raise ValueError(f"aggregation {clause.aggregation.value!r} is not supported yet")
-
-    runner = MetricQueryRunner(
-        team=team,
-        metric_name=clause.metric_name,
-        aggregation=runner_aggregation,
-        date_from=request.date_from,
-        date_to=request.date_to,
-        filters=clause.filters,
-        group_by=clause.group_by,
-        interval=request.interval,
-        quantile=clause.quantile if runner_aggregation == "histogram_quantile" else None,
+    # Validate the formula before any early return so bad formulas always 400.
+    formula_node_checked = (
+        parse_formula(request.formula, frozenset(rows_by_clause)) if request.formula is not None else None
     )
-    rows = runner.run()
-    if not rows:
-        return [MetricSeries(labels={}, points=(), metric_name=clause.metric_name, clause=clause.name)]
 
-    grid = sorted({row["time"] for row in rows})
-    return _assemble_series(rows, metric_name=clause.metric_name, clause_name=clause.name, grid=grid)
+    grid = sorted({row["time"] for rows in rows_by_clause.values() for row in rows})
+    if not grid:
+        empty_clause = "formula" if formula_node_checked is not None else request.clauses[0].name
+        metric_name = None if formula_node_checked is not None else request.clauses[0].metric_name
+        return [MetricSeries(labels={}, points=(), metric_name=metric_name, clause=empty_clause)]
+
+    series_by_clause = {
+        clause.name: _assemble_series(
+            rows_by_clause[clause.name], metric_name=clause.metric_name, clause_name=clause.name, grid=grid
+        )
+        for clause in request.clauses
+    }
+
+    if request.formula is not None:
+        return _evaluate_formula(request.formula, series_by_clause, grid)
+
+    return [series for clause in request.clauses for series in series_by_clause[clause.name]]
 
 
 def list_metric_names(

--- a/products/metrics/backend/formula.py
+++ b/products/metrics/backend/formula.py
@@ -1,0 +1,133 @@
+"""Server-side formula evaluation over metric query clauses.
+
+A formula combines clause results by name — `(a - b) / a` — evaluated
+point-by-point on the shared time grid. Parsing is a tiny recursive-descent
+parser (numbers, clause identifiers, + - * /, unary minus, parentheses);
+nothing is ever eval()'d.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+_TOKEN_RE = re.compile(r"\s*(?:(?P<ident>[A-Za-z_][A-Za-z0-9_]*)|(?P<number>\d+(?:\.\d+)?)|(?P<op>[()+\-*/]))")
+
+# (kind, value) tuples; kind is "ident" | "number" | "op"
+_Token = tuple[str, str]
+
+
+def _tokenize(formula: str) -> list[_Token]:
+    tokens: list[_Token] = []
+    position = 0
+    while position < len(formula):
+        match = _TOKEN_RE.match(formula, position)
+        if match is None:
+            remainder = formula[position:].strip()
+            if not remainder:
+                break
+            raise ValueError(f"Unexpected character in formula: {remainder[0]!r}")
+        if match.group("ident"):
+            tokens.append(("ident", match.group("ident")))
+        elif match.group("number"):
+            tokens.append(("number", match.group("number")))
+        else:
+            tokens.append(("op", match.group("op")))
+        position = match.end()
+    return tokens
+
+
+class _Parser:
+    """expr := term (('+'|'-') term)* ; term := factor (('*'|'/') factor)* ;
+    factor := NUMBER | IDENT | '(' expr ')' | '-' factor"""
+
+    def __init__(self, tokens: list[_Token], known_names: frozenset[str]) -> None:
+        self.tokens = tokens
+        self.position = 0
+        self.known_names = known_names
+
+    def parse(self) -> _Node:
+        node = self._expr()
+        if self.position < len(self.tokens):
+            raise ValueError(f"Unexpected token in formula: {self.tokens[self.position][1]!r}")
+        return node
+
+    def _peek(self) -> _Token | None:
+        return self.tokens[self.position] if self.position < len(self.tokens) else None
+
+    def _take(self) -> _Token:
+        token = self._peek()
+        if token is None:
+            raise ValueError("Unexpected end of formula")
+        self.position += 1
+        return token
+
+    def _expr(self) -> _Node:
+        node = self._term()
+        while (token := self._peek()) is not None and token[0] == "op" and token[1] in "+-":
+            self._take()
+            node = ("binop", token[1], node, self._term())
+        return node
+
+    def _term(self) -> _Node:
+        node = self._factor()
+        while (token := self._peek()) and token[0] == "op" and token[1] in "*/":
+            self._take()
+            node = ("binop", token[1], node, self._factor())
+        return node
+
+    def _factor(self) -> _Node:
+        token = self._take()
+        if token == ("op", "-"):
+            return ("neg", self._factor())
+        if token == ("op", "("):
+            node = self._expr()
+            closing = self._take()
+            if closing != ("op", ")"):
+                raise ValueError("Unbalanced parentheses in formula")
+            return node
+        if token[0] == "number":
+            return ("number", float(token[1]))
+        if token[0] == "ident":
+            if token[1] not in self.known_names:
+                raise ValueError(
+                    f"Unknown clause {token[1]!r} in formula; available clauses: {sorted(self.known_names)}"
+                )
+            return ("ident", token[1])
+        raise ValueError(f"Unexpected token in formula: {token[1]!r}")
+
+
+# AST nodes are plain tuples: ("number", float) | ("ident", str) |
+# ("neg", node) | ("binop", "+-*/", left, right)
+_Node = tuple
+
+
+def parse_formula(formula: str, known_names: frozenset[str]) -> _Node:
+    """Parse and validate a formula; raises `ValueError` on any problem."""
+    tokens = _tokenize(formula)
+    if not tokens:
+        raise ValueError("Formula is empty")
+    return _Parser(tokens, known_names).parse()
+
+
+def evaluate(node: _Node, values: Mapping[str, float]) -> float:
+    """Evaluate one grid point. Division by zero yields 0.0 — charts and
+    alert thresholds want a number, not a NaN hole."""
+    kind = node[0]
+    if kind == "number":
+        return node[1]
+    if kind == "ident":
+        return values[node[1]]
+    if kind == "neg":
+        return -evaluate(node[1], values)
+    operator, left_node, right_node = node[1], node[2], node[3]
+    left, right = evaluate(left_node, values), evaluate(right_node, values)
+    if operator == "+":
+        return left + right
+    if operator == "-":
+        return left - right
+    if operator == "*":
+        return left * right
+    if right == 0.0:
+        return 0.0
+    return left / right

--- a/products/metrics/backend/presentation/api.py
+++ b/products/metrics/backend/presentation/api.py
@@ -62,10 +62,46 @@ class _MetricGroupBySerializer(serializers.Serializer):
     )
 
 
+class _MetricClauseSerializer(serializers.Serializer):
+    name = serializers.CharField(
+        max_length=64,
+        help_text="Clause name a formula refers to (e.g. 'a').",
+    )
+    metricName = serializers.CharField(
+        max_length=255,
+        help_text="Exact metric name this clause queries.",
+    )
+    aggregation = serializers.ChoiceField(
+        choices=["sum", "avg", "count", "p95", "rate", "increase", "histogram_quantile"],
+        default="sum",
+        help_text="Aggregation applied per time bucket; same semantics as the top-level aggregation.",
+    )
+    quantile = serializers.FloatField(
+        required=False,
+        allow_null=True,
+        min_value=0.0,
+        max_value=1.0,
+        help_text="Quantile in (0, 1) for 'histogram_quantile'.",
+    )
+    filters = _MetricFilterSerializer(
+        many=True,
+        required=False,
+        default=list,
+        help_text="Label predicates ANDed together for this clause.",
+    )
+    groupBy = _MetricGroupBySerializer(
+        many=True,
+        required=False,
+        default=list,
+        help_text="Labels to split this clause into separate series by.",
+    )
+
+
 class _MetricQueryBodySerializer(serializers.Serializer):
     metricName = serializers.CharField(
         max_length=255,
-        help_text="Exact metric name to query (e.g. 'http.server.duration').",
+        required=False,
+        help_text="Exact metric name to query (e.g. 'http.server.duration'). Single-clause shorthand — mutually exclusive with 'clauses'.",
     )
     aggregation = serializers.ChoiceField(
         choices=["sum", "avg", "count", "p95", "rate", "increase", "histogram_quantile"],
@@ -97,6 +133,17 @@ class _MetricQueryBodySerializer(serializers.Serializer):
         allow_null=True,
         help_text="Bucket size for the shared time grid. Omit to auto-pick (~60 buckets across the range).",
     )
+    clauses = _MetricClauseSerializer(
+        many=True,
+        required=False,
+        help_text="Full multi-clause form: each clause is an independent metric selection sharing the request's time grid. Mutually exclusive with 'metricName'.",
+    )
+    formula = serializers.CharField(
+        required=False,
+        allow_null=True,
+        max_length=512,
+        help_text="Arithmetic over clause names evaluated server-side per grid point, e.g. '(a - b) / a'. Supports + - * / and parentheses; division by zero yields 0. When set, only the formula result series are returned.",
+    )
     dateFrom = serializers.DateTimeField(
         help_text="Lower bound (inclusive) for the query range. ISO 8601.",
     )
@@ -105,9 +152,46 @@ class _MetricQueryBodySerializer(serializers.Serializer):
         help_text="Upper bound (exclusive) for the query range. Defaults to now if omitted.",
     )
 
+    def validate(self, attrs: dict) -> dict:
+        has_single = bool(attrs.get("metricName"))
+        has_clauses = bool(attrs.get("clauses"))
+        if has_single == has_clauses:
+            raise serializers.ValidationError("Provide exactly one of 'metricName' or 'clauses'.")
+        if attrs.get("formula") and not has_clauses:
+            raise serializers.ValidationError("'formula' requires 'clauses'.")
+        return attrs
+
 
 class _MetricQueryRequestSerializer(serializers.Serializer):
     query = _MetricQueryBodySerializer(help_text="The metric query to execute.")
+
+
+def _build_clause(data: dict, *, name: str) -> MetricQueryClause:
+    """Validated wire clause (or single-clause shorthand body) → contract.
+
+    The wire aggregation "p95" is contract QUANTILE(0.95)."""
+    aggregation_raw: str = data["aggregation"]
+    quantile: float | None = None
+    if aggregation_raw == "p95":
+        aggregation, quantile = MetricAggregation.QUANTILE, 0.95
+    elif aggregation_raw == "histogram_quantile":
+        aggregation, quantile = MetricAggregation.HISTOGRAM_QUANTILE, data.get("quantile")
+    else:
+        aggregation = MetricAggregation(aggregation_raw)
+
+    return MetricQueryClause(
+        name=name,
+        metric_name=data["metricName"],
+        aggregation=aggregation,
+        quantile=quantile,
+        filters=tuple(
+            MetricFilter(key=f["key"], op=FilterOp(f["op"]), value=f["value"], scope=AttributeScope(f["scope"]))
+            for f in data.get("filters") or []
+        ),
+        group_by=tuple(
+            MetricGroupBy(key=g["key"], scope=AttributeScope(g["scope"])) for g in data.get("groupBy") or []
+        ),
+    )
 
 
 class _MetricQueryPointSerializer(serializers.Serializer):
@@ -217,46 +301,18 @@ class MetricsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         body.is_valid(raise_exception=True)
         query_data = body.validated_data["query"]
 
-        # The wire aggregation "p95" is contract QUANTILE(0.95).
-        aggregation_raw: str = query_data["aggregation"]
-        if aggregation_raw == "p95":
-            aggregation, quantile = MetricAggregation.QUANTILE, 0.95
-        elif aggregation_raw == "histogram_quantile":
-            aggregation, quantile = MetricAggregation.HISTOGRAM_QUANTILE, query_data.get("quantile")
-            if quantile is None:
-                raise ParseError("histogram_quantile requires 'quantile'")
-        else:
-            aggregation, quantile = MetricAggregation(aggregation_raw), None
-
-        filters = tuple(
-            MetricFilter(
-                key=f["key"],
-                op=FilterOp(f["op"]),
-                value=f["value"],
-                scope=AttributeScope(f["scope"]),
-            )
-            for f in query_data.get("filters") or []
-        )
-        group_by = tuple(
-            MetricGroupBy(key=g["key"], scope=AttributeScope(g["scope"])) for g in query_data.get("groupBy") or []
-        )
-
         date_to: dt.datetime = query_data.get("dateTo") or timezone.now()
         try:
+            if query_data.get("clauses"):
+                clauses = tuple(_build_clause(c, name=c["name"]) for c in query_data["clauses"])
+            else:
+                clauses = (_build_clause(query_data, name="a"),)
             metric_request = MetricQueryRequest(
-                clauses=(
-                    MetricQueryClause(
-                        name="a",
-                        metric_name=query_data["metricName"],
-                        aggregation=aggregation,
-                        quantile=quantile,
-                        filters=filters,
-                        group_by=group_by,
-                    ),
-                ),
+                clauses=clauses,
                 date_from=query_data["dateFrom"],
                 date_to=date_to,
                 interval=query_data.get("interval"),
+                formula=query_data.get("formula"),
             )
             series = run_metric_query(team=self.team, request=metric_request)
         except ValueError as exc:
@@ -266,7 +322,9 @@ class MetricsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             request.user,
             "metrics query ran",
             {
-                "aggregation": query_data["aggregation"],
+                "aggregations": sorted({c.aggregation.value for c in clauses}),
+                "clause_count": len(clauses),
+                "has_formula": metric_request.formula is not None,
                 "series_count": len(series),
                 "result_count": sum(len(s.points) for s in series),
             },

--- a/products/metrics/backend/tests/test_metric_query_runner.py
+++ b/products/metrics/backend/tests/test_metric_query_runner.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from typing import Any
 
+import pytest
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import patch
 
@@ -19,6 +20,7 @@ from posthog.clickhouse.client.connection import Workload
 from products.metrics.backend.facade.api import run_metric_query
 from products.metrics.backend.facade.contracts import MetricFilter, MetricGroupBy, MetricQueryClause, MetricQueryRequest
 from products.metrics.backend.facade.enums import AttributeScope, FilterOp, MetricAggregation
+from products.metrics.backend.formula import evaluate, parse_formula
 from products.metrics.backend.metric_query_runner import (
     MetricQueryRunner,
     _histogram_quantile,
@@ -341,16 +343,6 @@ class TestRunMetricQueryFacade(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            (
-                "multi_clause",
-                {
-                    "clauses": (
-                        MetricQueryClause(name="a", metric_name="m1", aggregation=MetricAggregation.SUM),
-                        MetricQueryClause(name="b", metric_name="m2", aggregation=MetricAggregation.SUM),
-                    )
-                },
-            ),
-            ("formula", {"formula": "a / b"}),
             (
                 "unsupported_aggregation",
                 {"clauses": (MetricQueryClause(name="a", metric_name="m1", aggregation=MetricAggregation.MIN),)},
@@ -887,6 +879,191 @@ class TestHistogramQuantileRunner(ClickhouseTestMixin, APIBaseTest):
                 "query": {
                     "metricName": "latency",
                     "aggregation": "histogram_quantile",
+                    "dateFrom": (self.anchor - dt.timedelta(minutes=1)).isoformat(),
+                }
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TestFormulaParser:
+    @parameterized.expand(
+        [
+            ("add", "a + b", {"a": 3.0, "b": 4.0}, 7.0),
+            ("precedence", "a + b * 2", {"a": 1.0, "b": 2.0}, 5.0),
+            ("parens", "(a - b) / a", {"a": 10.0, "b": 4.0}, 0.6),
+            ("unary_minus", "-a + 5", {"a": 2.0}, 3.0),
+            ("division_by_zero_yields_zero", "a / b", {"a": 5.0, "b": 0.0}, 0.0),
+            ("number_only_arithmetic", "a * 0 + 1.5", {"a": 9.0}, 1.5),
+        ]
+    )
+    def test_evaluate(self, _name, formula, values, expected):
+        node = parse_formula(formula, frozenset(values))
+        assert abs(evaluate(node, values) - expected) < 1e-9
+
+    @parameterized.expand(
+        [
+            ("unknown_clause", "a + zz", frozenset({"a", "b"})),
+            ("unbalanced_parens", "(a + b", frozenset({"a", "b"})),
+            ("trailing_garbage", "a + b )", frozenset({"a", "b"})),
+            ("empty", "   ", frozenset({"a"})),
+            ("bad_char", "a ^ b", frozenset({"a", "b"})),
+        ]
+    )
+    def test_rejects(self, _name, formula, names):
+        with pytest.raises(ValueError):
+            parse_formula(formula, names)
+
+
+class TestMultiClauseAndFormulas(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    def setUp(self):
+        super().setUp()
+        sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+        self.anchor = (timezone.now() - dt.timedelta(minutes=30)).replace(second=0, microsecond=0)
+        # errors: 2 then 4; requests: 10 then 20 (per-minute buckets)
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="errors",
+            points=[(self.anchor + dt.timedelta(seconds=10), 2.0), (self.anchor + dt.timedelta(seconds=70), 4.0)],
+        )
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="requests",
+            points=[(self.anchor + dt.timedelta(seconds=10), 10.0), (self.anchor + dt.timedelta(seconds=70), 20.0)],
+        )
+
+    def _request(self, formula=None, clauses=None):
+        return MetricQueryRequest(
+            clauses=clauses
+            or (
+                MetricQueryClause(name="a", metric_name="errors", aggregation=MetricAggregation.SUM),
+                MetricQueryClause(name="b", metric_name="requests", aggregation=MetricAggregation.SUM),
+            ),
+            date_from=self.anchor - dt.timedelta(minutes=1),
+            date_to=self.anchor + dt.timedelta(minutes=2),
+            interval="minute",
+            formula=formula,
+        )
+
+    def test_multi_clause_returns_all_series_on_shared_grid(self):
+        series = run_metric_query(team=self.team, request=self._request())
+        self.assertEqual(len(series), 2)
+        by_clause = {s.clause: s for s in series}
+        self.assertEqual([p.value for p in by_clause["a"].points], [2.0, 4.0])
+        self.assertEqual([p.value for p in by_clause["b"].points], [10.0, 20.0])
+        self.assertEqual(
+            [p.time for p in by_clause["a"].points],
+            [p.time for p in by_clause["b"].points],
+        )
+
+    def test_formula_error_rate(self):
+        series = run_metric_query(team=self.team, request=self._request(formula="a / b"))
+        self.assertEqual(len(series), 1)
+        self.assertEqual(series[0].clause, "formula")
+        self.assertIsNone(series[0].metric_name)
+        self.assertEqual([p.value for p in series[0].points], [0.2, 0.2])
+
+    def test_formula_matches_grouped_series_by_label_set(self):
+        sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+        for env, errors, requests in [("prod", 1.0, 10.0), ("dev", 3.0, 6.0)]:
+            seed_metric(
+                team_id=self.team.id,
+                metric_name="errors",
+                points=[(self.anchor + dt.timedelta(seconds=10), errors)],
+                labels={"env": env},
+            )
+            seed_metric(
+                team_id=self.team.id,
+                metric_name="requests",
+                points=[(self.anchor + dt.timedelta(seconds=10), requests)],
+                labels={"env": env},
+            )
+        group = (MetricGroupBy(key="env"),)
+        series = run_metric_query(
+            team=self.team,
+            request=self._request(
+                formula="a / b",
+                clauses=(
+                    MetricQueryClause(
+                        name="a", metric_name="errors", aggregation=MetricAggregation.SUM, group_by=group
+                    ),
+                    MetricQueryClause(
+                        name="b", metric_name="requests", aggregation=MetricAggregation.SUM, group_by=group
+                    ),
+                ),
+            ),
+        )
+        by_env = {s.labels["env"]: [p.value for p in s.points] for s in series}
+        self.assertEqual(by_env, {"prod": [0.1], "dev": [0.5]})
+
+    def test_formula_broadcasts_ungrouped_clause(self):
+        sync_execute("TRUNCATE TABLE IF EXISTS metrics1")
+        for env, errors in [("prod", 2.0), ("dev", 6.0)]:
+            seed_metric(
+                team_id=self.team.id,
+                metric_name="errors",
+                points=[(self.anchor + dt.timedelta(seconds=10), errors)],
+                labels={"env": env},
+            )
+        seed_metric(
+            team_id=self.team.id,
+            metric_name="requests",
+            points=[(self.anchor + dt.timedelta(seconds=10), 20.0)],
+        )
+        series = run_metric_query(
+            team=self.team,
+            request=self._request(
+                formula="a / b",
+                clauses=(
+                    MetricQueryClause(
+                        name="a",
+                        metric_name="errors",
+                        aggregation=MetricAggregation.SUM,
+                        group_by=(MetricGroupBy(key="env"),),
+                    ),
+                    MetricQueryClause(name="b", metric_name="requests", aggregation=MetricAggregation.SUM),
+                ),
+            ),
+        )
+        by_env = {s.labels["env"]: [p.value for p in s.points] for s in series}
+        self.assertEqual(by_env, {"prod": [0.1], "dev": [0.3]})
+
+    def test_unknown_clause_in_formula_raises(self):
+        with self.assertRaises(ValueError):
+            run_metric_query(team=self.team, request=self._request(formula="a / zz"))
+
+    def test_clauses_and_formula_via_api(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/metrics/query",
+            data={
+                "query": {
+                    "clauses": [
+                        {"name": "a", "metricName": "errors", "aggregation": "sum"},
+                        {"name": "b", "metricName": "requests", "aggregation": "sum"},
+                    ],
+                    "formula": "(b - a) / b",
+                    "interval": "minute",
+                    "dateFrom": (self.anchor - dt.timedelta(minutes=1)).isoformat(),
+                    "dateTo": (self.anchor + dt.timedelta(minutes=2)).isoformat(),
+                }
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        series = response.json()["results"][0]
+        self.assertEqual(series["clause"], "formula")
+        self.assertEqual([p["value"] for p in series["points"]], [0.8, 0.8])
+
+    def test_api_rejects_both_shorthand_and_clauses(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/metrics/query",
+            data={
+                "query": {
+                    "metricName": "errors",
+                    "clauses": [{"name": "a", "metricName": "errors"}],
                     "dateFrom": (self.anchor - dt.timedelta(minutes=1)).isoformat(),
                 }
             },

--- a/products/metrics/frontend/generated/api.schemas.ts
+++ b/products/metrics/frontend/generated/api.schemas.ts
@@ -132,12 +132,46 @@ export const MetricQueryIntervalEnumApi = {
     Week: 'week',
 } as const
 
-export interface _MetricQueryBodyApi {
+export interface _MetricClauseApi {
     /**
-     * Exact metric name to query (e.g. 'http.server.duration').
+     * Clause name a formula refers to (e.g. 'a').
+     * @maxLength 64
+     */
+    name: string
+    /**
+     * Exact metric name this clause queries.
      * @maxLength 255
      */
     metricName: string
+    /** Aggregation applied per time bucket; same semantics as the top-level aggregation.
+     *
+     * * `sum` - sum
+     * * `avg` - avg
+     * * `count` - count
+     * * `p95` - p95
+     * * `rate` - rate
+     * * `increase` - increase
+     * * `histogram_quantile` - histogram_quantile */
+    aggregation?: AggregationEnumApi
+    /**
+     * Quantile in (0, 1) for 'histogram_quantile'.
+     * @minimum 0
+     * @maximum 1
+     * @nullable
+     */
+    quantile?: number | null
+    /** Label predicates ANDed together for this clause. */
+    filters?: _MetricFilterApi[]
+    /** Labels to split this clause into separate series by. */
+    groupBy?: _MetricGroupByApi[]
+}
+
+export interface _MetricQueryBodyApi {
+    /**
+     * Exact metric name to query (e.g. 'http.server.duration'). Single-clause shorthand — mutually exclusive with 'clauses'.
+     * @maxLength 255
+     */
+    metricName?: string
     /** Aggregation applied per time bucket. 'rate' (per-second) and 'increase' are counter-aware: per-series deltas with Prometheus counter-reset handling, temporality-aware (delta-temporality samples count as-is). 'histogram_quantile' interpolates from OTel histogram buckets and requires 'quantile'.
      *
      * * `sum` - sum
@@ -170,6 +204,14 @@ export interface _MetricQueryBodyApi {
      * * `day` - day
      * * `week` - week */
     interval?: MetricQueryIntervalEnumApi | null
+    /** Full multi-clause form: each clause is an independent metric selection sharing the request's time grid. Mutually exclusive with 'metricName'. */
+    clauses?: _MetricClauseApi[]
+    /**
+     * Arithmetic over clause names evaluated server-side per grid point, e.g. '(a - b) / a'. Supports + - * / and parentheses; division by zero yields 0. When set, only the formula result series are returned.
+     * @maxLength 512
+     * @nullable
+     */
+    formula?: string | null
     /** Lower bound (inclusive) for the query range. ISO 8601. */
     dateFrom: string
     /** Upper bound (exclusive) for the query range. Defaults to now if omitted. */

--- a/products/metrics/frontend/generated/api.zod.ts
+++ b/products/metrics/frontend/generated/api.zod.ts
@@ -22,6 +22,22 @@ export const metricsQueryCreateBodyQueryOneFiltersItemScopeDefault = `auto`
 export const metricsQueryCreateBodyQueryOneGroupByItemKeyMax = 255
 
 export const metricsQueryCreateBodyQueryOneGroupByItemScopeDefault = `auto`
+export const metricsQueryCreateBodyQueryOneClausesItemNameMax = 64
+
+export const metricsQueryCreateBodyQueryOneClausesItemMetricNameMax = 255
+
+export const metricsQueryCreateBodyQueryOneClausesItemAggregationDefault = `sum`
+export const metricsQueryCreateBodyQueryOneClausesItemQuantileMin = 0
+export const metricsQueryCreateBodyQueryOneClausesItemQuantileMax = 1
+
+export const metricsQueryCreateBodyQueryOneClausesItemFiltersItemKeyMax = 255
+
+export const metricsQueryCreateBodyQueryOneClausesItemFiltersItemOpDefault = `eq`
+export const metricsQueryCreateBodyQueryOneClausesItemFiltersItemScopeDefault = `auto`
+export const metricsQueryCreateBodyQueryOneClausesItemGroupByItemKeyMax = 255
+
+export const metricsQueryCreateBodyQueryOneClausesItemGroupByItemScopeDefault = `auto`
+export const metricsQueryCreateBodyQueryOneFormulaMax = 512
 
 export const MetricsQueryCreateBody = /* @__PURE__ */ zod.object({
     query: zod
@@ -29,7 +45,10 @@ export const MetricsQueryCreateBody = /* @__PURE__ */ zod.object({
             metricName: zod
                 .string()
                 .max(metricsQueryCreateBodyQueryOneMetricNameMax)
-                .describe("Exact metric name to query (e.g. 'http.server.duration')."),
+                .optional()
+                .describe(
+                    "Exact metric name to query (e.g. 'http.server.duration'). Single-clause shorthand — mutually exclusive with 'clauses'."
+                ),
             aggregation: zod
                 .enum(['sum', 'avg', 'count', 'p95', 'rate', 'increase', 'histogram_quantile'])
                 .describe(
@@ -107,6 +126,99 @@ export const MetricsQueryCreateBody = /* @__PURE__ */ zod.object({
                 .optional()
                 .describe(
                     'Bucket size for the shared time grid. Omit to auto-pick (~60 buckets across the range).\n\n\* `second` - second\n\* `minute` - minute\n\* `minute_5` - minute_5\n\* `minute_15` - minute_15\n\* `hour` - hour\n\* `hour_6` - hour_6\n\* `day` - day\n\* `week` - week'
+                ),
+            clauses: zod
+                .array(
+                    zod.object({
+                        name: zod
+                            .string()
+                            .max(metricsQueryCreateBodyQueryOneClausesItemNameMax)
+                            .describe("Clause name a formula refers to (e.g. 'a')."),
+                        metricName: zod
+                            .string()
+                            .max(metricsQueryCreateBodyQueryOneClausesItemMetricNameMax)
+                            .describe('Exact metric name this clause queries.'),
+                        aggregation: zod
+                            .enum(['sum', 'avg', 'count', 'p95', 'rate', 'increase', 'histogram_quantile'])
+                            .describe(
+                                '\* `sum` - sum\n\* `avg` - avg\n\* `count` - count\n\* `p95` - p95\n\* `rate` - rate\n\* `increase` - increase\n\* `histogram_quantile` - histogram_quantile'
+                            )
+                            .default(metricsQueryCreateBodyQueryOneClausesItemAggregationDefault)
+                            .describe(
+                                'Aggregation applied per time bucket; same semantics as the top-level aggregation.\n\n\* `sum` - sum\n\* `avg` - avg\n\* `count` - count\n\* `p95` - p95\n\* `rate` - rate\n\* `increase` - increase\n\* `histogram_quantile` - histogram_quantile'
+                            ),
+                        quantile: zod
+                            .number()
+                            .min(metricsQueryCreateBodyQueryOneClausesItemQuantileMin)
+                            .max(metricsQueryCreateBodyQueryOneClausesItemQuantileMax)
+                            .nullish()
+                            .describe("Quantile in (0, 1) for 'histogram_quantile'."),
+                        filters: zod
+                            .array(
+                                zod.object({
+                                    key: zod
+                                        .string()
+                                        .max(metricsQueryCreateBodyQueryOneClausesItemFiltersItemKeyMax)
+                                        .describe(
+                                            "Attribute name to filter on, without any type-tag suffix (e.g. 'k8s.pod.name', 'env')."
+                                        ),
+                                    op: zod
+                                        .enum(['eq', 'neq', 'regex', 'not_regex'])
+                                        .describe(
+                                            '\* `eq` - eq\n\* `neq` - neq\n\* `regex` - regex\n\* `not_regex` - not_regex'
+                                        )
+                                        .default(metricsQueryCreateBodyQueryOneClausesItemFiltersItemOpDefault)
+                                        .describe(
+                                            "Comparison operator. 'regex'\/'not_regex' use RE2 syntax. Negative operators also match rows that lack the key entirely, mirroring Prometheus negative matchers.\n\n\* `eq` - eq\n\* `neq` - neq\n\* `regex` - regex\n\* `not_regex` - not_regex"
+                                        ),
+                                    value: zod
+                                        .string()
+                                        .describe('Value to compare against. For regex operators this is the pattern.'),
+                                    scope: zod
+                                        .enum(['resource', 'attribute', 'auto'])
+                                        .describe(
+                                            '\* `resource` - resource\n\* `attribute` - attribute\n\* `auto` - auto'
+                                        )
+                                        .default(metricsQueryCreateBodyQueryOneClausesItemFiltersItemScopeDefault)
+                                        .describe(
+                                            "Where the attribute lives: 'resource' = per-target resource attributes (k8s.pod.name, service.version), 'attribute' = per-datapoint attributes (http.method, path), 'auto' = resource first with per-datapoint fallback. Use 'auto' unless you know the exact scope.\n\n\* `resource` - resource\n\* `attribute` - attribute\n\* `auto` - auto"
+                                        ),
+                                })
+                            )
+                            .optional()
+                            .describe('Label predicates ANDed together for this clause.'),
+                        groupBy: zod
+                            .array(
+                                zod.object({
+                                    key: zod
+                                        .string()
+                                        .max(metricsQueryCreateBodyQueryOneClausesItemGroupByItemKeyMax)
+                                        .describe("Attribute name to split series by (e.g. 'k8s.pod.name', 'env')."),
+                                    scope: zod
+                                        .enum(['resource', 'attribute', 'auto'])
+                                        .describe(
+                                            '\* `resource` - resource\n\* `attribute` - attribute\n\* `auto` - auto'
+                                        )
+                                        .default(metricsQueryCreateBodyQueryOneClausesItemGroupByItemScopeDefault)
+                                        .describe(
+                                            "Where the attribute lives; same semantics as filter scope. Use 'auto' unless you know the exact scope.\n\n\* `resource` - resource\n\* `attribute` - attribute\n\* `auto` - auto"
+                                        ),
+                                })
+                            )
+                            .optional()
+                            .describe('Labels to split this clause into separate series by.'),
+                    })
+                )
+                .optional()
+                .describe(
+                    "Full multi-clause form: each clause is an independent metric selection sharing the request's time grid. Mutually exclusive with 'metricName'."
+                ),
+            formula: zod
+                .string()
+                .max(metricsQueryCreateBodyQueryOneFormulaMax)
+                .nullish()
+                .describe(
+                    "Arithmetic over clause names evaluated server-side per grid point, e.g. '(a - b) \/ a'. Supports + - \* \/ and parentheses; division by zero yields 0. When set, only the formula result series are returned."
                 ),
             dateFrom: zod.iso
                 .datetime({ offset: true })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48267,6 +48267,40 @@ export namespace Schemas {
       scope?: MetricAttributeScopeEnum;
     }
 
+    export interface _MetricClause {
+      /**
+         * Clause name a formula refers to (e.g. 'a').
+         * @maxLength 64
+         */
+      name: string;
+      /**
+         * Exact metric name this clause queries.
+         * @maxLength 255
+         */
+      metricName: string;
+      /** Aggregation applied per time bucket; same semantics as the top-level aggregation.
+       *
+       * * `sum` - sum
+       * * `avg` - avg
+       * * `count` - count
+       * * `p95` - p95
+       * * `rate` - rate
+       * * `increase` - increase
+       * * `histogram_quantile` - histogram_quantile */
+      aggregation?: AggregationEnum;
+      /**
+         * Quantile in (0, 1) for 'histogram_quantile'.
+         * @minimum 0
+         * @maximum 1
+         * @nullable
+         */
+      quantile?: number | null;
+      /** Label predicates ANDed together for this clause. */
+      filters?: _MetricFilter[];
+      /** Labels to split this clause into separate series by. */
+      groupBy?: _MetricGroupBy[];
+    }
+
     export interface _MetricName {
       /** Metric name as it appears in the team's data. */
       name: string;
@@ -48281,10 +48315,10 @@ export namespace Schemas {
 
     export interface _MetricQueryBody {
       /**
-         * Exact metric name to query (e.g. 'http.server.duration').
+         * Exact metric name to query (e.g. 'http.server.duration'). Single-clause shorthand — mutually exclusive with 'clauses'.
          * @maxLength 255
          */
-      metricName: string;
+      metricName?: string;
       /** Aggregation applied per time bucket. 'rate' (per-second) and 'increase' are counter-aware: per-series deltas with Prometheus counter-reset handling, temporality-aware (delta-temporality samples count as-is). 'histogram_quantile' interpolates from OTel histogram buckets and requires 'quantile'.
        *
        * * `sum` - sum
@@ -48317,6 +48351,14 @@ export namespace Schemas {
        * * `day` - day
        * * `week` - week */
       interval?: MetricQueryIntervalEnum | null;
+      /** Full multi-clause form: each clause is an independent metric selection sharing the request's time grid. Mutually exclusive with 'metricName'. */
+      clauses?: _MetricClause[];
+      /**
+         * Arithmetic over clause names evaluated server-side per grid point, e.g. '(a - b) / a'. Supports + - * / and parentheses; division by zero yields 0. When set, only the formula result series are returned.
+         * @maxLength 512
+         * @nullable
+         */
+      formula?: string | null;
       /** Lower bound (inclusive) for the query range. ISO 8601. */
       dateFrom: string;
       /** Upper bound (exclusive) for the query range. Defaults to now if omitted. */


### PR DESCRIPTION
## Problem

Real dashboard panels and investigations need derived values — error *ratio*, bytes *per record* — not just raw series. Client-side math can't be reused by alerts or the MCP; this belongs server-side.

## Changes

- Query body accepts either the single-metric shorthand **or** `clauses: [{name, metricName, aggregation, …}]` (mutually exclusive, serializer-validated). Each clause supports its own filters/group-by; all clauses share the request's zero-filled time grid.
- `formula` ("(a - b) / a") over clause names, evaluated per grid point by a ~100-line recursive-descent parser (`products/metrics/backend/formula.py`): numbers, identifiers, `+ - * /`, unary minus, parentheses. **Nothing is eval'd.** Unknown clause names 400 with the available names listed.
- Series matched across clauses by exact label-set equality (Prometheus one-to-one vector matching); an ungrouped clause broadcasts to every label-set. Division by zero yields 0 (charts and thresholds want a number, not NaN).
- With a formula set, only the formula result series return (`clause: "formula"`).

## How did you test this code?

I'm an agent. Automated: parser unit tests (precedence, parens, unary minus, rejection cases) + ClickHouse-backed tests for multi-clause grids, grouped-formula label matching, broadcast, and the API path. Live check with the local pipe:

```bash
... -d '{"query": {"clauses": [{"name": "bytes", "metricName": "metrics_ingestion_bytes_received_total", "aggregation": "rate"}, {"name": "recs", "metricName": "metrics_ingestion_records_received_total", "aggregation": "rate"}], "formula": "bytes / recs", "interval": "minute_5", "dateFrom": "<30m ago>"}}'
# => a steady ~201 bytes-per-record series computed server-side
```

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @DanielVisca

This completes the query-layer scope from the dashboard-MVP design doc (P0–P7). The doc's P8–P13 (widget/dashboard UI) are intentionally not in this stack.