### PR TITLE
feat(destinations): add type column and filter to destination lists

### DIFF
--- a/frontend/src/scenes/hog-functions/hog-function-utils.test.ts
+++ b/frontend/src/scenes/hog-functions/hog-function-utils.test.ts
@@ -1,0 +1,13 @@
+import { getHogFunctionDeliveryType } from './hog-function-utils'
+
+describe('getHogFunctionDeliveryType', () => {
+    it.each([
+        ['batch-export-9', 'batch'],
+        ['batch-export-AwsS3', 'batch'],
+        ['plugin-7', 'realtime'],
+        ['abc123', 'realtime'],
+        ['template-slack', 'realtime'],
+    ])('classifies %s as %s', (id, expected) => {
+        expect(getHogFunctionDeliveryType({ id })).toBe(expected)
+    })
+})

--- a/frontend/src/scenes/hog-functions/hog-function-utils.ts
+++ b/frontend/src/scenes/hog-functions/hog-function-utils.ts
@@ -1,5 +1,12 @@
 import { HogFunctionTypeType } from '~/types'
 
+export type HogFunctionDeliveryType = 'batch' | 'realtime'
+
+// Batch exports vs realtime destinations share `type: 'destination'`; the only signal is the id prefix.
+export function getHogFunctionDeliveryType(item: { id: string }): HogFunctionDeliveryType {
+    return item.id.startsWith('batch-export-') ? 'batch' : 'realtime'
+}
+
 export function humanizeHogFunctionType(type: HogFunctionTypeType, plural: boolean = false): string {
     if (type === 'source_webhook') {
         return 'source' + (plural ? 's' : '')

--- a/frontend/src/scenes/hog-functions/list/DeliveryTypeTag.tsx
+++ b/frontend/src/scenes/hog-functions/list/DeliveryTypeTag.tsx
@@ -1,0 +1,24 @@
+import { IconClock, IconLive } from '@posthog/icons'
+import { LemonSelectOptions, LemonTag } from '@posthog/lemon-ui'
+
+import { HogFunctionDeliveryType, getHogFunctionDeliveryType } from '../hog-function-utils'
+
+// Batch exports vs realtime destinations (hog functions). Shared by the destinations list and the
+// new-destination picker so the colour/icon/label stay in one place.
+export function DeliveryTypeTag({ item }: { item: { id: string } }): JSX.Element {
+    return getHogFunctionDeliveryType(item) === 'batch' ? (
+        <LemonTag type="completion" icon={<IconClock />} className="text-xs">
+            Batch
+        </LemonTag>
+    ) : (
+        <LemonTag type="highlight" icon={<IconLive />} className="text-xs">
+            Realtime
+        </LemonTag>
+    )
+}
+
+export const DELIVERY_TYPE_FILTER_OPTIONS: LemonSelectOptions<HogFunctionDeliveryType | null> = [
+    { label: 'All types', value: null },
+    { label: 'Realtime', value: 'realtime' },
+    { label: 'Batch', value: 'batch' },
+]

--- a/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
@@ -1,8 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconClock, IconLive, IconMegaphone, IconPlusSmall } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSelect, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
+import { IconMegaphone, IconPlusSmall } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonSelect, LemonTable, Link } from '@posthog/lemon-ui'
 
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
@@ -13,8 +13,8 @@ import { SourceReleaseTag } from 'products/data_warehouse/frontend/shared/compon
 import { isManagedSourceTemplate } from 'products/data_warehouse/frontend/utils'
 
 import { HogFunctionIcon } from '../configuration/HogFunctionIcon'
-import { getHogFunctionDeliveryType } from '../hog-function-utils'
 import { HogFunctionStatusTag } from '../misc/HogFunctionStatusTag'
+import { DELIVERY_TYPE_FILTER_OPTIONS, DeliveryTypeTag } from './DeliveryTypeTag'
 import { hogFunctionRequestModalLogic } from './hogFunctionRequestModalLogic'
 import { HogFunctionTemplateListLogicProps, hogFunctionTemplateListLogic } from './hogFunctionTemplateListLogic'
 
@@ -53,11 +53,7 @@ export function HogFunctionTemplateList({
                         size="small"
                         value={filters.deliveryType ?? null}
                         onChange={(value) => setFilters({ deliveryType: value ?? undefined })}
-                        options={[
-                            { label: 'All types', value: null },
-                            { label: 'Realtime', value: 'realtime' },
-                            { label: 'Batch', value: 'batch' },
-                        ]}
+                        options={DELIVERY_TYPE_FILTER_OPTIONS}
                     />
                 )}
                 {extraControls}
