### PR TITLE
fix(cdp): block deleting integrations used by enabled hog functions

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -75,6 +75,7 @@ from posthog.permissions import (
 from posthog.rate_limit import GitHubRepositoryRefreshThrottle
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
+from products.cdp.backend.services.integration_usage import get_enabled_hog_functions_using_integration
 from products.workflows.backend.services.integration_usage import get_active_hog_flows_using_integration
 
 logger = structlog.get_logger(__name__)
@@ -633,11 +634,22 @@ class IntegrationViewSet(
         flows_using_integration = get_active_hog_flows_using_integration(
             team_id=instance.team_id, integration_id=instance.id
         )
+        functions_using_integration = get_enabled_hog_functions_using_integration(
+            team_id=instance.team_id, integration_id=instance.id
+        )
+        used_by = []
         if flows_using_integration:
             flow_names = ", ".join(sorted(flow.name or str(flow.id) for flow in flows_using_integration))
+            used_by.append(f"active workflows: {flow_names}")
+        if functions_using_integration:
+            function_names = ", ".join(
+                sorted(function.name or str(function.id) for function in functions_using_integration)
+            )
+            used_by.append(f"enabled data pipelines: {function_names}")
+        if used_by:
             raise ValidationError(
-                f"This integration is used by active workflows: {flow_names}. "
-                "Update those workflows to use a different integration before disconnecting it."
+                f"This integration is used by {' and '.join(used_by)}. "
+                "Update them to use a different integration before disconnecting it."
             )
 
         if instance.kind == "stripe":

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -3633,10 +3633,15 @@ class TestIntegrationDeletionHogFunctionGuard:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Integration.objects.filter(id=self.integration.id).exists()
 
-    def test_destroy_allowed_when_integration_id_in_non_integration_input(self, client: HttpClient):
+    @pytest.mark.parametrize("input_type,value_form", [("string", "bare_id"), ("json", "dict_value")])
+    def test_destroy_allowed_when_integration_id_in_non_integration_input(
+        self, input_type: str, value_form: str, client: HttpClient
+    ):
         # A matching ID in an input the runtime never resolves as an integration must not block deletion
-        self._create_function(input_type="string")
-        self._create_function(input_type="json", input_value={"integrationId": self.integration.id})
+        input_value: int | dict = (
+            self.integration.id if value_form == "bare_id" else {"integrationId": self.integration.id}
+        )
+        self._create_function(input_type=input_type, input_value=input_value)
 
         response = self._delete(client)
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -39,6 +39,7 @@ from posthog.models.user_integration import UserIntegration
 from posthog.models.utils import hash_key_value
 from posthog.rate_limit import GitHubRepositoryRefreshThrottle
 
+from products.cdp.backend.models import HogFunction
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.workflows.backend.models import HogFlow
 
@@ -3559,3 +3560,110 @@ class TestIntegrationDeletionWorkflowGuard:
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not Integration.objects.filter(id=self.integration.id).exists()
+
+
+class TestIntegrationDeletionHogFunctionGuard:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            config={"team": {"id": "T123", "name": "Test workspace"}},
+            created_by=self.user,
+        )
+
+    def _create_function(
+        self,
+        *,
+        enabled: bool = True,
+        deleted: bool = False,
+        input_value: int | dict | None = None,
+        input_type: str = "integration",
+        name: str = "Slack notifier",
+    ) -> HogFunction:
+        return HogFunction.objects.create(
+            team=self.team,
+            name=name,
+            type="destination",
+            hog="return event",
+            enabled=enabled,
+            deleted=deleted,
+            inputs_schema=[{"key": "slack_workspace", "type": input_type, "label": "Slack workspace"}],
+            inputs={
+                "slack_workspace": {"value": input_value if input_value is not None else self.integration.id},
+            },
+        )
+
+    def _delete(self, client: HttpClient):
+        client.force_login(self.user)
+        return client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+    @pytest.mark.parametrize("value_form", ["bare_id", "dict_value"])
+    def test_destroy_blocked_when_enabled_function_references_integration(self, value_form: str, client: HttpClient):
+        input_value: int | dict = (
+            self.integration.id if value_form == "bare_id" else {"integrationId": self.integration.id}
+        )
+        self._create_function(input_value=input_value)
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Slack notifier" in response.content.decode()
+        assert Integration.objects.filter(id=self.integration.id).exists()
+
+    @pytest.mark.parametrize("enabled,deleted", [(False, False), (True, True)])
+    def test_destroy_allowed_when_function_disabled_or_deleted(self, enabled: bool, deleted: bool, client: HttpClient):
+        self._create_function(enabled=enabled, deleted=deleted)
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Integration.objects.filter(id=self.integration.id).exists()
+
+    def test_destroy_allowed_when_function_references_other_integration(self, client: HttpClient):
+        self._create_function(input_value=self.integration.id + 1)
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Integration.objects.filter(id=self.integration.id).exists()
+
+    def test_destroy_allowed_when_integration_id_in_non_integration_input(self, client: HttpClient):
+        # A matching ID in an input the runtime never resolves as an integration must not block deletion
+        self._create_function(input_type="string")
+        self._create_function(input_type="json", input_value={"integrationId": self.integration.id})
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Integration.objects.filter(id=self.integration.id).exists()
+
+    def test_destroy_blocked_message_includes_workflows_and_functions(self, client: HttpClient):
+        self._create_function(name="Slack notifier")
+        HogFlow.objects.create(
+            team=self.team,
+            name="Slack flow",
+            status="active",
+            actions=[
+                {
+                    "id": "action_function_1",
+                    "name": "Notify",
+                    "type": "function",
+                    "config": {"inputs": {"slack_workspace": {"value": {"integrationId": self.integration.id}}}},
+                }
+            ],
+            edges=[],
+        )
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        content = response.content.decode()
+        assert "Slack flow" in content
+        assert "Slack notifier" in content
+        assert Integration.objects.filter(id=self.integration.id).exists()

--- a/products/cdp/backend/services/integration_usage.py
+++ b/products/cdp/backend/services/integration_usage.py
@@ -36,5 +36,5 @@ def get_enabled_hog_functions_using_integration(team_id: int, integration_id: in
         enabled=True,
         deleted=False,
         inputs_schema__contains=[{"type": "integration"}],
-    )
+    ).only("id", "name", "inputs", "inputs_schema")
     return [function for function in functions if _function_references_integration(function, integration_id)]

