### PR TITLE
chore(devex): rework isolation skill PR strategy around review latency

### DIFF
--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: isolating-product-facade-contracts
-description: Plan and execute incremental product isolation migrations to a facade plus contract layer in PostHog, following the Visual review architecture. Use when a product still exposes internals (models/logic/views) across boundaries and needs a safe, multi-PR migration toward contracts.py + facade/api.py + presentation separation.
+description: Plan and execute product isolation migrations to a facade plus contract layer in PostHog, following the Visual review architecture. Use when a product still exposes internals (models/logic/views) across boundaries and needs migration toward contracts.py + facade/api.py + presentation separation, with a PR strategy that minimizes review latency and conflicts with parallel work.
 ---
 
 # Isolating a product with facade and contracts
 
 Use this skill to migrate an existing product to the isolated architecture used by Visual review.
-Keep migrations incremental, with narrow PRs that avoid broad breakage.
+Optimize for short calendar exposure, not small diffs: authoring is cheap and the verification
+chain catches mechanical breakage, while human review latency and a fast-moving master are the
+real bottlenecks. Default to two PRs — design, then mechanical sweep — per the PR strategy below.
 
 **Prerequisite:** the product must already live under `products/<name>/`. This skill does not cover moving code out of `posthog/`, `ee/`, or other shared directories — do that first.
 
@@ -38,9 +40,12 @@ Before changing code, get the baseline:
 hogli product:maturity <name>    # scores models, facade, presentation, boundaries, codegen
 hogli product:lint <name>        # structural lint + isolation chain (strict if facade/contracts.py exists)
 rg -n "from products\.<name>\.backend\.(models|logic|presentation|tasks|storage)" .
