### PR TITLE
feat(ci): show vs-base delta in the eager graph comment

### DIFF
--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -199,17 +199,20 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
 }
 
 // Consumed by the workflow's comment + enforcement steps; written even on failure so
-// the PR comment can show what went over. The filename carries the built tree's HEAD
-// sha because compressed-size-action runs this for BOTH the PR build and the base
-// build in the same workspace — a plain filename would be overwritten by the base
-// build, making downstream steps report the wrong branch.
+// the PR comment can show what went over. The filename and the embedded sha carry the
+// built tree's HEAD because compressed-size-action runs this for BOTH the PR build and
+// the base build in the same workspace — the PR build's report is found by sha, and the
+// plain filename (last write = the base build) doubles as the base-branch measurement
+// for the comment's vs-base delta.
+try {
+    report.sha = execSync('git rev-parse HEAD', { cwd: frontendDir, encoding: 'utf-8' }).trim()
+} catch (err) {
+    console.error(`Could not resolve HEAD sha for the report: ${err.message}`)
+}
 const serialized = JSON.stringify(report, null, 2)
 fs.writeFileSync(path.join(frontendDir, 'eager-graph-report.json'), serialized)
-try {
-    const headSha = execSync('git rev-parse HEAD', { cwd: frontendDir, encoding: 'utf-8' }).trim()
-    fs.writeFileSync(path.join(frontendDir, `eager-graph-report-${headSha}.json`), serialized)
-} catch (err) {
-    console.error(`Could not write sha-specific report: ${err.message}`)
+if (report.sha) {
+    fs.writeFileSync(path.join(frontendDir, `eager-graph-report-${report.sha}.json`), serialized)
 }
 
 if (process.env.GITHUB_STEP_SUMMARY) {

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -46,6 +46,36 @@ if (!shaReportPath) {
 
 const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8'))
 
+// The base build runs last, so the plain report filename holds the base branch's
+// measurement — that's the comparison baseline, like the compressed-size check's.
+// The embedded sha guards against the plain file being this PR's own report (the
+// base build didn't run the check, e.g. a base branch that predates it).
+const baseReport = (() => {
+    const baseSha = event.pull_request?.base?.sha
+    const candidates = [
+        baseSha ? path.join(frontendDir, `eager-graph-report-${baseSha}.json`) : null,
+        path.join(frontendDir, 'eager-graph-report.json'),
+    ].filter(Boolean)
+    for (const candidate of candidates) {
+        if (!fs.existsSync(candidate)) {
+            continue
+        }
+        try {
+            const parsed = JSON.parse(fs.readFileSync(candidate, 'utf-8'))
+            if (parsed.sha && report.sha && parsed.sha !== report.sha) {
+                return parsed
+            }
+        } catch {
+            continue
+        }
+    }
+    return null
+})()
+const baseBytes = Object.fromEntries((baseReport?.roots ?? []).map((r) => [r.root, r.bytes]))
+if (!baseReport) {
+    console.warn('No base-branch report found — the comment will not show a vs-base delta.')
+}
+
 function formatBytes(bytes) {
     const abs = Math.abs(bytes)
     if (abs >= 1024 * 1024) {
@@ -57,15 +87,17 @@ function formatBytes(bytes) {
     return `${bytes} B`
 }
 
-function formatDelta(bytes, previousBytes) {
-    if (previousBytes === undefined) {
-        return '_(first run)_'
+function formatDelta(bytes, baselineBytes) {
+    if (baselineBytes === undefined) {
+        return '_(no base measurement)_'
     }
-    const delta = bytes - previousBytes
+    const delta = bytes - baselineBytes
     if (delta === 0) {
         return 'no change'
     }
-    return `${delta > 0 ? '+' : '-'}${formatBytes(Math.abs(delta))}`
+    const sign = delta > 0 ? '+' : '-'
+    const percent = ((Math.abs(delta) / baselineBytes) * 100).toFixed(1)
+    return `${delta > 0 ? '🔺' : '🟢'} ${sign}${formatBytes(Math.abs(delta))} (${sign}${percent}%)`
 }
 
 function budgetBar(bytes, budgetBytes) {
@@ -106,31 +138,21 @@ try {
     process.exit(0)
 }
 
-const previous = (() => {
-    const match = existing?.body?.match(/<!-- posthog-eager-graph-data (.*?) -->/s)
-    try {
-        return match ? JSON.parse(match[1]) : {}
-    } catch {
-        return {}
-    }
-})()
-
 const anyFailure = report.roots.some((r) => r.overBudget || r.forbiddenHits.length > 0) || report.errors?.length > 0
 const lines = [
     MARKER,
-    `<!-- posthog-eager-graph-data ${JSON.stringify(Object.fromEntries(report.roots.map((r) => [r.root, r.bytes])))} -->`,
     `## ${anyFailure ? '❌' : '🕸️'} Eager graph`,
     '',
     "How much code each root forces the browser to download and decode through *static* imports — the regression class total bundle size can't see.",
     '',
-    '| Root | Eager closure | Δ this PR run | Budget |',
+    '| Root | Eager closure | Δ vs base | Budget |',
     '| --- | --- | --- | --- |',
 ]
 
 for (const r of report.roots) {
     const status = r.overBudget ? '❌ ' : ''
     lines.push(
-        `| ${status}**${r.label}**<br/>\`${r.root}\` | ${formatBytes(r.bytes)} · ${r.files.toLocaleString()} files | ${formatDelta(r.bytes, previous[r.root])} | ${budgetBar(r.bytes, r.budgetBytes)} |`
+        `| ${status}**${r.label}**<br/>\`${r.root}\` | ${formatBytes(r.bytes)} · ${r.files.toLocaleString()} files | ${formatDelta(r.bytes, baseBytes[r.root])} | ${budgetBar(r.bytes, r.budgetBytes)} |`
     )
 }
 lines.push('')

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -46,28 +46,23 @@ if (!shaReportPath) {
 
 const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8'))
 
-// The base build runs last, so the plain report filename holds the base branch's
-// measurement — that's the comparison baseline, like the compressed-size check's.
-// The embedded sha guards against the plain file being this PR's own report (the
-// base build didn't run the check, e.g. a base branch that predates it).
+// The base build runs last (see the write-side comment in check-eager-graph.mjs),
+// so the plain report filename holds the base branch's measurement — the comparison
+// baseline, like the compressed-size check's. The embedded sha guards against the
+// plain file being this PR's own report (the base build didn't run the check, e.g.
+// a base branch that predates it).
 const baseReport = (() => {
-    const baseSha = event.pull_request?.base?.sha
-    const candidates = [
-        baseSha ? path.join(frontendDir, `eager-graph-report-${baseSha}.json`) : null,
-        path.join(frontendDir, 'eager-graph-report.json'),
-    ].filter(Boolean)
-    for (const candidate of candidates) {
-        if (!fs.existsSync(candidate)) {
-            continue
+    const candidate = path.join(frontendDir, 'eager-graph-report.json')
+    if (!fs.existsSync(candidate)) {
+        return null
+    }
+    try {
+        const parsed = JSON.parse(fs.readFileSync(candidate, 'utf-8'))
+        if (parsed.sha && report.sha && parsed.sha !== report.sha) {
+            return parsed
         }
-        try {
-            const parsed = JSON.parse(fs.readFileSync(candidate, 'utf-8'))
-            if (parsed.sha && report.sha && parsed.sha !== report.sha) {
-                return parsed
-            }
-        } catch {
-            continue
-        }
+    } catch {
+        return null
     }
     return null
 })()
@@ -96,8 +91,12 @@ function formatDelta(bytes, baselineBytes) {
         return 'no change'
     }
     const sign = delta > 0 ? '+' : '-'
+    const magnitude = `${delta > 0 ? '🔺' : '🟢'} ${sign}${formatBytes(Math.abs(delta))}`
+    if (baselineBytes === 0) {
+        return `${magnitude} (new)`
+    }
     const percent = ((Math.abs(delta) / baselineBytes) * 100).toFixed(1)
-    return `${delta > 0 ? '🔺' : '🟢'} ${sign}${formatBytes(Math.abs(delta))} (${sign}${percent}%)`
+    return `${magnitude} (${sign}${percent}%)`
 }
 
 function budgetBar(bytes, budgetBytes) {


### PR DESCRIPTION
## Problem

The eager graph comment (#63099) showed a delta against the PR's own previous run — so a PR that cuts the authed shell by 17% versus master reads as "(first run)" or "no change", while the compressed-size comment right next to it shows a proper vs-base comparison. #62957 is the live example: the headline number is the drop vs master, and the comment can't say it.

References #32479

## Changes

- `check-eager-graph.mjs` embeds the checkout sha in the report it writes
- `post-eager-graph-comment.mjs` resolves the **base branch's report** — compressed-size-action's base build (which runs last) already writes it to the plain filename — and the delta column becomes **Δ vs base** with direction, magnitude, and percentage: `🟢 -9.72 MiB (-14.9%)` / `🔺 +2.86 MiB (+5.4%)`. The embedded sha distinguishes the base build's report from the PR's own (covering bases that predate the check, where it falls back to `(no base measurement)`)
- the now-unused hidden data marker (previous-run numbers) is removed

No workflow changes; no extra builds.

## How did you test this code?

I'm an agent; verification was local against the real metafile and a live PR comment:

- improvement direction: synthetic base 9.72 MiB larger renders `🟢 -9.72 MiB (-14.9%)`
- regression direction: synthetic base 2.86 MiB smaller renders `🔺 +2.86 MiB (+5.4%)`
- no-base fallback: plain report with matching sha renders `(no base measurement)` with a log warning
- oxlint clean; both check modes (`--report-only`, `--assert-report`) re-verified

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @pauldambra — follow-up to #63099 after seeing the first real comment on #62957 fail to express the drop it was posted to demonstrate. Considered keeping the per-run delta as a second column but dropped it: vs-base is the comparison reviewers act on, and the budget bar already anchors the absolute trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)