### PR TITLE
feat(capture): warn when replay snapshots are dropped for size

### DIFF
--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -129,14 +129,73 @@ describe('handleClientIngestionWarningStep', () => {
                     distinctId: 'my_id',
                     message: 'Replay data dropped',
                 },
-                alwaysSend: true,
+                key: 'session-abc',
             })
+            expect(result.warnings[0].alwaysSend).toBeUndefined()
+        })
+
+        it('persists only the sanitized fields, never the raw client payload', async () => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_type: 'replay_message_too_large',
+                        $$client_ingestion_warning_details: {
+                            ...replayDetails,
+                            replayRecord: { session_id: 'session-abc', injected: 'x'.repeat(100000) },
+                            snapshotBytes: 'not-a-number',
+                            arbitraryBlob: { nested: 'x'.repeat(100000) },
+                        },
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].type).toBe('replay_message_too_large')
+            expect(result.warnings[0].details.arbitraryBlob).toBeUndefined()
+            expect(result.warnings[0].details.snapshotBytes).toBeUndefined()
+            expect(result.warnings[0].details.replayRecord).toEqual({ session_id: 'session-abc' })
+        })
+
+        it('does not persist client details on the generic fallback', async () => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_message: 'some message',
+                        $$client_ingestion_warning_details: { arbitraryBlob: 'x'.repeat(100000) },
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0]).toMatchObject({ type: 'client_ingestion_warning', alwaysSend: true })
+            expect(result.warnings[0].details.arbitraryBlob).toBeUndefined()
         })
 
         it.each([
             ['missing details', undefined],
             ['details without replayRecord', { timestamp: '2026-06-12T10:00:00.000Z' }],
-            ['replayRecord without session_id', { replayRecord: {} }],
+            ['replayRecord without session_id', { timestamp: '2026-06-12T10:00:00.000Z', replayRecord: {} }],
+            ['missing timestamp', { replayRecord: { session_id: 'session-abc' } }],
+            ['non-string timestamp', { timestamp: 123, replayRecord: { session_id: 'session-abc' } }],
+            ['oversized timestamp', { timestamp: 'x'.repeat(1000), replayRecord: { session_id: 'session-abc' } }],
+            [
+                'non-string session_id',
+                { timestamp: '2026-06-12T10:00:00.000Z', replayRecord: { session_id: { evil: true } } },
+            ],
+            [
+                'oversized session_id',
+                { timestamp: '2026-06-12T10:00:00.000Z', replayRecord: { session_id: 'x'.repeat(1000) } },
+            ],
             ['non-object details', 'not-an-object'],
         ])('falls back to client_ingestion_warning when override has %s', async (_name, details) => {
             const input: HandleClientIngestionWarningStepInput = {

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -93,6 +93,58 @@ describe('handleClientIngestionWarningStep', () => {
             }
             expect(result.warnings[0].details.message).toBeUndefined()
         })
+
+        it('caps an oversized client message and drops non-string messages', async () => {
+            const oversized = await handleStep({
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: { $$client_ingestion_warning_message: 'x'.repeat(100000) },
+                },
+            })
+            expect(oversized.warnings[0].details.message).toBeUndefined()
+
+            const nonString = await handleStep({
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: { $$client_ingestion_warning_message: { nested: 'x'.repeat(100000) } },
+                },
+            })
+            expect(nonString.warnings[0].details.message).toBeUndefined()
+        })
+
+        it.each(['constructor', '__proto__', 'hasOwnProperty', 'toString', 'valueOf'])(
+            'does not let the forged prototype-key type %s bypass the allowlist',
+            async (forgedType) => {
+                const input: HandleClientIngestionWarningStepInput = {
+                    ...baseInput,
+                    event: {
+                        ...baseEvent,
+                        event: '$$client_ingestion_warning',
+                        properties: {
+                            $$client_ingestion_warning_type: forgedType,
+                            $$client_ingestion_warning_details: {
+                                replayRecord: { session_id: 'session-abc' },
+                                timestamp: '2026-06-12T10:00:00.000Z',
+                                injected: 'x'.repeat(100000),
+                            },
+                        },
+                    },
+                }
+
+                // a prototype-chain lookup would either throw or persist the raw payload
+                const result = await handleStep(input)
+
+                expect(result.type).toBe(PipelineResultType.OK)
+                expect(result.warnings[0].type).toBe('client_ingestion_warning')
+                expect(result.warnings[0].details.injected).toBeUndefined()
+                expect(result.warnings[0].key).toBeUndefined()
+                expect(result.warnings[0].alwaysSend).toBe(true)
+            }
+        )
     })
 
     describe('warning type overrides', () => {

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -184,6 +184,7 @@ describe('handleClientIngestionWarningStep', () => {
                     event: '$$client_ingestion_warning',
                     properties: {
                         $$client_ingestion_warning_message: 'real message',
+                        $$client_ingestion_warning_type: 'replay_message_too_large',
                         $$client_ingestion_warning_details: {
                             ...replayDetails,
                             eventUuid: 'spoofed',
@@ -196,6 +197,7 @@ describe('handleClientIngestionWarningStep', () => {
             const result = await handleStep(input)
 
             expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].type).toBe('replay_message_too_large')
             expect(result.warnings[0].details.eventUuid).toBe(eventUuid)
             expect(result.warnings[0].details.message).toBe('real message')
         })

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -95,6 +95,112 @@ describe('handleClientIngestionWarningStep', () => {
         })
     })
 
+    describe('warning type overrides', () => {
+        const replayDetails = {
+            timestamp: '2026-06-12T10:00:00.000Z',
+            replayRecord: { session_id: 'session-abc' },
+            snapshotBytes: 21000000,
+            snapshotItemsCount: 3,
+        }
+
+        it('honors the replay_message_too_large override with valid details', async () => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_message: 'Replay data dropped',
+                        $$client_ingestion_warning_type: 'replay_message_too_large',
+                        $$client_ingestion_warning_details: replayDetails,
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings).toHaveLength(1)
+            expect(result.warnings[0]).toMatchObject({
+                type: 'replay_message_too_large',
+                details: {
+                    ...replayDetails,
+                    eventUuid: eventUuid,
+                    distinctId: 'my_id',
+                    message: 'Replay data dropped',
+                },
+                alwaysSend: true,
+            })
+        })
+
+        it.each([
+            ['missing details', undefined],
+            ['details without replayRecord', { timestamp: '2026-06-12T10:00:00.000Z' }],
+            ['replayRecord without session_id', { replayRecord: {} }],
+            ['non-object details', 'not-an-object'],
+        ])('falls back to client_ingestion_warning when override has %s', async (_name, details) => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_type: 'replay_message_too_large',
+                        $$client_ingestion_warning_details: details,
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].type).toBe('client_ingestion_warning')
+        })
+
+        it('ignores warning types outside the allowlist', async () => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_type: 'cannot_merge_already_identified',
+                        $$client_ingestion_warning_details: replayDetails,
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].type).toBe('client_ingestion_warning')
+        })
+
+        it('does not let extra details override the base detail fields', async () => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_message: 'real message',
+                        $$client_ingestion_warning_details: {
+                            ...replayDetails,
+                            eventUuid: 'spoofed',
+                            message: 'spoofed',
+                        },
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].details.eventUuid).toBe(eventUuid)
+            expect(result.warnings[0].details.message).toBe('real message')
+        })
+    })
+
     describe('non-client ingestion warning events', () => {
         it('DLQs regular events', async () => {
             const input: HandleClientIngestionWarningStepInput = {

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -20,30 +20,34 @@ interface SanitizedOverride {
     debounceKey: string
 }
 
-// Allowed $$client_ingestion_warning_type overrides. Each sanitizer rebuilds
-// the details its UI renderer needs from scratch, or returns null to fall
-// back to the generic warning type (clients can send anything here).
-const WARNING_TYPE_OVERRIDES: Record<string, (details: Record<string, unknown>) => SanitizedOverride | null> = {
+// Allowlisted $$client_ingestion_warning_type overrides. Each sanitizer rebuilds the
+// details its renderer needs from scratch (clients can send anything), or returns null
+// to fall back to the generic type. A Map, not an object literal, so a forged type like
+// `constructor` or `__proto__` can't reach Object.prototype.
+const WARNING_TYPE_OVERRIDES = new Map<string, (details: Record<string, unknown>) => SanitizedOverride | null>([
     // emitted by capture when a replay snapshot batch is too large to ingest
-    replay_message_too_large: (details) => {
-        const replayRecord = isPlainObject(details.replayRecord) ? details.replayRecord : undefined
-        const sessionId = boundedString(replayRecord?.session_id)
-        const timestamp = boundedString(details.timestamp)
-        if (sessionId === null || timestamp === null) {
-            return null
-        }
-        return {
-            details: {
-                timestamp,
-                replayRecord: { session_id: sessionId },
-                snapshotBytes: finiteNumber(details.snapshotBytes),
-                snapshotItemsCount: finiteNumber(details.snapshotItemsCount),
-                lib: boundedString(details.lib) ?? undefined,
-            },
-            debounceKey: sessionId,
-        }
-    },
-}
+    [
+        'replay_message_too_large',
+        (details) => {
+            const replayRecord = isPlainObject(details.replayRecord) ? details.replayRecord : undefined
+            const sessionId = boundedString(replayRecord?.session_id)
+            const timestamp = boundedString(details.timestamp)
+            if (sessionId === null || timestamp === null) {
+                return null
+            }
+            return {
+                details: {
+                    timestamp,
+                    replayRecord: { session_id: sessionId },
+                    snapshotBytes: finiteNumber(details.snapshotBytes),
+                    snapshotItemsCount: finiteNumber(details.snapshotItemsCount),
+                    lib: boundedString(details.lib) ?? undefined,
+                },
+                debounceKey: sessionId,
+            }
+        },
+    ],
+])
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -69,7 +73,8 @@ export function createHandleClientIngestionWarningStep<
             )
         }
 
-        const message = event.properties?.$$client_ingestion_warning_message
+        // bound the client-controlled message everywhere - never persist raw client JSON
+        const message = boundedString(event.properties?.$$client_ingestion_warning_message, MAX_MESSAGE_LENGTH)
         const baseDetails = {
             eventUuid: event.uuid,
             event: event.event,
@@ -78,21 +83,22 @@ export function createHandleClientIngestionWarningStep<
 
         let warning: PipelineWarning = {
             type: 'client_ingestion_warning',
-            details: { ...baseDetails, message },
+            details: { ...baseDetails, message: message ?? undefined },
             alwaysSend: true,
         }
 
         const requestedType = event.properties?.$$client_ingestion_warning_type
         const extraDetails = event.properties?.$$client_ingestion_warning_details
-        if (typeof requestedType === 'string' && isPlainObject(extraDetails)) {
-            const override = WARNING_TYPE_OVERRIDES[requestedType]?.(extraDetails)
+        const sanitize = typeof requestedType === 'string' ? WARNING_TYPE_OVERRIDES.get(requestedType) : undefined
+        if (sanitize && isPlainObject(extraDetails)) {
+            const override = sanitize(extraDetails)
             if (override) {
                 warning = {
-                    type: requestedType,
+                    type: requestedType as string,
                     details: {
                         ...override.details,
                         ...baseDetails,
-                        message: boundedString(message, MAX_MESSAGE_LENGTH) ?? undefined,
+                        message: message ?? undefined,
                     },
                     key: override.debounceKey,
                 }

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -8,22 +8,19 @@ export interface HandleClientIngestionWarningStepInput {
     event: PluginEvent
 }
 
-// Upper bounds on persisted client-controlled strings, so engineered payloads
-// can't grow warning rows or limiter keys.
+// Cap persisted client-controlled strings so engineered payloads can't bloat warning rows or limiter keys.
 const MAX_DETAIL_STRING_LENGTH = 200
 const MAX_MESSAGE_LENGTH = 1000
 
 interface SanitizedOverride {
-    /** The exact details to persist - never the raw client payload. */
+    /** Rebuilt details to persist, never the raw client payload. */
     details: Record<string, unknown>
-    /** Debounce key for the ingestion warning limiter (scoped by team and type). */
     debounceKey: string
 }
 
-// Allowlisted $$client_ingestion_warning_type overrides. Each sanitizer rebuilds the
-// details its renderer needs from scratch (clients can send anything), or returns null
-// to fall back to the generic type. A Map, not an object literal, so a forged type like
-// `constructor` or `__proto__` can't reach Object.prototype.
+// Allowlisted warning-type overrides: each sanitizer rebuilds only the details its renderer needs,
+// or returns null to fall back to the generic type. A Map, not an object, so a forged type like
+// `__proto__` can't reach Object.prototype.
 const WARNING_TYPE_OVERRIDES = new Map<string, (details: Record<string, unknown>) => SanitizedOverride | null>([
     // emitted by capture when a replay snapshot batch is too large to ingest
     [
@@ -73,7 +70,7 @@ export function createHandleClientIngestionWarningStep<
             )
         }
 
-        // bound the client-controlled message everywhere - never persist raw client JSON
+        // never persist raw client JSON
         const message = boundedString(event.properties?.$$client_ingestion_warning_message, MAX_MESSAGE_LENGTH)
         const baseDetails = {
             eventUuid: event.uuid,

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { PipelineWarning } from '../pipelines/pipeline.interface'
 import { PipelineResult, dlq, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
@@ -7,18 +8,53 @@ export interface HandleClientIngestionWarningStepInput {
     event: PluginEvent
 }
 
-// Allowed $$client_ingestion_warning_type overrides, each validating the
-// details shape its UI renderer needs (clients can send anything here).
-const WARNING_TYPE_OVERRIDES: Record<string, (details: Record<string, unknown>) => boolean> = {
+// Upper bounds on persisted client-controlled strings, so engineered payloads
+// can't grow warning rows or limiter keys.
+const MAX_DETAIL_STRING_LENGTH = 200
+const MAX_MESSAGE_LENGTH = 1000
+
+interface SanitizedOverride {
+    /** The exact details to persist - never the raw client payload. */
+    details: Record<string, unknown>
+    /** Debounce key for the ingestion warning limiter (scoped by team and type). */
+    debounceKey: string
+}
+
+// Allowed $$client_ingestion_warning_type overrides. Each sanitizer rebuilds
+// the details its UI renderer needs from scratch, or returns null to fall
+// back to the generic warning type (clients can send anything here).
+const WARNING_TYPE_OVERRIDES: Record<string, (details: Record<string, unknown>) => SanitizedOverride | null> = {
     // emitted by capture when a replay snapshot batch is too large to ingest
     replay_message_too_large: (details) => {
-        const replayRecord = details.replayRecord
-        return isPlainObject(replayRecord) && typeof (replayRecord as Record<string, unknown>).session_id === 'string'
+        const replayRecord = isPlainObject(details.replayRecord) ? details.replayRecord : undefined
+        const sessionId = boundedString(replayRecord?.session_id)
+        const timestamp = boundedString(details.timestamp)
+        if (sessionId === null || timestamp === null) {
+            return null
+        }
+        return {
+            details: {
+                timestamp,
+                replayRecord: { session_id: sessionId },
+                snapshotBytes: finiteNumber(details.snapshotBytes),
+                snapshotItemsCount: finiteNumber(details.snapshotItemsCount),
+                lib: boundedString(details.lib) ?? undefined,
+            },
+            debounceKey: sessionId,
+        }
     },
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function boundedString(value: unknown, maxLength: number = MAX_DETAIL_STRING_LENGTH): string | null {
+    return typeof value === 'string' && value.length > 0 && value.length <= maxLength ? value : null
+}
+
+function finiteNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 export function createHandleClientIngestionWarningStep<
@@ -33,31 +69,36 @@ export function createHandleClientIngestionWarningStep<
             )
         }
 
-        const extraDetails = event.properties?.$$client_ingestion_warning_details
-        const validatedDetails = isPlainObject(extraDetails) ? extraDetails : {}
+        const message = event.properties?.$$client_ingestion_warning_message
+        const baseDetails = {
+            eventUuid: event.uuid,
+            event: event.event,
+            distinctId: event.distinct_id,
+        }
+
+        let warning: PipelineWarning = {
+            type: 'client_ingestion_warning',
+            details: { ...baseDetails, message },
+            alwaysSend: true,
+        }
 
         const requestedType = event.properties?.$$client_ingestion_warning_type
-        const type =
-            typeof requestedType === 'string' && WARNING_TYPE_OVERRIDES[requestedType]?.(validatedDetails)
-                ? requestedType
-                : 'client_ingestion_warning'
-
-        return ok(
-            undefined,
-            [],
-            [
-                {
-                    type,
+        const extraDetails = event.properties?.$$client_ingestion_warning_details
+        if (typeof requestedType === 'string' && isPlainObject(extraDetails)) {
+            const override = WARNING_TYPE_OVERRIDES[requestedType]?.(extraDetails)
+            if (override) {
+                warning = {
+                    type: requestedType,
                     details: {
-                        ...validatedDetails,
-                        eventUuid: event.uuid,
-                        event: event.event,
-                        distinctId: event.distinct_id,
-                        message: event.properties?.$$client_ingestion_warning_message,
+                        ...override.details,
+                        ...baseDetails,
+                        message: boundedString(message, MAX_MESSAGE_LENGTH) ?? undefined,
                     },
-                    alwaysSend: true,
-                },
-            ]
-        )
+                    key: override.debounceKey,
+                }
+            }
+        }
+
+        return ok(undefined, [], [warning])
     }
 }

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -7,12 +7,10 @@ export interface HandleClientIngestionWarningStepInput {
     event: PluginEvent
 }
 
-// Warning types that may be requested via $$client_ingestion_warning_type,
-// with a validator for the shape their UI renderer depends on. Allowlisted so
-// arbitrary client traffic can't emit unrelated or malformed warning types.
+// Allowed $$client_ingestion_warning_type overrides, each validating the
+// details shape its UI renderer needs (clients can send anything here).
 const WARNING_TYPE_OVERRIDES: Record<string, (details: Record<string, unknown>) => boolean> = {
-    // capture emits this when a snapshot batch exceeds the maximum message
-    // size; the renderer needs details.replayRecord.session_id
+    // emitted by capture when a replay snapshot batch is too large to ingest
     replay_message_too_large: (details) => {
         const replayRecord = details.replayRecord
         return isPlainObject(replayRecord) && typeof (replayRecord as Record<string, unknown>).session_id === 'string'

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -7,6 +7,22 @@ export interface HandleClientIngestionWarningStepInput {
     event: PluginEvent
 }
 
+// Warning types that may be requested via $$client_ingestion_warning_type,
+// with a validator for the shape their UI renderer depends on. Allowlisted so
+// arbitrary client traffic can't emit unrelated or malformed warning types.
+const WARNING_TYPE_OVERRIDES: Record<string, (details: Record<string, unknown>) => boolean> = {
+    // capture emits this when a snapshot batch exceeds the maximum message
+    // size; the renderer needs details.replayRecord.session_id
+    replay_message_too_large: (details) => {
+        const replayRecord = details.replayRecord
+        return isPlainObject(replayRecord) && typeof (replayRecord as Record<string, unknown>).session_id === 'string'
+    },
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 export function createHandleClientIngestionWarningStep<
     TInput extends HandleClientIngestionWarningStepInput,
 >(): ProcessingStep<TInput, void> {
@@ -19,13 +35,23 @@ export function createHandleClientIngestionWarningStep<
             )
         }
 
+        const extraDetails = event.properties?.$$client_ingestion_warning_details
+        const validatedDetails = isPlainObject(extraDetails) ? extraDetails : {}
+
+        const requestedType = event.properties?.$$client_ingestion_warning_type
+        const type =
+            typeof requestedType === 'string' && WARNING_TYPE_OVERRIDES[requestedType]?.(validatedDetails)
+                ? requestedType
+                : 'client_ingestion_warning'
+
         return ok(
             undefined,
             [],
             [
                 {
-                    type: 'client_ingestion_warning',
+                    type,
                     details: {
+                        ...validatedDetails,
                         eventUuid: event.uuid,
                         event: event.event,
                         distinctId: event.distinct_id,

--- a/nodejs/src/utils/token-bucket.test.ts
+++ b/nodejs/src/utils/token-bucket.test.ts
@@ -122,6 +122,53 @@ describe('Storage', () => {
             expect(() => storage.consume(key, 1)).toThrow(BucketKeyMissingError)
         })
     })
+
+    describe('maxBuckets', () => {
+        it('evicts the oldest bucket when the cap is reached', () => {
+            const storage = new Storage(10, 1, 2)
+
+            storage.replenish('first')
+            storage.replenish('second')
+            storage.replenish('third')
+
+            expect(storage.buckets.size).toEqual(2)
+            expect(storage.buckets.has('first')).toEqual(false)
+            expect(storage.buckets.has('second')).toEqual(true)
+            expect(storage.buckets.has('third')).toEqual(true)
+        })
+
+        it('does not evict when replenishing an existing key', () => {
+            const storage = new Storage(10, 1, 2)
+
+            storage.replenish('first')
+            storage.replenish('second')
+            storage.replenish('first')
+
+            expect(storage.buckets.size).toEqual(2)
+            expect(storage.buckets.has('first')).toEqual(true)
+            expect(storage.buckets.has('second')).toEqual(true)
+        })
+
+        it('stays bounded under sustained unique key churn', () => {
+            const storage = new Storage(1, 1, 100)
+
+            for (let i = 0; i < 10000; i++) {
+                storage.replenish(`key-${i}`)
+            }
+
+            expect(storage.buckets.size).toEqual(100)
+        })
+
+        it('is unbounded when maxBuckets is not set', () => {
+            const storage = new Storage(10, 1)
+
+            storage.replenish('first')
+            storage.replenish('second')
+            storage.replenish('third')
+
+            expect(storage.buckets.size).toEqual(3)
+        })
+    })
 })
 
 describe('Limiter', () => {
@@ -175,6 +222,18 @@ describe('Limiter', () => {
             expect(limiter.consume(key, 1)).toEqual(false)
             // Even though we are not advancing time, we are passing the time to use with now
             expect(limiter.consume(key, 1, now.valueOf() + 1000)).toEqual(true)
+        })
+
+        it('allows a fresh consume for keys evicted by the bucket cap', () => {
+            const limiter = new Limiter(1, 0, 1)
+            const now = new Date('2023-02-08T08:00:00')
+            jest.useFakeTimers().setSystemTime(now)
+
+            expect(limiter.consume('a', 1)).toEqual(true)
+            expect(limiter.consume('a', 1)).toEqual(false)
+            // 'b' evicts 'a', so 'a' starts over with a full bucket
+            expect(limiter.consume('b', 1)).toEqual(true)
+            expect(limiter.consume('a', 1)).toEqual(true)
         })
     })
 })

--- a/nodejs/src/utils/token-bucket.ts
+++ b/nodejs/src/utils/token-bucket.ts
@@ -13,17 +13,27 @@ export class Storage {
     public buckets: Map<string, Bucket>
     public replenishRate: number
     public bucketCapacity: number
+    public maxBuckets?: number
 
-    constructor(bucketCapacity: number, replenishRate: number) {
+    constructor(bucketCapacity: number, replenishRate: number, maxBuckets?: number) {
         this.buckets = new Map()
         this.bucketCapacity = bucketCapacity
         this.replenishRate = replenishRate
+        this.maxBuckets = maxBuckets
     }
 
     replenish(key: string, now?: number): void {
         const replenish_timestamp: number = now ?? Date.now()
         const bucket = this.buckets.get(key)
         if (bucket === undefined) {
+            // Bound memory when keys are caller-controlled (e.g. session ids): evict the
+            // oldest bucket, which at worst re-allows one extra consume for that key.
+            if (this.maxBuckets !== undefined && this.buckets.size >= this.maxBuckets) {
+                const oldestKey = this.buckets.keys().next().value
+                if (oldestKey !== undefined) {
+                    this.buckets.delete(oldestKey)
+                }
+            }
             this.buckets.set(key, [this.bucketCapacity, replenish_timestamp])
             return
         }
@@ -56,8 +66,8 @@ export class Storage {
 export class Limiter {
     public storage: Storage
 
-    constructor(bucketCapacity: number, replenishRate: number) {
-        this.storage = new Storage(bucketCapacity, replenishRate)
+    constructor(bucketCapacity: number, replenishRate: number, maxBuckets?: number) {
+        this.storage = new Storage(bucketCapacity, replenishRate, maxBuckets)
     }
 
     consume(key: string, tokens: number, now?: number): boolean {
@@ -72,6 +82,8 @@ export const ConfiguredLimiter: Limiter = new Limiter(
     defaultConfig.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE
 )
 
-export const IngestionWarningLimiter: Limiter = new Limiter(1, 1.0 / 3600)
+// Debounce keys can include client-controlled values (session ids), so cap the
+// bucket count to keep memory bounded under engineered key churn.
+export const IngestionWarningLimiter: Limiter = new Limiter(1, 1.0 / 3600, 100_000)
 
 export const LoggingLimiter: Limiter = new Limiter(1, 1.0 / 60)

--- a/nodejs/src/utils/token-bucket.ts
+++ b/nodejs/src/utils/token-bucket.ts
@@ -26,8 +26,7 @@ export class Storage {
         const replenish_timestamp: number = now ?? Date.now()
         const bucket = this.buckets.get(key)
         if (bucket === undefined) {
-            // Bound memory when keys are caller-controlled (e.g. session ids): evict the
-            // oldest bucket, which at worst re-allows one extra consume for that key.
+            // Cap memory for caller-controlled keys: evict the oldest bucket (at worst re-allows one consume).
             if (this.maxBuckets !== undefined && this.buckets.size >= this.maxBuckets) {
                 const oldestKey = this.buckets.keys().next().value
                 if (oldestKey !== undefined) {
@@ -82,8 +81,7 @@ export const ConfiguredLimiter: Limiter = new Limiter(
     defaultConfig.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE
 )
 
-// Debounce keys can include client-controlled values (session ids), so cap the
-// bucket count to keep memory bounded under engineered key churn.
+// Cap bucket count: debounce keys can be client-controlled (session ids).
 export const IngestionWarningLimiter: Limiter = new Limiter(1, 1.0 / 3600, 100_000)
 
 export const LoggingLimiter: Limiter = new Limiter(1, 1.0 / 60)

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -402,8 +402,7 @@ pub async fn process_replay_events(
     match sink.send(ProcessedEvent { metadata, event }).await {
         Ok(()) => {}
         Err(err @ CaptureError::EventTooBig(_)) => {
-            // The drop may cost the session its full snapshot, so surface a
-            // team-visible warning (best effort) before failing with 413.
+            // surface a team-visible warning (best effort) before failing with 413
             counter!("capture_replay_snapshot_too_large_total").increment(1);
             let warning = replay_message_too_large_warning(
                 context,
@@ -429,9 +428,7 @@ pub async fn process_replay_events(
     Ok(())
 }
 
-/// Warning event for a snapshot batch dropped for size. Ingestion resolves
-/// the team from the token and persists it as a `replay_message_too_large`
-/// ingestion warning.
+/// Warning for a snapshot batch dropped for size, persisted as a `replay_message_too_large` warning.
 fn replay_message_too_large_warning(
     context: &ProcessingContext,
     distinct_id: String,
@@ -444,6 +441,7 @@ fn replay_message_too_large_warning(
     let message = format!(
         "Replay data for session {session_id} was dropped because it was too large to ingest ({snapshot_bytes} bytes, {snapshot_items_count} snapshot items)"
     );
+    let lib = bounded_warning_lib(snapshot_library);
     let data = json!({
         "event": "$$client_ingestion_warning",
         "distinct_id": &distinct_id,
@@ -455,10 +453,10 @@ fn replay_message_too_large_warning(
                 "replayRecord": { "session_id": session_id },
                 "snapshotBytes": snapshot_bytes,
                 "snapshotItemsCount": snapshot_items_count,
-                "lib": snapshot_library,
+                "lib": lib.as_str(),
             },
             "$session_id": session_id,
-            "$lib": snapshot_library,
+            "$lib": lib.as_str(),
         }
     })
     .to_string();
@@ -545,6 +543,12 @@ pub fn serialize_snapshot_data_sync(
         }
     })
     .to_string()
+}
+
+/// Cap the client-supplied `$lib` so an oversized value can't make the warning event itself too large.
+fn bounded_warning_lib(snapshot_library: &str) -> String {
+    const MAX_WARNING_LIB_CHARS: usize = 200;
+    snapshot_library.chars().take(MAX_WARNING_LIB_CHARS).collect()
 }
 
 fn snapshot_library_fallback_from(user_agent: Option<&String>) -> Option<String> {
@@ -1305,6 +1309,50 @@ mod tests {
         assert!(props["$$client_ingestion_warning_message"]
             .as_str()
             .is_some_and(|m| m.contains("test-session-123")));
+    }
+
+    #[tokio::test]
+    async fn test_oversized_snapshot_warning_caps_client_lib() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(RejectSnapshotsSink {
+            error: || CaptureError::EventTooBig("too big".to_string()),
+            events: events_captured.clone(),
+        });
+
+        let huge_lib = "x".repeat(5000);
+        let recording: RawRecording = serde_json::from_value(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": {
+                "$session_id": "test-session-123",
+                "$window_id": "test-window",
+                "$snapshot_data": [{"type": 1, "data": {"test": "data"}}],
+                "$snapshot_source": "web",
+                "$lib": huge_lib,
+            }
+        }))
+        .unwrap();
+        let context = create_test_context();
+
+        let result = process_replay_events(sink, None, None, vec![recording], &context).await;
+        assert!(matches!(result, Err(CaptureError::EventTooBig(_))));
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let data: Value = serde_json::from_str(&captured[0].event.data).unwrap();
+        let props = &data["properties"];
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["lib"]
+                .as_str()
+                .map(|s| s.chars().count()),
+            Some(200),
+            "client lib must be capped in the warning details"
+        );
+        assert_eq!(
+            props["$lib"].as_str().map(|s| s.chars().count()),
+            Some(200),
+            "top-level $lib must be capped too"
+        );
     }
 
     #[tokio::test]

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -548,7 +548,10 @@ pub fn serialize_snapshot_data_sync(
 /// Cap the client-supplied `$lib` so an oversized value can't make the warning event itself too large.
 fn bounded_warning_lib(snapshot_library: &str) -> String {
     const MAX_WARNING_LIB_CHARS: usize = 200;
-    snapshot_library.chars().take(MAX_WARNING_LIB_CHARS).collect()
+    snapshot_library
+        .chars()
+        .take(MAX_WARNING_LIB_CHARS)
+        .collect()
 }
 
 fn snapshot_library_fallback_from(user_agent: Option<&String>) -> Option<String> {

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -383,6 +383,7 @@ pub async fn process_replay_events(
 
     let event = CapturedEvent {
         uuid,
+        // cloned (~200 bytes max) so the EventTooBig branch below can still build the warning
         distinct_id: distinct_id.clone(),
         session_id: Some(session_id_str.to_string()),
         ip: context.client_ip.clone(),

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -401,10 +401,8 @@ pub async fn process_replay_events(
     match sink.send(ProcessedEvent { metadata, event }).await {
         Ok(()) => {}
         Err(err @ CaptureError::EventTooBig(_)) => {
-            // A snapshot batch this size usually carries the session's full
-            // snapshot; dropping it silently leaves the recording unplayable
-            // with no trace. Flag it as a team-visible ingestion warning
-            // (best effort) before failing the request with 413.
+            // The drop may cost the session its full snapshot, so surface a
+            // team-visible warning (best effort) before failing with 413.
             counter!("capture_replay_snapshot_too_large_total").increment(1);
             let warning = replay_message_too_large_warning(
                 context,
@@ -430,11 +428,9 @@ pub async fn process_replay_events(
     Ok(())
 }
 
-/// Build a `$$client_ingestion_warning` event flagging a replay snapshot batch
-/// that the sink rejected for exceeding the maximum message size. It is routed
-/// to the client ingestion warning topic, where ingestion resolves the team
-/// from the token and persists a `replay_message_too_large` warning that shows
-/// up in the ingestion warnings UI.
+/// Warning event for a snapshot batch dropped for size. Ingestion resolves
+/// the team from the token and persists it as a `replay_message_too_large`
+/// ingestion warning.
 fn replay_message_too_large_warning(
     context: &ProcessingContext,
     distinct_id: String,
@@ -492,8 +488,7 @@ fn replay_message_too_large_warning(
             token: context.token.clone(),
             event: "$$client_ingestion_warning".to_string(),
             timestamp,
-            // Deliberately not propagating cookieless mode: the warning is a
-            // synthetic event without the properties cookieless hashing needs.
+            // synthetic event without the properties cookieless hashing needs
             is_cookieless_mode: false,
             historical_migration: false,
         },
@@ -1234,14 +1229,10 @@ mod tests {
     }
 
     // ============ oversized snapshot flagging tests ============
-    // When the sink rejects the $snapshot_items message for size, the pipeline
-    // must emit a replay_message_too_large client ingestion warning (so teams
-    // can see why a recording is missing data) and still fail the request.
 
     use async_trait::async_trait;
 
-    /// Sink that rejects snapshot sends with the given error but accepts
-    /// everything else (i.e. the synthesized ingestion warning event).
+    /// Rejects snapshot sends with the given error, accepts everything else.
     struct RejectSnapshotsSink {
         error: fn() -> CaptureError,
         events: Arc<Mutex<Vec<ProcessedEvent>>>,

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -378,9 +378,12 @@ pub async fn process_replay_events(
 
     debug_or_info!(chatty_debug_enabled, metadata=?metadata, context=?context, "serialized snapshot data");
 
+    let snapshot_items_count = snapshot_items.len();
+    let snapshot_bytes = serialized_data.len();
+
     let event = CapturedEvent {
         uuid,
-        distinct_id, // No clone - we own it from extract_distinct_id()
+        distinct_id: distinct_id.clone(),
         session_id: Some(session_id_str.to_string()),
         ip: context.client_ip.clone(),
         data: serialized_data,
@@ -395,11 +398,106 @@ pub async fn process_replay_events(
         historical_migration: context.historical_migration,
     };
 
-    sink.send(ProcessedEvent { metadata, event }).await?;
+    match sink.send(ProcessedEvent { metadata, event }).await {
+        Ok(()) => {}
+        Err(err @ CaptureError::EventTooBig(_)) => {
+            // A snapshot batch this size usually carries the session's full
+            // snapshot; dropping it silently leaves the recording unplayable
+            // with no trace. Flag it as a team-visible ingestion warning
+            // (best effort) before failing the request with 413.
+            counter!("capture_replay_snapshot_too_large_total").increment(1);
+            let warning = replay_message_too_large_warning(
+                context,
+                distinct_id,
+                session_id_str,
+                computed_timestamp,
+                snapshot_bytes,
+                snapshot_items_count,
+                &snapshot_library,
+            );
+            if let Err(warning_err) = sink.send(warning).await {
+                error!(
+                    "failed to send replay_message_too_large ingestion warning: {warning_err:?}"
+                );
+            }
+            return Err(err);
+        }
+        Err(err) => return Err(err),
+    }
 
     debug_or_info!(chatty_debug_enabled, context=?context, "sent recordings CapturedEvent");
 
     Ok(())
+}
+
+/// Build a `$$client_ingestion_warning` event flagging a replay snapshot batch
+/// that the sink rejected for exceeding the maximum message size. It is routed
+/// to the client ingestion warning topic, where ingestion resolves the team
+/// from the token and persists a `replay_message_too_large` warning that shows
+/// up in the ingestion warnings UI.
+fn replay_message_too_large_warning(
+    context: &ProcessingContext,
+    distinct_id: String,
+    session_id: &str,
+    timestamp: chrono::DateTime<chrono::Utc>,
+    snapshot_bytes: usize,
+    snapshot_items_count: usize,
+    snapshot_library: &str,
+) -> ProcessedEvent {
+    let message = format!(
+        "Replay data for session {session_id} was dropped because it was too large to ingest ({snapshot_bytes} bytes, {snapshot_items_count} snapshot items)"
+    );
+    let data = json!({
+        "event": "$$client_ingestion_warning",
+        "distinct_id": &distinct_id,
+        "properties": {
+            "$$client_ingestion_warning_message": message,
+            "$$client_ingestion_warning_type": "replay_message_too_large",
+            "$$client_ingestion_warning_details": {
+                "timestamp": timestamp.to_rfc3339(),
+                "replayRecord": { "session_id": session_id },
+                "snapshotBytes": snapshot_bytes,
+                "snapshotItemsCount": snapshot_items_count,
+                "lib": snapshot_library,
+            },
+            "$session_id": session_id,
+            "$lib": snapshot_library,
+        }
+    })
+    .to_string();
+
+    ProcessedEvent {
+        metadata: ProcessedEventMetadata {
+            data_type: DataType::ClientIngestionWarning,
+            session_id: Some(session_id.to_string()),
+            computed_timestamp: Some(timestamp),
+            event_name: "$$client_ingestion_warning".to_string(),
+            force_overflow: false,
+            skip_person_processing: false,
+            redirect_to_dlq: false,
+            redirect_to_topic: None,
+            skip_heatmap_processing: false,
+            overflow_reason: None,
+        },
+        event: CapturedEvent {
+            uuid: uuid_v7(),
+            distinct_id,
+            session_id: Some(session_id.to_string()),
+            ip: context.client_ip.clone(),
+            data,
+            now: context
+                .now
+                .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+            sent_at: context.sent_at,
+            token: context.token.clone(),
+            event: "$$client_ingestion_warning".to_string(),
+            timestamp,
+            // Deliberately not propagating cookieless mode: the warning is a
+            // synthetic event without the properties cookieless hashing needs.
+            is_cookieless_mode: false,
+            historical_migration: false,
+        },
+    }
 }
 
 /// Asynchronously serialize snapshot data by offloading to blocking thread pool
@@ -1132,6 +1230,107 @@ mod tests {
             records[0].key.as_deref(),
             Some("test-session-123"),
             "replay overflow keeps session_id partition key"
+        );
+    }
+
+    // ============ oversized snapshot flagging tests ============
+    // When the sink rejects the $snapshot_items message for size, the pipeline
+    // must emit a replay_message_too_large client ingestion warning (so teams
+    // can see why a recording is missing data) and still fail the request.
+
+    use async_trait::async_trait;
+
+    /// Sink that rejects snapshot sends with the given error but accepts
+    /// everything else (i.e. the synthesized ingestion warning event).
+    struct RejectSnapshotsSink {
+        error: fn() -> CaptureError,
+        events: Arc<Mutex<Vec<ProcessedEvent>>>,
+    }
+
+    #[async_trait]
+    impl Event for RejectSnapshotsSink {
+        async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
+            if event.metadata.data_type == DataType::SnapshotMain {
+                return Err((self.error)());
+            }
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+
+        async fn send_batch(&self, _events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+            unreachable!("replay pipeline sends single events")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_oversized_snapshot_emits_replay_message_too_large_warning() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(RejectSnapshotsSink {
+            error: || CaptureError::EventTooBig("too big".to_string()),
+            events: events_captured.clone(),
+        });
+
+        let recording = create_test_recording();
+        let context = create_test_context();
+
+        let result = process_replay_events(sink, None, None, vec![recording], &context).await;
+        assert!(
+            matches!(result, Err(CaptureError::EventTooBig(_))),
+            "the request must still fail with EventTooBig, got {result:?}"
+        );
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1, "exactly one warning event must be sent");
+
+        let warning = &captured[0];
+        assert_eq!(warning.metadata.data_type, DataType::ClientIngestionWarning);
+        assert_eq!(warning.event.event, "$$client_ingestion_warning");
+        assert_eq!(warning.event.token, "test_token");
+        assert_eq!(
+            warning.event.session_id.as_deref(),
+            Some("test-session-123")
+        );
+        assert_eq!(warning.event.distinct_id, "test_user");
+
+        let data: Value = serde_json::from_str(&warning.event.data).unwrap();
+        assert_eq!(data["event"], "$$client_ingestion_warning");
+        let props = &data["properties"];
+        assert_eq!(
+            props["$$client_ingestion_warning_type"],
+            "replay_message_too_large"
+        );
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["replayRecord"]["session_id"],
+            "test-session-123"
+        );
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["snapshotItemsCount"],
+            1
+        );
+        assert!(props["$$client_ingestion_warning_details"]["snapshotBytes"]
+            .as_u64()
+            .is_some_and(|b| b > 0));
+        assert!(props["$$client_ingestion_warning_message"]
+            .as_str()
+            .is_some_and(|m| m.contains("test-session-123")));
+    }
+
+    #[tokio::test]
+    async fn test_other_sink_errors_do_not_emit_warning() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(RejectSnapshotsSink {
+            error: || CaptureError::RetryableSinkError,
+            events: events_captured.clone(),
+        });
+
+        let recording = create_test_recording();
+        let context = create_test_context();
+
+        let result = process_replay_events(sink, None, None, vec![recording], &context).await;
+        assert!(matches!(result, Err(CaptureError::RetryableSinkError)));
+        assert!(
+            events_captured.lock().unwrap().is_empty(),
+            "only EventTooBig should produce a warning"
         );
     }
 }


### PR DESCRIPTION
## Problem

rrweb full snapshots are single, unsplittable events, so a large-DOM page can produce a snapshot batch that exceeds the maximum Kafka message size. When that happens, capture rejects the produce (`MessageSizeTooLarge` → `EventTooBig` → HTTP 413) and the SDK permanently drops the batch, since retrying an oversized payload cannot succeed. The smaller incremental events that follow keep flowing, so the stored recording ends up with mutations referencing nodes from a full snapshot that never arrived. Until #62709 that meant the player buffered forever; with it, playback clamps forward, but the data loss itself is still invisible: no ingestion warning, no replay-specific metric, nothing a team (or support) can look at to see why a recording is missing data.

The `replay_message_too_large` ingestion warning type still has a renderer in the frontend (with a "view recording" button), but nothing produces it anymore — its producer was lost when replay capture moved to the current pipeline. This PR restores that observability at the new drop point.

Base of a stack: **this PR** ← #63282 (warn on rejected payloads) ← #63283 (warn on rate-limit drops) ← #63284 (surface the warnings in the player).

## Changes

- **capture** (`process_replay_events`): when the sink rejects the `$snapshot_items` message with `EventTooBig`, capture now emits a best-effort `$$client_ingestion_warning` event through the existing client warnings topic, carrying the session id, payload bytes, and snapshot item count, then fails the request with 413 exactly as before. Also adds a `capture_replay_snapshot_too_large_total` counter. Capture can't write ingestion warnings directly (it doesn't know the team), so it rides the existing client-warning path where ingestion resolves the team from the token.
- **plugin-server** (`handleClientIngestionWarningStep`): supports an allowlisted `$$client_ingestion_warning_type` override so the warning is persisted as `replay_message_too_large` instead of the generic `client_ingestion_warning`. The client warnings topic carries arbitrary SDK traffic, so the override is hardened against engineered payloads: the allowlist is keyed through a `Map` (a forged type like `constructor` or `__proto__` can't reach `Object.prototype`), each allowed type rebuilds its persisted details from scratch out of validated, length-bounded fields (never spreading the raw client payload), requires the `timestamp` and `session_id` the renderer needs, and debounces per session through the ingestion warning limiter instead of bypassing it with `alwaysSend`. The client message is length-bounded on every path.

No frontend changes needed: the existing `replay_message_too_large` renderer in the ingestion warnings view picks these up as-is.

## How did you test this code?

Authored by an agent — automated tests only, no manual testing:

- New capture unit tests: an `EventTooBig` sink rejection emits exactly one warning event with the right type, details, token, and session id, and the request still fails with 413; other sink errors emit no warning (`cargo test -p capture --lib events::recordings`, 22 passed).
- Extended jest tests for the warning step: override honored with valid details, sanitization drops raw client payload, fallback to `client_ingestion_warning` on missing/malformed details or a forged prototype-key type (`constructor`/`__proto__`), oversized/non-string messages dropped, base detail fields not overridable. Token-bucket eviction tests for the bounded limiter.
- `cargo clippy -p capture --lib` and `tsc --noEmit` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — restores an existing documented warning type.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code while root-causing a recording that was unplayable due to a missing full snapshot. The investigation found that size is the only drop filter that systematically discriminates full snapshots from incrementals, and that this drop path is the one place in the chain with no team-visible trace.
- Considered and rejected: emitting the warning from posthog-js on 413 (requires SDK upgrades to take effect), and detecting missing full snapshots at ingestion (ingestion never sees the dropped message). Flagging at capture covers all SDK versions.
- The warning type override is allowlisted server-side specifically because the client warnings topic receives arbitrary SDK traffic and the frontend renderer dereferences `details.replayRecord.session_id` unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


