### PR TITLE
fix(feature-flags): show all projects' flags in comparison grid

### DIFF
--- a/frontend/src/scenes/feature-flags/projects-grid/ProjectsGrid.tsx
+++ b/frontend/src/scenes/feature-flags/projects-grid/ProjectsGrid.tsx
@@ -7,19 +7,17 @@ import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { teamLogic } from 'scenes/teamLogic'
-import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
-import { FeatureFlagType, OrganizationFeatureFlag } from '~/types'
+import { OrganizationFeatureFlag } from '~/types'
 
 import { CellState, ProjectsGridCell } from './ProjectsGridCell'
-import { projectsGridLogic } from './projectsGridLogic'
+import { ProjectsGridRow, projectsGridLogic } from './projectsGridLogic'
 import { ProjectsGridToolbar } from './ProjectsGridToolbar'
 
 function cellStateFor(
-    flag: FeatureFlagType,
+    row: ProjectsGridRow,
     teamId: number,
-    currentTeamId: number,
     accessibleTeamIds: Set<number>,
     siblings: OrganizationFeatureFlag[] | undefined,
     siblingsLoading: boolean
@@ -29,18 +27,18 @@ function cellStateFor(
         return { kind: 'present', sibling: siblingForTeam }
     }
 
-    // Before siblings load, render the current team's cell from the flag directly
-    // (eval count unavailable until siblings arrive).
-    if (teamId === currentTeamId) {
+    // Before siblings load, render the representative project's cell directly so it doesn't flash
+    // a skeleton (eval count is unavailable until siblings arrive).
+    if (teamId === row.team_id) {
         return {
             kind: 'present',
             sibling: {
-                flag_id: flag.id,
+                flag_id: row.flag_id,
                 team_id: teamId,
-                created_by: flag.created_by ?? null,
-                filters: flag.filters,
-                created_at: flag.created_at ?? '',
-                active: flag.active,
+                created_by: null,
+                filters: row.filters,
+                created_at: '',
+                active: row.active,
             },
         }
     }
@@ -98,16 +96,16 @@ export function ProjectsGrid(): JSX.Element {
 
     const columnWidth = `${100 / (visibleColumns.length + 1)}%`
 
-    const columns: LemonTableColumns<FeatureFlagType> = [
+    const columns: LemonTableColumns<ProjectsGridRow> = [
         {
             title: 'Flag',
             key: 'flag',
             width: columnWidth,
-            render: (_, flag) => (
+            render: (_, row) => (
                 <LemonTableLink
-                    to={urls.featureFlag(flag.id as number)}
-                    title={flag.name || flag.key}
-                    description={flag.key}
+                    to={`/project/${row.team_id}/feature_flags/${row.flag_id}`}
+                    title={row.name || row.key}
+                    description={row.key}
                 />
             ),
         },
@@ -122,15 +120,14 @@ export function ProjectsGrid(): JSX.Element {
             ),
             key: `project-${teamId}`,
             width: columnWidth,
-            render: (_: unknown, flag: FeatureFlagType) => (
+            render: (_: unknown, row: ProjectsGridRow) => (
                 <ProjectsGridCell
                     state={cellStateFor(
-                        flag,
+                        row,
                         teamId,
-                        currentTeamId,
                         accessibleTeamIds,
-                        siblingsByFlagKey[flag.key],
-                        siblingsLoadingKeys.includes(flag.key)
+                        siblingsByFlagKey[row.key],
+                        siblingsLoadingKeys.includes(row.key)
                     )}
                 />
             ),
@@ -146,7 +143,7 @@ export function ProjectsGrid(): JSX.Element {
             <LemonTable
                 columns={columns}
                 dataSource={flags}
-                rowKey="id"
+                rowKey="key"
                 loading={flagsPageLoading && flags.length === 0}
                 emptyState="No flags match your search."
                 data-attr="projects-grid-table"

--- a/frontend/src/scenes/feature-flags/projects-grid/projectsGridLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/projects-grid/projectsGridLogic.test.ts
@@ -5,19 +5,21 @@ import { initKeaTests } from '~/test/init'
 
 import { projectsGridLogic } from './projectsGridLogic'
 
-interface MockFlag {
-    id: number
+interface MockRow {
     key: string
     name: string
+    flag_id: number
+    team_id: number
     filters: { groups: [] }
     active: boolean
 }
 
-function buildFlag(i: number): MockFlag {
+function buildRow(i: number): MockRow {
     return {
-        id: i,
         key: `flag_${i}`,
         name: `Flag ${i}`,
+        flag_id: i,
+        team_id: 1,
         filters: { groups: [] },
         active: true,
     }
@@ -27,10 +29,16 @@ describe('projectsGridLogic', () => {
     let logic: ReturnType<typeof projectsGridLogic.build>
 
     describe('rows and pagination', () => {
+        let lastRequestedTeamIds: string | null
+
         beforeEach(() => {
+            lastRequestedTeamIds = null
             useMocks({
                 get: {
-                    '/api/projects/:team/feature_flags/': (req) => {
+                    // `keys/` must be registered before the `:key/` sibling route so it isn't
+                    // swallowed by the single-segment path parameter.
+                    '/api/organizations/:org/feature_flags/keys/': (req) => {
+                        lastRequestedTeamIds = req.url.searchParams.get('team_ids')
                         const offset = Number(req.url.searchParams.get('offset') ?? 0)
                         const count = 40
                         const remaining = Math.max(0, count - offset)
@@ -40,7 +48,8 @@ describe('projectsGridLogic', () => {
                             {
                                 count,
                                 next: offset + pageSize < count ? 'next' : null,
-                                results: Array.from({ length: pageSize }, (_, i) => buildFlag(offset + i + 1)),
+                                previous: offset > 0 ? 'prev' : null,
+                                results: Array.from({ length: pageSize }, (_, i) => buildRow(offset + i + 1)),
                             },
                         ]
                     },
@@ -74,6 +83,27 @@ describe('projectsGridLogic', () => {
             expect(logic.values.flags.length).toBeGreaterThan(0)
             expect(logic.values.flagsOffset).toBeLessThanOrEqual(25)
         })
+
+        it('reloads rows from the top when the compared projects change', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            logic.actions.loadMoreFlags()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.flagsOffset).toBe(40)
+
+            logic.actions.setPickedTeamIds([2])
+            await expectLogic(logic).toFinishAllListeners()
+            // The row set changed, so pagination restarts from the first page.
+            expect(logic.values.flags).toHaveLength(25)
+            expect(logic.values.flagsOffset).toBe(25)
+        })
+
+        it('requests keys for the visible columns', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            logic.actions.setPickedTeamIds([7, 9])
+            await expectLogic(logic).toFinishAllListeners()
+            // Current team is always first, followed by the picked teams.
+            expect(lastRequestedTeamIds).toBe(`${logic.values.currentTeamId},7,9`)
+        })
     })
 
     describe('sibling queue (serial)', () => {
@@ -88,10 +118,11 @@ describe('projectsGridLogic', () => {
 
             useMocks({
                 get: {
-                    '/api/projects/:team/feature_flags/': {
+                    '/api/organizations/:org/feature_flags/keys/': {
                         count: 3,
                         next: null,
-                        results: [buildFlag(1), buildFlag(2), buildFlag(3)],
+                        previous: null,
+                        results: [buildRow(1), buildRow(2), buildRow(3)],
                     },
                     '/api/organizations/:org/feature_flags/:key/': async (req) => {
                         const key = req.params.key as string
@@ -133,7 +164,7 @@ describe('projectsGridLogic', () => {
             localStorage.clear()
             useMocks({
                 get: {
-                    '/api/projects/:team/feature_flags/': { count: 0, next: null, results: [] },
+                    '/api/organizations/:org/feature_flags/keys/': { count: 0, next: null, previous: null, results: [] },
                     '/api/organizations/:org/feature_flags/:key/': [],
                 },
             })

--- a/frontend/src/scenes/feature-flags/projects-grid/projectsGridLogic.ts
+++ b/frontend/src/scenes/feature-flags/projects-grid/projectsGridLogic.ts
@@ -5,21 +5,33 @@ import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { organizationLogic } from 'scenes/organizationLogic'
-import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { FeatureFlagType, OrganizationFeatureFlag, OrganizationType } from '~/types'
+import { FeatureFlagFilters, OrganizationFeatureFlag, OrganizationType } from '~/types'
 
 import type { projectsGridLogicType } from './projectsGridLogicType'
 
 export const PAGE_SIZE = 25
+
+/**
+ * One row in the comparison grid: a distinct flag key found in at least one of the compared
+ * projects, plus a representative flag (used for the row's name and link).
+ */
+export interface ProjectsGridRow {
+    key: string
+    name: string
+    flag_id: number
+    team_id: number
+    filters: FeatureFlagFilters
+    active: boolean
+}
 
 export interface LoadFlagsResult {
     offset: number
     search: string
     count: number
     next: string | null
-    results: FeatureFlagType[]
+    results: ProjectsGridRow[]
 }
 
 const storageKey = (teamId: number): string => `ff-projects-grid.picked-teams.${teamId}`
@@ -27,14 +39,7 @@ const storageKey = (teamId: number): string => `ff-projects-grid.picked-teams.${
 export const projectsGridLogic = kea<projectsGridLogicType>([
     path(['scenes', 'feature-flags', 'projects-grid', 'projectsGridLogic']),
     connect(() => ({
-        values: [
-            teamLogic,
-            ['currentTeamId'],
-            organizationLogic,
-            ['currentOrganization'],
-            projectLogic,
-            ['currentProjectId'],
-        ],
+        values: [teamLogic, ['currentTeamId'], organizationLogic, ['currentOrganization']],
     })),
     actions({
         setSearch: (search: string) => ({ search }),
@@ -52,11 +57,13 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
     reducers({
         search: ['', { setSearch: (_, { search }) => search }],
         flags: [
-            [] as FeatureFlagType[],
+            [] as ProjectsGridRow[],
             {
                 loadFlagsPageSuccess: (state, { flagsPage }: { flagsPage: LoadFlagsResult }) =>
                     flagsPage.offset === 0 ? flagsPage.results : [...state, ...flagsPage.results],
                 setSearch: () => [],
+                setPickedTeamIds: () => [],
+                resetPickedTeamIds: () => [],
             },
         ],
         flagsOffset: [
@@ -65,6 +72,8 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
                 loadFlagsPageSuccess: (_, { flagsPage }: { flagsPage: LoadFlagsResult }) =>
                     flagsPage.offset + flagsPage.results.length,
                 setSearch: () => 0,
+                setPickedTeamIds: () => 0,
+                resetPickedTeamIds: () => 0,
             },
         ],
         flagsHasMore: [
@@ -72,6 +81,8 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
             {
                 loadFlagsPageSuccess: (_, { flagsPage }: { flagsPage: LoadFlagsResult }) => flagsPage.next !== null,
                 setSearch: () => true,
+                setPickedTeamIds: () => true,
+                resetPickedTeamIds: () => true,
             },
         ],
         siblingsByFlagKey: [
@@ -87,6 +98,8 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
                 siblingsLoaded: (state, { flagKey }) => state.filter((k) => k !== flagKey),
                 siblingsFailed: (state, { flagKey }) => state.filter((k) => k !== flagKey),
                 setSearch: () => [],
+                setPickedTeamIds: () => [],
+                resetPickedTeamIds: () => [],
             },
         ],
         siblingQueue: [
@@ -98,6 +111,8 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
                 },
                 startSiblingFetch: (state, { flagKey }) => state.filter((k) => k !== flagKey),
                 setSearch: () => [],
+                setPickedTeamIds: () => [],
+                resetPickedTeamIds: () => [],
             },
         ],
         pickedTeamIds: [
@@ -113,9 +128,16 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
             null as LoadFlagsResult | null,
             {
                 loadFlagsPage: async ({ offset, search }: { offset: number; search: string }) => {
-                    const params = toParams({ limit: PAGE_SIZE, offset, search })
+                    const orgId = values.currentOrganization?.id
+                    const params = toParams({
+                        limit: PAGE_SIZE,
+                        offset,
+                        search,
+                        team_ids: values.visibleColumns.join(','),
+                        ...(values.currentTeamId ? { current_team_id: values.currentTeamId } : {}),
+                    })
                     const response = await api.get<Omit<LoadFlagsResult, 'offset' | 'search'>>(
-                        `api/projects/${values.currentProjectId}/feature_flags/?${params}`
+                        `api/organizations/${orgId}/feature_flags/keys/?${params}`
                     )
                     return { offset, search, ...response }
                 },
@@ -160,9 +182,12 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
         },
         setPickedTeamIds: ({ teamIds }) => {
             localStorage.setItem(storageKey(getCurrentTeamId()), JSON.stringify(teamIds))
+            // The compared projects changed, so the set of rows does too — reload from the top.
+            actions.loadFlagsPage({ offset: 0, search: values.search })
         },
         resetPickedTeamIds: () => {
             localStorage.removeItem(storageKey(getCurrentTeamId()))
+            actions.loadFlagsPage({ offset: 0, search: values.search })
         },
     })),
     afterMount(({ actions }) => {
@@ -170,8 +195,10 @@ export const projectsGridLogic = kea<projectsGridLogicType>([
         if (raw) {
             try {
                 const parsed = JSON.parse(raw)
-                if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'number')) {
+                if (Array.isArray(parsed) && parsed.length > 0 && parsed.every((x) => typeof x === 'number')) {
+                    // Hydrating picks triggers the initial load through the setPickedTeamIds listener.
                     actions.setPickedTeamIds(parsed)
+                    return
                 }
             } catch {
                 // ignore malformed entry

--- a/products/feature_flags/backend/api/organization_feature_flag.py
+++ b/products/feature_flags/backend/api/organization_feature_flag.py
@@ -2,10 +2,12 @@ import copy
 from typing import cast
 
 import structlog
+from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.response import Response
+from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 from posthog.api.cohort import CohortSerializer
 from posthog.api.documentation import _FallbackSerializer, extend_schema
@@ -65,6 +67,9 @@ class CopyFlagsResponseSerializer(serializers.Serializer):
 
 logger = structlog.get_logger(__name__)
 
+KEYS_DEFAULT_LIMIT = 25
+KEYS_MAX_LIMIT = 100
+
 
 class OrganizationFeatureFlagView(
     TeamAndOrgViewSetMixin,
@@ -117,6 +122,109 @@ class OrganizationFeatureFlagView(
         ]
 
         return Response(flags_data)
+
+    # Excluded from the public OpenAPI spec: this is an INTERNAL endpoint consumed only by the
+    # "Projects" comparison grid via a handwritten client, so it doesn't need generated types.
+    @extend_schema(exclude=True)
+    @action(detail=False, methods=["get"], url_path="keys", pagination_class=None)
+    def keys(self, request, *args, **kwargs):
+        """
+        Lists the distinct feature flag keys across the selected projects, paginated.
+
+        The list-level "Projects" comparison grid uses this so its rows span every flag in the
+        compared projects, not just the flags that happen to exist in the user's current project.
+
+        Query params: ``team_ids`` (comma-separated; defaults to all accessible teams),
+        ``current_team_id`` (preferred when picking each key's representative flag, so row links
+        stay in the current project), ``search``, ``limit`` (max 100), and ``offset``.
+        """
+        # Only consider teams the user can access within this organization.
+        user_permissions = UserPermissions(user=request.user)
+        accessible_team_ids = set(user_permissions.team_ids_visible_for_user)
+        org_team_ids = set(self.organization.teams.values_list("id", flat=True))
+        allowed_team_ids = org_team_ids & accessible_team_ids
+
+        requested_team_ids = request.GET.get("team_ids")
+        if requested_team_ids:
+            try:
+                requested = {int(part) for part in requested_team_ids.split(",") if part.strip()}
+            except ValueError:
+                return Response(
+                    {"error": "team_ids must be a comma-separated list of integers."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            team_ids = list(allowed_team_ids & requested)
+        else:
+            team_ids = list(allowed_team_ids)
+
+        try:
+            limit = min(int(request.GET.get("limit", KEYS_DEFAULT_LIMIT)), KEYS_MAX_LIMIT)
+            offset = max(int(request.GET.get("offset", 0)), 0)
+        except ValueError:
+            return Response(
+                {"error": "limit and offset must be integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if limit <= 0:
+            limit = KEYS_DEFAULT_LIMIT
+
+        current_team_id = None
+        raw_current_team_id = request.GET.get("current_team_id")
+        if raw_current_team_id:
+            try:
+                current_team_id = int(raw_current_team_id)
+            except ValueError:
+                current_team_id = None
+
+        base_qs = FeatureFlag.objects.filter(team_id__in=team_ids, deleted=False)
+        search = request.GET.get("search", "").strip()
+        if search:
+            base_qs = base_qs.filter(Q(key__icontains=search) | Q(name__icontains=search))
+
+        distinct_keys = base_qs.order_by("key").values_list("key", flat=True).distinct()
+        count = distinct_keys.count()
+        page_keys = list(distinct_keys[offset : offset + limit])
+
+        # Pick one representative flag per key for the name + link, preferring the current project
+        # when it has the key so the row's link opens where the user is.
+        representatives: dict[str, FeatureFlag] = {}
+        page_flags = FeatureFlag.objects.filter(team_id__in=team_ids, key__in=page_keys, deleted=False).order_by(
+            "key", "team_id"
+        )
+        for flag in page_flags:
+            existing = representatives.get(flag.key)
+            prefers_current = (
+                current_team_id is not None
+                and flag.team_id == current_team_id
+                and (existing is None or existing.team_id != current_team_id)
+            )
+            if existing is None or prefers_current:
+                representatives[flag.key] = flag
+
+        results = [
+            {
+                "key": flag.key,
+                "name": flag.name or "",
+                "flag_id": flag.id,
+                "team_id": flag.team_id,
+                "filters": flag.get_filters(),
+                "active": flag.active,
+            }
+            for flag in (representatives[key] for key in page_keys)
+        ]
+
+        url = request.build_absolute_uri()
+        next_url = replace_query_param(url, "offset", offset + limit) if offset + limit < count else None
+        previous_url = None
+        if offset > 0:
+            previous_offset = max(0, offset - limit)
+            previous_url = (
+                remove_query_param(url, "offset")
+                if previous_offset == 0
+                else replace_query_param(url, "offset", previous_offset)
+            )
+
+        return Response({"count": count, "next": next_url, "previous": previous_url, "results": results})
 
     @extend_schema(
         request=CopyFlagsRequestSerializer,

--- a/products/feature_flags/backend/api/test/test_organization_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_organization_feature_flag.py
@@ -133,6 +133,84 @@ class TestOrganizationFeatureFlagGet(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response_data[0]["team_id"], self.team_1.id)
 
 
+class TestOrganizationFeatureFlagKeys(APIBaseTest):
+    def setUp(self):
+        self.team_1 = self.team
+        self.team_2 = Team.objects.create(organization=self.organization)
+
+        # Shared key in both projects, plus a key unique to each project.
+        FeatureFlag.objects.create(team=self.team_1, created_by=self.user, key="shared", name="Shared flag")
+        FeatureFlag.objects.create(team=self.team_2, created_by=self.user, key="shared", name="Shared flag in team 2")
+        FeatureFlag.objects.create(team=self.team_1, created_by=self.user, key="only-team-1")
+        FeatureFlag.objects.create(team=self.team_2, created_by=self.user, key="only-team-2")
+        FeatureFlag.objects.create(team=self.team_2, created_by=self.user, key="deleted", deleted=True)
+
+        super().setUp()
+
+    def _url(self, query: str = "") -> str:
+        return f"/api/organizations/{self.organization.id}/feature_flags/keys{query}"
+
+    def test_returns_union_of_keys_across_selected_projects(self):
+        # Core fix: the union spans both projects, not just the current one.
+        response = self.client.get(self._url(f"?team_ids={self.team_1.id},{self.team_2.id}"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        body = response.json()
+        self.assertEqual(body["count"], 3)
+        self.assertEqual([row["key"] for row in body["results"]], ["only-team-1", "only-team-2", "shared"])
+
+    def test_excludes_deleted_flags(self):
+        response = self.client.get(self._url(f"?team_ids={self.team_2.id}"))
+        keys = [row["key"] for row in response.json()["results"]]
+        self.assertNotIn("deleted", keys)
+
+    def test_team_ids_filters_to_selected_projects(self):
+        response = self.client.get(self._url(f"?team_ids={self.team_2.id}"))
+        keys = [row["key"] for row in response.json()["results"]]
+        self.assertEqual(keys, ["only-team-2", "shared"])
+        self.assertNotIn("only-team-1", keys)
+
+    def test_search_filters_by_key(self):
+        response = self.client.get(self._url(f"?team_ids={self.team_1.id},{self.team_2.id}&search=only-team-1"))
+        self.assertEqual([row["key"] for row in response.json()["results"]], ["only-team-1"])
+
+    def test_representative_prefers_current_team(self):
+        response = self.client.get(
+            self._url(f"?team_ids={self.team_1.id},{self.team_2.id}&current_team_id={self.team_1.id}")
+        )
+        shared = next(row for row in response.json()["results"] if row["key"] == "shared")
+        self.assertEqual(shared["team_id"], self.team_1.id)
+        self.assertEqual(shared["name"], "Shared flag")
+
+    def test_pagination(self):
+        response = self.client.get(self._url(f"?team_ids={self.team_1.id},{self.team_2.id}&limit=2&offset=0"))
+        body = response.json()
+        self.assertEqual(body["count"], 3)
+        self.assertEqual(len(body["results"]), 2)
+        self.assertIsNotNone(body["next"])
+        self.assertIsNone(body["previous"])
+
+        response = self.client.get(self._url(f"?team_ids={self.team_1.id},{self.team_2.id}&limit=2&offset=2"))
+        body = response.json()
+        self.assertEqual(len(body["results"]), 1)
+        self.assertIsNone(body["next"])
+        self.assertIsNotNone(body["previous"])
+
+    def test_defaults_to_all_accessible_teams(self):
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 3)
+
+    def test_invalid_team_ids_returns_400(self):
+        response = self.client.get(self._url("?team_ids=not-an-int"))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unauthorized(self):
+        self.client.logout()
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
 class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
     def setUp(self):
         self.team_1 = self.team


### PR DESCRIPTION
## Problem

The feature flags **Projects** tab promises to "compare each flag's status, rollout, and recent usage across your organization's projects", but it only ever listed flags that exist in the **currently active** project. If you were on a project with 2 flags and compared it against a project with many more, you still saw only those 2 rows — the rest of the compared project's flags were invisible. Users expect every flag in the compared projects to appear.

Closes #63155

## Changes

- **Backend:** add an internal, paginated, searchable `keys` action on the organization feature flag viewset (`GET /api/organizations/{org}/feature_flags/keys/`). It returns the **distinct flag keys across the selected projects** (intersected with the teams the user can access), each with a representative flag — preferring the current project — for the row's name and link.
- **Frontend:** the Projects grid now drives its rows from that endpoint (union across the compared projects) instead of the current project's flag list. Picking or resetting the compared projects reloads the rows from the top, and each row links into the project where its representative flag lives. The per-project sibling fetch that fills the columns is unchanged.

The endpoint is excluded from the public OpenAPI spec (`@extend_schema(exclude=True)`) since it's an internal endpoint consumed only by this grid via a handwritten client.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not perform manual testing. I added and updated automated tests but could not execute them in this environment (no installed JS/Python deps or test DB):

- Backend: a new `TestOrganizationFeatureFlagKeys` class covering the cross-project union, `team_ids` filtering, deleted-flag exclusion, search, representative preference for the current team, pagination, default-to-accessible-teams, invalid input, and auth.
- Frontend: updated `projectsGridLogic.test.ts` for the new endpoint shape, plus cases asserting rows reload from the top when the compared projects change and that keys are requested for the visible columns.

These should be run in CI before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at @phillram's request to fix #63155. Key decision: the row set is the union of distinct flag keys across the *visible* projects (current + picked), which matches the "compare selected projects" mental model. Rather than fetching every project's flag list client-side, I added one backend endpoint that computes the distinct-key union with pagination/search, picking a representative flag per key (preferring the current project so row links stay local). Excluded it from the OpenAPI spec to avoid drifting generated types, consistent with the file's existing handwritten client usage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1781226201045199)*
