### PR TITLE
fix(google_search_console): refresh stale db connection before integration lookup

### DIFF
--- a/posthog/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import quote
 
 from django.conf import settings
+from django.db import close_old_connections
 
 import requests
 import structlog
@@ -104,6 +105,11 @@ class GoogleSearchConsoleResumeConfig:
 
 
 def _credentials(integration_id: int, team_id: int) -> OAuthCredentials:
+    # Temporal activities run in a thread pool where Django DB connections can go
+    # stale between uses (Postgres closes the connection server-side). This is
+    # invoked lazily from inside `get_rows`, so the connection has often been idle
+    # for minutes by the time we reach it — drop any stale connection first.
+    close_old_connections()
     integration = Integration.objects.get(id=integration_id, team_id=team_id)
     return OAuthCredentials(
         token=None,

--- a/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/posthog/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -13,6 +13,7 @@ from posthog.temporal.data_imports.sources.google_search_console.google_search_c
     QUOTA_MAX_RETRIES,
     GoogleSearchConsoleQuotaExceededError,
     GoogleSearchConsoleResumeConfig,
+    _credentials,
     _initial_start_date,
     _is_daily_quota_error,
     _is_quota_error,
@@ -106,6 +107,30 @@ def test_row_to_dict_prefers_api_date_over_iter_date():
     out = _row_to_dict(row, ["date", "query"], iter_date=dt.date(1999, 1, 1))
 
     assert out["date"] == dt.date(2026, 4, 15)
+
+
+def test_credentials_refreshes_stale_db_connection_before_query(monkeypatch):
+    # The ORM read runs lazily inside `get_rows` on a worker thread whose pooled
+    # Django connection may have been closed server-side, surfacing as
+    # `OperationalError: the connection is closed`. We must drop the stale
+    # connection before querying, so the read happens on a fresh connection.
+    calls: list[str] = []
+
+    monkeypatch.setattr(gsc, "close_old_connections", lambda: calls.append("close_old_connections"))
+
+    integration = mock.MagicMock()
+    integration.refresh_token = "refresh-token"
+
+    def fake_get(*args, **kwargs):
+        calls.append("Integration.objects.get")
+        return integration
+
+    monkeypatch.setattr(gsc.Integration.objects, "get", fake_get)
+
+    creds = _credentials(integration_id=1, team_id=1)
+
+    assert calls == ["close_old_connections", "Integration.objects.get"]
+    assert creds.refresh_token == "refresh-token"
 
 
 def _make_response(config: GoogleSearchConsoleSourceConfig, rows_per_call: list[list[dict]]):


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: the connection is closed` originating in the Google Search Console data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ebadc-664d-7f92-8a2d-82451ff8c8cc)).

The stack trace ends in `_credentials` (`google_search_console.py`) → `Integration.objects.get(...)`, where psycopg reports the Postgres connection as already closed. This ORM read happens lazily inside the `get_rows` generator, which the import pipeline consumes on a worker thread. By the time iteration reaches the credentials lookup the thread's pooled Django connection may have been idle long enough for Postgres to close it server-side, so the next query blows up.

This is a transient infrastructure failure (a stale DB connection), not a credential/config problem — so it should stay retryable rather than become a `NonRetryableError`. But our code is fragile here: we can prevent the crash entirely instead of relying on a full Temporal activity retry.

The sibling `google_ads` source already hit and fixed this exact failure mode the same way.

## Changes

- Call `close_old_connections()` in `_credentials` immediately before the `Integration.objects.get(...)` read, so Django drops any stale connection and the lookup runs on a fresh one. This mirrors the existing pattern in `sources/google_ads/google_ads.py`.
- Add a regression test asserting `close_old_connections()` is invoked before the ORM read.

Scope is limited to this source; no change to global retry policy or `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I ran the source's unit test suite (39 tests, all passing) and confirmed the new regression test fails without the fix and passes with it. Lint (`ruff check` / `ruff format --check`) is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Read the full stack trace via the PostHog error-tracking MCP tools and confirmed the failure genuinely originates in this source's `_credentials` ORM read (not just serialized log context). Classified it as a transient stale-connection bug rather than a user/upstream error, so the fix is to harden the code (refresh the connection) while keeping the error retryable — explicitly not adding it to `NonRetryableErrors`. Chose `close_old_connections()` because the `google_ads` source already established this exact pattern for the same lazy-`get_rows` ORM lookup.
