### PR TITLE
feat(replay-vision): add scanning from scanner overview page

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScanSessionButton.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScanSessionButton.tsx
@@ -1,0 +1,74 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconPlay } from '@posthog/icons'
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown/LemonDropdown'
+
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { replayScannerLogic } from '../replayScannerLogic'
+
+export function ScanSessionButton({ scannerId }: { scannerId: string }): JSX.Element {
+    const { triggeringOnDemandObservation } = useValues(replayScannerLogic({ id: scannerId }))
+    const { triggerOnDemandObservation } = useActions(replayScannerLogic({ id: scannerId }))
+    const [open, setOpen] = useState(false)
+    const [sessionId, setSessionId] = useState('')
+
+    const trimmed = sessionId.trim()
+    const submit = (): void => {
+        if (!trimmed || triggeringOnDemandObservation) {
+            return
+        }
+        triggerOnDemandObservation(trimmed)
+        setSessionId('')
+        setOpen(false)
+    }
+
+    return (
+        <LemonDropdown
+            visible={open}
+            onVisibilityChange={setOpen}
+            closeOnClickInside={false}
+            placement="bottom-end"
+            overlay={
+                <div className="w-80 p-2 space-y-2">
+                    <div className="text-xs text-muted">Scan a session recording with this scanner.</div>
+                    <div className="flex items-center gap-2">
+                        <LemonInput
+                            value={sessionId}
+                            onChange={setSessionId}
+                            onPressEnter={submit}
+                            placeholder="Session recording ID"
+                            size="small"
+                            fullWidth
+                            autoFocus
+                            data-attr="vision-scanner-scan-session-input"
+                        />
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.SessionRecording}
+                            minAccessLevel={AccessControlLevel.Editor}
+                        >
+                            <LemonButton
+                                size="small"
+                                type="primary"
+                                onClick={submit}
+                                loading={triggeringOnDemandObservation}
+                                disabledReason={!trimmed ? 'Paste a session ID first' : undefined}
+                                data-attr="vision-scanner-scan-session-submit"
+                            >
+                                Scan
+                            </LemonButton>
+                        </AccessControlAction>
+                    </div>
+                </div>
+            }
+        >
+            <LemonButton size="small" type="secondary" icon={<IconPlay />} data-attr="vision-scanner-scan-session-open">
+                Scan session
+            </LemonButton>
+        </LemonDropdown>
+    )
+}

