### PR TITLE
chore(dashboard): remove "open insights in new PostHog tabs" from panel

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
+++ b/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
@@ -29,7 +29,6 @@ import {
     ScenePanelDivider,
     ScenePanelInfoSection,
 } from '~/layout/scenes/SceneLayout'
-import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { notebooksModel } from '~/models/notebooksModel'
 import { tagsModel } from '~/models/tagsModel'
 import { AccessControlLevel, AccessControlResourceType, DashboardMode, ExporterFormat } from '~/types'
@@ -55,7 +54,6 @@ export function DashboardScenePanel(): JSX.Element | null {
     const { setDashboardMode, updateDashboardTags, togglePinned, setTerraformModalOpen } = useActions(dashboardLogic)
     const { createNotebookFromDashboard } = useActions(notebooksModel)
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
-    const { setScenePanelOpen } = useActions(sceneLayoutLogic)
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
 

--- a/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
+++ b/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCode2, IconCopy, IconGraph, IconNotebook, IconPalette, IconTrash } from '@posthog/icons'
+import { IconCode2, IconCopy, IconNotebook, IconPalette, IconTrash } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { SceneExportDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu'
@@ -17,7 +17,6 @@ import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { slugify } from 'lib/utils'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
-import { newInternalTab } from 'lib/utils/newInternalTab'
 import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
 import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogic'
 import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
@@ -50,9 +49,7 @@ export function DashboardScenePanel(): JSX.Element | null {
         isSavingTags,
         isPinned,
         asDashboardTemplate,
-        effectiveEditBarFilters,
         effectiveDashboardVariableOverrides,
-        tiles,
         apiUrl,
     } = useValues(dashboardLogic)
     const { setDashboardMode, updateDashboardTags, togglePinned, setTerraformModalOpen } = useActions(dashboardLogic)
@@ -182,35 +179,6 @@ export function DashboardScenePanel(): JSX.Element | null {
                 <DashboardSaveAsTemplateSceneActions />
 
                 {dashboard && <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />}
-                {dashboard && (
-                    <ButtonPrimitive
-                        onClick={() => {
-                            tiles.forEach((tile) => {
-                                if (tile.insight?.short_id == null) {
-                                    return
-                                }
-                                const url = urls.insightView(
-                                    tile.insight.short_id,
-                                    dashboard.id,
-                                    effectiveDashboardVariableOverrides,
-                                    effectiveEditBarFilters,
-                                    tile?.filters_overrides
-                                )
-                                newInternalTab(url)
-                            })
-                            setScenePanelOpen(false)
-                        }}
-                        menuItem
-                        data-attr="open-insights-in-new-posthog-tabs"
-                        disabledReasons={{
-                            'Cannot open insights when editing dashboard': dashboardMode === DashboardMode.Edit,
-                            'Dashboard has no insights': tiles.length === 0,
-                        }}
-                    >
-                        <IconGraph />
-                        Open insights in new PostHog tabs
-                    </ButtonPrimitive>
-                )}
             </ScenePanelActionsSection>
             {dashboard && canEditDashboard && (
                 <>


### PR DESCRIPTION
## Problem

- PostHog tabs no longer exist, so the dashboard scene panel still showing an "Open insights in new PostHog tabs" action is stale.

## Changes

- Removed the "Open insights in new PostHog tabs" button from the dashboard scene panel (sidebar).
- Cleaned up now-unused imports/values (`newInternalTab`, `IconGraph`, `tiles`, `effectiveEditBarFilters`).

## How did you test this code?

- Agent-authored. Ran the frontend TypeScript check against the edited file (no errors). No manual UI testing performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code at the user's direction, scoped to the sidebar panel per the screenshot.
- Left the sibling menu-bar item ("Open insights in new tabs") untouched as it was out of scope.
