### PR TITLE
feat(insights): show group info in $group_key filter chip tooltip

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -43,6 +43,7 @@ from posthog.models.group_type_mapping import (
 from posthog.models.user import User
 from posthog.personhog_client.converters import GroupTypeMappingResult
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+from posthog.utils import str_to_bool
 
 from products.event_definitions.backend.models.property_definition import PropertyType
 from products.notebooks.backend.models import Notebook, ResourceNotebook
@@ -468,16 +469,25 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 description="Specify the key of the group to find",
                 required=True,
             ),
+            OpenApiParameter(
+                "skip_create_notebook",
+                OpenApiTypes.BOOL,
+                description="When true, do not lazily create the group's CRM notebook. "
+                "Use for read-only lookups (e.g. resolving a group's display name) that should not have side effects.",
+                required=False,
+            ),
         ]
     )
     @action(methods=["GET"], detail=False, required_scopes=["group:read"])
     def find(self, request: request.Request, **kw) -> response.Response:
         group_type_index, group_key = self._safely_get_query_params(require_group_key=True)
+        skip_create_notebook = str_to_bool(request.GET.get("skip_create_notebook"))
         group = get_group_by_key(self.team.pk, int(group_type_index), group_key)
         if group is None:
             raise NotFound()
         if (
-            self._is_crm_enabled(cast(User, request.user))
+            not skip_create_notebook
+            and self._is_crm_enabled(cast(User, request.user))
             and not ResourceNotebook.objects.filter(group=group.id).exists()
         ):
             try:

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -243,6 +243,27 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(notebook.content[1]["type"], "text")
 
     @freeze_time("2021-05-02")
