### PR TITLE
chore(playwright): retry comparison selection if the click is swallowed

### DIFF
--- a/playwright/page-models/insights/chartInsightBase.ts
+++ b/playwright/page-models/insights/chartInsightBase.ts
@@ -3,6 +3,9 @@ import { Locator, Page, expect } from '@playwright/test'
 export class ChartInsightBase {
     readonly chart: Locator
     readonly tooltip: Locator
+    readonly dateRangeButton: Locator
+    readonly chartTypeButton: Locator
+    readonly comparisonButton: Locator
 
     constructor(
         protected readonly page: Page,
@@ -10,6 +13,61 @@ export class ChartInsightBase {
     ) {
         this.chart = chartLocator
         this.tooltip = page.getByTestId('insight-tooltip')
+        this.dateRangeButton = page.getByTestId('date-filter')
+        this.chartTypeButton = page.getByTestId('chart-filter')
+        this.comparisonButton = page.getByTestId('compare-filter')
+    }
+
+    async waitForChart(): Promise<void> {
+        await this.page.getByTestId('insight-loading-waiting-message').waitFor({ state: 'detached', timeout: 30000 })
+        await expect(this.chart).toBeVisible({ timeout: 30000 })
+    }
+
+    async selectChartType(namePattern: RegExp): Promise<void> {
+        await this.page.keyboard.press('Escape')
+        await expect(async () => {
+            await this.chartTypeButton.click({ timeout: 500 })
+            await this.page.getByRole('menuitem', { name: namePattern }).click({ timeout: 500 })
+            await expect(this.chartTypeButton).toHaveText(namePattern, { timeout: 1000 })
+        }).toPass({ timeout: 15000 })
+        await this.waitForChart()
+    }
+
+    async selectDateRange(text: string): Promise<void> {
+        await this.page.keyboard.press('Escape')
+        const dataAttr = `date-filter-${text.toLowerCase().replace(/\s+/g, '-')}`
+        await expect(async () => {
+            await this.dateRangeButton.click({ timeout: 500 })
+            await this.page.getByTestId(dataAttr).click({ timeout: 500 })
+            // Verify the selection actually applied — an edit-mode remount can
+            // swallow the click, leaving the old range. Retry the whole open+click.
+            await expect(this.dateRangeButton).toContainText(text, { timeout: 1000 })
+        }).toPass({ timeout: 15000 })
+        await this.waitForChart()
+    }
+
+    async selectComparison(text: string): Promise<void> {
+        await this.page.keyboard.press('Escape')
+        // Maps each dropdown option to the button label it produces. On narrow
+        // viewports the button shows a short label ("Previous period" / "No
+        // comparison"), so match a substring common to both variants.
+        const appliedLabels: Record<string, RegExp> = {
+            'No comparison between periods': /no comparison/i,
+            'Compare to previous period': /previous period/i,
+        }
+        const appliedLabel = appliedLabels[text]
+        if (!appliedLabel) {
+            throw new Error(`selectComparison: no expected button label mapped for option "${text}"`)
+        }
+        await expect(async () => {
+            await this.comparisonButton.click({ timeout: 500 })
+            await this.page.getByRole('menuitem', { name: text }).click({ timeout: 500 })
+            // Verify the selection actually applied — an edit-mode remount can swallow
+            // the click, and the resulting query update is debounced by 500ms. Retry
+            // the whole open+click if the button label doesn't change.
+            await expect(this.comparisonButton).toContainText(appliedLabel, { timeout: 2000 })
+        }).toPass({ timeout: 15000 })
+        await this.waitForChart()
     }
 
     async hoverChartAt(xFraction: number = 0.3, yFraction: number = 0.5): Promise<void> {

--- a/playwright/page-models/insights/retentionInsight.ts
+++ b/playwright/page-models/insights/retentionInsight.ts
@@ -59,7 +59,7 @@ export class RetentionInsight extends ChartInsightBase {
         }).toPass({ timeout: 30000 })
     }
 
-    async waitForChart(): Promise<void> {
+    override async waitForChart(): Promise<void> {
         const loading = this.page.getByTestId('insight-loading-waiting-message')
         // Wait for the loading indicator to appear (query started), then disappear.
         // Short timeout on 'attached' handles cached/instant queries where it never appears.

--- a/playwright/page-models/insights/stickinessInsight.ts
+++ b/playwright/page-models/insights/stickinessInsight.ts
@@ -78,8 +78,18 @@ export class StickinessInsight extends ChartInsightBase {
     }
 
     async selectComparison(text: string): Promise<void> {
-        await this.comparisonButton.click()
-        await this.page.getByText(text).click()
+        await this.page.keyboard.press('Escape')
+        // On narrow viewports the button shows a short label ("Previous period" /
+        // "No comparison"), so verify with a substring common to both variants.
+        const appliedLabel = text.startsWith('No comparison') ? /no comparison/i : /previous period/i
+        await expect(async () => {
+            await this.comparisonButton.click({ timeout: 500 })
+            await this.page.getByRole('menuitem', { name: text }).click({ timeout: 500 })
+            // Verify the selection actually applied — an edit-mode remount can swallow
+            // the click, and the resulting query update is debounced by 500ms. Retry
+            // the whole open+click if the button label doesn't change.
+            await expect(this.comparisonButton).toContainText(appliedLabel, { timeout: 2000 })
+        }).toPass({ timeout: 15000 })
         await this.waitForChart()
     }
 

--- a/playwright/page-models/insights/stickinessInsight.ts
+++ b/playwright/page-models/insights/stickinessInsight.ts
@@ -8,9 +8,6 @@ export class StickinessInsight extends ChartInsightBase {
     readonly detailsTable: Locator
     readonly firstSeries: Locator
     readonly secondSeries: Locator
-    readonly dateRangeButton: Locator
-    readonly chartTypeButton: Locator
-    readonly comparisonButton: Locator
     readonly taxonomicFilter: TaxonomicFilter
 
     private readonly detailsLoader: Locator
@@ -24,19 +21,11 @@ export class StickinessInsight extends ChartInsightBase {
         this.addSeriesButton = page.getByTestId('add-action-event-button')
         this.firstSeries = page.getByTestId('trend-element-subject-0')
         this.secondSeries = page.getByTestId('trend-element-subject-1')
-        this.dateRangeButton = page.getByTestId('date-filter')
-        this.chartTypeButton = page.getByTestId('chart-filter')
-        this.comparisonButton = page.getByTestId('compare-filter')
         this.taxonomicFilter = new TaxonomicFilter(page)
     }
 
     seriesEventButton(index: number): Locator {
         return this.page.getByTestId(`trend-element-subject-${index}`)
-    }
-
-    async waitForChart(): Promise<void> {
-        await this.page.getByTestId('insight-loading-waiting-message').waitFor({ state: 'detached', timeout: 30000 })
-        await expect(this.chart).toBeVisible({ timeout: 30000 })
     }
 
     async waitForDetailsTable(): Promise<void> {
@@ -52,45 +41,6 @@ export class StickinessInsight extends ChartInsightBase {
         await this.page.keyboard.press('Escape')
         await this.seriesEventButton(seriesIndex).click()
         await this.taxonomicFilter.selectItem(eventName)
-    }
-
-    async selectChartType(namePattern: RegExp): Promise<void> {
-        await this.page.keyboard.press('Escape')
-        await expect(async () => {
-            await this.chartTypeButton.click({ timeout: 500 })
-            await this.page.getByRole('menuitem', { name: namePattern }).click({ timeout: 500 })
-            await expect(this.chartTypeButton).toHaveText(namePattern, { timeout: 1000 })
-        }).toPass({ timeout: 15000 })
-        await this.waitForChart()
-    }
-
-    async selectDateRange(text: string): Promise<void> {
-        await this.page.keyboard.press('Escape')
-        const dataAttr = `date-filter-${text.toLowerCase().replace(/\s+/g, '-')}`
-        await expect(async () => {
-            await this.dateRangeButton.click({ timeout: 500 })
-            await this.page.getByTestId(dataAttr).click({ timeout: 500 })
-            // Verify the selection actually applied — an edit-mode remount can
-            // swallow the click, leaving the old range. Retry the whole open+click.
-            await expect(this.dateRangeButton).toContainText(text, { timeout: 1000 })
-        }).toPass({ timeout: 15000 })
-        await this.waitForChart()
-    }
-
-    async selectComparison(text: string): Promise<void> {
-        await this.page.keyboard.press('Escape')
-        // On narrow viewports the button shows a short label ("Previous period" /
-        // "No comparison"), so verify with a substring common to both variants.
-        const appliedLabel = text.startsWith('No comparison') ? /no comparison/i : /previous period/i
-        await expect(async () => {
-            await this.comparisonButton.click({ timeout: 500 })
-            await this.page.getByRole('menuitem', { name: text }).click({ timeout: 500 })
-            // Verify the selection actually applied — an edit-mode remount can swallow
-            // the click, and the resulting query update is debounced by 500ms. Retry
-            // the whole open+click if the button label doesn't change.
-            await expect(this.comparisonButton).toContainText(appliedLabel, { timeout: 2000 })
-        }).toPass({ timeout: 15000 })
-        await this.waitForChart()
     }
 
     get details(): TableHelper {

--- a/playwright/page-models/insights/trendsInsight.ts
+++ b/playwright/page-models/insights/trendsInsight.ts
@@ -185,8 +185,18 @@ export class TrendsInsight extends ChartInsightBase {
     }
 
     async selectComparison(text: string): Promise<void> {
-        await this.comparisonButton.click()
-        await this.page.getByText(text).click()
+        await this.page.keyboard.press('Escape')
+        // On narrow viewports the button shows a short label ("Previous period" /
+        // "No comparison"), so verify with a substring common to both variants.
+        const appliedLabel = text.startsWith('No comparison') ? /no comparison/i : /previous period/i
+        await expect(async () => {
+            await this.comparisonButton.click({ timeout: 500 })
+            await this.page.getByRole('menuitem', { name: text }).click({ timeout: 500 })
+            // Verify the selection actually applied — an edit-mode remount can swallow
+            // the click, and the resulting query update is debounced by 500ms. Retry
+            // the whole open+click if the button label doesn't change.
+            await expect(this.comparisonButton).toContainText(appliedLabel, { timeout: 2000 })
+        }).toPass({ timeout: 15000 })
         await this.waitForChart()
     }
 

--- a/playwright/page-models/insights/trendsInsight.ts
+++ b/playwright/page-models/insights/trendsInsight.ts
@@ -12,9 +12,6 @@ export class TrendsInsight extends ChartInsightBase {
     readonly breakdownButton: Locator
     readonly formulaSwitch: Locator
     readonly formulaInput: Locator
-    readonly dateRangeButton: Locator
-    readonly chartTypeButton: Locator
-    readonly comparisonButton: Locator
     readonly taxonomicFilter: TaxonomicFilter
     readonly boldNumber: Locator
     readonly boldNumberComparison: Locator
@@ -34,9 +31,6 @@ export class TrendsInsight extends ChartInsightBase {
         this.breakdownButton = page.getByTestId('add-breakdown-button')
         this.formulaSwitch = page.locator('#trends-formula-switch')
         this.formulaInput = page.getByPlaceholder('Example: (A + B) / 100')
-        this.dateRangeButton = page.getByTestId('date-filter')
-        this.chartTypeButton = page.getByTestId('chart-filter')
-        this.comparisonButton = page.getByTestId('compare-filter')
         this.taxonomicFilter = new TaxonomicFilter(page)
         this.boldNumber = page.getByTestId('bold-number-value')
         this.boldNumberComparison = page.getByTestId('bold-number-comparison')
@@ -44,11 +38,6 @@ export class TrendsInsight extends ChartInsightBase {
 
     seriesEventButton(index: number): Locator {
         return this.page.getByTestId(`trend-element-subject-${index}`)
-    }
-
-    async waitForChart(): Promise<void> {
-        await this.page.getByTestId('insight-loading-waiting-message').waitFor({ state: 'detached', timeout: 30000 })
-        await expect(this.chart).toBeVisible({ timeout: 30000 })
     }
 
     async waitForDetailsTable(): Promise<void> {
@@ -133,29 +122,6 @@ export class TrendsInsight extends ChartInsightBase {
         await this.waitForChart()
     }
 
-    async selectChartType(namePattern: RegExp): Promise<void> {
-        await this.page.keyboard.press('Escape')
-        await expect(async () => {
-            await this.chartTypeButton.click({ timeout: 500 })
-            await this.page.getByRole('menuitem', { name: namePattern }).click({ timeout: 500 })
-            await expect(this.chartTypeButton).toHaveText(namePattern, { timeout: 1000 })
-        }).toPass({ timeout: 15000 })
-        await this.waitForChart()
-    }
-
-    async selectDateRange(text: string): Promise<void> {
-        await this.page.keyboard.press('Escape')
-        const dataAttr = `date-filter-${text.toLowerCase().replace(/\s+/g, '-')}`
-        await expect(async () => {
-            await this.dateRangeButton.click({ timeout: 500 })
-            await this.page.getByTestId(dataAttr).click({ timeout: 500 })
-            // Verify the selection actually applied — an edit-mode remount can
-            // swallow the click, leaving the old range. Retry the whole open+click.
-            await expect(this.dateRangeButton).toContainText(text, { timeout: 1000 })
-        }).toPass({ timeout: 15000 })
-        await this.waitForChart()
-    }
-
     async openOptionsPanel(): Promise<void> {
         await this.page.locator('[data-attr="insight-filters"]').getByRole('button', { name: 'Options' }).click()
     }
@@ -181,22 +147,6 @@ export class TrendsInsight extends ChartInsightBase {
 
     async unpinInterval(): Promise<void> {
         await this.page.getByRole('button', { name: 'Unpin interval' }).click()
-        await this.waitForChart()
-    }
-
-    async selectComparison(text: string): Promise<void> {
-        await this.page.keyboard.press('Escape')
-        // On narrow viewports the button shows a short label ("Previous period" /
-        // "No comparison"), so verify with a substring common to both variants.
-        const appliedLabel = text.startsWith('No comparison') ? /no comparison/i : /previous period/i
-        await expect(async () => {
-            await this.comparisonButton.click({ timeout: 500 })
-            await this.page.getByRole('menuitem', { name: text }).click({ timeout: 500 })
-            // Verify the selection actually applied — an edit-mode remount can swallow
-            // the click, and the resulting query update is debounced by 500ms. Retry
-            // the whole open+click if the button label doesn't change.
-            await expect(this.comparisonButton).toContainText(appliedLabel, { timeout: 2000 })
-        }).toPass({ timeout: 15000 })
         await this.waitForChart()
     }
 


### PR DESCRIPTION
## Problem

`stickiness.spec.ts › Change date range and toggle comparison` has been flaky in CI (13 failures over the last 2 weeks, e.g. [run 26832126231](https://github.com/PostHog/posthog/actions/runs/26832126231)). The failure is always the same: after `selectComparison('No comparison between periods')`, the compare-filter button keeps showing "Previous period" for the full 40s assertion timeout.

The CI call logs show the dropdown option click is dispatched without error but never takes effect. Two mechanisms in the same race class:

- an insight scene remount can swallow the option click — the same documented race `selectDateRange` in this page model already guards against
- even a registered click can be silently dropped: `updateCompareFilter` in `insightVizDataLogic` sits behind a 500ms kea `breakpoint`, which aborts on remount before `updateQuerySource` runs

## Changes

Applies the established `selectDateRange` retry pattern to `selectComparison` in both `stickinessInsight.ts` and `trendsInsight.ts` (the trends model had the identical unguarded helper, used by `trends.spec.ts`):

- open the dropdown and click the option inside an `expect(...).toPass()` retry loop
- target the option via `getByRole('menuitem', ...)` — LemonSelect options render with `role="menuitem"`, and this avoids matching the button's own text on wide viewports
- verify the button label actually changed before declaring success, with a 2s window so the product's 500ms debounce has time to apply; the verification accepts the short labels rendered below the `2xl` breakpoint ("Previous period" / "No comparison"), which is what CI runs at
- retry the whole open+click if the label didn't change

This cures both mechanisms: a swallowed click gets re-issued, and a debounce dropped by a remount gets re-dispatched.

Possible follow-up (not in this PR): the 500ms debounce on `updateCompareFilter` exists for the rolling-date number input, but it also delays plain dropdown selections and can silently drop them if the logic remounts in that window — dispatching `none`/`previous` selections without the debounce would close that hole for real users too.

## How did you test this code?

I'm an agent; the e2e suite could not be run in my sandbox (no docker for the full stack), so validation is analytical, grounded in the CI failure logs. Automated checks actually run: `tsc --noEmit` (no errors in the playwright files) and `oxlint` (clean). The retry pattern is the same one already proven by `selectDateRange` in the same test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code). Investigated the CI failure logs from the linked runs, traced the failing assertion to `selectComparison`, and inspected `CompareFilter.tsx` / `insightVizDataLogic.ts` to identify the swallowed-click and dropped-debounce mechanisms.
- Considered and rejected a ConcurrencyController/stale-query explanation: the button label derives from local query-source state, so the failure happens before query concurrency is involved.
- Chose a test-side retry over a product change (removing the debounce for dropdown selections) to keep the fix low-risk; the product-side race is noted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

