### PR TITLE
fix(conversations): stop support checkbox clearing itself on click

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2448,6 +2448,19 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 4.3.0
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^5.17.0
+        version: 5.17.0
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
 
   products/core_events: {}
 

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { Ticket } from '../../types'
+import { SupportTicketsTable } from './SupportTicketsScene'
+import { supportTicketsSceneLogic } from './supportTicketsSceneLogic'
+
+const TICKET: Ticket = {
+    id: 'ticket-1',
+    ticket_number: 1,
+    distinct_id: 'distinct-1',
+    status: 'open',
+    channel_source: 'email',
+    anonymous_traits: {},
+    ai_resolved: false,
+    created_at: '2026-06-12T00:00:00Z',
+    updated_at: '2026-06-12T00:00:00Z',
+    message_count: 1,
+    last_message_at: '2026-06-12T00:00:00Z',
+    last_message_text: 'Hello',
+    unread_team_count: 0,
+    unread_customer_count: 0,
+}
+
+describe('SupportTicketsTable selection', () => {
+    let logic: ReturnType<typeof supportTicketsSceneLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/conversations/tickets/': () => [200, { results: [TICKET], count: 1 }],
+                '/api/organizations/:organization_id/members/': () => [200, { results: [] }],
+            },
+        })
+        initKeaTests()
+        logic = supportTicketsSceneLogic()
+        logic.mount()
+        // Seed a ticket directly so we don't depend on the debounced loadTickets request.
+        act(() => {
+            logic.actions.setTickets([TICKET])
+        })
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        cleanup()
+    })
+
+    function getRowCheckbox(): HTMLInputElement {
+        // Two checkboxes render: [0] the header "select all on page", [1] the single row.
+        const checkboxes = screen.getAllByRole('checkbox')
+        expect(checkboxes).toHaveLength(2)
+        return checkboxes[1] as HTMLInputElement
+    }
+
+    // Regression: the hook selection (selectedKeys) and kea (selectedTicketIds) were synced by
+    // two effects, and on the first click the "clear when kea is empty" effect fired before the
+    // push effect had propagated — instantly wiping the selection. The checkbox never stuck.
+    it('keeps a row checked after clicking and pushes the id into kea', async () => {
+        render(
+            <Provider>
+                <SupportTicketsTable />
+            </Provider>
+        )
+
+        const rowCheckbox = getRowCheckbox()
+        expect(rowCheckbox).not.toBeChecked()
+
+        await userEvent.click(rowCheckbox)
+
+        await waitFor(() => expect(getRowCheckbox()).toBeChecked())
+        expect(logic.values.selectedTicketIds).toEqual([TICKET.id])
+    })
+
+    it('clears the checkbox when the kea selection is reset externally', async () => {
+        render(
+            <Provider>
+                <SupportTicketsTable />
+            </Provider>
+        )
+
+        await userEvent.click(getRowCheckbox())
+        await waitFor(() => expect(getRowCheckbox()).toBeChecked())
+
+        // A bulk update / page reload resets the kea selection — the hook should follow.
+        act(() => {
+            logic.actions.clearSelectedTickets()
+        })
+
+        await waitFor(() => expect(getRowCheckbox()).not.toBeChecked())
+        expect(logic.values.selectedTicketIds).toEqual([])
+    })
+})

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { IconChevronDown, IconClock, IconRefresh, IconX } from '@posthog/icons'
 import {
@@ -276,9 +276,16 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
         setSelectedTicketIds(selectedKeys)
     }, [selectedKeys, setSelectedTicketIds])
 
