### PR TITLE
fix(data-warehouse): use 'after' instead of 'gte' in plain incremental sync filter

### DIFF
--- a/posthog/temporal/data_imports/sources/plain/plain.py
+++ b/posthog/temporal/data_imports/sources/plain/plain.py
@@ -235,7 +235,8 @@ def _fetch_paginated_endpoint(
     variables: dict[str, Any] = {"first": PLAIN_DEFAULT_PAGE_SIZE}
 
     if updated_at_gte is not None:
-        variables["filter"] = {"updatedAt": {"gte": _datetime_to_plain_iso8601(updated_at_gte)}}
+        # Plain's DatetimeFilter only supports `after` (>=) and `before` (<).
+        variables["filter"] = {"updatedAt": {"after": _datetime_to_plain_iso8601(updated_at_gte)}}
 
     has_next_page = True
     while has_next_page:
@@ -267,7 +268,8 @@ def _fetch_timeline_entries(
     """
     variables: dict[str, Any] = {"first": PLAIN_DEFAULT_PAGE_SIZE}
     if created_at_gte is not None:
-        variables["filter"] = {"updatedAt": {"gte": _datetime_to_plain_iso8601(created_at_gte)}}
+        # Plain's DatetimeFilter only supports `after` (>=) and `before` (<).
+        variables["filter"] = {"updatedAt": {"after": _datetime_to_plain_iso8601(created_at_gte)}}
 
     has_next_page = True
     while has_next_page:

--- a/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
+++ b/posthog/temporal/data_imports/sources/plain/tests/test_plain.py
@@ -4,10 +4,12 @@ import pytest
 from unittest import mock
 
 import requests
+from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.plain.plain import (
     PlainRetryableError,
     _datetime_to_plain_iso8601,
+    _fetch_paginated_endpoint,
     _fetch_thread_timeline_entries,
     _fetch_timeline_entries,
     _flatten_datetime,
@@ -17,6 +19,7 @@ from posthog.temporal.data_imports.sources.plain.plain import (
     plain_source,
     validate_credentials,
 )
+from posthog.temporal.data_imports.sources.plain.queries import QUERIES
 
 
 class TestFlattenDatetime:
@@ -340,6 +343,54 @@ class TestTimelineEntryIncrementalFilter:
         assert [e["id"] for e in pages[0]] == ["te_null"]
 
 
+class TestFetchPaginatedEndpointIncrementalFilter:
+    """Plain's DatetimeFilter only accepts `after`/`before` — `gte` is rejected with a 400."""
+
+    @parameterized.expand(["customers", "threads"])
+    def test_sends_after_filter_when_incremental(self, endpoint_name):
+        recorded = []
+
+        def execute(query, variables):
+            recorded.append((query, dict(variables)))
+            return {"data": {endpoint_name: {"edges": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+
+        list(
+            _fetch_paginated_endpoint(
+                execute,
+                endpoint_name=endpoint_name,
+                query=QUERIES[endpoint_name],
+                logger=mock.MagicMock(),
+                updated_at_gte=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            )
+        )
+
+        assert recorded, "expected a query to be issued"
+        _, variables = recorded[0]
+        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00Z"}}
+
+    @parameterized.expand(["customers", "threads"])
+    def test_omits_filter_when_not_incremental(self, endpoint_name):
+        recorded = []
+
+        def execute(query, variables):
+            recorded.append((query, dict(variables)))
+            return {"data": {endpoint_name: {"edges": [], "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+
+        list(
+            _fetch_paginated_endpoint(
+                execute,
+                endpoint_name=endpoint_name,
+                query=QUERIES[endpoint_name],
+                logger=mock.MagicMock(),
+                updated_at_gte=None,
+            )
+        )
+
+        assert recorded, "expected a query to be issued"
+        _, variables = recorded[0]
+        assert "filter" not in variables
+
+
 class TestFetchTimelineEntriesStreaming:
     def test_sends_updatedat_filter_when_incremental(self):
         recorded = []
@@ -360,7 +411,7 @@ class TestFetchTimelineEntriesStreaming:
 
         assert recorded, "expected threads query to be issued"
         _, variables = recorded[0]
-        assert variables["filter"] == {"updatedAt": {"gte": "2024-01-15T10:30:00Z"}}
+        assert variables["filter"] == {"updatedAt": {"after": "2024-01-15T10:30:00Z"}}
 
     def test_streams_thread_pages_without_buffering_all_ids(self):
         executed_queries: list[str] = []


### PR DESCRIPTION
## Problem

Incremental syncs for the Plain data warehouse source fail on every run. The source sends a `DatetimeFilter` of the shape `{"updatedAt": {"gte": "..."}}`, but Plain's GraphQL `DatetimeFilter` input type only defines `after` (greater-or-equal) and `before` (less-than) fields, so the API rejects the query with:

```
400 Client Error: Bad Request (Plain API: Variable "$filter" got invalid value { gte: "..." } at "filter.updatedAt"; Field "gte" is not defined by type "DatetimeFilter".)
```

Initial full-refresh syncs work because no filter is sent, but every subsequent incremental sync fails — so the source breaks for everyone as soon as the first sync completes.

## Changes

- Replace `gte` with `after` in the incremental filter for both the paginated endpoints (`customers`, `threads`) and the timeline entries thread scan. Plain documents `after` as "timestamps greater or equal than this value", so the inclusive semantics are unchanged.
- Add parameterized tests asserting the filter shape sent for `customers` and `threads` incremental syncs, and that no filter is sent for full refreshes. Updated the existing timeline entries filter assertion.

## How did you test this code?

Automated tests only: `pytest posthog/temporal/data_imports/sources/plain/tests/` (41 passed). Verified the correct field names (`after`/`before` on `DatetimeFilter`, and that `CustomersFilter.updatedAt`/`ThreadsFilter.updatedAt` accept it) against Plain's published GraphQL schema in their TypeScript SDK.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update
