### PR TITLE
feat(replay): surface replay ingestion warnings in the player

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -78,6 +78,7 @@ function posthogCORSResponse(req: RestRequest, res: ResponseComposition, ctx: Re
 export const defaultMocks: Mocks = {
     get: {
         '/api/projects/:team_id/my_notifications/': EMPTY_PAGINATED_RESPONSE,
+        '/api/projects/:team_id/ingestion_warnings': { results: [] },
         '/api/projects/:team_id/actions/': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/annotations/': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/event_definitions/': EMPTY_PAGINATED_RESPONSE,

--- a/frontend/src/scenes/session-recordings/player/PlayerIngestionWarningsBanner.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerIngestionWarningsBanner.tsx
@@ -1,0 +1,30 @@
+import { useValues } from 'kea'
+
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
+
+import { playerIngestionWarningsLogic } from './playerIngestionWarningsLogic'
+import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
+
+export function PlayerIngestionWarningsBanner(): JSX.Element | null {
+    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { droppedDataPhrases } = useValues(
+        playerIngestionWarningsLogic({ sessionRecordingId: logicProps.sessionRecordingId })
+    )
+
+    if (!droppedDataPhrases.length) {
+        return null
+    }
+
+    return (
+        <LemonBanner
+            type="warning"
+            className="mb-2"
+            dismissKey={`replay-ingestion-warnings-${logicProps.sessionRecordingId}`}
+        >
+            This recording is missing data ({droppedDataPhrases.join('; ')}), so playback may be incomplete.{' '}
+            <Link to={urls.ingestionWarnings()}>View ingestion warnings</Link>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -10,6 +10,7 @@ import { MatchingEventsMatchType } from 'scenes/session-recordings/playlist/sess
 
 import { ObservationsDock } from 'products/replay_vision/frontend/components/ObservationsDock'
 
+import { PlayerIngestionWarningsBanner } from './PlayerIngestionWarningsBanner'
 import { playerSettingsLogic } from './playerSettingsLogic'
 import { PlayerSidebar } from './PlayerSidebar'
 import { PlayerSummaryDock } from './PlayerSummaryDock'
@@ -104,6 +105,7 @@ function SessionRecordingPlayerInternal({
             })}
         >
             <div className="flex flex-col flex-1 min-w-0 min-h-0">
+                {showSummaryDock && <PlayerIngestionWarningsBanner />}
                 <PurePlayer noMeta={noMeta} noBorder={noBorder} />
                 {showVisionDock ? <ObservationsDock /> : showSummaryDock && <PlayerSummaryDock />}
             </div>

--- a/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.test.ts
@@ -1,5 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { IngestionWarning } from 'scenes/data-management/ingestion-warnings/ingestionWarningsLogic'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -44,6 +46,20 @@ describe('playerIngestionWarningsLogic', () => {
                                 },
                             ],
                         },
+                        {
+                            // a forged prototype-key type must not match the phrase map
+                            type: 'constructor',
+                            lastSeen: '2026-06-12T10:00:00Z',
+                            count: 1,
+                            sparkline: [],
+                            warnings: [
+                                {
+                                    type: 'constructor',
+                                    timestamp: '2026-06-12T10:00:00Z',
+                                    details: { sessionId: 'session-1' },
+                                },
+                            ],
+                        },
                     ],
                 },
             },
@@ -58,6 +74,14 @@ describe('playerIngestionWarningsLogic', () => {
 
         expect(logic.values.replayWarnings).toHaveLength(1)
         expect(logic.values.replayWarnings[0].type).toBe('replay_message_too_large')
+        expect(logic.values.droppedDataPhrases).toEqual(['some data was too large to ingest'])
+    })
+
+    it('does not let a forged prototype-key warning type leak into the banner', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+
+        const types = logic.values.replayWarnings.map((w: IngestionWarning) => w.type)
+        expect(types).not.toContain('constructor')
         expect(logic.values.droppedDataPhrases).toEqual(['some data was too large to ingest'])
     })
 })