-    // Clear hook selection when kea resets (e.g. after bulk update or page reload)
+    // Clear hook selection only when kea's selection is reset *externally* (e.g. after a bulk
+    // update or page reload). We detect that as a non-empty -> empty transition. Reacting to
+    // `selectedTicketIds.length === 0` alone would also fire during the brief window right after
+    // the first selection, before the effect above has pushed `selectedKeys` into kea — which
+    // would immediately wipe the selection the user just made.
+    const prevSelectedTicketIdCount = useRef(selectedTicketIds.length)
     useEffect(() => {
-        if (selectedTicketIds.length === 0 && selectedKeys.length > 0) {
+        const wasSelected = prevSelectedTicketIdCount.current > 0
+        prevSelectedTicketIdCount.current = selectedTicketIds.length
+        if (wasSelected && selectedTicketIds.length === 0 && selectedKeys.length > 0) {
             clearSelection()
         }
     }, [selectedTicketIds, selectedKeys, clearSelection])

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -11,9 +11,18 @@
         "posthog-js": "catalog:",
         "ts-pattern": "catalog:"
     },
+    "devDependencies": {
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^14.3.1",
+        "@testing-library/user-event": "^14.6.1",
+        "jest": "^29.7.0"
+    },
     "peerDependencies": {
         "@posthog/icons": "*",
         "@posthog/lemon-ui": "*",
+        "@testing-library/jest-dom": "*",
+        "@testing-library/react": "*",
+        "@testing-library/user-event": "*",
         "@tiptap/core": "*",
         "@tiptap/extension-code-block-lowlight": "*",
         "@tiptap/extension-document": "*",
@@ -26,6 +35,7 @@
         "@types/react": "*",
         "@types/react-dom": "*",
         "clsx": "*",
+        "jest": "*",
         "lowlight": "*",
         "react": "*",
         "react-dom": "*"


### PR DESCRIPTION
## Problem

Clicking a checkbox in the Support tickets table did nothing — the box never stayed checked, and rapid clicking could surface a React error. Reported against a project with a single ticket, but it affected any selection.

The root cause is a race in how row selection is synced between the `useBulkSelection` hook (`selectedKeys`) and kea (`selectedTicketIds`). Two effects keep them in sync:

- one pushes the hook's selection into kea, and
- one clears the hook whenever kea's selection is empty (so selection resets after a bulk update or page reload).

On the very first click, the hook has the new selection but kea has not caught up yet (the push effect runs after that render). In that window the clear-on-empty effect sees an empty kea selection and immediately wipes the selection the user just made — so the checkbox never sticks. This is a pre-existing design issue, **not** introduced by the dependency-array refactor in #62868 (whose effect bodies were behaviorally identical).

## Changes

- **Fix:** only clear the hook selection on a genuine **non-empty → empty** transition of the kea selection (a real external reset from a bulk update or page reload), tracked with a ref. The propagation window right after the first selection is no longer mistaken for a reset, so selections stick and external resets still clear correctly.
- **Test:** `SupportTicketsScene.test.tsx` renders `SupportTicketsTable` and locks in both behaviors — a clicked row checkbox stays checked and pushes its id into kea, and an external reset clears it. This test was pushed first and confirmed failing in CI against the unfixed code, then made green by the fix.
- **Plumbing:** `products/*` are individual pnpm workspace packages, so the new test's `@testing-library/*` + `jest` imports only resolve if conversations declares them. Added those dev/peer deps (mirroring `products/dashboards`) and the matching `pnpm-lock.yaml` importer entry.

## How did you test this code?

I'm the PostHog Slack app (agent, PostHog Code / Claude Opus). The frontend toolchain isn't available in my environment, so I did not run jest/format/type-check locally. Instead I pushed the test alone first and used CI to prove it fails against unfixed `master`, then added the fix in a follow-up commit to turn it green. Please confirm the final CI run is green before merging.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Zendesk-reported checkbox bug initially attributed to #62868. Diffing that PR against its parent showed the two sync effects' bodies were byte-for-byte identical — only dependency arrays and destructuring changed — so the PR didn't alter runtime behavior; the race predates it. Per the reviewer's request, shipped the failing test first (CI confirmed it as a real regression guard), then added the fix.

Tool: PostHog Code (Claude Opus).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1781260283017679?thread_ts=1781260283.017679&cid=C08S2L0S5MZ)*