+rg -o "(from|import) products\.<name>" posthog ee | wc -l   # core-coupling count
 ```
 
 The `rg` output is your import map: every line is a caller that needs to migrate to the facade.
+The core-coupling count picks the PR strategy below: near zero means the whole migration fits
+the two-PR default; triple digits means the caller sweep needs slicing by owning team.
 
 ## Guardrails
 
@@ -69,9 +74,14 @@ The `rg` output is your import map: every line is a caller that needs to migrate
 3. Introduce a thin facade in `backend/facade/api.py`.
    - Map ORM instances to contracts with explicit mapper functions.
    - Keep method names capability-oriented and stable.
-4. Migrate callers in small batches.
-   - Replace one caller cluster at a time (single endpoint, single task, or single service area).
-   - Keep compatibility shims only when needed; remove promptly.
+4. Migrate callers in one pass by default.
+   - The rewrite is mechanical (import swap + call mapping) and fully checked by the
+     verification chain; batching it only stretches the window in which master drifts
+     under the branch.
+   - Compatibility shims exist to bridge between serial PRs — the one-pass shape rarely
+     needs them. If one is unavoidable, it dies in the final cleanup PR, not "later".
+   - Exception: callers with subtle behavior (transaction boundaries, write-path
+     semantics) may move in their own small PR — see the PR strategy below.
 5. Move presentation to consume the facade.
    - Serializers convert JSON <-> contracts.
    - Views call facade methods only.
@@ -99,30 +109,66 @@ The `rg` output is your import map: every line is a caller that needs to migrate
 
 ### Legacy leaks during migration
 
+This is the exception path for high-coupling products whose caller sweep is sliced
+across teams (see PR strategy below) — isolation turns on before every core import
+has moved. With the two-PR default, all core callers land in the sweep PR and this
+block never needs to exist.
+
 If `posthog/` or `ee/` still imports product internals (`backend.models`,
-`backend.oauth`, …) when you cut the first isolation PR, add a second
+`backend.oauth`, …) when the isolation chain turns on, add a second
 `[[interfaces]]` block under the "Legacy leaks" section of `tach.toml`
 allow-listing exactly the modules core still touches. This keeps the build
-green while you migrate callers in subsequent PRs. Shrink and delete that
-block as imports move behind the facade — the final PR removes it entirely.
+green while the remaining team-sliced PRs land. Shrink and delete that
+block as imports move behind the facade — the final cleanup PR removes it entirely.
 `hogli product:lint` flags any product that still has legacy leak interfaces
 with a `⚠ has legacy interface leaks` warning.
 
-## PR slicing strategy
+## PR strategy
 
-Default to several PRs instead of one big migration:
+The scarce resources are reviewer attention and calendar time — not authoring effort.
+Every day a migration branch stays open, parallel work lands in the same files; serial
+PR chains multiply that exposure because each PR waits in review while the next can't
+be authored stably until it merges. Slice to minimize how long branches stay open, and
+let the verification chain carry the mechanical review burden.
 
-- PR 1: Add contracts + facade methods, with no caller behavior changes. For a small product this PR can also flip `api.py`/`webhooks.py` into `presentation/` and enable the 4-step chain (see `user_interviews` PR #59132 for that combined shape).
-- PR 2-N: Migrate caller clusters one-by-one to the facade.
-- Final PR: Remove deprecated internal import paths, drop "Legacy leaks" `[[interfaces]]` blocks and `ignore_imports` TODOs, and clean dead adapters.
+Default to exactly two PRs:
 
-If a product has many endpoints, migrate in this order:
+- **PR 1 — design (where human review matters).** Contracts + facade methods +
+  behavioral-parity tests for the facade, with no caller changes. New files only, so it
+  cannot conflict with parallel work. The contract surface is the long-lived API —
+  spend review attention on naming, capability shape, and field selection, not
+  mechanics. For a small product this PR can also flip `api.py`/`webhooks.py` into
+  `presentation/` and enable the 4-step chain (see `user_interviews` PR #59132 for
+  that combined shape).
+- **PR 2 — mechanical sweep (where verification carries it).** All caller migrations,
+  the presentation flip, and the 4-step chain. Reviewers sample rather than read
+  line-by-line; the parity tests from PR 1 plus tach, import-linter, contract-check,
+  and the product tests are the safety net.
 
-1. Read-only list/detail APIs (lowest risk)
-2. Internal service-to-service call sites
-3. Write paths (create/update/delete)
-4. Background tasks / async entrypoints
-5. Remaining edge endpoints and cleanup
+Treat PR 2 as regenerable, not rebasable: the import map plus the merged facade fully
+determine the rewrite, so on conflict, regenerate the branch against fresh master
+instead of hand-resolving. Keep it open only for the review window.
+
+Gate by the core-coupling count from the baseline, not by product size:
+
+- **Low (zero to low double digits):** the two-PR default applies; skip the
+  legacy-leaks machinery entirely.
+- **High (triple digits):** PR 2 won't review as one unit. Slice the sweep by who owns
+  the calling code (the consuming team/area, not the product's own owner) so each team
+  reviews its own call sites in parallel — never serially by capability, which trades
+  calendar time for an authoring risk that no longer exists. Turn the isolation chain on behind a
+  legacy-leaks block (above) and add a final cleanup PR that drops the block,
+  `ignore_imports` TODOs, dead adapters, and shims.
+
+Within the sweep, use risk to direct review attention, not PR boundaries: write paths
+and transaction boundaries get the close read; read-only list/detail swaps, internal
+call sites, and task entrypoints get the sample. If a write path is genuinely subtle,
+pull those few callers into their own small PR as the exception.
+
+Trade-off to accept: one sweep PR reverts coarser than many small ones. That is fine
+precisely because PR 1 isolated the design risk and the mappers are behavior-preserving —
+per-file reverts stay possible, and weeks of serial PRs on a hot product cost more in
+conflicts and forfeited isolated-CI time than an occasional coarse revert.
 
 ## Done criteria
 

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -40,7 +40,7 @@ Before changing code, get the baseline:
 hogli product:maturity <name>    # scores models, facade, presentation, boundaries, codegen
 hogli product:lint <name>        # structural lint + isolation chain (strict if facade/contracts.py exists)
 rg -n "from products\.<name>\.backend\.(models|logic|presentation|tasks|storage)" .
-rg -o "(from|import) products\.<name>" posthog ee | wc -l   # core-coupling count
+rg -o --pcre2 "(from|import) products\.<name>\.backend\.(?!facade)" posthog ee | wc -l   # core-coupling count (internals only)
 ```
 
 The `rg` output is your import map: every line is a caller that needs to migrate to the facade.
@@ -110,9 +110,11 @@ the two-PR default; triple digits means the caller sweep needs slicing by owning
 ### Legacy leaks during migration
 
 This is the exception path for high-coupling products whose caller sweep is sliced
-across teams (see PR strategy below) — isolation turns on before every core import
-has moved. With the two-PR default, all core callers land in the sweep PR and this
-block never needs to exist.
+across teams (see PR strategy below) — the tach boundary turns on before every core
+import has moved, while the `backend:contract-check` CI switch must wait until the
+block is gone (`hogli product:lint` rejects the script while leaks remain). With the
+two-PR default, all core callers land in the sweep PR and this block never needs to
+exist.
 
 If `posthog/` or `ee/` still imports product internals (`backend.models`,
 `backend.oauth`, …) when the isolation chain turns on, add a second
@@ -134,12 +136,13 @@ let the verification chain carry the mechanical review burden.
 Default to exactly two PRs:
 
 - **PR 1 — design (where human review matters).** Contracts + facade methods +
