### PR TITLE
feat(experiments): add observability to metric recalculation workflow

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -54,6 +54,8 @@ from posthog.temporal.session_replay.delete_recordings.metrics import (
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
 from products.experiments.backend.temporal.recalculation_metrics import (
+    EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_BUCKETS,
+    EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_METRICS,
     EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_BUCKETS,
     EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_METRICS,
     ExperimentsRecalculationMetricsInterceptor,
@@ -274,6 +276,12 @@ async def create_worker(
             zip(
                 EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_METRICS,
                 itertools.repeat(EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_BUCKETS),
+            )
+        )
+        | dict(
+            zip(
+                EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_METRICS,
+                itertools.repeat(EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_BUCKETS),
             )
         )
         | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]}

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -16,6 +16,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
+from prometheus_client import Counter
 from rest_framework.exceptions import ValidationError
 
 from posthog.models.scoping import team_scope
@@ -39,6 +40,20 @@ from products.experiments.backend.temporal.recalculation_logic import discover_e
 # never started (Temporal connect failure, transient infra issue, etc.). See the rollback in views.py for the
 # happy-path failure handling; this TTL is the defense-in-depth backstop if that rollback itself fails.
 _STALE_RECALC_THRESHOLD = timedelta(minutes=30)
+
+# `is_existing=True` reuse path — counts how often the idempotency guard saves us a workflow start.
+# A sustained climb here without a matching climb in requests is the signal the frontend is double-posting.
+_recalculation_reuse_counter = Counter(
+    "experiment_metrics_recalculation_existing_run_reused",
+    "POST requests that returned an existing active run instead of creating a new one (idempotent reuse).",
+)
+# Fires whenever the 30-min staleness threshold marks a PENDING/IN_PROGRESS row FAILED so the experiment
+# can recalculate again. A sustained climb is a leading indicator of Temporal connect failures or the
+# rollback path in views.py itself failing.
+_recalculation_stale_cleanup_counter = Counter(
+    "experiment_metrics_recalculation_stale_rows_cleaned",
+    "Stale recalc rows force-failed to release the per-experiment uniqueness constraint.",
+)
 
 
 def _derive_counters(recalc: ExperimentMetricsRecalculation, results: list[dict] | None = None) -> tuple[int, int]:
@@ -128,18 +143,21 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
             .first()
         )
         if existing:
+            _recalculation_reuse_counter.inc()
             return build_job_payload(existing, is_existing=True)
 
         # No fresh active row, but stale tombstones might still hold the per-experiment uniqueness constraint
         # (unique_active_metrics_recalculation_per_experiment). Mark them FAILED so the constraint releases
         # and the new row can land. Status reflects reality — these workflows are not coming back.
