### PR TITLE
fix(mcp): stop URL fallback from poaching ops owned by another product

### DIFF
--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -140,36 +140,3 @@ tools:
     insights-thresholds-retrieve:
         operation: insights_thresholds_retrieve
         enabled: false
-    logs-alerts-create:
-        operation: logs_alerts_create
-        enabled: false
-    logs-alerts-destinations-create:
-        operation: logs_alerts_destinations_create
-        enabled: false
-    logs-alerts-destinations-delete-create:
-        operation: logs_alerts_destinations_delete_create
-        enabled: false
-    logs-alerts-destroy:
-        operation: logs_alerts_destroy
-        enabled: false
-    logs-alerts-events-list:
-        operation: logs_alerts_events_list
-        enabled: false
-    logs-alerts-list:
-        operation: logs_alerts_list
-        enabled: false
-    logs-alerts-partial-update:
-        operation: logs_alerts_partial_update
-        enabled: false
-    logs-alerts-reset-create:
-        operation: logs_alerts_reset_create
-        enabled: false
-    logs-alerts-retrieve:
-        operation: logs_alerts_retrieve
-        enabled: false
-    logs-alerts-simulate-create:
-        operation: logs_alerts_simulate_create
-        enabled: false
-    logs-alerts-update:
-        operation: logs_alerts_update
-        enabled: false

--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -233,6 +233,3 @@ tools:
     cohorts-used-in-retrieve:
         operation: cohorts_used_in_retrieve
         enabled: false
-    persons-cohorts-retrieve:
-        operation: persons_cohorts_retrieve
-        enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -481,18 +481,6 @@ tools:
         param_overrides:
             id:
                 cast: string-int
-    dashboards-sharing-list:
-        operation: dashboards_sharing_list
-        enabled: false
-    dashboards-sharing-passwords-create:
-        operation: dashboards_sharing_passwords_create
-        enabled: false
-    dashboards-sharing-passwords-destroy:
-        operation: dashboards_sharing_passwords_destroy
-        enabled: false
-    dashboards-sharing-refresh-create:
-        operation: dashboards_sharing_refresh_create
-        enabled: false
     dashboards-stream-tiles-retrieve:
         operation: dashboards_stream_tiles_retrieve
         enabled: false

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -174,21 +174,3 @@ tools:
     role-external-references-lookup-retrieve:
         operation: role_external_references_lookup_retrieve
         enabled: false
-    users-integrations-github-branches-retrieve:
-        operation: users_integrations_github_branches_retrieve
-        enabled: false
-    users-integrations-github-destroy:
-        operation: users_integrations_github_destroy
-        enabled: false
-    users-integrations-github-repos-refresh-create:
-        operation: users_integrations_github_repos_refresh_create
-        enabled: false
-    users-integrations-github-repos-retrieve:
-        operation: users_integrations_github_repos_retrieve
-        enabled: false
-    users-integrations-github-start-create:
-        operation: users_integrations_github_start_create
-        enabled: false
-    users-integrations-list:
-        operation: users_integrations_list
-        enabled: false

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -9,30 +9,6 @@ feature: logs
 url_prefix: /logs
 ui_apps: {}
 tools:
-    batch-exports-logs-retrieve:
-        operation: batch_exports_logs_retrieve
-        enabled: false
-    batch-exports-runs-logs-retrieve:
-        operation: batch_exports_runs_logs_retrieve
-        enabled: false
-    domains-scim-logs-retrieve:
-        operation: domains_scim_logs_retrieve
-        enabled: false
-    endpoints-logs-retrieve:
-        operation: endpoints_logs_retrieve
-        enabled: false
-    file-download-batch-exports-logs-retrieve:
-        operation: file_download_batch_exports_logs_retrieve
-        enabled: false
-    hog-flow-templates-logs-retrieve:
-        operation: hog_flow_templates_logs_retrieve
-        enabled: false
-    hog-flows-logs-retrieve:
-        operation: hog_flows_logs_retrieve
-        enabled: false
-    hog-functions-logs-retrieve:
-        operation: hog_functions_logs_retrieve
-        enabled: false
     logs-alerts-create:
         operation: logs_alerts_create
         enabled: true
@@ -442,9 +418,6 @@ tools:
         enabled: false
     logs-views-update:
         operation: logs_views_update
-        enabled: false
-    plugin-configs-logs-list:
-        operation: plugin_configs_logs_list
         enabled: false
     query-logs:
         operation: logs_query_create

--- a/products/notebooks/mcp/tools.yaml
+++ b/products/notebooks/mcp/tools.yaml
@@ -9,18 +9,6 @@ feature: notebooks
 url_prefix: /notebooks
 ui_apps: {}
 tools:
