### PR TITLE
chore(dashboards): update codeowners to team-analytics-platform

### DIFF
--- a/products/dashboards/product.yaml
+++ b/products/dashboards/product.yaml
@@ -1,4 +1,3 @@
 name: Dashboards
 owners:
-    - team-product-analytics
     - team-analytics-platform


### PR DESCRIPTION
## Problem

The dashboards product was owned by `team-product-analytics` in `product.yaml`, but dashboards belong to the analytics platform team.

## Changes

Removed `team-product-analytics` from the owners list in `products/dashboards/product.yaml`, leaving `team-analytics-platform` as the sole owner.

## How did you test this code?

Agent-authored config change — no automated tests apply. The change is a one-line YAML edit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Matt Pua via Claude Code. The `product.yaml` for `products/dashboards` listed `team-product-analytics` first (and `team-analytics-platform` second), causing the soft-ownership bot to assign `team-product-analytics` reviewers on dashboards PRs. The fix removes `team-product-analytics` from the owners list so only `team-analytics-platform` is assigned going forward.