### PR TITLE
feat(ingestion): support ip conditions in event filters

### DIFF
--- a/nodejs/src/ingestion/common/event-filters/evaluate.ts
+++ b/nodejs/src/ingestion/common/event-filters/evaluate.ts
@@ -1,5 +1,12 @@
 import { FilterConditionNode, FilterNode } from './schema'
 
+/** Event fields that filter conditions can match on, keyed by condition `field`. */
+export interface FilterableEvent {
+    event_name?: string
+    distinct_id?: string
+    ip?: string
+}
+
 /**
  * Recursively evaluate a filter tree node against event fields.
  *
@@ -12,7 +19,7 @@ import { FilterConditionNode, FilterNode } from './schema'
  * This is intentional — when in doubt, don't drop. Dropping is irreversible,
  * while not dropping just means unwanted events get through temporarily.
  */
-export function evaluateFilterTree(node: FilterNode, event: { event_name?: string; distinct_id?: string }): boolean {
+export function evaluateFilterTree(node: FilterNode, event: FilterableEvent): boolean {
     switch (node.type) {
         case 'condition':
             return evaluateCondition(node, event)
@@ -26,7 +33,7 @@ export function evaluateFilterTree(node: FilterNode, event: { event_name?: strin
     }
 }
 
-function evaluateCondition(node: FilterConditionNode, event: { event_name?: string; distinct_id?: string }): boolean {
+function evaluateCondition(node: FilterConditionNode, event: FilterableEvent): boolean {
     const value = event[node.field]
     if (value === undefined || value === null) {
         return false

--- a/nodejs/src/ingestion/common/event-filters/schema.test.ts
+++ b/nodejs/src/ingestion/common/event-filters/schema.test.ts
@@ -11,6 +11,16 @@ describe('FilterNodeSchema', () => {
         expect(result.success).toBe(true)
     })
 
+    it('accepts a valid ip condition', () => {
+        const result = FilterNodeSchema.safeParse({
+            type: 'condition',
+            field: 'ip',
+            operator: 'exact',
+            value: '203.0.113.7',
+        })
+        expect(result.success).toBe(true)
+    })
+
     it('rejects condition with empty value', () => {
         const result = FilterNodeSchema.safeParse({
             type: 'condition',

--- a/nodejs/src/ingestion/common/event-filters/schema.ts
+++ b/nodejs/src/ingestion/common/event-filters/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 const FilterConditionSchema = z.object({
     type: z.literal('condition'),
-    field: z.enum(['event_name', 'distinct_id']),
+    field: z.enum(['event_name', 'distinct_id', 'ip']),
     operator: z.enum(['exact', 'contains']),
     value: z.string().min(1),
 })

--- a/nodejs/src/ingestion/common/steps/event-filters-steps.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-filters-steps.test.ts
@@ -253,7 +253,7 @@ describe('createApplyEventFiltersStep', () => {
     interface FilterScenario {
         name: string
         filter: FilterNode
-        event: { event_name?: string; distinct_id?: string }
+        event: { event_name?: string; distinct_id?: string; ip?: string }
         drops: boolean
     }
 
@@ -302,6 +302,44 @@ describe('createApplyEventFiltersStep', () => {
             drops: false,
         },
         { name: 'undefined field', filter: cond('event_name', 'exact', 'test'), event: {}, drops: false },
+
+        // ip matching
+        {
+            name: 'exact ip match',
+            filter: cond('ip', 'exact', '203.0.113.7'),
+            event: { ip: '203.0.113.7' },
+            drops: true,
+        },
+        {
+            name: 'exact ip no match',
+            filter: cond('ip', 'exact', '203.0.113.7'),
+            event: { ip: '203.0.113.8' },
+            drops: false,
+        },
+        {
+            name: 'ip contains match (prefix)',
+            filter: cond('ip', 'contains', '10.0.0.'),
+            event: { ip: '10.0.0.42' },
+            drops: true,
+        },
+        {
+            name: 'missing ip header never drops',
+            filter: cond('ip', 'exact', '203.0.113.7'),
+            event: { event_name: '$pageview' },
+            drops: false,
+        },
+        {
+            name: 'AND of ip and event_name both match',
+            filter: and(cond('ip', 'exact', '203.0.113.7'), cond('event_name', 'exact', '$pageview')),
+            event: { ip: '203.0.113.7', event_name: '$pageview' },
+            drops: true,
+        },
+        {
+            name: 'AND of ip and event_name only ip matches',
+            filter: and(cond('ip', 'exact', '203.0.113.7'), cond('event_name', 'exact', '$pageview')),
+            event: { ip: '203.0.113.7', event_name: '$click' },
+            drops: false,
+        },
 
         // empty groups are conservative (never drop)
         { name: 'empty AND', filter: { type: 'and', children: [] }, event: { event_name: '$pageview' }, drops: false },
@@ -474,7 +512,7 @@ describe('createApplyEventFiltersStep', () => {
         const step = createApplyEventFiltersStep(mockManager)
         const input = {
             team: createTestTeam({ id: 1 }),
-            headers: createTestEventHeaders({ event: event.event_name, distinct_id: event.distinct_id }),
+            headers: createTestEventHeaders({ event: event.event_name, distinct_id: event.distinct_id, ip: event.ip }),
             eventFiltersBatchAppMetrics: metrics,
         }
 

--- a/nodejs/src/ingestion/common/steps/event-filters-steps.ts
+++ b/nodejs/src/ingestion/common/steps/event-filters-steps.ts
@@ -38,7 +38,7 @@ export interface ApplyEventFiltersInput {
 /**
  * Creates a pipeline step that evaluates customer-configured event filters.
  *
- * Uses event headers (event name, distinct_id) so it can run before the Kafka
+ * Uses event headers (event name, distinct_id, ip) so it can run before the Kafka
  * message is parsed into a full event — avoiding wasted work on dropped events.
  *
  * In "live" mode, matching events are dropped and a "dropped" metric is recorded.
@@ -61,6 +61,7 @@ export function createApplyEventFiltersStep<T extends ApplyEventFiltersInput>(
         const matched = evaluateFilterTree(filter.filter_tree, {
             event_name: input.headers.event,
             distinct_id: input.headers.distinct_id,
+            ip: input.headers.ip,
         })
 
         if (matched) {

--- a/nodejs/src/kafka/consumer/consumer-v1.test.ts
+++ b/nodejs/src/kafka/consumer/consumer-v1.test.ts
@@ -565,6 +565,12 @@ describe('parseEventHeaders', () => {
         expect(result).toEqual(createTestEventHeaders({ distinct_id: 'user-123' }))
     })
 
+    it('should parse ip header only', () => {
+        const headers: MessageHeader[] = [{ ip: Buffer.from('203.0.113.7') }]
+        const result = parseEventHeaders(headers)
+        expect(result).toEqual(createTestEventHeaders({ ip: '203.0.113.7' }))
+    })
+
     it('should parse timestamp header only', () => {
         const headers: MessageHeader[] = [{ timestamp: Buffer.from('1234567890') }]
         const result = parseEventHeaders(headers)

--- a/nodejs/src/kafka/consumer/consumer-v1.ts
+++ b/nodejs/src/kafka/consumer/consumer-v1.ts
@@ -883,6 +883,8 @@ export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
                 result.token = sanitizeString(value)
             } else if (key === 'distinct_id') {
                 result.distinct_id = sanitizeString(value)
+            } else if (key === 'ip') {
+                result.ip = sanitizeString(value)
             } else if (key === 'session_id') {
                 result.session_id = normalizeSessionId(sanitizeString(value))
             } else if (key === 'timestamp') {
@@ -910,6 +912,7 @@ export const parseEventHeaders = (headers?: MessageHeader[]): EventHeaders => {
     const trackedHeaders = [
         'token',
         'distinct_id',
+        'ip',
         'session_id',
         'timestamp',
         'event',

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -882,6 +882,7 @@ export interface PipelineEvent extends Omit<PluginEvent, 'team_id'> {
 export interface EventHeaders {
     token?: string
     distinct_id?: string
+    ip?: string
     session_id?: string
     timestamp?: string
     event?: string


### PR DESCRIPTION
## Problem

Ingestion event filters currently match on event name and distinct ID only. To let teams drop unwanted traffic by source address (e.g. a misbehaving crawler hitting from a known IP), the filter tree needs to support IP conditions. Capture now emits the client IP as an `ip` Kafka message header (#63177), so the pipeline can evaluate IP conditions from headers alone, before parsing the message payload — same as the existing fields.

## Changes

- Parse the `ip` Kafka header into `EventHeaders` in the consumer (sanitized like `distinct_id`, tracked in the header status metric).
- Allow `ip` as a condition field in the filter tree zod schema, and introduce a shared `FilterableEvent` type for the evaluator instead of repeating the inline field list.
- Pass `headers.ip` into the filter evaluation in `createApplyEventFiltersStep`.

Events produced before the capture change simply have no `ip` header; IP conditions evaluate to no-match for them (the evaluator already treats missing fields conservatively and never drops on them).

Note for rollout: the Django/API side gains `ip` as an allowed field in a follow-up PR — this one must deploy first so the pipeline accepts rows containing `ip` conditions before users can save them.

## How did you test this code?

- New unit tests: `ip` header parsing in `parseEventHeaders`, schema acceptance of `ip` conditions, and filter scenarios for exact/contains/missing-IP/AND combinations in the step tests.
- `pnpm build`, `pnpm lint`, and the affected test suites (123 tests across consumer, schema, and step suites) all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update
