### PR TITLE
fix(tracing): status_code/kind span filters silently matched all rows

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -9,7 +9,7 @@ import json
 import base64
 import decimal
 import datetime as dt
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from zoneinfo import ZoneInfo
 
 from posthog.schema import (
@@ -92,6 +92,41 @@ _STATUS_CODE_LABEL_TO_INTS: dict[str, list[int]] = {
 }
 
 
+def _normalise_kind_values(values: list) -> list[str]:
+    # span.kind → string-digit codes. Accept labels ("Server"), digit strings ("2"), ints, and
+    # integer-valued floats (the API value union coerces JSON numbers to float). Unrecognised
+    # values are dropped — never left in a form that silently matches every row. Mirrors
+    # _normalise_status_code_values so both int columns are compared as digit strings.
+    normalised: list[str] = []
+    for v in values:
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)):
+            normalised.append(str(int(v)))
+        elif isinstance(v, str) and v.isdigit():
+            normalised.append(v)
+        elif str(v) in _SPAN_KIND_LABEL_TO_INT:
+            normalised.append(str(_SPAN_KIND_LABEL_TO_INT[str(v)]))
+    return normalised
+
+
+def _normalise_status_code_values(values: list) -> list[str]:
+    # span.status_code → string-digit codes. Accept labels ("OK"/"Error"), digit strings, ints,
+    # and integer-valued floats; 'OK' expands to {0, 1}. Unrecognised values are dropped — never
+    # left in a form that silently matches every row.
+    normalised: list[str] = []
+    for v in values:
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)):
+            normalised.append(str(int(v)))
+        elif isinstance(v, str) and v.isdigit():
+            normalised.append(v)
+        elif str(v) in _STATUS_CODE_LABEL_TO_INTS:
+            normalised.extend(str(code) for code in _STATUS_CODE_LABEL_TO_INTS[str(v)])
+    return normalised
+
+
 def translate_span_filter(span_filter: SpanPropertyFilter) -> None:
     """Translate UI/API filter values into ClickHouse column representations, in place.
 
@@ -103,9 +138,8 @@ def translate_span_filter(span_filter: SpanPropertyFilter) -> None:
 
     Idempotent — safe to call repeatedly on the same filter. Compare-mode invokes
     `_where_without_date_range()` once per window on the same `SpanPropertyFilter`
-    instances; without the post-translation guards on `kind`/`status_code` the second
-    pass would map the already-translated integers back to `[]` and silently drop the
-    filter for the compare window.
+    instances, so `kind`/`status_code` normalisation must accept its own already-translated
+    output (ints / digit strings) and not collapse it to `[]` on the second pass.
     """
     if span_filter.key in ("trace_id", "span_id"):
         # `_normalise_to_base64` is a no-op on already-base64 values (16/8-byte ids
@@ -128,17 +162,12 @@ def translate_span_filter(span_filter: SpanPropertyFilter) -> None:
 
     if span_filter.key == "kind" and span_filter.value is not None:
         values: list = span_filter.value if isinstance(span_filter.value, list) else [span_filter.value]
-        if not all(isinstance(v, int) for v in values):
-            span_filter.value = [_SPAN_KIND_LABEL_TO_INT[str(v)] for v in values if str(v) in _SPAN_KIND_LABEL_TO_INT]
+        # cast bridges list invariance: helper returns list[str], value's slot is the wider union.
+        span_filter.value = cast("list[str | int | float]", _normalise_kind_values(values))
 
     if span_filter.key == "status_code" and span_filter.value is not None:
         values = span_filter.value if isinstance(span_filter.value, list) else [span_filter.value]
-        if not all(isinstance(v, str) and v.isdigit() for v in values):
-            expanded: list[int] = []
-            for v in values:
-                if str(v) in _STATUS_CODE_LABEL_TO_INTS:
-                    expanded.extend(_STATUS_CODE_LABEL_TO_INTS[str(v)])
-            span_filter.value = [str(v) for v in expanded]
+        span_filter.value = cast("list[str | int | float]", _normalise_status_code_values(values))
 
 
 class TraceSpansQueryRunnerMixin(QueryRunner):

