### PR TITLE
fix(replay): treat gemini 403 as already-gone in file cleanup

### DIFF
--- a/posthog/temporal/session_replay/gemini_cleanup_sweep/activities.py
+++ b/posthog/temporal/session_replay/gemini_cleanup_sweep/activities.py
@@ -114,9 +114,10 @@ async def sweep_gemini_files_activity(inputs: CleanupSweepInputs) -> CleanupSwee
             try:
                 await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=tracked.gemini_file_name)
             except APIError as e:
-                if e.code == 404:
-                    # File already gone (e.g., a previous untrack failed). Drop the key so we
-                    # don't keep retrying a doomed delete.
+                if e.code in (403, 404):
+                    # File already gone (e.g., a previous untrack failed). Gemini reports missing
+                    # files as 403 PERMISSION_DENIED ("...or it may not exist"), not just 404.
+                    # Drop the key so we don't keep retrying a doomed delete.
                     logger.info(
                         "cleanup_sweep.delete_already_gone",
                         gemini_file_name=tracked.gemini_file_name,

--- a/posthog/temporal/session_replay/gemini_cleanup_sweep/activities.py
+++ b/posthog/temporal/session_replay/gemini_cleanup_sweep/activities.py
@@ -7,7 +7,6 @@ from django.conf import settings
 import structlog
 from asgiref.sync import sync_to_async
 from google.genai import Client as RawGenAIClient
-from google.genai.errors import APIError
 from temporalio import activity
 from temporalio.client import Client, WorkflowExecutionStatus
 from temporalio.service import RPCError, RPCStatusCode
@@ -21,6 +20,7 @@ from posthog.temporal.session_replay.gemini_cleanup_sweep.constants import (
 )
 from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import (
     index_size,
+    is_gemini_file_gone,
     iter_tracked_files,
     untrack_uploaded_file,
 )
@@ -113,35 +113,24 @@ async def sweep_gemini_files_activity(inputs: CleanupSweepInputs) -> CleanupSwee
         async with delete_sem:
             try:
                 await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=tracked.gemini_file_name)
