### PR TITLE
fix(dev): register seaweedfs s3 identities so presigned post uploads work

### DIFF
--- a/devenv/news.txt
+++ b/devenv/news.txt
@@ -1,3 +1,6 @@
+2026-06-12
+objectstorage seaweedfs now registers dev S3 identities at startup (fixes presigned POST / symbol set upload); recreate the container to pick it up: docker compose -f docker-compose.dev.yml up -d objectstorage
+
 2026-06-08
 objectstorage swapped minio -> seaweedfs; old local files stay on the old volume, run hogli deploy:upgrade-objectstorage to copy them over
 

--- a/devenv/news.txt
+++ b/devenv/news.txt
@@ -1,6 +1,3 @@
-2026-06-12
-objectstorage now registers s3 identities at boot, fixing symbol set upload; recreate the container to apply
-
 2026-06-08
 objectstorage swapped minio -> seaweedfs; old local files stay on the old volume, run hogli deploy:upgrade-objectstorage to copy them over
 

--- a/devenv/news.txt
+++ b/devenv/news.txt
@@ -1,5 +1,5 @@
 2026-06-12
-objectstorage seaweedfs now registers dev S3 identities at startup (fixes presigned POST / symbol set upload); recreate the container to pick it up: docker compose -f docker-compose.dev.yml up -d objectstorage
+objectstorage now registers s3 identities at boot, fixing symbol set upload; recreate the container to apply
 
 2026-06-08
 objectstorage swapped minio -> seaweedfs; old local files stay on the old volume, run hogli deploy:upgrade-objectstorage to copy them over

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -256,21 +256,26 @@ services:
         entrypoint:
             - /bin/sh
             - -c
-            # Background a create-and-verify loop and exec weed as PID 1 so SIGTERM
+            # Background a setup-and-verify loop and exec weed as PID 1 so SIGTERM
             # reaches it directly. `weed shell` exits 0 as long as the master is
             # reachable, even if individual commands fail (e.g. while the filer is still
