### PR TITLE
fix(streamlit-apps): address review feedback and fix mypy

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -88,6 +88,7 @@ ActivityScope = Literal[
     "Ticket",
     "InstanceSetting",
     "SignalScoutConfig",
+    "StreamlitApp",
 ]
 ChangeAction = Literal[
     "changed", "created", "deleted", "merged", "split", "exported", "revoked", "logged_in", "logged_out", "copied"

--- a/products/streamlit_apps/backend/presentation/bridge_views.py
+++ b/products/streamlit_apps/backend/presentation/bridge_views.py
@@ -11,6 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from posthog.models.organization import OrganizationMembership
 from posthog.models.team import Team
 from posthog.rate_limit import PersonalApiKeyRateThrottle
 
@@ -39,6 +40,26 @@ class StreamlitBridgeThrottle(PersonalApiKeyRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
+class StreamlitBridgeIPThrottle(PersonalApiKeyRateThrottle):
+    """IP-keyed companion to StreamlitBridgeThrottle.
+
+    The per-token throttle is bucketed by the (unvalidated) bearer value, so an
+    unauthenticated caller could rotate a fresh random token per request and dodge
+    it while still forcing OAuth token lookups. This throttle caps total attempts
+    per source IP regardless of token, closing that bypass. Kept higher than the
+    per-token rate because legitimate sandboxes may share an egress IP.
+    """
+
+    scope = "streamlit_bridge_ip"
+    rate = "600/hour"
+
+    def allow_request(self, request: Request, view: APIView) -> bool:
+        return self._allow_request_internal(request, view, personal_api_key_only=False)
+
+    def get_cache_key(self, request: Request, view: APIView) -> str:
+        return self.cache_format % {"scope": self.scope, "ident": self.get_ident(request)}
+
+
 def _authenticate_bearer(auth_header: str) -> tuple[int | None, str | None, str | None]:
     """Returns (team_id, user_distinct_id, error)."""
     from posthog.models.oauth import find_oauth_access_token
@@ -63,8 +84,23 @@ def _authenticate_bearer(auth_header: str) -> tuple[int | None, str | None, str 
         return None, None, "Invalid token application."
     if len(access_token.scoped_teams) != 1:
         return None, None, "Token must be scoped to exactly one team."
-    user_distinct_id = access_token.user.distinct_id if access_token.user else None
-    return access_token.scoped_teams[0], user_distinct_id, None
+
+    team_id = access_token.scoped_teams[0]
+
+    # The token outlives membership changes, so re-validate the minting user
+    # against the scoped team rather than trusting the embedded scope. A
+    # deactivated user, or one removed from the org, must lose bridge access.
+    user = access_token.user
+    if user is None or not user.is_active:
+        return None, None, "Token user is inactive."
+
+    team = Team.objects.filter(id=team_id).only("organization_id").first()
+    if team is None:
+        return None, None, "Token team not found."
+    if not OrganizationMembership.objects.filter(user=user, organization_id=team.organization_id).exists():
+        return None, None, "Token user is not a member of the team's organization."
+
+    return team_id, user.distinct_id, None
 
 
 def _streamlit_apps_enabled_for_team(team_id: int, user_distinct_id: str | None) -> bool:
@@ -78,7 +114,7 @@ def _streamlit_apps_enabled_for_team(team_id: int, user_distinct_id: str | None)
 class StreamlitBridgeView(APIView):
     authentication_classes: list = []
     permission_classes = [AllowAny]
-    throttle_classes = [StreamlitBridgeThrottle]
+    throttle_classes = [StreamlitBridgeThrottle, StreamlitBridgeIPThrottle]
     http_method_names = ["post"]
 
     def post(self, request: Request) -> Response:

--- a/products/streamlit_apps/backend/presentation/serializers.py
+++ b/products/streamlit_apps/backend/presentation/serializers.py
@@ -1,6 +1,8 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import posthoganalytics
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from loginas.utils import is_impersonated_session
 from rest_framework import serializers
 from rest_framework.permissions import BasePermission
@@ -9,6 +11,10 @@ from rest_framework.views import APIView
 
 from posthog.api.shared import UserBasicSerializer
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
+from posthog.models.user import User
+
+if TYPE_CHECKING:
+    from posthog.api.routing import TeamAndOrgViewSetMixin
 
 from products.streamlit_apps.backend.models import (
     MAX_CPU_CORES,
@@ -26,10 +32,12 @@ class StreamlitAppVersionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = StreamlitAppVersion
+        # `zip_file` (the object-storage key) is deliberately omitted — the client
+        # never needs the raw storage path, and exposing it leaks the internal
+        # tenant→path layout. Add a signed-URL endpoint instead if downloads are needed.
         fields = [
             "id",
             "version_number",
-            "zip_file",
             "zip_hash",
             "snapshot_id",
             "created_by",
@@ -54,9 +62,11 @@ class StreamlitAppSandboxSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = fields
 
+    @extend_schema_field(OpenApiTypes.INT)
     def get_restart_count(self, obj: StreamlitAppSandbox) -> int:
         return obj.app.restart_count
 
+    @extend_schema_field(OpenApiTypes.INT)
     def get_version_number(self, obj: StreamlitAppSandbox) -> int | None:
         return obj.version.version_number if obj.version else None
 
@@ -81,6 +91,7 @@ class StreamlitAppMinimalSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = fields
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_status(self, obj: StreamlitApp) -> str:
         try:
             return obj.sandbox.status
@@ -173,6 +184,48 @@ class StreamlitAppSerializer(StreamlitAppMinimalSerializer):
         return updated_app
 
 
+class StreamlitAppStatusSerializer(serializers.Serializer):
+    status = serializers.CharField(help_text="Sandbox lifecycle status, or 'stopped' when no sandbox exists.")
+    restart_count = serializers.IntegerField(help_text="Number of times the app's sandbox has been restarted.")
+    last_error = serializers.CharField(
+        allow_blank=True, help_text="Most recent sandbox error message, empty when there is none."
+    )
+    started_at = serializers.DateTimeField(
+        allow_null=True, help_text="When the current sandbox started, null when stopped."
+    )
+    last_activity_at = serializers.DateTimeField(
+        allow_null=True, help_text="Timestamp of the last recorded viewer activity, null when none."
+    )
+    version_number = serializers.IntegerField(
+        allow_null=True, required=False, help_text="Version number the running sandbox was booted from."
+    )
+
+
+class StreamlitAppVersionListSerializer(serializers.Serializer):
+    results = StreamlitAppVersionSerializer(
+        many=True, help_text="Most recent versions of the app, newest first (capped at 50)."
+    )
+
+
+class ActivateVersionRequestSerializer(serializers.Serializer):
+    version_number = serializers.IntegerField(
+        help_text="Version number to activate. Must reference an existing version of this app."
+    )
+
+
+class ActivateVersionResponseSerializer(serializers.Serializer):
+    active_version = StreamlitAppVersionSerializer(help_text="The version that is now active for the app.")
+
+
+class UploadVersionRequestSerializer(serializers.Serializer):
+    file = serializers.FileField(help_text="Zip archive containing the Streamlit app sources (max 10 MB).")
+
+
+class StreamlitConnectInfoSerializer(serializers.Serializer):
+    iframe_url = serializers.CharField(help_text="Authenticated URL to embed the running app in an iframe.")
+    expires_in = serializers.IntegerField(help_text="Seconds until the embedded session credential expires.")
+
+
 def streamlit_apps_flag_enabled(distinct_id: str, organization_id: str) -> bool:
     return bool(
         posthoganalytics.feature_enabled(
@@ -193,4 +246,6 @@ class StreamlitAppsAccessPermission(BasePermission):
         user = request.user
         if not user or not user.is_authenticated:
             return False
-        return streamlit_apps_flag_enabled(user.distinct_id, str(view.organization.id))
+        organization = cast("TeamAndOrgViewSetMixin", view).organization
+        distinct_id = cast(User, user).distinct_id or str(organization.id)
+        return streamlit_apps_flag_enabled(distinct_id, str(organization.id))

--- a/products/streamlit_apps/backend/presentation/views.py
+++ b/products/streamlit_apps/backend/presentation/views.py
@@ -1,7 +1,7 @@
 import io
 import uuid
 import hashlib
-from typing import Any
+from typing import Any, cast
 
 from django.core.cache import cache
 from django.db import IntegrityError, transaction
@@ -9,6 +9,7 @@ from django.db.models import QuerySet
 from django.utils import timezone
 
 import structlog
+from drf_spectacular.utils import extend_schema
 from loginas.utils import is_impersonated_session
 from rest_framework import status, viewsets
 from rest_framework.request import Request
@@ -18,17 +19,24 @@ from rest_framework.serializers import BaseSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.models.activity_logging.activity_log import Detail, log_activity
+from posthog.models.user import User
 from posthog.rate_limit import ClickHouseBurstRateThrottle
 
 from products.streamlit_apps.backend.logic.app_runtime import AppRuntimeService
-from products.streamlit_apps.backend.logic.zip_validator import validate_zip
+from products.streamlit_apps.backend.logic.zip_validator import MAX_ZIP_SIZE, validate_zip
 from products.streamlit_apps.backend.models import StreamlitApp, StreamlitAppSandbox, StreamlitAppVersion
 from products.streamlit_apps.backend.presentation.serializers import (
+    ActivateVersionRequestSerializer,
+    ActivateVersionResponseSerializer,
     StreamlitAppMinimalSerializer,
     StreamlitAppsAccessPermission,
     StreamlitAppSandboxSerializer,
     StreamlitAppSerializer,
+    StreamlitAppStatusSerializer,
+    StreamlitAppVersionListSerializer,
     StreamlitAppVersionSerializer,
+    StreamlitConnectInfoSerializer,
+    UploadVersionRequestSerializer,
 )
 
 logger = structlog.get_logger(__name__)
@@ -91,10 +99,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         instance.save(update_fields=["deleted", "deleted_at", "updated_at"])
 
         request = self.request
+        user = cast(User, request.user)
         log_activity(
-            organization_id=request.user.current_organization_id,
+            organization_id=user.current_organization_id,
             team_id=self.team_id,
-            user=request.user,
+            user=user,
             was_impersonated=is_impersonated_session(request),
             item_id=str(instance.id),
             scope="StreamlitApp",
@@ -102,6 +111,10 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             detail=Detail(name=instance.name),
         )
 
+    @extend_schema(
+        summary="List app versions",
+        responses={200: StreamlitAppVersionListSerializer},
+    )
     @action(methods=["GET"], detail=True, url_path="versions")
     def versions(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
@@ -109,6 +122,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer = StreamlitAppVersionSerializer(versions, many=True)
         return Response({"results": serializer.data})
 
+    @extend_schema(
+        summary="Upload a new app version",
+        request=UploadVersionRequestSerializer,
+        responses={201: StreamlitAppVersionSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="upload_version")
     def upload_version(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
@@ -116,6 +134,14 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         if not zip_file:
             return Response({"detail": "No file provided."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Reject oversized uploads by their declared size before reading the body
+        # into memory, so a large multipart POST can't force a full allocation.
+        if zip_file.size is not None and zip_file.size > MAX_ZIP_SIZE:
+            return Response(
+                {"detail": f"Zip file too large (max {MAX_ZIP_SIZE // (1024 * 1024)} MB)."},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
 
         file_content = zip_file.read()
         validation = validate_zip(io.BytesIO(file_content))
@@ -150,7 +176,7 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     version_number=next_version_number,
                     zip_file=zip_path,
                     zip_hash=zip_hash,
-                    created_by=request.user,
+                    created_by=cast(User, request.user),
                 )
 
                 app.active_version = version
@@ -167,10 +193,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         self._stop_active_sandbox_after_version_change(app)
 
+        user = cast(User, request.user)
         log_activity(
-            organization_id=request.user.current_organization_id,
+            organization_id=user.current_organization_id,
             team_id=self.team_id,
-            user=request.user,
+            user=user,
             was_impersonated=is_impersonated_session(request),
             item_id=str(app.id),
             scope="StreamlitApp",
@@ -181,6 +208,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer = StreamlitAppVersionSerializer(version)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    @extend_schema(
+        summary="Activate an existing app version",
+        request=ActivateVersionRequestSerializer,
+        responses={200: ActivateVersionResponseSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="activate_version")
     def activate_version(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
@@ -188,6 +220,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         if version_number is None:
             return Response({"detail": "version_number is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Guard the type before the ORM lookup: a non-integer (e.g. "abc" or 1.5)
+        # would otherwise raise ValueError and surface as a 500 instead of a 400.
+        if not isinstance(version_number, int) or isinstance(version_number, bool):
+            return Response({"detail": "version_number must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             version = app.versions.get(version_number=version_number)
@@ -199,10 +236,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         self._stop_active_sandbox_after_version_change(app)
 
+        user = cast(User, request.user)
         log_activity(
-            organization_id=request.user.current_organization_id,
+            organization_id=user.current_organization_id,
             team_id=self.team_id,
-            user=request.user,
+            user=user,
             was_impersonated=is_impersonated_session(request),
             item_id=str(app.id),
             scope="StreamlitApp",
@@ -212,6 +250,10 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return Response({"active_version": StreamlitAppVersionSerializer(version).data})
 
+    @extend_schema(
+        summary="Get app sandbox status",
+        responses={200: StreamlitAppStatusSerializer},
+    )
     @action(methods=["GET"], detail=True, url_path="status")
     def get_status(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
@@ -238,6 +280,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             return Response(payload)
         return Response(cached)
 
+    @extend_schema(
+        summary="Start the app sandbox",
+        request=None,
+        responses={200: StreamlitAppSerializer, 202: StreamlitAppSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="start", throttle_classes=[ClickHouseBurstRateThrottle])
     def start(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
@@ -262,6 +309,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             status=status.HTTP_202_ACCEPTED,
         )
 
+    @extend_schema(
+        summary="Stop the app sandbox",
+        request=None,
+        responses={200: StreamlitAppSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="stop")
     def stop(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
@@ -275,15 +327,20 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return Response(StreamlitAppSerializer(app, context=self.get_serializer_context()).data)
 
+    @extend_schema(
+        summary="Get iframe connection info for a running app",
+        responses={200: StreamlitConnectInfoSerializer},
+    )
     @action(methods=["GET"], detail=True, url_path="connect_info", throttle_classes=[ClickHouseBurstRateThrottle])
     def connect_info(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()
-        sandbox_record = StreamlitAppSandbox.objects.filter(app=app).first()
+        sandbox_record = self._get_sandbox_or_none(app)
         if not sandbox_record or sandbox_record.status != StreamlitAppSandbox.Status.RUNNING:
             return Response({"detail": "App is not running."}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
+        user = cast(User, request.user)
         runtime = AppRuntimeService()
-        connect_data = runtime.get_connect_url(app, user_id=request.user.id, team_id=self.team_id)
+        connect_data = runtime.get_connect_url(app, user_id=user.id, team_id=self.team_id)
         if not connect_data:
             return Response({"detail": "Unable to connect to app."}, status=status.HTTP_502_BAD_GATEWAY)
 
@@ -300,9 +357,9 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             find_reusable_streamlit_access_token,
         )
 
-        access_token = find_reusable_streamlit_access_token(user=request.user, team_id=self.team_id)
+        access_token = find_reusable_streamlit_access_token(user=user, team_id=self.team_id)
         if access_token is None:
-            access_token = create_streamlit_access_token(user=request.user, team_id=self.team_id)
+            access_token = create_streamlit_access_token(user=user, team_id=self.team_id)
 
         sandbox_url = connect_data["url"].rstrip("/")
         # Docker sandboxes have no Modal connect token; only Modal tunnels need it.
@@ -320,6 +377,11 @@ class StreamlitAppViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             }
         )
 
+    @extend_schema(
+        summary="Restart the app sandbox",
+        request=None,
+        responses={202: StreamlitAppSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="restart", throttle_classes=[ClickHouseBurstRateThrottle])
     def restart(self, request: Request, **kwargs: Any) -> Response:
         app = self.get_object()

--- a/products/streamlit_apps/backend/routes.py
+++ b/products/streamlit_apps/backend/routes.py
@@ -4,4 +4,4 @@ from products.streamlit_apps.backend.presentation import StreamlitAppViewSet
 
 
 def register_routes(routers: RouterRegistry) -> None:
-    routers.environments.register(r"streamlit_apps", StreamlitAppViewSet, "environment_streamlit_apps", ["team_id"])
+    routers.projects.register(r"streamlit_apps", StreamlitAppViewSet, "project_streamlit_apps", ["team_id"])

--- a/products/streamlit_apps/backend/tests/test_bridge.py
+++ b/products/streamlit_apps/backend/tests/test_bridge.py
@@ -94,6 +94,40 @@ class TestStreamlitBridgeView(_StreamlitAppsFlagMixin, APIBaseTest):
         )
         assert response.status_code == 401
 
+    def test_inactive_user_token_rejected(self):
+        # A bridge token outlives the minting user, so deactivating the user must
+        # immediately revoke the sandbox's access to team data.
+        token = self._streamlit_token()
+        self.user.is_active = False
+        self.user.save()
+
+        response = self.client.post(
+            self._url(),
+            data=json.dumps({"query": "SELECT 1"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401
+
+    def test_non_member_user_token_rejected(self):
+        # A token whose user no longer belongs to the scoped team's organization
+        # must not grant query access, even with a valid bridge scope.
+        from posthog.models import Organization, User
+
+        from products.streamlit_apps.backend.logic.oauth import create_sandbox_bridge_token
+
+        other_org = Organization.objects.create(name="Outsider Org")
+        outsider = User.objects.create_and_join(other_org, "outsider@example.com", None)
+        token = create_sandbox_bridge_token(user=outsider, team_id=self.team.id)
+
+        response = self.client.post(
+            self._url(),
+            data=json.dumps({"query": "SELECT 1"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 401
+
     def test_invalid_json_body(self):
         response = self.client.post(
             self._url(),

--- a/products/streamlit_apps/backend/tests/test_presentation.py
+++ b/products/streamlit_apps/backend/tests/test_presentation.py
@@ -69,9 +69,9 @@ class _StreamlitAppsFlagMixin:
 
 
 class TestStreamlitAppAPI(_StreamlitAppsFlagMixin, APIBaseTest):
-    # The viewset is registered under /environments/ via the product's routes.py.
+    # The viewset is registered under /projects/ via the product's routes.py.
     def _url(self, suffix: str = "") -> str:
-        base = f"/api/environments/{self.team.id}/streamlit_apps"
+        base = f"/api/projects/{self.team.id}/streamlit_apps"
         if suffix:
             return f"{base}/{suffix}"
         return f"{base}/"
@@ -218,7 +218,7 @@ class TestStreamlitAppAPI(_StreamlitAppsFlagMixin, APIBaseTest):
 
 class TestStreamlitAppVersionAPI(_StreamlitAppsFlagMixin, APIBaseTest):
     def _url(self, short_id: str, suffix: str = "") -> str:
-        base = f"/api/environments/{self.team.id}/streamlit_apps/{short_id}"
+        base = f"/api/projects/{self.team.id}/streamlit_apps/{short_id}"
         if suffix:
             return f"{base}/{suffix}"
         return f"{base}/"
@@ -432,10 +432,38 @@ class TestStreamlitAppVersionAPI(_StreamlitAppsFlagMixin, APIBaseTest):
         response = self.client.post(self._url(app.short_id, "activate_version/"))
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    @parameterized.expand([("string", "abc"), ("float", 1.5), ("bool", True)])
+    def test_activate_version_rejects_non_integer(self, _name, version_number):
+        # A non-integer would otherwise hit the ORM and raise a 500 rather than a 400.
+        app = self._create_app()
+        self._create_version(app, 1)
+        response = self.client.post(
+            self._url(app.short_id, "activate_version/"),
+            data={"version_number": version_number},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("posthog.storage.object_storage.write")
+    def test_upload_version_too_large_413(self, mock_storage_write):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        from products.streamlit_apps.backend.logic.zip_validator import MAX_ZIP_SIZE
+
+        app = self._create_app()
+        oversized = SimpleUploadedFile("app.zip", b"\0" * (MAX_ZIP_SIZE + 1), content_type="application/zip")
+        response = self.client.post(
+            self._url(app.short_id, "upload_version/"),
+            data={"file": oversized},
+            format="multipart",
+        )
+        assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+        # The body is rejected by size before it is ever read or persisted.
+        mock_storage_write.assert_not_called()
+
 
 class TestStreamlitAppSandboxControlAPI(_StreamlitAppsFlagMixin, APIBaseTest):
     def _url(self, short_id: str, suffix: str = "") -> str:
-        base = f"/api/environments/{self.team.id}/streamlit_apps/{short_id}"
+        base = f"/api/projects/{self.team.id}/streamlit_apps/{short_id}"
         if suffix:
             return f"{base}/{suffix}"
         return f"{base}/"


### PR DESCRIPTION
## Problem

PR #54879 had mypy failures plus a round of automated review comments (security and correctness). This branch stacks the fixes on top of #54879 so it can be merged into `streamlit-apps-api` to update that PR in place.

## Changes

**Type-checking (mypy → clean):**
- Add `"StreamlitApp"` to the `ActivityScope` literal so `log_activity`/`changes_between` type-check.
- `cast` `request.user` to `User` across the viewset actions and the access permission.

**Security / correctness (from review):**
- Drop `zip_file` (the object-storage key) from `StreamlitAppVersionSerializer` — clients never need the raw path.
- Validate `version_number` is an integer before the ORM lookup in `activate_version` (400 instead of a 500).
- Reject oversized uploads by declared size **before** reading the body (413).
- Add an IP-keyed bridge throttle (`StreamlitBridgeIPThrottle`) so rotating random bearer tokens can't bypass the per-token rate limit.
- Re-validate the bridge token's user is active **and** still a member of the scoped team's organization before executing queries.
- `connect_info` reuses the prefetched sandbox instead of issuing an extra query.

**Conventions (`/improving-drf-endpoints`):**
- Register the viewset under `routers.projects` (the canonical path for new team-nested endpoints) instead of `routers.environments`; test URLs updated.
- Add `@extend_schema` request/response serializers to the custom actions and `@extend_schema_field` on the method fields so generated OpenAPI/MCP types aren't empty.

## How did you test this code?

I'm an agent. I could not run the DB-backed test suite or `hogli build:openapi` in this environment (no Postgres / frontend toolchain). Locally verified: `mypy` (0 errors on the changed files), `ruff check`, `ruff format --check`, and `py_compile` all pass. Added automated tests for the new behaviours — non-integer `version_number`, oversized upload (413), and inactive / non-member bridge tokens — to be exercised by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code) at the request of the PR owner to clear mypy and address the bot review comments on #54879. Notable decisions:

- **Routing:** switched `environments` → `projects` per the documented convention for new endpoints; safe because there are no external consumers yet (no frontend, only in-repo tests).
- **Bridge RBAC:** added an active-user + org-membership re-check (closes deactivated/removed-user access). The deeper resource-level "query read" access-control check was left as a follow-up to avoid over-scoping.
- **iframe-token-in-URL** (hex finding) was intentionally **not** rearchitected here: the iframe token is short-lived and carries only the `streamlit:iframe` scope (it can't hit the data bridge, which needs a separate `streamlit:bridge` token). A one-time-token exchange belongs in the sandbox proxy (outside this repo).
- **`_sync_sandbox_status` rename** (greptile P2) skipped: it's an established internal helper used across `app_runtime`, the product facade, tasks, and tests — renaming would be out-of-scope churn.

This PR was opened against `streamlit-apps-api` (not `master`) because the tooling guards the PR branch from direct commits; merging this updates #54879.
