### PR TITLE
feat(experiments): auto-load results for newly launched experiments

### DIFF
--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -49,11 +49,9 @@ export const DEFAULT_MDE = 30
 // Autorefresh constants
 export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5
 export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min
-// While a launched experiment is still gathering its first exposures, force a one-shot refresh on
-// page load when the cached results are older than this. The queries are cheap with little data, and
-// it's exactly when users are watching for the first sign that the experiment is working. Once an
-// experiment has enough exposures to show results we leave it to the cached paint and the in-tab
-// auto-refresh, since recomputes over real data are expensive.
+// While a launched experiment is still gathering its first exposures, force refresh results on page
+// load (queries are fast with little data and this is better UX to not let users wait until they see
+// the experiment is working).
 export const NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES = 1
 
 // Mirrors EXPERIMENT_RECALCULATION_MAX_AGE_DAYS in posthog/temporal/experiments/activities.py

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -49,13 +49,12 @@ export const DEFAULT_MDE = 30
 // Autorefresh constants
 export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5
 export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min
-// On page load, force a refresh if the freshest cached result is older than this. The window is
-// short while an experiment is still gathering its first exposures — feedback should be fast and
-// the queries are cheap with little data — and longer once it has enough data to show results,
-// where recomputes get expensive. Auto-refresh otherwise only runs while a tab is open, so results
-// can sit stale overnight.
-export const EXPERIMENT_RESULTS_STALE_AFTER_MINUTES = 180 // 3h, once results are showing
-export const EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES = 1 // until exposures are seen
+// While a launched experiment is still gathering its first exposures, force a one-shot refresh on
+// page load when the cached results are older than this. The queries are cheap with little data, and
+// it's exactly when users are watching for the first sign that the experiment is working. Once an
+// experiment has enough exposures to show results we leave it to the cached paint and the in-tab
+// auto-refresh, since recomputes over real data are expensive.
+export const NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES = 1
 
 // Mirrors EXPERIMENT_RECALCULATION_MAX_AGE_DAYS in posthog/temporal/experiments/activities.py
 export const EXPERIMENT_RECALCULATION_MAX_AGE_DAYS = 60

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -49,6 +49,13 @@ export const DEFAULT_MDE = 30
 // Autorefresh constants
 export const EXPERIMENT_MIN_REFRESH_INTERVAL_MINUTES = 5
 export const EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 1800 // 30 min
+// On page load, force a refresh if the freshest cached result is older than this. The window is
+// short while an experiment is still gathering its first exposures — feedback should be fast and
+// the queries are cheap with little data — and longer once it has enough data to show results,
+// where recomputes get expensive. Auto-refresh otherwise only runs while a tab is open, so results
+// can sit stale overnight.
+export const EXPERIMENT_RESULTS_STALE_AFTER_MINUTES = 180 // 3h, once results are showing
+export const EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES = 1 // until exposures are seen
 
 // Mirrors EXPERIMENT_RECALCULATION_MAX_AGE_DAYS in posthog/temporal/experiments/activities.py
 export const EXPERIMENT_RECALCULATION_MAX_AGE_DAYS = 60

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -683,6 +683,7 @@ export const experimentLogic = kea<experimentLogicType>([
             triggeredBy: triggeredBy ?? 'manual',
             refreshIfStale: !!refreshIfStale,
         }),