@@ -118,15 +114,7 @@ export function HogFunctionTemplateList({
                                   title: 'Type',
                                   width: 0,
                                   render: function RenderDeliveryType(_: any, template: HogFunctionTemplateType) {
-                                      return getHogFunctionDeliveryType(template) === 'batch' ? (
-                                          <LemonTag type="completion" icon={<IconClock />} className="text-xs">
-                                              Batch
-                                          </LemonTag>
-                                      ) : (
-                                          <LemonTag type="highlight" icon={<IconLive />} className="text-xs">
-                                              Realtime
-                                          </LemonTag>
-                                      )
+                                      return <DeliveryTypeTag item={template} />
                                   },
                               },
                           ]

--- a/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
@@ -1,18 +1,19 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconMegaphone, IconPlusSmall } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonTable, Link } from '@posthog/lemon-ui'
+import { IconClock, IconLive, IconMegaphone, IconPlusSmall } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonSelect, LemonTable, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, HogFunctionTemplateType } from '~/types'
 
 import { SourceReleaseTag } from 'products/data_warehouse/frontend/shared/components/SourceReleaseTag'
 import { isManagedSourceTemplate } from 'products/data_warehouse/frontend/utils'
 
 import { HogFunctionIcon } from '../configuration/HogFunctionIcon'
+import { getHogFunctionDeliveryType } from '../hog-function-utils'
 import { HogFunctionStatusTag } from '../misc/HogFunctionStatusTag'
 import { hogFunctionRequestModalLogic } from './hogFunctionRequestModalLogic'
 import { HogFunctionTemplateListLogicProps, hogFunctionTemplateListLogic } from './hogFunctionTemplateListLogic'
@@ -47,6 +48,18 @@ export function HogFunctionTemplateList({
                     </Link>
                 ) : null}
                 <div className="flex-1" />
+                {props.type === 'destination' && (
+                    <LemonSelect
+                        size="small"
+                        value={filters.deliveryType ?? null}
+                        onChange={(value) => setFilters({ deliveryType: value ?? undefined })}
+                        options={[
+                            { label: 'All types', value: null },
+                            { label: 'Realtime', value: 'realtime' },
+                            { label: 'Batch', value: 'batch' },
+                        ]}
+                    />
+                )}
                 {extraControls}
             </div>
 
@@ -99,6 +112,25 @@ export function HogFunctionTemplateList({
                         },
                     },
 
