### PR TITLE
fix(error-tracking): preserve exception list order in derived properties

### DIFF
--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -334,16 +334,18 @@ impl FingerprintedErrProps {
     }
 }
 
+// Deduplicates while preserving first-seen order, so derived properties
+// ($exception_types, $exception_values, ...) follow the $exception_list order.
 fn unique_by<T, I, F, K>(items: I, key_extractor: F) -> Vec<K>
 where
     I: Iterator<Item = T>,
     F: Fn(T) -> Option<K>,
     K: Eq + Hash + Clone,
 {
+    let mut seen = HashSet::new();
     items
         .filter_map(key_extractor)
-        .collect::<HashSet<_>>()
-        .into_iter()
+        .filter(|key| seen.insert(key.clone()))
         .collect()
 }
 
@@ -542,7 +544,7 @@ mod test {
 
     use crate::{frames::RawFrame, types::Stacktrace};
 
-    use super::RawErrProps;
+    use super::{Exception, ExceptionList, RawErrProps};
 
     #[test]
     fn it_deserialises_error_props() {
@@ -628,6 +630,33 @@ mod test {
         assert_eq!(
             props.unwrap_err().to_string(),
             "missing field `type` at line 5 column 13"
+        );
+    }
+
+    #[test]
+    fn unique_properties_preserve_exception_list_order() {
+        let make_exception = |t: &str, v: &str| Exception {
+            exception_id: None,
+            exception_type: t.to_string(),
+            exception_message: v.to_string(),
+            mechanism: None,
+            module: None,
+            thread_id: None,
+            stack: None,
+        };
+
+        let list: ExceptionList = vec![
+            make_exception("ZError", "z happened"),
+            make_exception("AError", "a happened"),
+            make_exception("ZError", "z happened"),
+            make_exception("MError", "m happened"),
+        ]
+        .into();
+
+        assert_eq!(list.get_unique_types(), vec!["ZError", "AError", "MError"]);
+        assert_eq!(
+            list.get_unique_messages(),
+            vec!["z happened", "a happened", "m happened"]
         );
     }
 }

--- a/rust/cymbal/tests/remote_resolution_parity.rs
+++ b/rust/cymbal/tests/remote_resolution_parity.rs
@@ -161,22 +161,9 @@ async fn local_and_remote_stages_produce_identical_exception_list_for_empty_stac
 
     // Properties derived by PropertiesResolver should also match in both
     // paths, since they're computed from the (parity-checked) exception_list.
-    // `exception_types` / `exception_messages` come back through cymbal's
-    // `unique_by` helper, which round-trips through a HashSet — order is
-    // therefore implementation-defined per run, so we compare as sorted sets.
-    fn sorted(input: Option<Vec<String>>) -> Vec<String> {
-        let mut out = input.unwrap_or_default();
-        out.sort();
-        out
-    }
-    assert_eq!(
-        sorted(local_out.exception_types),
-        sorted(remote_out.exception_types)
-    );
-    assert_eq!(
-        sorted(local_out.exception_messages),
-        sorted(remote_out.exception_messages)
-    );
+    // `unique_by` preserves exception_list order, so compare directly.
+    assert_eq!(local_out.exception_types, remote_out.exception_types);
+    assert_eq!(local_out.exception_messages, remote_out.exception_messages);
     assert_eq!(local_out.exception_handled, remote_out.exception_handled);
 }
 


### PR DESCRIPTION
## Problem

Cymbal derives `$exception_types`, `$exception_values`, `$exception_sources`, and `$exception_functions` from `$exception_list`, but the dedup helper round-tripped through a `HashSet`, so these arrays came out in arbitrary order — they didn't match the order of the exceptions (or frames) they were derived from, and the order could differ between otherwise-identical events.

## Changes

- `unique_by` in `rust/cymbal/src/types/mod.rs` now deduplicates while preserving first-seen order, so derived properties follow `$exception_list` order (and in-app frame order for sources/functions). Both code paths that compute these properties (`PropertiesResolver` and `FingerprintedErrProps::to_output`) go through this helper.
- Tightened the remote-resolution parity test to compare these arrays directly instead of as sorted sets — the sorting workaround existed only because of the nondeterministic order.
- Added a unit test asserting order preservation and deduplication.

## How did you test this code?

Authored by an agent; no manual testing. Automated tests run locally:

- New unit test `unique_properties_preserve_exception_list_order` passes.
- `cargo test -p cymbal --test remote_resolution_parity` passes with the stricter direct-order assertions.
- Full `cargo test -p cymbal`: 106 passed; the 16 failures are pre-existing `#[sqlx::test]` tests that require a local test Postgres (not running) and fail at DB setup before any test logic.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Root cause was located by tracing the property derivation from `PropertiesResolver` to `ExceptionList::get_unique_*` and the shared `unique_by` helper. Considered fixing only types/values as requested, but functions/sources share the same helper, so all four are now consistently ordered. The parity test already documented the HashSet nondeterminism in a comment, confirming the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)