### PR TITLE
fix: harden file parser

### DIFF
--- a/products/business_knowledge/backend/file_parse.py
+++ b/products/business_knowledge/backend/file_parse.py
@@ -152,6 +152,8 @@ def _check_zip_bomb(zf: zipfile.ZipFile) -> None:
                         raise ZipBombError(
                             f"Decompressed size exceeds the {MAX_FILE_DECOMPRESSED_BYTES // (1024 * 1024)} MB cap."
                         )
+    except zipfile.BadZipFile:
+        raise FileParseError("File appears corrupt — cannot read ZIP contents.")
     except (RuntimeError, NotImplementedError):
         raise FileParseError("File is encrypted or uses an unsupported compression method.")
 

--- a/products/business_knowledge/backend/file_parse.py
+++ b/products/business_knowledge/backend/file_parse.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 import structlog
 from docx import Document
 from docx.opc.exceptions import PackageNotFoundError
+from docx.table import Table as DocxTable
 from pypdf import PdfReader
 from pypdf.errors import PdfReadError
 
@@ -87,16 +88,24 @@ def detect_content_type(data: bytes, filename: str) -> str:
         return "application/pdf"
 
     if data[:2] == b"PK":
-        _check_zip_bomb(data)
         try:
-            with zipfile.ZipFile(io.BytesIO(data)) as zf:
-                if "[Content_Types].xml" in zf.namelist():
-                    with zf.open("[Content_Types].xml") as ct_file:
-                        ct = ct_file.read(4096).decode("utf-8", errors="replace")
-                    if "wordprocessingml" in ct:
-                        return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        except (zipfile.BadZipFile, KeyError, OSError):
-            pass
+            zf = zipfile.ZipFile(io.BytesIO(data))
+        except zipfile.BadZipFile:
+            pass  # Not actually a zip — fall through to extension check
+        else:
+            with zf:
+                _check_zip_bomb(zf)
+                try:
+                    if "[Content_Types].xml" in zf.namelist():
+                        with zf.open("[Content_Types].xml") as ct_file:
+                            ct = ct_file.read(4096).decode("utf-8", errors="replace")
+                        if "wordprocessingml" in ct:
+                            return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                except (KeyError, OSError):
+                    pass
+                raise UnsupportedFileTypeError(
+                    "Unsupported file type. Allowed: PDF, DOCX, Markdown (.md), CSV, plain text (.txt)."
+                )
 
     lower = os.path.basename(filename).lower()
     if lower.endswith((".md", ".markdown")):
@@ -107,11 +116,16 @@ def detect_content_type(data: bytes, filename: str) -> str:
         return "text/plain"
 
     # Last resort: if it decodes as UTF-8, treat as plain text.
+    sample = data[:8192]
     try:
-        data[:8192].decode("utf-8")
+        sample.decode("utf-8")
         return "text/plain"
-    except UnicodeDecodeError:
-        pass
+    except UnicodeDecodeError as exc:
+        # Slicing may split a multibyte char at the boundary; if the only
+        # error is "unexpected end of data" at the tail AND more data exists,
+        # the full file is valid UTF-8.
+        if exc.reason == "unexpected end of data" and len(data) > len(sample):
+            return "text/plain"
 
     raise UnsupportedFileTypeError("Unsupported file type. Allowed: PDF, DOCX, Markdown (.md), CSV, plain text (.txt).")
 
