### PR TITLE
feat(tasks): resolve sandbox MCP URL on hosted dev

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -36,6 +36,7 @@ class TestGetSandboxMcpConfigs(TestCase):
             ("https://app.posthog.com", "https://mcp.posthog.com/mcp"),
             ("https://us.posthog.com", "https://mcp.posthog.com/mcp"),
             ("https://eu.posthog.com", "https://mcp-eu.posthog.com/mcp"),
+            ("https://app.dev.posthog.dev", "https://mcp.dev.posthog.dev/mcp"),
         ]
     )
     def test_derives_mcp_config_from_site_url(self, site_url: str, expected_mcp_url: str) -> None:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -326,6 +326,7 @@ def get_sandbox_ph_mcp_configs(
     Uses SANDBOX_MCP_URL if explicitly set, otherwise derives it from SITE_URL:
     - app.posthog.com / us.posthog.com → https://mcp.posthog.com/mcp
     - eu.posthog.com → https://mcp-eu.posthog.com/mcp
+    - app.dev.posthog.dev → https://mcp.dev.posthog.dev/mcp
     - Other hosts → empty list (MCP not available)
     """
     url = _resolve_mcp_url()
@@ -355,6 +356,8 @@ def _resolve_mcp_url() -> str | None:
         return "https://mcp.posthog.com/mcp"
     if hostname == "eu.posthog.com":
         return "https://mcp-eu.posthog.com/mcp"
+    if hostname == "app.dev.posthog.dev":
+        return "https://mcp.dev.posthog.dev/mcp"
 
     # Local dev: point to the local wrangler dev MCP server via
     # host.docker.internal, since the sandbox runs in Docker.


### PR DESCRIPTION
## Problem

PostHog Code on the hosted dev environment fails with `No MCP configs were resolved for this run` followed by a 401 on the initial task message. `_resolve_mcp_url` in `products/tasks/backend/temporal/process_task/utils.py` only knows about us / eu / localhost — `app.dev.posthog.dev` falls through to `return None`, so the agent runs without an `Authorization: Bearer` header and PostHog rejects it.

## Changes

Add an `app.dev.posthog.dev → https://mcp.dev.posthog.dev/mcp` branch alongside the existing us / eu mappings. Extend the parameterized resolver test with the dev case.

## How did you test this code?

Agent-authored. `hogli test products/tasks/backend/temporal/process_task/tests/test_utils.py` — 55/55 pass. No manual end-to-end yet; that requires the paired `mcp.dev.posthog.dev` ingress in posthog/charts to land first.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.7). Traced the failure from a worker log (`No MCP configs were resolved for this run` → 401 on `/slack/event-callback/`-adjacent flow) through `get_sandbox_ph_mcp_configs` to the hostname switch in `_resolve_mcp_url`. Paired with PostHog/charts#12045 which exposes the dev MCP server on `mcp.dev.posthog.dev`. Without that ingress, this change just changes which URL the agent tries and fails to reach.
