### PR TITLE
docs(onboarding): document React Native native crash autocapture

### DIFF
--- a/docs/onboarding/error-tracking/react-native.tsx
+++ b/docs/onboarding/error-tracking/react-native.tsx
@@ -64,7 +64,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                         {dedent`
                             \`nativeCrashes\` captures native iOS and Android crashes that the JavaScript layer can't see. Beyond the config above, it needs:
 
-                            1. The optional native plugin installed — \`npx expo install @posthog/react-native-plugin\` (Expo) or \`npm i @posthog/react-native-plugin\` (bare React Native). This is the same plugin that powers session replay (renamed from \`posthog-react-native-session-replay\` in 4.47.0+), so you may already have it. If it's missing, native capture is a no-op and your JS-level autocapture is unaffected.
+                            1. The optional native plugin installed — \`npx expo install @posthog/react-native-plugin\` (Expo) or \`npm i @posthog/react-native-plugin\` (bare React Native). If it's missing, native capture is a no-op and your JS-level autocapture is unaffected.
                             2. Your project's **Enable exception autocapture** setting enabled in [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture) — the same server-side setting that gates JavaScript autocapture.
                             3. Native debug symbols uploaded at build time, so crash stack traces are readable. See [native crash symbolication](https://posthog.com/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication).
                         `}

--- a/docs/onboarding/error-tracking/react-native.tsx
+++ b/docs/onboarding/error-tracking/react-native.tsx
@@ -39,6 +39,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                     uncaughtExceptions: true,
                                     unhandledRejections: true,
                                     console: ['error', 'warn'],
+                                    nativeCrashes: true, // native iOS/Android crashes (see below)
                                   },
                                 },
                               })
@@ -55,8 +56,20 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                         | \`uncaughtExceptions\` | Captures Uncaught exceptions (\`ReactNativeGlobal.ErrorUtils.setGlobalHandler\`) |
                         | \`unhandledRejections\` | Captures Unhandled rejections (\`ReactNativeGlobal.onunhandledrejection\`) |
                         | \`console\` | Captures console logs as errors according to the reported \`LogLevel\` |
+                        | \`nativeCrashes\` | Captures native iOS/Android crashes. Requires \`@posthog/react-native-plugin\` and uploaded native symbols (see below) |
                     `}
                 </Markdown>
+                <CalloutBox type="fyi" title="Capturing native crashes">
+                    <Markdown>
+                        {dedent`
+                            \`nativeCrashes\` captures native iOS and Android crashes that the JavaScript layer can't see. Beyond the config above, it needs:
+
+                            1. The optional native plugin installed — \`npx expo install @posthog/react-native-plugin\` (Expo) or \`npm i @posthog/react-native-plugin\` (bare React Native). This is the same plugin that powers session replay (renamed from \`posthog-react-native-session-replay\` in 4.47.0+), so you may already have it. If it's missing, native capture is a no-op and your JS-level autocapture is unaffected.
+                            2. Your project's **Enable exception autocapture** setting enabled in [error tracking settings](https://app.posthog.com/settings/project-error-tracking#exception-autocapture) — the same server-side setting that gates JavaScript autocapture.
+                            3. Native debug symbols uploaded at build time, so crash stack traces are readable. See [native crash symbolication](https://posthog.com/docs/error-tracking/upload-source-maps/react-native#native-crash-symbolication).
+                        `}
+                    </Markdown>
+                </CalloutBox>
             </>
         ),
     }
@@ -181,10 +194,9 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                 {dedent`
                     We currently don't support the following features:
 
-                    - No native Android and iOS exception capture
                     - No automatic source map uploads on React Native web
 
-                    These features will be added in future releases. We recommend you stay up to date with the latest version of the PostHog React Native SDK.
+                    This will be added in a future release. We recommend you stay up to date with the latest version of the PostHog React Native SDK.
                 `}
             </Markdown>
         ),

--- a/docs/onboarding/session-replay/react-native.tsx
+++ b/docs/onboarding/session-replay/react-native.tsx
@@ -21,14 +21,14 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Expo',
                                 code: dedent`
-                                    npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization posthog-react-native-session-replay
+                                    npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization @posthog/react-native-plugin
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'yarn',
                                 code: dedent`
-                                    yarn add posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize posthog-react-native-session-replay
+                                    yarn add posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize @posthog/react-native-plugin
 
                                     # for iOS
                                     cd ios && pod install
@@ -38,7 +38,7 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'npm',
                                 code: dedent`
-                                    npm i -s posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize posthog-react-native-session-replay
+                                    npm i -s posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize @posthog/react-native-plugin
 
                                     # for iOS
                                     cd ios && pod install
@@ -46,6 +46,13 @@ export const getReactNativeSteps = (ctx: OnboardingComponentsContext): StepDefin
                             },
                         ]}
                     />
+                    <CalloutBox type="fyi" title="Plugin renamed in 4.47.0+">
+                        <Markdown>
+                            {dedent`
+                                \`@posthog/react-native-plugin\` (\`>= 2.0.1\`) is the renamed \`posthog-react-native-session-replay\` plugin — it was renamed in \`posthog-react-native\` 4.47.0+ and now also powers [native error tracking](https://posthog.com/docs/error-tracking/installation/react-native). If you're on a \`posthog-react-native\` version earlier than 4.47.0, install \`posthog-react-native-session-replay\` instead.
+                            `}
+                        </Markdown>
+                    </CalloutBox>
                     <CalloutBox type="fyi" title="SDK version">
                         <Markdown>
                             Session replay requires PostHog React Native SDK version 3.2.0 or higher. We recommend


### PR DESCRIPTION
## Problem

React Native error tracking onboarding didn't cover native iOS/Android crashes, and the session replay install still referenced `posthog-react-native-session-replay` (now renamed to `@posthog/react-native-plugin`).

## Changes

- **Error tracking** (`docs/onboarding/error-tracking/react-native.tsx`): document `errorTracking.autocapture.nativeCrashes` in the "Set up exception autocapture" step (config, options-table row, native-setup callout); drop the stale "no native capture" item from "Future features".
- **Session replay** (`docs/onboarding/session-replay/react-native.tsx`): install `@posthog/react-native-plugin` (`>= 2.0.1`) instead of the legacy package, with a callout explaining the rename and a fallback for `posthog-react-native < 4.47.0`.

> [!NOTE]
> Targets `posthog-react-native` 4.47.0+ / `@posthog/react-native-plugin >= 2.0.1` (not yet released) — should land alongside that release.

## How did you test this code?

Agent (Claude Code); docs-only onboarding `.tsx`, no automated tests run. Verified the error tracking onboarding renders via posthog.com locally (`GATSBY_POSTHOG_BRANCH` on this branch → page returned 200). Versions confirmed against the `posthog-js` feature branch `package.json`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @ioannisj (DRI).

Drafted with Claude Code. Merged `nativeCrashes` into the existing autocapture step (vs a separate step) per review; framed the plugin change as a rename with a legacy fallback. Agent-authored — requires human review.
