### PR TITLE
feat(data-pipelines): capture template_id on notify_me_pipeline events

### DIFF
--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -302,6 +302,10 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
             posthog.capture('notify_me_pipeline', {
                 name: template.name,
                 type: template.type,
+                // Canonical template id (e.g. "managed-<SourceType>" for coming-soon
+                // warehouse sources) so consumers can match requests exactly instead
+                // of via the free-text display name.
+                template_id: template.id,
                 email: values.user?.email,
             })
 


### PR DESCRIPTION
## Problem

The "Notify me" button on coming-soon pipeline templates captures `notify_me_pipeline` with only the display `name` (free text). Consumers that want to know *which* source/destination was requested have to fuzzy-match the display name, which silently breaks when labels change or new sources land — e.g. matching warehouse-source requests to canonical source types for release announcements.

## Changes

Adds `template_id: template.id` to the `notify_me_pipeline` capture in `registerInterest`. For coming-soon warehouse sources this is the canonical `managed-<SourceType>` id synthesized from the source catalog, so downstream matching can be exact. No behavioural change to the UI; the existing `name`/`type`/`email` properties are unchanged.

## How did you test this code?

One-property addition to an existing analytics capture; verified the template object exposes `id` at the call site (it's the listing key). No automated test — the listener has no existing coverage and captures are fire-and-forget.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