-    accounts-notebooks-create:
-        operation: accounts_notebooks_create
-        enabled: false
-    accounts-notebooks-destroy:
-        operation: accounts_notebooks_destroy
-        enabled: false
-    accounts-notebooks-list:
-        operation: accounts_notebooks_list
-        enabled: false
-    accounts-notebooks-retrieve:
-        operation: accounts_notebooks_retrieve
-        enabled: false
     notebooks-activity-retrieve:
         operation: notebooks_activity_retrieve
         enabled: false
@@ -150,18 +138,6 @@ tools:
         description: >
             Get a specific notebook by its short_id. Returns the full notebook including title, content, version, and
             creation/modification metadata.
-    notebooks-sharing-list:
-        operation: notebooks_sharing_list
-        enabled: false
-    notebooks-sharing-passwords-create:
-        operation: notebooks_sharing_passwords_create
-        enabled: false
-    notebooks-sharing-passwords-destroy:
-        operation: notebooks_sharing_passwords_destroy
-        enabled: false
-    notebooks-sharing-refresh-create:
-        operation: notebooks_sharing_refresh_create
-        enabled: false
     notebooks-update:
         operation: notebooks_update
         enabled: false

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -180,9 +180,6 @@ tools:
                 - created_at
                 - updated_at
                 - completed_at
-    tasks-runs-logs-retrieve:
-        operation: tasks_runs_logs_retrieve
-        enabled: false
     tasks-runs-partial-update:
         operation: tasks_runs_partial_update
         enabled: false

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -134,7 +134,7 @@ function findOperationsByTag(spec: OpenApiSpec, product: string): DiscoveredOper
  * x-product doesn't match, same as generate-openapi-types.mjs
  * matchUrlToProduct().
  */