-  behavioral-parity tests for the facade, with no caller changes. New files only, so it
-  cannot conflict with parallel work. The contract surface is the long-lived API —
-  spend review attention on naming, capability shape, and field selection, not
-  mechanics. For a small product this PR can also flip `api.py`/`webhooks.py` into
-  `presentation/` and enable the 4-step chain (see `user_interviews` PR #59132 for
-  that combined shape).
+  behavioral-parity tests for the facade, with no caller changes. The base shape adds
+  only new files, keeping conflict exposure near zero. The contract surface is the
+  long-lived API — spend review attention on naming, capability shape, and field
+  selection, not mechanics. For a small product this PR can also flip
+  `api.py`/`webhooks.py` into `presentation/` and enable the 4-step chain (see
+  `user_interviews` PR #59132 for that combined shape — that variant does touch
+  existing files and gives up some of the conflict immunity).
 - **PR 2 — mechanical sweep (where verification carries it).** All caller migrations,
   the presentation flip, and the 4-step chain. Reviewers sample rather than read
   line-by-line; the parity tests from PR 1 plus tach, import-linter, contract-check,
@@ -156,9 +159,12 @@ Gate by the core-coupling count from the baseline, not by product size:
 - **High (triple digits):** PR 2 won't review as one unit. Slice the sweep by who owns
   the calling code (the consuming team/area, not the product's own owner) so each team
   reviews its own call sites in parallel — never serially by capability, which trades
-  calendar time for an authoring risk that no longer exists. Turn the isolation chain on behind a
-  legacy-leaks block (above) and add a final cleanup PR that drops the block,
-  `ignore_imports` TODOs, dead adapters, and shims.
+  calendar time for an authoring risk that no longer exists. Add the legacy-leaks tach
+  block (above) so boundaries are enforced while the sweeps land, but do NOT add
+  `backend:contract-check` yet — `hogli product:lint` rejects that script while leaks
+  remain. The final cleanup PR drops the block, `ignore_imports` TODOs, dead adapters,
+  and shims, and only then enables contract-check + narrowed `turbo.json` inputs — the
+  CI payoff for this path lands at the end.
 
 Within the sweep, use risk to direct review attention, not PR boundaries: write paths
 and transaction boundaries get the close read; read-only list/detail swaps, internal

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -228,15 +228,43 @@ when the sweep must be sliced.** Gate on the core-coupling count from the baseli
     TODOs, dead adapters, and shims, and only then enables contract-check + narrowed
     `turbo.json` inputs — the CI payoff for this path lands at the end.
 
-**Thick-views deferral (step 5) adds one optional follow-up on either path:** a
-presentation-wave PR that designs the facade functions the views need, swaps the views
-onto them, and deletes the product's `ignore_imports` entries — the step that turns the
-narrowed contract inputs from optimistic into sound.
+**Deferred view modules (step 5) add one follow-up on either path:** the presentation
+wave — see the section below for its flow and outputs.
 
 Trade-off to accept: one PR reverts coarser than several. That is fine because the
 mappers are behavior-preserving, the behavior-bearing edits are enumerated up front,
 and the whole PR is regenerable — weeks of serial PRs on a hot product cost more in
 conflicts and forfeited isolated-CI time than an occasional coarse revert.
+
+## Presentation wave
+
+The second demand wave on the same facade: the functions the product's _own views_
+need, where the first wave served external consumers. Run it once per product, after
+the migration PR lands, working from the deferred modules listed in the PR (the scan's
+view-module table is the worklist).
+
+Per deferred module:
+
+1. Design the facade functions its views need. Query endpoints get run-functions that
+   take `posthog.schema` query objects and return the runner's response types — those
+   are already framework-free, so usually no new contracts. Model-backed endpoints get
+   contracts plus CRUD/capability functions (the `DataclassSerializer` pattern from
+   visual_review).
+2. Draw the line: execution and transaction concerns (`ExecutionMode`, query tagging,
+   `select_for_update` caps, cross-product side effects) move behind the facade; HTTP
+   concerns (request validation, response codes, `report_user_action` analytics) stay
+   in the view.
+3. Thin the view to parse → facade → serialize, with parity tests for the new facade
+   functions, same as wave one.
+4. Delete the module's `ignore_imports` entries — `lint-imports` must pass without
+   them. That deletion is the output that marks the module done.
+
+This is a design PR, not a sweep: it carries the same review weight as the facade
+commit (the contract and function shapes are the long-lived API), so it gets its own
+PR rather than riding along with mechanical work. Refactoring a wave-one function while
+here (e.g. subsuming a runner builder under a run-function) is fine — its callers are
+few and the parity tests pin behavior. The product's done criteria below are only fully
+satisfiable once this wave has emptied the allowlist.
 
 ## Done criteria
 

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -113,16 +113,19 @@ migration against fresh master starts from a fresh scan.
      semantics) may move in their own small PR — see the PR strategy below.
 5. Move presentation to consume the facade.
    - Serializers convert JSON <-> contracts; views call facade methods only.
