### PR TITLE
fix(phai): conversation crashes

### DIFF
--- a/ee/hogai/django_checkpoint/checkpointer.py
+++ b/ee/hogai/django_checkpoint/checkpointer.py
@@ -46,9 +46,6 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
             else []
         )
 
-    def _load_json(self, obj: Any):
-        return self.jsonplus_serde.loads(self.jsonplus_serde.dumps(obj))
-
     def _dump_json(self, obj: Any) -> dict[str, Any]:
         serialized_metadata = self.jsonplus_serde.dumps(obj)
         # NOTE: we're using JSON serializer (not msgpack), so we need to remove null characters before writing
@@ -97,11 +94,10 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
     def _get_checkpoint_channel_values(self, checkpoint: ConversationCheckpoint):
         if not checkpoint.checkpoint:
             return None
-        loaded_checkpoint = self._load_json(checkpoint.checkpoint)
-        if "channel_versions" not in loaded_checkpoint:
+        if "channel_versions" not in checkpoint.checkpoint:
             return None
         query = Q()
-        for channel, version in loaded_checkpoint["channel_versions"].items():
+        for channel, version in checkpoint.checkpoint["channel_versions"].items():
             query |= Q(channel=channel, version=version)
         return ConversationCheckpointBlob.objects.filter(
             Q(thread_id=checkpoint.thread_id, checkpoint_ns=checkpoint.checkpoint_ns) & query
@@ -135,7 +131,7 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
 
         async for checkpoint in qs:
             channel_values = self._get_checkpoint_channel_values(checkpoint)
-            loaded_checkpoint: Checkpoint = self._load_json(checkpoint.checkpoint)
+            loaded_checkpoint: Checkpoint = checkpoint.checkpoint
 
             pending_sends = (
                 [
@@ -159,11 +155,15 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
                 else {}
             )
 
-            checkpoint_dict: Checkpoint = {  # ty: ignore[missing-typed-dict-key]
-                **loaded_checkpoint,
-                "pending_sends": pending_sends,
-                "channel_values": channel_values,
-            }
+            # langgraph-checkpoint 2.1 dropped `pending_sends` from the Checkpoint TypedDict, but the langgraph runtime still consumes it via `.get()`, so keep emitting it as an extra key
+            checkpoint_dict = cast(
+                Checkpoint,
+                {
+                    **loaded_checkpoint,
+                    "pending_sends": pending_sends,
+                    "channel_values": channel_values,
+                },
+            )
 
             yield CheckpointTuple(
                 {
@@ -174,7 +174,7 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
                     }
                 },
                 checkpoint_dict,
-                self._load_json(checkpoint.metadata),
+                checkpoint.metadata,
                 (
                     {
                         "configurable": {
@@ -350,7 +350,8 @@ class DjangoCheckpointer(BaseCheckpointSaver[str]):
                 update_fields=["channel", "type", "blob"],
             )
 
-    def get_next_version(self, current: Optional[str | int], channel: ChannelProtocol) -> str:
+    # `channel` is typed `None` (deprecated) in the 2.1 base class, but langgraph 0.4 still passes a real channel object, so accept both
+    def get_next_version(self, current: Optional[str | int], channel: Optional[ChannelProtocol] = None) -> str:
         if current is None:
             current_v = 0
         elif isinstance(current, int):

--- a/ee/hogai/django_checkpoint/test/test_checkpointer.py
+++ b/ee/hogai/django_checkpoint/test/test_checkpointer.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import operator
+from datetime import UTC, datetime
 from typing import Annotated, Any, Optional, TypedDict
 from uuid import uuid4
 
@@ -19,6 +20,8 @@ from langgraph.graph import END, START
 from langgraph.graph.state import CompiledStateGraph, StateGraph
 from pydantic import BaseModel, Field
 
+from posthog.schema import AssistantMessage, HumanMessage
+
 from products.posthog_ai.backend.models.assistant import (
     Conversation,
     ConversationCheckpoint,
@@ -27,6 +30,7 @@ from products.posthog_ai.backend.models.assistant import (
 )
 
 from ee.hogai.django_checkpoint.checkpointer import DjangoCheckpointer
+from ee.hogai.utils.types import AssistantState, PartialAssistantState
 
 
 class TestDjangoCheckpointer(NonAtomicBaseTest):
@@ -614,3 +618,78 @@ class TestDjangoCheckpointer(NonAtomicBaseTest):
         }
         retrieved_null = await saver.aget_tuple(null_config)
         self.assertIsNone(retrieved_null)
+
+    async def test_metadata_returns_stored_json_on_load(self):
+        thread = await Conversation.objects.acreate(user=self.user, team=self.team)
+        saver = DjangoCheckpointer()
+
+        graph = StateGraph(AssistantState)
+        graph.add_node(
+            "node",
+            lambda state: PartialAssistantState(
+                messages=[AssistantMessage(content="hello", id=str(uuid4()))],
+                start_dt=datetime(2026, 6, 12, tzinfo=UTC),
+            ),
+        )
+        graph.add_edge(START, "node")
+        graph.add_edge("node", END)
+        compiled = graph.compile(checkpointer=saver)
+
+        config = {"configurable": {"thread_id": str(thread.id)}}
+        await compiled.ainvoke(AssistantState(messages=[HumanMessage(content="hi", id=str(uuid4()))]), config)
+
+        checkpoints = [
+            checkpoint
+            async for checkpoint in ConversationCheckpoint.objects.filter(thread=thread, checkpoint__isnull=False)
+        ]
+        self.assertGreater(len(checkpoints), 0)
+
+        # The write side still produces lc markers at this langgraph version
+        metadata_by_source = {checkpoint.metadata["source"]: checkpoint.metadata for checkpoint in checkpoints}
+        raw_input_state = metadata_by_source["input"]["writes"]["__start__"]
+        self.assertEqual(raw_input_state["lc"], 2)
+        self.assertEqual(raw_input_state["type"], "constructor")
+
+        raw_by_id = {str(checkpoint.id): checkpoint for checkpoint in checkpoints}
+        loaded_tuples = [result async for result in saver.alist(config)]
+        self.assertEqual(len(loaded_tuples), len(checkpoints))
+        for loaded in loaded_tuples:
+            raw = raw_by_id[str(loaded.config["configurable"]["checkpoint_id"])]
+            with self.subTest(checkpoint_id=str(raw.id)):
+                self.assertEqual(loaded.metadata, raw.metadata)
+                expected_checkpoint = {
+                    **raw.checkpoint,
+                    "pending_sends": loaded.checkpoint["pending_sends"],
+                    "channel_values": loaded.checkpoint["channel_values"],
+                }
+                self.assertEqual(loaded.checkpoint, expected_checkpoint)
+
+    async def test_unknown_constructor_marker_returned_as_plain_dict(self):
+        thread = await Conversation.objects.acreate(user=self.user, team=self.team)
+        saver = DjangoCheckpointer()
+
+        marker = {
+            "lc": 2,
+            "type": "constructor",
+            "id": ["pprint", "pprint"],
+            "kwargs": {"object": "HELLO"},
+        }
+        checkpoint_id = str(uuid6(clock_seq=-2))
+        await ConversationCheckpoint.objects.acreate(
+            id=checkpoint_id,
+            thread=thread,
+            checkpoint_ns="",
+            checkpoint={
+                "v": 1,
+                "ts": "2024-07-31T20:14:19.804150+00:00",
+                "id": checkpoint_id,
+                "channel_versions": {},
+                "versions_seen": {},
+                "pending_sends": [],
+            },
+            metadata={"source": "input", "step": -1, "writes": {"node": marker}},
+        )
+
+        config = {"configurable": {"thread_id": str(thread.id), "checkpoint_ns": ""}}
+        loaded = await saver.aget_tuple(config)
+        self.assertEqual(loaded.metadata["writes"]["node"], marker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
     "langchain-openai~=0.3.35",
     "langchain-anthropic~=0.3.22",
     "langgraph==0.4.10",
+    "langgraph-checkpoint==2.1.2",
     "lxml==6.0.2",
     "lzstring==1.0.4",
     "markdown-it-py~=3.0.0",
@@ -284,9 +285,6 @@ required-version = ">=0.10.2"
 add-bounds = "major"
 exclude-newer = "7 days"
 exclude-newer-package = { hogql-parser = false, hogql-parser-rs = false, posthoganalytics = false, pixelhog = false, django = false, modal = false }
-constraint-dependencies = [
-    "langgraph-checkpoint<3",
-]
 
 [tool.uv.workspace]
 members = ["tools/hogli"]

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,6 @@ members = [
     "hogli",
     "posthog",
 ]
-constraints = [{ name = "langgraph-checkpoint", specifier = "<3" }]
 
 [[package]]
 name = "aioboto3"
@@ -3814,15 +3813,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "2.0.26"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/61/e2518ac9216a4e9f4efda3ac61595e3c9e9ac00833141c9688e8d56bd7eb/langgraph_checkpoint-2.0.26.tar.gz", hash = "sha256:2b800195532d5efb079db9754f037281225ae175f7a395523f4bf41223cbc9d6", size = 37874, upload-time = "2025-05-15T17:31:22.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/83/6404f6ed23a91d7bc63d7df902d144548434237d017820ceaa8d014035f2/langgraph_checkpoint-2.1.2.tar.gz", hash = "sha256:112e9d067a6eff8937caf198421b1ffba8d9207193f14ac6f89930c1260c06f9", size = 142420, upload-time = "2025-10-07T17:45:17.129Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/48/d7cec540a3011b3207470bb07294a399e3b94b2e8a602e38cb007ce5bc10/langgraph_checkpoint-2.0.26-py3-none-any.whl", hash = "sha256:ad4907858ed320a208e14ac037e4b9244ec1cb5aa54570518166ae8b25752cec", size = 44247, upload-time = "2025-05-15T17:31:21.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f2/06bf5addf8ee664291e1b9ffa1f28fc9d97e59806dc7de5aea9844cbf335/langgraph_checkpoint-2.1.2-py3-none-any.whl", hash = "sha256:911ebffb069fd01775d4b5184c04aaafc2962fcdf50cf49d524cd4367c4d0c60", size = 45763, upload-time = "2025-10-07T17:45:16.19Z" },
 ]
 
 [[package]]
@@ -5514,6 +5513,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint" },
     { name = "linkedin-api-client" },
     { name = "lxml" },
     { name = "lzstring" },
@@ -5782,6 +5782,7 @@ requires-dist = [
     { name = "langchain-core", specifier = "~=0.3.81" },
     { name = "langchain-openai", specifier = "~=0.3.35" },
     { name = "langgraph", specifier = "==0.4.10" },
+    { name = "langgraph-checkpoint", specifier = "==2.1.2" },
     { name = "linkedin-api-client", specifier = "~=0.3.0" },
     { name = "lxml", specifier = "==6.0.2" },
     { name = "lzstring", specifier = "==1.0.4" },


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

A customer reported crashes during conversations.

## Changes

- Fix mismatch of types.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