--- a/products/replay_vision/frontend/replay_scanners/components/ScanSessionButton.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScanSessionButton.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { IconPlay } from '@posthog/icons'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
@@ -12,10 +12,21 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 import { replayScannerLogic } from '../replayScannerLogic'
 
 export function ScanSessionButton({ scannerId }: { scannerId: string }): JSX.Element {
-    const { triggeringOnDemandObservation } = useValues(replayScannerLogic({ id: scannerId }))
+    const { triggeringOnDemandObservation, onDemandObservationSuccessCount } = useValues(
+        replayScannerLogic({ id: scannerId })
+    )
     const { triggerOnDemandObservation } = useActions(replayScannerLogic({ id: scannerId }))
     const [open, setOpen] = useState(false)
     const [sessionId, setSessionId] = useState('')
+    const lastSeenSuccessCount = useRef(onDemandObservationSuccessCount)
+
+    useEffect(() => {
+        if (onDemandObservationSuccessCount > lastSeenSuccessCount.current) {
+            lastSeenSuccessCount.current = onDemandObservationSuccessCount
+            setSessionId('')
+            setOpen(false)
+        }
+    }, [onDemandObservationSuccessCount])
 
     const trimmed = sessionId.trim()
     const submit = (): void => {
@@ -23,8 +34,6 @@ export function ScanSessionButton({ scannerId }: { scannerId: string }): JSX.Ele
             return
         }
         triggerOnDemandObservation(trimmed)
-        setSessionId('')
-        setOpen(false)
     }
 
     return (

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -282,8 +282,6 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
             <LemonTable
                 columns={columns}
                 dataSource={observations}
-                // `observationsLoading` flashes every poll while in-flight observations are pending; only show
-                // the loading bar for the initial empty load and for explicit user-initiated triggers.
                 loading={(observationsLoading && observations.length === 0) || triggeringOnDemandObservation}
                 rowKey="id"
                 pagination={{

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -17,6 +17,7 @@ import {
     ObservationVerdictValue,
     replayScannerLogic,
 } from '../replayScannerLogic'
+import { ScanSessionButton } from './ScanSessionButton'
 
 const STATUS_OPTIONS: { value: ObservationStatusValue; label: string }[] = [
     { value: 'succeeded', label: 'Succeeded' },
@@ -92,6 +93,7 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
         availableTags,
         observationStats,
         scanner,
+        triggeringOnDemandObservation,
     } = useValues(logic)
     const {
         loadObservations,
@@ -197,6 +199,7 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
                 </p>
                 <div className="ml-auto flex items-center gap-3">
                     <div className="flex items-center gap-2">
+                        <ScanSessionButton scannerId={scannerId} />
                         {(observationStats.total > 0 || hasActiveObservationFilters) && (
                             <>
                                 <FilterPill<ObservationStatusValue>
@@ -279,7 +282,9 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
             <LemonTable
                 columns={columns}
                 dataSource={observations}
-                loading={observationsLoading}
+                // `observationsLoading` flashes every poll while in-flight observations are pending; only show
+                // the loading bar for the initial empty load and for explicit user-initiated triggers.
+                loading={(observationsLoading && observations.length === 0) || triggeringOnDemandObservation}
                 rowKey="id"
                 pagination={{
                     controlled: true,

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerObservationsTable.tsx
@@ -94,9 +94,10 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
         observationStats,
         scanner,
         triggeringOnDemandObservation,
+        refreshing,
     } = useValues(logic)
     const {
-        loadObservations,
+        refreshObservations,
         setObservationsPage,
         setObservationsSort,
         setObservationStatusFilter,
@@ -248,8 +249,8 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
                                 size="small"
                                 type="secondary"
                                 icon={<IconRefresh />}
-                                onClick={() => loadObservations()}
-                                loading={observationsLoading}
+                                onClick={() => refreshObservations()}
+                                loading={refreshing}
                                 data-attr="vision-observations-refresh"
                             >
                                 Refresh
@@ -282,7 +283,9 @@ export function ScannerObservationsTable({ scannerId }: { scannerId: string }): 
             <LemonTable
                 columns={columns}
                 dataSource={observations}
-                loading={(observationsLoading && observations.length === 0) || triggeringOnDemandObservation}
+                loading={
+                    refreshing || triggeringOnDemandObservation || (observationsLoading && observations.length === 0)
+                }
                 rowKey="id"
                 pagination={{
                     controlled: true,

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -18,12 +18,17 @@ import { ClassifierScanner, ReplayScanner, ScorerScanner } from './types'
 
 describe('replayScannerLogic', () => {
     let logic: ReturnType<typeof replayScannerLogic.build>
+    let observeSpy: jest.Mock
 
     beforeEach(() => {
+        observeSpy = jest.fn(() => [202, { workflow_id: 'wf-test' }])
         useMocks({
             get: {
                 '/api/projects/:team/vision/scanners/:id/': () => [404, {}],
                 '/api/projects/:team/vision/scanners/:id/observations/': { results: [] },
+            },
+            post: {
+                '/api/projects/:team/vision/scanners/:id/observe/': observeSpy,
             },
         })
         initKeaTests()
@@ -442,6 +447,7 @@ describe('replayScannerLogic', () => {
                     persisted.actions.triggerOnDemandObservation(input)
                 ).toDispatchActions(['triggerOnDemandObservationFailure'])
                 expect(persisted.values.triggeringOnDemandObservation).toBe(false)
+                expect(observeSpy).not.toHaveBeenCalled()
             } finally {
                 persisted.unmount()
             }
@@ -452,6 +458,7 @@ describe('replayScannerLogic', () => {
                 ['triggerOnDemandObservationFailure']
             )
             expect(logic.values.triggeringOnDemandObservation).toBe(false)
+            expect(observeSpy).not.toHaveBeenCalled()
         })
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -429,4 +429,29 @@ describe('replayScannerLogic', () => {
             })
         })
     })
+
+    describe('triggerOnDemandObservation', () => {
+        it.each([
+            { name: 'empty string', input: '' },
+            { name: 'whitespace only', input: '   ' },
+        ])('bails on $name session ID without calling the API', async ({ input }) => {
+            const persisted = replayScannerLogic({ id: 'abc-123' })
+            persisted.mount()
+            try {
+                await expectLogic(persisted, () =>
+                    persisted.actions.triggerOnDemandObservation(input)
+                ).toDispatchActions(['triggerOnDemandObservationFailure'])
+                expect(persisted.values.triggeringOnDemandObservation).toBe(false)
+            } finally {
+                persisted.unmount()
+            }
+        })
+
+        it('bails when scanner ID is new (unsaved scanner)', async () => {
+            await expectLogic(logic, () => logic.actions.triggerOnDemandObservation('019a3f47-8c2d')).toDispatchActions(
+                ['triggerOnDemandObservationFailure']
+            )
+            expect(logic.values.triggeringOnDemandObservation).toBe(false)
+        })
+    })
 })

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -43,6 +43,8 @@ export type ObservationVerdictValue = 'yes' | 'no' | 'inconclusive'
 
 export const OBSERVATIONS_PAGE_SIZE = 50
 
+const OBSERVE_POLL_GRACE_MS = 30_000
+
 function currentTemplateKey(): string | null {
     const value = router.values.searchParams.template
     return typeof value === 'string' ? value : null
@@ -234,6 +236,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         triggerOnDemandObservation: (sessionId: string) => ({ sessionId }),
         triggerOnDemandObservationSuccess: true,
         triggerOnDemandObservationFailure: true,
+        refreshObservations: true,
     }),
 
     forms(({ props, values, actions }) => ({
@@ -328,6 +331,26 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 triggerOnDemandObservation: () => true,
                 triggerOnDemandObservationSuccess: () => false,
                 triggerOnDemandObservationFailure: () => false,
+            },
+        ],
+        onDemandObservationSuccessCount: [
+            0,
+            {
+                triggerOnDemandObservationSuccess: (state: number) => state + 1,
+            },
+        ],
+        pollUntil: [
+            0,
+            {
+                triggerOnDemandObservationSuccess: () => Date.now() + OBSERVE_POLL_GRACE_MS,
+            },
+        ],
+        refreshing: [
+            false,
+            {
+                refreshObservations: () => true,
+                loadObservationsSuccess: () => false,
+                loadObservationsFailure: () => false,
             },
         ],
         scannerLoading: [
@@ -752,13 +775,14 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     await visionScannersObserveCreate(String(teamId), props.id, { session_id: trimmed })
                     lemonToast.success('Scanning session — new observation will appear below shortly.')
                     actions.triggerOnDemandObservationSuccess()
-                    actions.loadObservations()
-                    actions.loadObservationStats()
+                    actions.refreshObservations()
                 } catch (error: any) {
                     lemonToast.error(`Failed to scan session${error.detail ? `: ${error.detail}` : ''}`)
                     actions.triggerOnDemandObservationFailure()
                 }
             },
+
+            refreshObservations: () => reloadObservationsAndStats(),
 
             loadObservations: async () => {
                 if (props.id === 'new') {
@@ -817,11 +841,19 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
             },
 
             loadObservationStatsSuccess: () => {
-                scheduleObservationPoll(cache.disposables, values.hasObservationsInFlight, reloadObservationsAndStats)
+                scheduleObservationPoll(
+                    cache.disposables,
+                    values.hasObservationsInFlight || Date.now() < values.pollUntil,
+                    reloadObservationsAndStats
+                )
             },
             // Reschedule on failure too — a transient API hiccup shouldn't permanently kill the polling cycle.
             loadObservationStatsFailure: () => {
-                scheduleObservationPoll(cache.disposables, values.hasObservationsInFlight, reloadObservationsAndStats)
+                scheduleObservationPoll(
+                    cache.disposables,
+                    values.hasObservationsInFlight || Date.now() < values.pollUntil,
+                    reloadObservationsAndStats
+                )
             },
         }
     }),

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -752,7 +752,6 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     await visionScannersObserveCreate(String(teamId), props.id, { session_id: trimmed })
                     lemonToast.success('Scanning session — new observation will appear below shortly.')
                     actions.triggerOnDemandObservationSuccess()
-                    // Surface the pending observation immediately rather than waiting for the next poll.
                     actions.loadObservations()
                     actions.loadObservationStats()
                 } catch (error: any) {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -15,6 +15,7 @@ import {
     visionScannersEstimateCreate,
     visionScannersObservationsList,
     visionScannersObservationsStatsRetrieve,
+    visionScannersObserveCreate,
     visionScannersPartialUpdate,
     visionScannersRetrieve,
 } from '../generated/api'
@@ -230,6 +231,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         loadScannerEstimate: true,
         loadScannerEstimateSuccess: (estimate: EstimateResponseApi) => ({ estimate }),
         loadScannerEstimateFailure: (error: string | null = null) => ({ error }),
+        triggerOnDemandObservation: (sessionId: string) => ({ sessionId }),
+        triggerOnDemandObservationSuccess: true,
+        triggerOnDemandObservationFailure: true,
     }),
 
     forms(({ props, values, actions }) => ({
@@ -316,6 +320,14 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 toggleEnabled: () => true,
                 toggleEnabledSuccess: () => false,
                 toggleEnabledFailure: () => false,
+            },
+        ],
+        triggeringOnDemandObservation: [
+            false,
+            {
+                triggerOnDemandObservation: () => true,
+                triggerOnDemandObservationSuccess: () => false,
+                triggerOnDemandObservationFailure: () => false,
             },
         ],
         scannerLoading: [
@@ -718,6 +730,34 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     const verb = next ? 'enable' : 'disable'
                     lemonToast.error(`Failed to ${verb} scanner${error.detail ? `: ${error.detail}` : ''}`)
                     actions.toggleEnabledFailure()
+                }
+            },
+
+            triggerOnDemandObservation: async ({ sessionId }) => {
+                if (props.id === 'new') {
+                    actions.triggerOnDemandObservationFailure()
+                    return
+                }
+                const teamId = teamLogic.values.currentTeamId
+                if (!teamId) {
+                    actions.triggerOnDemandObservationFailure()
+                    return
+                }
+                const trimmed = sessionId.trim()
+                if (!trimmed) {
+                    actions.triggerOnDemandObservationFailure()
+                    return
+                }
+                try {
+                    await visionScannersObserveCreate(String(teamId), props.id, { session_id: trimmed })
+                    lemonToast.success('Scanning session — new observation will appear below shortly.')
+                    actions.triggerOnDemandObservationSuccess()
+                    // Surface the pending observation immediately rather than waiting for the next poll.
+                    actions.loadObservations()
+                    actions.loadObservationStats()
+                } catch (error: any) {
+                    lemonToast.error(`Failed to scan session${error.detail ? `: ${error.detail}` : ''}`)
+                    actions.triggerOnDemandObservationFailure()
                 }
             },
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Based on customer feedback, seemed like a nice idea.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="2134" height="218" alt="Screenshot 2026-06-12 at 10 33 44" src="https://github.com/user-attachments/assets/34841027-dd8e-4147-9de3-0f4e7ec7f214" />

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

