### PR TITLE
fix(data-warehouse): attach dashboard when saving SQL insight from dashboard flow

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -1489,7 +1489,10 @@ describe('sqlEditorLogic', () => {
             jest.restoreAllMocks()
         })
 
-        it('passes dashboards to insightsApi.create when a dashboardId is set', async () => {
+        it.each([
+            { name: 'passes dashboards to insightsApi.create when a dashboardId is set', dashboardId: DASHBOARD_ID },
+            { name: 'does not pass dashboards to insightsApi.create when no dashboardId is set', dashboardId: null },
+        ])('$name', async ({ dashboardId }) => {
             const createSpy = jest.spyOn(insightsApi, 'create').mockResolvedValue(MOCK_INSIGHT)
 
             logic = sqlEditorLogic({
@@ -1501,40 +1504,45 @@ describe('sqlEditorLogic', () => {
 
             logic.actions.createTab('SELECT count() FROM events')
             await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
-            logic.actions.setDashboardId(DASHBOARD_ID)
+            if (dashboardId !== null) {
+                logic.actions.setDashboardId(dashboardId)
+            }
 
             logic.actions.saveAsInsightSubmit('My SQL insight')
             await expectLogic(logic).toFinishAllListeners()
 
             expect(createSpy).toHaveBeenCalledTimes(1)
-            expect(createSpy.mock.calls[0][0]).toMatchObject({
-                name: 'My SQL insight',
-                saved: true,
-                dashboards: [DASHBOARD_ID],
-            })
+            const createPayload = createSpy.mock.calls[0][0]
+            expect(createPayload).toMatchObject({ name: 'My SQL insight', saved: true })
+            if (dashboardId !== null) {
+                expect(createPayload.dashboards).toEqual([dashboardId])
+            } else {
+                expect(createPayload).not.toHaveProperty('dashboards')
+            }
         })
 
-        it('does not pass dashboards to insightsApi.create when no dashboardId is set', async () => {
-            const createSpy = jest.spyOn(insightsApi, 'create').mockResolvedValue(MOCK_INSIGHT)
-
-            logic = sqlEditorLogic({
-                tabId: TAB_ID,
-                monaco: createMockMonaco(),
-                editor: createMockEditor(),
-            })
-            logic.mount()
-
-            logic.actions.createTab('SELECT count() FROM events')
-            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
-
-            logic.actions.saveAsInsightSubmit('My SQL insight')
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(createSpy).toHaveBeenCalledTimes(1)
-            expect(createSpy.mock.calls[0][0]).not.toHaveProperty('dashboards')
-        })
-
-        it('attaches the dashboard without dropping existing links when updating an insight', async () => {
+        // The update path unions the target dashboard with the insight's existing links, read
+        // from both dashboard_tiles (preferred) and the legacy dashboards field, deduped.
+        it.each([
+            {
+                name: 'merges the dashboard with existing legacy dashboards links',
+                dashboards: [7],
+                dashboardTiles: [],
+                expected: [7, DASHBOARD_ID],
+            },
+            {
+                name: 'merges the dashboard with existing dashboard_tiles links',
+                dashboards: [],
+                dashboardTiles: [{ id: 1, dashboard_id: 7, deleted: null }],
+                expected: [7, DASHBOARD_ID],
+            },
+            {
+                name: 'does not duplicate a dashboard the insight is already linked to',
+                dashboards: [],
+                dashboardTiles: [{ id: 1, dashboard_id: DASHBOARD_ID, deleted: null }],
+                expected: [DASHBOARD_ID],
+            },
+        ])('$name', async ({ dashboards, dashboardTiles, expected }) => {
             const updateSpy = jest.spyOn(insightsApi, 'update').mockResolvedValue(MOCK_INSIGHT)
 
             logic = sqlEditorLogic({
@@ -1546,7 +1554,11 @@ describe('sqlEditorLogic', () => {
             editorRootLogic = editorSceneLogic({ tabId: TAB_ID })
             editorRootLogic.mount()
 
-            const insightOnDashboards = { ...MOCK_INSIGHT, dashboards: [7] } as QueryBasedInsightModel
+            const insightOnDashboards = {
+                ...MOCK_INSIGHT,
+                dashboards,
+                dashboard_tiles: dashboardTiles,
+            } as QueryBasedInsightModel
             logic.actions.editInsight(MOCK_INSIGHT_QUERY.source.query, insightOnDashboards)
             await expectLogic(logic)
                 .toDispatchActions(['createTab', 'updateTab'])
@@ -1558,7 +1570,8 @@ describe('sqlEditorLogic', () => {
 
             expect(updateSpy).toHaveBeenCalledTimes(1)
             const [, updatePayload] = updateSpy.mock.calls[0]
-            expect(updatePayload.dashboards).toEqual([7, DASHBOARD_ID])
+            // Order-independent: only the set of linked dashboards matters.
+            expect([...(updatePayload.dashboards ?? [])].sort()).toEqual([...expected].sort())
         })
     })
 })

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -2,6 +2,7 @@ import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { insightsApi } from 'scenes/insights/utils/api'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -1478,6 +1479,86 @@ describe('sqlEditorLogic', () => {
             act()
 
             expect(model.pushEditOperations).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('attaching the dashboard when saving from a dashboard flow', () => {
+        const DASHBOARD_ID = 99
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('passes dashboards to insightsApi.create when a dashboardId is set', async () => {
+            const createSpy = jest.spyOn(insightsApi, 'create').mockResolvedValue(MOCK_INSIGHT)
+
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            logic.actions.createTab('SELECT count() FROM events')
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+            logic.actions.setDashboardId(DASHBOARD_ID)
+
+            logic.actions.saveAsInsightSubmit('My SQL insight')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledTimes(1)
+            expect(createSpy.mock.calls[0][0]).toMatchObject({
+                name: 'My SQL insight',
+                saved: true,
+                dashboards: [DASHBOARD_ID],
+            })
+        })
+
+        it('does not pass dashboards to insightsApi.create when no dashboardId is set', async () => {
+            const createSpy = jest.spyOn(insightsApi, 'create').mockResolvedValue(MOCK_INSIGHT)
+
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            logic.actions.createTab('SELECT count() FROM events')
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+            logic.actions.saveAsInsightSubmit('My SQL insight')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledTimes(1)
+            expect(createSpy.mock.calls[0][0]).not.toHaveProperty('dashboards')
+        })
+
+        it('attaches the dashboard without dropping existing links when updating an insight', async () => {
+            const updateSpy = jest.spyOn(insightsApi, 'update').mockResolvedValue(MOCK_INSIGHT)
+
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+            editorRootLogic = editorSceneLogic({ tabId: TAB_ID })
+            editorRootLogic.mount()
+
+            const insightOnDashboards = { ...MOCK_INSIGHT, dashboards: [7] } as QueryBasedInsightModel
+            logic.actions.editInsight(MOCK_INSIGHT_QUERY.source.query, insightOnDashboards)
+            await expectLogic(logic)
+                .toDispatchActions(['createTab', 'updateTab'])
+                .toMatchValues({ editingInsight: partial({ short_id: MOCK_INSIGHT_SHORT_ID }) })
+
+            logic.actions.setDashboardId(DASHBOARD_ID)
+            logic.actions.updateInsight()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(updateSpy).toHaveBeenCalledTimes(1)
+            const [, updatePayload] = updateSpy.mock.calls[0]
+            expect(updatePayload.dashboards).toEqual([7, DASHBOARD_ID])
         })
     })
 })

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1566,6 +1566,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     name,
                     query: sourceQueryToSave,
                     saved: true,
+                    ...(dashboardId ? { dashboards: [dashboardId] } : {}),
                 })
                 const logic = insightLogic({
                     dashboardItemId: insight.short_id,
@@ -1683,6 +1684,17 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     query: currentVisualizationQuery,
                 }
 
+                // When saving from a dashboard flow, attach the tile server-side without
+                // dropping the insight's existing dashboard links.
+                const dashboardId = values.dashboardId
+                if (dashboardId) {
+                    const existingDashboardIds = [
+                        ...(values.editingInsight.dashboard_tiles?.map((tile) => tile.dashboard_id) ?? []),
+                        ...(values.editingInsight.dashboards ?? []),
+                    ]
+                    insightRequest.dashboards = Array.from(new Set([...existingDashboardIds, dashboardId]))
+                }
+
                 let savedInsight: QueryBasedInsightModel
                 try {
                     savedInsight = await insightsApi.update(values.editingInsight.id, insightRequest)
@@ -1715,7 +1727,6 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     })
                 }
 
-                const dashboardId = values.dashboardId
                 if (dashboardId) {
                     dashboardsModel.findMounted()?.actions.updateDashboardInsight(savedInsight)
                     dashboardLogic.findMounted({ id: dashboardId })?.actions.loadDashboard({


### PR DESCRIPTION
## TL;DR

SQL insights created from a dashboard's "Add insight" modal showed a success toast but weren't actually linked to the dashboard. This restores the `dashboards` field on insight creation/update that was dropped during the multi-query refactor (PR #53241), which had previously been added by PR #52500.

## Problem

When creating or editing a SQL insight from a dashboard's "Add insight" flow, the insight would save successfully (showing a success toast) but would not be attached to the dashboard. The root cause was that the `saveInsight` and `updateInsight` listeners in `sqlEditorLogic.tsx` lost the `dashboards` field during the multi-query refactor.

## Changes

- On insight **creation** (`saveAsInsightSubmit`), include `dashboards: [dashboardId]` in the `insightsApi.create` payload when a `dashboardId` is set.
- On insight **update** (`updateInsight`), attach the dashboard server-side by merging the new `dashboardId` with the insight's existing dashboard links (from both `dashboard_tiles` and `dashboards`), deduplicated, so existing links are not dropped.
- Added regression tests in `sqlEditorLogic.test.ts` covering:
  - `dashboards` is passed to `insightsApi.create` when a `dashboardId` is set
  - `dashboards` is omitted when no `dashboardId` is set
  - updating an insight merges the new dashboard with existing links without dropping them

## How did you test this code?

I'm an agent. I added automated tests to `sqlEditorLogic.test.ts` that verify the `dashboards` field is correctly passed on creation and merged on update. I did not perform manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*