### PR TITLE
feat(slack): pass region as person property to untagged flag check

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1485,6 +1485,7 @@ def _untagged_thread_followups_enabled(integration: Integration, slack_team_id: 
             UNTAGGED_THREAD_FOLLOWUPS_FLAG,
             f"slack_workspace:{slack_team_id}",
             groups={"organization": str(integration.team.organization_id)},
+            person_properties={"region": get_instance_region() or "unknown"},
             only_evaluate_locally=False,
             send_feature_flag_events=False,
         )


### PR DESCRIPTION
## Problem

The `posthog-slack-app-untagged-thread-followups` feature flag is evaluated without a `region` person property, so a release condition keyed on region (e.g. `region == "DEV"` to roll out on the hosted dev environment first) silently never matches. The deleted `POSTHOG_CODE_SLACK_AVAILABILITY_FLAG` check used to forward `person_properties={"region": get_instance_region() or "unknown"}`, but that pattern wasn't carried over when this flag was added.

## Changes

Add `person_properties={"region": get_instance_region() or "unknown"}` to the `feature_enabled` call in `_untagged_thread_followups_enabled` (`products/slack_app/backend/api.py`). Mirrors the convention used elsewhere in the codebase (e.g. `posthog/hogql_queries/property_values_query_runner.py:93`).

`get_instance_region` is already imported. No new dependencies, no new helpers.

## How did you test this code?

Agent-authored. `hogli test products/slack_app/backend/tests/test_thread_message_routing.py` — 13/13 pass. The existing tests mock `_untagged_thread_followups_enabled` wholesale rather than asserting the inner `feature_enabled` call shape, so the added kwarg is transparent to them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.7). Follow-up on the dev unblock work — the flag was already created and an instance-group condition tried, but that path requires also passing the `instance` group to `feature_enabled`. Going with the person-property pattern instead matches what other PostHog products do and lets dev be targeted explicitly via `region == "DEV"` once this lands.