--- a/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.test.ts
@@ -1,0 +1,63 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { playerIngestionWarningsLogic } from './playerIngestionWarningsLogic'
+
+describe('playerIngestionWarningsLogic', () => {
+    let logic: ReturnType<typeof playerIngestionWarningsLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team_id/ingestion_warnings': {
+                    results: [
+                        {
+                            type: 'replay_message_too_large',
+                            lastSeen: '2026-06-12T10:00:00Z',
+                            count: 2,
+                            sparkline: [],
+                            warnings: [
+                                {
+                                    type: 'replay_message_too_large',
+                                    timestamp: '2026-06-12T10:00:00Z',
+                                    details: { replayRecord: { session_id: 'session-1' } },
+                                },
+                                {
+                                    type: 'replay_message_too_large',
+                                    timestamp: '2026-06-12T10:00:00Z',
+                                    details: { replayRecord: { session_id: 'other-session' } },
+                                },
+                            ],
+                        },
+                        {
+                            type: 'cannot_merge_already_identified',
+                            lastSeen: '2026-06-12T10:00:00Z',
+                            count: 1,
+                            sparkline: [],
+                            warnings: [
+                                {
+                                    type: 'cannot_merge_already_identified',
+                                    timestamp: '2026-06-12T10:00:00Z',
+                                    details: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        })
+        initKeaTests()
+        logic = playerIngestionWarningsLogic({ sessionRecordingId: 'session-1' })
+        logic.mount()
+    })
+
+    it('loads warnings and keeps only replay types for this session', async () => {
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.replayWarnings).toHaveLength(1)
+        expect(logic.values.replayWarnings[0].type).toBe('replay_message_too_large')
+        expect(logic.values.droppedDataPhrases).toEqual(['some data was too large to ingest'])
+    })
+})

--- a/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.ts
@@ -17,13 +17,12 @@ export const REPLAY_INGESTION_WARNING_PHRASES: Record<string, string> = {
     replay_message_invalid: 'some data was rejected as invalid',
 }
 
-/** Phrase for a warning type, or undefined if not a replay drop type. Own-property check
- * so a forged type like `constructor` can't reach an inherited Object.prototype member. */
+/** Phrase for a replay-drop warning type, else undefined. Own-property check keeps forged types like `constructor` out. */
 function replayWarningPhrase(type: string): string | undefined {
     return Object.hasOwn(REPLAY_INGESTION_WARNING_PHRASES, type) ? REPLAY_INGESTION_WARNING_PHRASES[type] : undefined
 }
 
-/** The session id of a replay warning: too_large uses details.replayRecord.session_id, the rest details.sessionId. */
+/** Session id of a replay warning: too_large nests it under replayRecord, others use sessionId. */
 function warningSessionId(warning: IngestionWarning): string | undefined {
     return warning.details?.replayRecord?.session_id ?? warning.details?.sessionId
 }

--- a/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.ts
@@ -17,6 +17,12 @@ export const REPLAY_INGESTION_WARNING_PHRASES: Record<string, string> = {
     replay_message_invalid: 'some data was rejected as invalid',
 }
 
