### PR TITLE
feat(metrics): add internal-infra exemption to metrics rate limiter

### DIFF
--- a/nodejs/src/metrics-ingestion/config.ts
+++ b/nodejs/src/metrics-ingestion/config.ts
@@ -36,6 +36,7 @@ export type MetricsIngestionConsumerConfig = {
     METRICS_REDIS_TLS: boolean
     METRICS_LIMITER_ENABLED_TEAMS: string
     METRICS_LIMITER_DISABLED_FOR_TEAMS: string
+    METRICS_LIMITER_EXEMPT_TEAMS: string
     METRICS_LIMITER_BUCKET_SIZE_KB: number
     METRICS_LIMITER_REFILL_RATE_KB_PER_SECOND: number
     METRICS_LIMITER_TTL_SECONDS: number
@@ -60,6 +61,9 @@ export function getDefaultMetricsIngestionConsumerConfig(): MetricsIngestionCons
         METRICS_REDIS_TLS: isProdEnv() ? true : false,
         METRICS_LIMITER_ENABLED_TEAMS: isProdEnv() ? '' : '*',
         METRICS_LIMITER_DISABLED_FOR_TEAMS: '',
+        // Internal-infrastructure teams (comma-separated IDs) that bypass both quota and rate
+        // limiting — their metrics must never be dropped by per-team throttling.
+        METRICS_LIMITER_EXEMPT_TEAMS: '',
         METRICS_LIMITER_BUCKET_SIZE_KB: 10000,
         METRICS_LIMITER_REFILL_RATE_KB_PER_SECOND: 1000,
         METRICS_LIMITER_TTL_SECONDS: 60 * 60 * 24,

--- a/nodejs/src/metrics-ingestion/metrics-ingestion-consumer.test.ts
+++ b/nodejs/src/metrics-ingestion/metrics-ingestion-consumer.test.ts
@@ -1,0 +1,91 @@
+import { QuotaLimiting } from '~/common/services/quota-limiting.service'
+
+import { MetricsIngestionConsumerConfig, getDefaultMetricsIngestionConsumerConfig } from './config'
+import { MetricsIngestionConsumer, MetricsIngestionConsumerDeps } from './metrics-ingestion-consumer'
+import { MetricsIngestionMessage } from './types'
+
+describe('MetricsIngestionConsumer', () => {
+    describe('filterQuotaLimitedMessages', () => {
+        let isTeamTokenQuotaLimited: jest.Mock
+
+        const createConsumer = (overrides: Partial<MetricsIngestionConsumerConfig> = {}): MetricsIngestionConsumer => {
+            const config: MetricsIngestionConsumerConfig = {
+                ...getDefaultMetricsIngestionConsumerConfig(),
+                ...overrides,
+            }
+            const deps: MetricsIngestionConsumerDeps = {
+                teamManager: {} as any,
+                quotaLimiting: { isTeamTokenQuotaLimited } as unknown as QuotaLimiting,
+                outputs: {} as any,
+            }
+            return new MetricsIngestionConsumer(config, deps)
+        }
+
+        const createMessage = (teamId: number): MetricsIngestionMessage => ({
+            token: `token-${teamId}`,
+            teamId,
+            message: { value: Buffer.from('test') } as any,
+            bytesUncompressed: 1024,
+            bytesCompressed: 512,
+            recordCount: 1,
+        })
+
+        beforeEach(() => {
+            isTeamTokenQuotaLimited = jest.fn().mockResolvedValue(false)
+        })
+
+        it('should allow messages when not quota limited', async () => {
+            const consumer = createConsumer()
+            const messages = [createMessage(1), createMessage(2)]
+
+            const { quotaAllowedMessages, quotaDroppedMessages } =
+                await consumer['filterQuotaLimitedMessages'](messages)
+
+            expect(quotaAllowedMessages).toHaveLength(2)
+            expect(quotaDroppedMessages).toHaveLength(0)
+        })
+
+        it('should drop quota-limited messages for non-exempt teams', async () => {
+            isTeamTokenQuotaLimited.mockImplementation((token: string) => Promise.resolve(token === 'token-1'))
+            const consumer = createConsumer()
+            const messages = [createMessage(1), createMessage(2)]
+
+            const { quotaAllowedMessages, quotaDroppedMessages } =
+                await consumer['filterQuotaLimitedMessages'](messages)
+
+            expect(quotaAllowedMessages).toHaveLength(1)
+            expect(quotaAllowedMessages[0].teamId).toBe(2)
+            expect(quotaDroppedMessages).toHaveLength(1)
+            expect(quotaDroppedMessages[0].teamId).toBe(1)
+        })
+
+        it('should bypass quota enforcement for teams in METRICS_LIMITER_EXEMPT_TEAMS', async () => {
+            isTeamTokenQuotaLimited.mockResolvedValue(true) // every token is quota limited
+            const consumer = createConsumer({ METRICS_LIMITER_EXEMPT_TEAMS: '2' })
+            const messages = [createMessage(1), createMessage(2)]
+
+            const { quotaAllowedMessages, quotaDroppedMessages } =
+                await consumer['filterQuotaLimitedMessages'](messages)
+
+            expect(quotaAllowedMessages).toHaveLength(1)
+            expect(quotaAllowedMessages[0].teamId).toBe(2)
+            expect(quotaDroppedMessages).toHaveLength(1)
+            expect(quotaDroppedMessages[0].teamId).toBe(1)
+            // Exempt teams skip the quota lookup entirely
+            expect(isTeamTokenQuotaLimited).toHaveBeenCalledTimes(1)
+            expect(isTeamTokenQuotaLimited).toHaveBeenCalledWith('token-1', 'metrics_mb_ingested')
+        })
+
+        it('should enforce quota for everyone when the exemption list is empty', async () => {
+            isTeamTokenQuotaLimited.mockResolvedValue(true)
+            const consumer = createConsumer({ METRICS_LIMITER_EXEMPT_TEAMS: '' })
+            const messages = [createMessage(1), createMessage(2)]
+
+            const { quotaAllowedMessages, quotaDroppedMessages } =
+                await consumer['filterQuotaLimitedMessages'](messages)
+
+            expect(quotaAllowedMessages).toHaveLength(0)
+            expect(quotaDroppedMessages).toHaveLength(2)
+        })
+    })
+})

--- a/nodejs/src/metrics-ingestion/metrics-ingestion-consumer.ts
+++ b/nodejs/src/metrics-ingestion/metrics-ingestion-consumer.ts
@@ -235,7 +235,12 @@ export class MetricsIngestionConsumer {
         const quotaDroppedMessages: MetricsIngestionMessage[] = []
         const quotaAllowedMessages: MetricsIngestionMessage[] = []
 
-        const uniqueTokens = [...new Set(messages.map((m) => m.token))]
+        // Internal-infra teams (METRICS_LIMITER_EXEMPT_TEAMS) bypass quota enforcement entirely:
+        // their tokens are excluded from the quota lookup, so their messages can never be dropped
+        // here. A token maps to exactly one team, so filtering by team is sufficient.
+        const uniqueTokens = [
+            ...new Set(messages.filter((m) => !this.rateLimiter.isTeamExempt(m.teamId)).map((m) => m.token)),
+        ]
 
         const quotaLimitedTokens = new Set(
             (

--- a/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.test.ts
+++ b/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.test.ts
@@ -1,0 +1,181 @@
+import { deleteKeysWithPrefix } from '~/cdp/_tests/redis'
+import { RedisV2, createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
+
+import { MetricsIngestionConsumerConfig, getDefaultMetricsIngestionConsumerConfig } from '../config'
+import { BASE_REDIS_KEY, MetricsRateLimiterService } from './metrics-rate-limiter.service'
+
+const mockNow: jest.SpyInstance = jest.spyOn(Date, 'now')
+
+describe('MetricsRateLimiterService', () => {
+    jest.retryTimes(3)
+    const BUCKET_SIZE_KB = 10
+    const BUCKET_EXCEEDED_UNCOMPRESSED_BYTES = 15360 // 15KB > 10KB bucket
+
+    let config: MetricsIngestionConsumerConfig
+    let rateLimiter: MetricsRateLimiterService
+    let redis: RedisV2
+
+    const createMessage = (teamId: number, bytesUncompressed: number): any => ({
+        teamId,
+        bytesUncompressed,
+        bytesCompressed: Math.floor(bytesUncompressed / 2),
+        recordCount: 1,
+        token: `token-${teamId}`,
+        message: { value: Buffer.from('test') },
+    })
+
+    beforeEach(async () => {
+        mockNow.mockReturnValue(1720000000000)
+
+        config = {
+            ...getDefaultMetricsIngestionConsumerConfig(),
+            METRICS_LIMITER_BUCKET_SIZE_KB: BUCKET_SIZE_KB,
+            METRICS_LIMITER_REFILL_RATE_KB_PER_SECOND: 1,
+            METRICS_LIMITER_TTL_SECONDS: 3600,
+            METRICS_LIMITER_ENABLED_TEAMS: '*',
+            METRICS_LIMITER_DISABLED_FOR_TEAMS: '',
+            METRICS_LIMITER_EXEMPT_TEAMS: '',
+            METRICS_LIMITER_TEAM_BUCKET_SIZE_KB: '',
+            METRICS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND: '',
+        }
+
+        redis = createRedisV2PoolFromConfig({
+            connection: {
+                url: config.METRICS_REDIS_HOST,
+                options: { port: config.METRICS_REDIS_PORT, tls: config.METRICS_REDIS_TLS ? {} : undefined },
+            },
+            poolMinSize: config.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: config.REDIS_POOL_MAX_SIZE,
+        })
+        await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
+
+        rateLimiter = new MetricsRateLimiterService(config, redis)
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('filterMessages', () => {
+        it('should allow messages within bucket size', async () => {
+            const messages = [createMessage(1, 5120), createMessage(1, 3072)] // 5KB + 3KB = 8KB < 10KB
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(2)
+            expect(result.dropped).toHaveLength(0)
+        })
+
+        it('should drop messages exceeding bucket size', async () => {
+            const messages = [createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES)] // 15KB > 10KB
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(0)
+            expect(result.dropped).toHaveLength(1)
+        })
+
+        it('should skip rate limiting when METRICS_LIMITER_ENABLED_TEAMS is empty', async () => {
+            config.METRICS_LIMITER_ENABLED_TEAMS = ''
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            const messages = [createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES)]
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(1)
+            expect(result.dropped).toHaveLength(0)
+        })
+    })
+
+    describe('exemption (METRICS_LIMITER_EXEMPT_TEAMS)', () => {
+        it('should keep throttling unchanged when the exemption list is empty', async () => {
+            const messages = [createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES)]
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(0)
+            expect(result.dropped).toHaveLength(1)
+        })
+
+        it('should always allow exempt teams while still throttling non-exempt teams', async () => {
+            config.METRICS_LIMITER_EXEMPT_TEAMS = '1'
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            const messages = [
+                createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES), // exempt - allowed despite exceeding bucket
+                createMessage(2, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES), // not exempt - dropped
+            ]
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(1)
+            expect(result.allowed[0].teamId).toBe(1)
+            expect(result.dropped).toHaveLength(1)
+            expect(result.dropped[0].teamId).toBe(2)
+        })
+
+        it('should prioritize METRICS_LIMITER_EXEMPT_TEAMS over METRICS_LIMITER_ENABLED_TEAMS', async () => {
+            config.METRICS_LIMITER_ENABLED_TEAMS = '1, 2'
+            config.METRICS_LIMITER_EXEMPT_TEAMS = '1'
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            const messages = [
+                createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES),
+                createMessage(2, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES),
+            ]
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(1)
+            expect(result.allowed[0].teamId).toBe(1)
+            expect(result.dropped).toHaveLength(1)
+            expect(result.dropped[0].teamId).toBe(2)
+        })
+
+        it('should exempt all teams when METRICS_LIMITER_EXEMPT_TEAMS is *', async () => {
+            config.METRICS_LIMITER_EXEMPT_TEAMS = '*'
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            const messages = [
+                createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES),
+                createMessage(2, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES),
+            ]
+
+            const result = await rateLimiter.filterMessages(messages)
+
+            expect(result.allowed).toHaveLength(2)
+            expect(result.dropped).toHaveLength(0)
+        })
+
+        it('should not consume tokens for exempt teams', async () => {
+            config.METRICS_LIMITER_EXEMPT_TEAMS = '1'
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            const result = await rateLimiter.filterMessages([createMessage(1, BUCKET_EXCEEDED_UNCOMPRESSED_BYTES)])
+            expect(result.allowed).toHaveLength(1)
+
+            // The exempt traffic must not have touched team 1's token bucket: a limiter
+            // without the exemption should still see a full bucket for that team.
+            config.METRICS_LIMITER_EXEMPT_TEAMS = ''
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            const [[, limit]] = await rateLimiter.rateLimitMany([['1', 0, Math.round(Date.now() / 1000)]])
+            expect(limit.tokensBefore).toBe(BUCKET_SIZE_KB)
+        })
+
+        it.each([
+            { exemptConfig: '', teamId: 2, expected: false, description: 'empty list exempts nobody' },
+            { exemptConfig: '2', teamId: 2, expected: true, description: 'single team match' },
+            { exemptConfig: '2', teamId: 3, expected: false, description: 'single team non-match' },
+            { exemptConfig: '1, 2', teamId: 2, expected: true, description: 'multiple teams with spaces' },
+            { exemptConfig: '*', teamId: 99, expected: true, description: 'wildcard exempts everyone' },
+            { exemptConfig: 'abc', teamId: 2, expected: false, description: 'malformed entry is ignored' },
+        ])('isTeamExempt: $description', ({ exemptConfig, teamId, expected }) => {
+            config.METRICS_LIMITER_EXEMPT_TEAMS = exemptConfig
+            rateLimiter = new MetricsRateLimiterService(config, redis)
+
+            expect(rateLimiter.isTeamExempt(teamId)).toBe(expected)
+        })
+    })
+})

--- a/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.ts
+++ b/nodejs/src/metrics-ingestion/services/metrics-rate-limiter.service.ts
@@ -20,6 +20,7 @@ export type MetricsRateLimiterConfig = Pick<
     | 'METRICS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND'
     | 'METRICS_LIMITER_DISABLED_FOR_TEAMS'
     | 'METRICS_LIMITER_ENABLED_TEAMS'
+    | 'METRICS_LIMITER_EXEMPT_TEAMS'
     | 'METRICS_LIMITER_BUCKET_SIZE_KB'
     | 'METRICS_LIMITER_REFILL_RATE_KB_PER_SECOND'
     | 'METRICS_LIMITER_TTL_SECONDS'
@@ -45,6 +46,7 @@ export class MetricsRateLimiterService {
     private teamRefillRates: Map<number, number>
     private disabledTeamIds: Set<number> | '*' | null
     private enabledTeamIds: Set<number> | '*' | null
+    private exemptTeamIds: Set<number> | '*' | null
 
     constructor(
         private config: MetricsRateLimiterConfig,
@@ -54,6 +56,7 @@ export class MetricsRateLimiterService {
         this.teamRefillRates = this.parseTeamConfig(config.METRICS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND)
         this.disabledTeamIds = this.parseTeamIdList(config.METRICS_LIMITER_DISABLED_FOR_TEAMS)
         this.enabledTeamIds = this.parseTeamIdList(config.METRICS_LIMITER_ENABLED_TEAMS)
+        this.exemptTeamIds = this.parseTeamIdList(config.METRICS_LIMITER_EXEMPT_TEAMS)
     }
 
     private parseTeamIdList(config: string): Set<number> | '*' | null {
@@ -154,7 +157,23 @@ export class MetricsRateLimiterService {
         })
     }
 
+    /**
+     * Internal-infrastructure teams (METRICS_LIMITER_EXEMPT_TEAMS) whose metrics must never be
+     * throttled. Exempt teams bypass both quota and rate limiting, and skip token-bucket
+     * accounting so their traffic doesn't pollute per-team quota state.
+     */
+    public isTeamExempt(teamId: number): boolean {
+        if (this.exemptTeamIds === '*') {
+            return true
+        }
+        return this.exemptTeamIds?.has(teamId) ?? false
+    }
+
     private isRateLimitingEnabledForTeam(teamId: number): boolean {
+        if (this.isTeamExempt(teamId)) {
+            return false
+        }
+
         if (this.disabledTeamIds === '*') {
             return false
         }


### PR DESCRIPTION
## Problem

When the vmagent→otel-collector bridge starts feeding PostHog's own infra metrics into team 2 (hosted envs), those metrics must not be throttled away by per-team limits — and crucially, the **billing-quota stage is not gated by the limiter's enabled-teams list**, so a rate-limiter-only exemption would not protect them. This is INFRA-B from the dashboard-MVP plan, a prerequisite for the prod bridge.

## Changes

- `METRICS_LIMITER_EXEMPT_TEAMS` (comma-separated team IDs, `'*'` supported, default empty = exact current behavior), following the existing `METRICS_LIMITER_*` config style.
- Exempt teams bypass **both** drop stages in the metrics consumer: the Redis token-bucket rate limiter (checked before `ENABLED_TEAMS`, never touches bucket state) and the `metrics_mb_ingested` quota lookup. Billing usage emission is unchanged — still metered, never enforced.
- First test coverage for the metrics limiter (none existed): exemption pass/throttle/empty-list/wildcard/priority/no-token-consumption + consumer quota-bypass tests, mirroring the logs limiter test style.

## How did you test this code?

I'm an agent. Automated: `pnpm jest src/metrics-ingestion --runInBand` in `nodejs/` — 2 suites, 18 tests, all passing (local Redis). No behavior change with the default empty list, which is what ships.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @DanielVisca

Investigated the existing limiter semantics first: `METRICS_LIMITER_ENABLED_TEAMS` defaults empty (rate limiting off unless opted in), but quota enforcement is always on — hence the exemption covers both. No exemption pattern existed in the logs/traces limiters to mirror, so this follows the established config conventions instead.