### PR TITLE
feat(capture): warn when replay payloads are rejected as invalid

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -32,6 +32,7 @@ export const WARNING_TYPE_TO_DESCRIPTION: Record<string, string> = {
     replay_timestamp_invalid: 'Replay event timestamp is invalid',
     replay_timestamp_too_far: 'Replay event timestamp was too far in the future',
     replay_message_too_large: 'Replay data was dropped because it was too large to ingest',
+    replay_message_invalid: 'Replay data was rejected at capture because the payload was invalid',
     set_on_exception: '$set or $set_once is ignored on exception events and should not be sent',
     schema_validation_failed: 'Event rejected due to schema validation failure',
 }
@@ -204,6 +205,24 @@ const WARNING_TYPE_RENDERER = {
                         data-attr="skewed-timestamp-view-recording"
                     />
                 </div>
+            </>
+        )
+    },
+    replay_message_invalid: function Render(warning: IngestionWarning): JSX.Element {
+        const details: {
+            reason: string
+            sessionId?: string
+        } = {
+            reason: warning.details.reason,
+            sessionId: warning.details.sessionId,
+        }
+        return (
+            <>
+                Session replay data was rejected at capture, so the recording is missing data:
+                <ul>
+                    <li>reason: {details.reason}</li>
+                    {details.sessionId ? <li>session_id: {details.sessionId}</li> : null}
+                </ul>
             </>
         )
     },

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -209,18 +209,19 @@ const WARNING_TYPE_RENDERER = {
         )
     },
     replay_message_invalid: function Render(warning: IngestionWarning): JSX.Element {
+        // details are sanitized at ingestion, but never render non-string values
         const details: {
-            reason: string
+            reason?: string
             sessionId?: string
         } = {
-            reason: warning.details.reason,
-            sessionId: warning.details.sessionId,
+            reason: typeof warning.details.reason === 'string' ? warning.details.reason : undefined,
+            sessionId: typeof warning.details.sessionId === 'string' ? warning.details.sessionId : undefined,
         }
         return (
             <>
                 Session replay data was rejected at capture, so the recording is missing data:
                 <ul>
-                    <li>reason: {details.reason}</li>
+                    {details.reason ? <li>reason: {details.reason}</li> : null}
                     {details.sessionId ? <li>session_id: {details.sessionId}</li> : null}
                 </ul>
             </>

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -268,6 +268,29 @@ describe('handleClientIngestionWarningStep', () => {
             expect(result.warnings[0].type).toBe('client_ingestion_warning')
         })
 
+        it.each([
+            ['valid reason', { reason: 'invalid_session_id', sessionId: 'bad!id' }, 'replay_message_invalid'],
+            ['missing reason', { sessionId: 'bad!id' }, 'client_ingestion_warning'],
+            ['non-string reason', { reason: 42 }, 'client_ingestion_warning'],
+        ])('replay_message_invalid override with %s', async (_name, details, expectedType) => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_type: 'replay_message_invalid',
+                        $$client_ingestion_warning_details: details,
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].type).toBe(expectedType)
+        })
+
         it('ignores warning types outside the allowlist', async () => {
             const input: HandleClientIngestionWarningStepInput = {
                 ...baseInput,

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.test.ts
@@ -272,6 +272,7 @@ describe('handleClientIngestionWarningStep', () => {
             ['valid reason', { reason: 'invalid_session_id', sessionId: 'bad!id' }, 'replay_message_invalid'],
             ['missing reason', { sessionId: 'bad!id' }, 'client_ingestion_warning'],
             ['non-string reason', { reason: 42 }, 'client_ingestion_warning'],
+            ['oversized reason', { reason: 'x'.repeat(1000) }, 'client_ingestion_warning'],
         ])('replay_message_invalid override with %s', async (_name, details, expectedType) => {
             const input: HandleClientIngestionWarningStepInput = {
                 ...baseInput,
@@ -289,6 +290,48 @@ describe('handleClientIngestionWarningStep', () => {
 
             expect(result.type).toBe(PipelineResultType.OK)
             expect(result.warnings[0].type).toBe(expectedType)
+        })
+
+        it.each([
+            [
+                'debounces per session when a session id is present',
+                { reason: 'invalid_session_id', sessionId: 'bad!id' },
+                'bad!id',
+                { reason: 'invalid_session_id', sessionId: 'bad!id' },
+            ],
+            [
+                'debounces per reason when the session id is missing',
+                { reason: 'missing_session_id' },
+                'missing_session_id',
+                { reason: 'missing_session_id', sessionId: undefined },
+            ],
+            [
+                'drops non-string session ids and extra client fields',
+                { reason: 'missing_snapshot_data', sessionId: { evil: true }, arbitraryBlob: 'x'.repeat(100000) },
+                'missing_snapshot_data',
+                { reason: 'missing_snapshot_data', sessionId: undefined },
+            ],
+        ])('replay_message_invalid %s', async (_name, details, expectedKey, expectedDetails) => {
+            const input: HandleClientIngestionWarningStepInput = {
+                ...baseInput,
+                event: {
+                    ...baseEvent,
+                    event: '$$client_ingestion_warning',
+                    properties: {
+                        $$client_ingestion_warning_type: 'replay_message_invalid',
+                        $$client_ingestion_warning_details: details,
+                    },
+                },
+            }
+
+            const result = await handleStep(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(result.warnings[0].type).toBe('replay_message_invalid')
+            expect(result.warnings[0].key).toBe(expectedKey)
+            expect(result.warnings[0].alwaysSend).toBeUndefined()
+            expect(result.warnings[0].details).toMatchObject(expectedDetails)
+            expect(result.warnings[0].details.arbitraryBlob).toBeUndefined()
         })
 
         it('ignores warning types outside the allowlist', async () => {

--- a/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
+++ b/nodejs/src/ingestion/event-processing/handle-client-ingestion-warning-step.ts
@@ -44,6 +44,21 @@ const WARNING_TYPE_OVERRIDES = new Map<string, (details: Record<string, unknown>
             }
         },
     ],
+    // emitted by capture when a replay payload fails validation
+    [
+        'replay_message_invalid',
+        (details) => {
+            const reason = boundedString(details.reason)
+            if (reason === null) {
+                return null
+            }
+            const sessionId = boundedString(details.sessionId)
+            return {
+                details: { reason, sessionId: sessionId ?? undefined },
+                debounceKey: sessionId ?? reason,
+            }
+        },
+    ],
 ])
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -210,29 +210,64 @@ pub async fn process_replay_events(
     let mut first_event = events_iter.next().ok_or(CaptureError::EmptyBatch)?;
 
     let uuid = first_event.uuid.unwrap_or_else(uuid_v7);
-    let distinct_id = first_event
-        .extract_distinct_id()
-        .ok_or(CaptureError::MissingDistinctId)?;
+    let Some(distinct_id) = first_event.extract_distinct_id() else {
+        return Err(reject_replay_batch(
+            &sink,
+            context,
+            CaptureError::MissingDistinctId,
+            "missing_distinct_id",
+            None,
+            None,
+            computed_timestamp,
+        )
+        .await);
+    };
+    // no warning here: extract_is_cookieless_mode never returns None
     let is_cookieless_mode = first_event
         .extract_is_cookieless_mode()
         .ok_or(CaptureError::InvalidCookielessMode)?;
 
     // Take metadata fields by ownership (no clone!)
-    let session_id = first_event
-        .properties
-        .session_id
-        .take()
-        .ok_or(CaptureError::MissingSessionId)?;
+    let Some(session_id) = first_event.properties.session_id.take() else {
+        return Err(reject_replay_batch(
+            &sink,
+            context,
+            CaptureError::MissingSessionId,
+            "missing_session_id",
+            None,
+            Some(&distinct_id),
+            computed_timestamp,
+        )
+        .await);
+    };
 
     // Validate session_id
-    let session_id_str = session_id.as_str().ok_or(CaptureError::InvalidSessionId)?;
-    if session_id_str.len() > 70
-        || !session_id_str
+    let session_id_valid = session_id
+        .as_str()
+        .is_some_and(|s| s.len() <= 70 && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+    if !session_id_valid {
+        // include the malformed value so teams can spot integration bugs
+        let raw_session_id: String = session_id
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| session_id.to_string())
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-')
-    {
-        return Err(CaptureError::InvalidSessionId);
+            .take(100)
+            .collect();
+        return Err(reject_replay_batch(
+            &sink,
+            context,
+            CaptureError::InvalidSessionId,
+            "invalid_session_id",
+            Some(&raw_session_id),
+            Some(&distinct_id),
+            computed_timestamp,
+        )
+        .await);
     }
+    let session_id_str = session_id
+        .as_str()
+        .expect("session_id validated as string above");
     Span::current().record("session_id", session_id_str);
 
     // Apply event restrictions
@@ -284,36 +319,29 @@ pub async fn process_replay_events(
     // Start with the first event's snapshot data, then iterate over the rest
     let mut snapshot_items: Vec<Value> = Vec::new();
 
-    // Process first event's snapshot_data
-    let Some(snapshot_data) = first_event.properties.snapshot_data.take() else {
-        return Err(CaptureError::MissingSnapshotData);
-    };
-    match snapshot_data {
-        Value::Array(mut arr) => {
-            snapshot_items.append(&mut arr);
-        }
-        Value::Object(obj) => {
-            snapshot_items.push(Value::Object(obj));
-        }
-        _ => {
-            return Err(CaptureError::MissingSnapshotData);
-        }
-    }
-
-    // Process remaining events' snapshot_data
-    for mut event in events_iter {
-        let Some(snapshot_data) = event.properties.snapshot_data.take() else {
-            return Err(CaptureError::MissingSnapshotData);
-        };
+    // Process first event's snapshot_data, then the remaining events'
+    let first_snapshot_data = first_event.properties.snapshot_data.take();
+    for snapshot_data in std::iter::once(first_snapshot_data)
+        .chain(events_iter.map(|mut event| event.properties.snapshot_data.take()))
+    {
         match snapshot_data {
-            Value::Array(mut arr) => {
+            Some(Value::Array(mut arr)) => {
                 snapshot_items.append(&mut arr);
             }
-            Value::Object(obj) => {
+            Some(Value::Object(obj)) => {
                 snapshot_items.push(Value::Object(obj));
             }
             _ => {
-                return Err(CaptureError::MissingSnapshotData);
+                return Err(reject_replay_batch(
+                    &sink,
+                    context,
+                    CaptureError::MissingSnapshotData,
+                    "missing_snapshot_data",
+                    Some(session_id_str),
+                    Some(&distinct_id),
+                    computed_timestamp,
+                )
+                .await);
             }
         }
     }
@@ -441,22 +469,76 @@ fn replay_message_too_large_warning(
     let message = format!(
         "Replay data for session {session_id} was dropped because it was too large to ingest ({snapshot_bytes} bytes, {snapshot_items_count} snapshot items)"
     );
-    let lib = bounded_warning_lib(snapshot_library);
+    let details = json!({
+        "timestamp": timestamp.to_rfc3339(),
+        "replayRecord": { "session_id": session_id },
+        "snapshotBytes": snapshot_bytes,
+        "snapshotItemsCount": snapshot_items_count,
+        "lib": bounded_warning_lib(snapshot_library),
+    });
+    client_ingestion_warning_event(
+        context,
+        distinct_id,
+        Some(session_id),
+        timestamp,
+        "replay_message_too_large",
+        message,
+        details,
+    )
+}
+
+/// Flag the rejected payload with a `replay_message_invalid` warning (best
+/// effort, since the SDK drops the 400 silently), then hand back the error.
+#[allow(clippy::too_many_arguments)]
+async fn reject_replay_batch(
+    sink: &Arc<dyn sinks::Event + Send + Sync>,
+    context: &ProcessingContext,
+    err: CaptureError,
+    reason: &'static str,
+    session_id: Option<&str>,
+    distinct_id: Option<&str>,
+    timestamp: chrono::DateTime<chrono::Utc>,
+) -> CaptureError {
+    counter!("capture_replay_message_invalid_total", "reason" => reason).increment(1);
+    let message = format!("Replay data was rejected at capture: {reason}");
+    let details = json!({
+        "reason": reason,
+        "sessionId": session_id,
+    });
+    let warning = client_ingestion_warning_event(
+        context,
+        distinct_id.unwrap_or("unknown").to_string(),
+        None,
+        timestamp,
+        "replay_message_invalid",
+        message,
+        details,
+    );
+    if let Err(warning_err) = sink.send(warning).await {
+        error!("failed to send replay_message_invalid ingestion warning: {warning_err:?}");
+    }
+    err
+}
+
+/// Build a `$$client_ingestion_warning` event. Ingestion resolves the team
+/// from the token and persists it as an ingestion warning of `warning_type`.
+fn client_ingestion_warning_event(
+    context: &ProcessingContext,
+    distinct_id: String,
+    session_id: Option<&str>,
+    timestamp: chrono::DateTime<chrono::Utc>,
+    warning_type: &str,
+    message: String,
+    details: Value,
+) -> ProcessedEvent {
     let data = json!({
         "event": "$$client_ingestion_warning",
         "distinct_id": &distinct_id,
         "properties": {
             "$$client_ingestion_warning_message": message,
-            "$$client_ingestion_warning_type": "replay_message_too_large",
-            "$$client_ingestion_warning_details": {
-                "timestamp": timestamp.to_rfc3339(),
-                "replayRecord": { "session_id": session_id },
-                "snapshotBytes": snapshot_bytes,
-                "snapshotItemsCount": snapshot_items_count,
-                "lib": lib.as_str(),
-            },
+            "$$client_ingestion_warning_type": warning_type,
+            "$$client_ingestion_warning_details": details,
             "$session_id": session_id,
-            "$lib": lib.as_str(),
         }
     })
     .to_string();
@@ -464,7 +546,7 @@ fn replay_message_too_large_warning(
     ProcessedEvent {
         metadata: ProcessedEventMetadata {
             data_type: DataType::ClientIngestionWarning,
-            session_id: Some(session_id.to_string()),
+            session_id: session_id.map(|s| s.to_string()),
             computed_timestamp: Some(timestamp),
             event_name: "$$client_ingestion_warning".to_string(),
             force_overflow: false,
@@ -477,7 +559,7 @@ fn replay_message_too_large_warning(
         event: CapturedEvent {
             uuid: uuid_v7(),
             distinct_id,
-            session_id: Some(session_id.to_string()),
+            session_id: session_id.map(|s| s.to_string()),
             ip: context.client_ip.clone(),
             data,
             now: context
@@ -1314,6 +1396,122 @@ mod tests {
             .is_some_and(|m| m.contains("test-session-123")));
     }
 
+    // ============ rejected payload flagging tests ============
+
+    async fn run_rejected_payload_case(
+        recording_json: Value,
+    ) -> (Result<(), CaptureError>, Vec<ProcessedEvent>) {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+        let recording: RawRecording = serde_json::from_value(recording_json).unwrap();
+        let context = create_test_context();
+        let result = process_replay_events(sink, None, None, vec![recording], &context).await;
+        let captured = events_captured.lock().unwrap().clone();
+        (result, captured)
+    }
+
+    fn assert_invalid_warning(captured: &[ProcessedEvent], reason: &str) -> Value {
+        assert_eq!(captured.len(), 1, "exactly one warning event must be sent");
+        let warning = &captured[0];
+        assert_eq!(warning.metadata.data_type, DataType::ClientIngestionWarning);
+        let data: Value = serde_json::from_str(&warning.event.data).unwrap();
+        let props = data["properties"].clone();
+        assert_eq!(
+            props["$$client_ingestion_warning_type"],
+            "replay_message_invalid"
+        );
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["reason"],
+            reason
+        );
+        props
+    }
+
+    #[tokio::test]
+    async fn test_missing_session_id_emits_invalid_warning() {
+        let (result, captured) = run_rejected_payload_case(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": { "$snapshot_data": [{"type": 1}] }
+        }))
+        .await;
+
+        assert!(matches!(result, Err(CaptureError::MissingSessionId)));
+        assert_invalid_warning(&captured, "missing_session_id");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_session_id_emits_warning_with_offending_value() {
+        let (result, captured) = run_rejected_payload_case(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": {
+                "$session_id": "not!a!valid!session!id",
+                "$snapshot_data": [{"type": 1}]
+            }
+        }))
+        .await;
+
+        assert!(matches!(result, Err(CaptureError::InvalidSessionId)));
+        let props = assert_invalid_warning(&captured, "invalid_session_id");
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["sessionId"],
+            "not!a!valid!session!id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_snapshot_data_emits_invalid_warning() {
+        let (result, captured) = run_rejected_payload_case(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": { "$session_id": "test-session-123" }
+        }))
+        .await;
+
+        assert!(matches!(result, Err(CaptureError::MissingSnapshotData)));
+        let props = assert_invalid_warning(&captured, "missing_snapshot_data");
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["sessionId"],
+            "test-session-123"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_distinct_id_emits_invalid_warning_with_fallback_id() {
+        let (result, captured) = run_rejected_payload_case(json!({
+            "event": "$snapshot",
+            "properties": {
+                "$session_id": "test-session-123",
+                "$snapshot_data": [{"type": 1}]
+            }
+        }))
+        .await;
+
+        assert!(matches!(result, Err(CaptureError::MissingDistinctId)));
+        assert_invalid_warning(&captured, "missing_distinct_id");
+        assert_eq!(captured[0].event.distinct_id, "unknown");
+    }
+
+    #[tokio::test]
+    async fn test_valid_payload_emits_no_invalid_warning() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+        let context = create_test_context();
+
+        let result =
+            process_replay_events(sink, None, None, vec![create_test_recording()], &context).await;
+
+        assert!(result.is_ok());
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].metadata.data_type, DataType::SnapshotMain);
+    }
+
     #[tokio::test]
     async fn test_oversized_snapshot_warning_caps_client_lib() {
         let events_captured = Arc::new(Mutex::new(Vec::new()));
@@ -1350,11 +1548,6 @@ mod tests {
                 .map(|s| s.chars().count()),
             Some(200),
             "client lib must be capped in the warning details"
-        );
-        assert_eq!(
-            props["$lib"].as_str().map(|s| s.chars().count()),
-            Some(200),
-            "top-level $lib must be capped too"
         );
     }
 

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -213,6 +213,7 @@ pub async fn process_replay_events(
     let Some(distinct_id) = first_event.extract_distinct_id() else {
         return Err(reject_replay_batch(
             &sink,
+            restriction_service.as_ref(),
             context,
             CaptureError::MissingDistinctId,
             "missing_distinct_id",
@@ -231,6 +232,7 @@ pub async fn process_replay_events(
     let Some(session_id) = first_event.properties.session_id.take() else {
         return Err(reject_replay_batch(
             &sink,
+            restriction_service.as_ref(),
             context,
             CaptureError::MissingSessionId,
             "missing_session_id",
@@ -256,6 +258,7 @@ pub async fn process_replay_events(
         };
         return Err(reject_replay_batch(
             &sink,
+            restriction_service.as_ref(),
             context,
             CaptureError::InvalidSessionId,
             "invalid_session_id",
@@ -334,6 +337,7 @@ pub async fn process_replay_events(
             _ => {
                 return Err(reject_replay_batch(
                     &sink,
+                    restriction_service.as_ref(),
                     context,
                     CaptureError::MissingSnapshotData,
                     "missing_snapshot_data",
@@ -488,11 +492,14 @@ fn replay_message_too_large_warning(
     )
 }
 
-/// Flag the rejected payload with a `replay_message_invalid` warning (best
-/// effort, since the SDK drops the 400 silently), then hand back the error.
+/// Flag the rejected payload with a `replay_message_invalid` warning (best effort,
+/// since the SDK drops the 400 silently), then hand back the error. A token operators
+/// have marked for drop stays silent, so its invalid payloads can't force a warning the
+/// valid path would have shed.
 #[allow(clippy::too_many_arguments)]
 async fn reject_replay_batch(
     sink: &Arc<dyn sinks::Event + Send + Sync>,
+    restriction_service: Option<&EventRestrictionService>,
     context: &ProcessingContext,
     err: CaptureError,
     reason: &'static str,
@@ -501,6 +508,24 @@ async fn reject_replay_batch(
     timestamp: chrono::DateTime<chrono::Utc>,
 ) -> CaptureError {
     counter!("capture_replay_message_invalid_total", "reason" => reason).increment(1);
+
+    if let Some(service) = restriction_service {
+        let event_ctx = RestrictionEventContext {
+            distinct_id,
+            session_id,
+            event_name: Some("$snapshot_items"),
+            event_uuid: None,
+            now_ts: context.now.timestamp(),
+        };
+        if service
+            .get_restrictions(&context.token, &event_ctx, Pipeline::SessionRecordings)
+            .await
+            .should_drop()
+        {
+            return err;
+        }
+    }
+
     let message = format!("Replay data was rejected at capture: {reason}");
     let details = json!({
         "reason": reason,
@@ -795,6 +820,48 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(events_captured.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_drop_event_restriction_silences_invalid_payload_warning() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+
+        let service = EventRestrictionService::new(
+            vec![Pipeline::SessionRecordings],
+            Duration::from_secs(300),
+        );
+        let mut manager = RestrictionManager::new();
+        manager.insert_restrictions(
+            Pipeline::SessionRecordings,
+            "test_token",
+            vec![Restriction {
+                restriction_type: RestrictionType::DropEvent,
+                scope: RestrictionScope::AllEvents,
+                args: None,
+            }],
+        );
+        service.update(manager).await;
+
+        // invalid payload (missing session id) from a load-shed token
+        let recording: RawRecording = serde_json::from_value(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": { "$snapshot_data": [{"type": 1}] }
+        }))
+        .unwrap();
+        let context = create_test_context();
+
+        let result =
+            process_replay_events(sink, Some(service), None, vec![recording], &context).await;
+
+        assert!(matches!(result, Err(CaptureError::MissingSessionId)));
+        assert!(
+            events_captured.lock().unwrap().is_empty(),
+            "a dropped token must not force a warning produce"
+        );
     }
 
     #[tokio::test]

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -484,7 +484,6 @@ fn replay_message_too_large_warning(
         context,
         distinct_id,
         Some(session_id),
-        Some(snapshot_library),
         timestamp,
         "replay_message_too_large",
         message,
@@ -535,7 +534,6 @@ async fn reject_replay_batch(
         context,
         distinct_id.unwrap_or("unknown").to_string(),
         None,
-        None,
         timestamp,
         "replay_message_invalid",
         message,
@@ -549,30 +547,24 @@ async fn reject_replay_batch(
 
 /// Build a `$$client_ingestion_warning` event. Ingestion resolves the team
 /// from the token and persists it as an ingestion warning of `warning_type`.
-#[allow(clippy::too_many_arguments)]
 fn client_ingestion_warning_event(
     context: &ProcessingContext,
     distinct_id: String,
     session_id: Option<&str>,
-    lib: Option<&str>,
     timestamp: chrono::DateTime<chrono::Utc>,
     warning_type: &str,
     message: String,
     details: Value,
 ) -> ProcessedEvent {
-    let mut properties = json!({
-        "$$client_ingestion_warning_message": message,
-        "$$client_ingestion_warning_type": warning_type,
-        "$$client_ingestion_warning_details": details,
-        "$session_id": session_id,
-    });
-    if let Some(lib) = lib {
-        properties["$lib"] = json!(lib);
-    }
     let data = json!({
         "event": "$$client_ingestion_warning",
         "distinct_id": &distinct_id,
-        "properties": properties,
+        "properties": {
+            "$$client_ingestion_warning_message": message,
+            "$$client_ingestion_warning_type": warning_type,
+            "$$client_ingestion_warning_details": details,
+            "$session_id": session_id,
+        },
     })
     .to_string();
 
@@ -1469,10 +1461,8 @@ mod tests {
         assert!(props["$$client_ingestion_warning_message"]
             .as_str()
             .is_some_and(|m| m.contains("test-session-123")));
-        assert!(
-            props["$lib"].is_string(),
-            "warning must keep the $lib property for SDK attribution"
-        );
+        // lib is carried in the warning details (the event itself is never stored)
+        assert!(props["$$client_ingestion_warning_details"]["lib"].is_string());
     }
 
     // ============ rejected payload flagging tests ============

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -248,8 +248,7 @@ pub async fn process_replay_events(
         .as_str()
         .is_some_and(|s| s.len() <= 70 && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
     if !session_id_valid {
-        // Include the malformed value so teams can spot integration bugs, but
-        // never serialize engineered objects/arrays of arbitrary size.
+        // surface the malformed value for debugging, but never serialize engineered objects/arrays
         let raw_session_id: String = match &session_id {
             Value::String(s) => s.chars().take(100).collect(),
             Value::Object(_) => "(object)".to_string(),
@@ -322,7 +321,6 @@ pub async fn process_replay_events(
     // Start with the first event's snapshot data, then iterate over the rest
     let mut snapshot_items: Vec<Value> = Vec::new();
 
-    // Process first event's snapshot_data, then the remaining events'
     let first_snapshot_data = first_event.properties.snapshot_data.take();
     for snapshot_data in std::iter::once(first_snapshot_data)
         .chain(events_iter.map(|mut event| event.properties.snapshot_data.take()))
@@ -491,10 +489,8 @@ fn replay_message_too_large_warning(
     )
 }
 
-/// Flag the rejected payload with a `replay_message_invalid` warning (best effort,
-/// since the SDK drops the 400 silently), then hand back the error. A token operators
-/// have marked for drop stays silent, so its invalid payloads can't force a warning the
-/// valid path would have shed.
+/// Warn that the payload was rejected (best effort, since the SDK drops the 400 silently),
+/// then return the error. Drop-listed tokens stay silent, matching the valid path's load-shedding.
 #[allow(clippy::too_many_arguments)]
 async fn reject_replay_batch(
     sink: &Arc<dyn sinks::Event + Send + Sync>,
@@ -1461,7 +1457,6 @@ mod tests {
         assert!(props["$$client_ingestion_warning_message"]
             .as_str()
             .is_some_and(|m| m.contains("test-session-123")));
-        // lib is carried in the warning details (the event itself is never stored)
         assert!(props["$$client_ingestion_warning_details"]["lib"].is_string());
     }
 

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -246,14 +246,14 @@ pub async fn process_replay_events(
         .as_str()
         .is_some_and(|s| s.len() <= 70 && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
     if !session_id_valid {
-        // include the malformed value so teams can spot integration bugs
-        let raw_session_id: String = session_id
-            .as_str()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| session_id.to_string())
-            .chars()
-            .take(100)
-            .collect();
+        // Include the malformed value so teams can spot integration bugs, but
+        // never serialize engineered objects/arrays of arbitrary size.
+        let raw_session_id: String = match &session_id {
+            Value::String(s) => s.chars().take(100).collect(),
+            Value::Object(_) => "(object)".to_string(),
+            Value::Array(_) => "(array)".to_string(),
+            other => other.to_string().chars().take(100).collect(),
+        };
         return Err(reject_replay_batch(
             &sink,
             context,
@@ -480,6 +480,7 @@ fn replay_message_too_large_warning(
         context,
         distinct_id,
         Some(session_id),
+        Some(snapshot_library),
         timestamp,
         "replay_message_too_large",
         message,
@@ -509,6 +510,7 @@ async fn reject_replay_batch(
         context,
         distinct_id.unwrap_or("unknown").to_string(),
         None,
+        None,
         timestamp,
         "replay_message_invalid",
         message,
@@ -522,24 +524,30 @@ async fn reject_replay_batch(
 
 /// Build a `$$client_ingestion_warning` event. Ingestion resolves the team
 /// from the token and persists it as an ingestion warning of `warning_type`.
+#[allow(clippy::too_many_arguments)]
 fn client_ingestion_warning_event(
     context: &ProcessingContext,
     distinct_id: String,
     session_id: Option<&str>,
+    lib: Option<&str>,
     timestamp: chrono::DateTime<chrono::Utc>,
     warning_type: &str,
     message: String,
     details: Value,
 ) -> ProcessedEvent {
+    let mut properties = json!({
+        "$$client_ingestion_warning_message": message,
+        "$$client_ingestion_warning_type": warning_type,
+        "$$client_ingestion_warning_details": details,
+        "$session_id": session_id,
+    });
+    if let Some(lib) = lib {
+        properties["$lib"] = json!(lib);
+    }
     let data = json!({
         "event": "$$client_ingestion_warning",
         "distinct_id": &distinct_id,
-        "properties": {
-            "$$client_ingestion_warning_message": message,
-            "$$client_ingestion_warning_type": warning_type,
-            "$$client_ingestion_warning_details": details,
-            "$session_id": session_id,
-        }
+        "properties": properties,
     })
     .to_string();
 
@@ -1394,6 +1402,10 @@ mod tests {
         assert!(props["$$client_ingestion_warning_message"]
             .as_str()
             .is_some_and(|m| m.contains("test-session-123")));
+        assert!(
+            props["$lib"].is_string(),
+            "warning must keep the $lib property for SDK attribution"
+        );
     }
 
     // ============ rejected payload flagging tests ============
@@ -1459,6 +1471,46 @@ mod tests {
         assert_eq!(
             props["$$client_ingestion_warning_details"]["sessionId"],
             "not!a!valid!session!id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oversized_invalid_session_id_is_truncated_in_warning() {
+        let (result, captured) = run_rejected_payload_case(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": {
+                "$session_id": "!".repeat(5000),
+                "$snapshot_data": [{"type": 1}]
+            }
+        }))
+        .await;
+
+        assert!(matches!(result, Err(CaptureError::InvalidSessionId)));
+        let props = assert_invalid_warning(&captured, "invalid_session_id");
+        let session_id = props["$$client_ingestion_warning_details"]["sessionId"]
+            .as_str()
+            .unwrap();
+        assert_eq!(session_id.chars().count(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_non_string_invalid_session_id_is_not_serialized_into_warning() {
+        let (result, captured) = run_rejected_payload_case(json!({
+            "event": "$snapshot",
+            "distinct_id": "test_user",
+            "properties": {
+                "$session_id": { "engineered": "x".repeat(5000) },
+                "$snapshot_data": [{"type": 1}]
+            }
+        }))
+        .await;
+
+        assert!(matches!(result, Err(CaptureError::InvalidSessionId)));
+        let props = assert_invalid_warning(&captured, "invalid_session_id");
+        assert_eq!(
+            props["$$client_ingestion_warning_details"]["sessionId"],
+            "(object)"
         );
     }
 


### PR DESCRIPTION
## Problem

Validation failures on the replay capture endpoint (missing or malformed session id, missing snapshot data, missing distinct id) return 400, which posthog-js drops without retry and without any team-visible trace. An integration bug like custom session ids in the wrong format silently loses every recording, and only a support escalation surfaces it. This extends the mechanism introduced in #63270 to the validation reject paths.

Part of a stack: #63270 (base) ← **this PR** ← #63283 ← #63284.

## Changes

- **capture**: each replay validation reject now emits a best-effort `$$client_ingestion_warning` with a `replay_message_invalid` type, the rejection reason, and the offending session id (truncated) before returning 400 as before. Adds a `capture_replay_message_invalid_total` counter labeled by reason. `InvalidCookielessMode` is deliberately excluded: that error path is unreachable (`extract_is_cookieless_mode` never returns `None`).
- **capture**: the warning builders are refactored into a shared `client_ingestion_warning_event` helper. The SDK library is carried inside the warning details; the synthetic `$$client_ingestion_warning` event is denied by the analytics pipeline and only ever converted to an ingestion warning, so a top-level `$lib` property would never be read (this is why greptile's note about dropping `$lib` does not apply). Malformed session ids are truncated and non-string session id values are never serialized into the warning details, and the reject paths consult event restrictions so a token operators have marked for drop (load-shedding) stays fully silent instead of forcing a warning produce.
- **plugin-server**: `replay_message_invalid` added to the allowlisted overrides; like the other typed warnings it rebuilds bounded details (`reason`, optional `sessionId`) and debounces per session, or per reason when no session id is present.
- **frontend**: description and renderer for the new warning type in the ingestion warnings view.

## How did you test this code?

Authored by an agent — automated tests only, no manual testing:

- New capture unit tests per rejection reason assert the warning payload and that the original error still propagates (`cargo test -p capture --lib events::recordings`, 27 passed)
- Extended jest tests for the warning step override validation (16 passed)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code as part of a Graphite stack on #63270, following an investigation into silently-dropped replay data.
- Reasons are emitted as one warning type with a `reason` detail rather than one type per reason, to keep the ingestion warnings UI manageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


