### PR TITLE
feat(llm-gateway): allow dev Array OAuth app on agent products

### DIFF
--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -27,6 +27,7 @@ BEDROCK_MODELS = BEDROCK_MODEL_IDS
 # OAuth application IDs per region
 POSTHOG_CODE_US_APP_ID = "019a3066-4aa2-0000-ca70-48ecdcc519cf"
 POSTHOG_CODE_EU_APP_ID = "019a3067-5be7-0000-33c7-c6743eb59a79"
+POSTHOG_CODE_DEV_APP_ID = "019ebb47-c750-0000-e1ea-723a6ff112d3"
 TWIG_US_APP_ID = POSTHOG_CODE_US_APP_ID
 TWIG_EU_APP_ID = POSTHOG_CODE_EU_APP_ID
 WIZARD_US_APP_ID = "019a0c79-b69d-0000-f31b-b41345208c9d"
@@ -60,12 +61,12 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allow_api_keys=True,
     ),
     "posthog_code": ProductConfig(
-        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID}),
+        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
         allowed_models=_POSTHOG_CODE_AGENT_MODELS | BEDROCK_MODELS,
         allow_api_keys=False,
     ),
     "background_agents": ProductConfig(
-        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID}),
+        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
         allowed_models=frozenset(
             {
                 "claude-opus-4-5",
@@ -85,7 +86,7 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allow_api_keys=False,
     ),
     "slack_app": ProductConfig(
-        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID}),
+        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
         allowed_models=_POSTHOG_CODE_AGENT_MODELS | BEDROCK_MODELS,
         allow_api_keys=False,
         billable=True,
@@ -142,7 +143,7 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allow_api_keys=True,
     ),
     "signals": ProductConfig(
-        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID}),
+        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
         allowed_models=None,  # any model — the signals pipeline picks models per stage (haiku, sonnet, ...)
         allow_api_keys=True,
         billable=False,


### PR DESCRIPTION
## Problem

After the sandbox-side env-propagation fixes for the hosted dev environment, OAuth tokens minted by the dev Array OAuth application will reach the LLM gateway — but `check_product_access` (`services/llm-gateway/src/llm_gateway/products/config.py:226-231`) only knows about the US and EU `POSTHOG_CODE` app IDs:

```python
is_oauth = auth_method == "oauth_access_token"
if is_oauth and not settings.debug:
    allowed_application_ids = config.allowed_application_ids or frozenset()
    if application_id not in allowed_application_ids:
        return False, f"OAuth application not authorized for product '{product}'"
```

So a dev-issued token would be rejected with `OAuth application not authorized for product 'posthog_code'` even though the token itself validates fine.

## Changes

- Add `POSTHOG_CODE_DEV_APP_ID = "019ebb47-c750-0000-e1ea-723a6ff112d3"` next to the existing US / EU constants.
- Include it in `allowed_application_ids` for the four OAuth-only / app-id-gated products: `posthog_code`, `background_agents`, `slack_app`, `signals`.

No new product entries, no behavior change for US / EU traffic.

## How did you test this code?

Agent-authored. `pytest services/llm-gateway/tests/ -x -q` — 1001 passed, 72 skipped. No new tests added: the change is a constant-list extension and the existing per-product authz tests already cover the allow / deny branches.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.7). Companion to the dev unblock chain:
- PostHog/charts#12045 — public ingress for `mcp.dev.posthog.dev`
- PostHog/posthog#63205 — `_resolve_mcp_url` dev branch
- PostHog/charts#12057 — `SANDBOX_LLM_GATEWAY_URL` on dev tasks-agent (reverted in PostHog/charts#12066)
- PostHog/code#2637 — `getGatewayBaseUrl` dev branch
- PostHog/code#2641 — `LLM_GATEWAY_URL` env override product-aware

Without this PR, even after the chain above lands the dev gateway would 401 the sandbox token because of the application-ID allowlist. The dev app UUID was provided by the user and verified to match the row created by the earlier `OAuthApplication.objects.get_or_create` bootstrap on dev's DB.
