### PR TITLE
chore(data-warehouse): teach source skill the pk/sort/pagination oom traps

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -249,7 +249,7 @@ source, also append a short "Notes on partially-tracked sources" entry explainin
 - Register with `@SourceRegistry.register`.
 - Inherit `SimpleSource[GeneratedConfig]` unless resumable/webhook behavior is required.
 - API sources should usually return `table_format="delta"` in endpoint resources.
-- `primary_keys` are endpoint-specific (declare in `settings.py`, not always `id`). Use composite keys when no single field is unique.
+- `primary_keys` are endpoint-specific (declare in `settings.py`, not always `id`). Use composite keys when no single field is unique. **The key must be unique across the whole table, not per parent**: fan-out child endpoints aggregate rows from every parent, so include the parent identifier in the key (e.g. `["form_id", "token"]`) unless the API explicitly documents global uniqueness. Non-unique keys seed duplicate rows in the Delta table, and every later merge multi-matches them — merges get slower each sync until the pod OOMs.
 - Add partitioning for new sources where possible:
   - API sources: `partition_mode="datetime"` with a **stable** datetime field.
   - Database sources: `partition_count` and `partition_size`.
@@ -266,7 +266,9 @@ source, also append a short "Notes on partially-tracked sources" entry explainin
 - **Per-endpoint sort enums vary.** Don't hardcode `?sorting=created_at` (or whatever) globally. Verify each list endpoint's allowed sort values against the API spec **and** with a curl smoke-test against the live API — APIs frequently document one set of options and silently reject another, or use a different timestamp column on certain resources.
 - **Pass `?sorting=` explicitly on a stable monotonic field when paginating.** For incremental sources, the request sort must match `SourceResponse.sort_mode` (`"asc"` typically; `"desc"` only when forced by the API — see `stripe/stripe.py`, `github/settings.py`) so the pipeline's cursor watermark advances correctly. For full-refresh sources, an explicit sort prevents page-boundary skips/duplicates if the API's implicit default is unstable or shifts as rows are inserted during the sync.
 - If the API only supports cursor pagination, still declare incremental fields if reliable and let merge semantics dedupe.