@@ -121,20 +135,23 @@ def detect_content_type(data: bytes, filename: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _check_zip_bomb(data: bytes) -> None:
+def _check_zip_bomb(zf: zipfile.ZipFile) -> None:
+    """Stream-check that decompressed size stays within cap.
+
+    Accepts an already-opened ZipFile so the caller controls the
+    BadZipFile boundary (non-zips that start with ``PK`` fall through
+    to the extension check rather than hard-failing).
+    """
     try:
-        with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            total = 0
-            for info in zf.infolist():
-                with zf.open(info) as f:
-                    while chunk := f.read(65536):
-                        total += len(chunk)
-                        if total > MAX_FILE_DECOMPRESSED_BYTES:
-                            raise ZipBombError(
-                                f"Decompressed size exceeds the {MAX_FILE_DECOMPRESSED_BYTES // (1024 * 1024)} MB cap."
-                            )
-    except zipfile.BadZipFile:
-        raise FileParseError("File appears corrupt — cannot read as ZIP.")
+        total = 0
+        for info in zf.infolist():
+            with zf.open(info) as f:
+                while chunk := f.read(65536):
+                    total += len(chunk)
+                    if total > MAX_FILE_DECOMPRESSED_BYTES:
+                        raise ZipBombError(
+                            f"Decompressed size exceeds the {MAX_FILE_DECOMPRESSED_BYTES // (1024 * 1024)} MB cap."
+                        )
     except (RuntimeError, NotImplementedError):
         raise FileParseError("File is encrypted or uses an unsupported compression method.")
 
@@ -161,18 +178,31 @@ def _parse_pdf(data: bytes, filename: str) -> ParsedFile:
         reader = PdfReader(io.BytesIO(data))
     except PdfReadError as exc:
         raise FileParseError(f"Could not read PDF: {exc}")
+    except Exception as exc:
+        logger.warning("pdf_reader_unexpected_error", error=str(exc), exc_info=True)
+        raise FileParseError(f"Could not read PDF: {exc}")
 
     if reader.is_encrypted:
         raise EncryptedPDFError("Encrypted PDFs are not supported. Remove the password and re-upload.")
 
-    if len(reader.pages) > MAX_PDF_PAGES:
+    try:
+        page_count = len(reader.pages)
+    except Exception as exc:
+        logger.warning("pdf_page_count_error", error=str(exc), exc_info=True)
+        raise FileParseError(f"Could not read PDF: {exc}")
+
+    if page_count > MAX_PDF_PAGES:
         raise FileTooLargeError(
-            f"PDF has {len(reader.pages):,} pages (cap is {MAX_PDF_PAGES:,}). Split it into smaller files."
+            f"PDF has {page_count:,} pages (cap is {MAX_PDF_PAGES:,}). Split it into smaller files."
         )
 
     pages: list[str] = []
     for i, page in enumerate(reader.pages):
-        text = page.extract_text() or ""
+        try:
+            text = page.extract_text() or ""
+        except Exception:
+            logger.warning("pdf_page_extract_error", page=i, exc_info=True)
+            continue
         if text.strip():
             pages.append(f"[Page {i + 1}]\n{text.strip()}")
 
@@ -184,7 +214,7 @@ def _parse_pdf(data: bytes, filename: str) -> ParsedFile:
         title=_title_from_filename(filename),
         content=content,
         content_type="application/pdf",
-        metadata={"source_type": "file", "file_type": "pdf", "page_count": len(reader.pages)},
+        metadata={"source_type": "file", "file_type": "pdf", "page_count": page_count},
     )
 
 
@@ -197,20 +227,26 @@ def _parse_docx(data: bytes, filename: str) -> ParsedFile:
         raise FileParseError(f"Could not read DOCX: {exc}")
 
     parts: list[str] = []
-    for para in doc.paragraphs:
-        text = para.text.strip()
-        if not text:
-            continue
-        style_name = (para.style.name or "").lower() if para.style else ""
-        if "heading" in style_name:
-            level = 1
-            for ch in style_name:
-                if ch.isdigit():
-                    level = int(ch)
-                    break
-            parts.append(f"{'#' * level} {text}")
+    for block in doc.iter_inner_content():
+        if isinstance(block, DocxTable):
+            for row in block.rows:
+                cells = [cell.text.strip() for cell in row.cells]
+                if any(cells):
+                    parts.append(" | ".join(cells))
         else:
-            parts.append(text)
+            text = block.text.strip()
+            if not text:
+                continue
+            style_name = (block.style.name or "").lower() if block.style else ""
+            if "heading" in style_name:
+                level = 1
+                for ch in style_name:
+                    if ch.isdigit():
+                        level = int(ch)
+                        break
+                parts.append(f"{'#' * level} {text}")
+            else:
+                parts.append(text)
 
     content = "\n\n".join(parts)
     if not content.strip():