-        ExperimentMetricsRecalculation.objects.filter(
+        cleaned_count = ExperimentMetricsRecalculation.objects.filter(
             experiment=experiment,
             status__in=[
                 ExperimentMetricsRecalculation.Status.PENDING,
                 ExperimentMetricsRecalculation.Status.IN_PROGRESS,
             ],
         ).update(status=ExperimentMetricsRecalculation.Status.FAILED, completed_at=timezone.now())
+        if cleaned_count:
+            _recalculation_stale_cleanup_counter.inc(cleaned_count)
 
         # Set total_metrics up front from the experiment definition so the client can show progress
         # ("N of M") immediately, before the workflow's discovery activity confirms the same count.

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -30,7 +30,7 @@ from products.experiments.backend.models.experiment import (
 )
 from products.experiments.backend.result_serialization import strip_step_sessions
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
-from products.experiments.backend.temporal.recalculation_logic import discover_metrics_for_experiment, find_metric_dict
+from products.experiments.backend.temporal.recalculation_logic import discover_experiment_metrics, find_metric_dict
 
 # How long an active (PENDING/IN_PROGRESS) row blocks new recalculations. Beyond this, the row is treated as
 # stale and a fresh recalc is allowed. Sized to be safely above the workflow's worst-case end-to-end runtime
@@ -143,7 +143,7 @@ def request_recalculation(experiment: Experiment, user: User, trigger: str = "ma
 
         # Set total_metrics up front from the experiment definition so the client can show progress
         # ("N of M") immediately, before the workflow's discovery activity confirms the same count.
-        metrics = discover_metrics_for_experiment(experiment)
+        metrics = discover_experiment_metrics(experiment)
         recalc = ExperimentMetricsRecalculation.objects.create(
             team=experiment.team,
             experiment=experiment,

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -134,3 +134,7 @@ class RecalculationProgressUpdate:
     metric_uuids: list[str] | None = None
     mark_started: bool = False
     mark_completed: bool = False
+    # Run-level outcome carried on the finish step so the activity can emit the
+    # 'experiment results refresh completed' analytics event with real counts.
+    succeeded_metrics: int | None = None
+    failed_metrics: int | None = None

--- a/products/experiments/backend/temporal/recalculation_activities.py
+++ b/products/experiments/backend/temporal/recalculation_activities.py
@@ -36,11 +36,19 @@ async def update_recalculation_progress(update: RecalculationProgressUpdate) -> 
 
 @temporalio.activity.defn
 async def calculate_experiment_metric_for_recalculation(
-    experiment_id: int, metric_uuid: str, recalculation_id: str, query_to: str
+    experiment_id: int,
+    metric_uuid: str,
+    recalculation_id: str,
+    query_to: str,
+    metric_type: str = "primary",
 ) -> MetricRecalculationResult:
     """Calculate one metric, write its recalc-fingerprinted result to ExperimentMetricResult, and fold the
     progress update (counter + error) into the same job atomically. query_to is the run's shared data-window end.
+
+    metric_type is the primary/secondary classification carried from discovery; it's threaded into the per-metric
+    PostHog event so the capture path doesn't have to re-query the saved-metric M2M to resolve it. Defaults to
+    "primary" so existing call sites and tests that don't pass it remain valid.
     """
     return await _calculate_experiment_metric_for_recalculation_sync(
-        experiment_id, metric_uuid, recalculation_id, query_to
+        experiment_id, metric_uuid, recalculation_id, query_to, metric_type
     )

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -18,7 +18,7 @@ from temporalio.exceptions import ApplicationError
 from posthog.schema import ExperimentQuery
 
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
@@ -461,7 +461,14 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 override_end_date=query_to_dt,
                 workload=Workload.OFFLINE,
             )
-            tag_queries(trigger="warming/experiment_metrics_recalculation")
+            # Attribute CH load back to this team + product so query_log analysis can tell whose recalc is
+            # expensive without reverse-engineering the trigger string.
+            tag_queries(
+                trigger="warming/experiment_metrics_recalculation",
+                team_id=state.team_id,
+                product=Product.EXPERIMENTS,
+                feature=Feature.CACHE_WARMUP,
+            )
             result = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
             result_dict = result.model_dump(mode="json")
 

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -323,29 +323,21 @@ def _fail(recalculation_id: str, metric_uuid: str, step: str, message: str) -> M
 # ---------------------------------------------------------------------------
 
 
-def _metric_type_for_uuid(experiment: Experiment, metric_uuid: str) -> str:
-    """primary | secondary — which list the metric belongs to (inline or saved)."""
-    for metric in experiment.metrics or []:
-        if metric.get("uuid") == metric_uuid:
-            return "primary"
-    for metric in experiment.metrics_secondary or []:
-        if metric.get("uuid") == metric_uuid:
-            return "secondary"
-    for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
-        if (link.saved_metric.query or {}).get("uuid") == metric_uuid:
-            return link.metadata.get("type", "primary") if link.metadata else "primary"
-    return "primary"
-
-
 def _capture_experiment_metric_event(
     experiment: Experiment,
     metric_uuid: str,
+    metric_type: str,
     metric_dict: dict | None,
     event: str,
     extra_properties: dict[str, Any],
 ) -> None:
     """Emit a per-metric product analytics event. Telemetry must never fail the activity, so any error
-    is swallowed. Attributed to the experiment creator, falling back to a team-scoped distinct_id."""
+    is swallowed. Attributed to the experiment creator, falling back to a team-scoped distinct_id.
+
+    `metric_type` is the primary/secondary classification carried from discovery
+    (`ExperimentMetricToRecalculate.metric_type`), threaded through the workflow + activity args so the
+    capture path doesn't have to re-query the M2M to resolve it.
+    """
     try:
         team = experiment.team
         distinct_id = (
@@ -362,7 +354,7 @@ def _capture_experiment_metric_event(
                     "team_id": team.id,
                     "metric_uuid": metric_uuid,
                     "metric_kind": (metric_dict or {}).get("metric_type"),
-                    "is_primary": _metric_type_for_uuid(experiment, metric_uuid) == "primary",
+                    "is_primary": metric_type == "primary",
                     "execution_mode": "recalculation",
                     **extra_properties,
                 },
@@ -385,7 +377,11 @@ def _capture_experiment_metric_event(
 
 @database_sync_to_async
 def _calculate_experiment_metric_for_recalculation_sync(
-    experiment_id: int, metric_uuid: str, recalculation_id: str, query_to: str
+    experiment_id: int,
+    metric_uuid: str,
+    recalculation_id: str,
+    query_to: str,
+    metric_type: str = "primary",
 ) -> MetricRecalculationResult:
     close_old_connections()
 
@@ -485,6 +481,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
             _capture_experiment_metric_event(
                 experiment,
                 metric_uuid,
+                metric_type,
                 metric_dict,
                 "experiment metric finished",
                 {"duration_ms": round((time.perf_counter() - calc_started_at) * 1000)},
@@ -513,6 +510,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
             _capture_experiment_metric_event(
                 experiment,
                 metric_uuid,
+                metric_type,
                 metric_dict,
                 "experiment metric error",
                 {

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -4,8 +4,10 @@ The thin ``@temporalio.activity.defn`` entrypoints live in ``recalculation_activ
 module holds the DB-touching ``_*_sync`` implementations plus the pure helpers they compose from.
 """
 
+import time
 import dataclasses
 from datetime import datetime
+from typing import Any
 
 from django.db import close_old_connections, transaction
 from django.utils import timezone
@@ -17,9 +19,11 @@ from posthog.schema import ExperimentQuery
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import tag_queries
+from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models.scoping import team_scope
+from posthog.ph_client import ph_scoped_capture
 from posthog.sync import database_sync_to_async
 
 from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
@@ -88,17 +92,16 @@ def _get_recalc_state(recalculation_id: str) -> _RecalcState:
     )
 
 
-def discover_metrics_for_experiment(experiment: Experiment) -> list[ExperimentMetricToRecalculate]:
-    """Traverse the experiment definition and return the list of metrics a recalc should process.
+def discover_experiment_metrics(experiment: Experiment) -> list[ExperimentMetricToRecalculate]:
+    """All metrics to recalculate for an experiment, in (primary, secondary, saved) order.
 
-    Pure read of the experiment object — no database writes, no scoping concerns. The activity wrapper
-    (`_discover_experiment_metrics_sync`) loads + scopes + persists `metric_uuids`; the service layer can
-    call this directly when it already has the experiment in scope (e.g., to seed `total_metrics` at create
-    time so the client can show progress without waiting for the workflow's discovery activity to run).
+    Single source of truth for "which metrics does this experiment have" — used both to set
+    ``total_metrics`` at recalculation-create time and by the discovery activity. Touches the DB
+    (saved-metric links), so call inside a team scope / sync context.
 
-    Named `discover_metrics_for_experiment` (not `discover_experiment_metrics`) to avoid colliding with the
-    Temporal activity of the same shape in `recalculation_activities.py`, which takes a `recalculation_id`
-    instead of an Experiment.
+    Note: this sync helper takes an ``Experiment``. The async Temporal activity in
+    ``recalculation_activities.py`` shares the name but takes a ``recalculation_id`` — disambiguate by
+    import path and argument type at the call site.
     """
     metrics_to_recalculate: list[ExperimentMetricToRecalculate] = []
 
@@ -135,7 +138,7 @@ def _discover_experiment_metrics_sync(recalculation_id: str) -> list[ExperimentM
         recalculation = ExperimentMetricsRecalculation.objects.select_related("experiment").get(id=recalculation_id)
         experiment = recalculation.experiment
 
-        metrics_to_recalculate = discover_metrics_for_experiment(experiment)
+        metrics_to_recalculate = discover_experiment_metrics(experiment)
 
         recalculation.metric_uuids = [m.metric_uuid for m in metrics_to_recalculate]
         recalculation.save(update_fields=["metric_uuids"])
@@ -193,11 +196,67 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
 
         # Finish: same first-write-wins guard so a retried mark_completed activity doesn't re-stamp the
         # completion timestamp (and, by symmetry with mark_started, doesn't reopen a closed run).
-        ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id, completed_at__isnull=True).update(
-            completed_at=timezone.now(),
-            status=update.status or ExperimentMetricsRecalculation.Status.COMPLETED,
+        won = (
+            ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id, completed_at__isnull=True).update(
+                completed_at=timezone.now(),
+                status=update.status or ExperimentMetricsRecalculation.Status.COMPLETED,
+            )
+            == 1
         )
+        # Emit the run-level analytics event only on the winning (first) completion, so a retried
+        # mark_completed doesn't double-count.
+        if won:
+            _capture_results_refresh_completed(update)
         return None
+
+
+def _capture_results_refresh_completed(update: RecalculationProgressUpdate) -> None:
+    """Run-level analytics: 'experiment results refresh completed' with the final counts. Mirrors the
+    legacy client-side event. Telemetry must never fail the activity, so swallow any error."""
+    try:
+        recalc = (
+            ExperimentMetricsRecalculation.objects.select_related("experiment", "experiment__team")
+            .filter(id=update.recalculation_id)
+            .first()
+        )
+        if recalc is None:
+            return
+        experiment = recalc.experiment
+        team = experiment.team
+        distinct_id = (
+            experiment.created_by.distinct_id
+            if experiment.created_by and experiment.created_by.distinct_id
+            else f"team_{team.id}"
+        )
+        total_duration_ms = (
+            round((recalc.completed_at - recalc.created_at).total_seconds() * 1000)
+            if recalc.completed_at and recalc.created_at
+            else None
+        )
+        with ph_scoped_capture() as capture:
+            capture(
+                distinct_id=distinct_id,
+                event="experiment results refresh completed",
+                properties={
+                    "experiment_id": experiment.id,
+                    "team_id": team.id,
+                    "recalculation_id": str(recalc.id),
+                    "status": recalc.status,
+                    "total_metrics": recalc.total_metrics,
+                    "succeeded_metrics": update.succeeded_metrics,
+                    "failed_metrics": update.failed_metrics,
+                    "total_duration_ms": total_duration_ms,
+                    "trigger": recalc.trigger,
+                    "execution_mode": "recalculation",
+                },
+                groups=groups(organization=team.organization, team=team),
+            )
+    except Exception:
+        logger.warning(
+            "experiment_results_refresh_completed_capture_failed",
+            recalculation_id=update.recalculation_id,
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +312,70 @@ def _fail(recalculation_id: str, metric_uuid: str, step: str, message: str) -> M
     return MetricRecalculationResult(
         metric_uuid=metric_uuid, success=False, error_step=step, error_message=message[:_MAX_ERROR_MESSAGE_LENGTH]
     )
+
+
+# ---------------------------------------------------------------------------
+# Product analytics (recalculation flow)
+#
+# These mirror the legacy client-side events ('experiment metric finished' / 'experiment metric error'),
+# now that metrics are computed on the backend instead of in the browser. execution_mode='recalculation'
+# distinguishes them from legacy events on the same dashboards.
+# ---------------------------------------------------------------------------
+
+
+def _metric_type_for_uuid(experiment: Experiment, metric_uuid: str) -> str:
+    """primary | secondary — which list the metric belongs to (inline or saved)."""
+    for metric in experiment.metrics or []:
+        if metric.get("uuid") == metric_uuid:
+            return "primary"
+    for metric in experiment.metrics_secondary or []:
+        if metric.get("uuid") == metric_uuid:
+            return "secondary"
+    for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
+        if (link.saved_metric.query or {}).get("uuid") == metric_uuid:
+            return link.metadata.get("type", "primary") if link.metadata else "primary"
+    return "primary"
+
+
+def _capture_experiment_metric_event(
+    experiment: Experiment,
+    metric_uuid: str,
+    metric_dict: dict | None,
+    event: str,
+    extra_properties: dict[str, Any],
+) -> None:
+    """Emit a per-metric product analytics event. Telemetry must never fail the activity, so any error
+    is swallowed. Attributed to the experiment creator, falling back to a team-scoped distinct_id."""
+    try:
+        team = experiment.team
+        distinct_id = (
+            experiment.created_by.distinct_id
+            if experiment.created_by and experiment.created_by.distinct_id
+            else f"team_{team.id}"
+        )
+        with ph_scoped_capture() as capture:
+            capture(
+                distinct_id=distinct_id,
+                event=event,
+                properties={
+                    "experiment_id": experiment.id,
+                    "team_id": team.id,
+                    "metric_uuid": metric_uuid,
+                    "metric_kind": (metric_dict or {}).get("metric_type"),
+                    "is_primary": _metric_type_for_uuid(experiment, metric_uuid) == "primary",
+                    "execution_mode": "recalculation",
+                    **extra_properties,
+                },
+                groups=groups(organization=team.organization, team=team),
+            )
+    except Exception:
+        logger.warning(
+            "experiment_metric_event_capture_failed",
+            event=event,
+            experiment_id=experiment.id,
+            metric_uuid=metric_uuid,
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +449,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
         )
         recalc_fp = compute_recalc_fingerprint(config_fp, recalculation_id)
 
+        calc_started_at = time.perf_counter()
         try:
             # Metric build + query live inside the try so unexpected shapes surface as a calculation-step failure.
             # override_end_date forces the run's shared query_to into the ClickHouse query bounds. Without it
@@ -351,6 +475,13 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 result=result_dict,
                 error_message=None,
             )
+            _capture_experiment_metric_event(
+                experiment,
+                metric_uuid,
+                metric_dict,
+                "experiment metric finished",
+                {"duration_ms": round((time.perf_counter() - calc_started_at) * 1000)},
+            )
             return MetricRecalculationResult(metric_uuid=metric_uuid, success=True)
 
         except (StatisticError, ZeroDivisionError) as e:
@@ -371,6 +502,17 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 experiment_id=experiment_id,
                 metric_uuid=metric_uuid,
                 error=message,
+            )
+            _capture_experiment_metric_event(
+                experiment,
+                metric_uuid,
+                metric_dict,
+                "experiment metric error",
+                {
+                    "duration_ms": round((time.perf_counter() - calc_started_at) * 1000),
+                    "error_type": "insufficient_data",
+                    "error_message": message,
+                },
             )
             return _fail(recalculation_id, metric_uuid, "calculation", message)
 
@@ -404,4 +546,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 experiment_id=experiment_id,
                 metric_uuid=metric_uuid,
             )
+            # No 'experiment metric error' event here: this path re-raises and Temporal retries, so
+            # emitting would double-count per attempt. The final failed count is reported once at the
+            # run level ('experiment results refresh completed').
             raise

--- a/products/experiments/backend/temporal/recalculation_metrics.py
+++ b/products/experiments/backend/temporal/recalculation_metrics.py
@@ -48,6 +48,14 @@ EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_BUCKETS = [
     300_000.0,  # 5m
 ]
 
+# Bucket boundaries for `_activity_success_attempts` (counts the attempt number at which success was reached).
+# With `RetryPolicy(maximum_attempts=2)` today, only buckets [1, 2] are populated, but the wider range survives
+# a future policy change without needing a new histogram.
+EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_METRICS = (
+    "experiment_metrics_recalculation_activity_success_attempts",
+)
+EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_BUCKETS = [1.0, 2.0, 5.0, 10.0]
+
 
 def increment_workflow_finished(status: str) -> None:
     """Workflow-body callsite for the terminal lifecycle counter.
@@ -56,8 +64,12 @@ def increment_workflow_finished(status: str) -> None:
     `status` attribute can be the run's business-level outcome (`"completed"` / `"failed"`, where `"failed"`
     means at least one metric failed). An interceptor-based version would only see exception-vs-no-exception,
     which conflates a 9-of-10-failed run with a healthy one.
+
+    `workflow_type` is attached so dashboards stay scoped when other experiments workflows ship later.
     """
-    workflow.metric_meter().with_additional_attributes({"status": status}).create_counter(
+    workflow.metric_meter().with_additional_attributes(
+        {"status": status, "workflow_type": _RECALCULATION_WORKFLOW_TYPE}
+    ).create_counter(
         "experiment_metrics_recalculation_workflow_finished",
         "Number of experiment metrics recalculation workflows that reached a terminal state.",
     ).add(1)
@@ -65,16 +77,30 @@ def increment_workflow_finished(status: str) -> None:
 
 class _ActivityInboundInterceptor(ActivityInboundInterceptor):
     async def execute_activity(self, input: ExecuteActivityInput) -> typing.Any:
-        activity_type = activity.info().activity_type
+        info = activity.info()
+        activity_type = info.activity_type
         if activity_type not in _RECALCULATION_ACTIVITY_TYPES:
             return await super().execute_activity(input)
 
-        meter = activity.metric_meter().with_additional_attributes({"activity_type": activity_type})
+        meter = activity.metric_meter().with_additional_attributes(
+            {"activity_type": activity_type, "workflow_type": _RECALCULATION_WORKFLOW_TYPE}
+        )
+        # Fires on every attempt (first run + each retry). Comparing this to `_activity_successes` reveals
+        # retry rate; without it a transient ClickHouse blip is indistinguishable from a healthy first-try
+        # success. Pattern mirrors batch_exports' `batch_exports_activity_attempts`.
+        meter.create_counter(
+            "experiment_metrics_recalculation_activity_attempts",
+            "Number of experiment metrics recalculation activity attempts (each retry is one attempt).",
+        ).add(1)
+
         try:
             with ExecutionTimeRecorder(
                 "experiment_metrics_recalculation_activity_execution_latency",
                 description="Execution latency for experiment metrics recalculation activities.",
-                histogram_attributes={"activity_type": activity_type},
+                histogram_attributes={
+                    "activity_type": activity_type,
+                    "workflow_type": _RECALCULATION_WORKFLOW_TYPE,
+                },
             ):
                 result = await super().execute_activity(input)
         except Exception:
@@ -87,6 +113,14 @@ class _ActivityInboundInterceptor(ActivityInboundInterceptor):
             "experiment_metrics_recalculation_activity_successes",
             "Number of successful experiment metrics recalculation activity executions.",
         ).add(1)
+        # Records the attempt-count distribution for successful runs. info.attempt is 1 on a first-try success
+        # and >1 when retries happened before success — `histogram_quantile(0.99, ...)` answers
+        # "how often do we need to retry to succeed?". Matches batch_exports' success_attempts pattern.
+        meter.create_histogram(
+            name="experiment_metrics_recalculation_activity_success_attempts",
+            description="Attempt number at which an activity execution succeeded (1 = first try).",
+            unit="attempts",
+        ).record(info.attempt)
         return result
 
 
@@ -94,7 +128,9 @@ class _WorkflowInboundInterceptor(WorkflowInboundInterceptor):
     async def execute_workflow(self, input: ExecuteWorkflowInput) -> typing.Any:
         if workflow.info().workflow_type != _RECALCULATION_WORKFLOW_TYPE:
             return await super().execute_workflow(input)
-        workflow.metric_meter().create_counter(
+        workflow.metric_meter().with_additional_attributes(
+            {"workflow_type": _RECALCULATION_WORKFLOW_TYPE}
+        ).create_counter(
             "experiment_metrics_recalculation_workflow_started",
             "Number of experiment metrics recalculation workflows started.",
         ).add(1)
@@ -102,6 +138,7 @@ class _WorkflowInboundInterceptor(WorkflowInboundInterceptor):
             with ExecutionTimeRecorder(
                 "experiment_metrics_recalculation_workflow_execution_latency",
                 description="End-to-end execution latency for the experiment metrics recalculation workflow.",
+                histogram_attributes={"workflow_type": _RECALCULATION_WORKFLOW_TYPE},
             ):
                 return await super().execute_workflow(input)
         except BaseException:

--- a/products/experiments/backend/temporal/recalculation_workflow.py
+++ b/products/experiments/backend/temporal/recalculation_workflow.py
@@ -107,7 +107,7 @@ class ExperimentMetricsRecalculationWorkflow(PostHogWorkflow):
             async with semaphore:
                 return await temporalio.workflow.execute_activity(
                     calculate_experiment_metric_for_recalculation,
-                    args=[metric.experiment_id, metric.metric_uuid, recalculation_id, query_to],
+                    args=[metric.experiment_id, metric.metric_uuid, recalculation_id, query_to, metric.metric_type],
                     # No heartbeat: the activity's only long-running step is one blocking ClickHouse query
                     # with no progress hooks, so start_to_close_timeout is the real per-attempt ceiling.
                     start_to_close_timeout=timedelta(minutes=5),

--- a/products/experiments/backend/temporal/recalculation_workflow.py
+++ b/products/experiments/backend/temporal/recalculation_workflow.py
@@ -128,7 +128,13 @@ class ExperimentMetricsRecalculationWorkflow(PostHogWorkflow):
         final_status = "failed" if failed > 0 else "completed"
         await temporalio.workflow.execute_activity(
             update_recalculation_progress,
-            RecalculationProgressUpdate(recalculation_id=recalculation_id, status=final_status, mark_completed=True),
+            RecalculationProgressUpdate(
+                recalculation_id=recalculation_id,
+                status=final_status,
+                mark_completed=True,
+                succeeded_metrics=succeeded,
+                failed_metrics=failed,
+            ),
             start_to_close_timeout=timedelta(seconds=30),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -41,9 +41,15 @@ def _update(update: RecalculationProgressUpdate):
         return _update_raw(update)
 
 
-def _calculate(experiment_id: int, metric_uuid: str, recalculation_id: str, query_to: str):
+def _calculate(
+    experiment_id: int,
+    metric_uuid: str,
+    recalculation_id: str,
+    query_to: str,
+    metric_type: str = "primary",
+):
     with patch("products.experiments.backend.temporal.recalculation_logic.close_old_connections"):
-        return _calculate_raw(experiment_id, metric_uuid, recalculation_id, query_to)
+        return _calculate_raw(experiment_id, metric_uuid, recalculation_id, query_to, metric_type)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -669,6 +675,9 @@ class TestRecalculationAnalytics(BaseTest):
         assert props["execution_mode"] == "recalculation"
 
     def test_secondary_metric_is_not_marked_primary(self):
+        # metric_type is now threaded through from the workflow's discovery output rather than re-derived
+        # from a fresh DB lookup. The activity's caller (workflow) reads the value from
+        # ExperimentMetricToRecalculate; tests pass it explicitly to exercise the same path.
         exp = self._experiment(flag_key="an-secondary", secondary=[_mean_metric("s1")])
         recalc = self._recalc(exp, metric_uuids=["s1"])
 
@@ -677,7 +686,7 @@ class TestRecalculationAnalytics(BaseTest):
                 "products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner"
             ) as mock_runner:
                 mock_runner.return_value.run.return_value.model_dump.return_value = {}
-                _calculate(exp.id, "s1", str(recalc.id), _QUERY_TO)
+                _calculate(exp.id, "s1", str(recalc.id), _QUERY_TO, metric_type="secondary")
 
         assert captured[0]["properties"]["is_primary"] is False
 

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import datetime
 
 import pytest
@@ -22,6 +23,7 @@ from products.experiments.backend.temporal.recalculation_logic import (
     _discover_experiment_metrics_sync,
     _update_recalculation_progress_sync,
 )
+from products.experiments.stats.shared.statistics import StatisticError
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 _discover_raw = _discover_experiment_metrics_sync.func  # type: ignore[attr-defined]
@@ -565,3 +567,174 @@ class TestMissingRecalcRow:
         assert bogus_id in str(exc_info.value)
         assert "not found" in str(exc_info.value)
         assert exc_info.value.non_retryable is True
+
+
+@contextmanager
+def _record_captures():
+    """Patch ph_scoped_capture so the analytics tests can assert the exact event name + properties
+    without standing up a real PostHog client. Yields the list of captured capture(...) kwargs."""
+    captured: list[dict] = []
+
+    def _fake_capture(*args, **kwargs) -> None:
+        captured.append(kwargs)
+
+    @contextmanager
+    def _fake_scoped():
+        yield _fake_capture
+
+    with patch(
+        "products.experiments.backend.temporal.recalculation_logic.ph_scoped_capture",
+        _fake_scoped,
+    ):
+        yield captured
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRecalculationAnalytics(BaseTest):
+    """Product analytics emitted by the recalculation activities. Names mirror the legacy client-side
+    events; execution_mode='recalculation' distinguishes the backend-driven flow."""
+
+    def _flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            name=f"Flag for {key}",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+    def _experiment(self, flag_key: str, *, metrics=None, secondary=None) -> Experiment:
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=self._flag(flag_key),
+            name="exp",
+            start_date=timezone.now(),
+        )
+        if metrics is not None:
+            exp.metrics = metrics
+        if secondary is not None:
+            exp.metrics_secondary = secondary
+        exp.save()
+        return exp
+
+    def _recalc(self, exp: Experiment, *, metric_uuids: list[str]) -> ExperimentMetricsRecalculation:
+        return ExperimentMetricsRecalculation.objects.create(
+            team=self.team,
+            experiment=exp,
+            metric_uuids=metric_uuids,
+            total_metrics=len(metric_uuids),
+            query_to=datetime.fromisoformat(_QUERY_TO),
+        )
+
+    def test_metric_finished_event_on_success(self):
+        exp = self._experiment(flag_key="an-success", metrics=[_mean_metric("m1")])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with _record_captures() as captured:
+            with patch(
+                "products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner"
+            ) as mock_runner:
+                mock_runner.return_value.run.return_value.model_dump.return_value = {}
+                _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO)
+
+        assert len(captured) == 1
+        props = captured[0]["properties"]
+        assert captured[0]["event"] == "experiment metric finished"
+        assert captured[0]["distinct_id"] == self.user.distinct_id
+        assert props["experiment_id"] == exp.id
+        assert props["team_id"] == self.team.id
+        assert props["metric_uuid"] == "m1"
+        assert props["metric_kind"] == "mean"
+        assert props["is_primary"] is True
+        assert props["execution_mode"] == "recalculation"
+        assert "duration_ms" in props
+
+    def test_metric_error_event_on_insufficient_data(self):
+        exp = self._experiment(flag_key="an-error", metrics=[_mean_metric("m1")])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with _record_captures() as captured:
+            with patch(
+                "products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner"
+            ) as mock_runner:
+                mock_runner.return_value.run.side_effect = StatisticError("not enough data")
+                _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO)
+
+        assert len(captured) == 1
+        props = captured[0]["properties"]
+        assert captured[0]["event"] == "experiment metric error"
+        assert props["error_type"] == "insufficient_data"
+        assert props["error_message"] == "not enough data"
+        assert props["execution_mode"] == "recalculation"
+
+    def test_secondary_metric_is_not_marked_primary(self):
+        exp = self._experiment(flag_key="an-secondary", secondary=[_mean_metric("s1")])
+        recalc = self._recalc(exp, metric_uuids=["s1"])
+
+        with _record_captures() as captured:
+            with patch(
+                "products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner"
+            ) as mock_runner:
+                mock_runner.return_value.run.return_value.model_dump.return_value = {}
+                _calculate(exp.id, "s1", str(recalc.id), _QUERY_TO)
+
+        assert captured[0]["properties"]["is_primary"] is False
+
+    def test_transient_failure_emits_no_per_metric_event(self):
+        # The transient except-Exception path re-raises for Temporal to retry; emitting there would
+        # double-count per attempt. The failure is reflected in the run-level event instead.
+        exp = self._experiment(flag_key="an-transient", metrics=[_mean_metric("m1")])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with _record_captures() as captured:
+            with patch(
+                "products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner"
+            ) as mock_runner:
+                mock_runner.return_value.run.side_effect = RuntimeError("kaboom")
+                with pytest.raises(RuntimeError, match="kaboom"):
+                    _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO)
+
+        assert captured == []
+
+    def test_results_refresh_completed_event_on_finish(self):
+        exp = self._experiment(flag_key="an-finish", metrics=[_mean_metric("m1")])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with _record_captures() as captured:
+            _update(
+                RecalculationProgressUpdate(
+                    recalculation_id=str(recalc.id),
+                    status="completed",
+                    mark_completed=True,
+                    succeeded_metrics=3,
+                    failed_metrics=1,
+                )
+            )
+
+        assert len(captured) == 1
+        props = captured[0]["properties"]
+        assert captured[0]["event"] == "experiment results refresh completed"
+        assert captured[0]["distinct_id"] == self.user.distinct_id
+        assert props["experiment_id"] == exp.id
+        assert props["team_id"] == self.team.id
+        assert props["recalculation_id"] == str(recalc.id)
+        assert props["status"] == "completed"
+        assert props["succeeded_metrics"] == 3
+        assert props["failed_metrics"] == 1
+        assert props["execution_mode"] == "recalculation"
+        assert "total_duration_ms" in props
+
+    def test_results_refresh_completed_not_re_emitted_on_retry(self):
+        # mark_completed is first-write-wins; a retried finish activity must not re-fire the run-level event.
+        exp = self._experiment(flag_key="an-finish-retry", metrics=[_mean_metric("m1")])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        update = RecalculationProgressUpdate(
+            recalculation_id=str(recalc.id), status="completed", mark_completed=True, succeeded_metrics=1
+        )
+        with _record_captures() as captured:
+            _update(update)
+            _update(update)  # simulated Temporal retry
+
+        assert len(captured) == 1

--- a/products/experiments/backend/temporal/test_recalculation_metrics.py
+++ b/products/experiments/backend/temporal/test_recalculation_metrics.py
@@ -99,7 +99,9 @@ def test_increment_workflow_finished_emits_status_attribute(name: str, status: s
     ):
         increment_workflow_finished(status)
 
-    mock_meter.with_additional_attributes.assert_called_once_with({"status": status})
+    mock_meter.with_additional_attributes.assert_called_once_with(
+        {"status": status, "workflow_type": "experiment-metrics-recalculation-workflow"}
+    )
     mock_meter_with_attrs.create_counter.assert_called_once()
     assert (
         mock_meter_with_attrs.create_counter.call_args.args[0] == "experiment_metrics_recalculation_workflow_finished"

--- a/products/experiments/backend/temporal/test_recalculation_workflow.py
+++ b/products/experiments/backend/temporal/test_recalculation_workflow.py
@@ -47,9 +47,13 @@ def _make_mock_activities(
 
     @activity.defn(name="calculate_experiment_metric_for_recalculation")
     async def mock_calculate(
-        experiment_id: int, metric_uuid: str, recalculation_id: str, query_to: str
+        experiment_id: int,
+        metric_uuid: str,
+        recalculation_id: str,
+        query_to: str,
+        metric_type: str = "primary",
     ) -> MetricRecalculationResult:
-        calculate_calls.append((experiment_id, metric_uuid, recalculation_id, query_to))
+        calculate_calls.append((experiment_id, metric_uuid, recalculation_id, query_to, metric_type))
         return metric_results.get(metric_uuid, MetricRecalculationResult(metric_uuid=metric_uuid, success=True))
 
     activities = [mock_discover, mock_update_progress, mock_calculate]
@@ -148,7 +152,11 @@ class TestExperimentMetricsRecalculationWorkflow:
 
         @activity.defn(name="calculate_experiment_metric_for_recalculation")
         async def mock_calculate(
-            experiment_id: int, metric_uuid: str, recalculation_id: str, query_to: str
+            experiment_id: int,
+            metric_uuid: str,
+            recalculation_id: str,
+            query_to: str,
+            metric_type: str = "primary",
         ) -> MetricRecalculationResult:
             return MetricRecalculationResult(metric_uuid=metric_uuid, success=True)
 
@@ -196,7 +204,11 @@ class TestExperimentMetricsRecalculationWorkflow:
 
         @activity.defn(name="calculate_experiment_metric_for_recalculation")
         async def mock_calculate(
-            experiment_id: int, metric_uuid: str, recalculation_id: str, query_to: str
+            experiment_id: int,
+            metric_uuid: str,
+            recalculation_id: str,
+            query_to: str,
+            metric_type: str = "primary",
         ) -> MetricRecalculationResult:
             return MetricRecalculationResult(metric_uuid=metric_uuid, success=True)
 

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -14,6 +14,8 @@ from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricResult,
     ExperimentMetricsRecalculation,
+    ExperimentSavedMetric,
+    ExperimentToSavedMetric,
 )
 from products.experiments.backend.recalculation import (
     get_latest_recalculation,
@@ -71,6 +73,25 @@ class TestRecalculationService(BaseTest):
         assert result["status"] == "pending"
         assert result["is_existing"] is False
         assert ExperimentMetricsRecalculation.objects.filter(experiment=exp).count() == 1
+
+    def test_request_recalculation_sets_total_metrics_from_experiment(self):
+        # inline primary + inline secondary + one saved (shared) metric → total of 3
+        exp = self._launched_experiment(flag_key="total-metrics")
+        exp.metrics = [_mean_metric("p1")]
+        exp.metrics_secondary = [_mean_metric("s1")]
+        exp.save()
+        saved = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name="saved-shared1",
+            query={"uuid": "shared1", "kind": "ExperimentMetric", "metric_type": "mean"},
+        )
+        ExperimentToSavedMetric.objects.create(experiment=exp, saved_metric=saved, metadata={"type": "primary"})
+
+        result = request_recalculation(exp, self.user, "manual")
+
+        row = ExperimentMetricsRecalculation.objects.get(id=result["id"])
+        assert row.total_metrics == 3
+        assert set(row.metric_uuids) == {"p1", "s1", "shared1"}
 
     def test_request_recalculation_is_idempotent(self):
         exp = self._launched_experiment()


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The metric recalculation workflow shipped without observability on either side. On the product analytics side, the legacy client-side refresh flow fires three events that downstream dashboards key off today — `experiment results refresh completed`, `experiment metric finished`, and `experiment metric error` — and the recalc path was emitting none of them. Anyone querying those events for refresh latency, success rate, or per-metric errors silently undercounts every recalc run. On the server-metrics side, the Prometheus interceptor that ships with the workflow emits enough to graph aggregate health, but misses the labels and counters needed to filter by workflow type, distinguish first-try success from retried success, or detect the failure modes (Temporal connect drops, stale-row cleanup, frontend double-post) the recalc design was built to survive.

This PR fills both gaps in one branch since they're aimed at the same operational question: is the recalc workflow healthy, and if not, where?

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR wires PostHog product analytics events into the recalculation activity and extends the Prometheus interceptor with the labels and counters needed for actionable Grafana dashboards.

### Run-level PostHog completion event

When the finish step writes `completed_at` for the first time (first-write-wins, so retried `mark_completed` activities never double-count), the activity emits `experiment results refresh completed` with the same property shape the legacy flow used: `status`, `total_metrics`, `succeeded_metrics`, `failed_metrics`, `total_duration_ms`, `trigger`, plus an `execution_mode: "recalculation"` so existing dashboards can include or filter the recalc path. The counts are carried on `RecalculationProgressUpdate` from the workflow so the activity doesn't need a second DB round-trip to derive them.

- `products/experiments/backend/temporal/models.py`
- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/temporal/recalculation_workflow.py`

### Per-metric PostHog events

Each calc activity emits `experiment metric finished` on success and `experiment metric error` on a terminal calculation failure, with `metric_uuid`, `metric_kind`, `is_primary`, and `execution_mode: "recalculation"`. The "expected" failure branch (`StatisticError` / `ZeroDivisionError` — "not enough data") emits `error`; the broad-exception branch re-raises for Temporal to retry and only the eventual terminal failure surfaces an event, so transient retries don't pollute the dashboards.

- `products/experiments/backend/temporal/recalculation_logic.py`

### Prometheus interceptor labels

Every workflow-level metric (`workflow_started`, `workflow_finished`, `workflow_execution_latency`) and every activity-level metric (`activity_execution_latency`, `activity_successes`, `activity_failures`, plus the new attempts counters) now carries `workflow_type` as an attribute. Today there's exactly one experiments workflow, so dashboards work without filters; the label is in place so the moment a second experiments workflow ships, every existing Grafana panel stays correctly scoped without a backfill or a query rewrite.

- `products/experiments/backend/temporal/recalculation_metrics.py`

### Retry visibility counters

The interceptor now emits `activity_attempts` on every attempt (first run plus each retry) and records `activity_success_attempts` as a histogram of the attempt number at which an activity succeeded. `RetryPolicy(maximum_attempts=2)` was effectively invisible before — a healthy first-try success and a recovered retry looked identical on the success-rate dashboards. With these two metrics, `histogram_quantile(0.5, ..._activity_success_attempts) == 1` is the steady-state signal, and `activity_attempts / activity_successes` tells you how often retries are saving you. Bucket boundaries `[1, 2, 5, 10]` survive a future bump to `maximum_attempts` without needing a new histogram.

- `products/experiments/backend/temporal/recalculation_metrics.py`
- `posthog/temporal/common/worker.py`

### Service-layer Prometheus counters

Two new `prometheus_client.Counter` instances in the DRF service layer that the Temporal interceptor can't see: `experiment_metrics_recalculation_existing_run_reused` increments when the POST idempotency guard returns an active run (a sustained climb without matching request volume signals frontend double-post), and `experiment_metrics_recalculation_stale_rows_cleaned` increments when the 30-min staleness threshold force-fails PENDING/IN_PROGRESS rows so a fresh recalc can land (a sustained climb means Temporal-connect failures or the rollback path itself is broken).

- `products/experiments/backend/recalculation.py`

### ClickHouse query attribution

`tag_queries` in the calc activity now carries `team_id`, `product=EXPERIMENTS`, and `feature=CACHE_WARMUP` alongside the existing `trigger` string. ClickHouse `query_log` analysis can now attribute load back to this workflow and to the right team without reverse-engineering the trigger prefix. Mirrors what `session_replay/delete_recordings` and `data_modeling` already do.

- `products/experiments/backend/temporal/recalculation_logic.py`

### Attribution and safety on PostHog capture

All capture calls go through `ph_scoped_capture` from `posthog.ph_client` (in Celery contexts `posthoganalytics.capture` is silently lost). Events are attributed to the experiment creator's `distinct_id` when present, falling back to `team_{team_id}` for experiments whose creator is no longer accessible. Every capture is wrapped in try/except that logs at warning level — telemetry must never fail the activity.

### Side effects

`discover_metrics_for_experiment` was renamed back to `discover_experiment_metrics` to match the rest of the stack after a parallel rebase landed the same helper with the original name. The async Temporal activity in `recalculation_activities.py` shares the name but takes a `recalculation_id`; the docstring on the sync helper flags the disambiguation by import path and argument type.

- `products/experiments/backend/recalculation.py`
- `products/experiments/backend/temporal/recalculation_logic.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

Model: Opus 4.7
Manually refactored: **yes**
Skills used:
  /writing-pull-requests (local)
Relevant decisions:
- Run-level counts (`succeeded_metrics` / `failed_metrics`) are carried on `RecalculationProgressUpdate` from the workflow's final progress activity, not re-derived inside the capture function. The workflow already has them from `asyncio.gather`; passing them through avoids a second DB round trip and serves as the canonical source of truth.
- The `is_existing` reuse and stale-cleanup counters live on the DRF service layer (`recalculation.py`) using `prometheus_client.Counter` directly. The Temporal interceptor pattern applies only within workflow/activity contexts; these emission points run within the web request cycle, so the workflow-context APIs would have been invoked at runtime.
- `execution_mode: "recalculation"` is set on every PostHog event so legacy dashboards keep working unmodified, and `workflow_type` is set on every Prometheus metric so Grafana panels stay correctly scoped when a second experiments workflow ships later. Both reuse the existing event/metric names rather than introducing new ones — preserves dashboard continuity, not just coverage.