### PR TITLE
fix(data-warehouse): converge temporal sync schedules with schema state

### DIFF
--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -848,7 +848,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             instance.table.soft_delete()
         instance.soft_delete()
 
-        # Best-effort: a failed delete must not resurrect the request, but an orphaned
+        # Best-effort: a failed schedule delete must not fail the deletion, but an orphaned
         # schedule keeps syncing (and billing) a schema the user can no longer see.
         try:
             delete_external_data_schedule(str(instance.id))
@@ -958,7 +958,6 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             hide_direct_postgres_table(instance.table)
             instance.should_sync = False
             instance.save(update_fields=["should_sync", "updated_at"])
-            sync_schema_schedule_state(instance)
             return Response(status=status.HTTP_200_OK)
 
         instance.delete_table()

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -24,14 +24,12 @@ from posthog.temporal.data_imports.sources.common.sql import (
 
 from products.data_warehouse.backend.data_load.service import (
     cancel_external_data_workflow,
-    external_data_workflow_exists,
+    delete_external_data_schedule,
     is_any_external_data_schema_paused,
     is_cdc_enabled_for_team,
-    pause_external_data_schedule,
     sync_cdc_extraction_schedule,
-    sync_external_data_job_workflow,
+    sync_schema_schedule_state,
     trigger_external_data_workflow,
-    unpause_external_data_schedule,
 )
 from products.data_warehouse.backend.direct_postgres import hide_direct_postgres_table
 from products.data_warehouse.backend.external_data_source.webhooks import (
@@ -634,23 +632,7 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
         if source.supports_scheduled_sync and (
             should_sync is not None or was_sync_frequency_updated or was_sync_time_of_day_updated
         ):
-
-            def update_schedule() -> None:
-                should_sync_value = should_sync if should_sync is not None else updated_instance.should_sync
-                schedule_exists = external_data_workflow_exists(str(updated_instance.id))
-
-                if schedule_exists:
-                    if should_sync is False:
-                        pause_external_data_schedule(str(updated_instance.id))
-                    elif should_sync is True:
-                        unpause_external_data_schedule(str(updated_instance.id))
-                elif should_sync is True:
-                    sync_external_data_job_workflow(updated_instance, create=True, should_sync=should_sync_value)
-
-                if was_sync_frequency_updated or was_sync_time_of_day_updated:
-                    sync_external_data_job_workflow(updated_instance, create=False, should_sync=should_sync_value)
-
-            self._run_temporal_side_effect(update_schedule)
+            self._run_temporal_side_effect(lambda: sync_schema_schedule_state(updated_instance))
 
         if trigger_refresh:
             self._run_temporal_side_effect(lambda: trigger_external_data_workflow(updated_instance))
@@ -866,6 +848,14 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             instance.table.soft_delete()
         instance.soft_delete()
 
+        # Best-effort: a failed delete must not resurrect the request, but an orphaned
+        # schedule keeps syncing (and billing) a schema the user can no longer see.
+        try:
+            delete_external_data_schedule(str(instance.id))
+        except Exception as e:
+            logger.exception("Failed to delete sync schedule for deleted schema", exc_info=e)
+            capture_exception(e, {"schema_id": str(instance.id), "team_id": instance.team_id})
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=["POST"], detail=True)
@@ -968,6 +958,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             hide_direct_postgres_table(instance.table)
             instance.should_sync = False
             instance.save(update_fields=["should_sync", "updated_at"])
+            sync_schema_schedule_state(instance)
             return Response(status=status.HTTP_200_OK)
 
         instance.delete_table()

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -2667,18 +2667,17 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             logger.exception("Failed engine-side CDC cleanup during disable_cdc", exc_info=e)
             capture_exception(e, {"source_id": str(instance.id)})
 
-        disabled_schemas = list(
-            ExternalDataSchema.objects.select_related("source")
-            .filter(
-                source=instance,
-                sync_type=ExternalDataSchema.SyncType.CDC,
-            )
-            .exclude(deleted=True)
-        )
-
         with transaction.atomic():
             # Force CDC schemas to pick a new strategy by clearing sync_type and pausing.
             # Per-instance saves (not a queryset update) so activity logging fires.
+            disabled_schemas = list(
+                ExternalDataSchema.objects.select_related("source")
+                .filter(
+                    source=instance,
+                    sync_type=ExternalDataSchema.SyncType.CDC,
+                )
+                .exclude(deleted=True)
+            )
             for disabled_schema in disabled_schemas:
                 disabled_schema.sync_type = None
                 disabled_schema.should_sync = False

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -18,7 +18,7 @@ import temporalio
 from dateutil import parser
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_field
 from rest_framework import filters, serializers, status, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -73,6 +73,7 @@ from products.data_warehouse.backend.data_load.service import (
     sync_cdc_extraction_schedule,
     sync_discover_schemas_schedule,
     sync_external_data_job_workflow,
+    sync_schema_schedule_state,
     trigger_external_data_source_workflow,
 )
 from products.data_warehouse.backend.direct_postgres import upsert_direct_postgres_table
@@ -2666,12 +2667,22 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             logger.exception("Failed engine-side CDC cleanup during disable_cdc", exc_info=e)
             capture_exception(e, {"source_id": str(instance.id)})
 
-        with transaction.atomic():
-            # Force CDC schemas to pick a new strategy by clearing sync_type and pausing.
-            ExternalDataSchema.objects.filter(
+        disabled_schemas = list(
+            ExternalDataSchema.objects.select_related("source")
+            .filter(
                 source=instance,
                 sync_type=ExternalDataSchema.SyncType.CDC,
-            ).exclude(deleted=True).update(sync_type=None, should_sync=False)
+            )
+            .exclude(deleted=True)
+        )
+
+        with transaction.atomic():
+            # Force CDC schemas to pick a new strategy by clearing sync_type and pausing.
+            # Per-instance saves (not a queryset update) so activity logging fires.
+            for disabled_schema in disabled_schemas:
+                disabled_schema.sync_type = None
+                disabled_schema.should_sync = False
+                disabled_schema.save(update_fields=["sync_type", "should_sync", "updated_at"])
 
             # Soft-delete `_cdc` companion DataWarehouseTable rows so the next sync
             # rebuilds them once the user picks a new strategy.
@@ -2691,6 +2702,19 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                     job_inputs.pop(key, None)
             instance.job_inputs = job_inputs
             instance.save(update_fields=["job_inputs", "updated_at"])
+
+        # Pause the per-schema sync schedules after the commit — best-effort like the
+        # rest of the teardown, but without it the schedules keep firing while the
+        # schemas read as disabled.
+        for disabled_schema in disabled_schemas:
+            try:
+                sync_schema_schedule_state(disabled_schema)
+            except Exception as e:
+                logger.exception(
+                    "Failed to pause sync schedule during disable_cdc",
+                    extra={"source_id": str(instance.id), "schema_id": str(disabled_schema.id)},
+                )
+                capture_exception(e, {"source_id": str(instance.id), "schema_id": str(disabled_schema.id)})
 
         return Response(status=status.HTTP_200_OK, data={"success": True})
 
@@ -3341,8 +3365,22 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 schema_serializer.is_valid(raise_exception=True)
                 updated_schemas.append(schema_serializer.save())
 
+        # Run every action even if one throws — the DB changes are already committed, and
+        # skipping the remaining actions would leave those schemas' schedules on stale state.
+        post_commit_failures = 0
         for post_commit_action in post_commit_actions:
-            post_commit_action()
+            try:
+                post_commit_action()
+            except Exception as e:
+                post_commit_failures += 1
+                logger.exception("bulk_update_schemas post-commit action failed", exc_info=e)
+                capture_exception(e, {"source_id": str(source.id), "team_id": self.team_id})
+
+        if post_commit_failures:
+            raise APIException(
+                f"Schema changes were saved, but updating the sync schedule failed for "
+                f"{post_commit_failures} schema(s). Save the affected schemas again to retry."
+            )
 
         return Response(
             ExternalDataSchemaSerializer(updated_schemas, many=True, context=serializer_context).data,

--- a/products/data_warehouse/backend/api/test/test_cdc_table_mode_patch.py
+++ b/products/data_warehouse/backend/api/test/test_cdc_table_mode_patch.py
@@ -34,10 +34,10 @@ _PATCH_TARGETS = {
         "posthog.temporal.data_imports.sources.postgres.cdc.adapter.PostgresCDCAdapter._alter_publication_membership"
     ),
     "external_data_workflow_exists": (
-        "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists"
+        "products.data_warehouse.backend.data_load.service.external_data_workflow_exists"
     ),
     "sync_external_data_job_workflow": (
-        "products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"
+        "products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow"
     ),
     "sync_cdc_extraction_schedule": (
         "products.data_warehouse.backend.api.external_data_schema.sync_cdc_extraction_schedule"

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -366,7 +366,7 @@ class TestExternalDataSchema(APIBaseTest):
                 "products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow"
             ) as mock_trigger_external_data_workflow,
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
         ):
@@ -380,6 +380,44 @@ class TestExternalDataSchema(APIBaseTest):
             schema.refresh_from_db()
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+
+    def test_update_sync_frequency_on_disabled_never_activated_schema_is_db_only(self):
+        source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+
+        with (
+            mock.patch(
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
+                return_value=False,
+            ),
+            mock.patch(
+                "products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow"
+            ) as mock_sync,
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={"sync_frequency": "7day"},
+            )
+
+        assert response.status_code == 200, response.content
+        schema.refresh_from_db()
+        assert schema.sync_frequency_interval == timedelta(days=7)
+        # No schedule exists and the schema is disabled — there is nothing to update,
+        # and blind-updating used to 500 with a Temporal NOT_FOUND.
+        mock_sync.assert_not_called()
 
     @parameterized.expand(
         [
@@ -447,7 +485,7 @@ class TestExternalDataSchema(APIBaseTest):
             ),
             mock.patch("products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow"),
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
         ):
@@ -532,10 +570,10 @@ class TestExternalDataSchema(APIBaseTest):
                 return_value=True,
             ),
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
-            mock.patch("products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"),
+            mock.patch("products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow"),
             mock.patch("products.data_warehouse.backend.api.external_data_schema.sync_cdc_extraction_schedule"),
         ):
             response = self.client.patch(
@@ -643,7 +681,7 @@ class TestExternalDataSchema(APIBaseTest):
                 "products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow"
             ) as mock_trigger_external_data_workflow,
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=True,
             ),
             mock.patch(
@@ -887,7 +925,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -936,7 +974,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -988,7 +1026,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -1041,7 +1079,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -1075,7 +1113,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -1105,7 +1143,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -1145,7 +1183,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
@@ -1184,7 +1222,7 @@ class TestExternalDataSchema(APIBaseTest):
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch.object(StripeSource, "get_schemas", return_value=mock_non_webhook_schemas),
@@ -1426,10 +1464,10 @@ class TestUpdateExternalDataSchema:
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists"
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists"
             ) as mock_external_data_workflow_exists,
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"
+                "products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow"
             ) as mock_sync_external_data_job_workflow,
         ):
             response = client.patch(
@@ -1561,10 +1599,10 @@ class TestUpdateExternalDataSchema:
                 "posthog.temporal.data_imports.sources.postgres.cdc.adapter.PostgresCDCAdapter.add_table"
             ) as mock_add_table,
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
-            mock.patch("products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"),
+            mock.patch("products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow"),
             mock.patch("products.data_warehouse.backend.api.external_data_schema.sync_cdc_extraction_schedule"),
         ):
             response = client.patch(
@@ -1776,14 +1814,14 @@ class TestUpdateExternalDataSchema:
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
                 "products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow",
             ) as mock_trigger,
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow",
+                "products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow",
             ),
         ):
             response = client.patch(
@@ -1818,14 +1856,14 @@ class TestUpdateExternalDataSchema:
 
         with (
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
                 return_value=False,
             ),
             mock.patch(
                 "products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow",
             ) as mock_trigger,
             mock.patch(
-                "products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow",
+                "products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow",
             ),
         ):
             response = client.patch(

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -378,7 +378,7 @@ class TestExternalDataSource(APIBaseTest):
         assert source.description == "edited"
 
     @patch(
-        "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+        "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
         return_value=False,
     )
     def test_bulk_update_schemas(self, _mock_workflow_exists):
@@ -421,7 +421,7 @@ class TestExternalDataSource(APIBaseTest):
         assert schema_two.should_sync is False
 
     @patch(
-        "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+        "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
         return_value=False,
     )
     def test_bulk_update_schemas_runs_deferred_temporal_updates(self, _mock_workflow_exists):
@@ -435,7 +435,7 @@ class TestExternalDataSource(APIBaseTest):
         )
 
         with patch(
-            "products.data_warehouse.backend.api.external_data_schema.sync_external_data_job_workflow"
+            "products.data_warehouse.backend.data_load.service.sync_external_data_job_workflow"
         ) as mock_sync_external_data_job_workflow:
             response = self.client.patch(
                 f"/api/environments/{self.team.pk}/external_data_sources/{source.id}/bulk_update_schemas",
@@ -448,11 +448,55 @@ class TestExternalDataSource(APIBaseTest):
         schema.refresh_from_db()
         assert sync_frequency_interval_to_sync_frequency(schema.sync_frequency_interval) == "7day"
         assert mock_sync_external_data_job_workflow.call_count == 1
-        assert mock_sync_external_data_job_workflow.call_args.kwargs == {"create": False, "should_sync": True}
+        # The schedule does not exist (mocked above), so an enabled schema gets it created
+        # rather than blind-updated into a NOT_FOUND error.
+        assert mock_sync_external_data_job_workflow.call_args.kwargs == {"create": True, "should_sync": True}
         assert mock_sync_external_data_job_workflow.call_args.args[0].id == schema.id
 
+    def test_bulk_update_schemas_one_failing_schedule_does_not_strand_the_rest(self):
+        source = self._create_external_data_source()
+        schema_one = ExternalDataSchema.objects.create(
+            name="Customers",
+            team_id=self.team.pk,
+            source=source,
+            should_sync=True,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+        schema_two = ExternalDataSchema.objects.create(
+            name="Invoices",
+            team_id=self.team.pk,
+            source=source,
+            should_sync=True,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+
+        with patch(
+            "products.data_warehouse.backend.api.external_data_schema.sync_schema_schedule_state",
+            side_effect=[Exception("temporal down"), None],
+        ) as mock_converge:
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.id}/bulk_update_schemas",
+                data={
+                    "schemas": [
+                        {"id": str(schema_one.id), "sync_frequency": "7day"},
+                        {"id": str(schema_two.id), "sync_frequency": "7day"},
+                    ]
+                },
+                format="json",
+            )
+
+        # Every schema's schedule update ran despite the first one failing, the DB changes
+        # stayed committed, and the failure surfaced to the caller.
+        assert mock_converge.call_count == 2
+        assert response.status_code == 500
+        assert "sync schedule" in response.json()["detail"]
+        schema_one.refresh_from_db()
+        schema_two.refresh_from_db()
+        assert sync_frequency_interval_to_sync_frequency(schema_one.sync_frequency_interval) == "7day"
+        assert sync_frequency_interval_to_sync_frequency(schema_two.sync_frequency_interval) == "7day"
+
     @patch(
-        "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+        "products.data_warehouse.backend.data_load.service.external_data_workflow_exists",
         return_value=False,
     )
     def test_bulk_update_schemas_webhook_reconcile_raising_does_not_500(self, _mock_workflow_exists):
@@ -8004,9 +8048,12 @@ class TestDisableCDC(APIBaseTest):
             should_sync=True,
         )
 
