### PR TITLE
fix(bigquery): treat invalid JWT signature as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -71,6 +71,21 @@ def _make_config(
     )
 
 
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        # The exact RefreshError surfaced by error tracking from `get_columns`.
+        "('invalid_grant: Invalid JWT Signature.', {'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'})",
+        "RefreshError: ('invalid_grant: Invalid JWT Signature.', ...)",
+    ],
+)
+def test_bigquery_invalid_jwt_signature_is_non_retryable(error_message):
+    """A service account key rotated/revoked in Google Cloud yields an unrecoverable
+    `invalid_grant: Invalid JWT Signature.` RefreshError — retrying can't help."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    assert any(key in error_message for key in non_retryable_errors)
+
+
 def test_bigquery_get_columns_filters_existing_destination_tables():
     """`get_columns` strips `__posthog_import_*` tables before returning."""
     fake_client = mock.MagicMock()


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `RefreshError` from the BigQuery data-warehouse import source:

```
RefreshError: ('invalid_grant: Invalid JWT Signature.', {'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'})
```

Issue: https://us.posthog.com/project/2/error_tracking/019ebc4b-7c21-7421-8b0b-46558024c6bf

The top in-app frame is `get_columns` in `posthog/temporal/data_imports/sources/bigquery/bigquery.py`, where the source issues its first authenticated query. `google.auth` raises this when exchanging the service account key for an OAuth2 token fails because Google's token endpoint rejects the signed JWT — i.e. the service account key was **rotated, revoked, or deleted** in Google Cloud. Retrying with the same key can never succeed, but the pipeline keeps retrying.

## Changes

Add `Invalid JWT Signature` to the BigQuery source's `get_non_retryable_errors()` with an actionable message telling the user to upload a new key file and reconnect.

This is a user/upstream credential problem (bad/revoked credentials), so it matches the NonRetryableErrors pattern used by the Stripe source. I matched the specific signature-rejection substring rather than the broader `invalid_grant` OAuth code — `invalid_grant` can also appear for transient/clock-skew conditions that should stay retryable — and not on the `RefreshError` type, since that can also wrap transient network failures reaching the token endpoint.

## How did you test this code?

I'm an agent. I added a parametrized regression test (`test_bigquery_invalid_jwt_signature_is_non_retryable`) asserting the observed error string is recognised as non-retryable, and ran the BigQuery source test suite:

```
.venv/bin/pytest posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
# 22 passed
```

`ruff check` and `ruff format --check` pass on both changed files.

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the BigQuery import source. Confirmed the failure originates in `bigquery.py:get_columns` (not just in serialized log context), read the source/credential helpers to understand the call path, and classified the `invalid_grant: Invalid JWT Signature.` `RefreshError` as an unrecoverable upstream credential error rather than a fixable bug. Chose to extend `NonRetryableErrors` with a low-false-positive substring, mirroring the Stripe source pattern, rather than touching retry policy. Tools used: Claude Code with the PostHog error-tracking MCP (`query-error-tracking-issue`).
