### PR TITLE
feat(oauth): add raycast extension client metadata endpoint

### DIFF
--- a/posthog/api/oauth/raycast_metadata.py
+++ b/posthog/api/oauth/raycast_metadata.py
@@ -30,7 +30,7 @@ class RaycastClientMetadataView(View):
 
         metadata = {
             "client_id": client_id,
-            "client_name": "Raycast",
+            "client_name": "Raycast extension for PostHog",
             "redirect_uris": [
                 "https://raycast.com/redirect?packageName=Extension",
                 "https://raycast.com/redirect?packageName=posthog",

--- a/posthog/api/oauth/raycast_metadata.py
+++ b/posthog/api/oauth/raycast_metadata.py
@@ -1,0 +1,47 @@
+from django.conf import settings
+from django.http import JsonResponse
+from django.views import View
+
+RAYCAST_METADATA_PATH = "api/oauth/raycast/client-metadata"
+
+# Scope ceiling for tokens issued to the Raycast extension. OIDC scopes
+# (openid/profile/email) bypass the ceiling via ALWAYS_ALLOWED_SCOPES.
+RAYCAST_SCOPES = [
+    "project:read",
+    "feature_flag:read",
+    "cohort:read",
+    "dashboard:read",
+    "person:read",
+]
+
+
+class RaycastClientMetadataView(View):
+    """
+    Serves a static CIMD (Client ID Metadata Document) for the PostHog Raycast extension.
+
+    The client_id in the response is the canonical URL where this document is hosted,
+    constructed from SITE_URL so it's correct on each region (US, EU, self-hosted).
+    """
+
+    http_method_names = ["get"]
+
+    def get(self, request):
+        client_id = f"{settings.SITE_URL}/{RAYCAST_METADATA_PATH}"
+
+        metadata = {
+            "client_id": client_id,
+            "client_name": "Raycast",
+            "redirect_uris": [
+                "https://raycast.com/redirect?packageName=Extension",
+                "https://raycast.com/redirect?packageName=posthog",
+            ],
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "com.posthog": {"scopes": RAYCAST_SCOPES},
+        }
+
+        response = JsonResponse(metadata)
+        response["Cache-Control"] = "public, max-age=3600"
+        response["Content-Type"] = "application/json"
+        return response

--- a/posthog/api/oauth/test_raycast_metadata.py
+++ b/posthog/api/oauth/test_raycast_metadata.py
@@ -1,0 +1,51 @@
+from django.test import SimpleTestCase, override_settings
+
+from posthog.api.oauth.raycast_metadata import RAYCAST_SCOPES
+from posthog.scopes import UNPRIVILEGED_SCOPES
+
+
+@override_settings(SITE_URL="https://us.posthog.com")
+class TestRaycastClientMetadataView(SimpleTestCase):
+    def test_returns_valid_cimd_metadata(self):
+        res = self.client.get("/api/oauth/raycast/client-metadata")
+        assert res.status_code == 200
+        data = res.json()
+
+        assert data["client_id"] == "https://us.posthog.com/api/oauth/raycast/client-metadata"
+        assert data["client_name"] == "Raycast"
+        assert data["redirect_uris"] == [
+            "https://raycast.com/redirect?packageName=Extension",
+            "https://raycast.com/redirect?packageName=posthog",
+        ]
+        assert data["grant_types"] == ["authorization_code"]
+        assert data["response_types"] == ["code"]
+        assert data["token_endpoint_auth_method"] == "none"
+        assert data["com.posthog"]["scopes"] == RAYCAST_SCOPES
+
+    def test_client_id_matches_hosted_path(self):
+        res = self.client.get("/api/oauth/raycast/client-metadata")
+        data = res.json()
+        assert data["client_id"].endswith("/api/oauth/raycast/client-metadata")
+
+    @override_settings(SITE_URL="https://eu.posthog.com")
+    def test_client_id_uses_site_url_for_eu(self):
+        res = self.client.get("/api/oauth/raycast/client-metadata")
+        data = res.json()
+        assert data["client_id"] == "https://eu.posthog.com/api/oauth/raycast/client-metadata"
+
+    def test_declared_scopes_are_unprivileged(self):
+        # A scope falling out of UNPRIVILEGED_SCOPES would make CIMD registration
+        # reject the metadata document outright (see _resolve_scopes in cimd.py).
+        assert set(RAYCAST_SCOPES) <= set(UNPRIVILEGED_SCOPES)
+
+    def test_cache_control_header_set(self):
+        res = self.client.get("/api/oauth/raycast/client-metadata")
+        assert res["Cache-Control"] == "public, max-age=3600"
+
+    def test_content_type_is_json(self):
+        res = self.client.get("/api/oauth/raycast/client-metadata")
+        assert "application/json" in res["Content-Type"]
+
+    def test_post_not_allowed(self):
+        res = self.client.post("/api/oauth/raycast/client-metadata")
+        assert res.status_code == 405

--- a/posthog/api/oauth/test_raycast_metadata.py
+++ b/posthog/api/oauth/test_raycast_metadata.py
@@ -1,9 +1,28 @@
+import json
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
 from django.test import SimpleTestCase, override_settings
 
+from oauth2_provider.models import AbstractApplication
 from parameterized import parameterized
 
+from posthog.api.oauth.cimd import fetch_and_upsert_cimd_application, get_application_by_client_id
 from posthog.api.oauth.raycast_metadata import RAYCAST_SCOPES
 from posthog.scopes import UNPRIVILEGED_SCOPES
+
+
+def _mock_cimd_response(document: dict):
+    body = json.dumps(document).encode()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.is_redirect = False
+    resp.is_permanent_redirect = False
+    resp.close = MagicMock()
+    resp.iter_content = MagicMock(return_value=iter([body]))
+    return resp
 
 
 @override_settings(SITE_URL="https://us.posthog.com")
@@ -15,7 +34,7 @@ class TestRaycastClientMetadataView(SimpleTestCase):
         assert "application/json" in res["Content-Type"]
 
         data = res.json()
-        assert data["client_name"] == "Raycast"
+        assert data["client_name"] == "Raycast extension for PostHog"
         assert data["redirect_uris"] == [
             "https://raycast.com/redirect?packageName=Extension",
             "https://raycast.com/redirect?packageName=posthog",
@@ -44,3 +63,32 @@ class TestRaycastClientMetadataView(SimpleTestCase):
     def test_post_not_allowed(self):
         res = self.client.post("/api/oauth/raycast/client-metadata")
         assert res.status_code == 405
+
+
+@override_settings(SITE_URL="https://us.posthog.com")
+class TestRaycastClientMetadataRegistration(APIBaseTest):
+    @patch("posthog.api.oauth.cimd.is_url_allowed", return_value=(True, None))
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_document_registers_through_cimd(self, mock_get, _url_mock):
+        # Serve the live document back through the CIMD fetch path (the HTTP fetch
+        # is patched since CIMD client_ids must be HTTPS), then assert it registers
+        # as the public client this endpoint promises. Locks the contract between
+        # this document and the CIMD validation rules.
+        document = self.client.get("/api/oauth/raycast/client-metadata").json()
+        client_id = document["client_id"]
+        mock_get.return_value = _mock_cimd_response(document)
+
+        app = fetch_and_upsert_cimd_application(client_id)
+
+        assert app is not None
+        assert app.is_cimd_client
+        assert app.cimd_metadata_url == client_id
+        assert app.name == "Raycast extension for PostHog"
+        assert app.client_type == AbstractApplication.CLIENT_PUBLIC
+        assert app.authorization_grant_type == AbstractApplication.GRANT_AUTHORIZATION_CODE
+        assert app.redirect_uris == " ".join(document["redirect_uris"])
+        assert set(app.scopes) == set(RAYCAST_SCOPES)
+        assert app.organization is None
+
+        # The authorize-time lookup resolves the URL-form client_id back to this app.
+        assert get_application_by_client_id(client_id).pk == app.pk

--- a/posthog/api/oauth/test_raycast_metadata.py
+++ b/posthog/api/oauth/test_raycast_metadata.py
@@ -1,5 +1,7 @@
 from django.test import SimpleTestCase, override_settings
 
+from parameterized import parameterized
+
 from posthog.api.oauth.raycast_metadata import RAYCAST_SCOPES
 from posthog.scopes import UNPRIVILEGED_SCOPES
 
@@ -9,9 +11,10 @@ class TestRaycastClientMetadataView(SimpleTestCase):
     def test_returns_valid_cimd_metadata(self):
         res = self.client.get("/api/oauth/raycast/client-metadata")
         assert res.status_code == 200
-        data = res.json()
+        assert res["Cache-Control"] == "public, max-age=3600"
+        assert "application/json" in res["Content-Type"]
 
-        assert data["client_id"] == "https://us.posthog.com/api/oauth/raycast/client-metadata"
+        data = res.json()
         assert data["client_name"] == "Raycast"
         assert data["redirect_uris"] == [
             "https://raycast.com/redirect?packageName=Extension",
@@ -22,29 +25,21 @@ class TestRaycastClientMetadataView(SimpleTestCase):
         assert data["token_endpoint_auth_method"] == "none"
         assert data["com.posthog"]["scopes"] == RAYCAST_SCOPES
 
-    def test_client_id_matches_hosted_path(self):
-        res = self.client.get("/api/oauth/raycast/client-metadata")
-        data = res.json()
-        assert data["client_id"].endswith("/api/oauth/raycast/client-metadata")
-
-    @override_settings(SITE_URL="https://eu.posthog.com")
-    def test_client_id_uses_site_url_for_eu(self):
-        res = self.client.get("/api/oauth/raycast/client-metadata")
-        data = res.json()
-        assert data["client_id"] == "https://eu.posthog.com/api/oauth/raycast/client-metadata"
+    @parameterized.expand(
+        [
+            ("https://us.posthog.com", "https://us.posthog.com/api/oauth/raycast/client-metadata"),
+            ("https://eu.posthog.com", "https://eu.posthog.com/api/oauth/raycast/client-metadata"),
+        ]
+    )
+    def test_client_id_is_built_from_site_url(self, site_url: str, expected_client_id: str):
+        with override_settings(SITE_URL=site_url):
+            res = self.client.get("/api/oauth/raycast/client-metadata")
+        assert res.json()["client_id"] == expected_client_id
 
     def test_declared_scopes_are_unprivileged(self):
         # A scope falling out of UNPRIVILEGED_SCOPES would make CIMD registration
         # reject the metadata document outright (see _resolve_scopes in cimd.py).
         assert set(RAYCAST_SCOPES) <= set(UNPRIVILEGED_SCOPES)
-
-    def test_cache_control_header_set(self):
-        res = self.client.get("/api/oauth/raycast/client-metadata")
-        assert res["Cache-Control"] == "public, max-age=3600"
-
-    def test_content_type_is_json(self):
-        res = self.client.get("/api/oauth/raycast/client-metadata")
-        assert "application/json" in res["Content-Type"]
 
     def test_post_not_allowed(self):
         res = self.client.post("/api/oauth/raycast/client-metadata")

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -32,6 +32,7 @@ from posthog.api import (
 from posthog.api.github_callback.personal_finish import github_link_complete
 from posthog.api.id_jag import IdJagViewSet
 from posthog.api.oauth.connected_apps import ConnectedAppsViewSet
+from posthog.api.oauth.raycast_metadata import RAYCAST_METADATA_PATH, RaycastClientMetadataView
 from posthog.api.oauth.wizard_metadata import WIZARD_METADATA_PATH, WizardClientMetadataView
 from posthog.api.query import progress
 from posthog.api.sdk_health import sdk_health
@@ -359,6 +360,11 @@ urlpatterns = [
         WIZARD_METADATA_PATH,
         WizardClientMetadataView.as_view(),
         name="wizard-client-metadata",
+    ),
+    path(
+        RAYCAST_METADATA_PATH,
+        RaycastClientMetadataView.as_view(),
+        name="raycast-client-metadata",
     ),
     re_path(r"^api.+", api_not_found),
     path("authorize_and_redirect/", login_required(authorize_and_redirect)),


### PR DESCRIPTION
## Problem

A community PR ([raycast/extensions#28206](https://github.com/raycast/extensions/pull/28206)) adds OAuth and multi-account support to the PostHog Raycast extension. Since no PostHog-owned OAuth client exists for it, the author self-registered via CIMD (Client ID Metadata Document) by hosting the metadata document on a personal proxy app. That works, but:

- the consent screen shows the **"Unverified application"** warning,
- the client identity — including the allowed redirect URIs — is controlled by a third-party domain (a domain lapse would let someone repoint the redirect URI for every previously-consented user),
- the app is stuck in the unverified rate-limit tier.

## Changes

Adds a PostHog-hosted CIMD document for the Raycast extension at `/api/oauth/raycast/client-metadata`, following the existing `wizard_metadata.py` pattern. The metadata URL is the canonical `client_id`, built from `SITE_URL` so it is correct per region (US, EU, self-hosted) with zero per-region configuration.

Document contents, backed by the [Raycast OAuth docs](https://developers.raycast.com/api-reference/oauth):

- **`redirect_uris`**: `https://raycast.com/redirect?packageName=Extension` is the static redirect URL Raycast's `OAuth.PKCEClient` uses with `RedirectMethod.Web` (the documented default; the same URL is shared by all extensions). `?packageName=posthog` is included defensively to match the community extension's registration. Our redirect URI validation accepts query strings, so the documented slash-based fallback (`https://raycast.com/redirect/extension`) isn't needed.
- **`token_endpoint_auth_method: "none"`** + authorization code grant: Raycast extensions are public clients that cannot hold a secret — Raycast's API only offers a PKCE client, matching our `PKCE_REQUIRED` setting.
- **`com.posthog.scopes`** ceiling: `project:read`, `feature_flag:read`, `cohort:read`, `dashboard:read`, `person:read` — exactly the resource scopes the extension requests. OIDC scopes (`openid`/`profile`/`email`) bypass the ceiling via `ALWAYS_ALLOWED_SCOPES`, so login/userinfo keep working. A compromised or modified extension cannot escalate to write scopes.

Deliberate non-changes:

- **Not** added to `CLIENT_IDS_WITHOUT_REFRESH_TOKEN` (unlike the wizard) — the extension keeps long-lived sessions and refreshes tokens.
- **No** `is_first_party` — the consent screen should stay for store-distributed code. Removing the unverified warning is a post-deploy admin flip (`is_verified=True`) on the auto-registered app in each region.
- No logo for now; `logo_uri` can be added to the document later.

## How did you test this code?

This PR was agent-authored; no manual browser testing was performed. Verification done:

- `pytest posthog/api/oauth/test_raycast_metadata.py` — 7 tests mirroring the wizard metadata suite (region-aware `client_id` via `SITE_URL` override, cache header, content type, 405 on POST), plus an assertion that every declared scope is in `UNPRIVILEGED_SCOPES` (a scope falling out of that set would make CIMD registration reject the document outright).
- `pytest posthog/api/oauth/test_wizard_metadata.py` — no regression.
- Against a running local dev server: curled the endpoint, then fed the live document through the real registration path (`fetch_and_upsert_cimd_application` in a Django shell, with only the HTTP fetch patched since CIMD client IDs are HTTPS-only): the app registers as a public authorization-code client named "Raycast" with the scope ceiling and both redirect URIs intact, and `get_application_by_client_id` (the authorize-time lookup) resolves it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Explored the OAuth provider implementation, the community Raycast PR, and its metadata proxy before settling on cloning the wizard CIMD pattern rather than a manually registered per-region app (CIMD gives one canonical client_id story across US/EU/self-hosted).
- Considered and rejected: generalizing wizard+raycast metadata views into a shared registry (two ~40-line modules don't justify it), `is_first_party` (consent should stay), and omitting the scope ceiling (the wizard omits it, but a store-distributed extension warrants one).
- Rollout after merge: deploy → one authorize per region auto-registers the app → staff set `is_verified=True` in Django admin → share the regional client_ids on the community PR so the personal proxy can be retired.
