### PR TITLE
fix(insights): label sidebar SQL entry as "New SQL"

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1459,6 +1459,7 @@ export const getTreeItemsNew = (): FileSystemImport[] => [
         path: `Insight/SQL`,
         type: 'insight',
         href: urls.sqlEditor({ query: (examples.HogQLForDataVisualization as HogQLQuery).query }),
+        displayLabel: 'New SQL',
         iconType: 'insight/hog',
         iconColor: ['var(--color-insight-sql-light)'] as FileSystemIconColor,
         visualOrder: INSIGHT_VISUAL_ORDER.sql,

--- a/products/product_analytics/manifest.tsx
+++ b/products/product_analytics/manifest.tsx
@@ -165,6 +165,9 @@ export const manifest: ProductManifest = {
             path: `Insight/SQL`,
             type: 'insight',
             href: urls.sqlEditor({ query: (examples.HogQLForDataVisualization as HogQLQuery).query }),
+            // The sibling insight items get a "New " prefix automatically because their hrefs include "new";
+            // the SQL editor href doesn't, so set the label explicitly to stay consistent.
+            displayLabel: 'New SQL',
             iconType: 'insight/hog',
             iconColor: ['var(--color-insight-sql-light)'] as FileSystemIconColor,
             visualOrder: INSIGHT_VISUAL_ORDER.sql,


### PR DESCRIPTION
## Problem

In the **Product analytics** sidebar "+" → "Create new insight type" menu, the SQL option rendered as a bare **"SQL"**, while every sibling read **"New trends"**, **"New funnel"**, etc. This was a small follow-up inconsistency left over from #63021 (which added SQL to that menu).

The siblings get the "New " prefix automatically because the nav derives the label from the item's path and prepends "New " when the item's `href` contains "new" (their `urls.insightNew(...)` hrefs do). The SQL item points at the `sqlEditor` URL, which has no "new" in it, so it fell through to the bare leaf name.

## Changes

Set an explicit `displayLabel: 'New SQL'` on the SQL tree item in the Product analytics manifest so it reads **"New SQL"**, consistent with the other options. Regenerated `frontend/src/products.tsx` from the manifest via the project's own `build:products` codegen so the committed artifact stays byte-identical (CI's `git diff --exit-code` check).

`displayLabel` was chosen over renaming the `path` deliberately: the global search palette derives its own "New {name} insight" label from the path, so a path rename would have produced "New New SQL insight" there. `displayLabel` only affects the nav, leaving search correct.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** run manual testing or the frontend typecheck/build (no frontend deps in this environment). I verified that:
- the regenerated `products.tsx` matches the manifest via the real `build:products` generator + oxfmt 0.35.0 (the repo's pinned version), and
- the net diff against master is exactly the `displayLabel` addition in the two files.

Worth a quick visual check of the sidebar "+" menu once CI is green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @vdekrijger from a Slack thread.

Follow-up to #63021. The human spotted that the new SQL entry read "SQL" rather than "New SQL" like its siblings. Initial investigation mistakenly concluded the siblings were also bare names; tracing the nav's label derivation (`convertFileSystemEntryToTreeDataItem` in `ProjectTree/utils.tsx`) revealed the automatic "New " prefix keyed on `href.includes('new')`, which confirmed the human's observation and pointed to `displayLabel` as the clean fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781192066127239?thread_ts=1781192066.127239&cid=C0ACRAMJUAG)*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

