### PR TITLE
refactor(agent_platform): scope product-DB sslmode to direct alias only

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -191,13 +191,11 @@ configured_product_databases: set[str] = set()
 PRODUCT_DB_WRITER_URLS: dict[str, str] = {}
 
 
-# Optional, per-product SSL settings for product-DB connections. dj_database_url
-# only sets connect_timeout, so without these a direct (non-PgBouncer) product DB
-# connects with libpq's default sslmode=prefer. Aurora's pg_hba requires SSL
-# (hostssl), so a direct-mode product DB on a dedicated cluster needs these set.
-# Scoped per product (e.g. PRODUCT_DB_AGENT_PLATFORM_SSL_MODE) so enabling SSL for
-# one product DB never touches the PgBouncer-routed ones. Left unset for local
-# dev/test (plain Postgres, no SSL) so those are unaffected.
+# Per-product SSL for the migration DIRECT_URL only. Runtime writer/reader route
+# through PgBouncer (in-cluster, plaintext, no SSL); only the direct migration
+# connection reaches Aurora, whose pg_hba requires SSL (hostssl). dj_database_url
+# sets only connect_timeout, so set sslmode here. Scoped per product (e.g.
+# PRODUCT_DB_AGENT_PLATFORM_SSL_MODE); unset for local dev/test (plain Postgres).
 def _apply_product_db_ssl_options(db: str, options: dict) -> None:
     ssl_mode = os.getenv(f"PRODUCT_DB_{db.upper()}_SSL_MODE")
     ssl_root_cert = os.getenv(f"PRODUCT_DB_{db.upper()}_SSL_ROOT_CERT")
@@ -229,12 +227,10 @@ for route in product_routes:
     PRODUCT_DB_WRITER_URLS[db] = writer_url
     DATABASES[writer_alias] = dict(dj_database_url.parse(writer_url, conn_max_age=0))
     DATABASES[writer_alias].setdefault("OPTIONS", {})["connect_timeout"] = 3
-    _apply_product_db_ssl_options(db, DATABASES[writer_alias]["OPTIONS"])
 
     reader_url = os.getenv(reader_env, writer_url)
     DATABASES[reader_alias] = dict(dj_database_url.parse(reader_url, conn_max_age=0))
     DATABASES[reader_alias].setdefault("OPTIONS", {})["connect_timeout"] = 3
-    _apply_product_db_ssl_options(db, DATABASES[reader_alias]["OPTIONS"])
 
     if TEST:
         # Skip the global migration-graph walk during test DB setup. Without


### PR DESCRIPTION
## Problem

Product-DB connections currently apply `PRODUCT_DB_<DB>_SSL_MODE` to the writer, reader **and** direct aliases. That was fine while `agent_platform` connected directly to Aurora (which requires `hostssl`). But we're moving the agent-platform product DB behind an in-cluster PgBouncer (transaction pooling, plaintext client side) — and forcing `sslmode=require` on the bouncer-routed writer/reader would break those connections. Only the migration `DIRECT_URL` still reaches Aurora directly.

## Changes

`_apply_product_db_ssl_options` now runs on the **direct (migration) alias only**, not writer/reader. No other product DB sets the SSL env (the PgBouncer-routed ones never did), so this is a no-op for everything except `agent_platform`, whose runtime now goes through the bouncer while migrations keep SSL on the direct connection.

Pairs with the charts change that routes the `agent_platform` product DB through pgbouncer (PostHog/charts#12035) — the two must deploy together.

## How did you test this code?

I'm an agent (Claude Code). No automated tests were run beyond the pre-commit hooks (ruff + `ty check`, which passed). This is a settings-module change exercised only at process startup; the behavior is covered by the deploy itself. Reviewer should sanity-check that no other product DB relies on writer/reader SSL (none set `PRODUCT_DB_<DB>_SSL_MODE` today).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben directed this while moving the agent-platform DB behind PgBouncer to remove the direct-Aurora SSL workarounds.

Authored with Claude Code. Key decision: rather than add a second SSL knob, scope the existing per-product `sslmode` to the direct/migration alias, since every product DB's runtime path now routes through PgBouncer (so writer/reader never need client SSL) and the migration `DIRECT_URL` is the only remaining direct-to-Aurora connection. Targeted at `agent-platform-django-base` (the branch that builds the dev-two image) rather than master, since the function only exists on that branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