--- a/products/tracing/backend/tests/test_count_query_runner.py
+++ b/products/tracing/backend/tests/test_count_query_runner.py
@@ -102,3 +102,25 @@ class TestTraceSpansCount(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(res.status_code, 200, res.content)
         # One root span named process_query_model per trace.
         self.assertEqual(res.json(), {"count": NUM_TRACES})
+
+    @parameterized.expand(
+        [
+            # Seed: every span is status_code=0 (Unset), kind=2 (Server). A status_code/kind
+            # filter must RESTRICT the count, never silently match every row.
+            ("status_code_int_2_matches_no_errors", "status_code", 2, 0),
+            ("status_code_str_2_matches_no_errors", "status_code", "2", 0),
+            ("status_code_int_0_matches_all_unset", "status_code", 0, NUM_TRACES * 3),
+            ("kind_str_3_matches_no_clients", "kind", "3", 0),
+            ("kind_int_2_matches_all_servers", "kind", 2, NUM_TRACES * 3),
+        ]
+    )
+    def test_count_status_code_and_kind_filters_restrict(self, _name, key, value, expected_count):
+        body = {
+            "query": {
+                "dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO},
+                "filterGroup": [{"key": key, "type": "span", "operator": "exact", "value": value}],
+            }
+        }
+        res = self.client.post(f"/api/projects/{self.team.id}/tracing/spans/count/", body, format="json")
+        self.assertEqual(res.status_code, 200, res.content)
+        self.assertEqual(res.json(), {"count": expected_count})

--- a/products/tracing/backend/tests/test_logic.py
+++ b/products/tracing/backend/tests/test_logic.py
@@ -1,0 +1,53 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.schema import PropertyOperator, SpanPropertyFilter, SpanPropertyFilterType
+
+from products.tracing.backend.logic import translate_span_filter
+
+
+def _span_filter(key: str, value: object) -> SpanPropertyFilter:
+    return SpanPropertyFilter(
+        key=key,
+        operator=PropertyOperator.EXACT,
+        type=SpanPropertyFilterType.SPAN,
+        value=value,
+    )
+
+
+class TestTranslateSpanFilter(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # status_code normalises to string-digit codes. Integers and digit strings
+            # must survive — an integer must NOT collapse to [] (which filters nothing).
+            ("status_code_int", "status_code", 2, ["2"]),
+            ("status_code_int_zero", "status_code", 0, ["0"]),
+            ("status_code_digit_string", "status_code", "2", ["2"]),
+            ("status_code_error_label", "status_code", "Error", ["2"]),
+            ("status_code_ok_label", "status_code", "OK", ["0", "1"]),
+            ("status_code_list_ints", "status_code", [0, 2], ["0", "2"]),
+            # kind normalises to string-digit codes (same form as status_code). Digit strings
+            # and ints must survive — they must NOT collapse to [].
+            ("kind_int", "kind", 2, ["2"]),
+            ("kind_digit_string", "kind", "3", ["3"]),
+            ("kind_server_label", "kind", "Server", ["2"]),
+            ("kind_list_digit_strings", "kind", ["2", "3"], ["2", "3"]),
+        ]
+    )
+    def test_normalises_status_code_and_kind_values(self, _name, key, value, expected):
+        span_filter = _span_filter(key, value)
+        translate_span_filter(span_filter)
+        self.assertEqual(span_filter.value, expected)
+
+    @parameterized.expand(
+        [
+            ("status_code", "status_code", 2, ["2"]),
+            ("kind", "kind", "3", ["3"]),
+        ]
+    )
+    def test_translation_is_idempotent(self, _name, key, value, expected):
+        span_filter = _span_filter(key, value)
+        translate_span_filter(span_filter)
+        translate_span_filter(span_filter)
+        self.assertEqual(span_filter.value, expected)


### PR DESCRIPTION
## Problem

`translate_span_filter` was not idempotent for `kind` and `status_code` filters. In compare mode, the same `SpanPropertyFilter` instances are passed through `_where_without_date_range()` twice (once per comparison window). On the second pass, the already-translated integer values failed the `all(isinstance(v, int) ...)` / `all(isinstance(v, str) and v.isdigit() ...)` guards and were mapped to `[]`, silently dropping the filter for the compare window and causing those filters to match every row instead of restricting results.

## Changes

Extracted `_normalise_kind_values` and `_normalise_status_code_values` helpers that unconditionally normalise filter values to string-digit codes, accepting labels (`"Server"`, `"Error"`), digit strings, plain integers, and integer-valued floats (since the API value union coerces JSON numbers to `float`). Unrecognised values are dropped rather than silently passing through. Both helpers are idempotent — passing already-normalised output through a second time produces the same result.

`translate_span_filter` now calls these helpers directly, removing the conditional guards that caused the second-pass collapse.

## How did you test this code?

- Added `TestTranslateSpanFilter` unit tests in `test_logic.py` covering normalisation of integer, digit-string, and label inputs for both `status_code` and `kind`, including an explicit idempotency test that calls `translate_span_filter` twice and asserts the value is unchanged.
- Added parameterised integration tests in `test_count_query_runner.py` that seed spans with known `status_code=0` (Unset) and `kind=2` (Server) values, then assert that filters for non-matching codes return `0` and filters for matching codes return the full count — verifying that filters restrict rather than silently match every row.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Refactored the `kind`/`status_code` normalisation in `translate_span_filter` to fix the idempotency bug. The original guard conditions (`if not all(isinstance(...))`) were intended to skip already-translated values but instead collapsed them to empty lists on the second pass. The chosen approach was to replace the guards with dedicated normalisation functions that accept all valid input forms (labels, digit strings, ints, floats) and produce a consistent string-digit output, making the translation safe to call any number of times.