+                    ...(props.type === 'destination'
+                        ? [
+                              {
+                                  title: 'Type',
+                                  width: 0,
+                                  render: function RenderDeliveryType(_: any, template: HogFunctionTemplateType) {
+                                      return getHogFunctionDeliveryType(template) === 'batch' ? (
+                                          <LemonTag type="completion" icon={<IconClock />} className="text-xs">
+                                              Batch
+                                          </LemonTag>
+                                      ) : (
+                                          <LemonTag type="highlight" icon={<IconLive />} className="text-xs">
+                                              Realtime
+                                          </LemonTag>
+                                      )
+                                  },
+                              },
+                          ]
+                        : []),
                     {
                         width: 0,
                         render: function Render(_, template) {

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -2,12 +2,13 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { useCallback, useMemo } from 'react'
 
-import { IconBell } from '@posthog/icons'
+import { IconBell, IconClock, IconLive } from '@posthog/icons'
 import {
     LemonBadge,
     LemonButton,
     LemonCheckbox,
     LemonInput,
+    LemonSelect,
     LemonTable,
     LemonTableColumn,
     LemonTag,
@@ -27,7 +28,7 @@ import { urls } from 'scenes/urls'
 import { HogFunctionConfigurationContextId, HogFunctionType } from '~/types'
 
 import { HogFunctionIcon } from '../configuration/HogFunctionIcon'
-import { humanizeHogFunctionType } from '../hog-function-utils'
+import { getHogFunctionDeliveryType, humanizeHogFunctionType } from '../hog-function-utils'
 import { HogFunctionStatusIndicator } from '../misc/HogFunctionStatusIndicator'
 import { eventToHogFunctionContextId } from '../sub-templates/sub-templates'
 import { HogFunctionOrderModal } from './HogFunctionOrderModal'
@@ -274,6 +275,26 @@ export function HogFunctionList({
             },
         ]
 
+        if (props.type === 'destination') {
+            // insert after the Name column
+            columns.splice(2, 0, {
+                title: 'Type',
+                key: 'deliveryType',
+                width: 0,
+                render: function RenderDeliveryType(_, hogFunction) {
+                    return getHogFunctionDeliveryType(hogFunction) === 'batch' ? (
+                        <LemonTag type="completion" icon={<IconClock />} className="text-xs">
+                            Batch
+                        </LemonTag>
+                    ) : (
+                        <LemonTag type="highlight" icon={<IconLive />} className="text-xs">
+                            Realtime
+                        </LemonTag>
+                    )
+                },
+            })
+        }
+
         if (props.type === 'transformation') {
             // insert it in the second column
             columns.splice(1, 0, {
@@ -329,6 +350,18 @@ export function HogFunctionList({
                         onChange={(user) => setFilters({ createdBy: user?.uuid || null })}
                     />
                 </div>
+                {props.type === 'destination' && (
+                    <LemonSelect
+                        size="small"
+                        value={filters.deliveryType ?? null}
+                        onChange={(value) => setFilters({ deliveryType: value ?? undefined })}
+                        options={[
+                            { label: 'All types', value: null },
+                            { label: 'Realtime', value: 'realtime' },
+                            { label: 'Batch', value: 'batch' },
+                        ]}
+                    />
+                )}
                 <LemonCheckbox
                     label="Show paused"
                     bordered

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { useCallback, useMemo } from 'react'
 
-import { IconBell, IconClock, IconLive } from '@posthog/icons'
+import { IconBell } from '@posthog/icons'
 import {
     LemonBadge,
     LemonButton,
@@ -28,9 +28,10 @@ import { urls } from 'scenes/urls'
 import { HogFunctionConfigurationContextId, HogFunctionType } from '~/types'
 
 import { HogFunctionIcon } from '../configuration/HogFunctionIcon'
-import { getHogFunctionDeliveryType, humanizeHogFunctionType } from '../hog-function-utils'
+import { humanizeHogFunctionType } from '../hog-function-utils'
 import { HogFunctionStatusIndicator } from '../misc/HogFunctionStatusIndicator'
 import { eventToHogFunctionContextId } from '../sub-templates/sub-templates'
+import { DELIVERY_TYPE_FILTER_OPTIONS, DeliveryTypeTag } from './DeliveryTypeTag'
 import { HogFunctionOrderModal } from './HogFunctionOrderModal'
 import { hogFunctionRequestModalLogic } from './hogFunctionRequestModalLogic'
 import { HogFunctionListLogicProps, hogFunctionsListLogic } from './hogFunctionsListLogic'
@@ -282,15 +283,7 @@ export function HogFunctionList({
                 key: 'deliveryType',
                 width: 0,
                 render: function RenderDeliveryType(_, hogFunction) {
-                    return getHogFunctionDeliveryType(hogFunction) === 'batch' ? (
-                        <LemonTag type="completion" icon={<IconClock />} className="text-xs">
-                            Batch
-                        </LemonTag>
-                    ) : (
-                        <LemonTag type="highlight" icon={<IconLive />} className="text-xs">
-                            Realtime
-                        </LemonTag>
-                    )
+                    return <DeliveryTypeTag item={hogFunction} />
                 },
             })
         }
@@ -355,11 +348,7 @@ export function HogFunctionList({
                         size="small"
                         value={filters.deliveryType ?? null}
                         onChange={(value) => setFilters({ deliveryType: value ?? undefined })}
-                        options={[
-                            { label: 'All types', value: null },
-                            { label: 'Realtime', value: 'realtime' },
-                            { label: 'Batch', value: 'batch' },
-                        ]}
+                        options={DELIVERY_TYPE_FILTER_OPTIONS}
                     />
                 )}
                 <LemonCheckbox

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.test.ts
@@ -1,6 +1,7 @@
 import { initKeaTests } from '~/test/init'
 import {
     CyclotronJobFiltersType,
+    HogFunctionTemplateType,
     HogFunctionTemplateWithSubTemplateType,
     PropertyFilterType,
     PropertyOperator,
@@ -57,5 +58,64 @@ describe('hogFunctionTemplateListLogic - configuration structure', () => {
         expect(configuration).toHaveProperty('filters')
         expect(configuration.filters).toHaveProperty('properties')
         expect(configuration).not.toHaveProperty('properties') // Should not be at top level
+    })
+})
+
+describe('hogFunctionTemplateListLogic - deliveryType filter', () => {
+    const makeTemplate = (id: string, name: string): HogFunctionTemplateType => ({
+        id,
+        name,
+        type: 'destination',
+        status: 'stable',
+        free: true,
+        code: '',
+        code_language: 'hog',
+    })
+
+    const batchTemplate = makeTemplate('batch-export-S3', 'S3 batch export')
+    const realtimeTemplate = makeTemplate('template-slack', 'Slack realtime')
+
+    const buildLogic = (): ReturnType<typeof hogFunctionTemplateListLogic.build> => {
+        const logic = hogFunctionTemplateListLogic.build({
+            type: 'destination',
+            manualTemplates: [batchTemplate, realtimeTemplate],
+        })
+        logic.mount()
+        return logic
+    }
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('shows both frequencies when no deliveryType filter is set', () => {
+        const logic = buildLogic()
+        expect(logic.values.filteredTemplates.map((t) => t.id)).toEqual(
+            expect.arrayContaining(['batch-export-S3', 'template-slack'])
+        )
+    })
+
+    it('filters to batch in the non-search branch', () => {
+        const logic = buildLogic()
+        logic.actions.setFilters({ deliveryType: 'batch' })
+        expect(logic.values.filteredTemplates.map((t) => t.id)).toEqual(['batch-export-S3'])
+    })
+
+    it('filters to realtime in the non-search branch', () => {
+        const logic = buildLogic()
+        logic.actions.setFilters({ deliveryType: 'realtime' })
+        expect(logic.values.filteredTemplates.map((t) => t.id)).toEqual(['template-slack'])
+    })
+
+    it('applies the deliveryType filter in the search branch too', () => {
+        const logic = buildLogic()
+        // Only the batch template's name contains "export", so the search matches just that one.
+        logic.actions.setFilters({ search: 'export', deliveryType: 'batch' })
+        expect(logic.values.filteredTemplates.map((t) => t.id)).toEqual(['batch-export-S3'])
+
+        // Same search still matches the batch template, but the realtime filter must drop it —
+        // an empty result proves the deliveryType filter is applied inside the search branch.
+        logic.actions.setFilters({ search: 'export', deliveryType: 'realtime' })
+        expect(logic.values.filteredTemplates.map((t) => t.id)).toEqual([])
     })
 })

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -25,6 +25,7 @@ import {
 
 import { cleanSourceId, isManagedSourceId, isSelfManagedSourceId } from 'products/data_warehouse/frontend/utils'
 
+import { HogFunctionDeliveryType, getHogFunctionDeliveryType } from '../hog-function-utils'
 import { getSubTemplate } from '../sub-templates/sub-templates'
 import type { hogFunctionTemplateListLogicType } from './hogFunctionTemplateListLogicType'
 
@@ -33,6 +34,7 @@ export interface Fuse extends FuseClass<HogFunctionTemplateType> {}
 
 export type HogFunctionTemplateListFilters = {
     search?: string
+    deliveryType?: HogFunctionDeliveryType
 }
 
 export type HogFunctionTemplateListLogicProps = {
@@ -205,13 +207,15 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                 hideComingSoonByDefault,
                 customFilterFunction
             ): HogFunctionTemplateType[] => {
-                const { search } = filters
+                const { search, deliveryType } = filters
+                const matchesDelivery = (template: HogFunctionTemplateType): boolean =>
+                    !deliveryType || getHogFunctionDeliveryType(template) === deliveryType
 
                 if (search) {
                     return templatesFuse
                         .search(search)
                         .map((x) => {
-                            if (!customFilterFunction(x.item)) {
+                            if (!customFilterFunction(x.item) || !matchesDelivery(x.item)) {
                                 return null
                             }
                             return x.item
@@ -221,7 +225,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
                 const [available, comingSoon] = templates.reduce(
                     ([available, comingSoon], template) => {
-                        if (!customFilterFunction(template)) {
+                        if (!customFilterFunction(template) || !matchesDelivery(template)) {
                             return [available, comingSoon]
                         }
 

--- a/frontend/src/scenes/hog-functions/list/hogFunctionsListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionsListLogic.tsx
@@ -14,6 +14,7 @@ import { userLogic } from 'scenes/userLogic'
 import { deleteFromTree, refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { CyclotronJobFiltersType, HogFunctionType, HogFunctionTypeType, UserType } from '~/types'
 
+import { HogFunctionDeliveryType, getHogFunctionDeliveryType } from '../hog-function-utils'
 import type { hogFunctionsListLogicType } from './hogFunctionsListLogicType'
 
 export const CDP_TEST_HIDDEN_FLAG = '[CDP-TEST-HIDDEN]'
@@ -23,6 +24,7 @@ export type HogFunctionListFilters = {
     search?: string
     showPaused?: boolean
     createdBy?: string | null
+    deliveryType?: HogFunctionDeliveryType
 }
 
 export type HogFunctionListLogicProps = {
@@ -178,7 +180,7 @@ export const hogFunctionsListLogic = kea<hogFunctionsListLogicType>([
         filteredHogFunctions: [
             (s) => [s.filters, s.sortedHogFunctions, s.user],
             (filters, hogFunctions, user): HogFunctionType[] => {
-                const { showPaused, createdBy } = filters
+                const { showPaused, createdBy, deliveryType } = filters
 
                 return hogFunctions.filter((x) => {
                     if (!shouldShowHogFunction(x, user)) {
@@ -190,6 +192,10 @@ export const hogFunctionsListLogic = kea<hogFunctionsListLogicType>([
                     }
 
                     if (createdBy && x.created_by?.uuid !== createdBy) {
+                        return false
+                    }
+
+                    if (deliveryType && getHogFunctionDeliveryType(x) !== deliveryType) {
                         return false
                     }
 

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -149,7 +149,8 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     [Scene.Destinations]: {
         projectBased: true,
         name: 'Destinations',
-        description: 'Destinations allow you to send your data to external systems in real time.',
+        description:
+            'Destinations allow you to send your data to external systems either in real time or in scheduled batches.',
         activityScope: ActivityScope.HOG_FUNCTION,
         iconType: 'data_pipeline',
     },


### PR DESCRIPTION
## Problem

Data pipeline destinations come in two delivery models that the UI rendered indistinguishably:

- **Batch exports** — scheduled bulk exports (S3, BigQuery, Snowflake, etc.)
- **Realtime destinations** — hog functions and legacy plugin destinations

Both share `type: 'destination'` in their data, so when browsing existing destinations or picking a new one, there was no easy way to tell which rows were batch vs realtime, and no way to filter by it.

## Changes

Adds a **Type** column (a `Batch` / `Realtime` tag) plus a matching dropdown filter to both destination surfaces — the existing-destinations table and the new-destination picker.

Batch vs realtime is derived from the existing `batch-export-` id prefix (no backend change), and the column/filter only appear on destination lists. Tags use `IconClock` (Batch) and `IconLive` (Realtime).

Also updates the Destinations scene description to note that destinations can deliver either in real time or in scheduled batches.

## How did you test this code?

Automated coverage I added and ran:

- `hog-function-utils.test.ts` — parameterized cases for `getHogFunctionDeliveryType` (batch-export / plugin / hog-function ids).
- `hogFunctionTemplateListLogic.test.ts` — `filteredTemplates` deliveryType filtering, covering both the search and non-search branches.

Ran `hogli test` on the two list suites plus the helper test (all green), `tsc --noEmit` (no errors in the changed files), and `oxfmt` + `oxlint` clean.

Ran stack locally to ensure filters work as expected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ross directed the work.

Built with PostHog Code (Claude). The reviewer-relevant decisions:

- **Derive delivery type from the id prefix** rather than adding a backend field — batch exports are already injected into these lists as synthetic `batch-export-*` items, and the prefix is the existing source of truth for routing. Kept the helper local to `hog-function-utils.ts`.
- **Iterated on presentation** with the human driver: settled on a `Type` column header, `Batch`/`Realtime` tags with `IconClock`/`IconLive`, `completion`/`highlight` colors, and a slightly bumped `text-xs` size. Considered green for Realtime but avoided it to not collide with Status-column health colors.
- **Filter lives in kea state, not props**, so logic keys are unaffected and `resetFilters` clears it automatically. On the main destinations scene the list mounts without `syncFiltersWithUrl`, so the filter is in-memory there (no deep-linking) — consistent with the existing Created-by / Show-paused filters.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*