### PR TITLE
feat(devex): add facade and contracts for logs product

### DIFF
--- a/products/logs/backend/facade/__init__.py
+++ b/products/logs/backend/facade/__init__.py
@@ -1,0 +1,6 @@
+"""Public surface of the logs product.
+
+Other apps may import only from this package — see the submodules for the
+capability-specific surfaces (``api``, ``queries``, ``tasks``, ``temporal``).
+Kept import-free so consumers of one surface don't pay for the others.
+"""

--- a/products/logs/backend/facade/api.py
+++ b/products/logs/backend/facade/api.py
@@ -1,0 +1,47 @@
+"""Facade API for logs.
+
+This is the only module other apps may import for logs configuration data.
+
+Responsibilities:
+- Call internal models/logic
+- Convert Django models to contracts before returning
+- Remain thin and stable
+
+Do NOT:
+- Implement business logic here
+- Import DRF, serializers, or HTTP concerns
+- Return ORM instances or QuerySets
+
+Kept deliberately light: query-runner, celery, and temporal surfaces live in
+sibling facade modules (``queries``, ``tasks``, ``temporal``) so importing this
+module doesn't pull HogQL or temporalio onto the caller's import path.
+"""
+
+from typing import TYPE_CHECKING
+
+from posthog.models.team.extensions import get_or_create_team_extension
+
+from products.logs.backend.facade.contracts import TeamLogsConfigData
+from products.logs.backend.models import TeamLogsConfig
+
+if TYPE_CHECKING:
+    from posthog.models.team import Team
+
+
+def _to_team_logs_config_data(config: TeamLogsConfig) -> TeamLogsConfigData:
+    return TeamLogsConfigData(
+        team_id=config.team_id,
+        logs_distinct_id_attribute_key=config.logs_distinct_id_attribute_key,
+    )
+
+
+def get_or_create_team_logs_config(team: "Team") -> TeamLogsConfigData:
+    config = get_or_create_team_extension(team, TeamLogsConfig)
+    return _to_team_logs_config_data(config)
+
+
+def update_team_logs_config(team: "Team", *, logs_distinct_id_attribute_key: str) -> TeamLogsConfigData:
+    config = get_or_create_team_extension(team, TeamLogsConfig)
+    config.logs_distinct_id_attribute_key = logs_distinct_id_attribute_key
+    config.save(update_fields=["logs_distinct_id_attribute_key"])
+    return _to_team_logs_config_data(config)

--- a/products/logs/backend/facade/contracts.py
+++ b/products/logs/backend/facade/contracts.py
@@ -1,0 +1,19 @@
+"""Contract types for logs.
+
+Stable, framework-free frozen dataclasses that define what this product
+exposes to the rest of the codebase. No Django imports.
+
+These use ``pydantic.dataclasses.dataclass`` rather than the stdlib variant —
+same syntax, but with runtime validation on construction, so structural
+mistakes from mappers or callers surface at the facade boundary.
+"""
+
+from pydantic.dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TeamLogsConfigData:
+    """Per-environment logs configuration."""
+
+    team_id: int
+    logs_distinct_id_attribute_key: str

