### PR TITLE
chore(data-warehouse): merge duplicate snowflake non-retryable test classes

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -479,22 +479,6 @@ class TestGetRowsToSync:
 # ---------------------------------------------------------------------------
 
 
-class TestSnowflakeSourceNonRetryableErrors:
-    @pytest.mark.parametrize(
-        "error_msg",
-        [
-            "Duo Security authentication is denied",
-            # The real shape from production: codes + host vary, but the Duo substring is stable.
-            "250001 (08001): None: Failed to connect to DB: wv65496-re80354.snowflakecomputing.com:443. "
-            "Duo Security authentication is denied.",
-        ],
-    )
-    def test_duo_security_denied_is_non_retryable(self, error_msg):
-        non_retryable = SnowflakeSource().get_non_retryable_errors()
-        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
-        assert is_non_retryable
-
-
 class TestBuildPipeline:
     def test_builds_source_response_and_streams(self, impl):
         # Two separate cursors: one for metadata pass, one for streaming.
@@ -576,6 +560,20 @@ class TestSnowflakeSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Disabled-user error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Duo Security authentication is denied",
+            # The real shape from production: codes + host vary, but the Duo substring is stable.
+            "250001 (08001): None: Failed to connect to DB: wv65496-re80354.snowflakecomputing.com:443. "
+            "Duo Security authentication is denied.",
+        ],
+    )
+    def test_duo_security_denied_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Duo-denied error should be non-retryable: {error_msg}"
 
     @pytest.mark.parametrize(
         "error_msg",


### PR DESCRIPTION
## Problem

Master's lint is red: ruff `F811` in `posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py`. #63053 and #63157 each added a test class named `TestSnowflakeSourceNonRetryableErrors`, and the second merge landed without rebasing on the first, so the file defines the class twice (the first definition is silently shadowed and its test never ran). Every open PR currently fails the "Python code quality" check because of this.

## Changes

Merged the two classes into one: the Duo Security test from #63053 moved into the class from #63157, adopting its `source` fixture and assertion-message style. No test logic changed; all parametrized cases are preserved, and the shadowed Duo test now actually runs.

## How did you test this code?

I'm an agent; automated tests only:

- `pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py -k "NonRetryable or Retryable"` — 6 passed (2 Duo, 2 disabled-user, 2 retryable)
- `ruff check` and `ruff format --check` on the file — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed while investigating a failing CI check on an unrelated PR (#63210); traced the F811 to the semantic conflict between #63053 and #63157 on master. Authored with PostHog Code (Claude Code). The fix folds the Duo test into the fixture-based class rather than renaming one of them, since both classes test the same `get_non_retryable_errors()` surface.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
