### PR TITLE
fix(capture-logs): exclude duplicated and server-generated bytes from records billing sum

### DIFF
--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -1,5 +1,5 @@
 use crate::avro_schema::AVRO_SCHEMA;
-use crate::log_record::{sum_kafka_log_row_bytes, KafkaLogRow};
+use crate::log_record::{sum_kafka_log_row_bytes_for_billing, KafkaLogRow};
 use crate::metric_record::KafkaMetricRow;
 use crate::metrics_avro_schema::METRICS_AVRO_SCHEMA;
 use crate::trace_record::KafkaTraceRow;
@@ -430,7 +430,7 @@ impl KafkaSink {
             counter!("capture_logs_timestamps_overridden").increment(timestamps_overridden);
         }
 
-        let records_uncompressed_bytes = sum_kafka_log_row_bytes(&rows);
+        let records_uncompressed_bytes = sum_kafka_log_row_bytes_for_billing(&rows);
         counter!("capture_logs_bytes_uncompressed_payload").increment(uncompressed_bytes);
         counter!("capture_logs_bytes_uncompressed_records").increment(records_uncompressed_bytes);
         if records_uncompressed_bytes > uncompressed_bytes {

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -64,14 +64,51 @@ pub fn compute_kafka_log_row_bytes(row: &KafkaLogRow) -> i64 {
     i64::try_from(total).unwrap_or(i64::MAX)
 }
 
-/// Sum of per-row `bytes_uncompressed` across a batch; rows without the field count as zero.
-/// Feeds the `bytes_uncompressed_records` Kafka header — the records-based counterpart to the
+/// Base64 placeholders produced by `extract_trace_id`/`extract_span_id` when the
+/// client sent no id. Not customer data, so excluded from the billing sum.
+const ZERO_TRACE_ID_B64: &str = "AAAAAAAAAAAAAAAAAAAAAA==";
+const ZERO_SPAN_ID_B64: &str = "AAAAAAAAAAA=";
+
+/// Billing-oriented batch size: sum of customer-sent variable-length content. Feeds the
+/// `bytes_uncompressed_records` Kafka header — the records-based counterpart to the
 /// payload-sized `bytes_uncompressed` header — so the two can be compared before billing
 /// switches to the records-based value.
-pub fn sum_kafka_log_row_bytes(rows: &[KafkaLogRow]) -> u64 {
-    rows.iter()
-        .map(|row| row.bytes_uncompressed.unwrap_or(0).max(0) as u64)
-        .sum()
+///
+/// Deliberately differs from the per-row `bytes_uncompressed` field (which keeps its
+/// denormalized per-row semantics for drop-rule accounting). Three sources of inflation
+/// that would otherwise push this sum past the payload the client actually sent are
+/// removed:
+/// - server-generated fields are excluded: `uuid`, and `service_name` (a copy of a
+///   resource attribute, which is already counted)
+/// - the base64 placeholder for an absent trace/span id is excluded
+/// - `resource_attributes` are counted once per distinct resource, not per row — OTLP
+///   sends the resource block once per batch; we denormalize it onto every row
+pub fn sum_kafka_log_row_bytes_for_billing(rows: &[KafkaLogRow]) -> u64 {
+    let mut total: usize = 0;
+    let mut counted_resources: Vec<&HashMap<String, String>> = Vec::new();
+    for row in rows {
+        total = total
+            .saturating_add(row.body.len())
+            .saturating_add(row.severity_text.len())
+            .saturating_add(row.instrumentation_scope.len())
+            .saturating_add(row.event_name.len());
+        if row.trace_id != ZERO_TRACE_ID_B64 {
+            total = total.saturating_add(row.trace_id.len());
+        }
+        if row.span_id != ZERO_SPAN_ID_B64 {
+            total = total.saturating_add(row.span_id.len());
+        }
+        for (k, v) in &row.attributes {
+            total = total.saturating_add(k.len()).saturating_add(v.len());
+        }
+        if !counted_resources.contains(&&row.resource_attributes) {
+            counted_resources.push(&row.resource_attributes);
+            for (k, v) in &row.resource_attributes {
+                total = total.saturating_add(k.len()).saturating_add(v.len());
+            }
+        }
+    }
+    u64::try_from(total).unwrap_or(u64::MAX)
 }
 
 impl KafkaLogRow {
@@ -399,35 +436,65 @@ mod tests {
         assert_eq!(compute_kafka_log_row_bytes(&row), 57);
     }
 
-    fn sample_row_bytes() -> u64 {
-        sample_row()
-            .with_computed_bytes()
-            .bytes_uncompressed
-            .unwrap() as u64
+    /// Billable bytes of a single `sample_row()` with non-zero trace/span ids:
+    /// trace_id(3) + span_id(3) + body(5) + severity_text(4) + instrumentation_scope(7)
+    /// + event_name(3) + attributes "k"+"v"(2) = 27 (uuid and service_name excluded);
+    /// resource_attributes "host.name"+"localhost"(18) are counted once per distinct resource.
+    const SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE: u64 = 27;
+    const SAMPLE_ROW_RESOURCE_BYTES: u64 = 18;
+
+    #[test]
+    fn test_billing_sum_empty_slice_is_zero() {
+        assert_eq!(sum_kafka_log_row_bytes_for_billing(&[]), 0);
     }
 
     #[test]
-    fn test_sum_kafka_log_row_bytes_empty_slice_is_zero() {
-        assert_eq!(sum_kafka_log_row_bytes(&[]), 0);
+    fn test_zero_id_placeholders_match_the_extractors_output() {
+        assert_eq!(ZERO_TRACE_ID_B64, BASE64_STANDARD.encode([0u8; 16]));
+        assert_eq!(ZERO_SPAN_ID_B64, BASE64_STANDARD.encode([0u8; 8]));
     }
 
     #[test]
-    fn test_sum_kafka_log_row_bytes_treats_missing_field_as_zero() {
-        let with_bytes = sample_row().with_computed_bytes();
-        let without_bytes = sample_row(); // bytes_uncompressed: None
+    fn test_billing_sum_excludes_uuid_service_name_and_zero_ids() {
+        let mut row = sample_row();
+        row.trace_id = ZERO_TRACE_ID_B64.to_string();
+        row.span_id = ZERO_SPAN_ID_B64.to_string();
+        // uuid, service_name, and the placeholder ids contribute nothing
         assert_eq!(
-            sum_kafka_log_row_bytes(&[with_bytes, without_bytes]),
-            sample_row_bytes()
+            sum_kafka_log_row_bytes_for_billing(&[row]),
+            SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE - 6 + SAMPLE_ROW_RESOURCE_BYTES
         );
     }
 
     #[test]
-    fn test_sum_kafka_log_row_bytes_sums_all_rows() {
-        let rows = [
-            sample_row().with_computed_bytes(),
-            sample_row().with_computed_bytes(),
-        ];
-        assert_eq!(sum_kafka_log_row_bytes(&rows), sample_row_bytes() * 2);
+    fn test_billing_sum_counts_nonzero_ids() {
+        assert_eq!(
+            sum_kafka_log_row_bytes_for_billing(&[sample_row()]),
+            SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE + SAMPLE_ROW_RESOURCE_BYTES
+        );
+    }
+
+    #[test]
+    fn test_billing_sum_counts_duplicate_resources_once() {
+        // Two rows sharing the same resource_attributes: resource counted once, not twice.
+        let rows = [sample_row(), sample_row()];
+        assert_eq!(
+            sum_kafka_log_row_bytes_for_billing(&rows),
+            SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE * 2 + SAMPLE_ROW_RESOURCE_BYTES
+        );
+    }
+
+    #[test]
+    fn test_billing_sum_counts_distinct_resources_separately() {
+        let mut other = sample_row();
+        other
+            .resource_attributes
+            .insert("host.name".to_string(), "otherhost".to_string());
+        let rows = [sample_row(), other];
+        assert_eq!(
+            sum_kafka_log_row_bytes_for_billing(&rows),
+            SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE * 2 + SAMPLE_ROW_RESOURCE_BYTES * 2
+        );
     }
 
     #[test]

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -438,9 +438,9 @@ mod tests {
     }
 
     /// Billable bytes of a single `sample_row()` with non-zero trace/span ids:
-    /// trace_id(3) + span_id(3) + body(5) + severity_text(4) + instrumentation_scope(7)
-    /// + event_name(3) + attributes "k"+"v"(2) = 27 (uuid and service_name excluded);
-    /// resource_attributes "host.name"+"localhost"(18) are counted once per distinct resource.
+    /// trace_id(3) + span_id(3) + body(5) + severity_text(4) + instrumentation_scope(7) +
+    /// event_name(3) + attributes "k"+"v"(2) = 27 (uuid and service_name excluded);
+    /// resource_attributes "host.name"+"localhost"(18) are counted once per contiguous run.
     const SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE: u64 = 27;
     const SAMPLE_ROW_RESOURCE_BYTES: u64 = 18;
 

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -81,11 +81,12 @@ const ZERO_SPAN_ID_B64: &str = "AAAAAAAAAAA=";
 /// - server-generated fields are excluded: `uuid`, and `service_name` (a copy of a
 ///   resource attribute, which is already counted)
 /// - the base64 placeholder for an absent trace/span id is excluded
-/// - `resource_attributes` are counted once per distinct resource, not per row — OTLP
-///   sends the resource block once per batch; we denormalize it onto every row
+/// - `resource_attributes` are counted once per contiguous run of rows sharing them, not
+///   per row — rows are built in OTLP `resource_logs` order, so a run corresponds to one
+///   `ResourceLogs` entry whose resource block appeared once on the wire
 pub fn sum_kafka_log_row_bytes_for_billing(rows: &[KafkaLogRow]) -> u64 {
     let mut total: usize = 0;
-    let mut counted_resources: Vec<&HashMap<String, String>> = Vec::new();
+    let mut last_resource: Option<&HashMap<String, String>> = None;
     for row in rows {
         total = total
             .saturating_add(row.body.len())
@@ -101,8 +102,8 @@ pub fn sum_kafka_log_row_bytes_for_billing(rows: &[KafkaLogRow]) -> u64 {
         for (k, v) in &row.attributes {
             total = total.saturating_add(k.len()).saturating_add(v.len());
         }
-        if !counted_resources.contains(&&row.resource_attributes) {
-            counted_resources.push(&row.resource_attributes);
+        if last_resource != Some(&row.resource_attributes) {
+            last_resource = Some(&row.resource_attributes);
             for (k, v) in &row.resource_attributes {
                 total = total.saturating_add(k.len()).saturating_add(v.len());
             }
@@ -494,6 +495,21 @@ mod tests {
         assert_eq!(
             sum_kafka_log_row_bytes_for_billing(&rows),
             SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE * 2 + SAMPLE_ROW_RESOURCE_BYTES * 2
+        );
+    }
+
+    #[test]
+    fn test_billing_sum_counts_resources_per_contiguous_run() {
+        // A, B, A: the second A run is a separate ResourceLogs entry on the wire,
+        // so its resource block is counted again.
+        let mut other = sample_row();
+        other
+            .resource_attributes
+            .insert("host.name".to_string(), "otherhost".to_string());
+        let rows = [sample_row(), other, sample_row()];
+        assert_eq!(
+            sum_kafka_log_row_bytes_for_billing(&rows),
+            SAMPLE_ROW_BILLING_BYTES_SANS_RESOURCE * 3 + SAMPLE_ROW_RESOURCE_BYTES * 3
         );
     }
 


### PR DESCRIPTION
Considering abandoning. Billing should stick to what the customer sent.
## Problem

With #63116 deployed, monitoring `bytes_uncompressed_records` against the payload-based `bytes_uncompressed` header shows the records sum is consistently **higher** — violating the invariant (records ≤ payload) required before billing can switch to the records basis. The inflation is structural: OTLP sends the resource block once per batch, but capture denormalizes it onto every row and the sum counted it every time; the `uuid` and `service_name` fields are server-generated copies rather than customer-sent data; and absent trace/span ids still counted as their 24/12-char base64 zero placeholders.

## Changes

- Replace the header's plain per-row sum with `sum_kafka_log_row_bytes_for_billing`, which counts customer-sent content only:
  - `resource_attributes` counted once per **distinct** resource per batch (not per row)
  - `uuid` and `service_name` excluded (server-generated / duplicate of a resource attribute)
  - base64 zero placeholders for absent trace/span ids excluded
- The per-row Avro `bytes_uncompressed` field is **unchanged** — drop-rule accounting and the ClickHouse per-row column keep their denormalized semantics.
- Known remaining (intentional) divergence from wire size: JSON-stringified attribute values, derived `severity_text`, and per-row `instrumentation_scope` are still counted; protobuf encoding is more compact than string lengths. These are minor next to the resource-attribute duplication.

After deploy, the `capture_logs_records_bytes_exceed_payload` counter and the records/payload ratio should be re-checked; if records still exceeds payload for some traffic shapes, the remaining items above are the next candidates.

## How did you test this code?

Agent-authored. Automated tests only: `cargo test -p capture-logs --lib` (43 passed — new tests cover empty batch, zero-id exclusion, uuid/service_name exclusion, duplicate-resource dedup, distinct-resource counting, and that the zero-id constants match the extractors' output) and `cargo clippy -p capture-logs` (clean). No manual testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Direction from the logs/APM team after observing the live header comparison (e.g. payload 3213 vs records 5041): count duplicated resource attributes once and drop server-generated bytes so the records-based billing basis can never exceed what the customer actually sent. Deliberately scoped to the header sum only — changing the per-row field would alter drop-rule and volume-preview accounting, which stays as is.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*