### PR TITLE
fix(llma): don't wrap non-insight queries in InsightVizNode for notebooks

### DIFF
--- a/ee/hogai/tools/create_notebook/helpers.py
+++ b/ee/hogai/tools/create_notebook/helpers.py
@@ -13,6 +13,20 @@ from ee.hogai.tools.create_notebook.parsing import parse_notebook_content_for_st
 from ee.hogai.tools.create_notebook.tiptap import blocks_to_tiptap_doc
 from ee.hogai.utils.types.base import AssistantMessageUnion
 
+# InsightVizNode is only a valid container for product-analytics insight kinds. Any other
+# source (e.g. TracesQuery, TraceQuery) wrapped in it crashes the insight scene with
+# "encountered unexpected type for view". Mirrors `nodeKindToInsightType` on the frontend.
+INSIGHT_VIZ_NODE_SOURCE_KINDS = frozenset(
+    {
+        "TrendsQuery",
+        "FunnelsQuery",
+        "RetentionQuery",
+        "PathsQuery",
+        "StickinessQuery",
+        "LifecycleQuery",
+    }
+)
+
 
 class ArtifactStatus(Enum):
     CREATED = "created"
@@ -84,8 +98,13 @@ async def save_notebook_to_db(
                 notebook_query = query
             elif kind == "HogQLQuery" or "HogQL" in kind:
                 notebook_query = {"kind": "DataVisualizationNode", "source": query}
-            else:
+            elif kind in INSIGHT_VIZ_NODE_SOURCE_KINDS:
                 notebook_query = {"kind": "InsightVizNode", "source": query}
+            else:
+                # Non-insight data sources (e.g. TracesQuery, TraceQuery) render as a table,
+                # the same as the AI observability product. Wrapping them in InsightVizNode
+                # produces a link that crashes the insight scene.
+                notebook_query = {"kind": "DataTableNode", "source": query}
             viz_lookup[ref_id] = {"query": notebook_query, "name": result.content.name}
 
     def resolve_visualization(artifact_id: str) -> dict | None:

--- a/ee/hogai/tools/create_notebook/test/test_helpers.py
+++ b/ee/hogai/tools/create_notebook/test/test_helpers.py
@@ -99,6 +99,22 @@ class TestSaveNotebookToDb(BaseTest):
                 "InsightVizNode",
                 "TrendsQuery",
             ),
+            (
+                "traces_query_wrapped_in_data_table_node",
+                "vtrc",
+                "ntrc",
+                {"kind": "TracesQuery", "limit": 50, "offset": 0, "properties": []},
+                "DataTableNode",
+                "TracesQuery",
+            ),
+            (
+                "trace_query_wrapped_in_data_table_node",
+                "vtrq",
+                "ntrq",
+                {"kind": "TraceQuery", "traceId": "abc123", "properties": []},
+                "DataTableNode",
+                "TraceQuery",
+            ),
         ]
     )
     def test_save_notebook_to_db_wraps_query_correctly(


### PR DESCRIPTION
## Problem

When PostHog AI (Max) investigates AI/LLM observability, its `search_traces` tool produces a `TracesQuery` (and single-trace investigations a `TraceQuery`). When that result is embedded into a notebook/chart artifact, `save_notebook_to_db` wraps the query for the embed's "open in new tab" link.

The catch-all branch wrapped **anything** that wasn't a SQL node in an `InsightVizNode`. But `InsightVizNode` is only a valid container for the six product-analytics insight kinds (Trends, Funnels, Retention, Paths, Stickiness, Lifecycle). A `TracesQuery`/`TraceQuery` wrapped in it produces a link to `/insights/new#q={InsightVizNode → TracesQuery}` that crashes the insight scene with `encountered unexpected type for view`.

This is the same bug class as #57815, which only added a passthrough for the `DataVisualizationNode → HogQLQuery` shape and left the catch-all wrapping (which still hits `TracesQuery`/`TraceQuery`) in place. It is the backend producer of the white screen that #63188 guards against on the frontend; this fix stops the malformed link from being generated in the first place.

## Changes

In `save_notebook_to_db`, only wrap a query in `InsightVizNode` when its kind is one of the product-analytics insight kinds. Other data sources (`TracesQuery`, `TraceQuery`, etc.) are wrapped in a `DataTableNode`, which is how the AI observability product itself renders them. The existing `DataVisualizationNode` passthrough and `HogQLQuery → DataVisualizationNode` behavior are unchanged.

Extends the parameterized test in `test_helpers.py` with `TracesQuery` and `TraceQuery` cases asserting they resolve to a `DataTableNode`.

## How did you test this code?

I'm the PostHog Slack app (agent), working agent-assisted. Automated only — no manual testing:

- Extended the parameterized `save_notebook_to_db` test with `TracesQuery` and `TraceQuery` cases (assert `DataTableNode`). The DB-backed test suite couldn't run in my sandbox (no Postgres), so it will be exercised in CI.
- Verified the wrapping logic in isolation against the real `posthog.schema` Pydantic models: `TracesQuery`/`TraceQuery → DataTableNode`, and the three pre-existing cases (`TrendsQuery → InsightVizNode`, `HogQLQuery → DataVisualizationNode`, `DataVisualizationNode` passthrough) are unchanged.
- `ruff check` / `ruff format` clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigation started from a Slack thread asking how users reach `/insights/new` with an `InsightVizNode` wrapping a `TracesQuery`. Using the PostHog error-tracking MCP, I pulled the live `$current_url`s for the tracked issue and found four malformed shapes — all freshly-constructed `/insights/new#q=` draft links (never saved insights), spanning many unrelated projects, which pointed at programmatic/AI link generation rather than user input or saved data.
- Traced the producer to Max's notebook artifact path: `search_traces` builds a `TracesQuery`, and `save_notebook_to_db`'s catch-all `else` wrapped it in `InsightVizNode`. Confirmed #57815 fixed the sibling `DataVisualizationNode → HogQLQuery` shape but left this branch.
- Chose `DataTableNode` for non-insight sources (matches AI observability's own rendering) over softening the InsightVizNode assertion, since `InsightVizNode` genuinely shouldn't contain these kinds.
- Tools: PostHog MCP (error tracking), repo exploration agents.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1781256556255469?thread_ts=1781256556.255469&cid=C0368RPHLQH)*
