### PR TITLE
feat(batch-exports): add env var to disable dynamic partitioning

### DIFF
--- a/posthog/settings/batch_exports.py
+++ b/posthog/settings/batch_exports.py
@@ -86,6 +86,11 @@ BATCH_EXPORT_INTERNAL_STAGING_BUCKET: str = os.getenv("BATCH_EXPORT_INTERNAL_STA
 # The number of partitions controls how many files ClickHouse writes to concurrently. Used as the fallback
 # when we have no size estimate to drive a dynamic partition count (e.g. the first ever run of an export).
 BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS: int = get_from_env("BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS", 10, type_cast=int)
+# Kill switch for dynamic partition sizing: when disabled, every run uses the static
+# BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS value.
+BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED: bool = get_from_env(
+    "BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED", True, type_cast=str_to_bool
+)
 # When a previous run's row count is known, the staging partition count is chosen to target roughly this many
 # rows per staging Arrow file (file size ≈ rows × per-team row width), clamped to [MIN, MAX]. Set MIN == MAX to
 # pin the partition count back to a fixed value.

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -321,10 +321,14 @@ async def compute_num_partitions(
     interval (we fall back and let the next run, which has a same-frequency predecessor, re-adjust).
 
     We fall back to the static default when there is no usable estimate (first run, frequency
-    change, or a run with no recorded count) or if the fetch fails.
+    change, or a run with no recorded count), if the fetch fails, or if dynamic partitioning is
+    disabled entirely via BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED.
     """
     logger = LOGGER.bind()
     static_default = settings.BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS
+
+    if not settings.BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED:
+        return static_default
 
     # Without the current interval's bounds we can't match the previous run's frequency, so don't risk
     # sizing off a differently-sized interval (e.g. an unbounded backfill) -> fall back to the default.

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -639,6 +639,21 @@ async def test_compute_num_partitions_db_error_falls_back_to_static_default():
     assert result == 10
 
 
+async def test_compute_num_partitions_disabled_uses_static_default():
+    with (
+        override_settings(
+            BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED=False,
+            BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS=10,
+        ),
+        patch(_FETCHER_PATH, new=AsyncMock(return_value=5_000_000)) as mock_fetch,
+    ):
+        result = await compute_num_partitions(
+            batch_export_id=str(uuid.uuid4()), data_interval_start=_INTERVAL_START, data_interval_end=_INTERVAL_END
+        )
+    assert result == 10
+    mock_fetch.assert_not_called()
+
+
 async def test_compute_num_partitions_without_interval_start_falls_back_to_static_default():
     """An unbounded interval (no start) gives no frequency to match, so we don't risk an estimate."""
     with (


### PR DESCRIPTION
## Problem

Batch exports dynamically size the number of staging partitions based on the previous run's row count (`compute_num_partitions`). If dynamic sizing misbehaves in production, there's currently no way to turn it off without a code change.

## Changes

Adds a `BATCH_EXPORT_DYNAMIC_PARTITIONING_ENABLED` env var (default `true`) as an operational kill switch. When disabled, `compute_num_partitions` returns the static `BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS` value immediately, skipping the previous-run row-count lookup entirely.

## How did you test this code?

Agent-authored; no manual testing. Added `test_compute_num_partitions_disabled_uses_static_default` (asserts the static default is used and the estimate fetcher is never called) and ran all `compute_num_partitions` tests in `products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py` — 15 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code (Claude Code). Ross requested an env var kill switch for dynamic partition sizing in the batch exports internal stage. The check is an early return at the top of `compute_num_partitions`, before the interval checks and DB fetch, following the existing `str_to_bool` settings pattern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*