### PR TITLE
fix(llma): order guaranteed teams first in clustering discovery

### DIFF
--- a/posthog/temporal/ai_observability/team_discovery.py
+++ b/posthog/temporal/ai_observability/team_discovery.py
@@ -164,7 +164,10 @@ async def get_team_ids_for_ai_observability(inputs: TeamDiscoveryInput) -> list[
             sample_size = math.ceil(len(remaining) * sample_percentage)
             sampled = random.sample(remaining, min(sample_size, len(remaining)))
 
-            result = sorted((guaranteed | set(sampled)) - skip)
+            # Guaranteed teams first: the coordinator processes teams in this order and
+            # may exhaust its run budget before reaching the tail, so allowlisted teams
+            # must never sit behind the sampled set.
+            result = sorted(guaranteed - skip) + sorted(sampled)
 
             logger.info(
                 "Team discovery completed",

--- a/posthog/temporal/ai_observability/test_team_discovery.py
+++ b/posthog/temporal/ai_observability/test_team_discovery.py
@@ -147,9 +147,6 @@ class TestGetTeamIdsForAIObservability:
         result = await get_team_ids_for_ai_observability(inputs)
 
         assert result == [9000, 3333, 5555, 7777]
-        guaranteed_index = result.index(9000)
-        sampled_indices = [result.index(t) for t in (3333, 5555, 7777)]
-        assert all(guaranteed_index < i for i in sampled_indices)
 
     @patch("posthog.tasks.ai_observability_usage_report.get_teams_with_ai_events")
     async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams, mock_ff):

--- a/posthog/temporal/ai_observability/test_team_discovery.py
+++ b/posthog/temporal/ai_observability/test_team_discovery.py
@@ -136,14 +136,20 @@ class TestGetTeamIdsForAIObservability:
         assert len(result) == len(set(result))
 
     @patch("posthog.tasks.ai_observability_usage_report.get_teams_with_ai_events")
-    async def test_result_is_sorted(self, mock_get_teams, mock_ff):
-        mock_ff.return_value = {"sample_percentage": 1.0}
-        mock_get_teams.return_value = [9999, 5555, 3333]
+    async def test_guaranteed_teams_ordered_before_sampled(self, mock_get_teams, mock_ff):
+        # High guaranteed id placed ahead of a lower sampled id proves ordering is by
+        # guaranteed-first, not global sort — the coordinator must reach allowlisted
+        # teams before it exhausts its run budget on the sampled tail.
+        mock_ff.return_value = {"guaranteed_team_ids": [9000], "sample_percentage": 1.0}
+        mock_get_teams.return_value = [5555, 3333, 7777]
         inputs = TeamDiscoveryInput()
 
         result = await get_team_ids_for_ai_observability(inputs)
 
-        assert result == sorted(result)
+        assert result == [9000, 3333, 5555, 7777]
+        guaranteed_index = result.index(9000)
+        sampled_indices = [result.index(t) for t in (3333, 5555, 7777)]
+        assert all(guaranteed_index < i for i in sampled_indices)
 
     @patch("posthog.tasks.ai_observability_usage_report.get_teams_with_ai_events")
     async def test_zero_sample_returns_only_guaranteed(self, mock_get_teams, mock_ff):


### PR DESCRIPTION
## Problem

AI observability clusters stopped appearing for active teams with high `team_id`s. The clustering coordinator discovers eligible teams, sorts them ascending by `team_id`, and processes them with a small concurrency under a fixed run budget. With ~3,700 eligible teams it only clears the lowest ~800 per daily run, so every team past a `team_id` cutoff — including allowlisted (`guaranteed_team_ids`) teams that happen to have high ids — is consistently never reached and never clustered.

Allowlisting a team was supposed to guarantee it gets processed, but guaranteed teams were merged into the same ascending sort as the sampled set, so a high-id guaranteed team sat behind hundreds of lower-id sampled teams and was starved just the same.

## Changes

In the team-discovery activity, return guaranteed teams **first** (sorted among themselves), then the sampled teams, instead of one globally sorted list. The coordinator processes teams in this order and preserves it across `continue_as_new`, so allowlisted teams are always reached before a run can exhaust its budget on the sampled tail.

This makes `guaranteed_team_ids` an effective lever again. It does **not** address the broader throughput limit or fairness for non-guaranteed high-id teams — those need a concurrency increase and day-to-day rotation of the sampled set, tracked as follow-up.

## How did you test this code?

I'm an agent (PostHog Code). Automated only — no manual testing claimed.

- Updated and ran `posthog/temporal/ai_observability/test_team_discovery.py` (31 tests pass). Replaced `test_result_is_sorted` with `test_guaranteed_teams_ordered_before_sampled`, which asserts a high guaranteed id is ordered ahead of lower sampled ids (proving guaranteed-first, not global sort).
- ruff check + format and `ty` check clean (via lint-staged on commit).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a support report of empty/stale clusters. Verified against production ClickHouse (via Metabase) that the affected team was highly active and that its summaries/embeddings were healthy — ruling out discovery dropout, summarization, and the min-traces gate. The decisive evidence: of 3,716 teams eligible in the last 7 days (max `team_id` 466,566), none above `team_id` ~320k received clusters, and the max clustered `team_id` each day sat around 250k–318k — a hard ordering cutoff, not random sampling. Root-caused to ascending-`team_id` processing order under an unmet run budget, surfaced when an earlier fix stopped a self-perpetuating discovery loop and shifted the pool from mostly fast no-op teams to all-real (slow) teams.

Chose the minimal, targeted fix (guaranteed-first ordering) for this PR and deliberately scoped out the concurrency/fairness work. Tools: PostHog Code (Claude), PostHog MCP, and the Metabase query CLI.
