### PR TITLE
feat(llm-gateway): grant rate-limit multiplier to staff users

### DIFF
--- a/services/llm-gateway/src/llm_gateway/auth/authenticators.py
+++ b/services/llm-gateway/src/llm_gateway/auth/authenticators.py
@@ -62,7 +62,7 @@ class PersonalApiKeyAuthenticator(Authenticator):
         async with acquire_connection(pool) as conn:
             row = await conn.fetchrow(
                 """
-                SELECT pak.id, pak.user_id, pak.scopes, u.current_team_id, u.distinct_id
+                SELECT pak.id, pak.user_id, pak.scopes, u.current_team_id, u.distinct_id, u.is_staff
                 FROM posthog_personalapikey pak
                 JOIN posthog_user u ON pak.user_id = u.id
                 WHERE pak.secure_value = $1 AND u.is_active = true
@@ -83,6 +83,7 @@ class PersonalApiKeyAuthenticator(Authenticator):
                 auth_method=self.auth_type,
                 distinct_id=row["distinct_id"],
                 scopes=scopes,
+                is_staff=bool(row["is_staff"]),
             )
 
 
@@ -108,7 +109,7 @@ class OAuthAccessTokenAuthenticator(Authenticator):
             row = await conn.fetchrow(
                 """
                 SELECT oat.id, oat.user_id, oat.scope, oat.expires,
-                       oat.application_id, u.current_team_id, u.distinct_id
+                       oat.application_id, u.current_team_id, u.distinct_id, u.is_staff
                 FROM posthog_oauthaccesstoken oat
                 JOIN posthog_user u ON oat.user_id = u.id
                 WHERE oat.token_checksum = $1 AND u.is_active = true
@@ -138,4 +139,5 @@ class OAuthAccessTokenAuthenticator(Authenticator):
                 scopes=scopes,
                 token_expires_at=expires,
                 application_id=str(row["application_id"]),
+                is_staff=bool(row["is_staff"]),
             )

--- a/services/llm-gateway/src/llm_gateway/auth/models.py
+++ b/services/llm-gateway/src/llm_gateway/auth/models.py
@@ -11,6 +11,7 @@ class AuthenticatedUser:
     scopes: list[str] | None = None
     token_expires_at: datetime | None = None
     application_id: str | None = None
+    is_staff: bool = False
 
 
 def resolve_distinct_id(auth_user: AuthenticatedUser, end_user_id: str | None) -> str:

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -1,7 +1,7 @@
 import json
 from functools import lru_cache
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -157,6 +157,10 @@ class Settings(BaseSettings):
     auth_cache_ttl_oauth: int = 300  # 5 minutes — OAuth tokens can be revoked on refresh, keep short
 
     team_rate_limit_multipliers: dict[int, int] = {}
+
+    # Cost-limit multiplier applied to PostHog staff users (is_staff on posthog_user),
+    # regardless of which project they currently have selected.
+    staff_rate_limit_multiplier: int = Field(default=1, ge=1)
 
     product_cost_limits: dict[str, ProductCostLimit] = DEFAULT_PRODUCT_COST_LIMITS
 

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -106,8 +106,9 @@ PRODUCT_COST_WINDOW_USD = Gauge(
     "llm_gateway_product_cost_window_usd",
     (
         "Current accumulated cost (USD) for a product within its configured window. "
-        "Reflects only the shared pool — spend from teams with a team_rate_limit_multipliers "
-        "override lives in a separate per-multiplier Redis bucket and is not included here."
+        "Reflects only the shared pool — spend from requests with a rate-limit multiplier "
+        "(team_rate_limit_multipliers or staff_rate_limit_multiplier) lives in a separate "
+        "per-multiplier Redis bucket and is not included here."
     ),
     labelnames=["product"],
 )
