### PR TITLE
feat(warehouse-sources): Support fallback keys in Temporal.io source

### DIFF
--- a/posthog/temporal/data_imports/sources/generated_configs.py
+++ b/posthog/temporal/data_imports/sources/generated_configs.py
@@ -1357,6 +1357,7 @@ class TemporalIOSourceConfig(config.Config):
     client_certificate: str
     client_private_key: str
     encryption_key: str | None = None
+    fallback_decryption_keys: str | None = None
 
 
 @config.config

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -141,11 +141,9 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
                     SourceFieldInputConfig(
                         name="fallback_decryption_keys",
                         label="Fallback decryption keys",
-                        # This should be a set/list/array of passwords, but container types
-                        # don't seem to be supported, so we expect it to be split by ','
                         type=SourceFieldInputConfigType.PASSWORD,
                         required=False,
-                        placeholder="",
+                        placeholder="key1,key2,key3",
                         secret=True,
                     ),
                     SourceFieldInputConfig(

--- a/posthog/temporal/data_imports/sources/temporalio/source.py
+++ b/posthog/temporal/data_imports/sources/temporalio/source.py
@@ -139,6 +139,16 @@ class TemporalIOSource(ResumableSource[TemporalIOSourceConfig, TemporalIOResumeC
                         secret=True,
                     ),
                     SourceFieldInputConfig(
+                        name="fallback_decryption_keys",
+                        label="Fallback decryption keys",
+                        # This should be a set/list/array of passwords, but container types
+                        # don't seem to be supported, so we expect it to be split by ','
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=False,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
                         name="server_client_root_ca",
                         label="Server client root CA",
                         type=SourceFieldInputConfigType.TEXTAREA,

--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -119,7 +119,7 @@ class FakeSettings:
 
 async def _get_temporal_client(config: TemporalIOSourceConfig) -> Client:
     if config.fallback_decryption_keys:
-        fallback_keys = config.fallback_decryption_keys.split(",")
+        fallback_keys = [k.strip() for k in config.fallback_decryption_keys.split(",") if k.strip()]
     else:
         fallback_keys = []
 

--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -118,13 +118,21 @@ class FakeSettings:
 
 
 async def _get_temporal_client(config: TemporalIOSourceConfig) -> Client:
+    if config.fallback_decryption_keys:
+        fallback_keys = config.fallback_decryption_keys.split(",")
+    else:
+        fallback_keys = []
+
     return await connect(
         host=config.host,
         port=config.port,
         namespace=config.namespace,
         client_cert=config.client_certificate,
         client_key=config.client_private_key,
-        settings=FakeSettings(config.encryption_key)
+        settings=FakeSettings(
+            TEMPORAL_SECRET_KEY=config.encryption_key,
+            TEMPORAL_FALLBACK_SECRET_KEYS=fallback_keys,
+        )
         if config.encryption_key and len(config.encryption_key) > 0
         else None,
     )


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

A Temporal.io source can have payloads encrypted by multiple keys.

Our current source configuration only supports one encryption/decryption key, whereas the common library codec supports 1 + any number of decryption keys.

This adds a new `decryption_fallback_keys` configuration parameter in which multiple decryption keys can be added. These are then passed along as settings so that the codec is populated with all of them.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I haven't (yet)
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Maybe? Not sure if we want to announce your temporalio source can now have multiple decryption keys.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Nothing, looked at logs, figured out the issue, wrote the code. All by hand.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
