### PR TITLE
fix(slack): skip cross-region routing outside US/EU cloud

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -52,6 +52,7 @@ from posthog.temporal.ai.posthog_code_slack_mention_command import (
 )
 from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
+from posthog.utils import get_instance_region
 
 from products.slack_app.backend.models import SlackChannel, SlackThreadTaskMapping, SlackUserProfileCache
 from products.slack_app.backend.services.integration_resolver import (
@@ -554,6 +555,16 @@ WORKSPACE_CLAIMS_TIMEOUT_SECONDS = (1, 1)
 # re-flap routing for every subsequent event. Short TTL keeps us responsive when an integration
 # moves between regions; None answers are never cached.
 WORKSPACE_CLAIMS_CACHE_TTL_SECONDS = 60
+
+
+def _cross_region_routing_enabled() -> bool:
+    # Cross-region routing only makes sense between PostHog Cloud US and EU — they share the
+    # Slack app's signing secret and split workspace ownership between them. The hosted dev
+    # environment (CLOUD_DEPLOYMENT="DEV"), local dev, E2E, and self-hosted deployments all run
+    # as a single region; proxying their Slack events to us.posthog.com targets a different
+    # signing secret and a workspace this region doesn't own, which surfaces as a 403 on every
+    # webhook hit (see slack_app_region_proxy_non_success).
+    return get_instance_region() in ("US", "EU")
 
 
 def _us_region_domain() -> str:
@@ -1680,7 +1691,7 @@ def route_posthog_code_event_to_relevant_region(
     # In local dev we run a single instance, so cross-region routing is meaningless: the only
     # consumer is this process. Disable both the probe and the proxy hop and always handle
     # locally.
-    can_defer_to_other_region = not _is_us_host(incoming_host) and not proxied and not settings.DEBUG
+    can_defer_to_other_region = _cross_region_routing_enabled() and not _is_us_host(incoming_host) and not proxied
 
     logger.info(
         "posthog_code_route_enter",
@@ -1923,9 +1934,10 @@ def _route_to_other_region_or_drop(
 ) -> str:
     """No local match: either forward to the other region or drop if we are the second hop.
 
-    In local dev there is no other region to forward to, so we just record the miss and stop.
+    Single-region deployments (local dev, hosted dev, E2E, self-hosted) have no other region
+    to forward to, so we just record the miss and stop.
     """
-    if proxied or settings.DEBUG:
+    if proxied or not _cross_region_routing_enabled():
         logger.warning(
             "posthog_code_no_integration_found",
             slack_team_id=slack_team_id,
@@ -3228,10 +3240,11 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         proxied=proxied,
     )
 
-    if not local and not proxied and not settings.DEBUG:
+    if not local and not proxied and _cross_region_routing_enabled():
         # The payload's integration_id pinpoints exactly one row, so a lookup would tell us
         # nothing new — just forward to the other region. The loop header keeps us at one hop.
-        # Skipped in local dev where there is only one region to talk to.
+        # Skipped in single-region deployments (local dev, hosted dev, E2E, self-hosted) where
+        # there is no other region to talk to.
         target = _other_region_domain(incoming_host)
         upstream = _proxy_event_to_region(request, target)
         if upstream is not None:

--- a/products/slack_app/backend/tests/test_channel_onboarding_routing.py
+++ b/products/slack_app/backend/tests/test_channel_onboarding_routing.py
@@ -19,7 +19,7 @@ from products.slack_app.backend.api import (
 )
 
 
-@override_settings(DEBUG=False)
+@override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
 class TestMemberJoinedChannelRouting(TestCase):
     """Routing-level coverage for the channel onboarding flow.
 

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -142,7 +142,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_local_match_starts_temporal_workflow(self, mock_sync_connect, mock_asyncio_run):
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
 
@@ -187,7 +187,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.SlackIntegration")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_explicit_repo_followup_handling(
         self,
         _name,
@@ -280,7 +280,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     )
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_ignored_does_not_start_workflow(
         self,
         _name,
@@ -303,7 +303,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api._post_slack_user_feedback")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_from_unknown_user_posts_in_thread_failure_reply(
         self, mock_sync_connect, mock_asyncio_run, mock_post_feedback, mock_capture
     ):
@@ -342,7 +342,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api._post_slack_user_feedback")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_unknown_user_in_unapproved_ext_shared_channel_suppresses_failure_reply(
         self, mock_sync_connect, mock_asyncio_run, mock_post_feedback, mock_capture
     ):
@@ -367,7 +367,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_filters_candidates_to_user_accessible_only(self, mock_sync_connect, mock_asyncio_run):
         # When the workspace spans two orgs and the resolved PostHog user only
         # belongs to one of them, ``resolve_from_candidates`` filters the other
@@ -396,7 +396,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_excludes_private_team_when_user_lacks_access_control_grant(
         self, mock_sync_connect, mock_asyncio_run
     ):
@@ -448,7 +448,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_passes_resolved_user_id_into_workflow_inputs(self, mock_sync_connect, mock_asyncio_run):
         # The routing layer must propagate the resolved PostHog user id into the
         # mention workflow inputs so the workflow can skip its legacy in-workflow
@@ -464,7 +464,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_command_workflow_receives_resolved_user_id(self, mock_sync_connect, mock_asyncio_run):
         # Command path mirrors the mention path: routing resolves the user once
         # and the command workflow gets ``user_id`` so it skips its legacy
@@ -482,7 +482,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_command_text_routes_to_command_workflow(self, mock_sync_connect, mock_asyncio_run):
         # Command text in a mention must dispatch the command workflow, never the agent
         # mention workflow — even when a single coding-agent integration exists.
@@ -503,7 +503,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_command_workflow_receives_all_workspace_candidates(self, mock_sync_connect, mock_asyncio_run):
         # When multiple coding-agent integrations exist for the same workspace, all of
         # their IDs must be forwarded to the command workflow so it can handle project
@@ -537,7 +537,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.does_other_region_claim_workspace", return_value=False)
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_rules_add_without_repo_routes_to_command_workflow_for_picker(
         self, mock_sync_connect, mock_asyncio_run, _mock_us_claim
     ):
@@ -560,7 +560,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert kicked_off == PostHogCodeSlackMentionCommandWorkflow.run
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_link_shared_routes_to_unfurl(self, mock_unfurl):
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
         link_shared_event = {"type": "link_shared", "channel": "C001", "links": []}
@@ -575,7 +575,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert passed_integration.id == self.posthog_code_integration.id
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_link_shared_works_with_only_notifications_integration(self, mock_unfurl):
         # Delete the coding-agent integration and create a notifications-only integration for same workspace
         self.posthog_code_integration.delete()
@@ -600,7 +600,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert passed_integration.integration_id == "T12345"
 
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_us_no_local_proxies_to_eu(self, mock_proxy):
         mock_proxy.return_value = "proxied"
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
@@ -614,7 +614,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert mock_proxy.call_args.args[1] == "eu.posthog.com"
 
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_proxy_failure_returns_proxy_failed(self, mock_proxy):
         mock_proxy.return_value = "proxy_failed"
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
@@ -628,7 +628,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_no_local_with_loop_header_returns_no_integration(self, mock_sync_connect, mock_asyncio_run, mock_proxy):
         request = self.factory.post(
             "/slack/event-callback/",
@@ -649,7 +649,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_eu_local_match_with_us_lookup_true_proxies_to_us(
         self, mock_sync_connect, mock_asyncio_run, mock_proxy, mock_lookup
     ):
@@ -674,7 +674,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.does_other_region_claim_workspace")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_eu_local_match_with_us_lookup_false_handles_locally(
         self, mock_sync_connect, mock_asyncio_run, mock_lookup
     ):
@@ -694,7 +694,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_eu_local_match_with_us_lookup_failure_optimistically_proxies(
         self, mock_sync_connect, mock_asyncio_run, mock_proxy, mock_lookup
     ):
@@ -718,7 +718,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
     @patch("products.slack_app.backend.api.does_other_region_claim_workspace")
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_eu_no_local_proxies_to_us_without_lookup(self, mock_proxy, mock_lookup):
         mock_proxy.return_value = "proxied"
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
@@ -734,9 +734,41 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert mock_proxy.call_args.args[1] == "us.posthog.com"
 
     @patch("products.slack_app.backend.api.does_other_region_claim_workspace")
+    @patch("products.slack_app.backend.api._proxy_event_and_return_route")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="DEV")
+    def test_hosted_dev_does_not_cross_region_proxy(self, mock_sync_connect, mock_asyncio_run, mock_proxy, mock_lookup):
+        # The hosted dev environment (app.dev.posthog.dev) runs as a single region and must not
+        # probe or proxy to us.posthog.com — it has no row in that workspace and the upstream
+        # responds 403 to every such hit (regression for slack_app_region_proxy_non_success).
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="app.dev.posthog.dev")
+
+        from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
+
+        result = route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        mock_lookup.assert_not_called()
+        mock_proxy.assert_not_called()
+        mock_sync_connect.assert_called_once()
+
+    @patch("products.slack_app.backend.api._proxy_event_and_return_route")
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="DEV")
+    def test_hosted_dev_no_local_match_drops_instead_of_proxying(self, mock_proxy):
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="app.dev.posthog.dev")
+
+        from products.slack_app.backend.api import ROUTE_NO_INTEGRATION, route_posthog_code_event_to_relevant_region
+
+        result = route_posthog_code_event_to_relevant_region(request, self.event, "T_UNKNOWN")
+
+        assert result == ROUTE_NO_INTEGRATION
+        mock_proxy.assert_not_called()
+
+    @patch("products.slack_app.backend.api.does_other_region_claim_workspace")
+    @patch("products.slack_app.backend.api.asyncio.run")
+    @patch("products.slack_app.backend.api.sync_connect")
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_eu_local_match_with_loop_header_skips_lookup_and_handles(
         self, mock_sync_connect, mock_asyncio_run, mock_lookup
     ):
@@ -769,7 +801,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api._post_slack_user_feedback")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_with_missing_scopes_posts_reauth_and_skips_workflow(
         self,
         _name,
@@ -834,7 +866,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.SlackIntegration")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_over_quota_team_still_starts_workflow_for_in_workflow_enforcement(
         self,
         mock_sync_connect,
@@ -920,7 +952,7 @@ class TestChannelApprovalGate(TestCase):
     @patch("products.slack_app.backend.api._post_channel_approval_prompt")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_external_channel_without_approval_posts_prompt(self, mock_sync_connect, mock_asyncio_run, mock_prompt):
         request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
 
@@ -936,7 +968,7 @@ class TestChannelApprovalGate(TestCase):
     @patch("products.slack_app.backend.api._post_channel_approval_prompt")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_external_channel_with_approval_starts_workflow(self, mock_sync_connect, mock_asyncio_run, mock_prompt):
         from django.utils import timezone
 
@@ -963,7 +995,7 @@ class TestChannelApprovalGate(TestCase):
     @patch("products.slack_app.backend.api._post_channel_approval_prompt")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_non_external_channel_starts_workflow_without_prompt(
         self, mock_sync_connect, mock_asyncio_run, mock_prompt
     ):
@@ -983,7 +1015,7 @@ class TestChannelApprovalGate(TestCase):
     @patch("products.slack_app.backend.api._post_channel_approval_prompt")
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_pending_row_without_approval_still_prompts(self, mock_sync_connect, mock_asyncio_run, mock_prompt):
         # A row with ``approved_at`` NULL has no semantic weight today, but must not bypass the
         # gate — only ``approved_at`` being set counts as approval.

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -530,7 +530,7 @@ class TestRepoPickerOptions(TestCase):
         mock_slack_client.chat_postMessage.assert_not_called()
 
 
-@override_settings(DEBUG=False)
+@override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
 class TestInteractivityRegionRouting(TestCase):
     """Region-aware proxying for /slack/interactivity-callback.
 

--- a/products/slack_app/backend/tests/test_thread_message_routing.py
+++ b/products/slack_app/backend/tests/test_thread_message_routing.py
@@ -248,7 +248,7 @@ class TestRouteThreadMessage(TestCase):
 
     # --- Scope + approval gates ------------------------------------------
 
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_missing_scopes_dropped_silently(self):
         """Scopes can only be missing if they were revoked after the mapping
         was created. Drop silently rather than reposting the notice on every
@@ -267,7 +267,7 @@ class TestRouteThreadMessage(TestCase):
         mock_notify.assert_not_called()
         mock_start.assert_not_called()
 
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_unapproved_ext_shared_channel_dropped_silently(self):
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
 
@@ -286,7 +286,7 @@ class TestRouteThreadMessage(TestCase):
 
     # --- Rules command not invoked for untagged --------------------------
 
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_rules_command_text_does_not_trigger_command_workflow(self):
         """A rules-shaped message in an untagged thread (no @mention) must not
         kick off the command workflow — the user never tagged us. It should
@@ -310,7 +310,7 @@ class TestRouteThreadMessage(TestCase):
 
     # --- Workflow handoff (happy path) -----------------------------------
 
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_tagged_message_starts_workflow_with_resolved_user_and_untagged_flag(self):
         """Happy path: the handler runs the same gates as a mention but on
         success starts the workflow with ``untagged_followup=True`` and the
@@ -330,7 +330,7 @@ class TestRouteThreadMessage(TestCase):
 
     # --- Symmetry with the app_mention path -------------------------------
 
-    @override_settings(DEBUG=False)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
     def test_app_mention_and_tagged_message_both_reach_mention_workflow(self):
         """Both event types end at ``_start_mention_workflow`` with the user
         resolved; only the ``untagged_followup`` kwarg differs."""


### PR DESCRIPTION
## Problem

The hosted dev environment (`app.dev.posthog.dev`, `CLOUD_DEPLOYMENT=DEV`) was proxying every Slack webhook to `https://us.posthog.com/slack/event-callback` and getting `403` back (`slack_app_region_proxy_non_success`). The cross-region gate keyed off `not settings.DEBUG`, which is False on hosted dev too — so dev wasn't recognized as a single-region deployment.

## Changes

Gate cross-region routing on `get_instance_region() in ("US", "EU")`. DEV, local, E2E, and self-hosted now stay single-region.

## How did you test this code?

Agent-authored. Added two regression tests pinning the hosted-dev behavior (local match handled locally without probe/proxy; unknown workspace dropped instead of proxied). Updated the existing `@override_settings(DEBUG=False)` decorators in the routing tests to also set `CLOUD_DEPLOYMENT="US"`. All 398 `products/slack_app/backend/tests` pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.7) — reproduced the bug from a dev log line the human supplied, traced it to three `not settings.DEBUG` gates in `products/slack_app/backend/api.py`, and replaced them with a `_cross_region_routing_enabled()` helper. Chose `get_instance_region()` over a raw `settings.CLOUD_DEPLOYMENT` check on the human's suggestion — it's the canonical region helper in the repo.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

