### PR TITLE
chore(ci): only post the eager graph comment for significant changes

### DIFF
--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -142,17 +142,22 @@ const anyFailure = report.roots.some((r) => r.overBudget || r.forbiddenHits.leng
 // A comment on every PR teaches people to ignore it — stay silent unless something
 // actually moved (or there is a failure to explain). An existing comment from an
 // earlier significant push is still updated so it never shows stale numbers.
+// A missing baseline is itself significant: with no base report the absolute numbers
+// are the signal, and a root absent from (or zero in) the base report is brand new —
+// the biggest change there is.
 const SIGNIFICANT_CHANGE_PERCENT = 2
-const maxChangePercent = Math.max(
-    0,
-    ...report.roots.map((r) => {
+const significantChange =
+    !baseReport ||
+    report.roots.some((r) => {
         const base = baseBytes[r.root]
-        return base ? (Math.abs(r.bytes - base) / base) * 100 : 0
+        if (base === undefined || base === 0) {
+            return true
+        }
+        return (Math.abs(r.bytes - base) / base) * 100 >= SIGNIFICANT_CHANGE_PERCENT
     })
-)
-if (!anyFailure && maxChangePercent < SIGNIFICANT_CHANGE_PERCENT && !existing) {
+if (!anyFailure && !significantChange && !existing) {
     console.info(
-        `Largest eager graph change is ${maxChangePercent.toFixed(2)}% (< ${SIGNIFICANT_CHANGE_PERCENT}%) and no budget/forbidden failures — not posting a comment.`
+        `No eager graph root changed by >= ${SIGNIFICANT_CHANGE_PERCENT}% vs base and no budget/forbidden failures — not posting a comment.`
     )
     process.exit(0)
 }

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -138,6 +138,25 @@ try {
 }
 
 const anyFailure = report.roots.some((r) => r.overBudget || r.forbiddenHits.length > 0) || report.errors?.length > 0
+
+// A comment on every PR teaches people to ignore it — stay silent unless something
+// actually moved (or there is a failure to explain). An existing comment from an
+// earlier significant push is still updated so it never shows stale numbers.
+const SIGNIFICANT_CHANGE_PERCENT = 2
+const maxChangePercent = Math.max(
+    0,
+    ...report.roots.map((r) => {
+        const base = baseBytes[r.root]
+        return base ? (Math.abs(r.bytes - base) / base) * 100 : 0
+    })
+)
+if (!anyFailure && maxChangePercent < SIGNIFICANT_CHANGE_PERCENT && !existing) {
+    console.info(
+        `Largest eager graph change is ${maxChangePercent.toFixed(2)}% (< ${SIGNIFICANT_CHANGE_PERCENT}%) and no budget/forbidden failures — not posting a comment.`
+    )
+    process.exit(0)
+}
+
 const lines = [
     MARKER,
     `## ${anyFailure ? '❌' : '🕸️'} Eager graph`,


### PR DESCRIPTION
## Problem

The eager graph comment (#63099, #63137) posts on every PR — including ones where the closure moved by a few hundred bytes (`+270 B (+0.0%)`). A comment that always appears with nothing to say trains people to ignore it, which defeats its purpose.

References #32479

## Changes

The poster stays silent unless:

- some root's eager closure moved **≥ 2% vs base**, or
- there's a failure to explain (over budget, forbidden module reachable, report error), or
- a comment already exists from an earlier significant push — it's updated rather than left stale

The enforcement step is unaffected — budgets are checked on every run regardless.

## How did you test this code?

I'm an agent; verified all three paths live:

- tiny delta + no existing comment: exits silently with a log line, nothing posted
- tiny delta + existing comment: comment updated (never stale)
- failure state + tiny delta: comment posted regardless
- oxlint clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by @pauldambra after seeing a `+270 B (+0.0%)` comment on a PR. Standalone (not in tonight's Graphite stack) so it can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)