+        refreshStaleResultsOnReentry: true,
         markRefreshStarted: (refreshId: string, triggeredBy: ExperimentTriggeredBy) => ({
             refreshId,
             triggeredBy,
@@ -1459,6 +1460,13 @@ export const experimentLogic = kea<experimentLogicType>([
             // Shows cached results immediately, then force-refreshes once if the experiment is warming up.
             if (experiment && isLaunched(experiment)) {
                 actions.refreshExperimentResults(false, payload?.triggeredBy ?? 'manual', true)
+            }
+        },
+        refreshStaleResultsOnReentry: () => {
+            // In-app navigation back to an already-mounted experiment doesn't re-fire loadExperiment,
+            // so run the same page-load refresh here (cached load + a one-shot force if warming up).
+            if (values.experiment && isLaunched(values.experiment)) {
+                actions.refreshExperimentResults(false, 'page_load', true)
             }
         },
         launchExperiment: async () => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1463,9 +1463,10 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         refreshStaleResultsOnReentry: () => {
-            // In-app navigation back to an already-mounted experiment doesn't re-fire loadExperiment,
-            // so run the same page-load refresh here (cached load + a one-shot force if warming up).
-            if (values.experiment && isLaunched(values.experiment)) {
+            // In-app navigation back to an already-mounted experiment doesn't re-fire loadExperiment.
+            // Only warming-up experiments need a refresh on return — mature ones already show results
+            // and recomputes might be expensive, so we leave their cached state untouched (as before).
+            if (values.experiment && isLaunched(values.experiment) && !values.hasMinimumExposureForResults) {
                 actions.refreshExperimentResults(false, 'page_load', true)
             }
         },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1456,9 +1456,7 @@ export const experimentLogic = kea<experimentLogicType>([
             experiment && actions.reportExperimentViewed(experiment, duration)
 
             // Load metrics for launched experiments (sets up auto-refresh once the load completes).
-            // Paint cached results for a fast first load, then — while the experiment is still warming
-            // up — fetch fresh once, so a freshly launched experiment surfaces its first numbers without
-            // requiring a manual refresh.
+            // Shows cached results immediately, then force-refreshes once if the experiment is warming up.
             if (experiment && isLaunched(experiment)) {
                 actions.refreshExperimentResults(false, payload?.triggeredBy ?? 'manual', true)
             }
@@ -1685,11 +1683,9 @@ export const experimentLogic = kea<experimentLogicType>([
                     actions.resetAutoRefreshInterval()
                 }
 
-                // On page load, a still-warming-up experiment can show a stale "no results yet" cached
-                // snapshot. Fetch fresh once so its first numbers surface without a manual refresh. Once
-                // it has the exposures needed to show results we leave it to the cached paint and the
-                // in-tab auto-refresh, since recomputes over real data are expensive. Gated on
-                // `!forceRefresh` so the refresh we trigger here can't re-trigger itself.
+                // A warming-up experiment can show a stale "no results yet" snapshot on load, so fetch
+                // fresh once. When it has results we leave it to the in-tab auto-refresh, since recomputes
+                // might be expensive. Gated on `!forceRefresh` so the refresh we trigger here can't loop.
                 if (
                     refreshIfStale &&
                     !forceRefresh &&

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -73,8 +73,7 @@ import {
 import {
     EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS,
     EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS,
-    EXPERIMENT_RESULTS_STALE_AFTER_MINUTES,
-    EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES,
+    NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES,
     MetricInsightId,
 } from './constants'
 import type { experimentLogicType } from './experimentLogicType'
@@ -536,20 +535,19 @@ export function isNewExperimentResponse(
 }
 
 /**
- * Decides whether a launched experiment's freshest cached result is stale enough to
- * warrant a forced refresh on page load. Returns true when there are no cached results
- * yet (queries are cheap until an experiment has data, so we just refresh) or when the
- * most recently refreshed metric is older than the staleness threshold (in minutes).
+ * Whether a launched experiment's freshest cached result is older than `staleAfterMinutes`.
+ * Returns true when there are no cached results yet, so we refresh to populate them. The results
+ * array can be sparse — metrics that returned no baseline leave holes — so entries without a
+ * `last_refresh` are skipped.
  */
 export function experimentResultsAreStale(
-    results: CachedNewExperimentQueryResponse[],
+    results: (CachedNewExperimentQueryResponse | undefined)[],
     staleAfterMinutes: number
 ): boolean {
     const refreshTimes = results
         .filter((result): result is CachedNewExperimentQueryResponse => !!result?.last_refresh)
         .map((result) => dayjs(result.last_refresh))
 
-    // No cached results yet — refresh to populate them (cheap while the experiment has no data).
     if (refreshTimes.length === 0) {
         return true
     }
@@ -679,11 +677,11 @@ export const experimentLogic = kea<experimentLogicType>([
         refreshExperimentResults: (
             forceRefresh?: boolean,
             triggeredBy?: ExperimentTriggeredBy,
-            autoRefreshIfStale?: boolean
+            refreshIfStale?: boolean
         ) => ({
             forceRefresh,
             triggeredBy: triggeredBy ?? 'manual',
-            autoRefreshIfStale: !!autoRefreshIfStale,
+            refreshIfStale: !!refreshIfStale,
         }),
         markRefreshStarted: (refreshId: string, triggeredBy: ExperimentTriggeredBy) => ({
             refreshId,
@@ -1457,10 +1455,10 @@ export const experimentLogic = kea<experimentLogicType>([
             const duration = experiment?.start_date ? dayjs().diff(experiment.start_date, 'second') : null
             experiment && actions.reportExperimentViewed(experiment, duration)
 
-            // Load metrics for launched experiments (will set up auto-refresh after load completes).
-            // Use cached results for a fast first paint, but force a one-shot refresh afterwards if
-            // those results have gone stale — auto-refresh only ticks while a tab is open, so results
-            // can otherwise sit unrefreshed overnight.
+            // Load metrics for launched experiments (sets up auto-refresh once the load completes).
+            // Paint cached results for a fast first load, then — while the experiment is still warming
+            // up — fetch fresh once, so a freshly launched experiment surfaces its first numbers without
+            // requiring a manual refresh.
             if (experiment && isLaunched(experiment)) {
                 actions.refreshExperimentResults(false, payload?.triggeredBy ?? 'manual', true)
             }
@@ -1575,7 +1573,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 lemonToast.error(error.detail || 'Failed to unarchive experiment')
             }
         },
-        refreshExperimentResults: async ({ forceRefresh, triggeredBy, autoRefreshIfStale }) => {
+        refreshExperimentResults: async ({ forceRefresh, triggeredBy, refreshIfStale }) => {
             const refreshId = generateRefreshId()
             const refreshStart = performance.now()
             const summaries: MetricLoadingSummary[] = []
@@ -1687,24 +1685,22 @@ export const experimentLogic = kea<experimentLogicType>([
                     actions.resetAutoRefreshInterval()
                 }
 
-                // After the initial cached page load, kick off a one-shot forced refresh when the
-                // freshest result has gone stale (or there are none yet). The staleness window is
-                // tight until the experiment has the exposures it needs to show results, so a freshly
-                // launched experiment surfaces its first numbers fast; once results are showing the
-                // window widens, since recomputes over real data are expensive. Gated on `!forceRefresh`
-                // so the forced refresh we trigger here can't re-trigger itself.
+                // On page load, a still-warming-up experiment can show a stale "no results yet" cached
+                // snapshot. Fetch fresh once so its first numbers surface without a manual refresh. Once
+                // it has the exposures needed to show results we leave it to the cached paint and the
+                // in-tab auto-refresh, since recomputes over real data are expensive. Gated on
+                // `!forceRefresh` so the refresh we trigger here can't re-trigger itself.
                 if (
-                    autoRefreshIfStale &&
+                    refreshIfStale &&
                     !forceRefresh &&
                     !caughtError &&
+                    !values.hasMinimumExposureForResults &&
                     experimentResultsAreStale(
                         [...values.primaryMetricsResults, ...values.secondaryMetricsResults],
-                        values.hasMinimumExposureForResults
-                            ? EXPERIMENT_RESULTS_STALE_AFTER_MINUTES
-                            : EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES
+                        NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES
                     )
                 ) {
-                    actions.refreshExperimentResults(true, 'auto_refresh')
+                    actions.refreshExperimentResults(true, 'page_load')
                 }
             }
         },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -73,6 +73,8 @@ import {
 import {
     EXPERIMENT_AUTO_REFRESH_INITIAL_INTERVAL_SECONDS,
     EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS,
+    EXPERIMENT_RESULTS_STALE_AFTER_MINUTES,
+    EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES,
     MetricInsightId,
 } from './constants'
 import type { experimentLogicType } from './experimentLogicType'
@@ -533,6 +535,29 @@ export function isNewExperimentResponse(
     return 'baseline' in response && response.baseline !== null
 }
 
+/**
+ * Decides whether a launched experiment's freshest cached result is stale enough to
+ * warrant a forced refresh on page load. Returns true when there are no cached results
+ * yet (queries are cheap until an experiment has data, so we just refresh) or when the
+ * most recently refreshed metric is older than the staleness threshold (in minutes).
+ */
+export function experimentResultsAreStale(
+    results: CachedNewExperimentQueryResponse[],
+    staleAfterMinutes: number
+): boolean {
+    const refreshTimes = results
+        .filter((result): result is CachedNewExperimentQueryResponse => !!result?.last_refresh)
+        .map((result) => dayjs(result.last_refresh))
+
+    // No cached results yet — refresh to populate them (cheap while the experiment has no data).
+    if (refreshTimes.length === 0) {
+        return true
+    }
+
+    const freshest = refreshTimes.reduce((latest, current) => (current.isAfter(latest) ? current : latest))
+    return dayjs().diff(freshest, 'minute', true) >= staleAfterMinutes
+}
+
 const sharedMetricsToExperimentMetrics = (
     sharedMetrics: ExperimentSavedMetric[],
     type: 'primary' | 'secondary'
@@ -651,9 +676,14 @@ export const experimentLogic = kea<experimentLogicType>([
         setLaunchExperimentLoading: (loading: boolean) => ({ loading }),
         setEndExperimentLoading: (loading: boolean) => ({ loading }),
         setEditExperiment: (editing: boolean) => ({ editing }),
-        refreshExperimentResults: (forceRefresh?: boolean, triggeredBy?: ExperimentTriggeredBy) => ({
+        refreshExperimentResults: (
+            forceRefresh?: boolean,
+            triggeredBy?: ExperimentTriggeredBy,
+            autoRefreshIfStale?: boolean
+        ) => ({
             forceRefresh,
             triggeredBy: triggeredBy ?? 'manual',
+            autoRefreshIfStale: !!autoRefreshIfStale,
         }),
         markRefreshStarted: (refreshId: string, triggeredBy: ExperimentTriggeredBy) => ({
             refreshId,
@@ -1427,9 +1457,12 @@ export const experimentLogic = kea<experimentLogicType>([
             const duration = experiment?.start_date ? dayjs().diff(experiment.start_date, 'second') : null
             experiment && actions.reportExperimentViewed(experiment, duration)
 
-            // Load metrics for launched experiments (will set up auto-refresh after load completes)
+            // Load metrics for launched experiments (will set up auto-refresh after load completes).
+            // Use cached results for a fast first paint, but force a one-shot refresh afterwards if
+            // those results have gone stale — auto-refresh only ticks while a tab is open, so results
+            // can otherwise sit unrefreshed overnight.
             if (experiment && isLaunched(experiment)) {
-                actions.refreshExperimentResults(false, payload?.triggeredBy ?? 'manual')
+                actions.refreshExperimentResults(false, payload?.triggeredBy ?? 'manual', true)
             }
         },
         launchExperiment: async () => {
@@ -1542,7 +1575,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 lemonToast.error(error.detail || 'Failed to unarchive experiment')
             }
         },
-        refreshExperimentResults: async ({ forceRefresh, triggeredBy }) => {
+        refreshExperimentResults: async ({ forceRefresh, triggeredBy, autoRefreshIfStale }) => {
             const refreshId = generateRefreshId()
             const refreshStart = performance.now()
             const summaries: MetricLoadingSummary[] = []
@@ -1652,6 +1685,26 @@ export const experimentLogic = kea<experimentLogicType>([
                     values.isPageVisible
                 ) {
                     actions.resetAutoRefreshInterval()
+                }
+
+                // After the initial cached page load, kick off a one-shot forced refresh when the
+                // freshest result has gone stale (or there are none yet). The staleness window is
+                // tight until the experiment has the exposures it needs to show results, so a freshly
+                // launched experiment surfaces its first numbers fast; once results are showing the
+                // window widens, since recomputes over real data are expensive. Gated on `!forceRefresh`
+                // so the forced refresh we trigger here can't re-trigger itself.
+                if (
+                    autoRefreshIfStale &&
+                    !forceRefresh &&
+                    !caughtError &&
+                    experimentResultsAreStale(
+                        [...values.primaryMetricsResults, ...values.secondaryMetricsResults],
+                        values.hasMinimumExposureForResults
+                            ? EXPERIMENT_RESULTS_STALE_AFTER_MINUTES
+                            : EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES
+                    )
+                ) {
+                    actions.refreshExperimentResults(true, 'auto_refresh')
                 }
             }
         },

--- a/frontend/src/scenes/experiments/experimentResultsStaleness.test.ts
+++ b/frontend/src/scenes/experiments/experimentResultsStaleness.test.ts
@@ -2,10 +2,7 @@ import { dayjs } from 'lib/dayjs'
 
 import { CachedNewExperimentQueryResponse } from '~/queries/schema/schema-general'
 
-import {
-    EXPERIMENT_RESULTS_STALE_AFTER_MINUTES,
-    EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES,
-} from './constants'
+import { NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES } from './constants'
 import { experimentResultsAreStale } from './experimentLogic'
 
 const resultRefreshedMinutesAgo = (minutes: number): CachedNewExperimentQueryResponse =>
@@ -15,45 +12,47 @@ const resultRefreshedMinutesAgo = (minutes: number): CachedNewExperimentQueryRes
 
 describe('experimentResultsAreStale', () => {
     it('treats an empty result set as stale (no results yet — cheap to refresh)', () => {
-        expect(experimentResultsAreStale([], EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(true)
+        expect(experimentResultsAreStale([], 60)).toBe(true)
     })
 
     it('treats results with no last_refresh as stale', () => {
-        const results = [{} as CachedNewExperimentQueryResponse]
-        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(true)
+        expect(experimentResultsAreStale([{} as CachedNewExperimentQueryResponse], 60)).toBe(true)
     })
 
     it('is not stale when the freshest result is within the threshold', () => {
-        const results = [resultRefreshedMinutesAgo(300), resultRefreshedMinutesAgo(120)]
-        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(false)
+        expect(experimentResultsAreStale([resultRefreshedMinutesAgo(120), resultRefreshedMinutesAgo(30)], 60)).toBe(
+            false
+        )
     })
 
     it('is stale when every result is older than the threshold', () => {
-        const results = [resultRefreshedMinutesAgo(200), resultRefreshedMinutesAgo(600)]
-        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(true)
+        expect(experimentResultsAreStale([resultRefreshedMinutesAgo(90), resultRefreshedMinutesAgo(200)], 60)).toBe(
+            true
+        )
     })
 
     it('uses the freshest result across primary and secondary metrics', () => {
         // One metric is stale, but another was refreshed recently — overall not stale.
-        const results = [resultRefreshedMinutesAgo(600), resultRefreshedMinutesAgo(5)]
-        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(false)
+        expect(experimentResultsAreStale([resultRefreshedMinutesAgo(600), resultRefreshedMinutesAgo(5)], 60)).toBe(
+            false
+        )
     })
 
     it('ignores sparse holes left by metrics that returned no baseline', () => {
-        const results = new Array(3) as CachedNewExperimentQueryResponse[]
+        const results = new Array(3) as (CachedNewExperimentQueryResponse | undefined)[]
         results[1] = resultRefreshedMinutesAgo(5)
-        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(false)
+        expect(experimentResultsAreStale(results, 60)).toBe(false)
     })
 
-    describe('warming-up window (until exposures are seen)', () => {
-        it('refreshes a result older than a minute', () => {
+    describe('warming-up window', () => {
+        it('refreshes results older than the warming-up window', () => {
             const results = [resultRefreshedMinutesAgo(2)]
-            expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES)).toBe(true)
+            expect(experimentResultsAreStale(results, NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES)).toBe(true)
         })
 
-        it('does not refresh a result from within the last minute', () => {
+        it('does not refresh results from within the warming-up window', () => {
             const results = [resultRefreshedMinutesAgo(0.5)]
-            expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES)).toBe(false)
+            expect(experimentResultsAreStale(results, NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES)).toBe(false)
         })
     })
 })

--- a/frontend/src/scenes/experiments/experimentResultsStaleness.test.ts
+++ b/frontend/src/scenes/experiments/experimentResultsStaleness.test.ts
@@ -5,6 +5,8 @@ import { CachedNewExperimentQueryResponse } from '~/queries/schema/schema-genera
 import { NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES } from './constants'
 import { experimentResultsAreStale } from './experimentLogic'
 
+const THRESHOLD = NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES
+
 const resultRefreshedMinutesAgo = (minutes: number): CachedNewExperimentQueryResponse =>
     ({
         last_refresh: dayjs().subtract(minutes, 'minute').toISOString(),
@@ -12,47 +14,32 @@ const resultRefreshedMinutesAgo = (minutes: number): CachedNewExperimentQueryRes
 
 describe('experimentResultsAreStale', () => {
     it('treats an empty result set as stale (no results yet — cheap to refresh)', () => {
-        expect(experimentResultsAreStale([], 60)).toBe(true)
+        expect(experimentResultsAreStale([], THRESHOLD)).toBe(true)
     })
 
     it('treats results with no last_refresh as stale', () => {
-        expect(experimentResultsAreStale([{} as CachedNewExperimentQueryResponse], 60)).toBe(true)
+        expect(experimentResultsAreStale([{} as CachedNewExperimentQueryResponse], THRESHOLD)).toBe(true)
     })
 
     it('is not stale when the freshest result is within the threshold', () => {
-        expect(experimentResultsAreStale([resultRefreshedMinutesAgo(120), resultRefreshedMinutesAgo(30)], 60)).toBe(
-            false
-        )
+        const results = [resultRefreshedMinutesAgo(THRESHOLD * 5), resultRefreshedMinutesAgo(THRESHOLD / 2)]
+        expect(experimentResultsAreStale(results, THRESHOLD)).toBe(false)
     })
 
     it('is stale when every result is older than the threshold', () => {
-        expect(experimentResultsAreStale([resultRefreshedMinutesAgo(90), resultRefreshedMinutesAgo(200)], 60)).toBe(
-            true
-        )
+        const results = [resultRefreshedMinutesAgo(THRESHOLD * 2), resultRefreshedMinutesAgo(THRESHOLD * 5)]
+        expect(experimentResultsAreStale(results, THRESHOLD)).toBe(true)
     })
 
     it('uses the freshest result across primary and secondary metrics', () => {
         // One metric is stale, but another was refreshed recently — overall not stale.
-        expect(experimentResultsAreStale([resultRefreshedMinutesAgo(600), resultRefreshedMinutesAgo(5)], 60)).toBe(
-            false
-        )
+        const results = [resultRefreshedMinutesAgo(THRESHOLD * 10), resultRefreshedMinutesAgo(THRESHOLD / 2)]
+        expect(experimentResultsAreStale(results, THRESHOLD)).toBe(false)
     })
 
     it('ignores sparse holes left by metrics that returned no baseline', () => {
         const results = new Array(3) as (CachedNewExperimentQueryResponse | undefined)[]
-        results[1] = resultRefreshedMinutesAgo(5)
-        expect(experimentResultsAreStale(results, 60)).toBe(false)
-    })
-
-    describe('warming-up window', () => {
-        it('refreshes results older than the warming-up window', () => {
-            const results = [resultRefreshedMinutesAgo(2)]
-            expect(experimentResultsAreStale(results, NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES)).toBe(true)
-        })
-
-        it('does not refresh results from within the warming-up window', () => {
-            const results = [resultRefreshedMinutesAgo(0.5)]
-            expect(experimentResultsAreStale(results, NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES)).toBe(false)
-        })
+        results[1] = resultRefreshedMinutesAgo(THRESHOLD / 2)
+        expect(experimentResultsAreStale(results, THRESHOLD)).toBe(false)
     })
 })

--- a/frontend/src/scenes/experiments/experimentResultsStaleness.test.ts
+++ b/frontend/src/scenes/experiments/experimentResultsStaleness.test.ts
@@ -1,0 +1,59 @@
+import { dayjs } from 'lib/dayjs'
+
+import { CachedNewExperimentQueryResponse } from '~/queries/schema/schema-general'
+
+import {
+    EXPERIMENT_RESULTS_STALE_AFTER_MINUTES,
+    EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES,
+} from './constants'
+import { experimentResultsAreStale } from './experimentLogic'
+
+const resultRefreshedMinutesAgo = (minutes: number): CachedNewExperimentQueryResponse =>
+    ({
+        last_refresh: dayjs().subtract(minutes, 'minute').toISOString(),
+    }) as CachedNewExperimentQueryResponse
+
+describe('experimentResultsAreStale', () => {
+    it('treats an empty result set as stale (no results yet — cheap to refresh)', () => {
+        expect(experimentResultsAreStale([], EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(true)
+    })
+
+    it('treats results with no last_refresh as stale', () => {
+        const results = [{} as CachedNewExperimentQueryResponse]
+        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(true)
+    })
+
+    it('is not stale when the freshest result is within the threshold', () => {
+        const results = [resultRefreshedMinutesAgo(300), resultRefreshedMinutesAgo(120)]
+        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(false)
+    })
+
+    it('is stale when every result is older than the threshold', () => {
+        const results = [resultRefreshedMinutesAgo(200), resultRefreshedMinutesAgo(600)]
+        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(true)
+    })
+
+    it('uses the freshest result across primary and secondary metrics', () => {
+        // One metric is stale, but another was refreshed recently — overall not stale.
+        const results = [resultRefreshedMinutesAgo(600), resultRefreshedMinutesAgo(5)]
+        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(false)
+    })
+
+    it('ignores sparse holes left by metrics that returned no baseline', () => {
+        const results = new Array(3) as CachedNewExperimentQueryResponse[]
+        results[1] = resultRefreshedMinutesAgo(5)
+        expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_STALE_AFTER_MINUTES)).toBe(false)
+    })
+
+    describe('warming-up window (until exposures are seen)', () => {
+        it('refreshes a result older than a minute', () => {
+            const results = [resultRefreshedMinutesAgo(2)]
+            expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES)).toBe(true)
+        })
+
+        it('does not refresh a result from within the last minute', () => {
+            const results = [resultRefreshedMinutesAgo(0.5)]
+            expect(experimentResultsAreStale(results, EXPERIMENT_RESULTS_WARMING_UP_STALE_AFTER_MINUTES)).toBe(false)
+        })
+    })
+})

--- a/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.test.ts
@@ -14,6 +14,7 @@ type ExperimentLogicMock = {
                 resetExperiment: jest.Mock
                 loadExperiment: jest.Mock
                 loadExposures: jest.Mock
+                refreshStaleResultsOnReentry: jest.Mock
             }
             props: any
         }
@@ -28,6 +29,7 @@ jest.mock('./experimentLogic', () => {
             resetExperiment: jest.fn(),
             loadExperiment: jest.fn(),
             loadExposures: jest.fn(),
+            refreshStaleResultsOnReentry: jest.fn(),
         },
         props: {},
     }

--- a/frontend/src/scenes/experiments/experimentSceneLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentSceneLogic.tsx
@@ -246,6 +246,9 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                 actions.setEditMode(false)
 
                 if (!currentLocation.initial && matchesExistingLogic && isSameSceneState) {
+                    // Same experiment, already mounted — skip the full reload, but still run the
+                    // page-load stale check so a warming-up experiment refreshes on in-app return.
+                    values.experimentLogicRef?.logic.actions.refreshStaleResultsOnReentry()
                     return
                 }
 
@@ -300,6 +303,9 @@ export const experimentSceneLogic = kea<experimentSceneLogicType>([
                 actions.setEditMode(false)
 
                 if (!currentLocation.initial && matchesExistingLogic && isSameSceneState) {
+                    // Same experiment, already mounted — skip the full reload, but still run the
+                    // page-load stale check so a warming-up experiment refreshes on in-app return.
+                    values.experimentLogicRef?.logic.actions.refreshStaleResultsOnReentry()
                     return
                 }
 


### PR DESCRIPTION
## Problem

Reopening a newly launched experiment did show stale, empty-looking results until a manual refresh.


## Changes

- Results are automatically loaded for launched experiments without results
- Triggered by in-app navigation and hard refreshes
- Experiments that already show results are left untouched (recomputes are expensive)
- Only refreshes if the cached results are older than 1 minute
- Tagged `triggeredBy: 'page_load'` so it's distinguishable in analytics

## How did you test this code?

- Unit tests for the pure `experimentResultsAreStale` helper (empty/never-computed, fresh vs. stale, freshest-result-wins across metrics, sparse holes)
- Manually: in-app navigation and reloads fire the ExperimentQuery request

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
Across two sessions