### PR TITLE
feat(quill-charts): add bars.valuePadding to reserve value-axis headroom

### DIFF
--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -87,6 +87,7 @@ function BarChartInner<Meta = unknown>({
         minBandSize,
         fitToHeight = false,
         valueDomain,
+        valuePadding,
         roundStackEnds = false,
         fillStyle: barFillStyle = 'flat',
     } = config?.bars ?? {}
@@ -173,6 +174,7 @@ function BarChartInner<Meta = unknown>({
                 fitToHeight,
                 minBandSize: resolvedMinBandSize,
                 valueDomain,
+                valuePadding,
             })
 
             const tickAxisLength = isHorizontal ? dimensions.plotWidth : dimensions.plotHeight
@@ -255,6 +257,7 @@ function BarChartInner<Meta = unknown>({
             fitToHeight,
             resolvedMinBandSize,
             valueDomain,
+            valuePadding,
         ]
     )
 

--- a/packages/quill/packages/charts/src/core/bar-scales.test.ts
+++ b/packages/quill/packages/charts/src/core/bar-scales.test.ts
@@ -181,6 +181,50 @@ describe('hog-charts bar scales', () => {
         })
     })
 
+    describe('createBarScales — valuePadding (headroom past the bars)', () => {
+        const plotBottom = dimensions.plotTop + dimensions.plotHeight
+        const plotRight = dimensions.plotLeft + dimensions.plotWidth
+
+        it('holds back the requested px at the value-axis data end (vertical), baseline pinned', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 50, 100] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, { valuePadding: 40 })
+            // nice([0,100]) stays [0,100], so the data max lands exactly `padding` px below the top edge.
+            expect(value(100)).toBeCloseTo(dimensions.plotTop + 40)
+            expect(value(0)).toBeCloseTo(plotBottom)
+        })
+
+        it('holds back the requested px at the value-axis data end (horizontal)', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 50, 100] })]
+            const { value } = createBarScales(series, ['a', 'b', 'c'], dimensions, {
+                axisOrientation: 'horizontal',
+                valuePadding: 60,
+            })
+            expect(value(100)).toBeCloseTo(plotRight - 60)
+            expect(value(0)).toBeCloseTo(dimensions.plotLeft)
+        })
+
+        it('reserves at the negative extent end for all-negative data', () => {
+            const series = [makeSeries({ key: 's1', data: [-50, -100] })]
+            const { value } = createBarScales(series, ['a', 'b'], dimensions, { valuePadding: 40 })
+            // Bars grow down to -100, which lands `padding` px above the bottom edge; zero stays at top.
+            expect(value(-100)).toBeCloseTo(plotBottom - 40)
+            expect(value(0)).toBeCloseTo(dimensions.plotTop)
+        })
+
+        it('leaves the axis untouched when padding is 0 / omitted', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 50, 100] })]
+            const withPadding = createBarScales(series, ['a', 'b', 'c'], dimensions, { valuePadding: 0 })
+            const without = createBarScales(series, ['a', 'b', 'c'], dimensions)
+            expect(withPadding.value(100)).toBeCloseTo(without.value(100))
+        })
+
+        it('caps the reserve at a third of the axis so it never swallows the plot', () => {
+            const series = [makeSeries({ key: 's1', data: [0, 100] })]
+            const { value } = createBarScales(series, ['a', 'b'], dimensions, { valuePadding: 100_000 })
+            expect(value(100)).toBeCloseTo(dimensions.plotTop + dimensions.plotHeight / 3)
+        })
+    })
+
     describe('createBarScales — valueDomain [min, max] (fixed)', () => {
         it.each([
             ['pins the domain regardless of data and skips nice()', undefined, [0, 40] as [number, number]],

--- a/packages/quill/packages/charts/src/core/scales.ts
+++ b/packages/quill/packages/charts/src/core/scales.ts
@@ -441,6 +441,8 @@ export function createBarScales(
         minBandSize?: number
         /** Fixed `[min, max]` or `{ include }` extra values the value axis must cover. */
         valueDomain?: ValueDomain
+        /** Px reserved past the bars at the value-axis data end(s) — see {@link BarsConfig.valuePadding}. */
+        valuePadding?: number
     } = {}
 ): BarScaleSet {
     const {
@@ -454,6 +456,7 @@ export function createBarScales(
         fitToHeight,
         minBandSize,
         valueDomain,
+        valuePadding = 0,
     } = options
 
     const isHorizontal = axisOrientation === 'horizontal'
@@ -514,7 +517,8 @@ export function createBarScales(
                 'grouped',
                 scaleType,
                 undefined,
-                axisIndex === 0 ? valueDomain : undefined
+                axisIndex === 0 ? valueDomain : undefined,
+                valuePadding
             )
             yAxes[axisId] = { scale, position }
         })
@@ -531,7 +535,8 @@ export function createBarScales(
             barLayout,
             scaleType,
             valueStackedSeries,
-            valueDomain
+            valueDomain,
+            valuePadding
         ),
         group,
     }
@@ -544,7 +549,8 @@ function buildBarValueScale(
     barLayout: 'stacked' | 'grouped' | 'percent',
     scaleType: 'linear' | 'log',
     stackedSeries: Series[] | undefined,
-    valueDomain: ValueDomain | undefined
+    valueDomain: ValueDomain | undefined,
+    valuePadding: number
 ): D3YScale {
     const { fixed, include } = resolveValueDomain(valueDomain)
     if (fixed) {
@@ -568,7 +574,26 @@ function buildBarValueScale(
     if (min === max) {
         max = min + 1
     }
-    return scaleLinear().domain([min, max]).nice(tickCount).range(valueRange)
+    const scale = scaleLinear().domain([min, max]).nice(tickCount)
+    return scale.range(padValueRange(valueRange, scale.domain() as [number, number], valuePadding))
+}
+
+// Hold back `paddingPx` of the value axis's pixel range at the data-extent end(s), so the bars stop
+// short of the edge and an overlay (e.g. a value label) has room beyond the bar tip. Reserving range
+// rather than extending the domain keeps the gap exactly `paddingPx` regardless of the data scale.
+// Only the end(s) the bars actually reach are padded — the zero baseline stays pinned to the edge.
+function padValueRange(
+    [start, end]: [number, number],
+    [min, max]: [number, number],
+    paddingPx: number
+): [number, number] {
+    const span = Math.abs(end - start)
+    if (paddingPx <= 0 || span === 0) {
+        return [start, end]
+    }
+    // Cap each reserved end at a third of the axis so padding can't swallow the plot.
+    const reserve = Math.min(paddingPx, span / 3) * Math.sign(start - end || 1)
+    return [min < 0 ? start - reserve : start, max > 0 ? end + reserve : end]
 }
 
 export function autoFormatYTick(value: number, domainMax: number): string {

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -276,6 +276,11 @@ export interface BarsConfig {
     fitToHeight?: boolean
     /** Value-axis domain control — omit for data-derived auto-scaling. See {@link ValueDomain}. */
     valueDomain?: ValueDomain
+    /** Px of headroom reserved past the bars at the value-axis data end(s), so overlays have room
+     *  beyond the bar tip — e.g. a `ValueLabels` overlay can float beside/above each bar instead of
+     *  being flipped onto it (an on-bar label looks like the bar grows when it lifts on hover). The
+     *  axis range converts px → value units, so the gap stays visually constant. Defaults to 0. */
+    valuePadding?: number
     /** Stacked layouts only — round both *outer* ends of the whole stack so it reads as one pill,
      *  rather than only the topmost segment's cap. Implemented by clipping the bar layer to a
      *  rounded rect spanning each band's full extent and drawing the segments square, so the outer


### PR DESCRIPTION
## Problem

Bar charts render bars flush against the end of the value axis, leaving no room for overlays like value labels past the bar tip. Survey question charts (#61828) need guaranteed headroom so value labels don't clip.

## Changes

Adds a `bars.valuePadding` option to quill-charts: a pixel amount of the value-axis range held back at the data-extent end(s), so bars stop short of the plot edge. Padding is applied to the range rather than the domain, keeping the reserved gap exactly `valuePadding` px regardless of data scale. The zero baseline stays pinned. Split out of #61828 so the library change can be reviewed and merged independently; that PR now stacks on this branch.

## How did you test this code?

I'm an agent. Automated tests only: `bar-scales.test.ts` (43 tests, includes new `valuePadding` coverage) via the frontend jest project, plus a `tsc --noEmit` pass of the quill-charts package.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session: rebased #61828 onto master (resolved conflicts in `core/scales.ts` against the multi-axis and fit-to-height refactors that landed on master since the branch was cut) and extracted the single `packages/quill` commit into this standalone PR per the author's request. The multi-axis `buildBarValueScale` call site added on master now also receives `valuePadding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
