### PR TITLE
fix(endpoints): make execution metrics actionable for alerting

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -113,7 +113,7 @@ from products.endpoints.backend.metrics import (
     ENDPOINT_EXECUTION_TOTAL,
     ENDPOINT_HOGQL_RESULT_ROWS,
     ENDPOINT_MATERIALIZATION_EVENT_TOTAL,
-    ENDPOINT_MATERIALIZED_AGE_SECONDS,
+    ENDPOINT_MATERIALIZED_FRESHNESS_RATIO,
     ENDPOINT_VALIDATION_ERROR_TOTAL,
     query_kind_label,
 )
@@ -1899,9 +1899,11 @@ class EndpointViewSet(
                     trigger_saved_query_schedule(saved_query)
                     raise
 
-            if saved_query.last_run_at:
+            # Freshness relative to the configured target: >1.0 means behind SLA.
+            # Absolute age is meaningless across endpoints with different frequencies.
+            if saved_query.last_run_at and version and version.data_freshness_seconds:
                 age_seconds = max((timezone.now() - saved_query.last_run_at).total_seconds(), 0.0)
-                ENDPOINT_MATERIALIZED_AGE_SECONDS.observe(age_seconds)
+                ENDPOINT_MATERIALIZED_FRESHNESS_RATIO.observe(age_seconds / version.data_freshness_seconds)
 
             return result
         except Exception as e:
@@ -2441,7 +2443,7 @@ class EndpointViewSet(
                     )
             execution_status = "success"
         except (ExposedHogQLError, ExposedCHQueryError) as e:
-            execution_status = "error"
+            execution_status = "user_error"
             error_label = getattr(e, "code_name", None) or type(e).__name__
             logger.exception(
                 "Endpoint execution failed",
@@ -2450,7 +2452,7 @@ class EndpointViewSet(
             )
             raise ValidationError("Query execution failed.", getattr(e, "code_name", None))
         except HogVMException:
-            execution_status = "error"
+            execution_status = "user_error"
             error_label = "HogVMException"
             logger.exception(
                 "Endpoint execution failed (HogVM)",
@@ -2458,7 +2460,7 @@ class EndpointViewSet(
             )
             raise ValidationError("Query execution failed: HogQL virtual machine error")
         except ResolutionError:
-            execution_status = "error"
+            execution_status = "user_error"
             error_label = "ResolutionError"
             logger.exception(
                 "Endpoint resolution failed",
@@ -2466,7 +2468,7 @@ class EndpointViewSet(
             )
             raise ValidationError("Query resolution failed: unable to resolve table or field references.")
         except ConcurrencyLimitExceeded:
-            ENDPOINT_CONCURRENCY_REJECTED_TOTAL.inc()
+            ENDPOINT_CONCURRENCY_REJECTED_TOTAL.labels(team_id=str(self.team_id)).inc()
             raise Throttled(detail="Too many concurrent requests. Please try again later.")
         except Exception as e:
             execution_status = "error"
@@ -2481,7 +2483,7 @@ class EndpointViewSet(
                 ENDPOINT_EXECUTION_TOTAL.labels(
                     execution_type=execution_type, query_kind=query_kind_metric, status=execution_status
                 ).inc()
-            if execution_status == "error":
+            if execution_status in ("error", "user_error"):
                 log_endpoint_execution(
                     team_id=self.team_id,
                     endpoint_id=str(endpoint.id),

--- a/products/endpoints/backend/metrics.py
+++ b/products/endpoints/backend/metrics.py
@@ -9,7 +9,8 @@ def query_kind_label(query: dict | None) -> str:
 
 ENDPOINT_EXECUTION_TOTAL = Counter(
     "posthog_endpoint_execution_total",
-    "Endpoint executions that reached query execution (excludes concurrency rejections; see posthog_endpoint_concurrency_rejected_total)",
+    "Endpoint executions that reached query execution (excludes concurrency rejections; see posthog_endpoint_concurrency_rejected_total). "
+    "status is success, user_error (invalid query/variables in the user's endpoint, returned as 4xx), or error (unexpected system failure)",
     labelnames=["execution_type", "query_kind", "status"],
 )
 
@@ -40,6 +41,7 @@ ENDPOINT_RATE_LIMITED_TOTAL = Counter(
 ENDPOINT_CONCURRENCY_REJECTED_TOTAL = Counter(
     "posthog_endpoint_concurrency_rejected_total",
     "Endpoint executions rejected because the concurrency limit was exceeded",
+    labelnames=["team_id"],
 )
 
 ENDPOINT_CACHE_RESULT_TOTAL = Counter(
@@ -61,8 +63,8 @@ ENDPOINT_VALIDATION_ERROR_TOTAL = Counter(
     labelnames=["reason"],
 )
 
-ENDPOINT_MATERIALIZED_AGE_SECONDS = Histogram(
-    "posthog_endpoint_materialized_age_seconds",
-    "Age of the materialized data served, observed when a materialized table is used",
-    buckets=(60, 300, 1800, 3600, 21600, 43200, 86400, 172800, 259200, 604800, 2592000, float("inf")),
+ENDPOINT_MATERIALIZED_FRESHNESS_RATIO = Histogram(
+    "posthog_endpoint_materialized_freshness_ratio",
+    "Age of the served materialized data relative to its data_freshness_seconds target; >1.0 means behind SLA",
+    buckets=(0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 2, 5, 10, float("inf")),
 )


### PR DESCRIPTION
## Problem

The Endpoints on-call alerts fire repeatedly without a real incident behind them:

- `posthog_endpoint_execution_total{status="error"}` lumps customers' broken queries (unknown warehouse tables, unresolvable fields, bad variables — all returned as 4xx) together with genuine system failures. Sustained bursts of user-caused errors from a handful of endpoints push the global error rate over the alert thresholds.
- `posthog_endpoint_materialized_age_seconds` tracks absolute age, which is meaningless across endpoints with different freshness targets: an endpoint refreshing daily legitimately serves ~23h-old data and sits just under the 24h staleness threshold all day, while a single old-but-within-target weekly endpoint blows the p95 into the top histogram bucket and pages.
- `posthog_endpoint_concurrency_rejected_total` has no `team_id`, so triaging a rejection spike requires a ClickHouse query-log dive instead of one PromQL `topk`.

## Changes

- Execution status is now `success` / `user_error` / `error`: `ExposedHogQLError`, `ExposedCHQueryError`, `HogVMException`, and `ResolutionError` (the 4xx paths) report `user_error`; only unexpected exceptions report `error`. Customer-facing execution logs still record both as failed runs.
- Replaced the absolute-age histogram with `posthog_endpoint_materialized_freshness_ratio` (age ÷ `data_freshness_seconds`), so >1.0 uniformly means "behind its configured freshness target" regardless of cadence.
- Added a `team_id` label to the concurrency-rejection counter.

Companion alert changes (thresholds moved to the ratio metric, error-rate alerts scoped to `status="error"`) ship separately in the internal alert config. The staleness alerts go dormant for the short window between this deploy and the alert config switch, since the old metric stops being emitted.

## How did you test this code?

I'm an agent; no manual testing. Automated: full `products/endpoints/backend/tests/` suite passes locally (580 tests), plus `ruff check`/`ruff format`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: investigated the firing alerts against production metrics and logs (Grafana/Loki MCP), confirmed the dominant error volume was customer-side 4xx query errors rather than system failures, and confirmed the staleness firings were artifacts of absolute-age bucketing. The freshness-ratio metric mirrors the version already drafted inside #62705; it's extracted here so the alert fix doesn't wait on the larger refactor.