@@ -261,6 +297,7 @@ def _parse_csv(data: bytes, filename: str) -> ParsedFile:
             raise FileParseError("CSV has no header row.")
 
         rows: list[str] = []
+        data_row_count = 0
         for i, row in enumerate(reader):
             if i >= MAX_CSV_ROWS:
                 rows.append(f"[Truncated at {MAX_CSV_ROWS:,} rows]")
@@ -268,6 +305,7 @@ def _parse_csv(data: bytes, filename: str) -> ParsedFile:
             line_parts = [f"{k}: {v}" for k, v in row.items() if v]
             if line_parts:
                 rows.append("\n".join(line_parts))
+                data_row_count += 1
     except csv.Error as exc:
         raise FileParseError(f"Could not parse CSV: {exc}")
 
@@ -279,7 +317,7 @@ def _parse_csv(data: bytes, filename: str) -> ParsedFile:
         title=_title_from_filename(filename),
         content=content,
         content_type="text/csv",
-        metadata={"source_type": "file", "file_type": "csv", "row_count": len(rows)},
+        metadata={"source_type": "file", "file_type": "csv", "row_count": data_row_count},
     )
 
 
@@ -311,6 +349,7 @@ def parse_file(data: bytes, filename: str) -> ParsedFile:
     if len(data) > MAX_FILE_SIZE_BYTES:
         raise FileTooLargeError(f"File exceeds the {MAX_FILE_SIZE_BYTES // (1024 * 1024)} MB cap.")
 
+    filename = sanitize_filename(filename)
     content_type = detect_content_type(data, filename)
     if content_type not in ALLOWED_TYPES:
         raise UnsupportedFileTypeError(f"Unsupported file type. Allowed: {', '.join(ALLOWED_TYPES.values())}.")

--- a/products/business_knowledge/backend/tests/test_file_ingest.py
+++ b/products/business_knowledge/backend/tests/test_file_ingest.py
@@ -55,6 +55,39 @@ def _make_minimal_docx(text: str = "Hello World") -> bytes:
     return buf.getvalue()
 
 
+def _make_docx_with_table() -> bytes:
+    from docx import Document
+
+    doc = Document()
+    doc.add_heading("Report", level=1)
+    doc.add_paragraph("Intro paragraph.")
+    table = doc.add_table(rows=3, cols=2)
+    table.cell(0, 0).text = "Name"
+    table.cell(0, 1).text = "Role"
+    table.cell(1, 0).text = "Alice"
+    table.cell(1, 1).text = "Engineer"
+    table.cell(2, 0).text = "Bob"
+    table.cell(2, 1).text = "Designer"
+    doc.add_paragraph("Closing paragraph.")
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _make_table_only_docx() -> bytes:
+    from docx import Document
+
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    table.cell(0, 0).text = "A"
+    table.cell(0, 1).text = "B"
+    table.cell(1, 0).text = "C"
+    table.cell(1, 1).text = "D"
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # detect_content_type
 # ---------------------------------------------------------------------------
@@ -100,6 +133,37 @@ class TestDetectContentType:
         pdf_data = _make_minimal_pdf()
         result = detect_content_type(pdf_data, "sneaky.txt")
         assert result == "application/pdf"
+
+    def test_pk_prefixed_text_falls_through_to_extension(self) -> None:
+        data = b"PKCS#11 is a standard for cryptographic token interfaces."
+        assert detect_content_type(data, "notes.txt") == "text/plain"
+
+    def test_pk_prefixed_text_falls_through_to_utf8(self) -> None:
+        data = b"PK stands for something in this context."
+        assert detect_content_type(data, "noext") == "text/plain"
+
+    def test_valid_non_docx_zip_rejected(self) -> None:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("data.txt", "Hello from a zip")
+        with pytest.raises(UnsupportedFileTypeError):
+            detect_content_type(buf.getvalue(), "archive.csv")
+
+    def test_xlsx_zip_rejected(self) -> None:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "[Content_Types].xml", '<Types><Default Extension="xml" ContentType="application/xml"/></Types>'
+            )
+            zf.writestr("xl/workbook.xml", "<workbook/>")
+        with pytest.raises(UnsupportedFileTypeError):
+            detect_content_type(buf.getvalue(), "sheet.xlsx")
+
+    def test_utf8_multibyte_boundary_split(self) -> None:
+        prefix = b"A" * 8190
+        # 3-byte UTF-8 char (e.g. U+2603 SNOWMAN: \xe2\x98\x83)
+        data = prefix + "☃".encode() + b"more text"
+        assert detect_content_type(data, "noext") == "text/plain"
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +223,31 @@ class TestParseFileHappyPaths:
         assert "# Test Heading" in result.content
         assert result.metadata["file_type"] == "docx"
 