-   - Thin views (CRUD over models): swap them onto the facade in the same PR — no
-     `ignore_imports` allowlist entry should ever exist for them.
-   - Thick views (query orchestration, execution modes, export hooks): moving them under
-     `presentation/` without the refactor requires exact-pair `ignore_imports` entries in
-     `pyproject.toml`'s TODO section. That defers the refactor to a follow-up
-     presentation-wave PR — and until the product's entries are gone, the narrowed
-     contract inputs are **optimistic, not sound**: an internal change can alter the HTTP
-     surface without re-running the full suite. Compensating controls exist (the OpenAPI
-     validation job runs on every backend PR, the product's own tests cover its views,
-     master pushes run everything), but make the deferral a named decision in the PR.
+   - Decide **per view module, on a size estimate**, whether its facade refactor lands
+     in this PR or defers. Estimate the wave per module: runner-execution swaps are
+     cheap (runners already return `posthog.schema` types — no new contracts needed);
+     plain model CRUD needs a small contract plus a few functions; transactional or
+     cross-product logic embedded in serializers is the expensive tier. Swap every
+     module whose wave is cheap; defer only the expensive ones, naming the reason and
+     the surviving `ignore_imports` entries in the PR description.
+   - Deferred modules keep exact-pair `ignore_imports` entries in `pyproject.toml`'s
+     TODO section. That debt is **architectural** (business logic in views, the internal
+     boundary unenforced), not a CI-coverage hole: the product's own job tests its views
+     either way, and the full-suite skip is made safe by the caller sweep, test
+     residency, and the parity tests — not by this refactor. A follow-up
+     presentation-wave PR deletes the entries.
    - The mechanical share is one command: `hogli product:isolate:move <name>` (run
      `--dry-run` first) moves the ViewSet modules into `presentation/views/` (auto-detected,
      `--views` to override), `tasks.py` into a `tasks/` package with celery names pinned,
@@ -143,7 +146,13 @@ migration against fresh master starts from a fresh scan.
    4. **Narrowed `turbo.json` inputs** — restrict `backend:contract-check`
       inputs to `backend/facade/**` and `backend/presentation/**` so the
       Django suite is only re-run on facade/presentation changes (see
-      `products/visual_review/turbo.json`).
+      `products/visual_review/turbo.json`). Widen the inputs when core
+      depends on the product **outside the import graph**: add
+      `backend/models.py` if hogql system tables expose the product's
+      tables or core config references its dotted paths (the scan's
+      string-reference section surfaces the latter). tach/import-linter
+      only police the import channel; a mechanical check for these
+      non-import channels is a known gap, noted and deferred.
    - Verify with `tach check --dependencies --interfaces`, `lint-imports`
      (import-linter contract for presentation → facade), and `hogli product:lint <name>`.
    - Use `hogli product:maturity <name>` for a detailed breakdown of remaining
@@ -242,8 +251,8 @@ Treat migration as complete only when:
   leak block remains.
 - `tach check --dependencies --interfaces` passes with no violations for this product.
 - `lint-imports` passes **with no `ignore_imports` entries left for this product** in the
-  `pyproject.toml` TODO section — the contract passes by allowlist until then, and narrowed
-  contract inputs stay optimistic rather than sound while entries remain.
+  `pyproject.toml` TODO section — entries are tracked architectural debt from deferred
+  view modules; the presentation wave deletes them.
 - `hogli product:lint <name>` shows no legacy leak warning and the isolation chain is intact.
 - `backend:contract-check` is present in `package.json` with `turbo.json` inputs
   narrowed to `backend/facade/**` and `backend/presentation/**` (enables isolated testing in CI).

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -38,23 +38,30 @@ Use Visual review as the concrete reference implementation:
 Before changing code, get the baseline:
 
 ```bash
-hogli product:maturity <name>    # scores models, facade, presentation, boundaries, codegen
-hogli product:lint <name>        # structural lint + isolation chain (strict if facade/contracts.py exists)
-rg -n "from products\.<name>\.backend\.(models|logic|presentation|tasks|storage)" .
-rg -o --pcre2 "(from|import) products\.<name>\.backend\.(?!facade)" posthog ee | wc -l   # core-coupling count (internals only)
+hogli product:maturity <name>       # scores models, facade, presentation, boundaries, codegen
+hogli product:lint <name>           # structural lint + isolation chain (strict if facade/contracts.py exists)
+hogli product:isolate:scan <name>   # the recon: import map, coupling gate, preflight (see below)
 ```
 
-The `rg` output is your import map: every line is a caller that needs to migrate to the facade.
-Also search for the bare module paths, not just import statements — string references
-(`@patch("products.<name>.backend...")` mock paths, dotted names in config) move with the code too.
-The core-coupling count picks the PR strategy below: near zero means the whole migration fits
-the single-PR default; triple digits means the caller sweep needs slicing by owning team.
+The scan does the recon that would otherwise cost a dozen ad-hoc greps, and is the
+source of truth for the rest of the flow:
 