--- a/products/logs/backend/facade/queries.py
+++ b/products/logs/backend/facade/queries.py
@@ -1,0 +1,42 @@
+"""Query-runner surface of the logs facade.
+
+Core's query-runner registry (server-side CSV export) and HogQL tooling
+construct the logs runner through this module instead of reaching into
+internals. The runner class itself is re-exported because registry-style
+consumers need class identity (``isinstance`` dispatch), which a data
+contract cannot provide.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from products.logs.backend.logs_query_runner import LogsQueryRunner
+
+if TYPE_CHECKING:
+    from posthog.schema import HogQLQueryModifiers, LogsQuery
+
+    from posthog.hogql.timings import HogQLTimings
+
+    from posthog.hogql_queries.query_runner import LimitContext
+    from posthog.models.team import Team
+    from posthog.models.user import User
+
+__all__ = ["LogsQueryRunner", "build_logs_query_runner"]
+
+
+def build_logs_query_runner(
+    query: "LogsQuery | dict[str, Any]",
+    team: "Team",
+    *,
+    timings: "HogQLTimings | None" = None,
+    modifiers: "HogQLQueryModifiers | None" = None,
+    limit_context: "LimitContext | None" = None,
+    user: "User | None" = None,
+) -> LogsQueryRunner:
+    return LogsQueryRunner(
+        query=query,
+        team=team,
+        timings=timings,
+        modifiers=modifiers,
+        limit_context=limit_context,
+        user=user,
+    )

--- a/products/logs/backend/facade/tasks.py
+++ b/products/logs/backend/facade/tasks.py
@@ -1,0 +1,9 @@
+"""Celery surface of the logs facade.
+
+Core's beat schedule registers the cleanup task through this module. Only
+task objects cross the boundary here — invocation happens via the queue.
+"""
+
+from products.logs.backend.tasks import logs_alert_events_cleanup_task
+
+__all__ = ["logs_alert_events_cleanup_task"]

--- a/products/logs/backend/facade/temporal.py
+++ b/products/logs/backend/facade/temporal.py
@@ -1,0 +1,35 @@
+"""Temporal wiring surface of the logs facade.
+
+Core registers the logs alerting workflow on its workers and manages its
+schedule through this module. Everything core's worker/schedule wiring
+touches must be re-exported here — that keeps the wiring inside the contract
+surface (``backend/facade/**``), so renaming or reshaping these entry points
+correctly re-runs the full suite, while the implementations behind them stay
+product-internal.
+"""
+
+from products.logs.backend.temporal import ACTIVITIES, WORKFLOWS, LogsAlertCheckWorkflow
+from products.logs.backend.temporal.activities import CheckAlertsInput
+from products.logs.backend.temporal.constants import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME
+from products.logs.backend.temporal.metrics import (
+    LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS,
+    LOGS_ALERTING_COUNT_HISTOGRAM_METRICS,
+    LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS,
+    LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS,
+    LogsAlertingMetricsInterceptor,
+)
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "LogsAlertCheckWorkflow",
+    "CheckAlertsInput",
+    "SCHEDULE_CRON",
+    "SCHEDULE_ID",
+    "WORKFLOW_NAME",
+    "LOGS_ALERTING_COUNT_HISTOGRAM_BUCKETS",
+    "LOGS_ALERTING_COUNT_HISTOGRAM_METRICS",
+    "LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS",
+    "LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS",
+    "LogsAlertingMetricsInterceptor",
+]

--- a/products/logs/backend/test/test_facade.py
+++ b/products/logs/backend/test/test_facade.py
@@ -1,0 +1,87 @@
+import dataclasses
+
+import pytest
+from posthog.test.base import BaseTest
+
+from posthog.schema import DateRange, FilterLogicalOperator, LogsQuery, PropertyGroupFilter, PropertyGroupFilterValue
+
+from products.logs.backend import (
+    tasks as internal_tasks,
+    temporal as internal_temporal,
+)
+from products.logs.backend.facade import (
+    api as facade_api,
+    queries as facade_queries,
+    tasks as facade_tasks,
+    temporal as facade_temporal,
+)
+from products.logs.backend.facade.contracts import TeamLogsConfigData
+from products.logs.backend.logs_query_runner import LogsQueryRunner
+from products.logs.backend.models import DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY, TeamLogsConfig
+
+
+class TestTeamLogsConfigFacade(BaseTest):
+    def test_get_or_create_returns_default_contract(self):
+        data = facade_api.get_or_create_team_logs_config(self.team)
+
+        assert isinstance(data, TeamLogsConfigData)
+        assert data.team_id == self.team.id
+        assert data.logs_distinct_id_attribute_key == DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEY
+        assert TeamLogsConfig.objects.filter(team=self.team).exists()
+
+    def test_get_or_create_is_idempotent(self):
+        first = facade_api.get_or_create_team_logs_config(self.team)
+        second = facade_api.get_or_create_team_logs_config(self.team)
+
+        assert first == second
+        assert TeamLogsConfig.objects.filter(team=self.team).count() == 1
+
+    def test_update_persists_and_returns_contract(self):
+        data = facade_api.update_team_logs_config(self.team, logs_distinct_id_attribute_key="userId")
+
+        assert data == TeamLogsConfigData(team_id=self.team.id, logs_distinct_id_attribute_key="userId")
+        assert TeamLogsConfig.objects.get(team=self.team).logs_distinct_id_attribute_key == "userId"
+
+    def test_contract_is_frozen(self):
+        data = facade_api.get_or_create_team_logs_config(self.team)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            data.logs_distinct_id_attribute_key = "mutated"  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+
+
+class TestLogsQueryFacade(BaseTest):
+    def _query(self) -> LogsQuery:
+        return LogsQuery(
+            dateRange=DateRange(date_from="2024-01-10T00:00:00Z", date_to="2024-01-15T23:59:59Z"),
+            serviceNames=[],
+            severityLevels=[],
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+            ),
+        )
+
+    def test_runner_class_is_reexported_identically(self):
+        assert facade_queries.LogsQueryRunner is LogsQueryRunner
+
+    def test_build_matches_direct_construction(self):
+        built = facade_queries.build_logs_query_runner(self._query(), self.team)
+        direct = LogsQueryRunner(query=self._query(), team=self.team)
+
+        assert type(built) is LogsQueryRunner
+        assert built.to_query() == direct.to_query()
+
+
+class TestWiringSurfaces(BaseTest):
+    def test_temporal_surface_reexports_same_objects(self):
+        assert facade_temporal.WORKFLOWS is internal_temporal.WORKFLOWS
+        assert facade_temporal.ACTIVITIES is internal_temporal.ACTIVITIES
+        assert facade_temporal.LogsAlertCheckWorkflow is internal_temporal.LogsAlertCheckWorkflow
+
+    def test_celery_task_surface_and_registered_name(self):
+        assert facade_tasks.logs_alert_events_cleanup_task is internal_tasks.logs_alert_events_cleanup_task
+        # Core's beat schedule depends on this registration name staying stable.
+        assert (
+            facade_tasks.logs_alert_events_cleanup_task.name
+            == "products.logs.backend.tasks.logs_alert_events_cleanup_task"
+        )


### PR DESCRIPTION
## Problem

The logs product exposes internals across boundaries: core imports its models (team API), its query runner (CSV-export registry, HogQL tooling), its celery task (beat schedule), and its temporal workflow/activities/metrics (worker + schedule wiring). That coupling means any logs change triggers the full backend suite, and there is no stable surface other code can rely on.

This is the first of two isolation PRs for logs, following the isolating-product-facade-contracts skill (PR strategy per #63171: design PR first, mechanical sweep second).

## Changes

- `backend/facade/contracts.py` — `TeamLogsConfigData`, the only data shape that currently crosses the boundary (frozen pydantic dataclass)
- `backend/facade/api.py` — team logs config capabilities (get-or-create, update), thin, returns contracts
- `backend/facade/queries.py` — `build_logs_query_runner` plus a class re-export, because registry-style consumers dispatch on class identity (`isinstance`), which a data contract can't provide
- `backend/facade/tasks.py` / `backend/facade/temporal.py` — celery and temporal wiring surfaces, so core's worker/schedule registration can route through `backend/facade/**` and stay inside the future contract surface
- behavioral-parity tests for all four surfaces, including a guard on the celery task's registered name

No caller changes — new files only. The follow-up PR migrates the ~10 core call sites to these surfaces, flips the api modules into `presentation/`, and enables the isolation chain (tach interface, `backend:contract-check`, narrowed turbo inputs).

## How did you test this code?

`hogli test products/logs/backend/test/test_facade.py` — 8 passed. `ruff` clean. I'm an agent; no manual testing beyond that.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal architecture change, no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, executing the isolating-product-facade-contracts skill end-to-end on a real product to validate the reworked two-PR strategy. Decisions: split the facade into capability-specific surface modules instead of one api.py so importing the config surface doesn't drag HogQL/temporalio onto callers' import paths (django.setup() budget); re-exported the runner class because core's registry does isinstance dispatch; kept contracts to the single field actually consumed today rather than mirroring the model.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

