### PR TITLE
fix(hogql): block multi-statement raw direct Postgres queries

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from typing import ClassVar, Literal, Optional, TypedDict, Union, cast
 
 import psycopg
+import sqlparse
 from opentelemetry import trace
 from psycopg.types.datetime import DateLoader
 
@@ -139,6 +140,20 @@ def postgres_error_to_message(error: Exception) -> str:
     if not message:
         return "Postgres query failed."
     return message.splitlines()[0]
+
+
+def ensure_single_direct_postgres_statement(sql: str) -> str:
+    """Reject multi-statement raw SQL.
+
+    Raw queries run without bound parameters, so psycopg uses the simple query
+    protocol, which runs every ``;``-separated statement in one round trip. A
+    caller could commit out of the read-only transaction and ``BEGIN READ WRITE``
+    to perform writes; restricting to one statement keeps it read-only.
+    """
+    statements = [statement for statement in sqlparse.split(sql) if statement.strip(" \t\r\n;")]
+    if len(statements) > 1:
+        raise ExposedHogQLError("Raw queries must contain a single statement.")
+    return sql
 
 
 def direct_postgres_session_setup_sql(
@@ -755,7 +770,7 @@ class HogQLQueryExecutor:
             raise ExposedHogQLError("Sending a raw query requires a valid connection.")
         self.connection_id = str(source.id)
         self.direct_postgres_source_id = self.connection_id
-        self.direct_postgres_sql = str(self.query)
+        self.direct_postgres_sql = ensure_single_direct_postgres_statement(str(self.query))
         self._execute_direct_postgres_query()
 
     def _capture_send_raw_query_translation_error(self) -> None:

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -18,6 +18,7 @@ from posthog.hogql.query import (
     HogQLQueryExecutor,
     LenientDirectPostgresDateLoader,
     direct_postgres_session_setup_sql,
+    ensure_single_direct_postgres_statement,
     get_runtime_direct_postgres_connection_metadata,
     parse_lenient_direct_postgres_date,
     postgres_error_to_message,
@@ -1098,6 +1099,62 @@ class TestDirectPostgresQuery(APIBaseTest):
         self.assertEqual(response.results, [(1,)])
         mocked_connection.execute.assert_called_once_with("SELECT current_database(), version()")
         mocked_cursor.execute.assert_called_once_with("SELECT 1 AS value", None)
+
+    @parameterized.expand(
+        [
+            ("explicit_read_write", "COMMIT; BEGIN READ WRITE; UPDATE t SET a = 1; COMMIT;"),
+            ("set_then_write", "SET default_transaction_read_only = off; UPDATE t SET a = 1;"),
+            ("two_selects", "SELECT 1; SELECT 2"),
+        ]
+    )
+    def test_ensure_single_direct_postgres_statement_rejects_multi_statement(self, _name: str, sql: str):
+        with self.assertRaises(ExposedHogQLError):
+            ensure_single_direct_postgres_statement(sql)
+
+    @parameterized.expand(
+        [
+            ("plain_select", "SELECT 1 AS value"),
+            ("trailing_semicolon", "SELECT 1 AS value;"),
+            ("stray_empty_statements", "SELECT 1 AS value;   ;  "),
+            ("percent_literal", "SELECT name FROM t WHERE name LIKE '%admin%'"),
+            ("semicolon_in_literal", "SELECT 'a;b' AS value"),
+            ("dollar_quoted", "SELECT $$a;b;c$$ AS value"),
+        ]
+    )
+    def test_ensure_single_direct_postgres_statement_allows_single_statement(self, _name: str, sql: str):
+        self.assertEqual(ensure_single_direct_postgres_statement(sql), sql)
+
+    @patch("posthog.hogql.query.psycopg.connect")
+    def test_send_raw_query_rejects_multi_statement_before_execution(self, mock_connect):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+            },
+        )
+
+        executor = HogQLQueryExecutor(
+            query="COMMIT; BEGIN READ WRITE; UPDATE t SET a = 1; COMMIT;",
+            team=self.team,
+            connection_id=str(source.id),
+            send_raw_query=True,
+        )
+
+        with self.assertRaises(ExposedHogQLError):
+            executor.execute()
+
+        mock_connect.assert_not_called()
 
     def test_selected_connection_rejects_disabled_direct_tables(self):
         source = ExternalDataSource.objects.create(


### PR DESCRIPTION
## Problem

Direct Postgres connections support a "send raw query" mode that runs a user-provided SQL string against the configured external database without translating it through HogQL. These connections are intended to be read-only — the connection is opened with `default_transaction_read_only=on`.

That read-only guarantee was bypassable. Because raw queries run without bound parameters, psycopg uses the simple query protocol, which executes every `;`-separated statement in a single round trip. A caller could therefore commit out of the read-only transaction and open a new `BEGIN READ WRITE` (or flip the `default_transaction_read_only` GUC) and then perform writes — `UPDATE`, `DELETE`, etc. — against the external database, provided the connection credentials had write privileges. This defeats the read-only contract the feature presents to users.

## Changes

Raw direct Postgres execution is now restricted to a single statement. With only one statement allowed, the request stays inside the read-only transaction the connection is opened with, so transaction-control escapes (`COMMIT; BEGIN READ WRITE; ...`) and read-only GUC flips are no longer possible, and any lone write statement is rejected by Postgres as read-only.

- Added `ensure_single_direct_postgres_statement`, applied only on the raw-query path before the SQL reaches `cursor.execute`. It uses `sqlparse.split` (already a dependency) to count real statements; this correctly ignores `;` inside string literals, dollar-quoting, comments, and stray empty statements, and is lenient across Postgres/DuckDB dialects.
- Left bound parameters as `None` for raw queries deliberately — forcing the extended protocol via empty params would change literal `%` handling and break `LIKE '%x%'` queries.
- The HogQL-translated path is untouched; it always emits a single printed `SELECT`.

Note for follow-up (not in this PR): the durable defense is to enforce read-only at the database-role level for these connections, so the application-layer setting is not the only barrier.

## How did you test this code?

I'm an agent (agent-assisted). I ran the automated tests; I did not perform manual testing.

- Added parameterized unit tests covering rejected multi-statement payloads (explicit `BEGIN READ WRITE`, `SET ... read_only=off` followed by a write, two `SELECT`s) and allowed single statements (trailing/stray semicolons, `%` literals, `;` inside string literals, dollar-quoting).
- Added an end-to-end test asserting a multi-statement raw query raises before any database connection is opened.
- `hogli test posthog/hogql/test/test_direct_postgres_query.py` — 84 passed.
- `ruff check` / `ruff format --check` clean on the changed files; `ty` type check passed via lint-staged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code at a maintainer's direction. The maintainer investigated a reported read-only-enforcement concern on the raw direct Postgres query path, confirmed the multi-statement simple-query-protocol bypass, and directed the fix.

Decisions: a statement-type allowlist (permit multiple read-only statements, reject transaction-control/GUC statements) was considered as a way to preserve multi-statement support, but rejected in favor of the simpler single-statement guard given there's no established need for multi-statement raw reads and the guard has a far smaller correctness surface. Forcing psycopg's extended protocol via empty params was also rejected because it alters literal `%` semantics. The longer-term database-role-level read-only enforcement is noted above as follow-up rather than implemented here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