-`product:lint` switches from lenient to strict the moment `facade/contracts.py` exists, so check
-the strict structural requirements up front instead of discovering them mid-migration: root
-`tsconfig.json`, `tasks.py` at `tasks/tasks.py` (pin the celery task `name=` to its pre-move path
-so queued messages stay routable), and only canonical `backend/` subdirectories (`_KNOWN_DIRS` in
-`tools/hogli-commands/.../product/checks.py` — e.g. `templates/` is recognized, `prompts/` is not).
+- **References by kind** — every cross-boundary reference to the product's internals,
+  classified (model-access, query-runner, celery-task, temporal-wiring, test-fixture,
+  string-reference) with the facade pattern each kind maps to. This is the sweep
+  checklist; string references (`@patch(...)` mock paths, dotted names in config) are
+  included, which import-oriented grepping misses.
+- **Core-coupling count** — picks the PR strategy below: near zero means the whole
+  migration fits the single-PR default; triple digits means the caller sweep needs
+  slicing by owning team.
+- **Strict-lint preflight** — `product:lint` switches from lenient to strict the moment
+  `facade/contracts.py` exists; the scan runs the structural checks in forced-strict
+  mode so those demands (root `tsconfig.json`, `tasks.py` at `tasks/tasks.py`, only
+  canonical `backend/` subdirectories) surface up front instead of mid-migration.
+- **Thin/thick signal per view module** — the future `ignore_imports` allowlist size.
+
+`--json` emits the machine-readable recipe — keep it with the PR; regenerating the
+migration against fresh master starts from a fresh scan.
 
 ## Guardrails
 
@@ -116,8 +123,11 @@ so queued messages stay routable), and only canonical `backend/` subdirectories 
      surface without re-running the full suite. Compensating controls exist (the OpenAPI
      validation job runs on every backend PR, the product's own tests cover its views,
      master pushes run everything), but make the deferral a named decision in the PR.
