### PR TITLE
fix(snowflake): treat disabled user account as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/source.py
+++ b/posthog/temporal/data_imports/sources/snowflake/source.py
@@ -176,6 +176,9 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             "404 Not Found": None,
             "Your free trial has ended": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",
             "Your account is suspended due to lack of payment method": "Your Snowflake account has been suspended or trial has ended. Please check your account status.",
+            # Snowflake error 250001: the user account was disabled by the customer's Snowflake admin
+            # (e.g. `ALTER USER ... SET DISABLED = TRUE`). Retrying can never succeed until they re-enable it.
+            "User access disabled. Contact your local system administrator": "Your Snowflake user account has been disabled. Please contact your Snowflake administrator to re-enable it, then resync.",
             "MFA authentication is required": None,
             "invalid credentials": "Snowflake authentication failed. Please check your username, password, and account details.",
             "authentication failed": "Snowflake authentication failed. Please check your username, password, and account details.",

--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -14,6 +14,7 @@ from posthog.temporal.data_imports.sources.snowflake.snowflake import (
     _split_display_name,
     filter_snowflake_incremental_fields,
 )
+from posthog.temporal.data_imports.sources.snowflake.source import SnowflakeSource
 
 from products.data_warehouse.backend.types import IncrementalFieldType
 
@@ -541,3 +542,33 @@ class TestBuildPipeline:
         assert pk_param == ("DB.analytics.users",)
         stream_param = streaming_cursor.execute.call_args.args[1]
         assert stream_param == ("DB.analytics.users",)
+
+
+class TestSnowflakeSourceNonRetryableErrors:
+    @pytest.fixture
+    def source(self):
+        return SnowflakeSource()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. User access disabled. Contact your local system administrator.",
+            "User access disabled. Contact your local system administrator.",
+        ],
+    )
+    def test_disabled_user_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Disabled-user error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "250003 (08001): Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. Connection timed out",
+            "Operation timed out while waiting for the warehouse to resume",
+        ],
+    )
+    def test_transient_errors_are_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Error should remain retryable: {error_msg}"


### PR DESCRIPTION
## Problem

The Snowflake data-warehouse import source surfaced a recurring failure via error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019eb9a3-8d6a-74b1-9ab3-bd1562e10c68)):

```
DatabaseError: 250001 (08001): None: Failed to connect to DB: <account>.snowflakecomputing.com:443.
User access disabled. Contact your local system administrator.
```

The stack originates in `posthog/temporal/data_imports/sources/snowflake/snowflake.py` at `connect()` (the `snowflake.connector.connect(...)` call), reached via `get_schemas`. Snowflake error `250001` is raised when the connecting user account has been disabled by the customer's own Snowflake administrator (e.g. `ALTER USER ... SET DISABLED = TRUE`). This is a customer-side account-status condition — retrying can never succeed until they re-enable the user — but the source did not classify it as non-retryable, so the import kept retrying a permanently-failing connection.

## Changes

- Add the stable message substring `"User access disabled. Contact your local system administrator"` to `SnowflakeSource.get_non_retryable_errors`, with an actionable user-facing message pointing them to their Snowflake admin. The match deliberately avoids the volatile parts of the message (the account hostname and port).
- Add a unit test (`TestSnowflakeSourceNonRetryableErrors`) asserting the disabled-user message is recognised as non-retryable, plus a guard that genuinely transient connection/timeout errors stay retryable.

This mirrors the existing account-status entries already in `get_non_retryable_errors` (suspended account, ended trial, decommissioned account) and the pattern used by the Stripe and Postgres sources.

## How did you test this code?

I'm an agent (Claude Code). I did not perform manual testing. Automated tests I ran:

- `pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` — 62 passed, including the 4 new non-retryable parametrized cases.
- `ruff check` and `ruff format` — clean on both changed files.

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the Snowflake import source using the PostHog error-tracking MCP tools to pull the full stack trace and a representative event. Confirmed the failure originates in this source's `connect()` frame (not merely referenced in serialized log context). Classified it as a user/upstream account-status error rather than a fixable bug or a transient infra error, and extended `get_non_retryable_errors` accordingly — matching on the stable Snowflake message text, not the per-request hostname. Tooling: Claude Code with the `posthog` error-tracking MCP server.