+- **`sort_mode` must match the order rows actually arrive in — verify it, don't assume it.** The pipeline trusts `sort_mode="asc"` to checkpoint the incremental watermark after every batch and to allow safe mid-sync worker shutdowns; declaring `asc` while the API returns newest-first corrupts the watermark and breaks resume semantics. Check the API's _default_ sort (it applies when you can't pass `sort`), and remember cursor pagination often rejects or ignores sort params entirely.
 - `sort_mode="desc"` only if the endpoint truly cannot return ascending. For descending sources, handle `db_incremental_field_earliest_value` to scroll earlier rows before newer ones (see Stripe).
+- **Incremental pagination must terminate at the watermark.** Some APIs reject mixing their time-window filter with cursor pagination, so only the first page is windowed and later pages walk back through history unbounded. If the server can't keep the filter on every page, the paginator must stop client-side once an entire page predates `db_incremental_field_last_value` (see `typeform/typeform.py:TypeformResponsesPaginator`) — otherwise **every incremental sync re-fetches and re-merges each parent's full history**, which is both an API-cost bug and a per-sync memory amplifier.
 - Default unknown endpoints to full refresh first; enable incremental only after confirming a stable filter field and API ordering semantics.
 - Confirm partition keys against response schemas, not endpoint names.
 
@@ -276,7 +278,8 @@ Before finalizing endpoint logic, verify from docs **and** with curl against the
 
 - Response shape: list vs object vs wrapped data (`{"data": [...]}`).
 - Pagination: Link header vs body cursor vs offset/page; how next-page termination is signaled.
-- Ordering guarantees: ascending/descending/undefined for time fields, and the API's _default_ sort if you don't pass one.
+- Ordering guarantees: ascending/descending/undefined for time fields, and the API's _default_ sort if you don't pass one. If you paginate with a cursor (`before`/`after` tokens), confirm whether the API allows `sort` and time-window params alongside it — many reject or ignore them, which dictates both your `sort_mode` and how pagination terminates on incremental syncs.
+- **Primary key uniqueness scope:** is the id unique globally, or only within its parent resource? For fan-out children, assume per-parent unless the docs say otherwise and put the parent id in the composite key.
 - **Sort enum per endpoint:** which `sorting=` values does each list endpoint accept? Some APIs vary the allowed enum per resource. Confirm with curl that the value you intend to pass returns 200, and probe with a future-date cutoff to confirm whether timestamp filters are honored or silently ignored.
 - **Server-side timestamp filter:** does `<field>_gte` / `since` / `modified_after` actually filter, or does the API accept it and ignore it? Test by passing a future date and checking whether the row drops out.
 - Rate-limit headers (window reset timestamp, concurrent limits).
@@ -433,6 +436,7 @@ Add at least two test modules:
   - for dependent-resource fan-out: mock `rest_api_resources`, pass rows with `_<parent>_<field>` keys to exercise parent-field injection and rename behavior
   - expected return schema checks for each declared endpoint in `settings.py`
   - for resumable sources: resume-from-saved-state path (manager returns state, transport uses it as starting point); state is saved after each batch
+  - for incremental cursor pagination: the paginator stops once a page predates the watermark, and keeps walking when no watermark is set (first sync)
 
 Prefer behavior tests over config-shape tests. Avoid brittle assertions on internal config dict structure unless they protect a known regression that cannot be asserted via output behavior.
 
@@ -454,6 +458,8 @@ Source implementation:
 - [ ] Add endpoint settings (settings.py)
 - [ ] Implement transport + paginator ({source}.py)
 - [ ] Return SourceResponse with correct primary_keys, partitioning, sort_mode
+      (keys unique table-wide — parent id in fan-out child keys; sort_mode verified against actual response order;
+      incremental cursor pagination stops at the watermark)
 - [ ] Implement get_resumable_source_manager if ResumableSource
 - [ ] Implement webhook methods if WebhookSource
 - [ ] Add get_non_retryable_errors for auth/permission errors
@@ -489,6 +495,8 @@ After changing source fields, re-run `pnpm run generate:source-configs` and `pnp
 - Source not visible in wizard: not registered/imported in `sources/__init__.py`, or `schema:build` not rerun.
 - Generated config class still empty: forgot `generate:source-configs` after updating fields.
 - Incremental sync misbehaving: wrong field name/type or wrong sort assumptions.
+- Pod OOMs on a busy table: primary key not actually unique (usually a fan-out child missing the parent id in its key) — duplicate rows accumulate and every merge multi-matches them; often paired with a paginator that re-walks full history each sync because the time filter only applies to page one.
+- `sort_mode="asc"` declared on an API that returns newest-first: the watermark checkpoints to ≈now after the first batch and mid-sync shutdowns lose data ordering guarantees.
 - Endless retries for bad credentials: missing `get_non_retryable_errors`.
 - Resumable state never saved: forgot to call `save_state` after yielding a batch; or saved before yield and a crash causes data loss.
 - Webhook rows not landing: schema `is_webhook=False`, or `initial_sync_complete=False`.


### PR DESCRIPTION
## Problem

Investigating repeated pod OOMs on a Typeform source (#63236) surfaced three implementation traps that the `implementing-warehouse-sources` skill didn't warn about, so newly implemented sources can repeat them:

- primary keys that aren't unique across the whole table (fan-out children missing the parent id in the key) seed duplicate Delta rows, and every later merge multi-matches them until syncs OOM
- `sort_mode` declared from assumption rather than the API's actual response order corrupts incremental watermark checkpointing and unsafe-shutdown semantics
- cursor pagination that can't carry the server-side time filter past page one silently re-fetches each parent's entire history on every incremental sync

## Changes

Updates `.agents/skills/implementing-warehouse-sources/SKILL.md` so the issues are caught at implementation time:

- the `primary_keys` convention now requires table-wide uniqueness and parent ids in fan-out child keys, with the OOM consequence spelled out
- new incremental-sync guidance: verify `sort_mode` against observed response order, and terminate cursor pagination at the watermark when the API rejects mixing time filters with cursors (pointing at `TypeformResponsesPaginator` as the reference)
- API verification checklist gains primary-key uniqueness scope and cursor/sort-param compatibility items
- testing expectations gain a watermark-termination paginator test; the implementation checklist and common pitfalls now name these failure signatures

## How did you test this code?

Docs-only change. `hogli lint:skills` passes (77 skills OK).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The skill file is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Tom directed the work; assigned as DRI.

Built with Claude Code. Distilled from the Typeform responses OOM investigation and fix (#63236); originally committed on that branch, then split into this standalone PR at Tom's request.