-   - When moving modules, rewrite string references too (`@patch(...)` paths) — and use a
-     rewrite tool with real word boundaries (perl; BSD sed's `\b` silently no-ops).
+   - The mechanical share is one command: `hogli product:isolate:move <name>` (run
+     `--dry-run` first) moves the ViewSet modules into `presentation/views/` (auto-detected,
+     `--views` to override), `tasks.py` into a `tasks/` package with celery names pinned,
+     absolutizes relative imports, and rewrites the dotted paths repo-wide — imports and
+     string references (`@patch(...)` mock paths) alike, with tested word boundaries.
 6. Enforce boundaries and verify. This is a four-step chain — each step depends
    on the previous one, and `hogli product:lint` (via `IsolationChainCheck`)
    fails if any step is skipped:
@@ -172,8 +182,9 @@ and let commit structure — not PR boundaries — organize review.
    behavioral-parity tests. Pure additions; reviewers read this commit as the design.
 2. **Commit — sweep.** All caller migrations. Mechanical; reviewers sample, the
    verification chain carries it.
-3. **Commit — structure + chain.** Presentation move, strict-lint fixes, tach
-   interface, `backend:contract-check`, narrowed `turbo.json`.
+3. **Commit — structure + chain.** Presentation move and rewrites
+   (`hogli product:isolate:move`), strict-lint fixes, tach interface,
+   `backend:contract-check`, narrowed `turbo.json`.
 
 Don't split the facade into its own PR for reviewability: new files cannot conflict
 regardless of which PR they sit in, so a standalone design PR buys no conflict

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -8,7 +8,8 @@ description: Plan and execute product isolation migrations to a facade plus cont
 Use this skill to migrate an existing product to the isolated architecture used by Visual review.
 Optimize for short calendar exposure, not small diffs: authoring is cheap and the verification
 chain catches mechanical breakage, while human review latency and a fast-moving master are the
-real bottlenecks. Default to two PRs — design, then mechanical sweep — per the PR strategy below.
+real bottlenecks. Default to one PR structured in reviewable commits; a separate facade-first PR
+exists only as the merge base for team-sliced sweeps — per the PR strategy below.
 
 **Prerequisite:** the product must already live under `products/<name>/`. This skill does not cover moving code out of `posthog/`, `ee/`, or other shared directories — do that first.
 
@@ -44,8 +45,16 @@ rg -o --pcre2 "(from|import) products\.<name>\.backend\.(?!facade)" posthog ee |
 ```
 
 The `rg` output is your import map: every line is a caller that needs to migrate to the facade.
+Also search for the bare module paths, not just import statements — string references
+(`@patch("products.<name>.backend...")` mock paths, dotted names in config) move with the code too.
 The core-coupling count picks the PR strategy below: near zero means the whole migration fits
-the two-PR default; triple digits means the caller sweep needs slicing by owning team.
+the single-PR default; triple digits means the caller sweep needs slicing by owning team.
+
+`product:lint` switches from lenient to strict the moment `facade/contracts.py` exists, so check
+the strict structural requirements up front instead of discovering them mid-migration: root
+`tsconfig.json`, `tasks.py` at `tasks/tasks.py` (pin the celery task `name=` to its pre-move path
+so queued messages stay routable), and only canonical `backend/` subdirectories (`_KNOWN_DIRS` in
+`tools/hogli-commands/.../product/checks.py` — e.g. `templates/` is recognized, `prompts/` is not).
 
 ## Guardrails
 
@@ -68,23 +77,47 @@ the two-PR default; triple digits means the caller sweep needs slicing by owning
 1. Build an import map for the target product.
    - Find cross-product imports into target internals (`models`, `logic`, `presentation`, non-facade modules).
    - Classify each usage by capability (read/list, detail/read, create/update/delete, async/task, webhook/event).
-2. Define the minimal contract surface.
-   - Start from currently consumed fields only.
+2. Define the contract surface from both demand sources.
+   - External consumers (core, other products): start from currently consumed fields only.
+   - The product's own presentation (step 5): the facade functions its views will call. For
+     thick views this share may be deferred — but name the deferral; it decides whether the
+     isolation you turn on is sound or optimistic (see step 5).
    - Create frozen dataclasses in `backend/facade/contracts.py` using `pydantic.dataclasses.dataclass` — same shape as the stdlib variant but with runtime type validation on construction.
 3. Introduce a thin facade in `backend/facade/api.py`.
    - Map ORM instances to contracts with explicit mapper functions.
    - Keep method names capability-oriented and stable.
+   - Wiring that core registers (celery beat tasks, temporal workflows/activities/metrics/
+     schedule constants, query-runner registry hooks) crosses the boundary as objects, not
+     data — give each its own facade submodule (`facade/tasks.py`, `facade/temporal.py`,
+     `facade/queries.py`) re-exporting exactly what core touches. Registry-style consumers
+     dispatch on class identity (`isinstance`), so re-export the class itself. Keep
+     `facade/api.py` free of heavy imports (HogQL, temporalio) so config-only consumers
+     don't drag them onto the `django.setup()` path.
 4. Migrate callers in one pass by default.
    - The rewrite is mechanical (import swap + call mapping) and fully checked by the
      verification chain; batching it only stretches the window in which master drifts
      under the branch.
+   - Core test fixtures that need product models: use `apps.get_model("<app_label>",
+"Model")` at runtime plus a `TYPE_CHECKING` import for annotations — tach ignores
+     type-only imports.
    - Compatibility shims exist to bridge between serial PRs — the one-pass shape rarely
      needs them. If one is unavoidable, it dies in the final cleanup PR, not "later".
    - Exception: callers with subtle behavior (transaction boundaries, write-path
      semantics) may move in their own small PR — see the PR strategy below.
 5. Move presentation to consume the facade.
-   - Serializers convert JSON <-> contracts.
-   - Views call facade methods only.
+   - Serializers convert JSON <-> contracts; views call facade methods only.
+   - Thin views (CRUD over models): swap them onto the facade in the same PR — no
+     `ignore_imports` allowlist entry should ever exist for them.
+   - Thick views (query orchestration, execution modes, export hooks): moving them under
+     `presentation/` without the refactor requires exact-pair `ignore_imports` entries in
+     `pyproject.toml`'s TODO section. That defers the refactor to a follow-up
+     presentation-wave PR — and until the product's entries are gone, the narrowed
+     contract inputs are **optimistic, not sound**: an internal change can alter the HTTP
+     surface without re-running the full suite. Compensating controls exist (the OpenAPI
+     validation job runs on every backend PR, the product's own tests cover its views,
+     master pushes run everything), but make the deferral a named decision in the PR.
+   - When moving modules, rewrite string references too (`@patch(...)` paths) — and use a
+     rewrite tool with real word boundaries (perl; BSD sed's `\b` silently no-ops).
 6. Enforce boundaries and verify. This is a four-step chain — each step depends
    on the previous one, and `hogli product:lint` (via `IsolationChainCheck`)
    fails if any step is skipped:
@@ -113,7 +146,7 @@ This is the exception path for high-coupling products whose caller sweep is slic
 across teams (see PR strategy below) — the tach boundary turns on before every core
 import has moved, while the `backend:contract-check` CI switch must wait until the
 block is gone (`hogli product:lint` rejects the script while leaks remain). With the
-two-PR default, all core callers land in the sweep PR and this block never needs to
+single-PR default, all core callers land in the same PR and this block never needs to
 exist.
 
 If `posthog/` or `ee/` still imports product internals (`backend.models`,
@@ -128,52 +161,61 @@ with a `⚠ has legacy interface leaks` warning.
 ## PR strategy
 
 The scarce resources are reviewer attention and calendar time — not authoring effort.
-Every day a migration branch stays open, parallel work lands in the same files; serial
-PR chains multiply that exposure because each PR waits in review while the next can't
-be authored stably until it merges. Slice to minimize how long branches stay open, and
-let the verification chain carry the mechanical review burden.
+Every open migration branch rots as parallel work lands, and every extra PR adds a
+serialized review window plus a full-suite CI run (the product isn't isolated yet, so
+each migration PR pays the full suite). Use the fewest PRs the merge topology requires,
+and let commit structure — not PR boundaries — organize review.
 
-Default to exactly two PRs:
+**Default: one PR, structured in reviewable commits.**
 
-- **PR 1 — design (where human review matters).** Contracts + facade methods +
-  behavioral-parity tests for the facade, with no caller changes. The base shape adds
-  only new files, keeping conflict exposure near zero. The contract surface is the
-  long-lived API — spend review attention on naming, capability shape, and field
-  selection, not mechanics. For a small product this PR can also flip
-  `api.py`/`webhooks.py` into `presentation/` and enable the 4-step chain (see
-  `user_interviews` PR #59132 for that combined shape — that variant does touch
-  existing files and gives up some of the conflict immunity).
-- **PR 2 — mechanical sweep (where verification carries it).** All caller migrations,
-  the presentation flip, and the 4-step chain. Reviewers sample rather than read
-  line-by-line; the parity tests from PR 1 plus tach, import-linter, contract-check,
-  and the product tests are the safety net.
+1. **Commit — facade.** Contracts + facade (including wiring submodules) +
+   behavioral-parity tests. Pure additions; reviewers read this commit as the design.
+2. **Commit — sweep.** All caller migrations. Mechanical; reviewers sample, the
+   verification chain carries it.
+3. **Commit — structure + chain.** Presentation move, strict-lint fixes, tach
+   interface, `backend:contract-check`, narrowed `turbo.json`.
 
-Treat PR 2 as regenerable, not rebasable: the import map plus the merged facade fully
+Don't split the facade into its own PR for reviewability: new files cannot conflict
+regardless of which PR they sit in, so a standalone design PR buys no conflict
+protection — it only serializes two review windows and doubles the migration's CI cost.
+Worse, a facade with no callers can only be reviewed in the abstract; in one PR the
+caller diffs sit next to the design and justify (or indict) it. See `user_interviews`
+PR #59132 and the logs migration (#63180 + #63184, done as two before this was learned)
+for the shapes.
+
+In the PR description, enumerate the behavior-bearing edits — write paths, transaction
+boundaries, serializer changes, anything renamed or with pinned compatibility (celery
+task names). That list is where review attention goes; everything else is sampled. If a
+write path is genuinely subtle, pull those few callers into their own small PR as the
+exception.
+
+Treat the PR as regenerable, not rebasable: the import map plus the facade design fully
 determine the rewrite, so on conflict, regenerate the branch against fresh master
 instead of hand-resolving. Keep it open only for the review window.
 
-Gate by the core-coupling count from the baseline, not by product size:
+**A separate facade-first PR exists for exactly one reason: it is the shared merge base
+when the sweep must be sliced.** Gate on the core-coupling count from the baseline:
 
-- **Low (zero to low double digits):** the two-PR default applies; skip the
-  legacy-leaks machinery entirely.
-- **High (triple digits):** PR 2 won't review as one unit. Slice the sweep by who owns
-  the calling code (the consuming team/area, not the product's own owner) so each team
-  reviews its own call sites in parallel — never serially by capability, which trades
-  calendar time for an authoring risk that no longer exists. Add the legacy-leaks tach
-  block (above) so boundaries are enforced while the sweeps land, but do NOT add
-  `backend:contract-check` yet — `hogli product:lint` rejects that script while leaks
-  remain. The final cleanup PR drops the block, `ignore_imports` TODOs, dead adapters,
-  and shims, and only then enables contract-check + narrowed `turbo.json` inputs — the
-  CI payoff for this path lands at the end.
+- **Low (zero to low double digits):** single PR, as above; skip the legacy-leaks
+  machinery entirely.
+- **High (triple digits):** the sweep won't review as one unit. Land contracts + facade
+  - parity tests first — that standalone review is meaningful here, because every slice
+    is about to code against it — then slice the sweep by who owns the calling code (the
+    consuming team/area, not the product's own owner), reviewed in parallel, never
+    serially by capability. Add the legacy-leaks tach block (above) while slices land,
+    but do NOT add `backend:contract-check` yet — `hogli product:lint` rejects that
+    script while leaks remain. The final cleanup PR drops the block, `ignore_imports`
+    TODOs, dead adapters, and shims, and only then enables contract-check + narrowed
+    `turbo.json` inputs — the CI payoff for this path lands at the end.
 
-Within the sweep, use risk to direct review attention, not PR boundaries: write paths
-and transaction boundaries get the close read; read-only list/detail swaps, internal
-call sites, and task entrypoints get the sample. If a write path is genuinely subtle,
-pull those few callers into their own small PR as the exception.
+**Thick-views deferral (step 5) adds one optional follow-up on either path:** a
+presentation-wave PR that designs the facade functions the views need, swaps the views
+onto them, and deletes the product's `ignore_imports` entries — the step that turns the
+narrowed contract inputs from optimistic into sound.
 
-Trade-off to accept: one sweep PR reverts coarser than many small ones. That is fine
-precisely because PR 1 isolated the design risk and the mappers are behavior-preserving —
-per-file reverts stay possible, and weeks of serial PRs on a hot product cost more in
+Trade-off to accept: one PR reverts coarser than several. That is fine because the
+mappers are behavior-preserving, the behavior-bearing edits are enumerated up front,
+and the whole PR is regenerable — weeks of serial PRs on a hot product cost more in
 conflicts and forfeited isolated-CI time than an occasional coarse revert.
 
 ## Done criteria
@@ -188,7 +230,9 @@ Treat migration as complete only when:
   exposing `backend.facade.*` and `backend.presentation.views.*` — no legacy
   leak block remains.
 - `tach check --dependencies --interfaces` passes with no violations for this product.
-- `lint-imports` passes (import-linter verifies presentation doesn't bypass the facade internally).
+- `lint-imports` passes **with no `ignore_imports` entries left for this product** in the
+  `pyproject.toml` TODO section — the contract passes by allowlist until then, and narrowed
+  contract inputs stay optimistic rather than sound while entries remain.
 - `hogli product:lint <name>` shows no legacy leak warning and the isolation chain is intact.
 - `backend:contract-check` is present in `package.json` with `turbo.json` inputs
   narrowed to `backend/facade/**` and `backend/presentation/**` (enables isolated testing in CI).

--- a/.claude/rules/product-isolation.md
+++ b/.claude/rules/product-isolation.md
@@ -7,12 +7,15 @@ paths:
 Look at the product's `package.json`: if `backend:contract-check` is listed under `scripts`,
 this product is isolated.
 
-- **Isolated:** external code (core, other products) may only import from
-  `backend/facade/api.py`. Do not expose internal modules directly, and do not add
-  raw cross-product imports — go through the target product's facade instead.
+- **Isolated:** external code (core, other products) may only import from the
+  `backend/facade/` package — `api.py` for data capabilities, and capability submodules
+  (`queries.py`, `tasks.py`, `temporal.py`, …) for wiring that core registers or
+  dispatches on. Do not expose internal modules directly, and do not add raw
+  cross-product imports — go through the target product's facade instead.
 - **Not isolated:** boundaries are not yet enforced by CI, but prefer using existing
   facades when they exist rather than importing internals.
 
-If you need to extend what's reachable across a boundary, add a method to the relevant
-`backend/facade/api.py` — not a `depends_on` entry in `tach.toml`.
+If you need to extend what's reachable across a boundary, add a function to the relevant
+facade module (or a re-export to its wiring submodule) — not a `depends_on` entry in
+`tach.toml`.
 Run `tach check --dependencies --interfaces` to verify import boundaries are clean.


### PR DESCRIPTION
## Problem

The isolating-product-facade-contracts skill prescribes serial caller-cluster PRs for isolation migrations. That shape predates agent-assisted work: authoring is no longer the constraint — human review latency and conflicts with parallel work landing on master are. Serial chains maximize both: each PR waits in review while the files it touches drift, and the next PR can't be authored until the previous one merges. Meanwhile every week a product stays non-isolated keeps full-suite CI runs on PRs that only touched that product.

## Changes

- default migrations to two PRs: a design PR (contracts + facade + behavioral-parity tests, new files only) where human review attention goes, and a mechanical sweep PR (callers + presentation + isolation chain) carried by the verification chain (tach, import-linter, contract-check, tests)
- treat the sweep PR as regenerable on conflict instead of hand-rebasing — the import map plus the merged facade fully determine the rewrite
- gate the shape on how hard core imports the product's internals (new baseline command) instead of product size; high-coupling products slice the sweep by the teams owning the call sites, reviewed in parallel rather than serially by capability
- reframe legacy-leak tach blocks and compatibility shims as exception-path tooling instead of standard steps
- keep the old risk ordering (read paths → writes → tasks) as review-attention guidance within the sweep, not as PR boundaries

Guardrails, the 4-step isolation chain, and done criteria are unchanged.

## How did you test this code?

Docs-only change to an agent skill. `hogli lint:skills` passes. I'm an agent; no manual testing beyond that.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal agent skill only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. The rewrite followed a blast-radius analysis replaying recent master history through the current dorny + turbo-discover selection, which showed full-suite runs triggered purely by non-isolated products make up a meaningful share of backend CI, and identified the serial PR shape as the main adoption drag. Decisions along the way: kept verification/guardrail sections untouched and made targeted edits rather than a full rewrite; made the two-PR shape the default with team-sliced sweeps as the high-coupling exception; slicing is by owners of the calling code, deliberately not CODEOWNERS (the repo doesn't use it for ordinary ownership).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