+    @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=True)
+    def test_find_with_skip_create_notebook_does_not_create_notebook(self, _):
+        index: GroupTypeIndex = 0
+        key = "key"
+        group = create_group(
+            team_id=self.team.pk,
+            group_type_index=index,
+            group_key=key,
+            properties={"industry": "finance", "name": "Mr. Krabs"},
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/groups/find?group_type_index={index}&group_key={key}&skip_create_notebook=true"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, "Should return 200 OK")
+        self.assertEqual(response.json()["notebook"], None)
+        self.assertFalse(ResourceNotebook.objects.filter(group=group.id).exists())
+        self.assertEqual(0, Notebook.objects.filter(team=self.team).count())
+
+    @freeze_time("2021-05-02")
     def test_retrieve_group_with_notebook(self):
         index: GroupTypeIndex = 0
         key = "key"

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
@@ -1,0 +1,138 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import { GroupTypeIndex } from '~/types'
+
+import { GroupKeyFilterTooltip } from './GroupKeyFilterTooltip'
+
+const MOCK_GROUPS = [
+    {
+        group_type_index: 0,
+        group_key: 'uuid-001',
+        group_properties: { name: 'Fjellride AB' },
+        created_at: '2024-01-01',
+    },
+    {
+        group_type_index: 0,
+        group_key: 'key-no-name',
+        group_properties: {},
+        created_at: '2024-01-02',
+    },
+    {
+        group_type_index: 0,
+        group_key: 'uuid-cache',
+        group_properties: { name: 'Cacheable Co' },
+        created_at: '2024-01-03',
+    },
+]
+
+describe('GroupKeyFilterTooltip', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team/groups/find': (req: any) => {
+                    const groupKey = req.url.searchParams.get('group_key')
+                    const group = MOCK_GROUPS.find((g) => g.group_key === groupKey)
+                    return group ? [200, group] : [404, { detail: 'Not found' }]
+                },
+            },
+        })
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders the resolved group name and key when the lookup succeeds', async () => {
+        render(
+            <Provider>
+                <GroupKeyFilterTooltip
+                    groupTypeIndex={0 as GroupTypeIndex}
+                    groupKeys={['uuid-001']}
+                    fallbackLabel="$group_key = uuid-001"
+                />
+            </Provider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText('Fjellride AB')).toBeInTheDocument()
+        })
+        expect(screen.getByText('uuid-001')).toBeInTheDocument()
+        expect(screen.queryByText('$group_key = uuid-001')).not.toBeInTheDocument()
+    })
+
+    it('falls back to the raw group key as the name when the group has no name property', async () => {
+        render(
+            <Provider>
+                <GroupKeyFilterTooltip
+                    groupTypeIndex={0 as GroupTypeIndex}
+                    groupKeys={['key-no-name']}
+                    fallbackLabel="$group_key = key-no-name"
+                />
+            </Provider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getAllByText('key-no-name').length).toBeGreaterThan(0)
+        })
+    })
+
+    it('caches a resolved lookup so the key is only fetched once across remounts', async () => {
+        let findCalls = 0
+        useMocks({
+            get: {
+                '/api/environments/:team/groups/find': (req: any) => {
+                    findCalls++
+                    const groupKey = req.url.searchParams.get('group_key')
+                    const group = MOCK_GROUPS.find((g) => g.group_key === groupKey)
+                    return group ? [200, group] : [404, { detail: 'Not found' }]
+                },
+            },
+        })
+
+        const renderTooltip = (): ReturnType<typeof render> =>
+            render(
+                <Provider>
+                    <GroupKeyFilterTooltip
+                        groupTypeIndex={0 as GroupTypeIndex}
+                        groupKeys={['uuid-cache']}
+                        fallbackLabel="$group_key = uuid-cache"
+                    />
+                </Provider>
+            )
+
+        const first = renderTooltip()
+        await waitFor(() => {
+            expect(screen.getByText('Cacheable Co')).toBeInTheDocument()
+        })
+        act(() => first.unmount())
+
+        renderTooltip()
+        await waitFor(() => {
+            expect(screen.getByText('Cacheable Co')).toBeInTheDocument()
+        })
+
+        expect(findCalls).toBe(1)
+    })
+
+    it('shows the fallback label when the group cannot be looked up', async () => {
+        render(
+            <Provider>
+                <GroupKeyFilterTooltip
+                    groupTypeIndex={0 as GroupTypeIndex}
+                    groupKeys={['unknown-uuid']}
+                    fallbackLabel="$group_key = unknown-uuid"
+                />
+            </Provider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText('$group_key = unknown-uuid')).toBeInTheDocument()
+        })
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
@@ -71,7 +71,7 @@ describe('GroupKeyFilterTooltip', () => {
             <Provider>
                 <GroupKeyFilterTooltip
                     groupTypeIndex={0 as GroupTypeIndex}
-                    groupKeys={[groupKey]}
+                    groupKey={groupKey}
                     fallbackLabel={`$group_key = ${groupKey}`}
                 />
             </Provider>
@@ -100,7 +100,7 @@ describe('GroupKeyFilterTooltip', () => {
                 <Provider>
                     <GroupKeyFilterTooltip
                         groupTypeIndex={0 as GroupTypeIndex}
-                        groupKeys={['uuid-cache']}
+                        groupKey="uuid-cache"
                         fallbackLabel="$group_key = uuid-cache"
                     />
                 </Provider>

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
@@ -8,6 +8,7 @@ import { initKeaTests } from '~/test/init'
 import { GroupTypeIndex } from '~/types'
 
 import { GroupKeyFilterTooltip } from './GroupKeyFilterTooltip'
+import { clearGroupLookupCache } from './groupKeyTooltipLogic'
 
 const MOCK_GROUPS = [
     {
@@ -42,6 +43,7 @@ describe('GroupKeyFilterTooltip', () => {
             },
         })
         initKeaTests()
+        clearGroupLookupCache()
     })
 
     afterEach(() => {

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.test.tsx
@@ -48,37 +48,35 @@ describe('GroupKeyFilterTooltip', () => {
         cleanup()
     })
 
-    it('renders the resolved group name and key when the lookup succeeds', async () => {
+    it.each([
+        {
+            description: 'the resolved group name when the lookup succeeds',
+            groupKey: 'uuid-001',
+            expectedText: 'Fjellride AB',
+        },
+        {
+            description: 'the raw group key as the name when the group has no name property',
+            groupKey: 'key-no-name',
+            expectedText: 'key-no-name',
+        },
+        {
+            description: 'the fallback label when the group cannot be looked up',
+            groupKey: 'unknown-uuid',
+            expectedText: '$group_key = unknown-uuid',
+        },
+    ])('renders $description', async ({ groupKey, expectedText }) => {
         render(
             <Provider>
                 <GroupKeyFilterTooltip
                     groupTypeIndex={0 as GroupTypeIndex}
-                    groupKeys={['uuid-001']}
-                    fallbackLabel="$group_key = uuid-001"
+                    groupKeys={[groupKey]}
+                    fallbackLabel={`$group_key = ${groupKey}`}
                 />
             </Provider>
         )
 
         await waitFor(() => {
-            expect(screen.getByText('Fjellride AB')).toBeInTheDocument()
-        })
-        expect(screen.getByText('uuid-001')).toBeInTheDocument()
-        expect(screen.queryByText('$group_key = uuid-001')).not.toBeInTheDocument()
-    })
-
-    it('falls back to the raw group key as the name when the group has no name property', async () => {
-        render(
-            <Provider>
-                <GroupKeyFilterTooltip
-                    groupTypeIndex={0 as GroupTypeIndex}
-                    groupKeys={['key-no-name']}
-                    fallbackLabel="$group_key = key-no-name"
-                />
-            </Provider>
-        )
-
-        await waitFor(() => {
-            expect(screen.getAllByText('key-no-name').length).toBeGreaterThan(0)
+            expect(screen.getAllByText(expectedText).length).toBeGreaterThan(0)
         })
     })
 
@@ -118,21 +116,5 @@ describe('GroupKeyFilterTooltip', () => {
         })
 
         expect(findCalls).toBe(1)
-    })
-
-    it('shows the fallback label when the group cannot be looked up', async () => {
-        render(
-            <Provider>
-                <GroupKeyFilterTooltip
-                    groupTypeIndex={0 as GroupTypeIndex}
-                    groupKeys={['unknown-uuid']}
-                    fallbackLabel="$group_key = unknown-uuid"
-                />
-            </Provider>
-        )
-
-        await waitFor(() => {
-            expect(screen.getByText('$group_key = unknown-uuid')).toBeInTheDocument()
-        })
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.tsx
@@ -5,7 +5,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 
-import { GroupTypeIndex } from '~/types'
+import { Group, GroupTypeIndex } from '~/types'
 
 import { groupKeyTooltipLogic } from './groupKeyTooltipLogic'
 
@@ -13,6 +13,25 @@ export interface GroupKeyFilterTooltipProps {
     groupTypeIndex: GroupTypeIndex
     groupKey: string
     fallbackLabel: string
+}
+
+export function GroupInfoCard({ group }: { group: Group }): JSX.Element {
+    return (
+        <div className="flex flex-col">
+            <span className="font-semibold">{groupDisplayId(group.group_key, group.group_properties)}</span>
+            <CopyToClipboardInline
+                selectable
+                description="group key"
+                tooltipMessage={null}
+                className="font-mono text-xs text-secondary"
+            >
+                {group.group_key}
+            </CopyToClipboardInline>
+            <span className="text-xs">
+                First seen: {group.created_at ? <TZLabel time={group.created_at} /> : 'unknown'}
+            </span>
+        </div>
+    )
 }
 
 export function GroupKeyFilterTooltip({
@@ -34,20 +53,5 @@ export function GroupKeyFilterTooltip({
         return <>{fallbackLabel}</>
     }
 
-    return (
-        <div className="flex flex-col">
-            <span className="font-semibold">{groupDisplayId(group.group_key, group.group_properties)}</span>
-            <CopyToClipboardInline
-                selectable
-                description="group key"
-                tooltipMessage={null}
-                className="font-mono text-xs text-secondary"
-            >
-                {group.group_key}
-            </CopyToClipboardInline>
-            <span className="text-xs">
-                First seen: {group.created_at ? <TZLabel time={group.created_at} /> : 'unknown'}
-            </span>
-        </div>
-    )
+    return <GroupInfoCard group={group} />
 }

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { TZLabel } from 'lib/components/TZLabel'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
@@ -10,38 +11,43 @@ import { groupKeyTooltipLogic } from './groupKeyTooltipLogic'
 
 export interface GroupKeyFilterTooltipProps {
     groupTypeIndex: GroupTypeIndex
-    groupKeys: string[]
+    groupKey: string
     fallbackLabel: string
 }
 
 export function GroupKeyFilterTooltip({
     groupTypeIndex,
-    groupKeys,
+    groupKey,
     fallbackLabel,
 }: GroupKeyFilterTooltipProps): JSX.Element {
-    const { groups, groupsLoading } = useValues(groupKeyTooltipLogic({ groupTypeIndex, groupKeys }))
+    const { group, groupLoading } = useValues(groupKeyTooltipLogic({ groupTypeIndex, groupKey }))
 
-    if (groupsLoading) {
-        return <Spinner />
+    if (groupLoading) {
+        return (
+            <div className="flex items-center justify-center min-w-32">
+                <Spinner />
+            </div>
+        )
     }
 
-    const resolved = groupKeys.map((groupKey) => groups[groupKey]).filter(Boolean)
-
-    if (resolved.length === 0) {
+    if (!group) {
         return <>{fallbackLabel}</>
     }
 
     return (
-        <div className="flex flex-col gap-2">
-            {resolved.map((group) => (
-                <div key={group.group_key} className="flex flex-col">
-                    <span className="font-semibold">{groupDisplayId(group.group_key, group.group_properties)}</span>
-                    <span className="font-mono text-xs text-secondary">{group.group_key}</span>
-                    <span className="text-xs">
-                        First seen: {group.created_at ? <TZLabel time={group.created_at} /> : 'unknown'}
-                    </span>
-                </div>
-            ))}
+        <div className="flex flex-col">
+            <span className="font-semibold">{groupDisplayId(group.group_key, group.group_properties)}</span>
+            <CopyToClipboardInline
+                selectable
+                description="group key"
+                tooltipMessage={null}
+                className="font-mono text-xs text-secondary"
+            >
+                {group.group_key}
+            </CopyToClipboardInline>
+            <span className="text-xs">
+                First seen: {group.created_at ? <TZLabel time={group.created_at} /> : 'unknown'}
+            </span>
         </div>
     )
 }

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeyFilterTooltip.tsx
@@ -1,0 +1,47 @@
+import { useValues } from 'kea'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
+
+import { GroupTypeIndex } from '~/types'
+
+import { groupKeyTooltipLogic } from './groupKeyTooltipLogic'
+
+export interface GroupKeyFilterTooltipProps {
+    groupTypeIndex: GroupTypeIndex
+    groupKeys: string[]
+    fallbackLabel: string
+}
+
+export function GroupKeyFilterTooltip({
+    groupTypeIndex,
+    groupKeys,
+    fallbackLabel,
+}: GroupKeyFilterTooltipProps): JSX.Element {
+    const { groups, groupsLoading } = useValues(groupKeyTooltipLogic({ groupTypeIndex, groupKeys }))
+
+    if (groupsLoading) {
+        return <Spinner />
+    }
+
+    const resolved = groupKeys.map((groupKey) => groups[groupKey]).filter(Boolean)
+
+    if (resolved.length === 0) {
+        return <>{fallbackLabel}</>
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            {resolved.map((group) => (
+                <div key={group.group_key} className="flex flex-col">
+                    <span className="font-semibold">{groupDisplayId(group.group_key, group.group_properties)}</span>
+                    <span className="font-mono text-xs text-secondary">{group.group_key}</span>
+                    <span className="text-xs">
+                        First seen: {group.created_at ? <TZLabel time={group.created_at} /> : 'unknown'}
+                    </span>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.test.tsx
@@ -9,6 +9,7 @@ import { initKeaTests } from '~/test/init'
 import { PropertyOperator } from '~/types'
 
 import { GroupKeySelect } from './GroupKeySelect'
+import { clearGroupLookupCache } from './groupKeyTooltipLogic'
 
 const MOCK_GROUPS = [
     {
@@ -31,6 +32,15 @@ const MOCK_GROUPS = [
     },
 ]
 
+// Resolvable via the find endpoint but absent from the list endpoint, like a
+// pasted group key that the search results don't include.
+const FIND_ONLY_GROUP = {
+    group_type_index: 0,
+    group_key: 'uuid-hidden',
+    group_properties: { name: 'Hidden Co' },
+    created_at: '2024-01-04',
+}
+
 describe('GroupKeySelect', () => {
     beforeEach(() => {
         useMocks({
@@ -41,12 +51,13 @@ describe('GroupKeySelect', () => {
                 },
                 '/api/environments/:team/groups/find': (req: any) => {
                     const groupKey = req.url.searchParams.get('group_key')
-                    const group = MOCK_GROUPS.find((g) => g.group_key === groupKey)
+                    const group = [...MOCK_GROUPS, FIND_ONLY_GROUP].find((g) => g.group_key === groupKey)
                     return group ? [200, group] : [404, { detail: 'Not found' }]
                 },
             },
         })
         initKeaTests()
+        clearGroupLookupCache()
     })
 
     afterEach(() => {
@@ -173,5 +184,72 @@ describe('GroupKeySelect', () => {
         await waitFor(() => {
             expect(screen.getByText('key-no-name')).toBeInTheDocument()
         })
+    })
+
+    it.each([
+        {
+            description: 'a group from the loaded options',
+            value: 'uuid-001',
+            snackLabel: 'Fjellride AB',
+            expectedKeyInCard: 'uuid-001',
+            forceSingleSelect: false,
+        },
+        {
+            description: 'a pasted group key resolved lazily via the find endpoint',
+            value: 'uuid-hidden',
+            snackLabel: 'Hidden Co',
+            expectedKeyInCard: 'uuid-hidden',
+            forceSingleSelect: false,
+        },
+        {
+            description: 'a single-select value snack',
+            value: 'uuid-001',
+            snackLabel: 'Fjellride AB',
+            expectedKeyInCard: 'uuid-001',
+            forceSingleSelect: true,
+        },
+    ])(
+        'shows the group info card when hovering the selected value snack for $description',
+        async ({ value, snackLabel, expectedKeyInCard, forceSingleSelect }) => {
+            render(
+                <Provider>
+                    <GroupKeySelect
+                        value={[value]}
+                        groupTypeIndex={0}
+                        operator={PropertyOperator.Exact}
+                        onChange={jest.fn()}
+                        forceSingleSelect={forceSingleSelect}
+                    />
+                </Provider>
+            )
+
+            const snack = await screen.findByText(snackLabel)
+            await userEvent.hover(snack)
+
+            expect(await screen.findByText(expectedKeyInCard)).toBeInTheDocument()
+            expect(await screen.findByText(/First seen:/)).toBeInTheDocument()
+        }
+    )
+
+    it('shows the group info card when hovering a dropdown option', async () => {
+        render(
+            <Provider>
+                <GroupKeySelect
+                    value={null}
+                    groupTypeIndex={0}
+                    operator={PropertyOperator.Exact}
+                    onChange={jest.fn()}
+                />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.click(input)
+
+        const option = await screen.findByText('Bitfusion PR LLC')
+        await userEvent.hover(option)
+
+        expect(await screen.findByText('uuid-002')).toBeInTheDocument()
+        expect(await screen.findByText(/First seen:/)).toBeInTheDocument()
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/GroupKeySelect.tsx
@@ -1,11 +1,13 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
+import { LemonInputSelect, LemonInputSelectOption } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { isOperatorMulti } from 'lib/utils'
+import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 
 import type { GroupTypeIndex, PropertyFilterValue, PropertyOperator } from '~/types'
 
+import { GroupInfoCard, GroupKeyFilterTooltip } from './GroupKeyFilterTooltip'
 import { groupKeySelectLogic } from './groupKeySelectLogic'
 
 export interface GroupKeySelectProps {
@@ -33,22 +35,36 @@ export function GroupKeySelect({
     )
 
     const logic = groupKeySelectLogic({ groupTypeIndex, value: currentValues })
-    const { groupOptions, groupsLoading, resolvedNames, searchQuery } = useValues(logic)
+    const { groups, groupsLoading, resolvedNames, searchQuery } = useValues(logic)
     const { setSearchQuery } = useActions(logic)
     const isMultiSelect = forceSingleSelect ? false : operator && isOperatorMulti(operator)
 
     const options = useMemo(() => {
-        const optionMap = new Map<string, { key: string; label: string }>()
-        for (const opt of groupOptions) {
-            optionMap.set(opt.key, opt)
+        const optionMap = new Map<string, LemonInputSelectOption>()
+        for (const group of groups) {
+            optionMap.set(group.group_key, {
+                key: group.group_key,
+                label: groupDisplayId(group.group_key, group.group_properties),
+                tooltip: <GroupInfoCard group={group} />,
+            })
         }
         for (const v of currentValues) {
             if (!optionMap.has(v)) {
-                optionMap.set(v, { key: v, label: resolvedNames[v] ?? v })
+                optionMap.set(v, {
+                    key: v,
+                    label: resolvedNames[v] ?? v,
+                    tooltip: (
+                        <GroupKeyFilterTooltip
+                            groupTypeIndex={groupTypeIndex}
+                            groupKey={v}
+                            fallbackLabel={resolvedNames[v] ?? v}
+                        />
+                    ),
+                })
             }
         }
         return Array.from(optionMap.values())
-    }, [groupOptions, currentValues, resolvedNames])
+    }, [groups, currentValues, resolvedNames, groupTypeIndex])
 
     return (
         <LemonInputSelect

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -12,9 +12,10 @@ import { midEllipsis } from 'lib/utils'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { AnyPropertyFilter, GroupPropertyFilter, GroupTypeIndex } from '~/types'
+import { AnyPropertyFilter, GroupPropertyFilter, GroupTypeIndex, PropertyFilterType } from '~/types'
 
 import { formatPropertyLabel, propertyFilterTypeToPropertyDefinitionType } from '../utils'
+import { GroupKeyFilterTooltip } from './GroupKeyFilterTooltip'
 
 export interface PropertyFilterButtonProps {
     onClick?: () => void
@@ -54,6 +55,22 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
             return <></>
         }
 
+        const groupTypeIndex = (item as GroupPropertyFilter).group_type_index
+        const groupKeys = Array.isArray(item.value)
+            ? item.value.map(String)
+            : item.value !== null && item.value !== undefined
+              ? [String(item.value)]
+              : []
+        // When a $group_key filter resolves to a real group we replace the bare
+        // "$group_key = <uuid>" tooltip with a formatted card so the user can
+        // confirm they picked the right group (e.g. after pasting a UUID).
+        const isGroupKeyFilter =
+            item.type === PropertyFilterType.Group &&
+            item.key === '$group_key' &&
+            groupTypeIndex !== null &&
+            groupTypeIndex !== undefined &&
+            groupKeys.length > 0
+
         const closable = onClose !== undefined
         const clickable = onClick !== undefined
 
@@ -72,7 +89,7 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
                 type={ButtonComponent === 'button' ? 'button' : undefined}
             >
                 <PropertyFilterIcon type={item.type} />
-                <span className="PropertyFilterButton-content" title={label}>
+                <span className="PropertyFilterButton-content" title={isGroupKeyFilter ? undefined : label}>
                     {midEllipsis(label, 32)}
                 </span>
                 {closable && !disabledReason && (
@@ -94,6 +111,22 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
 
         if (disabledReason) {
             return <Tooltip title={disabledReason}>{button}</Tooltip>
+        }
+
+        if (isGroupKeyFilter) {
+            return (
+                <Tooltip
+                    title={
+                        <GroupKeyFilterTooltip
+                            groupTypeIndex={groupTypeIndex as GroupTypeIndex}
+                            groupKeys={groupKeys}
+                            fallbackLabel={label}
+                        />
+                    }
+                >
+                    {button}
+                </Tooltip>
+            )
         }
 
         return button

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -61,15 +61,17 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
             : item.value !== null && item.value !== undefined
               ? [String(item.value)]
               : []
-        // When a $group_key filter resolves to a real group we replace the bare
-        // "$group_key = <uuid>" tooltip with a formatted card so the user can
-        // confirm they picked the right group (e.g. after pasting a UUID).
+        // When a single-group `$group_key` filter resolves to a real group we
+        // replace the bare "$group_key = <uuid>" tooltip with a formatted card so
+        // the user can confirm they picked the right group (e.g. after pasting a
+        // UUID). Restricted to a single value so hovering only ever looks up the
+        // one group under the mouse — never a fan-out across an "is one of" list.
         const isGroupKeyFilter =
             item.type === PropertyFilterType.Group &&
             item.key === '$group_key' &&
             groupTypeIndex !== null &&
             groupTypeIndex !== undefined &&
-            groupKeys.length > 0
+            groupKeys.length === 1
 
         const closable = onClose !== undefined
         const clickable = onClick !== undefined
@@ -116,10 +118,11 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
         if (isGroupKeyFilter) {
             return (
                 <Tooltip
+                    interactive
                     title={
                         <GroupKeyFilterTooltip
                             groupTypeIndex={groupTypeIndex as GroupTypeIndex}
-                            groupKeys={groupKeys}
+                            groupKey={groupKeys[0]}
                             fallbackLabel={label}
                         />
                     }

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
@@ -118,17 +118,6 @@ export const groupKeySelectLogic = kea<groupKeySelectLogicType>([
             },
         ],
     })),
-    selectors({
-        groupOptions: [
-            (s) => [s.groups],
-            (groups: Group[]): { key: string; label: string }[] => {
-                return groups.map((g) => ({
-                    key: g.group_key,
-                    label: groupDisplayId(g.group_key, g.group_properties),
-                }))
-            },
-        ],
-    }),
     listeners(({ actions }) => ({
         setSearchQuery: ({ query }: { query: string }) => {
             actions.loadGroups({ search: query })

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -14,30 +14,44 @@ export interface GroupKeySelectLogicProps {
     value: string[]
 }
 
-export async function resolveGroupNames(
+export async function findGroups(
     teamId: number | null,
     groupTypeIndex: GroupTypeIndex,
     groupKeys: string[]
-): Promise<Record<string, string>> {
+): Promise<Record<string, Group>> {
     if (!teamId || groupKeys.length === 0) {
         return {}
     }
     const results = await Promise.all(
         groupKeys.map(async (groupKey) => {
             try {
-                const response = await api.get(
+                const response: Group = await api.get(
                     `api/environments/${teamId}/groups/find/?${new URLSearchParams({
                         group_type_index: String(groupTypeIndex),
                         group_key: groupKey,
                     }).toString()}`
                 )
-                return [groupKey, groupDisplayId(response.group_key, response.group_properties)] as const
+                return [groupKey, response] as const
             } catch {
                 return null
             }
         })
     )
-    return Object.fromEntries(results.filter((r): r is readonly [string, string] => r !== null))
+    return Object.fromEntries(results.filter((r): r is readonly [string, Group] => r !== null))
+}
+
+export async function resolveGroupNames(
+    teamId: number | null,
+    groupTypeIndex: GroupTypeIndex,
+    groupKeys: string[]
+): Promise<Record<string, string>> {
+    const groups = await findGroups(teamId, groupTypeIndex, groupKeys)
+    return Object.fromEntries(
+        Object.entries(groups).map(([groupKey, group]) => [
+            groupKey,
+            groupDisplayId(group.group_key, group.group_properties),
+        ])
+    )
 }
 
 export const groupKeySelectLogic = kea<groupKeySelectLogicType>([

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -34,6 +34,9 @@ export async function findGroups(
                     `api/environments/${teamId}/groups/find/?${new URLSearchParams({
                         group_type_index: String(groupTypeIndex),
                         group_key: groupKey,
+                        // Resolving a display name is read-only; don't lazily
+                        // create the group's CRM notebook as a side effect.
+                        skip_create_notebook: 'true',
                     }).toString()}`
                 )
                 return [groupKey, response] as const

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeySelectLogic.ts
@@ -1,7 +1,9 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { ApiError } from 'lib/api-error'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -14,11 +16,14 @@ export interface GroupKeySelectLogicProps {
     value: string[]
 }
 
+// A `null` value is a definitive "no such group" (404) that callers may cache.
+// A key absent from the result hit a transient error and should be retried, not
+// remembered as a miss.
 export async function findGroups(
     teamId: number | null,
     groupTypeIndex: GroupTypeIndex,
     groupKeys: string[]
-): Promise<Record<string, Group>> {
+): Promise<Record<string, Group | null>> {
     if (!teamId || groupKeys.length === 0) {
         return {}
     }
@@ -32,12 +37,16 @@ export async function findGroups(
                     }).toString()}`
                 )
                 return [groupKey, response] as const
-            } catch {
+            } catch (error) {
+                if (error instanceof ApiError && error.status === 404) {
+                    return [groupKey, null] as const
+                }
+                posthog.captureException(error)
                 return null
             }
         })
     )
-    return Object.fromEntries(results.filter((r): r is readonly [string, Group] => r !== null))
+    return Object.fromEntries(results.filter((r): r is readonly [string, Group | null] => r !== null))
 }
 
 export async function resolveGroupNames(
@@ -46,12 +55,13 @@ export async function resolveGroupNames(
     groupKeys: string[]
 ): Promise<Record<string, string>> {
     const groups = await findGroups(teamId, groupTypeIndex, groupKeys)
-    return Object.fromEntries(
-        Object.entries(groups).map(([groupKey, group]) => [
-            groupKey,
-            groupDisplayId(group.group_key, group.group_properties),
-        ])
-    )
+    const names: Record<string, string> = {}
+    for (const [groupKey, group] of Object.entries(groups)) {
+        if (group) {
+            names[groupKey] = groupDisplayId(group.group_key, group.group_properties)
+        }
+    }
+    return names
 }
 
 export const groupKeySelectLogic = kea<groupKeySelectLogicType>([

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
@@ -32,8 +32,9 @@ async function cachedFindGroups(
     const resolved: Record<string, Group> = {}
     const uncachedKeys: string[] = []
     for (const groupKey of groupKeys) {
-        if (groupLookupCache.has(cacheKey(teamId, groupTypeIndex, groupKey))) {
-            const cached = groupLookupCache.get(cacheKey(teamId, groupTypeIndex, groupKey))
+        const k = cacheKey(teamId, groupTypeIndex, groupKey)
+        if (groupLookupCache.has(k)) {
+            const cached = groupLookupCache.get(k)
             if (cached) {
                 resolved[groupKey] = cached
             }
@@ -44,10 +45,15 @@ async function cachedFindGroups(
     if (uncachedKeys.length > 0) {
         const found = await findGroups(teamId, groupTypeIndex, uncachedKeys)
         for (const groupKey of uncachedKeys) {
-            const group = found[groupKey] ?? null
-            groupLookupCache.set(cacheKey(teamId, groupTypeIndex, groupKey), group)
-            if (group) {
-                resolved[groupKey] = group
+            // Only cache a definitive result (a group, or null for a 404 miss).
+            // Transient failures are absent from `found`, so we leave them
+            // uncached and the next hover retries them.
+            if (groupKey in found) {
+                const group = found[groupKey]
+                groupLookupCache.set(cacheKey(teamId, groupTypeIndex, groupKey), group)
+                if (group) {
+                    resolved[groupKey] = group
+                }
             }
         }
     }
@@ -56,7 +62,7 @@ async function cachedFindGroups(
 
 export const groupKeyTooltipLogic = kea<groupKeyTooltipLogicType>([
     props({} as GroupKeyTooltipLogicProps),
-    key((props) => `${props.groupTypeIndex}-${[...props.groupKeys].sort().join(',')}`),
+    key((props) => `${props.groupTypeIndex}-${JSON.stringify([...props.groupKeys].sort())}`),
     path((key) => ['lib', 'components', 'PropertyFilters', 'components', 'groupKeyTooltipLogic', key]),
     connect(() => ({
         values: [teamLogic, ['currentTeamId']],

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
@@ -1,0 +1,75 @@
+import { afterMount, connect, kea, key, path, props } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { Group, GroupTypeIndex } from '~/types'
+
+import { findGroups } from './groupKeySelectLogic'
+import type { groupKeyTooltipLogicType } from './groupKeyTooltipLogicType'
+
+export interface GroupKeyTooltipLogicProps {
+    groupTypeIndex: GroupTypeIndex
+    groupKeys: string[]
+}
+
+// Resolved lookups survive tooltip close/reopen so a given key is only ever
+// fetched once. A null entry records a key we looked up but didn't find, so we
+// don't keep retrying misses (e.g. a pasted UUID that isn't a real group).
+const groupLookupCache = new Map<string, Group | null>()
+
+const cacheKey = (teamId: number, groupTypeIndex: GroupTypeIndex, groupKey: string): string =>
+    `${teamId}:${groupTypeIndex}:${groupKey}`
+
+async function cachedFindGroups(
+    teamId: number | null,
+    groupTypeIndex: GroupTypeIndex,
+    groupKeys: string[]
+): Promise<Record<string, Group>> {
+    if (!teamId) {
+        return {}
+    }
+    const resolved: Record<string, Group> = {}
+    const uncachedKeys: string[] = []
+    for (const groupKey of groupKeys) {
+        if (groupLookupCache.has(cacheKey(teamId, groupTypeIndex, groupKey))) {
+            const cached = groupLookupCache.get(cacheKey(teamId, groupTypeIndex, groupKey))
+            if (cached) {
+                resolved[groupKey] = cached
+            }
+        } else {
+            uncachedKeys.push(groupKey)
+        }
+    }
+    if (uncachedKeys.length > 0) {
+        const found = await findGroups(teamId, groupTypeIndex, uncachedKeys)
+        for (const groupKey of uncachedKeys) {
+            const group = found[groupKey] ?? null
+            groupLookupCache.set(cacheKey(teamId, groupTypeIndex, groupKey), group)
+            if (group) {
+                resolved[groupKey] = group
+            }
+        }
+    }
+    return resolved
+}
+
+export const groupKeyTooltipLogic = kea<groupKeyTooltipLogicType>([
+    props({} as GroupKeyTooltipLogicProps),
+    key((props) => `${props.groupTypeIndex}-${[...props.groupKeys].sort().join(',')}`),
+    path((key) => ['lib', 'components', 'PropertyFilters', 'components', 'groupKeyTooltipLogic', key]),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    loaders(({ values, props }) => ({
+        groups: [
+            {} as Record<string, Group>,
+            {
+                loadGroups: async () => cachedFindGroups(values.currentTeamId, props.groupTypeIndex, props.groupKeys),
+            },
+        ],
+    })),
+    afterMount(({ actions }) => {
+        actions.loadGroups()
+    }),
+])

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
@@ -10,7 +10,7 @@ import type { groupKeyTooltipLogicType } from './groupKeyTooltipLogicType'
 
 export interface GroupKeyTooltipLogicProps {
     groupTypeIndex: GroupTypeIndex
-    groupKeys: string[]
+    groupKey: string
 }
 
 // Resolved lookups survive tooltip close/reopen so a given key is only ever
@@ -27,61 +27,46 @@ export function clearGroupLookupCache(): void {
     groupLookupCache.clear()
 }
 
-async function cachedFindGroups(
+async function cachedFindGroup(
     teamId: number | null,
     groupTypeIndex: GroupTypeIndex,
-    groupKeys: string[]
-): Promise<Record<string, Group>> {
+    groupKey: string
+): Promise<Group | null> {
     if (!teamId) {
-        return {}
+        return null
     }
-    const resolved: Record<string, Group> = {}
-    const uncachedKeys: string[] = []
-    for (const groupKey of groupKeys) {
-        const k = cacheKey(teamId, groupTypeIndex, groupKey)
-        if (groupLookupCache.has(k)) {
-            const cached = groupLookupCache.get(k)
-            if (cached) {
-                resolved[groupKey] = cached
-            }
-        } else {
-            uncachedKeys.push(groupKey)
-        }
+    const k = cacheKey(teamId, groupTypeIndex, groupKey)
+    if (groupLookupCache.has(k)) {
+        return groupLookupCache.get(k) ?? null
     }
-    if (uncachedKeys.length > 0) {
-        const found = await findGroups(teamId, groupTypeIndex, uncachedKeys)
-        for (const groupKey of uncachedKeys) {
-            // Only cache a definitive result (a group, or null for a 404 miss).
-            // Transient failures are absent from `found`, so we leave them
-            // uncached and the next hover retries them.
-            if (groupKey in found) {
-                const group = found[groupKey]
-                groupLookupCache.set(cacheKey(teamId, groupTypeIndex, groupKey), group)
-                if (group) {
-                    resolved[groupKey] = group
-                }
-            }
-        }
+    const found = await findGroups(teamId, groupTypeIndex, [groupKey])
+    // Only cache a definitive result (a group, or null for a 404 miss).
+    // Transient failures are absent from `found`, so we leave them uncached
+    // and the next hover retries them.
+    if (groupKey in found) {
+        const group = found[groupKey]
+        groupLookupCache.set(k, group)
+        return group
     }
-    return resolved
+    return null
 }
 
 export const groupKeyTooltipLogic = kea<groupKeyTooltipLogicType>([
     props({} as GroupKeyTooltipLogicProps),
-    key((props) => `${props.groupTypeIndex}-${JSON.stringify([...props.groupKeys].sort())}`),
+    key((props) => `${props.groupTypeIndex}-${props.groupKey}`),
     path((key) => ['lib', 'components', 'PropertyFilters', 'components', 'groupKeyTooltipLogic', key]),
     connect(() => ({
         values: [teamLogic, ['currentTeamId']],
     })),
     loaders(({ values, props }) => ({
-        groups: [
-            {} as Record<string, Group>,
+        group: [
+            null as Group | null,
             {
-                loadGroups: async () => cachedFindGroups(values.currentTeamId, props.groupTypeIndex, props.groupKeys),
+                loadGroup: async () => cachedFindGroup(values.currentTeamId, props.groupTypeIndex, props.groupKey),
             },
         ],
     })),
     afterMount(({ actions }) => {
-        actions.loadGroups()
+        actions.loadGroup()
     }),
 ])

--- a/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/groupKeyTooltipLogic.ts
@@ -21,6 +21,12 @@ const groupLookupCache = new Map<string, Group | null>()
 const cacheKey = (teamId: number, groupTypeIndex: GroupTypeIndex, groupKey: string): string =>
     `${teamId}:${groupTypeIndex}:${groupKey}`
 
+// Exposed for tests — the cache is a module singleton, so it must be reset
+// between cases to keep them independent.
+export function clearGroupLookupCache(): void {
+    groupLookupCache.clear()
+}
+
 async function cachedFindGroups(
     teamId: number | null,
     groupTypeIndex: GroupTypeIndex,

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -121,6 +121,7 @@ export interface LemonInputSelectOption<T = string> {
     key: string
     label: string
     labelComponent?: React.ReactNode
+    /** Shown when hovering the dropdown option row and any snack rendered for the selected value. */
     tooltip?: TooltipTitle
     /** @internal */
     __isInput?: boolean
@@ -294,8 +295,16 @@ export function LemonInputSelect<T = string>({
 
     const separateOnComma = allowCustomValues && mode === 'multiple' && !disableCommaSplitting
 
-    // We stringify the objects to prevent wasteful recalculations (esp. Fuse). Note: labelComponent is not serializable
-    const optionsKey = JSON.stringify(options, (key, value) => (key === 'labelComponent' ? value?.name : value))
+    // We stringify the objects to prevent wasteful recalculations (esp. Fuse). Note: labelComponent and non-string tooltips are not serializable
+    const optionsKey = JSON.stringify(options, (key, value) => {
+        if (key === 'labelComponent') {
+            return value?.name
+        }
+        if (key === 'tooltip' && typeof value !== 'string') {
+            return value?.type?.name
+        }
+        return value
+    })
     const stringKeys = values.map(getStringKey)
     const valuesKey = JSON.stringify(stringKeys)
     const allOptionsMap: Map<string, LemonInputSelectOption<T>> = useMemo(() => {
@@ -599,24 +608,28 @@ export function LemonInputSelect<T = string>({
         // For single mode with a selected value and no active input, show the value as prefix since
         // showing the entered value as placeholder was unintuitive
         if (mode === 'single' && values.length > 0 && !inputValue) {
-            const label = allOptionsMap.get(getStringKey(values[0]))?.label ?? getDisplayLabel(values[0])
+            const selectedOption = allOptionsMap.get(getStringKey(values[0]))
+            const label = selectedOption?.label ?? getDisplayLabel(values[0])
             if (singleValueAsSnack) {
                 const canClear = allowCustomValues && !disableEditing
+                const snack = (
+                    <LemonSnack
+                        title={String(label)}
+                        onClose={
+                            canClear
+                                ? () => {
+                                      setInputValue('')
+                                      onChange?.([])
+                                  }
+                                : undefined
+                        }
+                    >
+                        {label}
+                    </LemonSnack>
+                )
                 return (
                     <PopoverReferenceContext.Provider value={null}>
-                        <LemonSnack
-                            title={String(label)}
-                            onClose={
-                                canClear
-                                    ? () => {
-                                          setInputValue('')
-                                          onChange?.([])
-                                      }
-                                    : undefined
-                            }
-                        >
-                            {label}
-                        </LemonSnack>
+                        {selectedOption?.tooltip ? <Tooltip title={selectedOption.tooltip}>{snack}</Tooltip> : snack}
                     </PopoverReferenceContext.Provider>
                 )
             }
@@ -1073,17 +1086,19 @@ function DraggableValueSnack<T = string>({
     return (
         <Tooltip
             title={
-                <>
-                    <span>
-                        {onInitiateEdit && (
-                            <>
-                                Click on the text to edit.
-                                <br />
-                            </>
-                        )}
-                    </span>
-                    <span>Click on the X to remove.</span>
-                </>
+                option.tooltip ?? (
+                    <>
+                        <span>
+                            {onInitiateEdit && (
+                                <>
+                                    Click on the text to edit.
+                                    <br />
+                                </>
+                            )}
+                        </span>
+                        <span>Click on the X to remove.</span>
+                    </>
+                )
             }
         >
             <span
@@ -1168,17 +1183,19 @@ function ValueSnacks<T = string>({
             <Tooltip
                 key={value}
                 title={
-                    <>
-                        <span>
-                            {onInitiateEdit && (
-                                <>
-                                    Click on the text to edit.
-                                    <br />
-                                </>
-                            )}
-                        </span>
-                        <span>Click on the X to remove.</span>
-                    </>
+                    option.tooltip ?? (
+                        <>
+                            <span>
+                                {onInitiateEdit && (
+                                    <>
+                                        Click on the text to edit.
+                                        <br />
+                                    </>
+                                )}
+                            </span>
+                            <span>Click on the X to remove.</span>
+                        </>
+                    )
                 }
             >
                 <LemonSnack

--- a/frontend/src/lib/lemon-ui/LemonSnack/LemonSnack.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSnack/LemonSnack.tsx
@@ -6,7 +6,7 @@ import { IconX } from '@posthog/icons'
 // eslint-disable-next-line import/no-cycle
 import { LemonButton } from '@posthog/lemon-ui'
 
-export interface LemonSnackProps {
+export interface LemonSnackProps extends React.HTMLAttributes<HTMLSpanElement> {
     type?: 'regular' | 'pill'
     children?: React.ReactNode
     onClick?: React.MouseEventHandler
@@ -18,11 +18,17 @@ export interface LemonSnackProps {
 }
 
 export const LemonSnack: React.FunctionComponent<LemonSnackProps & React.RefAttributes<HTMLSpanElement>> = forwardRef(
-    function LemonSnack({ type = 'regular', children, wrap, onClick, onClose, title, className }, ref): JSX.Element {
+    function LemonSnack(
+        { type = 'regular', children, wrap, onClick, onClose, title, className, ...rest },
+        ref
+    ): JSX.Element {
         const isRegular = type === 'regular'
         const isClickable = !!onClick
         return (
             <span
+                // Spread first so wrappers like Tooltip can attach their trigger
+                // handlers; the explicit props below take precedence.
+                {...rest}
                 ref={ref}
                 className={twMerge(
                     'inline-flex text-primary-alt max-w-full overflow-hidden break-all items-center py-1 leading-5',

--- a/products/groups/frontend/generated/api.schemas.ts
+++ b/products/groups/frontend/generated/api.schemas.ts
@@ -80,6 +80,10 @@ export type GroupsFindRetrieveParams = {
      * Specify the group type to find
      */
     group_type_index: number
+    /**
+     * When true, do not lazily create the group's CRM notebook. Use for read-only lookups (e.g. resolving a group's display name) that should not have side effects.
+     */
+    skip_create_notebook?: boolean
 }
 
 export type GroupsRelatedRetrieveParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -45293,6 +45293,10 @@ export namespace Schemas {
      * Specify the group type to find
      */
     group_type_index: number;
+    /**
+     * When true, do not lazily create the group's CRM notebook. Use for read-only lookups (e.g. resolving a group's display name) that should not have side effects.
+     */
+    skip_create_notebook?: boolean;
     };
 
     export type EnvironmentsGroupsRelatedRetrieveParams = {
@@ -51135,6 +51139,10 @@ export namespace Schemas {
      * Specify the group type to find
      */
     group_type_index: number;
+    /**
+     * When true, do not lazily create the group's CRM notebook. Use for read-only lookups (e.g. resolving a group's display name) that should not have side effects.
+     */
+    skip_create_notebook?: boolean;
     };
 
     export type GroupsRelatedRetrieveParams = {


### PR DESCRIPTION
## Demo

**Hovering a group-key filter chip** — formatted card with name, key, first seen:


**Edit view: hovering the selected value** — same card on the value snack:

**Edit view: hovering a dropdown option** — card rendered from already-loaded data (no extra fetch):

## Problem

When you pick a group in the taxonomic filter — especially by pasting a raw group UUID into the group-key selector — the resulting filter chip only shows `$group_key = <uuid>`. There's no way to confirm you picked the right group without navigating away. The group profile page already renders a nice "Info" card (name, key, first seen), but that context never reaches the filter chip or the value-selection UI.

## Changes

Hovering a **single-value** `$group_key` filter chip now shows a formatted tooltip card with the group's **name**, **key**, and **First seen** time — mirroring the group profile Info card. The same card appears in the **edit view**: on the selected-value snack inside the group-key selector, and on the dropdown option rows while choosing.

Behavior:

- **Lazy** — the chip lookup fires only on first hover; results (including 404 misses) are cached in memory for the tab's lifetime, and transient errors are reported via `captureException` and retried on the next hover rather than cached.
- **Single group only** — the rich tooltip is restricted to single-value filters, so hovering looks up exactly the group under the mouse; multi-value "is one of" chips keep the plain label (no per-key fan-out).
- **Read-only** — the groups `find` endpoint gains a `skip_create_notebook` query param; display-name lookups pass it so a passive hover never lazily creates the group's CRM notebook. The group profile page keeps its existing behavior.
- **Interactive** — the tooltip stays open on hover-in and the group key is selectable/copyable; dropdown-option cards are built from the already-loaded group data with no extra request.

Implementation notes:

- `LemonSnack` now forwards rest props to its root span — it previously swallowed the trigger handlers a wrapping `Tooltip` attaches, so snack tooltips (including the pre-existing edit/remove hint) never opened.
- `LemonInputSelect` option `tooltip`s now also apply to selected-value snacks (multi, single, sortable), falling back to the existing edit/remove hint; React-element tooltips are excluded from the options memo key, which only expected serializable values.
- Extracted `findGroups()` (shared fetch) and presentational `GroupInfoCard` so the chip tooltip, snack tooltip, and option tooltips say it once.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests, plus a scripted live walkthrough against a local dev stack (the video above) — no human manual testing is claimed.

- `GroupKeyFilterTooltip.test.tsx`: parameterized render cases (resolved name / no-name fallback / unresolvable fallback) plus a cache-once-across-remounts case.
- `GroupKeySelect.test.tsx`: dropdown shows names not UUIDs, selection stores the key, parameterized snack-hover cases (loaded option / lazily-resolved pasted key / single-select snack), and dropdown-option hover showing the card.
- `ee/.../test_clickhouse_groups.py`: `find` with `skip_create_notebook=true` returns the group without creating a notebook (CRM enabled). This test relies on CI — the local environment has no Postgres/ClickHouse (the pre-existing CRM test fails the same way locally).
- Full `PropertyFilters` + `LemonSnack` suites pass (138 tests); `typescript:check` clean.

A note on test coverage: lemon-ui-level hover tests for the snack tooltip were written and removed — base-ui's shared hover-delay state makes tooltip-hover tests order-dependent in a file with many prior pointer interactions. The behavior is covered by the `GroupKeySelect` integration tests instead, which hover reliably.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8 / Fable 5). Paul directed the work: surface the group profile Info card wherever a group key is shown or chosen, since users may select groups by pasting UUIDs.

Key decisions:

- Reused `groupDisplayId` so the tooltip matches every other group-name surface and the documented name-or-key fallback.
- Lazy-on-hover fetch with an in-memory cache (negative-caching only genuine 404s) over eager fetching; restricted to single-value chips after review flagged uncapped per-key fan-out.
- Added `skip_create_notebook` to the `find` endpoint after review verified the lookup had a write side effect (lazy CRM notebook creation) now reachable from a passive hover.
- The `LemonSnack` rest-prop forwarding fixes a latent bug (snack tooltips never opened) discovered while wiring the edit-view tooltips.
- qa-swarm multi-perspective review ran on the PR; convergent findings (transient-error caching, fan-out, parameterized tests) were addressed in follow-up commits.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