@@ -116,8 +117,8 @@ PRODUCT_COST_LIMIT_USD = Gauge(
     "llm_gateway_product_cost_limit_usd",
     (
         "Configured cost cap (USD) for a product within its configured window. "
-        "This is the base (team_mult=1) cap that pairs with llm_gateway_product_cost_window_usd; "
-        "teams with a team_rate_limit_multipliers override get a multiplied cap not reflected here."
+        "This is the base (multiplier=1) cap that pairs with llm_gateway_product_cost_window_usd; "
+        "requests with a team or staff rate-limit multiplier get a multiplied cap not reflected here."
     ),
     labelnames=["product"],
 )

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -16,7 +16,7 @@ from llm_gateway.config import (
 if TYPE_CHECKING:
     from llm_gateway.config import UserCostLimit
 from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
-from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_team_multiplier
+from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_rate_limit_multiplier
 from llm_gateway.services.plan_resolver import POSTHOG_CODE_PRODUCT, get_billing_period_number, is_pro_plan
 
 logger = structlog.get_logger(__name__)
@@ -45,9 +45,6 @@ class CostThrottle(Throttle):
     def __init__(self, redis: Redis[bytes] | None):
         self._redis = redis
         self._limiters: dict[str, CostRateLimiter] = {}
-
-    def _get_team_multiplier(self, context: ThrottleContext) -> int:
-        return get_team_multiplier(context.user.team_id)
 
     @abstractmethod
     def _get_cache_key(self, context: ThrottleContext) -> str: ...
@@ -165,11 +162,11 @@ class ProductCostThrottle(CostThrottle):
         return "Product rate limit exceeded"
 
     def _get_cache_key(self, context: ThrottleContext) -> str:
-        team_mult = self._get_team_multiplier(context)
+        mult = get_rate_limit_multiplier(context.user)
         base = f"cost:product:{context.product}"
-        if team_mult == 1:
+        if mult == 1:
             return base
-        return f"{base}:tm{team_mult}"
+        return f"{base}:tm{mult}"
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         settings = get_settings()
@@ -180,15 +177,15 @@ class ProductCostThrottle(CostThrottle):
         else:
             base_limit = 1000.0
             window = 86400
-        team_mult = self._get_team_multiplier(context)
-        return base_limit * team_mult, window
+        mult = get_rate_limit_multiplier(context.user)
+        return base_limit * mult, window
 
     async def get_status_for_product(self, product: str) -> CostStatus | None:
-        """Return CostStatus for a product using the shared (team multiplier = 1) pool.
+        """Return CostStatus for a product using the shared (multiplier = 1) pool.
 
         Intended for monitoring/gauges, not throttling decisions — throttling needs
-        a full ThrottleContext to apply team multipliers. Returns None when the
-        product has no configured cost limit.
+        a full ThrottleContext to apply team/staff rate-limit multipliers. Returns
+        None when the product has no configured cost limit.
         """
         settings = get_settings()
         config = settings.product_cost_limits.get(product)
@@ -232,11 +229,11 @@ class _UserCostThrottleBase(CostThrottle):
     def _get_cache_key(self, context: ThrottleContext) -> str:
         if not context.end_user_id:
             return ""
-        team_mult = self._get_team_multiplier(context)
+        mult = get_rate_limit_multiplier(context.user)
         base = f"cost:user:{self.scope}:{context.product}:{context.end_user_id}"
-        if team_mult == 1:
+        if mult == 1:
             return base
-        return f"{base}:tm{team_mult}"
+        return f"{base}:tm{mult}"
 
     def _get_config(self, context: ThrottleContext) -> UserCostLimit:
         if _is_free_plan_throttled(context):
@@ -277,8 +274,8 @@ class UserCostBurstThrottle(_UserCostThrottleBase):
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._get_config(context)
-        team_mult = self._get_team_multiplier(context)
-        return config.burst_limit_usd * team_mult, config.burst_window_seconds
+        mult = get_rate_limit_multiplier(context.user)
+        return config.burst_limit_usd * mult, config.burst_window_seconds
 
 
 class UserCostSustainedThrottle(_UserCostThrottleBase):
@@ -302,5 +299,5 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._get_config(context)
-        team_mult = self._get_team_multiplier(context)
-        return config.sustained_limit_usd * team_mult, config.sustained_window_seconds
+        mult = get_rate_limit_multiplier(context.user)
+        return config.sustained_limit_usd * mult, config.sustained_window_seconds

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -7,11 +7,11 @@ from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.config import get_settings
 
 
-def get_team_multiplier(team_id: int | None) -> int:
-    if team_id is None:
-        return 1
-
-    return get_settings().team_rate_limit_multipliers.get(team_id, 1)
+def get_rate_limit_multiplier(user: AuthenticatedUser) -> int:
+    settings = get_settings()
+    staff_multiplier = settings.staff_rate_limit_multiplier if user.is_staff else 1
+    team_multiplier = settings.team_rate_limit_multipliers.get(user.team_id, 1) if user.team_id is not None else 1
+    return max(staff_multiplier, team_multiplier)
 
 
 @dataclass

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -113,6 +113,7 @@ def authenticated_client(mock_db_pool: MagicMock) -> Generator[TestClient]:
             "user_id": 1,
             "scopes": ["llm_gateway:read"],
             "current_team_id": 1,
+            "is_staff": False,
             "distinct_id": "test-distinct-id",
         }
     )

--- a/services/llm-gateway/tests/integration/conftest.py
+++ b/services/llm-gateway/tests/integration/conftest.py
@@ -98,6 +98,7 @@ def create_mock_db_pool():
             "id": 1,
             "user_id": 123,
             "current_team_id": 456,
+            "is_staff": False,
             "scopes": ["llm_gateway:read"],
             "distinct_id": "test-distinct-id",
         }

--- a/services/llm-gateway/tests/test_auth.py
+++ b/services/llm-gateway/tests/test_auth.py
@@ -104,6 +104,7 @@ class TestAuthService:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -130,6 +131,7 @@ class TestAuthService:
                 "user_id": 789,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 101,
+                "is_staff": False,
                 "distinct_id": "test-distinct-id",
             }
         )
@@ -140,6 +142,53 @@ class TestAuthService:
         assert result.user_id == 789
         assert result.team_id == 101
         assert result.auth_method == "personal_api_key"
+        assert result.is_staff is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "headers,row",
+        [
+            pytest.param(
+                {"x-api-key": "phx_valid_key"},
+                {
+                    "id": "k1",
+                    "user_id": 789,
+                    "scopes": ["llm_gateway:read"],
+                    "current_team_id": 101,
+                    "is_staff": True,
+                    "distinct_id": "test-distinct-id",
+                },
+                id="personal_api_key",
+            ),
+            pytest.param(
+                {"authorization": "Bearer pha_valid_token"},
+                {
+                    "id": 1,
+                    "user_id": 123,
+                    "scope": "llm_gateway:read",
+                    "expires": datetime.now(UTC) + timedelta(hours=1),
+                    "current_team_id": 456,
+                    "is_staff": True,
+                    "application_id": 789,
+                    "distinct_id": "test-distinct-id",
+                },
+                id="oauth_access_token",
+            ),
+        ],
+    )
+    async def test_staff_flag_flows_through_auth(
+        self, auth_service: AuthService, mock_pool: MagicMock, headers: dict[str, str], row: dict
+    ) -> None:
+        request = MagicMock(spec=Request)
+        request.headers = headers
+
+        conn = mock_pool.acquire.return_value
+        conn.fetchrow = AsyncMock(return_value=row)
+
+        result = await auth_service.authenticate_request(request, mock_pool)
+
+        assert result is not None
+        assert result.is_staff is True
 
     @pytest.mark.asyncio
     async def test_invalid_token_returns_none(self, auth_service: AuthService, mock_pool: MagicMock) -> None:
@@ -205,6 +254,7 @@ class TestPersonalApiKeyAuthenticator:
                 "user_id": 123,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 456,
+                "is_staff": False,
                 "distinct_id": "test-distinct-id",
             }
         )
@@ -223,19 +273,19 @@ class TestPersonalApiKeyAuthenticator:
         [
             pytest.param(None, id="key_not_found"),
             pytest.param(
-                {"id": "k1", "user_id": 123, "scopes": ["read:only"], "current_team_id": 456},
+                {"id": "k1", "user_id": 123, "scopes": ["read:only"], "current_team_id": 456, "is_staff": False},
                 id="missing_required_scope",
             ),
             pytest.param(
-                {"id": "k2", "user_id": 789, "scopes": None, "current_team_id": None},
+                {"id": "k2", "user_id": 789, "scopes": None, "current_team_id": None, "is_staff": False},
                 id="null_scopes",
             ),
             pytest.param(
-                {"id": "k3", "user_id": 100, "scopes": [], "current_team_id": 200},
+                {"id": "k3", "user_id": 100, "scopes": [], "current_team_id": 200, "is_staff": False},
                 id="empty_scopes",
             ),
             pytest.param(
-                {"id": "k4", "user_id": 101, "scopes": ["*"], "current_team_id": 201},
+                {"id": "k4", "user_id": 101, "scopes": ["*"], "current_team_id": 201, "is_staff": False},
                 id="wildcard_scope_rejected",
             ),
         ],
@@ -284,6 +334,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) - timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -305,6 +356,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": "llm_gateway:read",
                 "expires": None,
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -328,6 +380,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": None,
                 "distinct_id": "test-distinct-id",
             }
@@ -358,6 +411,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": scope,
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -390,6 +444,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": scope,
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -413,6 +468,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -439,6 +495,7 @@ class TestOAuthAccessTokenAuthenticator:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": None,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }

--- a/services/llm-gateway/tests/test_auth_cache.py
+++ b/services/llm-gateway/tests/test_auth_cache.py
@@ -237,6 +237,7 @@ class TestAuthServiceCaching:
                 "user_id": 123,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 456,
+                "is_staff": False,
                 "distinct_id": "test-distinct-id",
             }
         )
@@ -275,6 +276,7 @@ class TestAuthServiceCaching:
                 "scope": "llm_gateway:read",
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -314,6 +316,7 @@ class TestAuthServiceCaching:
                 "scope": "llm_gateway:read",
                 "expires": None,
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "distinct_id": "test-distinct-id",
             }
@@ -370,6 +373,7 @@ class TestAuthServiceMetrics:
                 "scopes": ["llm_gateway:read"],
                 "scope": "llm_gateway:read",
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "distinct_id": "test-distinct-id",
@@ -400,6 +404,7 @@ class TestAuthServiceMetrics:
                 "scopes": ["llm_gateway:read"],
                 "scope": "llm_gateway:read",
                 "current_team_id": 456,
+                "is_staff": False,
                 "application_id": 789,
                 "expires": datetime.now(UTC) + timedelta(hours=1),
                 "distinct_id": "test-distinct-id",

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -222,8 +222,7 @@ class TestProductCostThrottle:
 
 
 class TestStaffMultiplier:
-    @pytest.mark.asyncio
-    async def test_staff_user_gets_multiplied_limit_regardless_of_team(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_staff_user_gets_multiplied_limit_regardless_of_team(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
         get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
@@ -238,8 +237,7 @@ class TestStaffMultiplier:
         assert staff_limit == base_limit * 100
         get_settings.cache_clear()
 
-    @pytest.mark.asyncio
-    async def test_staff_free_plan_limit_is_multiplied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_staff_free_plan_limit_is_multiplied(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
         get_settings.cache_clear()
         from llm_gateway.config import FREE_PLAN_COST_LIMIT
@@ -257,8 +255,7 @@ class TestStaffMultiplier:
         assert limit == FREE_PLAN_COST_LIMIT.burst_limit_usd * 100
         get_settings.cache_clear()
 
-    @pytest.mark.asyncio
-    async def test_staff_bucket_is_stable_across_project_switches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_staff_bucket_is_stable_across_project_switches(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A staff user switching their active project must keep the same usage bucket,
         as long as the staff and team multipliers resolve to the same value."""
         monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -5,13 +5,16 @@ from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.throttles import ThrottleContext
 
 
-def make_user(user_id: int = 1, team_id: int = 1, auth_method: str = "oauth_access_token") -> AuthenticatedUser:
+def make_user(
+    user_id: int = 1, team_id: int = 1, auth_method: str = "oauth_access_token", is_staff: bool = False
+) -> AuthenticatedUser:
     return AuthenticatedUser(
         user_id=user_id,
         team_id=team_id,
         auth_method=auth_method,
         distinct_id=f"test-distinct-id-{user_id}",
         scopes=["llm_gateway:read"],
+        is_staff=is_staff,
     )
 
 
@@ -215,6 +218,59 @@ class TestProductCostThrottle:
         status = await throttle.get_status_for_product("llm_gateway")
         assert status is not None
         assert status.used_usd == pytest.approx(7.0), "gauge should reflect shared-pool spend only"
+        get_settings.cache_clear()
+
+
+class TestStaffMultiplier:
+    @pytest.mark.asyncio
+    async def test_staff_user_gets_multiplied_limit_regardless_of_team(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        staff_context = make_context(user=make_user(user_id=1, team_id=99, is_staff=True))
+        base_context = make_context(user=make_user(user_id=2, team_id=99))
+
+        staff_limit, _ = throttle._get_limit_and_window(staff_context)
+        base_limit, _ = throttle._get_limit_and_window(base_context)
+
+        assert staff_limit == base_limit * 100
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_staff_free_plan_limit_is_multiplied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
+        get_settings.cache_clear()
+        from llm_gateway.config import FREE_PLAN_COST_LIMIT
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        free_staff_context = make_context(
+            user=make_user(team_id=99, is_staff=True),
+            plan_key=None,
+            seat_created_at="2026-01-01T00:00:00+00:00",
+        )
+
+        limit, _ = throttle._get_limit_and_window(free_staff_context)
+
+        assert limit == FREE_PLAN_COST_LIMIT.burst_limit_usd * 100
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_staff_bucket_is_stable_across_project_switches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A staff user switching their active project must keep the same usage bucket,
+        as long as the staff and team multipliers resolve to the same value."""
+        monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 100}')
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        key_on_team_2 = throttle._get_cache_key(make_context(user=make_user(team_id=2, is_staff=True)))
+        key_on_other_team = throttle._get_cache_key(make_context(user=make_user(team_id=99, is_staff=True)))
+
+        assert key_on_team_2 == key_on_other_team
         get_settings.cache_clear()
 
 

--- a/services/llm-gateway/tests/test_openai.py
+++ b/services/llm-gateway/tests/test_openai.py
@@ -110,6 +110,7 @@ class TestChatCompletionsEndpoint:
                 "user_id": 1,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 1,
+                "is_staff": False,
                 "distinct_id": "test-distinct-id",
             }
         )

--- a/services/llm-gateway/tests/test_rate_limiting.py
+++ b/services/llm-gateway/tests/test_rate_limiting.py
@@ -229,6 +229,7 @@ class TestRateLimitResponseHeaders:
                 "user_id": 1,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 1,
+                "is_staff": False,
                 "distinct_id": "test-distinct-id",
             }
         )

--- a/services/llm-gateway/tests/test_throttles.py
+++ b/services/llm-gateway/tests/test_throttles.py
@@ -14,7 +14,7 @@ from llm_gateway.rate_limiting.throttles import (
     Throttle,
     ThrottleContext,
     ThrottleResult,
-    get_team_multiplier,
+    get_rate_limit_multiplier,
 )
 
 
@@ -24,6 +24,7 @@ def make_user(
     auth_method: str = "personal_api_key",
     scopes: list[str] | None = None,
     application_id: str | None = None,
+    is_staff: bool = False,
 ) -> AuthenticatedUser:
     return AuthenticatedUser(
         user_id=user_id,
@@ -32,6 +33,7 @@ def make_user(
         distinct_id=f"test-distinct-id-{user_id}",
         scopes=scopes or ["llm_gateway:read"],
         application_id=application_id,
+        is_staff=is_staff,
     )
 
 
@@ -169,19 +171,36 @@ class TestThrottleContext:
         assert context.request_id == "req-123"
 
 
-class TestGetTeamMultiplier:
-    def test_returns_1_for_none_team_id(self) -> None:
-        assert get_team_multiplier(None) == 1
+class TestGetRateLimitMultiplier:
+    def test_returns_1_for_non_staff_without_team_override(self) -> None:
+        assert get_rate_limit_multiplier(make_user(team_id=99)) == 1
+        assert get_rate_limit_multiplier(make_user(team_id=None)) == 1
 
-    def test_returns_1_for_unconfigured_team(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 10}')
-        get_settings.cache_clear()
-        assert get_team_multiplier(99) == 1
-        get_settings.cache_clear()
-
-    def test_returns_configured_multiplier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_configured_team_multiplier(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 10, "5": 5}')
         get_settings.cache_clear()
-        assert get_team_multiplier(2) == 10
-        assert get_team_multiplier(5) == 5
+        assert get_rate_limit_multiplier(make_user(team_id=2)) == 10
+        assert get_rate_limit_multiplier(make_user(team_id=5)) == 5
+        assert get_rate_limit_multiplier(make_user(team_id=99)) == 1
+        get_settings.cache_clear()
+
+    def test_staff_user_gets_staff_multiplier_on_any_team(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
+        get_settings.cache_clear()
+        assert get_rate_limit_multiplier(make_user(team_id=99, is_staff=True)) == 100
+        assert get_rate_limit_multiplier(make_user(team_id=None, is_staff=True)) == 100
+        get_settings.cache_clear()
+
+    def test_non_staff_user_does_not_get_staff_multiplier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
+        get_settings.cache_clear()
+        assert get_rate_limit_multiplier(make_user(team_id=99, is_staff=False)) == 1
+        get_settings.cache_clear()
+
+    def test_takes_max_of_staff_and_team_multiplier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER", "100")
+        monkeypatch.setenv("LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS", '{"2": 500}')
+        get_settings.cache_clear()
+        assert get_rate_limit_multiplier(make_user(team_id=2, is_staff=True)) == 500
+        assert get_rate_limit_multiplier(make_user(team_id=2, is_staff=False)) == 500
         get_settings.cache_clear()

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -67,6 +67,7 @@ class TestUsageEndpoint:
                 "user_id": 42,
                 "scopes": ["llm_gateway:read"],
                 "current_team_id": 1,
+                "is_staff": False,
                 "distinct_id": "test-distinct-id",
             }
         )


### PR DESCRIPTION
## Problem

Staff hit free-tier gateway cost limits whenever their last-used project sits outside the internal team. The elevated multiplier comes from `team_rate_limit_multipliers`, keyed on the authenticated user's `current_team_id`, so it silently drops the moment a staff member switches projects.

## Changes

Both authenticators now select `u.is_staff` from the already-joined user row, and throttles apply `max(staff_rate_limit_multiplier, team multiplier)`. The `tm{N}` Redis key suffix is unchanged, so when the staff and team multipliers match, a staff user keeps one continuous usage bucket across project switches. Takes effect once `LLM_GATEWAY_STAFF_RATE_LIMIT_MULTIPLIER` is set in the gateway's deploy config.

## How did you test this code?

I'm an agent, so automated tests only: the full llm-gateway suite passes (1008 passed), including new tests for staff flag propagation through both authenticators, multiplier resolution, free-plan limit scaling, and bucket-key stability across project switches. `ruff` is clean and `mypy` reports no new errors against the existing baseline.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal gateway configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with PostHog Code (Claude Code) at Richard's direction, after staff reported losing their elevated gateway limits when their active project changed.
- Traced the gating to `team_rate_limit_multipliers` in the gateway config rather than the billing service, which an earlier investigation had wrongly targeted.
- Chose a user-keyed `is_staff` multiplier over org-membership gating because the auth queries already join `posthog_user`, and deliberately kept the `tm{N}` cache-key format so existing usage buckets carry over at rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
