### PR TITLE
feat(capture): add client ip to kafka message headers

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -1061,6 +1061,7 @@ mod tests {
         let headers_historical = CapturedEventHeaders {
             token: Some("test_token".to_string()),
             distinct_id: Some("test_id".to_string()),
+            ip: None,
             session_id: None,
             timestamp: Some("2023-01-01T12:00:00Z".to_string()),
             event: Some("test_event".to_string()),
@@ -1083,6 +1084,7 @@ mod tests {
         let headers_main = CapturedEventHeaders {
             token: Some("test_token".to_string()),
             distinct_id: Some("test_id".to_string()),
+            ip: None,
             session_id: None,
             timestamp: Some("2023-01-01T12:00:00Z".to_string()),
             event: Some("test_event".to_string()),
@@ -1113,6 +1115,7 @@ mod tests {
         let headers = CapturedEventHeaders {
             token: Some("test_token".to_string()),
             distinct_id: Some("test_id".to_string()),
+            ip: None,
             session_id: None,
             timestamp: Some("2024-01-15T10:30:00Z".to_string()),
             event: Some("test_event".to_string()),
@@ -1148,6 +1151,7 @@ mod tests {
         let headers = CapturedEventHeaders {
             token: Some("test_token".to_string()),
             distinct_id: Some("test_id".to_string()),
+            ip: None,
             session_id: None,
             timestamp: Some("2024-01-15T10:30:00Z".to_string()),
             event: Some("test_event".to_string()),

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -169,6 +169,7 @@ impl SinkEvent for WrappedEvent {
         CapturedEventHeaders {
             token: Some(ctx.api_token.clone()),
             distinct_id: Some(self.event.distinct_id.clone()),
+            ip: Some(ctx.reported_client_ip().to_string()),
             session_id: self.event.session_id.clone(),
             timestamp: self
                 .adjusted_timestamp
@@ -191,19 +192,10 @@ impl SinkEvent for WrappedEvent {
 
     fn partition_key(&self, ctx: &Context, buf: &mut String) {
         use std::fmt::Write;
-        match (
-            self.event.options.cookieless_mode == Some(true),
-            ctx.capture_internal,
-        ) {
-            (true, true) => {
-                let _ = write!(buf, "{}:127.0.0.1", ctx.api_token);
-            }
-            (true, false) => {
-                let _ = write!(buf, "{}:{}", ctx.api_token, ctx.client_ip);
-            }
-            (false, _) => {
-                let _ = write!(buf, "{}:{}", ctx.api_token, self.event.distinct_id);
-            }
+        if self.event.options.cookieless_mode == Some(true) {
+            let _ = write!(buf, "{}:{}", ctx.api_token, ctx.reported_client_ip());
+        } else {
+            let _ = write!(buf, "{}:{}", ctx.api_token, self.event.distinct_id);
         }
     }
 
@@ -220,13 +212,7 @@ impl SinkEvent for WrappedEvent {
         let data = serde_json::to_string(&ingestion_data)
             .map_err(|e| anyhow::anyhow!("serializing IngestionData: {e:#}"))?;
 
-        let ip;
-        let ip_ref: &str = if ctx.capture_internal {
-            "127.0.0.1"
-        } else {
-            ip = ctx.client_ip.to_string();
-            &ip
-        };
+        let ip = ctx.reported_client_ip().to_string();
         let timestamp = self.adjusted_timestamp.ok_or_else(|| {
             anyhow::anyhow!("serialize_into called on event without adjusted_timestamp")
         })?;
@@ -236,7 +222,7 @@ impl SinkEvent for WrappedEvent {
         let ie = IngestionEvent {
             uuid: self.uuid,
             distinct_id: &self.event.distinct_id,
-            ip: ip_ref,
+            ip: &ip,
             data: &data,
             now: &now,
             sent_at: Some(ctx.client_timestamp),
@@ -927,6 +913,25 @@ mod tests {
         ctx.historical_migration = false;
         let h = ev.headers(&ctx);
         assert!(h.historical_migration.is_none());
+    }
+
+    #[test]
+    fn headers_include_client_ip() {
+        let mut ctx = test_utils::test_context();
+        ctx.client_ip = "10.0.0.42".parse().unwrap();
+        let ev = ok_wrapped("$pageview", "user-1");
+        let h = ev.headers(&ctx);
+        assert_eq!(h.ip.as_deref(), Some("10.0.0.42"));
+    }
+
+    #[test]
+    fn headers_ip_is_localhost_for_internal_capture() {
+        let mut ctx = test_utils::test_context();
+        ctx.client_ip = "10.0.0.42".parse().unwrap();
+        ctx.capture_internal = true;
+        let ev = ok_wrapped("$pageview", "user-1");
+        let h = ev.headers(&ctx);
+        assert_eq!(h.ip.as_deref(), Some("127.0.0.1"));
     }
 
     fn partition_key_str(ev: &WrappedEvent, ctx: &Context) -> String {

--- a/rust/capture/src/v1/context.rs
+++ b/rust/capture/src/v1/context.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use axum::extract::Query as AxumQuery;
 use axum::http::{header, HeaderMap, Method};
@@ -43,6 +43,16 @@ fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Result<&'a str, Error> 
 }
 
 impl Context {
+    /// Client IP as reported downstream (payload, headers, partition keys):
+    /// internal captures report localhost instead of the proxy-derived IP.
+    pub fn reported_client_ip(&self) -> IpAddr {
+        if self.capture_internal {
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        } else {
+            self.client_ip
+        }
+    }
+
     pub fn clock_skew(&self) -> chrono::Duration {
         self.client_timestamp
             .signed_duration_since(self.server_received_at)

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -26,6 +26,7 @@ fn empty_captured_headers() -> CapturedEventHeaders {
     CapturedEventHeaders {
         token: None,
         distinct_id: None,
+        ip: None,
         session_id: None,
         timestamp: None,
         event: None,

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -165,6 +165,7 @@ mod tests {
             CapturedEventHeaders {
                 token: None,
                 distinct_id: None,
+                ip: None,
                 session_id: None,
                 timestamp: None,
                 event: None,

--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -112,6 +112,7 @@ pub struct RawEngageEvent {
 pub struct CapturedEventHeaders {
     pub token: Option<String>,
     pub distinct_id: Option<String>,
+    pub ip: Option<String>,
     pub session_id: Option<String>,
     pub timestamp: Option<String>,
     pub event: Option<String>,
@@ -197,6 +198,12 @@ impl From<CapturedEventHeaders> for OwnedHeaders {
             });
 
         // Only add optional headers when present, to avoid bloating every message.
+        if let Some(ref ip) = headers.ip {
+            owned = owned.insert(Header {
+                key: "ip",
+                value: Some(ip.as_str()),
+            });
+        }
         if let Some(skip_heatmap_processing) = headers.skip_heatmap_processing {
             let val = skip_heatmap_processing.to_string();
             owned = owned.insert(Header {
@@ -247,6 +254,7 @@ impl From<OwnedHeaders> for CapturedEventHeaders {
         Self {
             token: headers_map.get("token").cloned(),
             distinct_id: headers_map.get("distinct_id").cloned(),
+            ip: headers_map.get("ip").cloned(),
             session_id: headers_map.get("session_id").cloned(),
             timestamp: headers_map.get("timestamp").cloned(),
             event: headers_map.get("event").cloned(),
@@ -309,6 +317,7 @@ impl CapturedEvent {
         CapturedEventHeaders {
             token: Some(self.token.clone()),
             distinct_id: Some(self.distinct_id.clone()),
+            ip: (!self.ip.is_empty()).then(|| self.ip.clone()),
             session_id: self.session_id.clone(),
             timestamp: Some(self.timestamp.timestamp_millis().to_string()),
             event: Some(self.event.clone()),
@@ -678,6 +687,62 @@ mod tests {
 
         let headers = event_without_session.to_headers();
         assert_eq!(headers.session_id, None);
+    }
+
+    #[test]
+    fn test_to_headers_includes_ip_and_round_trips() {
+        let event = CapturedEvent {
+            uuid: Uuid::nil(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "192.168.1.1".to_string(),
+            data: r#"{"event":"test_event"}"#.to_string(),
+            now: "2023-01-02T10:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "test_event".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let headers = event.to_headers();
+        assert_eq!(headers.ip, Some("192.168.1.1".to_string()));
+
+        let owned: OwnedHeaders = headers.into();
+        let recovered: CapturedEventHeaders = owned.into();
+        assert_eq!(recovered.ip, Some("192.168.1.1".to_string()));
+    }
+
+    #[test]
+    fn test_to_headers_omits_ip_when_empty() {
+        let event = CapturedEvent {
+            uuid: Uuid::nil(),
+            distinct_id: "test_user".to_string(),
+            session_id: None,
+            ip: "".to_string(),
+            data: r#"{"event":"test_event"}"#.to_string(),
+            now: "2023-01-02T10:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "test_event".to_string(),
+            timestamp: DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let headers = event.to_headers();
+        assert_eq!(headers.ip, None);
+
+        let owned: OwnedHeaders = headers.into();
+        assert!(
+            owned.iter().all(|h| h.key != "ip"),
+            "expected no ip key in OwnedHeaders when ip is empty"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Ingestion event filters can match on event name and distinct ID, both of which are available to the pipeline as Kafka message headers, so filtering happens before the message payload is parsed. To extend filtering to client IP, the IP needs to be available the same way — today it only exists inside the serialized payload (`CapturedEvent.ip`), so the pipeline would have to parse every message body just to evaluate an IP condition.

## Changes

- Add an optional `ip` field to `CapturedEventHeaders`, emitted as an `ip` Kafka header only when present (same pattern as the other optional headers) and parsed back in the `OwnedHeaders` conversion.
- v0 (`CapturedEvent::to_headers()`): populate `ip` from the event, omitting it when empty.
- v1 (`WrappedEvent::headers()`): populate `ip` from the request context, reporting localhost for internal captures — exactly the value the payload already carries.
- Extract the duplicated internal-capture IP logic (`capture_internal` → `127.0.0.1`) from `serialize_into()` and `partition_key()` into `Context::reported_client_ip()`, now shared by all three call sites.

The header is additive, so downstream consumers are unaffected until they opt in to reading it.

## How did you test this code?

- New unit tests: header round-trip through `OwnedHeaders` (present and empty IP), and v1 header population for proxy-derived and internal-capture IPs.
- `cargo test -p common-types -p capture --lib` (823 tests), `cargo fmt --check`, and `cargo clippy` all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

