### PR TITLE
fix(data-warehouse): remove duplicate snowflake non-retryable test class

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -479,22 +479,6 @@ class TestGetRowsToSync:
 # ---------------------------------------------------------------------------
 
 
-class TestSnowflakeSourceNonRetryableErrors:
-    @pytest.mark.parametrize(
-        "error_msg",
-        [
-            "Duo Security authentication is denied",
-            # The real shape from production: codes + host vary, but the Duo substring is stable.
-            "250001 (08001): None: Failed to connect to DB: wv65496-re80354.snowflakecomputing.com:443. "
-            "Duo Security authentication is denied.",
-        ],
-    )
-    def test_duo_security_denied_is_non_retryable(self, error_msg):
-        non_retryable = SnowflakeSource().get_non_retryable_errors()
-        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
-        assert is_non_retryable
-
-
 class TestBuildPipeline:
     def test_builds_source_response_and_streams(self, impl):
         # Two separate cursors: one for metadata pass, one for streaming.
@@ -588,3 +572,17 @@ class TestSnowflakeSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Error should remain retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "Duo Security authentication is denied",
+            # The real shape from production: codes + host vary, but the Duo substring is stable.
+            "250001 (08001): None: Failed to connect to DB: wv65496-re80354.snowflakecomputing.com:443. "
+            "Duo Security authentication is denied.",
+        ],
+    )
+    def test_duo_security_denied_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Duo Security denial should be non-retryable: {error_msg}"


### PR DESCRIPTION
## Problem

#63053 added a second `TestSnowflakeSourceNonRetryableErrors` class to `test_snowflake.py`, duplicating the existing class of the same name. Ruff now fails with `F811 Redefinition of unused TestSnowflakeSourceNonRetryableErrors` on master, which breaks the "Python code quality" check for every open PR (CI runs PRs merged with master).

## Changes

Folds the Duo Security MFA denial test from the duplicate class into the existing `TestSnowflakeSourceNonRetryableErrors` class (adopting its `source` fixture style) and deletes the duplicate. No production code changes — the Duo Security non-retryable behavior from #63053 is unchanged and still covered.

## How did you test this code?

I'm an agent; automated tests only:

- `ruff check` and `ruff format --check` on the file pass (previously failing with F811).
- `pytest posthog/temporal/data_imports/sources/snowflake/tests/test_snowflake.py -k NonRetryable` — 6 passed (disabled-user, transient-retryable, and Duo Security cases).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code task). Diagnosed the master CI breakage as an F811 duplicate-class lint error introduced by #63053, merged the duplicated test into the pre-existing class rather than renaming it, and verified with ruff and pytest locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