+    def test_parse_docx_with_table(self) -> None:
+        data = _make_docx_with_table()
+        result = parse_file(data, "report.docx")
+        assert "Alice" in result.content
+        assert "Engineer" in result.content
+        assert "Intro paragraph" in result.content
+        assert "Closing paragraph" in result.content
+
+    def test_parse_docx_table_only(self) -> None:
+        data = _make_table_only_docx()
+        result = parse_file(data, "table.docx")
+        assert "A" in result.content
+        assert "D" in result.content
+
+    def test_title_from_sanitized_filename(self) -> None:
+        result = parse_file(b"hello", "../../evil/notes.txt")
+        assert result.title == "notes"
+
+    def test_csv_row_count_excludes_truncation_marker(self) -> None:
+        header = "col1,col2\n"
+        rows = "".join(f"val{i},data{i}\n" for i in range(15_000))
+        data = (header + rows).encode()
+        result = parse_file(data, "big.csv")
+        assert result.metadata["row_count"] == 10_000
+
 
 # ---------------------------------------------------------------------------
 # parse_file — security rejections
@@ -192,6 +281,11 @@ class TestParseFileSecurity:
         with patch("products.business_knowledge.backend.file_parse.MAX_FILE_DECOMPRESSED_BYTES", 50):
             with pytest.raises(ZipBombError):
                 parse_file(data, "bomb.docx")
+
+    def test_malformed_pdf_raises_file_parse_error(self) -> None:
+        data = b"%PDF-1.4 this is not a real PDF structure at all"
+        with pytest.raises(FileParseError):
+            parse_file(data, "broken.pdf")
 
     def test_unsupported_binary_rejected(self) -> None:
         with pytest.raises(UnsupportedFileTypeError):

--- a/products/business_knowledge/backend/tests/test_file_ingest.py
+++ b/products/business_knowledge/backend/tests/test_file_ingest.py
@@ -226,8 +226,7 @@ class TestParseFileHappyPaths:
     def test_parse_docx_with_table(self) -> None:
         data = _make_docx_with_table()
         result = parse_file(data, "report.docx")
-        assert "Alice" in result.content
-        assert "Engineer" in result.content
+        assert "Alice | Engineer" in result.content
         assert "Intro paragraph" in result.content
         assert "Closing paragraph" in result.content
 


### PR DESCRIPTION
## Problem

The file parser in business knowledge had several issues

## Changes

All in products/business_knowledge/backend/file_parse.py:

- Restructured the PK detection branch: try ZipFile() first, fall through on BadZipFile. Refactored _check_zip_bomb to accept an already-opened ZipFile so it no longer independently raises on non-zip data.
- Valid ZIPs that aren't DOCX now raise UnsupportedFileTypeError immediately instead of falling to the text fallback.
- _parse_docx uses doc.iter_inner_content() (python-docx 1.2.0) to iterate paragraphs and tables in document order. Table rows render as cell1 | cell2 | ….
- _parse_pdf wraps all pypdf calls (PdfReader, len(pages), extract_text()) so unexpected exceptions become a user-safe FileParseError with a logged warning instead of a 500.
- UTF-8 last-resort detection handles "unexpected end of data" at the sample boundary when more data exists beyond the sample.
- parse_file sanitizes the filename before detection/title derivation. CSV row_count tracks actual data rows only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/PostHog/posthog/pull/63202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

