### PR TITLE
feat(settings): paginate, sort, and search org personal API keys

### DIFF
--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
@@ -100,7 +100,7 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
                 rowKey={(key) => `${key.owner.email}-${key.mask_value}-${key.created_at}`}
                 pagination={{ pageSize: 25 }}
                 emptyState={
-                    search
+                    search.trim()
                         ? 'No personal API keys match your search.'
                         : 'No personal API keys have access to this organization.'
                 }

--- a/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationPersonalAPIKeys.tsx
@@ -1,4 +1,6 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+
+import { LemonInput } from '@posthog/lemon-ui'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
@@ -24,8 +26,13 @@ function AccessScope({ accessScope }: { accessScope: OrganizationPersonalAPIKeyA
     return <TagList tags={(accessScope.projects ?? []).map((project) => project.name)} />
 }
 
+function ownerLabel(owner: OrganizationPersonalAPIKeyApi['owner']): string {
+    return fullName(owner) || owner.email
+}
+
 export function OrganizationPersonalAPIKeys(): JSX.Element {
-    const { keys, keysLoading } = useValues(organizationPersonalAPIKeysLogic)
+    const { filteredKeys, keysLoading, search } = useValues(organizationPersonalAPIKeysLogic)
+    const { setSearch } = useActions(organizationPersonalAPIKeysLogic)
     const restrictionReason = useRestrictedArea({ minimumAccessLevel: OrganizationMembershipLevel.Admin })
 
     if (restrictionReason) {
@@ -36,9 +43,10 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
         {
             title: 'Owner',
             key: 'owner',
+            sorter: (a, b) => ownerLabel(a.owner).localeCompare(ownerLabel(b.owner)),
             render: (_, key) => (
                 <div className="flex flex-col">
-                    <span>{fullName(key.owner) || key.owner.email}</span>
+                    <span>{ownerLabel(key.owner)}</span>
                     <span className="text-muted text-xs">{key.owner.email}</span>
                 </div>
             ),
@@ -46,6 +54,7 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
         {
             title: 'Masked value',
             key: 'mask_value',
+            sorter: (a, b) => a.mask_value.localeCompare(b.mask_value),
             render: (_, key) => <span className="font-mono">{key.mask_value}</span>,
         },
         {
@@ -61,24 +70,40 @@ export function OrganizationPersonalAPIKeys(): JSX.Element {
         {
             title: 'Last used',
             key: 'last_used_at',
+            sorter: (a, b) => new Date(a.last_used_at ?? 0).getTime() - new Date(b.last_used_at ?? 0).getTime(),
             render: (_, key) =>
                 key.last_used_at ? <TZLabel time={key.last_used_at} /> : <span className="text-muted">Never</span>,
         },
         {
             title: 'Created',
             key: 'created_at',
+            sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
             render: (_, key) => <TZLabel time={key.created_at} />,
         },
     ]
 
     return (
         <PayGateMini feature={AvailableFeature.ORGANIZATION_SECURITY_SETTINGS}>
+            <div className="mb-2">
+                <LemonInput
+                    type="search"
+                    placeholder="Search by name, email, or scope"
+                    value={search}
+                    onChange={setSearch}
+                    className="max-w-80"
+                />
+            </div>
             <LemonTable
-                dataSource={keys}
+                dataSource={filteredKeys}
                 loading={keysLoading}
                 columns={columns}
                 rowKey={(key) => `${key.owner.email}-${key.mask_value}-${key.created_at}`}
-                emptyState="No personal API keys have access to this organization."
+                pagination={{ pageSize: 25 }}
+                emptyState={
+                    search
+                        ? 'No personal API keys match your search.'
+                        : 'No personal API keys have access to this organization.'
+                }
             />
         </PayGateMini>
     )

--- a/frontend/src/scenes/settings/organization/organizationPersonalAPIKeysLogic.test.ts
+++ b/frontend/src/scenes/settings/organization/organizationPersonalAPIKeysLogic.test.ts
@@ -54,4 +54,23 @@ describe('organizationPersonalAPIKeysLogic', () => {
         expect(logic.values.keys).toEqual([])
         expect(logic.values.keysLoading).toEqual(true)
     })
+
+    it('filters by owner name, email, or scope', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setSearch('lovelace')
+        expect(logic.values.filteredKeys).toEqual([MOCK_KEYS[0]])
+
+        logic.actions.setSearch('alan@x.com')
+        expect(logic.values.filteredKeys).toEqual([MOCK_KEYS[1]])
+
+        logic.actions.setSearch('feature_flag')
+        expect(logic.values.filteredKeys).toEqual([MOCK_KEYS[1]])
+
+        logic.actions.setSearch('  ')
+        expect(logic.values.filteredKeys).toEqual(MOCK_KEYS)
+
+        logic.actions.setSearch('nomatch')
+        expect(logic.values.filteredKeys).toEqual([])
+    })
 })

--- a/frontend/src/scenes/settings/organization/organizationPersonalAPIKeysLogic.ts
+++ b/frontend/src/scenes/settings/organization/organizationPersonalAPIKeysLogic.ts
@@ -1,7 +1,8 @@
-import { afterMount, kea, path } from 'kea'
+import { actions, afterMount, kea, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api, { ApiConfig } from 'lib/api'
+import { fullName } from 'lib/utils'
 
 import { getPersonalApiKeysListUrl } from 'products/platform_features/frontend/generated/api'
 import type { OrganizationPersonalAPIKeyApi } from 'products/platform_features/frontend/generated/api.schemas'
@@ -10,6 +11,9 @@ import type { organizationPersonalAPIKeysLogicType } from './organizationPersona
 
 export const organizationPersonalAPIKeysLogic = kea<organizationPersonalAPIKeysLogicType>([
     path(['scenes', 'settings', 'organization', 'organizationPersonalAPIKeysLogic']),
+    actions({
+        setSearch: (search: string) => ({ search }),
+    }),
     loaders({
         keys: [
             [] as OrganizationPersonalAPIKeyApi[],
@@ -19,6 +23,26 @@ export const organizationPersonalAPIKeysLogic = kea<organizationPersonalAPIKeysL
                     const url = getPersonalApiKeysListUrl(ApiConfig.getCurrentOrganizationId())
                     return await api.loadPaginatedResults<OrganizationPersonalAPIKeyApi>(url)
                 },
+            },
+        ],
+    }),
+    reducers({
+        search: ['', { setSearch: (_, { search }) => search }],
+    }),
+    selectors({
+        // Client-side filtering — the full list is already loaded, so this stays in the browser.
+        filteredKeys: [
+            (s) => [s.keys, s.search],
+            (keys, search): OrganizationPersonalAPIKeyApi[] => {
+                const term = search.trim().toLowerCase()
+                if (!term) {
+                    return keys
+                }
+                return keys.filter((key) =>
+                    [fullName(key.owner), key.owner.email, ...key.scopes].some((field) =>
+                        field.toLowerCase().includes(term)
+                    )
+                )
             },
         ],
     }),


### PR DESCRIPTION
## Problem

On organizations with many members, the personal API key access list is an unbroken wall of rows that is hard to scan.

## Changes

- Paginate the list at 25 rows per page, client-side — the full list still loads from the backend
- Make the Owner, Masked value, Last used, and Created columns sortable
- Add a search field that filters by owner name, email, or scope

## How did you test this code?

- Frontend logic test extended (3 total) covering the search filter
- Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?