### PR TITLE
feat(replay): warn when per-session rate limiting drops recording data

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -210,29 +210,30 @@ const WARNING_TYPE_RENDERER = {
         )
     },
     replay_session_rate_limited: function Render(warning: IngestionWarning): JSX.Element {
+        // details are written by the recording consumer, but never render non-string values
         const details: {
-            sessionId: string
+            sessionId?: string
             timestamp?: string
         } = {
-            sessionId: warning.details.sessionId,
-            timestamp: warning.details.timestamp,
+            sessionId: typeof warning.details.sessionId === 'string' ? warning.details.sessionId : undefined,
+            timestamp: typeof warning.details.timestamp === 'string' ? warning.details.timestamp : undefined,
         }
         return (
             <>
                 Session replay data was dropped because the session sent too many events, so the recording is missing
                 data:
-                <ul>
-                    <li>session_id: {details.sessionId}</li>
-                </ul>
-                <div className="max-w-30 mt-2">
-                    <ViewRecordingButton
-                        sessionId={details.sessionId}
-                        timestamp={details.timestamp}
-                        type="primary"
-                        size="xsmall"
-                        data-attr="session-rate-limited-view-recording"
-                    />
-                </div>
+                <ul>{details.sessionId ? <li>session_id: {details.sessionId}</li> : null}</ul>
+                {details.sessionId ? (
+                    <div className="max-w-30 mt-2">
+                        <ViewRecordingButton
+                            sessionId={details.sessionId}
+                            timestamp={details.timestamp}
+                            type="primary"
+                            size="xsmall"
+                            data-attr="session-rate-limited-view-recording"
+                        />
+                    </div>
+                ) : null}
             </>
         )
     },

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -33,6 +33,7 @@ export const WARNING_TYPE_TO_DESCRIPTION: Record<string, string> = {
     replay_timestamp_too_far: 'Replay event timestamp was too far in the future',
     replay_message_too_large: 'Replay data was dropped because it was too large to ingest',
     replay_message_invalid: 'Replay data was rejected at capture because the payload was invalid',
+    replay_session_rate_limited: 'Replay data was dropped because a session exceeded the event rate limit',
     set_on_exception: '$set or $set_once is ignored on exception events and should not be sent',
     schema_validation_failed: 'Event rejected due to schema validation failure',
 }
@@ -203,6 +204,33 @@ const WARNING_TYPE_RENDERER = {
                         type="primary"
                         size="xsmall"
                         data-attr="skewed-timestamp-view-recording"
+                    />
+                </div>
+            </>
+        )
+    },
+    replay_session_rate_limited: function Render(warning: IngestionWarning): JSX.Element {
+        const details: {
+            sessionId: string
+            timestamp?: string
+        } = {
+            sessionId: warning.details.sessionId,
+            timestamp: warning.details.timestamp,
+        }
+        return (
+            <>
+                Session replay data was dropped because the session sent too many events, so the recording is missing
+                data:
+                <ul>
+                    <li>session_id: {details.sessionId}</li>
+                </ul>
+                <div className="max-w-30 mt-2">
+                    <ViewRecordingButton
+                        sessionId={details.sessionId}
+                        timestamp={details.timestamp}
+                        type="primary"
+                        size="xsmall"
+                        data-attr="session-rate-limited-view-recording"
                     />
                 </div>
             </>

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -222,6 +222,7 @@ export class SessionRecordingIngester {
             sessionFilter,
             keyStore: this.keyStore,
             encryptor: this.encryptor,
+            warningsOutput: outputs,
         })
     }
 

--- a/nodejs/src/session-recording/sessions/session-batch-manager.test.ts
+++ b/nodejs/src/session-recording/sessions/session-batch-manager.test.ts
@@ -117,7 +117,8 @@ describe('SessionBatchManager', () => {
             mockSessionFilter,
             mockKeyStore,
             mockEncryptor,
-            Number.MAX_SAFE_INTEGER
+            Number.MAX_SAFE_INTEGER,
+            undefined
         )
 
         const secondBatch = manager.getCurrentBatch()
@@ -212,7 +213,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                500
+                500,
+                undefined
             )
         })
 
@@ -244,7 +246,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                250
+                250,
+                undefined
             )
         })
 
@@ -274,7 +277,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                0
+                0,
+                undefined
             )
         })
 
@@ -304,7 +308,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                Number.MAX_SAFE_INTEGER
+                Number.MAX_SAFE_INTEGER,
+                undefined
             )
         })
     })