-            except APIError as e:
-                if e.code in (403, 404):
-                    # File already gone (e.g., a previous untrack failed). Gemini reports missing
-                    # files as 403 PERMISSION_DENIED ("...or it may not exist"), not just 404.
-                    # Drop the key so we don't keep retrying a doomed delete.
-                    logger.info(
-                        "cleanup_sweep.delete_already_gone",
+            except Exception as e:
+                if not is_gemini_file_gone(e):
+                    # Key kept for next-cycle retry; 48h TTL backstops.
+                    logger.exception(
+                        "cleanup_sweep.delete_failed",
                         gemini_file_name=tracked.gemini_file_name,
                         workflow_id=tracked.workflow_id,
                         signals_type="cleanup-sweep",
                     )
-                    await untrack_uploaded_file(tracked.gemini_file_name)
-                    return True
-                logger.exception(
-                    "cleanup_sweep.delete_failed",
+                    return False
+                # File already gone (e.g., a previous untrack failed). Drop the key so we
+                # don't keep retrying a doomed delete.
+                logger.info(
+                    "cleanup_sweep.delete_already_gone",
                     gemini_file_name=tracked.gemini_file_name,
                     workflow_id=tracked.workflow_id,
                     signals_type="cleanup-sweep",
                 )
-                return False
-            except Exception:
-                # Key kept for next-cycle retry; 48h TTL backstops.
-                logger.exception(
-                    "cleanup_sweep.delete_failed",
-                    gemini_file_name=tracked.gemini_file_name,
-                    workflow_id=tracked.workflow_id,
-                    signals_type="cleanup-sweep",
-                )
-                return False
             await untrack_uploaded_file(tracked.gemini_file_name)
             return True
 

--- a/posthog/temporal/session_replay/gemini_cleanup_sweep/tracking.py
+++ b/posthog/temporal/session_replay/gemini_cleanup_sweep/tracking.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 
 import structlog
+from google.genai.errors import APIError
 
 from posthog.redis import get_async_client
 from posthog.temporal.session_replay.gemini_cleanup_sweep.constants import (
@@ -16,6 +17,13 @@ from posthog.temporal.session_replay.gemini_cleanup_sweep.constants import (
 from posthog.temporal.session_replay.gemini_cleanup_sweep.types import TrackedFile
 
 logger = structlog.get_logger(__name__)
+
+
+def is_gemini_file_gone(error: Exception) -> bool:
+    """Whether a Gemini delete failure means the file no longer exists. Gemini reports missing
+    files as 403 PERMISSION_DENIED ("...or it may not exist"), not just 404 — callers should
+    untrack on either instead of retrying a doomed delete."""
+    return isinstance(error, APIError) and error.code in (403, 404)
 
 
 def _redis_key_for(gemini_file_name: str) -> str:

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a5_cleanup_gemini_file.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a5_cleanup_gemini_file.py
@@ -4,9 +4,8 @@ import structlog
 import temporalio
 from asgiref.sync import sync_to_async
 from google.genai import Client as RawGenAIClient
-from google.genai.errors import APIError
 
-from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import untrack_uploaded_file
+from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import is_gemini_file_gone, untrack_uploaded_file
 
 logger = structlog.get_logger(__name__)
 
@@ -23,8 +22,8 @@ async def cleanup_gemini_file_activity(gemini_file_name: str, session_id: str) -
             session_id=session_id,
             signals_type="session-summaries",
         )
-    except APIError as e:
-        if e.code not in (403, 404):
+    except Exception as e:
+        if not is_gemini_file_gone(e):
             logger.exception(
                 f"Failed to delete Gemini file {gemini_file_name} for session {session_id}",
                 gemini_file_name=gemini_file_name,
@@ -32,21 +31,12 @@ async def cleanup_gemini_file_activity(gemini_file_name: str, session_id: str) -
                 signals_type="session-summaries",
             )
             return
-        # File already gone: Gemini reports missing files as 403 PERMISSION_DENIED
-        # ("...or it may not exist"), not just 404. Untrack so the sweep doesn't retry forever.
+        # File already gone — untrack so the sweep doesn't retry a doomed delete forever.
         logger.info(
             f"Gemini file {gemini_file_name} already gone for session {session_id}",
             gemini_file_name=gemini_file_name,
             session_id=session_id,
             signals_type="session-summaries",
         )
-    except Exception:
-        logger.exception(
-            f"Failed to delete Gemini file {gemini_file_name} for session {session_id}",
-            gemini_file_name=gemini_file_name,
-            session_id=session_id,
-            signals_type="session-summaries",
-        )
-        return
 
     await untrack_uploaded_file(gemini_file_name)

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a5_cleanup_gemini_file.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a5_cleanup_gemini_file.py
@@ -4,6 +4,7 @@ import structlog
 import temporalio
 from asgiref.sync import sync_to_async
 from google.genai import Client as RawGenAIClient
+from google.genai.errors import APIError
 
 from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import untrack_uploaded_file
 
@@ -12,12 +13,29 @@ logger = structlog.get_logger(__name__)
 
 @temporalio.activity.defn
 async def cleanup_gemini_file_activity(gemini_file_name: str, session_id: str) -> None:
-    """Best-effort: on any failure the tracking key is left for the sweep to retry."""
+    """Best-effort: on transient failure the tracking key is left for the sweep to retry."""
     try:
         raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
         await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=gemini_file_name)
         logger.info(
             f"Deleted Gemini file {gemini_file_name} for session {session_id}",
+            gemini_file_name=gemini_file_name,
+            session_id=session_id,
+            signals_type="session-summaries",
+        )
+    except APIError as e:
+        if e.code not in (403, 404):
+            logger.exception(
+                f"Failed to delete Gemini file {gemini_file_name} for session {session_id}",
+                gemini_file_name=gemini_file_name,
+                session_id=session_id,
+                signals_type="session-summaries",
+            )
+            return
+        # File already gone: Gemini reports missing files as 403 PERMISSION_DENIED
+        # ("...or it may not exist"), not just 404. Untrack so the sweep doesn't retry forever.
+        logger.info(
+            f"Gemini file {gemini_file_name} already gone for session {session_id}",
             gemini_file_name=gemini_file_name,
             session_id=session_id,
             signals_type="session-summaries",

--- a/posthog/temporal/tests/session_replay/gemini_cleanup_sweep/test_activities.py
+++ b/posthog/temporal/tests/session_replay/gemini_cleanup_sweep/test_activities.py
@@ -238,13 +238,15 @@ async def test_delete_failure_keeps_redis_state_for_retry(activity_environment, 
     assert await _index_has(gemini_redis, "files/bad")
 
 
+@pytest.mark.parametrize("code", [403, 404])
 @pytest.mark.asyncio
-async def test_treats_gemini_404_as_success(activity_environment, fixed_now, gemini_redis):
+async def test_treats_gemini_already_gone_as_success(activity_environment, fixed_now, gemini_redis, code):
     # If a previous untrack failed and left an orphan key, the actual file may already be gone
-    # from Gemini. Don't keep retrying — drop the key and move on.
+    # from Gemini. Missing files surface as 403 PERMISSION_DENIED ("...or it may not exist")
+    # or 404. Don't keep retrying — drop the key and move on.
     await _track(gemini_redis, file_name="files/already-gone", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
     raw = _StubRawClient()
-    raw.files.delete_raises_for = {"files/already-gone": APIError(code=404, response_json={})}
+    raw.files.delete_raises_for = {"files/already-gone": APIError(code=code, response_json={})}
     tmp = _StubTemporal({"wf-1": _Outcome(status=WorkflowExecutionStatus.COMPLETED)})
     p1, p2 = _patch_clients(raw, tmp)
     with p1, p2:

--- a/posthog/temporal/tests/session_replay/session_summary/test_a5_cleanup_gemini_file.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_a5_cleanup_gemini_file.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from google.genai.errors import APIError
 from temporalio.testing import ActivityEnvironment
 
 from posthog.temporal.session_replay.gemini_cleanup_sweep.constants import REDIS_INDEX_KEY, REDIS_KEY_PREFIX
@@ -39,3 +40,22 @@ async def test_keeps_tracking_when_gemini_delete_fails(gemini_redis):
 
     assert await gemini_redis.exists(f"{REDIS_KEY_PREFIX}files/abc123") == 1
     assert await gemini_redis.zscore(REDIS_INDEX_KEY, "files/abc123") is not None
+
+
+@pytest.mark.parametrize("code", [403, 404])
+@pytest.mark.asyncio
+async def test_clears_tracking_when_file_already_gone(gemini_redis, code):
+    # Gemini reports missing files as 403 PERMISSION_DENIED ("...or it may not exist") or 404;
+    # either way the file can't be deleted, so the tracking key must be dropped.
+    await gemini_redis.set(f"{REDIS_KEY_PREFIX}files/abc123", "{}")
+    await gemini_redis.zadd(REDIS_INDEX_KEY, {"files/abc123": 0.0})
+    fake_client = MagicMock()
+    fake_client.files.delete.side_effect = APIError(code=code, response_json={})
+    with patch(
+        "posthog.temporal.session_replay.session_summary.activities.video_based.a5_cleanup_gemini_file.RawGenAIClient",
+        return_value=fake_client,
+    ):
+        await ActivityEnvironment().run(cleanup_gemini_file_activity, "files/abc123", "session-1")
+
+    assert await gemini_redis.exists(f"{REDIS_KEY_PREFIX}files/abc123") == 0
+    assert await gemini_redis.zscore(REDIS_INDEX_KEY, "files/abc123") is None

--- a/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
+++ b/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
@@ -5,6 +5,7 @@ from django.conf import settings
 import structlog
 from asgiref.sync import sync_to_async
 from google.genai import Client as RawGenAIClient
+from google.genai.errors import APIError
 from temporalio import activity
 
 from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import untrack_uploaded_file
@@ -18,10 +19,19 @@ logger = structlog.get_logger(__name__)
 @activity.defn(name="replay_vision_cleanup_gemini_file_activity")
 @track_activity()
 async def cleanup_gemini_file_activity(inputs: CleanupGeminiFileInputs) -> None:
-    """Best-effort delete of the uploaded Gemini file; the cleanup sweep retries on failure via the tracking key."""
+    """Best-effort delete of the uploaded Gemini file; the cleanup sweep retries on transient failure via the tracking key."""
     try:
         raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
         await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=inputs.gemini_file_name)
+    except APIError as e:
+        if e.code not in (403, 404):
+            logger.exception(
+                "replay_vision.cleanup_gemini_file.delete_failed", gemini_file_name=inputs.gemini_file_name
+            )
+            return
+        # File already gone: Gemini reports missing files as 403 PERMISSION_DENIED
+        # ("...or it may not exist"), not just 404. Untrack so the sweep doesn't retry forever.
+        logger.info("replay_vision.cleanup_gemini_file.already_gone", gemini_file_name=inputs.gemini_file_name)
     except Exception:
         logger.exception("replay_vision.cleanup_gemini_file.delete_failed", gemini_file_name=inputs.gemini_file_name)
         return

--- a/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
+++ b/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
@@ -5,10 +5,9 @@ from django.conf import settings
 import structlog
 from asgiref.sync import sync_to_async
 from google.genai import Client as RawGenAIClient
-from google.genai.errors import APIError
 from temporalio import activity
 
-from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import untrack_uploaded_file
+from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import is_gemini_file_gone, untrack_uploaded_file
 
 from products.replay_vision.backend.temporal.decorators import track_activity
 from products.replay_vision.backend.temporal.types import CleanupGeminiFileInputs
@@ -23,17 +22,13 @@ async def cleanup_gemini_file_activity(inputs: CleanupGeminiFileInputs) -> None:
     try:
         raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
         await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=inputs.gemini_file_name)
-    except APIError as e:
-        if e.code not in (403, 404):
+    except Exception as e:
+        if not is_gemini_file_gone(e):
             logger.exception(
                 "replay_vision.cleanup_gemini_file.delete_failed", gemini_file_name=inputs.gemini_file_name
             )
             return
-        # File already gone: Gemini reports missing files as 403 PERMISSION_DENIED
-        # ("...or it may not exist"), not just 404. Untrack so the sweep doesn't retry forever.
+        # File already gone — untrack so the sweep doesn't retry a doomed delete forever.
         logger.info("replay_vision.cleanup_gemini_file.already_gone", gemini_file_name=inputs.gemini_file_name)
-    except Exception:
-        logger.exception("replay_vision.cleanup_gemini_file.delete_failed", gemini_file_name=inputs.gemini_file_name)
-        return
 
     await untrack_uploaded_file(inputs.gemini_file_name)

--- a/products/replay_vision/backend/tests/conftest.py
+++ b/products/replay_vision/backend/tests/conftest.py
@@ -1,0 +1,1 @@
+from posthog.temporal.tests.session_replay.conftest import gemini_redis  # noqa: F401

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 import psycopg.errors
 from asgiref.sync import sync_to_async
+from google.genai.errors import APIError
 from prometheus_client import REGISTRY
 from structlog.testing import capture_logs
 from temporalio.exceptions import ActivityError, ApplicationError
@@ -19,6 +20,10 @@ from posthog.models import Organization, Team
 from posthog.models.user import User
 from posthog.redis import get_async_client
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
+from posthog.temporal.session_replay.gemini_cleanup_sweep.constants import (
+    REDIS_INDEX_KEY as _GEMINI_REDIS_INDEX_KEY,
+    REDIS_KEY_PREFIX as _GEMINI_REDIS_KEY_PREFIX,
+)
 
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.replay_vision.backend.api.observation_progress import stream_observation_progress
@@ -71,6 +76,7 @@ from products.replay_vision.backend.temporal.state import (
 )
 from products.replay_vision.backend.temporal.types import (
     ApplyScannerInputs,
+    CleanupGeminiFileInputs,
     CreateObservationInputs,
     CreateObservationOutput,
     EmbedSummarizerObservationInputs,
@@ -1196,6 +1202,56 @@ class TestEnsureSessionAssetActivity:
         ctx = asset.export_context or {}
         assert ctx["render_fingerprint"] == "abcdef"
         assert ctx["content_location"] == "s3://prior/video.mp4"
+
+
+class TestCleanupGeminiFileActivity:
+    async def _track(self, file_name: str) -> None:
+        redis = get_async_client()
+        await redis.set(f"{_GEMINI_REDIS_KEY_PREFIX}{file_name}", "{}")
+        await redis.zadd(_GEMINI_REDIS_INDEX_KEY, {file_name: 0.0})
+
+    async def _is_tracked(self, file_name: str) -> bool:
+        redis = get_async_client()
+        return bool(await redis.exists(f"{_GEMINI_REDIS_KEY_PREFIX}{file_name}"))
+
+    @pytest.mark.asyncio
+    async def test_deletes_file_and_clears_tracking(self) -> None:
+        await self._track("files/rv-ok")
+        fake_client = MagicMock()
+        with patch(
+            "products.replay_vision.backend.temporal.activities.cleanup_gemini_file.RawGenAIClient",
+            return_value=fake_client,
+        ):
+            await cleanup_gemini_file_activity(CleanupGeminiFileInputs(gemini_file_name="files/rv-ok"))
+        fake_client.files.delete.assert_called_once_with(name="files/rv-ok")
+        assert not await self._is_tracked("files/rv-ok")
+
+    @pytest.mark.asyncio
+    async def test_keeps_tracking_on_transient_failure(self) -> None:
+        await self._track("files/rv-transient")
+        fake_client = MagicMock()
+        fake_client.files.delete.side_effect = RuntimeError("gemini down")
+        with patch(
+            "products.replay_vision.backend.temporal.activities.cleanup_gemini_file.RawGenAIClient",
+            return_value=fake_client,
+        ):
+            await cleanup_gemini_file_activity(CleanupGeminiFileInputs(gemini_file_name="files/rv-transient"))
+        assert await self._is_tracked("files/rv-transient")
+
+    @pytest.mark.parametrize("code", [403, 404])
+    @pytest.mark.asyncio
+    async def test_clears_tracking_when_file_already_gone(self, code: int) -> None:
+        # Gemini reports missing files as 403 PERMISSION_DENIED ("...or it may not exist") or 404;
+        # either way the file can't be deleted, so the tracking key must be dropped.
+        await self._track("files/rv-gone")
+        fake_client = MagicMock()
+        fake_client.files.delete.side_effect = APIError(code=code, response_json={})
+        with patch(
+            "products.replay_vision.backend.temporal.activities.cleanup_gemini_file.RawGenAIClient",
+            return_value=fake_client,
+        ):
+            await cleanup_gemini_file_activity(CleanupGeminiFileInputs(gemini_file_name="files/rv-gone"))
+        assert not await self._is_tracked("files/rv-gone")
 
 
 def _build_inputs(**overrides: Any) -> ApplyScannerInputs:

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -1205,18 +1205,10 @@ class TestEnsureSessionAssetActivity:
 
 
 class TestCleanupGeminiFileActivity:
-    async def _track(self, file_name: str) -> None:
-        redis = get_async_client()
-        await redis.set(f"{_GEMINI_REDIS_KEY_PREFIX}{file_name}", "{}")
-        await redis.zadd(_GEMINI_REDIS_INDEX_KEY, {file_name: 0.0})
-
-    async def _is_tracked(self, file_name: str) -> bool:
-        redis = get_async_client()
-        return bool(await redis.exists(f"{_GEMINI_REDIS_KEY_PREFIX}{file_name}"))
-
     @pytest.mark.asyncio
-    async def test_deletes_file_and_clears_tracking(self) -> None:
-        await self._track("files/rv-ok")
+    async def test_deletes_file_and_clears_tracking(self, gemini_redis) -> None:
+        await gemini_redis.set(f"{_GEMINI_REDIS_KEY_PREFIX}files/rv-ok", "{}")
+        await gemini_redis.zadd(_GEMINI_REDIS_INDEX_KEY, {"files/rv-ok": 0.0})
         fake_client = MagicMock()
         with patch(
             "products.replay_vision.backend.temporal.activities.cleanup_gemini_file.RawGenAIClient",
@@ -1224,11 +1216,13 @@ class TestCleanupGeminiFileActivity:
         ):
             await cleanup_gemini_file_activity(CleanupGeminiFileInputs(gemini_file_name="files/rv-ok"))
         fake_client.files.delete.assert_called_once_with(name="files/rv-ok")
-        assert not await self._is_tracked("files/rv-ok")
+        assert await gemini_redis.exists(f"{_GEMINI_REDIS_KEY_PREFIX}files/rv-ok") == 0
+        assert await gemini_redis.zscore(_GEMINI_REDIS_INDEX_KEY, "files/rv-ok") is None
 
     @pytest.mark.asyncio
-    async def test_keeps_tracking_on_transient_failure(self) -> None:
-        await self._track("files/rv-transient")
+    async def test_keeps_tracking_on_transient_failure(self, gemini_redis) -> None:
+        await gemini_redis.set(f"{_GEMINI_REDIS_KEY_PREFIX}files/rv-transient", "{}")
+        await gemini_redis.zadd(_GEMINI_REDIS_INDEX_KEY, {"files/rv-transient": 0.0})
         fake_client = MagicMock()
         fake_client.files.delete.side_effect = RuntimeError("gemini down")
         with patch(
@@ -1236,14 +1230,16 @@ class TestCleanupGeminiFileActivity:
             return_value=fake_client,
         ):
             await cleanup_gemini_file_activity(CleanupGeminiFileInputs(gemini_file_name="files/rv-transient"))
-        assert await self._is_tracked("files/rv-transient")
+        assert await gemini_redis.exists(f"{_GEMINI_REDIS_KEY_PREFIX}files/rv-transient") == 1
+        assert await gemini_redis.zscore(_GEMINI_REDIS_INDEX_KEY, "files/rv-transient") is not None
 
     @pytest.mark.parametrize("code", [403, 404])
     @pytest.mark.asyncio
-    async def test_clears_tracking_when_file_already_gone(self, code: int) -> None:
+    async def test_clears_tracking_when_file_already_gone(self, gemini_redis, code: int) -> None:
         # Gemini reports missing files as 403 PERMISSION_DENIED ("...or it may not exist") or 404;
         # either way the file can't be deleted, so the tracking key must be dropped.
-        await self._track("files/rv-gone")
+        await gemini_redis.set(f"{_GEMINI_REDIS_KEY_PREFIX}files/rv-gone", "{}")
+        await gemini_redis.zadd(_GEMINI_REDIS_INDEX_KEY, {"files/rv-gone": 0.0})
         fake_client = MagicMock()
         fake_client.files.delete.side_effect = APIError(code=code, response_json={})
         with patch(
@@ -1251,7 +1247,8 @@ class TestCleanupGeminiFileActivity:
             return_value=fake_client,
         ):
             await cleanup_gemini_file_activity(CleanupGeminiFileInputs(gemini_file_name="files/rv-gone"))
-        assert not await self._is_tracked("files/rv-gone")
+        assert await gemini_redis.exists(f"{_GEMINI_REDIS_KEY_PREFIX}files/rv-gone") == 0
+        assert await gemini_redis.zscore(_GEMINI_REDIS_INDEX_KEY, "files/rv-gone") is None
 
 
 def _build_inputs(**overrides: Any) -> ApplyScannerInputs:


### PR DESCRIPTION
## Problem

The Gemini file cleanup sweep logs `cleanup_sweep.delete_failed` errors every 5-minute cycle for the same files. Gemini's Files API reports missing files as **403 PERMISSION_DENIED** ("...or it may not exist"), not 404, so the sweep's already-gone branch never fired and dead tracking keys were retried until their 48h Redis TTL expired.

## Changes

- New `is_gemini_file_gone()` predicate in `gemini_cleanup_sweep/tracking.py` treats APIError 403/404 as "file already gone".
- The sweep and both inline cleanup activities (session summaries, replay vision) use it to untrack instead of retrying; transient errors still leave the key for sweep retry.

## How did you test this code?

Agent-authored, automated tests only: parameterized 403/404 already-gone cases for the sweep and both inline cleanup activities. All affected suites pass locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code traced the recurring sweep errors in production logs to permanent 403s on already-gone files and ruled out API-key mismatch. Patched all three delete sites via a shared predicate rather than a unified delete helper, to keep the per-site log event names that monitoring queries rely on.