### PR TITLE
fix(ci): drop deleted services/agent-migrations from semgrep scan roots

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -111,7 +111,7 @@ jobs:
                     --error \
                     --metrics=off \
                     --verbose \
-                    frontend/ nodejs/ services/agent-console/ services/agent-ingress/ services/agent-janitor/ services/agent-migrations/ services/agent-runner/ services/agent-sandbox-host/ services/agent-shared/ services/agent-tests/ services/agent-tools/ services/agents/ services/mcp/ services/oauth-proxy/ services/stripe-app/
+                    frontend/ nodejs/ services/agent-console/ services/agent-ingress/ services/agent-janitor/ services/agent-runner/ services/agent-sandbox-host/ services/agent-shared/ services/agent-tests/ services/agent-tools/ services/agents/ services/mcp/ services/oauth-proxy/ services/stripe-app/
 
     semgrep-products-frontend:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The `semgrep-js` job in the Security workflow still lists `services/agent-migrations/` as a scanning root, but that directory was removed when agent platform migrations moved to a dedicated Django product DB. Semgrep exits with code 2 on a nonexistent scanning root (`[ERROR] Invalid scanning root: services/agent-migrations`), so the Security workflow fails on every PR into `ass`.

## Changes

Remove `services/agent-migrations/` from the `semgrep-js` scan list in `.github/workflows/ci-security.yaml`. One-line change; all other scan roots are unchanged.

## How did you test this code?

I'm an agent — no manual testing. The failure mode is deterministic: semgrep hard-fails on a missing scan root, and the directory no longer exists on this branch. The Security workflow run on this PR validates the fix.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with Claude Code while debugging CI on #62935: the only failing checks there were `semgrep-js` and its gate, caused by this stale scan root rather than by that PR's changes. The cleanup is split into its own PR since the breakage affects every PR targeting `ass`.