+/** Phrase for a warning type, or undefined if not a replay drop type. Own-property check
+ * so a forged type like `constructor` can't reach an inherited Object.prototype member. */
+function replayWarningPhrase(type: string): string | undefined {
+    return Object.hasOwn(REPLAY_INGESTION_WARNING_PHRASES, type) ? REPLAY_INGESTION_WARNING_PHRASES[type] : undefined
+}
+
 /** The session id of a replay warning: too_large uses details.replayRecord.session_id, the rest details.sessionId. */
 function warningSessionId(warning: IngestionWarning): string | undefined {
     return warning.details?.replayRecord?.session_id ?? warning.details?.sessionId
@@ -49,7 +55,7 @@ export const playerIngestionWarningsLogic = kea<playerIngestionWarningsLogicType
                         )}`
                     )
                     return (results as IngestionWarningSummary[])
-                        .filter((summary) => summary.type in REPLAY_INGESTION_WARNING_PHRASES)
+                        .filter((summary) => replayWarningPhrase(summary.type) !== undefined)
                         .flatMap((summary) => summary.warnings)
                         .filter((warning) => warningSessionId(warning) === props.sessionRecordingId)
                 },
@@ -61,9 +67,9 @@ export const playerIngestionWarningsLogic = kea<playerIngestionWarningsLogicType
         droppedDataPhrases: [
             (s) => [s.replayWarnings],
             (replayWarnings: IngestionWarning[]): string[] =>
-                Array.from(
-                    new Set(replayWarnings.map((warning) => REPLAY_INGESTION_WARNING_PHRASES[warning.type]))
-                ).filter(Boolean),
+                Array.from(new Set(replayWarnings.map((warning) => replayWarningPhrase(warning.type)))).filter(
+                    (phrase): phrase is string => phrase !== undefined
+                ),
         ],
     }),
 

--- a/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerIngestionWarningsLogic.ts
@@ -1,0 +1,73 @@
+import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import {
+    IngestionWarning,
+    IngestionWarningSummary,
+} from 'scenes/data-management/ingestion-warnings/ingestionWarningsLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import type { playerIngestionWarningsLogicType } from './playerIngestionWarningsLogicType'
+
+/** Warning types meaning replay data was dropped, mapped to their banner phrase. */
+export const REPLAY_INGESTION_WARNING_PHRASES: Record<string, string> = {
+    replay_message_too_large: 'some data was too large to ingest',
+    replay_session_rate_limited: 'the session exceeded the event rate limit',
+    replay_message_invalid: 'some data was rejected as invalid',
+}
+
+/** The session id of a replay warning: too_large uses details.replayRecord.session_id, the rest details.sessionId. */
+function warningSessionId(warning: IngestionWarning): string | undefined {
+    return warning.details?.replayRecord?.session_id ?? warning.details?.sessionId
+}
+
+export interface PlayerIngestionWarningsLogicProps {
+    sessionRecordingId: string
+}
+
+export const playerIngestionWarningsLogic = kea<playerIngestionWarningsLogicType>([
+    path((key) => ['scenes', 'session-recordings', 'player', 'playerIngestionWarningsLogic', key]),
+    props({} as PlayerIngestionWarningsLogicProps),
+    key((props) => props.sessionRecordingId),
+
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId']],
+    })),
+
+    loaders(({ props, values }) => ({
+        replayWarnings: [
+            [] as IngestionWarning[],
+            {
+                loadReplayWarnings: async () => {
+                    if (!props.sessionRecordingId) {
+                        return []
+                    }
+                    const { results } = await api.get(
+                        `api/projects/${values.currentProjectId}/ingestion_warnings?q=${encodeURIComponent(
+                            props.sessionRecordingId
+                        )}`
+                    )
+                    return (results as IngestionWarningSummary[])
+                        .filter((summary) => summary.type in REPLAY_INGESTION_WARNING_PHRASES)
+                        .flatMap((summary) => summary.warnings)
+                        .filter((warning) => warningSessionId(warning) === props.sessionRecordingId)
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        droppedDataPhrases: [
+            (s) => [s.replayWarnings],
+            (replayWarnings: IngestionWarning[]): string[] =>
+                Array.from(
+                    new Set(replayWarnings.map((warning) => REPLAY_INGESTION_WARNING_PHRASES[warning.type]))
+                ).filter(Boolean),
+        ],
+    }),
+
+    afterMount(({ actions }) => {
+        actions.loadReplayWarnings()
+    }),
+])


### PR DESCRIPTION
## Problem

When replay data is dropped during ingestion (too large, rate limited, or rejected as invalid), the person debugging is in the player staring at a recording that skips or won't play, while the explanation sits unnoticed on the data management ingestion warnings page. With the warning producers in place (#63270, #63282, #63283), the player can connect the dots itself.

Part of a stack: #63270 ← #63282 ← #63283 ← **this PR**.

## Changes

- New `playerIngestionWarningsLogic` (keyed by session id) queries the existing ingestion warnings endpoint with `?q=<session_id>` (the endpoint already supports substring search over warning details, so no backend change), keeps only replay warning types, and defensively filters individual warnings to the viewed session. The session id lives in two shapes depending on the type (`details.replayRecord.session_id` for too-large, `details.sessionId` for the others); a small helper covers both.
- New `PlayerIngestionWarningsBanner` renders a dismissible warning banner above the player explaining what was dropped, with a link to the ingestion warnings page. Only shown in the standard player mode (not shared/embedded players, which lack access to the endpoint).
- Default empty mock for the endpoint in `mocks/handlers.ts` so existing player tests and stories are unaffected.

No generated API client exists for this INTERNAL endpoint, so the call follows the existing manual `api.get` pattern used by `ingestionWarningsLogic`.

## How did you test this code?

Authored by an agent — automated tests only, no manual testing:

- New logic test: loads warnings for the session, filters to replay types, and drops warnings for other sessions (passes)
- Frontend type check clean for the changed files (remaining tsgo errors are pre-existing in unrelated files)

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Possibly worth a line in the replay troubleshooting docs once shipped.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code as the final PR of a Graphite stack.
- Considered extending the backend with a dedicated session_id filter param, but the existing `q` substring search over details already covers it with no API change; client-side session filtering guards against loose substring matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
