### PR TITLE
fix(replay): Stop researching low-value session problem signals

### DIFF
--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a7b_emit_session_problem_signals.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a7b_emit_session_problem_signals.py
@@ -11,6 +11,12 @@ from products.signals.backend.facade.api import emit_signal
 
 logger = structlog.get_logger(__name__)
 
+# A full agentic research run fires per promoted report, and a report promotes once its
+# signals' summed weight crosses 1.0. Emitting below that (0.5) means a single isolated
+# problem no longer triggers research on its own; it has to recur before we pay to research
+# it. (non_blocking_exception is intentionally not classified as a problem at all upstream.)
+SESSION_PROBLEM_SIGNAL_WEIGHT = 0.5
+
 
 @temporalio.activity.defn
 async def emit_session_problem_signals_activity(
@@ -64,7 +70,7 @@ async def emit_session_problem_signals_activity(
                 source_type="session_problem",
                 source_id=source_id,
                 description=problem.description,
-                weight=1.0,  # Always research
+                weight=SESSION_PROBLEM_SIGNAL_WEIGHT,
                 extra=extra,
             )
             signals_emitted += 1

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -147,8 +147,11 @@ def classify_consolidated_segment_problem(segment: ConsolidatedVideoSegment) -> 
         return "blocking_exception"
     if segment.abandonment_detected:
         return "abandonment"
-    if segment.exception == "non-blocking":
-        return "non_blocking_exception"
+    # A non-blocking exception on its own is deliberately not a problem: the user wasn't blocked,
+    # it's the largest and weakest slice of replay session problems, and the main source of false
+    # positives (e.g. console errors merely viewed on screen). It still shows in the session
+    # summary via the segment's `exception` field; we just don't research it as a signal. A segment
+    # that ALSO has confusion or a failure still classifies as that real problem below.
     if segment.confusion_detected:
         return "confusion"
     if not segment.success:

--- a/posthog/temporal/tests/session_replay/session_summary/test_emit_session_problem_signals.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_emit_session_problem_signals.py
@@ -28,12 +28,13 @@ class TestClassifyProblem:
         [
             ({"exception": "blocking"}, "blocking_exception"),
             ({"abandonment_detected": True}, "abandonment"),
-            ({"exception": "non-blocking"}, "non_blocking_exception"),
+            # A non-blocking exception on its own is deliberately not a problem (not researched).
+            ({"exception": "non-blocking"}, None),
             ({"confusion_detected": True}, "confusion"),
             ({"success": False}, "failure"),
             ({}, None),
         ],
-        ids=["blocking", "abandonment", "non_blocking", "confusion", "failure", "no_problem"],
+        ids=["blocking", "abandonment", "non_blocking_ignored", "confusion", "failure", "no_problem"],
     )
     def test_single_flag(self, kwargs, expected):
         assert classify_consolidated_segment_problem(_make_segment(**kwargs)) == expected
@@ -54,10 +55,12 @@ class TestClassifyProblem:
                 },
                 "abandonment",
             ),
-            ({"exception": "non-blocking", "confusion_detected": True, "success": False}, "non_blocking_exception"),
+            # Non-blocking is no longer a problem type, so a segment that also has confusion
+            # falls through to confusion (the real problem on that segment).
+            ({"exception": "non-blocking", "confusion_detected": True, "success": False}, "confusion"),
             ({"confusion_detected": True, "success": False}, "confusion"),
         ],
-        ids=["blocking_wins_all", "abandonment_wins_lower", "non_blocking_wins_lower", "confusion_wins_failure"],
+        ids=["blocking_wins_all", "abandonment_wins_lower", "non_blocking_falls_through", "confusion_wins_failure"],
     )
     def test_priority_ordering(self, kwargs, expected):
         assert classify_consolidated_segment_problem(_make_segment(**kwargs)) == expected
@@ -108,4 +111,9 @@ class TestCollectSessionProblems:
         ]
         problems = collect_session_problems(segments)
         assert len(problems) == 1
-        assert problems[0].problem_type == "non_blocking_exception"
+        # Non-blocking exception is ignored, so this segment classifies as its next real problem.
+        assert problems[0].problem_type == "confusion"
+
+    def test_segment_with_only_non_blocking_exception_is_not_a_problem(self):
+        segments = [_make_segment(title="Saw a console error but carried on", exception="non-blocking")]
+        assert collect_session_problems(segments) == []


### PR DESCRIPTION
## Problem

The replay session-summary pipeline emits a `session_problem` signal for every problem it detects, with weight 1.0, so every one is researched with Opus individually. makes it _rather expensive_.

Two things make it _very expensive_:

- The biggest category by far is `non_blocking_exception`, ~54% of replay session problem signals - the weakest thing we detect and the main source of false positives
- Even for the real categories, one-off problems are quite noisy in projects with more usage, 66% of Replay-only reports are single-signal (although, to be fair, one signal may be enough in smaller projects)

## Changes

Two small changes in the Replay source:

1. Stop treating `non_blocking_exception` as a problem at all. It's not strong enough
2. Emit the remaining session problems at weight 0.5 instead of 1.0. Anything that genuinely recurs still gets researched, noise doesn't

Net: we keep researching the problems that are more likely to hurt users and repeat, and stop burning tokens on blips.

## Docs update

No docs.
