### PR TITLE
feat(error-tracking): polish source maps wizard banner, modal and CTA

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
@@ -1,8 +1,8 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconMagicWand } from '@posthog/icons'
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { IconMagicWand, IconX } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
@@ -10,6 +10,7 @@ import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
 import { isSourceMapsRecommendation, recommendationsTabLogic } from '../recommendations/recommendationsTabLogic'
 import { SourceMapsFixModal } from '../recommendations/SourceMapsFixModal'
 import { SOURCE_MAPS_DOCS_URL, sourceMapsFixWizardLogic } from '../recommendations/sourceMapsFixWizardLogic'
+import { WizardHog } from '../recommendations/sourceMapsWizardVisuals'
 
 // Dismissal is independent of the source maps recommendation's own dismissed_at —
 // dismissing here only hides this banner, via the standard localStorage-backed pattern.
@@ -36,6 +37,7 @@ export function SourceMapsBanner(): JSX.Element | null {
 // the outer guards (including dismissal) gate the mount, so mounting here means it was seen.
 function SourceMapsBannerContent({ percent, lookbackHours }: { percent: number; lookbackHours: number }): JSX.Element {
     const { openModal } = useActions(sourceMapsFixWizardLogic)
+    const { dismiss } = useActions(lemonBannerLogic({ dismissKey: DISMISS_KEY }))
 
     useOnMountEffect(() => {
         posthog.capture('error_tracking_source_maps_banner_shown', {
@@ -46,27 +48,35 @@ function SourceMapsBannerContent({ percent, lookbackHours }: { percent: number; 
 
     return (
         <>
-            <LemonBanner
-                type="warning"
-                className="mb-2"
-                dismissKey={DISMISS_KEY}
-                action={{
-                    children: 'Fix with wizard',
-                    icon: <IconMagicWand />,
-                    onClick: () => openModal('issues_list'),
-                }}
-            >
-                <div className="flex items-center justify-between gap-2">
-                    <span>
-                        We detected that {percent}% of your stack frames in the last {lookbackHours} hours are missing
-                        source maps, so their stack traces aren't readable. Run the wizard or follow the docs to upload
-                        them.
-                    </span>
-                    <LemonButton type="secondary" to={SOURCE_MAPS_DOCS_URL} targetBlank>
-                        Read docs
-                    </LemonButton>
+            <div className="mb-2">
+                <div className="rounded-lg border border-border bg-bg-light pl-3 pr-4 py-3 mt-2">
+                    <div className="flex items-center gap-4">
+                        {/* The hog is absolutely positioned so it doesn't drive the card height —
+                            it overflows the card edges slightly by design. */}
+                        <div className="relative hidden sm:block shrink-0 self-stretch w-20">
+                            <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 pointer-events-none">
+                                <div className="absolute -inset-2 bg-[radial-gradient(circle,rgba(43,111,244,0.18),transparent_70%)]" />
+                                <WizardHog className="relative w-20 h-20 -rotate-3" />
+                            </div>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <div className="font-semibold">{percent}% of your stack traces aren't readable</div>
+                            <div className="text-sm text-secondary">
+                                Let the wizard set up automatic uploads in your project.
+                            </div>
+                        </div>
+                        <LemonButton type="tertiary" size="small" to={SOURCE_MAPS_DOCS_URL} targetBlank>
+                            Read docs
+                        </LemonButton>
+                        <LemonButton type="secondary" icon={<IconMagicWand />} onClick={() => openModal('issues_list')}>
+                            <span className="rainbow-text rainbow-text-animating font-semibold">
+                                Fix with AI wizard
+                            </span>
+                        </LemonButton>
+                        <LemonButton size="xsmall" icon={<IconX />} onClick={dismiss} aria-label="Dismiss banner" />
+                    </div>
                 </div>
-            </LemonBanner>
+            </div>
             <SourceMapsFixModal />
         </>
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
@@ -57,7 +57,7 @@ function WizardCommand({ onCopy }: { onCopy: (key: number) => void }): JSX.Eleme
             type="button"
             onClick={handleCopy}
             aria-label="Copy wizard command"
-            className="group inline-flex items-center gap-2 px-4 py-3 font-mono text-sm cursor-pointer max-w-full transition-colors rounded-lg bg-surface-primary border border-primary hover:border-accent"
+            className="group inline-flex items-center gap-2 px-4 py-3 font-mono text-sm cursor-pointer max-w-full transition-colors rounded-lg bg-surface-primary border border-primary hover:border-blue-500"
         >
             <IconTerminal className="size-4 text-muted" />
             <span className="relative min-w-0">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
@@ -57,7 +57,7 @@ function WizardCommand({ onCopy }: { onCopy: (key: number) => void }): JSX.Eleme
             type="button"
             onClick={handleCopy}
             aria-label="Copy wizard command"
-            className="group inline-flex items-center gap-2 px-4 py-3 font-mono text-sm cursor-pointer max-w-full transition-colors rounded-lg bg-surface-primary border border-primary hover:border-[#2b6ff4]"
+            className="group inline-flex items-center gap-2 px-4 py-3 font-mono text-sm cursor-pointer max-w-full transition-colors rounded-lg bg-surface-primary border border-primary hover:border-accent"
         >
             <IconTerminal className="size-4 text-muted" />
             <span className="relative min-w-0">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
@@ -1,117 +1,174 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
-import { IconCheckCircle, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { IconCheckCircle, IconCopy, IconTerminal, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonSegmentedButton, LemonTextArea } from '@posthog/lemon-ui'
 
-import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { Popover } from 'lib/lemon-ui/Popover'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 
 import { RATING_SCALE, sourceMapsFixWizardLogic } from './sourceMapsFixWizardLogic'
+import { WizardHog } from './sourceMapsWizardVisuals'
 
 export function SourceMapsFixModal(): JSX.Element {
-    const { isModalOpen, wizardCommand, feedbackRevealed, rating, ratingScore, feedbackText, feedbackSubmitted } =
+    const { isModalOpen } = useValues(sourceMapsFixWizardLogic)
+    const { closeModal } = useActions(sourceMapsFixWizardLogic)
+    const [castKey, setCastKey] = useState(0)
+
+    return (
+        <LemonModal isOpen={isModalOpen} onClose={closeModal} width={540} simple>
+            <div className="relative">
+                <div className="flex flex-col items-center gap-2 px-6 pt-8 pb-6 text-center bg-[radial-gradient(ellipse_at_top_left,rgba(43,111,244,0.18),transparent_55%),radial-gradient(ellipse_at_bottom_right,rgba(255,101,31,0.16),transparent_55%)]">
+                    <WizardHog castKey={castKey} className="w-24 h-24" />
+                    <h3 className="text-xl font-bold mb-0">Readable stack traces in one command</h3>
+                    <p className="text-secondary text-sm mb-0 max-w-sm">
+                        The wizard detects your framework, sets up automatic source map uploads in your project, and
+                        verifies everything works.
+                    </p>
+                </div>
+                <div className="flex flex-col gap-3 px-6 pb-6 pt-2">
+                    <div className="flex justify-center">
+                        <WizardCommand onCopy={setCastKey} />
+                    </div>
+                    <p className="text-xs text-muted text-center mb-0">Run it in your project's root directory</p>
+                    <WizardFeedbackSection />
+                </div>
+            </div>
+        </LemonModal>
+    )
+}
+
+// Local command renderer instead of CommandBlock: same rainbow text and green
+// "copied" flash, but no scale bounce on click, and a theme-aware hairline border.
+function WizardCommand({ onCopy }: { onCopy: (key: number) => void }): JSX.Element {
+    const { wizardCommand } = useValues(sourceMapsFixWizardLogic)
+    const [copyKey, setCopyKey] = useState(0)
+
+    const handleCopy = (): void => {
+        void copyToClipboard(wizardCommand, 'Wizard command')
+        const next = copyKey + 1
+        setCopyKey(next)
+        onCopy(next)
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={handleCopy}
+            aria-label="Copy wizard command"
+            className="group inline-flex items-center gap-2 px-4 py-3 font-mono text-sm cursor-pointer max-w-full transition-colors rounded-lg bg-surface-primary border border-primary hover:border-[#2b6ff4]"
+        >
+            <IconTerminal className="size-4 text-muted" />
+            <span className="relative min-w-0">
+                <code className="rainbow-text rainbow-text-animating !bg-transparent !p-0 !border-0 select-all">
+                    {wizardCommand}
+                </code>
+                {copyKey > 0 && (
+                    <code
+                        key={copyKey}
+                        className="SourceMapsWizard__flash !bg-transparent !p-0 !border-0"
+                        aria-hidden="true"
+                    >
+                        {wizardCommand}
+                    </code>
+                )}
+            </span>
+            <IconCopy className="size-4 text-muted group-hover:text-primary" />
+        </button>
+    )
+}
+
+function WizardFeedbackSection(): JSX.Element {
+    const { feedbackRevealed, rating, ratingScore, feedbackText, feedbackSubmitted } =
         useValues(sourceMapsFixWizardLogic)
-    const { closeModal, rateWizard, setRatingScore, setFeedbackText, submitFeedback, dismissFeedback } =
+    const { rateWizard, setRatingScore, setFeedbackText, submitFeedback, dismissFeedback } =
         useActions(sourceMapsFixWizardLogic)
 
     const positiveRating = ratingScore !== null && ratingScore > Math.ceil(RATING_SCALE / 2)
 
     return (
-        <LemonModal isOpen={isModalOpen} onClose={closeModal} width={540} title="Let the wizard set up source maps">
-            <div className="flex flex-col gap-4">
-                <div className="flex items-start gap-3">
-                    <p className="text-secondary mb-0">
-                        The PostHog wizard detects your framework and wires up source map uploads, and verifies
-                        everything works. Just run this in your project's root directory:
-                    </p>
-                </div>
-
-                <CodeSnippet language={Language.Bash}>{wizardCommand}</CodeSnippet>
-
-                <div
-                    className={cn(
-                        'grid transition-all duration-500 ease-out',
-                        feedbackRevealed ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-                    )}
-                >
-                    <div className="overflow-hidden">
-                        <div className="flex items-center justify-between gap-2 border-t border-primary pt-3 mt-1">
-                            <span className="font-medium">How did the wizard do?</span>
-                            <Popover
-                                visible={rating !== null}
-                                onClickOutside={dismissFeedback}
-                                placement="top-end"
-                                overlay={
-                                    <div className="flex flex-col gap-3 p-3 w-80">
-                                        {feedbackSubmitted ? (
-                                            <div className="flex items-center gap-2 py-1 font-medium text-success">
-                                                <IconCheckCircle className="text-lg" />
-                                                Thanks for the feedback!
-                                            </div>
-                                        ) : (
-                                            <>
-                                                <div className="flex flex-col gap-1">
-                                                    <span className="font-medium">How did the wizard do?</span>
-                                                    <LemonSegmentedButton
-                                                        fullWidth
-                                                        size="small"
-                                                        value={ratingScore ?? undefined}
-                                                        onChange={setRatingScore}
-                                                        options={Array.from({ length: RATING_SCALE }, (_, i) => ({
-                                                            value: i + 1,
-                                                            label: String(i + 1),
-                                                        }))}
-                                                    />
-                                                    <div className="flex justify-between text-xs text-muted">
-                                                        <span>Very bad</span>
-                                                        <span>Awesome</span>
-                                                    </div>
-                                                </div>
-                                                <LemonTextArea
-                                                    placeholder={
-                                                        positiveRating
-                                                            ? 'Nice! Anything that stood out? (optional)'
-                                                            : 'Sorry about that — what went wrong? (optional)'
-                                                    }
-                                                    value={feedbackText}
-                                                    onChange={setFeedbackText}
-                                                    minRows={3}
-                                                    autoFocus
-                                                />
-                                                <div className="flex justify-end">
-                                                    <LemonButton type="primary" size="small" onClick={submitFeedback}>
-                                                        Send
-                                                    </LemonButton>
-                                                </div>
-                                            </>
-                                        )}
+        <div
+            className={cn(
+                'grid transition-all duration-500 ease-out',
+                feedbackRevealed ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+            )}
+        >
+            <div className="overflow-hidden">
+                <div className="flex items-center justify-between gap-2 border-t border-primary pt-3 mt-1">
+                    <span className="font-medium">How did the wizard do?</span>
+                    <Popover
+                        visible={rating !== null}
+                        onClickOutside={dismissFeedback}
+                        placement="top-end"
+                        overlay={
+                            <div className="flex flex-col gap-3 p-3 w-80">
+                                {feedbackSubmitted ? (
+                                    <div className="flex items-center gap-2 py-1 font-medium text-success">
+                                        <IconCheckCircle className="text-lg" />
+                                        Thanks for the feedback!
                                     </div>
-                                }
-                            >
-                                <div className="flex gap-1">
-                                    <LemonButton
-                                        icon={<IconThumbsUp />}
-                                        type="secondary"
-                                        size="small"
-                                        active={rating === 'good'}
-                                        onClick={() => rateWizard('good')}
-                                        tooltip="It worked"
-                                    />
-                                    <LemonButton
-                                        icon={<IconThumbsDown />}
-                                        type="secondary"
-                                        size="small"
-                                        active={rating === 'bad'}
-                                        onClick={() => rateWizard('bad')}
-                                        tooltip="Didn't work"
-                                    />
-                                </div>
-                            </Popover>
+                                ) : (
+                                    <>
+                                        <div className="flex flex-col gap-1">
+                                            <span className="font-medium">How did the wizard do?</span>
+                                            <LemonSegmentedButton
+                                                fullWidth
+                                                size="small"
+                                                value={ratingScore ?? undefined}
+                                                onChange={setRatingScore}
+                                                options={Array.from({ length: RATING_SCALE }, (_, i) => ({
+                                                    value: i + 1,
+                                                    label: String(i + 1),
+                                                }))}
+                                            />
+                                            <div className="flex justify-between text-xs text-muted">
+                                                <span>Very bad</span>
+                                                <span>Awesome</span>
+                                            </div>
+                                        </div>
+                                        <LemonTextArea
+                                            placeholder={
+                                                positiveRating
+                                                    ? 'Nice! Anything that stood out? (optional)'
+                                                    : 'Sorry about that — what went wrong? (optional)'
+                                            }
+                                            value={feedbackText}
+                                            onChange={setFeedbackText}
+                                            minRows={3}
+                                            autoFocus
+                                        />
+                                        <div className="flex justify-end">
+                                            <LemonButton type="primary" size="small" onClick={submitFeedback}>
+                                                Send
+                                            </LemonButton>
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                        }
+                    >
+                        <div className="flex gap-1">
+                            <LemonButton
+                                icon={<IconThumbsUp />}
+                                type="secondary"
+                                size="small"
+                                active={rating === 'good'}
+                                onClick={() => rateWizard('good')}
+                                tooltip="It worked"
+                            />
+                            <LemonButton
+                                icon={<IconThumbsDown />}
+                                type="secondary"
+                                size="small"
+                                active={rating === 'bad'}
+                                onClick={() => rateWizard('bad')}
+                                tooltip="Didn't work"
+                            />
                         </div>
-                    </div>
+                    </Popover>
                 </div>
             </div>
-        </LemonModal>
+        </div>
     )
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsFixModal.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { IconCheckCircle, IconCopy, IconTerminal, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonSegmentedButton, LemonTextArea } from '@posthog/lemon-ui'
@@ -39,17 +39,16 @@ export function SourceMapsFixModal(): JSX.Element {
     )
 }
 
-// Local command renderer instead of CommandBlock: same rainbow text and green
-// "copied" flash, but no scale bounce on click, and a theme-aware hairline border.
+// Local command renderer instead of CommandBlock: same rainbow text, but no
+// scale bounce or color flash on click, and a theme-aware hairline border.
 function WizardCommand({ onCopy }: { onCopy: (key: number) => void }): JSX.Element {
     const { wizardCommand } = useValues(sourceMapsFixWizardLogic)
-    const [copyKey, setCopyKey] = useState(0)
+    const copyCount = useRef(0)
 
     const handleCopy = (): void => {
         void copyToClipboard(wizardCommand, 'Wizard command')
-        const next = copyKey + 1
-        setCopyKey(next)
-        onCopy(next)
+        copyCount.current += 1
+        onCopy(copyCount.current)
     }
 
     return (
@@ -60,20 +59,9 @@ function WizardCommand({ onCopy }: { onCopy: (key: number) => void }): JSX.Eleme
             className="group inline-flex items-center gap-2 px-4 py-3 font-mono text-sm cursor-pointer max-w-full transition-colors rounded-lg bg-surface-primary border border-primary hover:border-blue-500"
         >
             <IconTerminal className="size-4 text-muted" />
-            <span className="relative min-w-0">
-                <code className="rainbow-text rainbow-text-animating !bg-transparent !p-0 !border-0 select-all">
-                    {wizardCommand}
-                </code>
-                {copyKey > 0 && (
-                    <code
-                        key={copyKey}
-                        className="SourceMapsWizard__flash !bg-transparent !p-0 !border-0"
-                        aria-hidden="true"
-                    >
-                        {wizardCommand}
-                    </code>
-                )}
-            </span>
+            <code className="rainbow-text rainbow-text-animating !bg-transparent !p-0 !border-0 select-all min-w-0">
+                {wizardCommand}
+            </code>
             <IconCopy className="size-4 text-muted group-hover:text-primary" />
         </button>
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsRecommendationCard.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/SourceMapsRecommendationCard.tsx
@@ -41,11 +41,11 @@ export function SourceMapsRecommendationCard({
                 </div>
             </div>
             <div className="flex justify-center gap-2 mt-2">
-                <LemonButton type="secondary" to={SOURCE_MAPS_DOCS_URL} targetBlank>
+                <LemonButton type="tertiary" to={SOURCE_MAPS_DOCS_URL} targetBlank>
                     Read docs
                 </LemonButton>
-                <LemonButton type="primary" icon={<IconMagicWand />} onClick={() => openModal('recommendations')}>
-                    Fix with wizard
+                <LemonButton type="secondary" icon={<IconMagicWand />} onClick={() => openModal('recommendations')}>
+                    <span className="rainbow-text rainbow-text-animating font-semibold">Fix with AI wizard</span>
                 </LemonButton>
             </div>
             <SourceMapsFixModal />

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.scss
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.scss
@@ -28,25 +28,3 @@
         transform: rotate(0deg);
     }
 }
-
-// Green "copied" overlay that fades out — same feedback CommandBlock gives,
-// minus its scale bounce.
-.SourceMapsWizard__flash {
-    position: absolute;
-    inset: 0;
-    color: var(--color-success);
-    pointer-events: none;
-    animation: SourceMapsWizard-flash 1500ms ease-out forwards;
-}
-
-/* stylelint-disable-next-line keyframes-name-pattern */
-@keyframes SourceMapsWizard-flash {
-    0%,
-    50% {
-        opacity: 1;
-    }
-
-    100% {
-        opacity: 0;
-    }
-}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.scss
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.scss
@@ -34,7 +34,7 @@
 .SourceMapsWizard__flash {
     position: absolute;
     inset: 0;
-    color: #36c46f;
+    color: var(--color-success);
     pointer-events: none;
     animation: SourceMapsWizard-flash 1500ms ease-out forwards;
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.scss
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.scss
@@ -1,0 +1,52 @@
+// Hedgehog "casting a spell" wobble — played by remounting the <img> element
+// with a fresh key, so the animation runs from the start on every copy click.
+// Mirrors the onboarding WizardCommandBlock effect.
+
+.SourceMapsWizard__hogCast {
+    animation: SourceMapsWizard-hogCast 500ms ease-out;
+}
+
+/* stylelint-disable-next-line keyframes-name-pattern */
+@keyframes SourceMapsWizard-hogCast {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    20% {
+        transform: rotate(-8deg);
+    }
+
+    50% {
+        transform: rotate(5deg);
+    }
+
+    80% {
+        transform: rotate(-2deg);
+    }
+
+    100% {
+        transform: rotate(0deg);
+    }
+}
+
+// Green "copied" overlay that fades out — same feedback CommandBlock gives,
+// minus its scale bounce.
+.SourceMapsWizard__flash {
+    position: absolute;
+    inset: 0;
+    color: #36c46f;
+    pointer-events: none;
+    animation: SourceMapsWizard-flash 1500ms ease-out forwards;
+}
+
+/* stylelint-disable-next-line keyframes-name-pattern */
+@keyframes SourceMapsWizard-flash {
+    0%,
+    50% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
+}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/sourceMapsWizardVisuals.tsx
@@ -1,0 +1,17 @@
+import './sourceMapsWizardVisuals.scss'
+
+import { cn } from 'lib/utils/css-classes'
+
+// Same wizard hedgehog used by the onboarding install step.
+export const WIZARD_HOG_URL = 'https://res.cloudinary.com/dmukukwp6/image/upload/wizard_3f8bb7a240.png'
+
+export function WizardHog({ castKey = 0, className }: { castKey?: number; className?: string }): JSX.Element {
+    return (
+        <img
+            key={`wizard-hog-${castKey}`}
+            src={WIZARD_HOG_URL}
+            alt="PostHog wizard hedgehog"
+            className={cn('shrink-0 select-none', castKey > 0 && 'SourceMapsWizard__hogCast', className)}
+        />
+    )
+}


### PR DESCRIPTION
Make wizard banner and modal nicer. I tried following existing pattern when AI related stuff has this rainbow effect.

Rec tile:
<img width="800" height="417" alt="CleanShot 2026-06-12 at 12 18 36" src="https://github.com/user-attachments/assets/6b4a5984-0d0c-4ef7-81aa-a614776c7e8a" />


Banner:
<img width="2600" height="882" alt="CleanShot 2026-06-12 at 12 19 05@2x" src="https://github.com/user-attachments/assets/dc5eb0d4-2bcb-4e01-b59e-d944dc013d1a" />


Modal:
<img width="1266" height="986" alt="CleanShot 2026-06-12 at 12 19 19@2x" src="https://github.com/user-attachments/assets/16b670aa-7f5c-49c9-a3b1-7ff9cb42d644" />
