### PR TITLE
feat(logs): add Flutter to logs onboarding

### DIFF
--- a/docs/onboarding/logs/flutter.tsx
+++ b/docs/onboarding/logs/flutter.tsx
@@ -14,8 +14,8 @@ export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinitio
         content: (
             <>
                 <Markdown>
-                    Capture a structured log record with `Posthog().logger`. Records are batched and shipped to PostHog's
-                    logs product.
+                    Capture a structured log record with `Posthog().logger`. Requires `posthog_flutter` 5.27.0 or later.
+                    Records are batched and shipped to PostHog's logs product.
                 </Markdown>
                 <CodeBlock
                     blocks={[

--- a/docs/onboarding/logs/flutter.tsx
+++ b/docs/onboarding/logs/flutter.tsx
@@ -1,0 +1,48 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { getFlutterSteps as getFlutterStepsPA } from '../product-analytics/flutter'
+import { StepDefinition } from '../steps'
+
+export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, Markdown, dedent } = ctx
+
+    const installSteps = getFlutterStepsPA(ctx)
+
+    const sendLogStep: StepDefinition = {
+        title: 'Send a log',
+        badge: 'required',
+        content: (
+            <>
+                <Markdown>
+                    Capture a structured log record with `Posthog().logger`. Records are batched and shipped to PostHog's
+                    logs product.
+                </Markdown>
+                <CodeBlock
+                    blocks={[
+                        {
+                            language: 'dart',
+                            file: 'Dart',
+                            code: dedent`
+                                import 'package:posthog_flutter/posthog_flutter.dart';
+
+                                Posthog().logger.info('checkout completed', {
+                                    'order_id': 'ord_789',
+                                });
+                            `,
+                        },
+                    ]}
+                />
+                <Markdown>
+                    {dedent`
+                        Logs appear in PostHog within a few seconds. Use the [Logs page](https://app.posthog.com/logs) to search and filter
+                        by service name, severity, or any attribute you attach.
+                    `}
+                </Markdown>
+            </>
+        ),
+    }
+
+    return [...installSteps, sendLogStep]
+}
+
+export const FlutterInstallation = createInstallation(getFlutterSteps)

--- a/docs/onboarding/logs/index.ts
+++ b/docs/onboarding/logs/index.ts
@@ -1,4 +1,5 @@
 export { AndroidInstallation } from './android'
+export { FlutterInstallation } from './flutter'
 export { GoInstallation } from './go'
 export { IOSInstallation } from './ios'
 export { JavaInstallation } from './java'

--- a/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/logs/LogsSDKInstructions.tsx
@@ -1,5 +1,6 @@
 import {
     AndroidInstallation,
+    FlutterInstallation,
     GoInstallation,
     IOSInstallation,
     JavaInstallation,
@@ -53,6 +54,10 @@ const LogsAndroidInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: AndroidInstallation,
 })
 
+const LogsFlutterInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: FlutterInstallation,
+})
+
 export const LogsSDKInstructions: SDKInstructionsMap = {
     [SDKKey.NODE_JS]: LogsNodeJSInstructionsWrapper,
     [SDKKey.NEXT_JS]: LogsNextJSInstructionsWrapper,
@@ -63,4 +68,5 @@ export const LogsSDKInstructions: SDKInstructionsMap = {
     [SDKKey.IOS]: LogsIOSInstructionsWrapper,
     [SDKKey.REACT_NATIVE]: LogsReactNativeInstructionsWrapper,
     [SDKKey.ANDROID]: LogsAndroidInstructionsWrapper,
+    [SDKKey.FLUTTER]: LogsFlutterInstructionsWrapper,
 }


### PR DESCRIPTION
## Problem

The in-app Logs product onboarding offers iOS, Android, and React Native, but not Flutter — so Flutter users get no logs setup instructions when onboarding to the Logs product.

## Changes

- Add `docs/onboarding/logs/flutter.tsx` — reuses the product-analytics Flutter install steps and adds a "Send a log" step using `Posthog().logger`.
- Export `FlutterInstallation` from `docs/onboarding/logs/index.ts`.
- Wire `[SDKKey.FLUTTER]` into the logs `SDKInstructionsMap` in `LogsSDKInstructions.tsx`.

Completes mobile parity for logs onboarding: ios, android, react-native, flutter.

## How did you test this code?

Mirrors the existing iOS/Android/React Native logs onboarding wrappers exactly (same `createInstallation` + `withOnboardingDocsWrapper` pattern). Draft until the Flutter logs feature ships in `posthog_flutter` (PostHog/posthog-flutter#414) and the docs page lands (PostHog/posthog.com#17529).

🤖 Generated with [Claude Code](https://claude.com/claude-code)