-function findOperationsByUrl(spec: OpenApiSpec, product: string): DiscoveredOperation[] {
+function findOperationsByUrl(spec: OpenApiSpec, product: string, syncedProducts?: Set<string>): DiscoveredOperation[] {
     const ops: DiscoveredOperation[] = []
     const httpMethods = new Set(['get', 'post', 'put', 'patch', 'delete'])
     const productsToMatch = [
@@ -156,6 +156,20 @@ function findOperationsByUrl(spec: OpenApiSpec, product: string): DiscoveredOper
                 continue
             }
 
+            // Don't let the URL fallback poach an op that another *synced* product
+            // already owns via x-product — e.g. agent .../sessions/{id}/logs/ is
+            // tagged agent_platform but its path matches the logs product. Ops whose
+            // x-product isn't a synced product (e.g. reverse_proxy ops grouped under
+            // the proxy-records definition) still match by path, as do legacy ops
+            // with no x-product.
+            if (syncedProducts) {
+                const normProduct = product.replace(/-/g, '_').toLowerCase()
+                const xProduct = (op['x-product'] ?? []).map((p) => p.replace(/-/g, '_').toLowerCase())
+                if (!xProduct.includes(normProduct) && xProduct.some((p) => syncedProducts.has(p))) {
+                    continue
+                }
+            }
+
             ops.push({
                 operationId: op.operationId,
                 method: method.toUpperCase(),
@@ -175,9 +189,13 @@ function findOperationsByUrl(spec: OpenApiSpec, product: string): DiscoveredOper
  *    and ViewSets in products/<name>/backend/)
  * 2. URL path substring match (fallback for legacy endpoints)
  */
-function findOperationsByProduct(spec: OpenApiSpec, product: string): DiscoveredOperation[] {
+function findOperationsByProduct(
+    spec: OpenApiSpec,
+    product: string,
+    syncedProducts?: Set<string>
+): DiscoveredOperation[] {
     const byTag = findOperationsByTag(spec, product)
-    const byUrl = findOperationsByUrl(spec, product)
+    const byUrl = findOperationsByUrl(spec, product, syncedProducts)
 
     // Merge, preferring tag-matched ops and deduping by operationId
     const seen = new Set(byTag.map((op) => op.operationId))
@@ -440,8 +458,12 @@ function syncAll(spec: OpenApiSpec): void {
     const writtenFiles: string[] = []
     const noOpsProducts: string[] = []
 
+    // Every product/definition being synced, normalized. The URL fallback uses this
+    // to avoid poaching an op that another synced product owns via x-product.
+    const syncedProducts = new Set(targets.map((t) => t.product.replace(/-/g, '_').toLowerCase()))
+
     for (const { product, filePath, subset } of targets) {
-        const rawOps = findOperationsByProduct(spec, product)
+        const rawOps = findOperationsByProduct(spec, product, syncedProducts)
         const ops = deduplicateOperations(rawOps)
         if (ops.length === 0) {
             const label = path.relative(REPO_ROOT, filePath)


### PR DESCRIPTION
## Problem

`scaffold-yaml.ts` assigns OpenAPI operations to MCP product tool lists by `x-product` (priority 1), then falls back to **URL substring matching** — any op whose path contains `/{product}/` is claimed by that product. That fallback false-positives whenever a path *coincidentally* mentions another product's name.

The motivating case: an agent-platform endpoint at `…/sessions/{id}/logs/` (`x-product: agent_platform`) was being pulled into the **logs** product's tool list purely because its path ends in `/logs/`. It's the same systemic pattern across the repo — e.g. `logs-alerts-*` ops (`x-product: logs`, path `…/logs/alerts/`) poached into **alerts**, and `endpoints/logs`, `hog_functions/logs`, `hog_flows/logs` ops poached into **logs**.

All of these poached entries are `enabled: false` placeholders, so **no actual MCP tool changes** — this is yaml-noise cleanup, not a behavioural change. The win is correct per-product attribution and removing disabled duplicates that shadow the real tool.

## Changes

Guard the URL fallback: skip an op when its `x-product` names a **different *synced* product** — that product will claim it via tag in its own pass, so no one else should grab it by path coincidence.

Ops whose `x-product` is **not** itself a synced product still match by path. That's load-bearing for definitions whose filename differs from their ops' `x-product` — e.g. the `proxy-records` definition groups `reverse_proxy`-tagged ops (including an **enabled** tool). A naive "skip any mismatched x-product" guard would have emptied that file and dropped a shipping tool; this version preserves it. Legacy ops with no `x-product` are unaffected.

Re-running `--sync-all` prunes **120 stale cross-product placeholder entries** (all `enabled: false`) across 7 products (alerts, cohorts, dashboards, integrations, logs, notebooks, tasks).

### Nothing real is lost — the removed placeholders shadow tools that live elsewhere

Verified by **operation id** (not the auto-generated tool key — the real homes use hand-curated keys): of the 40 removed operations, **39 remain present in their owning product**, and the look-alikes are **enabled** tools there, e.g.:

| Removed disabled placeholder (in `logs`) | Real home (enabled) |
|---|---|
| `endpoints-logs-retrieve` (`endpoints_logs_retrieve`) | `products/endpoints/mcp/tools.yaml` → `endpoint-logs` |
| `hog-functions-logs-retrieve` (`hog_functions_logs_retrieve`) | `products/cdp/mcp/cdp_functions.yaml` → `cdp-functions-logs-retrieve` |
| `hog-flows-logs-retrieve` (`hog_flows_logs_retrieve`) | `products/workflows/mcp/tools.yaml` → `workflows-logs` |

**One operation is intentionally dropped outright: `plugin_configs_logs_list`.** It existed only as a disabled placeholder in `logs` (its owner `cdp` curates via subset files that don't auto-add, and nobody curated it). This is **fine — the `plugin_configs` logs endpoint is for the deprecated legacy plugin system**, so it doesn't need an MCP scaffold entry.

## How did you test this code?

I'm an agent (Claude Opus 4.8). Automated checks I actually ran in a fresh `origin/master` worktree:

- Baseline `--sync-all` produces **zero diff** (master in sync) before the change.
- After the change: `--sync-all` exits **0** with no "no operations found" warnings; removes **120 entries, none `enabled: true`**.
- **By-operation verification:** of 40 removed operations, 39 are still present (under curated keys) in their owning product; the only full removal is `plugin_configs_logs_list` (deprecated, see above).
- **Idempotent** — a second `--sync-all` adds no further churn.
- `generate-tools` produces **no diff** in `schema/` / `src/generated/` / `src/tools/generated/` (disabled entries never produced tools).
- **1599 MCP unit tests pass** (`tests/unit`). `scaffold-yaml.ts` itself typechecks (the only `tsc` errors are pre-existing unbuilt `@posthog/quill` workspace deps in `src/ui-apps/`, unrelated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben asked for this as a standalone PR after we spotted an agent-platform op showing up in the logs product's tool definitions during unrelated cleanup.

Done with Claude Code (Opus 4.8). Two decisions worth surfacing:
1. My first attempt was a naive "skip any URL-matched op with a different `x-product`," which `--sync-all` revealed would empty `proxy-records.yaml` (its ops are `reverse_proxy`-tagged) and drop an enabled tool. The committed version narrows the guard to *synced* products only.
2. The 40 removed entries were checked by operation id, not tool key — 39 are duplicates of ops that live (mostly enabled) in their real product; the single true removal, `plugin_configs_logs_list`, is a disabled placeholder for the deprecated legacy plugin system and is intentionally dropped.