--- a/nodejs/src/session-recording/sessions/session-batch-manager.ts
+++ b/nodejs/src/session-recording/sessions/session-batch-manager.ts
@@ -1,3 +1,5 @@
+import { IngestionWarningsOutput } from '../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../ingestion/outputs/ingestion-outputs'
 import { SessionFeatureStore } from '../../session-replay/shared/features/session-feature-store'
 import { SessionMetadataStore } from '../../session-replay/shared/metadata/session-metadata-store'
 import { KeyStore, RecordingEncryptor } from '../../session-replay/shared/types'
@@ -34,6 +36,8 @@ export interface SessionBatchManagerConfig {
     keyStore: KeyStore
     /** Encryptor for session recording data */
     encryptor: RecordingEncryptor
+    /** Output for team-visible ingestion warnings */
+    warningsOutput?: IngestionOutputs<IngestionWarningsOutput>
 }
 
 /**
@@ -85,6 +89,7 @@ export class SessionBatchManager {
     private readonly sessionFilter: SessionFilter
     private readonly keyStore: KeyStore
     private readonly encryptor: RecordingEncryptor
+    private readonly warningsOutput?: IngestionOutputs<IngestionWarningsOutput>
 
     constructor(config: SessionBatchManagerConfig) {
         this.maxBatchSizeBytes = config.maxBatchSizeBytes
@@ -99,6 +104,7 @@ export class SessionBatchManager {
         this.sessionFilter = config.sessionFilter
         this.keyStore = config.keyStore
         this.encryptor = config.encryptor
+        this.warningsOutput = config.warningsOutput
 
         this.currentBatch = new SessionBatchRecorder(
             this.offsetManager,
@@ -110,7 +116,8 @@ export class SessionBatchManager {
             this.sessionFilter,
             this.keyStore,
             this.encryptor,
-            this.maxEventsPerSessionPerBatch
+            this.maxEventsPerSessionPerBatch,
+            this.warningsOutput
         )
         this.lastFlushTime = Date.now()
     }
@@ -138,7 +145,8 @@ export class SessionBatchManager {
             this.sessionFilter,
             this.keyStore,
             this.encryptor,
-            this.maxEventsPerSessionPerBatch
+            this.maxEventsPerSessionPerBatch,
+            this.warningsOutput
         )
         this.lastFlushTime = Date.now()
     }

--- a/nodejs/src/session-recording/sessions/session-batch-recorder.test.ts
+++ b/nodejs/src/session-recording/sessions/session-batch-recorder.test.ts
@@ -1,6 +1,8 @@
 import { DateTime } from 'luxon'
 import { validate as uuidValidate } from 'uuid'
 
+import { IngestionWarningsOutput } from '../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../ingestion/outputs/ingestion-outputs'
 import { SessionFeatureStore } from '../../session-replay/shared/features/session-feature-store'
 import { SessionMetadataStore } from '../../session-replay/shared/metadata/session-metadata-store'
 import { createMockEncryptor, createMockKeyStore } from '../../session-replay/shared/test-helpers'
@@ -1745,6 +1747,39 @@ describe('SessionBatchRecorder', () => {
             await recorder.flush()
             const writtenData = captureWrittenData(mockWriter.writeSession as jest.Mock)
             expect(writtenData).toHaveLength(0)
+        })
+
+        it('should emit an ingestion warning when rate limited', async () => {
+            const mockWarningsOutput = {
+                queueMessages: jest.fn().mockResolvedValue(undefined),
+            } as unknown as IngestionOutputs<IngestionWarningsOutput>
+
+            recorder = new SessionBatchRecorder(
+                mockOffsetManager,
+                mockStorage,
+                mockMetadataStore,
+                mockConsoleLogStore,
+                mockFeatureStore,
+                mockSessionTracker,
+                mockSessionFilter,
+                mockKeyStore,
+                mockEncryptor,
+                1,
+                mockWarningsOutput
+            )
+
+            // unique id so the warning debouncer can't suppress this test
+            const sessionId = `rate-limit-warning-${Date.now()}`
+            await recorder.record(createMessage(sessionId, [{ type: EventType.Meta, timestamp: 1000, data: {} }]))
+            await recorder.record(createMessage(sessionId, [{ type: EventType.Meta, timestamp: 2000, data: {} }]))
+
+            expect(mockWarningsOutput.queueMessages).toHaveBeenCalledTimes(1)
+            const [output, messages] = (mockWarningsOutput.queueMessages as jest.Mock).mock.calls[0]
+            expect(output).toBe('ingestion_warnings')
+            const warning = parseJSON(messages[0].value.toString())
+            expect(warning.team_id).toBe(1)
+            expect(warning.type).toBe('replay_session_rate_limited')
+            expect(parseJSON(warning.details).sessionId).toBe(sessionId)
         })
 
         it('should delete session recorders when rate limited', async () => {

--- a/nodejs/src/session-recording/sessions/session-batch-recorder.ts
+++ b/nodejs/src/session-recording/sessions/session-batch-recorder.ts
@@ -1,11 +1,16 @@
 import { v7 as uuidv7 } from 'uuid'
 
+import { emitIngestionWarning } from '../../ingestion/common/ingestion-warnings'
+import { IngestionWarningsOutput } from '../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../ingestion/outputs/ingestion-outputs'
 import { SessionFeatureBlock, SessionFeatureStore } from '../../session-replay/shared/features/session-feature-store'
 import { SessionBlockMetadata } from '../../session-replay/shared/metadata/session-block-metadata'
 import { SessionMetadataStore } from '../../session-replay/shared/metadata/session-metadata-store'
 import { KeyStore, RecordingEncryptor, SessionKey } from '../../session-replay/shared/types'
+import { TimestampFormat } from '../../types'
 import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
+import { castTimestampOrNow } from '../../utils/utils'
 import { KafkaOffsetManager } from '../kafka/offset-manager'
 import { MessageWithTeam } from '../teams/types'
 import { SessionBatchMetrics } from './metrics'
@@ -81,7 +86,8 @@ export class SessionBatchRecorder {
         private readonly sessionFilter: SessionFilter,
         private readonly keyStore: KeyStore,
         private readonly encryptor: RecordingEncryptor,
-        maxEventsPerSessionPerBatch: number = Number.MAX_SAFE_INTEGER
+        maxEventsPerSessionPerBatch: number = Number.MAX_SAFE_INTEGER,
+        private readonly warningsOutput?: IngestionOutputs<IngestionWarningsOutput>
     ) {
         this.batchId = uuidv7()
         this.rateLimiter = new SessionRateLimiter(maxEventsPerSessionPerBatch)
@@ -134,13 +140,29 @@ export class SessionBatchRecorder {
         const isEventAllowed = this.rateLimiter.handleMessage(teamSessionKey, partition, message.message)
 
         if (!isEventAllowed) {
+            const eventCount = this.rateLimiter.getEventCount(teamSessionKey)
             logger.debug('🔁', 'session_batch_recorder_event_rate_limited', {
                 partition,
                 sessionId,
                 teamId,
-                eventCount: this.rateLimiter.getEventCount(teamSessionKey),
+                eventCount,
                 batchId: this.batchId,
             })
+
+            // dropping recording data is otherwise invisible to the team
+            if (this.warningsOutput) {
+                void emitIngestionWarning(
+                    this.warningsOutput,
+                    teamId,
+                    'replay_session_rate_limited',
+                    {
+                        sessionId,
+                        eventCount,
+                        timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
+                    },
+                    { key: sessionId }
+                )
+            }
 
             if (!this.partitionSessions.has(partition)) {
                 return this.ignoreMessage(message)


### PR DESCRIPTION
## Problem

When a session exceeds the per-batch event limit (`SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH`), the batch recorder drops the message and also evicts the session's already-buffered events from the current batch. The recording ends up with holes, and the only traces are a debug log and a worker metric — nothing a team can see.

Part of a stack: #63270 ← #63282 ← **this PR** ← #63284.

## Changes

- The session recording v2 consumer's existing warnings output is threaded through `SessionBatchManager` into `SessionBatchRecorder` (optional constructor param, so tests and other callers are unaffected).
- On a rate-limit drop the recorder emits a `replay_session_rate_limited` ingestion warning with the session id, event count, and timestamp, debounced per session via the standard warning limiter.
- The ingestion warnings UI gets a description and renderer for the new type, including a view-recording button.

## How did you test this code?

Authored by an agent — automated tests only, no manual testing:

- New jest test asserts the warning payload (team id, type, session id) and single emission on rate limit (`session-batch-recorder.test.ts`, 55 passed)
- `tsc --noEmit` clean for the nodejs package

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code as part of a Graphite stack on #63270/#63282.
- The warning is emitted directly from the batch recorder (server-side) rather than via the $$client_ingestion_warning event path, since the team is already resolved at that point; debounce key is the session id so a flood of rate-limited messages produces one warning per session per debounce window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
