### PR TITLE
fix(data-warehouse): surface TemporalIO TLS cert failures as config errors

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -30,6 +30,18 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.TEMPORALIO
 
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # rustls surfaces mTLS rejections as TLS alert names inside the tonic transport
+        # error. These are credential problems — retrying can never recover.
+        return {
+            "received fatal alert: UnknownCA": "Temporal rejected this source's client certificate because it is not signed by a certificate authority the namespace trusts. This usually means the namespace's CA certificates were rotated — update the source with a client certificate and key signed by the current CA.",
+            "received fatal alert: CertificateExpired": "This source's client certificate has expired. Update the source with a renewed client certificate and key.",
+            "received fatal alert: CertificateRevoked": "This source's client certificate has been revoked. Update the source with a new client certificate and key.",
+            "received fatal alert: BadCertificate": "Temporal rejected this source's client certificate as invalid. Update the source with a valid client certificate and key.",
+            "received fatal alert: CertificateUnknown": "Temporal rejected this source's client certificate. Update the source with a valid client certificate and key.",
+            "invalid peer certificate": "The Temporal server's certificate could not be verified. Check the host and port point at your Temporal namespace's gRPC endpoint.",
+        }
+
     def get_schemas(
         self,
         config: TemporalIOSourceConfig,

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -1,9 +1,11 @@
+import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from temporalio.client import Client
 
 from posthog.temporal.common.codec import EncryptionCodec
 from posthog.temporal.data_imports.sources.generated_configs import TemporalIOSourceConfig
+from posthog.temporal.data_imports.sources.temporalio.source import TemporalIOSource
 from posthog.temporal.data_imports.sources.temporalio.temporalio import FakeSettings, _get_temporal_client
 
 
@@ -34,3 +36,40 @@ class TestTemporalIOClient:
 
         data_converter = mock_connect.call_args.kwargs["data_converter"]
         assert isinstance(data_converter.payload_codec, EncryptionCodec)
+
+
+class TestTemporalIONonRetryableErrors:
+    def setup_method(self):
+        self.source = TemporalIOSource()
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Custom { kind: InvalidData, error: "received fatal alert: UnknownCA" }))) }',
+            "received fatal alert: CertificateExpired",
+            "received fatal alert: CertificateRevoked",
+            "received fatal alert: BadCertificate",
+            "received fatal alert: CertificateUnknown",
+            "invalid peer certificate: UnknownIssuer",
+        ],
+    )
+    def test_tls_certificate_failures_are_non_retryable(self, error_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert any(pattern in error_message for pattern in non_retryable_errors), (
+            f"Expected '{error_message}' to match a non-retryable pattern"
+        )
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "activity Heartbeat timeout",
+            'RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Os { code: 60, kind: TimedOut, message: "Operation timed out" }))) }',
+        ],
+    )
+    def test_transient_failures_stay_retryable(self, error_message):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+
+        assert not any(pattern in error_message for pattern in non_retryable_errors), (
+            f"'{error_message}' must not match a non-retryable pattern"
+        )


### PR DESCRIPTION
## Problem

When a Temporal namespace stops trusting the client certificate stored on a TemporalIO source (cert expired, revoked, or the namespace's accepted CA certificates were rotated), every sync fails at connect with an opaque error:

```
RuntimeError: Failed client connect: `get_system_info` call error after connection: Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Io, Custom { kind: InvalidData, error: "received fatal alert: UnknownCA" }))) }
```

This is a credential problem that retrying can never recover from, but the pipeline treats it as transient — the schema keeps retrying on every scheduled run indefinitely, and the user-facing error gives no hint that the fix is to update the source's certificate.

## Changes

Add `get_non_retryable_errors` to `TemporalIOSource`, mapping the TLS alert names rustls embeds in the tonic transport error (`UnknownCA`, `CertificateExpired`, `CertificateRevoked`, `BadCertificate`, `CertificateUnknown`) plus client-side server-cert verification failures (`invalid peer certificate`) to friendly messages that tell the user to update the source's client certificate and key.

With this, the existing non-retryable error machinery in `update_external_data_job_model` pauses the schema and surfaces the friendly message instead of retrying forever.

## How did you test this code?

I'm an agent — no manual testing. Added parameterized tests covering:

- the full production-shaped transport error and each TLS alert matching a non-retryable pattern
- transient failures (heartbeat timeout, plain connection timeout) staying retryable

Ran `pytest posthog/temporal/data_imports/sources/ -k "TemporalIONonRetryable or TestTemporalIOClient"` — 10 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code while diagnosing a TemporalIO source whose syncs had been failing hourly with the `UnknownCA` transport error for days without a clear user-facing signal.
- The connection failure itself is a credentials issue fixed by updating the source config; this PR addresses the failure mode — classifying certificate rejections as non-retryable so the schema pauses with an actionable message instead of silently retrying forever.
- Matched the existing per-source `get_non_retryable_errors` pattern (e.g. the Attio source) and its test conventions.