-            # coming up), so we run configure+create+list in one session and only touch
-            # the sentinel once the output reports every required bucket and identity.
+            # coming up), and setup output can't be grepped for success markers anyway:
+            # the identity is also named `posthog`, so its configure echo would shadow
+            # the `posthog` bucket check. The sentinel is therefore only touched once
+            # read-only `s3.bucket.list` / `s3.configure` sessions report every required
+            # bucket and identity from actual persisted state.
             - |
                 (
                     while true; do
-                        OUT=$$(printf 's3.configure -access_key=object_storage_root_user -secret_key=object_storage_root_password -user=posthog -actions=Admin -apply\ns3.configure -user=anonymous -actions=Admin -apply\ns3.bucket.create -name posthog\ns3.bucket.create -name ducklake-dev\ns3.bucket.create -name ai-blobs\ns3.bucket.list\n' \
-                                | /usr/bin/weed shell -master=localhost:19001 2>&1 || true)
-                        if echo "$$OUT" | grep -q object_storage_root_user \
-                                && echo "$$OUT" | grep -q anonymous \
-                                && echo "$$OUT" | grep -q posthog \
-                                && echo "$$OUT" | grep -q ducklake-dev \
-                                && echo "$$OUT" | grep -q ai-blobs; then
+                        printf 's3.configure -access_key=object_storage_root_user -secret_key=object_storage_root_password -user=posthog -actions=Admin -apply\ns3.configure -user=anonymous -actions=Admin -apply\ns3.bucket.create -name posthog\ns3.bucket.create -name ducklake-dev\ns3.bucket.create -name ai-blobs\n' \
+                                | /usr/bin/weed shell -master=localhost:19001 >/dev/null 2>&1 || true
+                        BUCKETS=$$(echo 's3.bucket.list' | /usr/bin/weed shell -master=localhost:19001 2>/dev/null || true)
+                        IDENTITIES=$$(echo 's3.configure' | /usr/bin/weed shell -master=localhost:19001 2>/dev/null || true)
+                        if echo "$$BUCKETS" | grep -q posthog \
+                                && echo "$$BUCKETS" | grep -q ducklake-dev \
+                                && echo "$$BUCKETS" | grep -q ai-blobs \
+                                && echo "$$IDENTITIES" | grep -q object_storage_root_user \
+                                && echo "$$IDENTITIES" | grep -q anonymous; then
                             touch /tmp/objectstorage-ready
                             echo "Objectstorage SeaweedFS ready with required buckets and identities"
                             break

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -238,11 +238,16 @@ services:
 
     objectstorage:
         # SeaweedFS, S3-compatible object storage on objectstorage:19000.
-        # Run in default open-access mode (no -s3.config) so every credential pair our
-        # test/CI/dev code uses just works — including object_storage_root_user and
-        # any/any. Identity-based auth (-s3.config) was tried first but triggers known
-        # SeaweedFS SigV4 signature failures and presigned-URL regressions; see
-        # seaweedfs/seaweedfs #6635 and discussion #3976.
+        # No static -s3.config (it triggers known SeaweedFS SigV4 signature failures and
+        # presigned-URL regressions; see seaweedfs/seaweedfs #6635 and discussion #3976),
+        # but pure open-access mode doesn't work either: the POST-policy handler always
+        # looks the access key up in the identity store (no open-access bypass, also on
+        # master), so presigned POST uploads — error tracking symbol sets via posthog-cli —
+        # fail with InvalidAccessKeyId when no identities exist. The bootstrap loop below
+        # therefore registers the canonical dev credentials at runtime via `s3.configure`
+        # (which doesn't hit the static-config regressions), plus an `anonymous` identity
+        # so unsigned clients keep working. Signed requests with any other access key are
+        # rejected — everything in this repo uses object_storage_root_user against :19000.
         # Pin >= 4.05: that's the first release that persists Content-Encoding metadata
         # (4.03/4.04 silently drop it, breaking gzipped objects that rely on the header
         # round-tripping). 4.29 is the newest release that's been out at least two weeks.
@@ -253,19 +258,21 @@ services:
             - -c
             # Background a create-and-verify loop and exec weed as PID 1 so SIGTERM
             # reaches it directly. `weed shell` exits 0 as long as the master is
-            # reachable, even if individual `s3.bucket.create` commands fail (e.g. while
-            # the filer is still coming up), so we run create+list in one session and
-            # only touch the sentinel once `s3.bucket.list` reports every required bucket.
+            # reachable, even if individual commands fail (e.g. while the filer is still
+            # coming up), so we run configure+create+list in one session and only touch
+            # the sentinel once the output reports every required bucket and identity.
             - |
                 (
                     while true; do
-                        OUT=$$(printf 's3.bucket.create -name posthog\ns3.bucket.create -name ducklake-dev\ns3.bucket.create -name ai-blobs\ns3.bucket.list\n' \
+                        OUT=$$(printf 's3.configure -access_key=object_storage_root_user -secret_key=object_storage_root_password -user=posthog -actions=Admin -apply\ns3.configure -user=anonymous -actions=Admin -apply\ns3.bucket.create -name posthog\ns3.bucket.create -name ducklake-dev\ns3.bucket.create -name ai-blobs\ns3.bucket.list\n' \
                                 | /usr/bin/weed shell -master=localhost:19001 2>&1 || true)
-                        if echo "$$OUT" | grep -q posthog \
+                        if echo "$$OUT" | grep -q object_storage_root_user \
+                                && echo "$$OUT" | grep -q anonymous \
+                                && echo "$$OUT" | grep -q posthog \
                                 && echo "$$OUT" | grep -q ducklake-dev \
                                 && echo "$$OUT" | grep -q ai-blobs; then
                             touch /tmp/objectstorage-ready
-                            echo "Objectstorage SeaweedFS ready with required buckets"
+                            echo "Objectstorage SeaweedFS ready with required buckets and identities"
                             break
                         fi
                         sleep 1

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -65,12 +65,14 @@ services:
             - |
                 (
                     while true; do
-                        OUT=$$(printf 's3.configure -access_key=object_storage_root_user -secret_key=object_storage_root_password -user=posthog -actions=Admin -apply\ns3.configure -user=anonymous -actions=Admin -apply\ns3.bucket.create -name capture\ns3.bucket.create -name posthog\ns3.bucket.list\n' \
-                                | /usr/bin/weed shell -master=localhost:19001 2>&1 || true)
-                        if echo "$$OUT" | grep -q object_storage_root_user \
-                                && echo "$$OUT" | grep -q anonymous \
-                                && echo "$$OUT" | grep -q capture \
-                                && echo "$$OUT" | grep -q posthog; then
+                        printf 's3.configure -access_key=object_storage_root_user -secret_key=object_storage_root_password -user=posthog -actions=Admin -apply\ns3.configure -user=anonymous -actions=Admin -apply\ns3.bucket.create -name capture\ns3.bucket.create -name posthog\n' \
+                                | /usr/bin/weed shell -master=localhost:19001 >/dev/null 2>&1 || true
+                        BUCKETS=$$(echo 's3.bucket.list' | /usr/bin/weed shell -master=localhost:19001 2>/dev/null || true)
+                        IDENTITIES=$$(echo 's3.configure' | /usr/bin/weed shell -master=localhost:19001 2>/dev/null || true)
+                        if echo "$$BUCKETS" | grep -q capture \
+                                && echo "$$BUCKETS" | grep -q posthog \
+                                && echo "$$IDENTITIES" | grep -q object_storage_root_user \
+                                && echo "$$IDENTITIES" | grep -q anonymous; then
                             touch /tmp/objectstorage-ready
                             echo "Objectstorage SeaweedFS ready with required buckets and identities"
                             break

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -50,9 +50,10 @@ services:
 
     objectstorage:
         # SeaweedFS, S3-compatible object storage on objectstorage:19000.
-        # Open-access mode (no -s3.config) so any credential pair our code uses just works.
-        # See docker-compose.base.yml `objectstorage` for full rationale (incl. the >= 4.05
-        # Content-Encoding pin).
+        # The bootstrap loop registers the canonical dev credentials plus an anonymous
+        # identity — SeaweedFS's POST-policy handler rejects presigned POST uploads when
+        # no identities exist. See docker-compose.base.yml `objectstorage` for full
+        # rationale (incl. the >= 4.05 Content-Encoding pin).
         image: chrislusf/seaweedfs:4.29
         restart: on-failure
         ports:
@@ -64,12 +65,14 @@ services:
             - |
                 (
                     while true; do
-                        OUT=$$(printf 's3.bucket.create -name capture\ns3.bucket.create -name posthog\ns3.bucket.list\n' \
+                        OUT=$$(printf 's3.configure -access_key=object_storage_root_user -secret_key=object_storage_root_password -user=posthog -actions=Admin -apply\ns3.configure -user=anonymous -actions=Admin -apply\ns3.bucket.create -name capture\ns3.bucket.create -name posthog\ns3.bucket.list\n' \
                                 | /usr/bin/weed shell -master=localhost:19001 2>&1 || true)
-                        if echo "$$OUT" | grep -q capture \
+                        if echo "$$OUT" | grep -q object_storage_root_user \
+                                && echo "$$OUT" | grep -q anonymous \
+                                && echo "$$OUT" | grep -q capture \
                                 && echo "$$OUT" | grep -q posthog; then
                             touch /tmp/objectstorage-ready
-                            echo "Objectstorage SeaweedFS ready with required buckets"
+                            echo "Objectstorage SeaweedFS ready with required buckets and identities"
                             break
                         fi
                         sleep 1


### PR DESCRIPTION
## Problem

#60432 swapped the local `objectstorage` service from MinIO to SeaweedFS in open-access mode (no identities), on the basis that any credential pair would work. That holds for regular signed requests and presigned PUT/GET, but not for presigned POST: SeaweedFS's POST-policy handler (`PostPolicyBucketHandler` → `doesPolicySignatureV4Match`) unconditionally looks the access key up in the identity store, with no open-access bypass — still true on upstream master, so bumping the image can't fix it.

Error tracking symbol set uploads are generated as presigned POSTs (`get_presigned_post` in `posthog/storage/object_storage.py`), so `posthog-cli sourcemap upload` against local dev fails every chunk with 403 `InvalidAccessKeyId`.

## Changes

- The existing bucket-bootstrap loop in the `objectstorage` entrypoint (`docker-compose.base.yml` and `rust/docker-compose.yml`) now also registers S3 identities via `weed shell s3.configure`: the canonical `object_storage_root_user` pair (Admin) and an `anonymous` identity so unsigned clients keep working (e.g. DuckLake test configs with empty credentials).
- The readiness sentinel now waits for identities as well as buckets, so `bin/wait-for-docker` can't race the identity bootstrap.
- `devenv/news.txt` entry telling devs with a running stack to recreate the container.

Note the original open-access rationale was that static `-s3.config` identity auth triggers known SeaweedFS SigV4/presigned regressions (seaweedfs/seaweedfs#6635). Registering identities at runtime via `s3.configure` does not hit those — verified below.

**Behavior change — this is no longer open-access.** Two things tighten: signed requests with unregistered access keys are now rejected, and signatures for the canonical pair are now actually validated (previously a wrong secret would pass). A repo sweep found every consumer of `:19000` uses the canonical pair (the `any`/`any` pair only targets the replay-v2 SeaweedFS on `:8333`, untouched), and unsigned clients are covered by the `anonymous` identity. Hobby still runs MinIO and is unaffected. Because signature validation is now live, every S3 client implementation in the stack was tested explicitly — see below.

## How did you test this code?

Agent-verified (no automated tests added; this is dev-stack compose config). The container was recreated from the new compose and reported healthy only after the bootstrap registered buckets + identities; pre-existing volume data stayed readable. Then every S3 client implementation used against `:19000` was exercised:

| Client | Used by | Result |
| --- | --- | --- |
| boto3 (Python) | Django, Temporal, batch exports, Dagster | presigned POST 204 (previously the failing 403), presigned PUT/GET, gzip `Content-Encoding` round-trip, 6 MiB multipart upload — all pass |
| ClickHouse `s3()` | web analytics pre-aggregated tables | read + `INSERT INTO FUNCTION s3(...)` write pass |
| `@aws-sdk/client-s3` (Node) | plugin-server, session recording | PUT/GET/DELETE pass |
| DuckDB httpfs | DuckLake | passes with canonical creds and with empty creds (unsigned → `anonymous` identity) |
| `aws-sdk-s3` (Rust) | capture S3 sink, cymbal symbol store | `cargo test -p common-s3 --test integration_tests` — 6/6 pass, including `create_bucket` |
| unauthenticated HTTP | misc unsigned clients | PUT/GET pass via `anonymous` identity |

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: diagnosed a local symbol set upload failure by reproducing presigned PUT (works) vs presigned POST (403) against the dev SeaweedFS, confirmed in SeaweedFS source (4.29 and master) that the POST-policy path has no auth-disabled bypass, and surveyed all in-repo credential pairs targeting `:19000` before enabling identities. Considered and rejected: switching symbol sets to presigned PUT (breaks released CLI versions — protocol change) and waiting on an upstream fix (none exists). Runtime `s3.configure` was validated specifically because the PR that introduced SeaweedFS documented static `-s3.config` as regression-prone; since enabling identities turns on real signature validation, each S3 client implementation in the stack (boto3, ClickHouse, Node SDK, DuckDB, Rust SDK) was tested individually rather than assumed compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
