### PR TITLE
chore(ci): add MERGE_FREEZE-gated merge-freeze check

### DIFF
--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -20,8 +20,10 @@ jobs:
         timeout-minutes: 5
         steps:
             - name: Check freeze flag
+              env:
+                  MERGE_FREEZE: ${{ vars.MERGE_FREEZE }}
               run: |
-                  if [ "${{ vars.MERGE_FREEZE }}" = "true" ]; then
+                  if [ "$MERGE_FREEZE" = "true" ]; then
                     echo "::error::Merges are frozen (MERGE_FREEZE=true). Try again once the freeze is lifted."
                     exit 1
                   fi

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -1,0 +1,28 @@
+name: Merge freeze
+
+# A lightweight required check (added to the master ruleset) that lets merges be
+# paused operationally: normally a no-op pass, but it fails when the `MERGE_FREEZE`
+# repository variable is `true`, which blocks the merge queue. Triggers on
+# `merge_group` (not `pull_request`), so open PRs are unaffected until they enter
+# the queue and nothing needs to be rebased.
+
+on:
+    merge_group:
+
+permissions:
+    contents: read
+
+jobs:
+    freeze-check:
+        name: Merge freeze check
+        if: github.repository == 'PostHog/posthog'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - name: Check freeze flag
+              run: |
+                  if [ "${{ vars.MERGE_FREEZE }}" = "true" ]; then
+                    echo "::error::Merges are frozen (MERGE_FREEZE=true). Try again once the freeze is lifted."
+                    exit 1
+                  fi
+                  echo "Merges are open."


### PR DESCRIPTION
## Problem

There's no operational switch to pause the merge queue — e.g. to briefly hold merges during a coordinated change — without disabling required checks by hand.

## Changes

Add `merge-freeze.yml`: a tiny `merge_group` check that

- passes (no-op) normally, and
- **fails when the `MERGE_FREEZE` repository variable is `true`**, which blocks the merge queue.

Dormant by default — it does nothing until the variable is set *and* the check is added to the master ruleset's required checks. Triggers on `merge_group` (not `pull_request`), so open PRs are unaffected and nothing needs to be rebased.

## How did you test this code?

I'm an agent (Claude Code). I did not run the workflow. Validation: YAML parse + `actionlint` — both clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by the PR assignee. A variable-gated `merge_group` no-op check; inert until the `MERGE_FREEZE` variable is set and the check is wired into the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