-        response = self.client.post(
-            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/disable_cdc/",
-        )
+        with patch(
+            "products.data_warehouse.backend.api.external_data_source.sync_schema_schedule_state"
+        ) as mock_converge:
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/disable_cdc/",
+            )
         assert response.status_code == 200, response.content
 
         source.refresh_from_db()
@@ -8021,6 +8068,11 @@ class TestDisableCDC(APIBaseTest):
         cdc_schema.refresh_from_db()
         assert cdc_schema.sync_type is None
         assert cdc_schema.should_sync is False
+
+        # The sync schedule must be converged (paused) for the disabled schema, or it
+        # keeps firing while the schema reads as disabled.
+        assert mock_converge.call_count == 1
+        assert mock_converge.call_args.args[0].id == cdc_schema.id
 
         # Non-CDC schema must NOT be touched.
         non_cdc_schema.refresh_from_db()

--- a/products/data_warehouse/backend/data_load/service.py
+++ b/products/data_warehouse/backend/data_load/service.py
@@ -167,6 +167,33 @@ def sync_external_data_job_workflow(
     return external_data_schema
 
 
+def sync_schema_schedule_state(external_data_schema: ExternalDataSchema) -> None:
+    """Converge the schema's Temporal sync schedule to its DB state.
+
+    Re-issues the full schedule — interval, time-of-day offset, and paused flag — so the
+    spec cannot diverge from `sync_frequency_interval` / `should_sync`. Every code path
+    that writes `should_sync` or the frequency must call this instead of pausing/updating
+    the schedule piecemeal.
+    """
+    if not external_data_schema.source.supports_scheduled_sync:
+        return
+
+    schedule_id = str(external_data_schema.id)
+
+    # No cadence means there is no spec to issue — just make sure nothing keeps firing.
+    if external_data_schema.sync_frequency_interval is None:
+        if external_data_workflow_exists(schedule_id):
+            pause_external_data_schedule(schedule_id)
+        return
+
+    if external_data_workflow_exists(schedule_id):
+        sync_external_data_job_workflow(
+            external_data_schema, create=False, should_sync=external_data_schema.should_sync
+        )
+    elif external_data_schema.should_sync:
+        sync_external_data_job_workflow(external_data_schema, create=True, should_sync=True)
+
+
 async def a_sync_external_data_job_workflow(
     external_data_schema: ExternalDataSchema, create: bool = False, should_sync: bool = True
 ) -> ExternalDataSchema:

--- a/products/data_warehouse/backend/data_load/test/test_service.py
+++ b/products/data_warehouse/backend/data_load/test/test_service.py
@@ -30,6 +30,7 @@ from products.data_warehouse.backend.data_load.service import (
     cdc_min_interval,
     get_discover_schemas_schedule,
     get_sync_schedule,
+    sync_schema_schedule_state,
 )
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -456,3 +457,79 @@ def test_bulk_update_edj_mixed_skip_fail_and_success():
     assert [sid for sid, _ in failures] == [str(broken.id)]
     assert create_mock.call_count == 0
     assert update_mock.call_count == 3
+
+
+def _patch_schedule_state(exists=True):
+    return (
+        patch(f"{SERVICE}.external_data_workflow_exists", return_value=exists),
+        patch(f"{SERVICE}.sync_external_data_job_workflow"),
+        patch(f"{SERVICE}.pause_external_data_schedule"),
+    )
+
+
+@pytest.mark.parametrize("should_sync", [True, False])
+def test_sync_schema_schedule_state_reissues_existing_schedule(should_sync):
+    team = _sync_team()
+    schema = _make_schema(team, _make_source(team), should_sync=should_sync)
+
+    exists, sync, pause = _patch_schedule_state(exists=True)
+    with exists, sync as sync_mock, pause as pause_mock:
+        sync_schema_schedule_state(schema)
+
+    assert sync_mock.call_count == 1
+    assert sync_mock.call_args.kwargs == {"create": False, "should_sync": should_sync}
+    pause_mock.assert_not_called()
+
+
+def test_sync_schema_schedule_state_creates_missing_schedule_when_enabled():
+    team = _sync_team()
+    schema = _make_schema(team, _make_source(team), should_sync=True)
+
+    exists, sync, pause = _patch_schedule_state(exists=False)
+    with exists, sync as sync_mock, pause:
+        sync_schema_schedule_state(schema)
+
+    assert sync_mock.call_count == 1
+    assert sync_mock.call_args.kwargs == {"create": True, "should_sync": True}
+
+
+def test_sync_schema_schedule_state_noops_on_missing_schedule_when_disabled():
+    team = _sync_team()
+    schema = _make_schema(team, _make_source(team), should_sync=False)
+
+    exists, sync, pause = _patch_schedule_state(exists=False)
+    with exists, sync as sync_mock, pause as pause_mock:
+        sync_schema_schedule_state(schema)
+
+    sync_mock.assert_not_called()
+    pause_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("schedule_exists,expect_pause", [(True, True), (False, False)])
+def test_sync_schema_schedule_state_pauses_when_no_frequency(schedule_exists, expect_pause):
+    team = _sync_team()
+    schema = _make_schema(team, _make_source(team), should_sync=True)
+    schema.sync_frequency_interval = None
+
+    exists, sync, pause = _patch_schedule_state(exists=schedule_exists)
+    with exists, sync as sync_mock, pause as pause_mock:
+        sync_schema_schedule_state(schema)
+
+    sync_mock.assert_not_called()
+    assert pause_mock.call_count == (1 if expect_pause else 0)
+
+
+def test_sync_schema_schedule_state_skips_direct_query_sources():
+    team = _sync_team()
+    source = _make_source(team)
+    source.access_method = ExternalDataSource.AccessMethod.DIRECT
+    source.save()
+    schema = _make_schema(team, source, should_sync=False)
+
+    exists, sync, pause = _patch_schedule_state()
+    with exists as exists_mock, sync as sync_mock, pause as pause_mock:
+        sync_schema_schedule_state(schema)
+
+    exists_mock.assert_not_called()
+    sync_mock.assert_not_called()
+    pause_mock.assert_not_called()

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -519,7 +519,7 @@ def sync_old_schemas_with_new_schemas(
                 except Exception as e:
                     # Soft-deleting now would orphan the live schedule forever (deleted
                     # schemas are never re-walked) — keep the row so the next run retries.
-                    capture_exception(e)
+                    capture_exception(e, {"schema_id": str(s.id), "team_id": team_id})
                     continue
                 s.soft_delete()
                 deleted_schemas.append(schema)
@@ -530,7 +530,7 @@ def sync_old_schemas_with_new_schemas(
                 try:
                     sync_schema_schedule_state(s)
                 except Exception as e:
-                    capture_exception(e)
+                    capture_exception(e, {"schema_id": str(s.id), "team_id": team_id})
 
     return actually_created, deleted_schemas
 

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -405,30 +405,13 @@ def aget_schema_by_id(schema_id: str, team_id: int) -> ExternalDataSchema | None
 def update_should_sync(schema_id: str, team_id: int, should_sync: bool) -> ExternalDataSchema | None:
     # data_load.service imports temporalio at module scope; this is a models module, so a
     # top-level import would put the Temporal client on the django.setup() path
-    from products.data_warehouse.backend.data_load.service import (  # noqa: PLC0415
-        external_data_workflow_exists,
-        pause_external_data_schedule,
-        sync_external_data_job_workflow,
-        unpause_external_data_schedule,
-    )
+    from products.data_warehouse.backend.data_load.service import sync_schema_schedule_state  # noqa: PLC0415
 
     schema = ExternalDataSchema.objects.select_related("source").get(id=schema_id, team_id=team_id)
     schema.should_sync = should_sync
     schema.save()
 
-    if not schema.source.supports_scheduled_sync:
-        return schema
-
-    schedule_exists = external_data_workflow_exists(schema_id)
-
-    if schedule_exists:
-        if should_sync is False:
-            pause_external_data_schedule(schema_id)
-        elif should_sync is True:
-            unpause_external_data_schedule(schema_id)
-    else:
-        if should_sync is True:
-            sync_external_data_job_workflow(schema, create=True)
+    sync_schema_schedule_state(schema)
 
     return schema
 
@@ -515,19 +498,39 @@ def sync_old_schemas_with_new_schemas(
         if created:
             actually_created.append(schema)
 
+    # data_load.service imports temporalio at module scope; this is a models module, so a
+    # top-level import would put the Temporal client on the django.setup() path
+    from products.data_warehouse.backend.data_load.service import (  # noqa: PLC0415
+        delete_external_data_schedule,
+        sync_schema_schedule_state,
+    )
+
     for schema in schemas_to_possibly_delete:
         # There _could_ exist multiple schemas with the same name, there shouldn't be, but it's not impossible
-        schemas_to_check = ExternalDataSchema.objects.filter(
+        schemas_to_check = ExternalDataSchema.objects.select_related("source").filter(
             team_id=team_id, name=schema, source_id=source_id, deleted=False
         )
         for s in schemas_to_check:
+            # Schedule cleanup failures are logged, not raised: discovery re-walks
+            # still-missing schemas on every run, so they self-heal on the next cycle.
             if s.table_id is None:
+                try:
+                    delete_external_data_schedule(str(s.id))
+                except Exception as e:
+                    # Soft-deleting now would orphan the live schedule forever (deleted
+                    # schemas are never re-walked) — keep the row so the next run retries.
+                    capture_exception(e)
+                    continue
                 s.soft_delete()
                 deleted_schemas.append(schema)
             else:
                 s.should_sync = False
                 s.status = ExternalDataSchema.Status.COMPLETED
                 s.save()
+                try:
+                    sync_schema_schedule_state(s)
+                except Exception as e:
+                    capture_exception(e)
 
     return actually_created, deleted_schemas
 

--- a/products/warehouse_sources/backend/tests/test_schema_discovery_reconcile.py
+++ b/products/warehouse_sources/backend/tests/test_schema_discovery_reconcile.py
@@ -166,3 +166,30 @@ class TestSchemaDiscoveryScheduleCleanup(BaseTest):
         schema.refresh_from_db()
         assert schema.deleted is False
         assert deleted == []
+
+    def test_vanished_schema_with_table_still_disabled_when_schedule_converge_fails(self) -> None:
+        source = self._make_source()
+        table = DataWarehouseTable.objects.create(
+            name="postgres_orders",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            url_pattern="https://bucket/team_1/*",
+            external_data_source=source,
+            columns={"id": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            team_id=self.team.pk,
+            source_id=source.pk,
+            name="orders",
+            should_sync=True,
+            table=table,
+        )
+
+        with mock.patch(f"{SERVICE}.sync_schema_schedule_state", side_effect=Exception("temporal down")):
+            sync_old_schemas_with_new_schemas({}, source_id=str(source.pk), team_id=self.team.pk)
+
+        # The disable sticks and discovery survives — still-missing schemas are re-walked
+        # every run, so the failed pause is retried on the next cycle.
+        schema.refresh_from_db()
+        assert schema.should_sync is False
+        assert schema.deleted is False

--- a/products/warehouse_sources/backend/tests/test_schema_discovery_reconcile.py
+++ b/products/warehouse_sources/backend/tests/test_schema_discovery_reconcile.py
@@ -1,6 +1,7 @@
 import uuid
 
 from posthog.test.base import BaseTest
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -87,3 +88,81 @@ class TestSchemaDiscoveryReconcile(BaseTest):
         assert existing.should_sync is True
         assert "analytics.users" in created
         assert ExternalDataSchema.objects.filter(source_id=source.pk, name="analytics.users").exists()
+
+
+SERVICE = "products.data_warehouse.backend.data_load.service"
+
+
+class TestSchemaDiscoveryScheduleCleanup(BaseTest):
+    def _make_source(self) -> ExternalDataSource:
+        return ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type="Postgres",
+            created_by=self.user,
+            job_inputs={"host": "localhost", "port": 5432, "schema": "public"},
+        )
+
+    def test_vanished_schema_with_table_is_disabled_and_schedule_converged(self) -> None:
+        source = self._make_source()
+        table = DataWarehouseTable.objects.create(
+            name="postgres_orders",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            url_pattern="https://bucket/team_1/*",
+            external_data_source=source,
+            columns={"id": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            team_id=self.team.pk,
+            source_id=source.pk,
+            name="orders",
+            should_sync=True,
+            table=table,
+        )
+
+        with mock.patch(f"{SERVICE}.sync_schema_schedule_state") as converge_mock:
+            sync_old_schemas_with_new_schemas({}, source_id=str(source.pk), team_id=self.team.pk)
+
+        schema.refresh_from_db()
+        assert schema.should_sync is False
+        assert schema.deleted is False
+        assert converge_mock.call_count == 1
+        assert converge_mock.call_args.args[0].id == schema.id
+
+    def test_vanished_schema_without_table_deletes_schedule_then_soft_deletes(self) -> None:
+        source = self._make_source()
+        schema = ExternalDataSchema.objects.create(
+            team_id=self.team.pk,
+            source_id=source.pk,
+            name="orders",
+            should_sync=True,
+        )
+
+        with mock.patch(f"{SERVICE}.delete_external_data_schedule") as delete_mock:
+            _, deleted = sync_old_schemas_with_new_schemas({}, source_id=str(source.pk), team_id=self.team.pk)
+
+        schema.refresh_from_db()
+        assert schema.deleted is True
+        assert deleted == ["orders"]
+        delete_mock.assert_called_once_with(str(schema.id))
+
+    def test_vanished_schema_kept_when_schedule_delete_fails(self) -> None:
+        source = self._make_source()
+        schema = ExternalDataSchema.objects.create(
+            team_id=self.team.pk,
+            source_id=source.pk,
+            name="orders",
+            should_sync=True,
+        )
+
+        with mock.patch(f"{SERVICE}.delete_external_data_schedule", side_effect=Exception("temporal down")):
+            _, deleted = sync_old_schemas_with_new_schemas({}, source_id=str(source.pk), team_id=self.team.pk)
+
+        # The row must survive so the next discovery run retries the schedule delete —
+        # soft-deleting now would orphan the live schedule forever.
+        schema.refresh_from_db()
+        assert schema.deleted is False
+        assert deleted == []


### PR DESCRIPTION
## Problem

A schema's `should_sync` / `sync_frequency_interval` in Postgres and its Temporal schedule are written independently, and several code paths updated one without the other. The result is silent drift: schedules that keep firing (and billing) after a schema is disabled, or that keep an old cadence after the user changes the sync frequency.

Concrete holes this closes:

- The schema serializer's post-save schedule update called `update_schedule` unconditionally on a frequency change — on a never-activated schema (no schedule) this raised Temporal `NOT_FOUND` **after** the DB commit.
- `bulk_update_schemas` ran its deferred Temporal updates with no per-schema isolation, so one failure skipped every remaining schema's schedule update while all DB rows were already committed — those schedules stayed on the old spec.
- Schema discovery (`sync_old_schemas_with_new_schemas`) disabled vanished tables and soft-deleted never-synced ones without pausing/deleting their schedules.
- `disable_cdc` disabled schemas via a queryset `.update()` (also bypassing activity logging) without pausing their sync schedules.
- Schema `destroy` soft-deleted the row but left the schedule firing.
- Re-enabling a schema only unpaused the schedule, never refreshing the spec — a stale interval survived the disable/enable cycle.
- A schedule update for a schema with no `sync_frequency_interval` crashed with `timedelta % NoneType`.

## Changes

- New `sync_schema_schedule_state(schema)` in `data_load/service.py`: converges the full schedule (interval, time-of-day offset, paused flag) to DB state. NOT_FOUND-safe — creates the schedule (and triggers a first run) when enabling a schema that never had one, no-ops for disabled schemas without one, pauses instead of crashing when no frequency is set, and skips direct-query sources.
- The schema serializer, `update_should_sync` (model helper used by Temporal activities and management commands), schema discovery, and `disable_cdc` all route through the converger instead of hand-rolling pause/unpause/update. (The direct-postgres `delete_data` path is unchanged — direct-query sources have no sync schedules, so there is nothing to converge.)
- `bulk_update_schemas` now runs every post-commit schedule update even when one throws, and surfaces an aggregate error afterwards.
- Schema `destroy` and discovery soft-deletes now delete the schedule; discovery defers the soft-delete until the schedule delete succeeds so a transient failure is retried on the next discovery run instead of orphaning a live schedule.
- Because unpause now re-issues the spec, a stale interval self-heals the next time the schema is re-enabled.

Existing drifted schedules in the fleet are not fixed by this PR — `update_data_import_schedules` re-issues schedules from DB state and handles that as a follow-up operational step.

## How did you test this code?

Agent-authored. Automated tests only:

- New unit tests for `sync_schema_schedule_state` (exists/missing × enabled/disabled, `None` frequency, direct-query skip).
- New API tests: frequency change on a disabled never-activated schema is DB-only; `bulk_update_schemas` keeps running schedule updates past a failure (and still 500s); `disable_cdc` converges each disabled schema's schedule.
- New discovery tests: vanished-with-table → disabled + converged; vanished-without-table → schedule deleted then soft-deleted; failed schedule delete keeps the row for retry.
- Updated an existing bulk-update test that asserted the old blind `create=False` update against a missing schedule (the NOT_FOUND bug this PR fixes).
- Ran the data warehouse schema/source API suites, discovery tests, and `data_load` service tests locally. Two pre-existing failures in `TestUpdateExternalDataSchema` (live local Temporal server state) reproduce identically on `master`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Root cause was traced from a customer report of a sync-frequency change not taking effect: the DB write succeeded but the deferred Temporal schedule update failed partway through a bulk request, stranding the remaining schemas on the old spec.
- Chose a single converger function over patching each call site's pause/unpause logic — the invariant ("`should_sync`/frequency and the schedule must change together") now has one owner, and every write path calls it. A follow-up could enforce this with a lint rule.
- Deliberately not in scope: narrowing the bulk endpoint's batch-wide transaction (changes partial-failure semantics; needs a response-shape decision) and a periodic spec reconciler for drift detection.