--- a/products/cdp/backend/services/integration_usage.py
+++ b/products/cdp/backend/services/integration_usage.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from products.cdp.backend.models import HogFunction
+
+
+def _input_references_integration(input_entry: Any, integration_id: int) -> bool:
+    if not isinstance(input_entry, dict):
+        return False
+    # Mirrors the runtime's resolution: input?.value?.integrationId ?? input?.value
+    # (see nodejs/src/cdp/services/hog-inputs.service.ts loadIntegrationInputs)
+    value = input_entry.get("value")
+    if isinstance(value, dict):
+        value = value.get("integrationId")
+    return value is not None and str(value) == str(integration_id)
+
+
+def _function_references_integration(function: HogFunction, integration_id: int) -> bool:
+    inputs = function.inputs if isinstance(function.inputs, dict) else {}
+    for schema in function.inputs_schema or []:
+        if not isinstance(schema, dict) or schema.get("type") != "integration":
+            continue
+        if _input_references_integration(inputs.get(schema.get("key")), integration_id):
+            return True
+    return False
+
+
+def get_enabled_hog_functions_using_integration(team_id: int, integration_id: int) -> list[HogFunction]:
+    """Enabled, non-deleted hog functions whose integration-typed inputs reference the integration.
+
+    Only inputs declared as type "integration" in the function's inputs_schema are considered —
+    that is the only surface the runtime resolves integrations from, so a matching ID planted
+    anywhere else cannot block deletion.
+    """
+    functions = HogFunction.objects.filter(
+        team_id=team_id,
+        enabled=True,
+        deleted=False,
+        inputs_schema__contains=[{"type": "integration"}],
+    )
+    return [function for function in functions if _function_references_integration(function, integration_id)]


### PR DESCRIPTION
## Problem

#63015 blocked deleting an integration while an active workflow references it, but the same hole remained for hog functions: an enabled destination (or any other hog function) pointing at an integration didn't stop that integration from being deleted. The function would keep running against a dangling integration ID and fail at invocation time, which is much harder for users to trace back than a clear error at deletion time. #58391 attempted to close this by cascade-disabling functions when their integration is deleted, but was closed unmerged.

## Changes

- New `products/cdp/backend/services/integration_usage.py` with `get_enabled_hog_functions_using_integration`, mirroring the workflows helper from #63015. It only matches inputs declared as type `integration` in the function's `inputs_schema` — the only surface the runtime resolves integrations from (`hog-inputs.service.ts` `loadIntegrationInputs`) — so a matching ID planted in some other input can't be used to block deletion. Both stored value forms are handled: bare ID and `{integrationId: N}`.
- `IntegrationViewSet.perform_destroy` now combines both guards into a single 400, e.g. `This integration is used by active workflows: Welcome flow and enabled data pipelines: Slack notifier. Update them to use a different integration before disconnecting it.`
- Disabled or soft-deleted functions don't block deletion, consistent with draft/archived workflows not blocking.

The frontend already surfaces this error as a toast via the `deleteIntegration` error handling added in #63015, so no frontend changes are needed.

## How did you test this code?

New `TestIntegrationDeletionHogFunctionGuard` covering: blocked for bare-ID and dict-form references, allowed when the function is disabled/soft-deleted/references a different integration, allowed when a matching ID sits in a non-integration-typed input, and the combined workflows + functions message. Ran it alongside the existing `TestIntegrationDeletionWorkflowGuard` — 16 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Follow-up to #63015, extending the same blocking-guard approach to hog functions rather than reviving #58391's cascade-disable: blocking at delete time keeps behavior consistent across workflows and pipelines and avoids silently turning off a user's destination. The guard deliberately scans only schema-typed integration inputs (matching the node runtime's resolution path) so it can't be abused to make an integration undeletable via planted IDs.
