### PR TITLE
feat(replay): explain unplayable recordings missing their full snapshot

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -69,7 +69,7 @@ const PlayerFrameOverlayActions = (): JSX.Element | null => {
 }
 
 const PlayerFrameOverlayContent = (): JSX.Element | null => {
-    const { currentPlayerState, endReached, logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { currentPlayerState, endReached, logicProps, playerError } = useValues(sessionRecordingPlayerLogic)
     const { setPlay } = useActions(sessionRecordingPlayerLogic)
 
     const handlePlay = (e: MouseEvent): void => {
@@ -85,24 +85,28 @@ const PlayerFrameOverlayContent = (): JSX.Element | null => {
     const showActionsOnOverlay = playerMode === SessionRecordingPlayerMode.Standard && pausedState
 
     if (currentPlayerState === SessionPlayerState.ERROR) {
+        const isMissingFullSnapshot = playerError === 'noPlayableFullSnapshot'
         content = (
             <div className="flex flex-col justify-center items-center p-6 bg-surface-primary rounded m-6 gap-2 max-w-120 shadow-sm">
                 <IconWarning className="text-danger text-5xl" />
                 <div className="font-bold text-text-3000 text-lg">We're unable to play this recording</div>
                 <div className="text-secondary text-sm text-center">
-                    An error occurred that is preventing this recording from being played. You can refresh the page to
-                    reload the recording.
+                    {isMissingFullSnapshot
+                        ? 'This part of the recording is missing the snapshot data needed to render it. The data never reached PostHog, usually because the browser was closed or went offline before the recording finished uploading.'
+                        : 'An error occurred that is preventing this recording from being played. You can refresh the page to reload the recording.'}
                 </div>
-                <LemonButton
-                    onClick={() => {
-                        window.location.reload()
-                    }}
-                    type="primary"
-                    fullWidth
-                    center
-                >
-                    Reload
-                </LemonButton>
+                {!isMissingFullSnapshot && (
+                    <LemonButton
+                        onClick={() => {
+                            window.location.reload()
+                        }}
+                        type="primary"
+                        fullWidth
+                        center
+                    >
+                        Reload
+                    </LemonButton>
+                )}
                 <LemonButton
                     targetBlank
                     to="https://posthog.com/support?utm_medium=in-product&utm_campaign=recording-not-found"

--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -7,12 +7,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
-import { BuilderHog2 } from 'lib/components/hedgehogs'
+import { BuilderHog2, WarningHog } from 'lib/components/hedgehogs'
 import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 import useIsHovering from 'lib/hooks/useIsHovering'
 import { HotkeysInterface, useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { usePageVisibilityCb } from 'lib/hooks/usePageVisibility'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
+import { Link } from 'lib/lemon-ui/Link'
 import { useNotebookDrag } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
 import { PlayerFrameCommentOverlay } from 'scenes/session-recordings/player/commenting/PlayerFrameCommentOverlay'
 import { RecordingDeleted } from 'scenes/session-recordings/player/RecordingDeleted'
@@ -93,6 +94,7 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
         isNotFound,
         loadMetaError,
         isRecentAndInvalid,
+        isOldAndInvalid,
         isRecordingDeleted,
         recordingDeletedAt,
         recordingDeletedBy,
@@ -131,6 +133,19 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [isRecentAndInvalid]
+    )
+
+    useEffect(
+        () => {
+            if (isOldAndInvalid) {
+                posthog.capture('session loaded old and invalid', {
+                    viewedSessionRecording: sessionRecordingId,
+                    recordingStartTime: sessionPlayerData?.start,
+                })
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [isOldAndInvalid]
     )
 
     // Track if the recording has ended to be able to reliably get it from the BE and stop the recording
@@ -285,6 +300,20 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
                                 <p>
                                     This recording hasn't been fully ingested yet. It should be ready to watch in a few
                                     minutes.
+                                </p>
+                                <LemonButton type="secondary" onClick={loadSnapshots}>
+                                    Reload
+                                </LemonButton>
+                            </div>
+                        ) : isOldAndInvalid ? (
+                            <div className="flex flex-1 flex-col items-center justify-center p-4 text-center">
+                                <WarningHog height={200} width={200} />
+                                <h1>This recording can't be played</h1>
+                                <p className="max-w-120">
+                                    The snapshot of the screen taken when this recording started never reached PostHog,
+                                    so there is nothing to play back. This usually happens when the browser is closed or
+                                    goes offline before the recording finishes uploading.{' '}
+                                    <Link to="https://posthog.com/docs/session-replay/troubleshooting">Learn more</Link>
                                 </p>
                                 <LemonButton type="secondary" onClick={loadSnapshots}>
                                     Reload

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.test.ts
@@ -29,6 +29,7 @@ import {
     recordingEventsJson,
     recordingMetaJson,
     setupSessionRecordingTest,
+    snapshotsAsJSONLines,
 } from './__mocks__/test-setup'
 import { snapshotDataLogic } from './snapshotDataLogic'
 
@@ -294,7 +295,7 @@ describe('sessionRecordingDataCoordinatorLogic', () => {
                 ],
             })}\n`
 
-        const mountWithoutFullSnapshot = (baseTimestamp: number, metaOverride?: Record<string, unknown>): void => {
+        const mountWithSnapshots = (jsonLines: string, metaOverride?: Record<string, unknown>): void => {
             logic?.unmount()
             snapshotLogic?.unmount()
             setupSessionRecordingTest({
@@ -302,7 +303,7 @@ describe('sessionRecordingDataCoordinatorLogic', () => {
                     '/api/environments/:team_id/session_recordings/:id/snapshots': async (req, res, ctx) => {
                         const sourceParam = req.url.searchParams.get('source')
                         if (sourceParam === 'blob_v2' || sourceParam === 'blob') {
-                            return res(ctx.text(incrementalOnlySnapshotsAsJSONLines(baseTimestamp)))
+                            return res(ctx.text(jsonLines))
                         }
                         return [200, { sources: [BLOB_SOURCE_V2] }]
                     },
@@ -330,35 +331,46 @@ describe('sessionRecordingDataCoordinatorLogic', () => {
             expect(logic.values.fullyLoaded).toBe(true)
         }
 
-        it('flags an old recording with no full snapshot as old and invalid', async () => {
-            mountWithoutFullSnapshot(1682952380877)
+        it.each<{
+            case: string
+            mocks: () => { jsonLines: string; metaOverride?: Record<string, unknown> }
+            expected: { snapshotsInvalid: boolean; isRecentAndInvalid: boolean; isOldAndInvalid: boolean }
+        }>([
+            {
+                case: 'an old recording with no full snapshot is old and invalid',
+                mocks: () => ({ jsonLines: incrementalOnlySnapshotsAsJSONLines(1682952380877) }),
+                expected: { snapshotsInvalid: true, isRecentAndInvalid: false, isOldAndInvalid: true },
+            },
+            {
+                case: 'a recent recording with no full snapshot is recent and invalid',
+                mocks: () => {
+                    const recentStart = dayjs().subtract(1, 'minute')
+                    return {
+                        jsonLines: incrementalOnlySnapshotsAsJSONLines(recentStart.valueOf()),
+                        metaOverride: {
+                            ...recordingMetaJson,
+                            start_time: recentStart.toISOString(),
+                            end_time: dayjs().toISOString(),
+                        },
+                    }
+                },
+                expected: { snapshotsInvalid: true, isRecentAndInvalid: true, isOldAndInvalid: false },
+            },
+            {
+                case: 'a recording with a full snapshot is valid',
+                mocks: () => ({ jsonLines: snapshotsAsJSONLines() }),
+                expected: { snapshotsInvalid: false, isRecentAndInvalid: false, isOldAndInvalid: false },
+            },
+        ])('$case', async ({ mocks, expected }) => {
+            const { jsonLines, metaOverride } = mocks()
+            mountWithSnapshots(jsonLines, metaOverride)
             await loadFully()
 
-            expect(logic.values.snapshotsInvalid).toBe(true)
-            expect(logic.values.isRecentAndInvalid).toBe(false)
-            expect(logic.values.isOldAndInvalid).toBe(true)
-        })
-
-        it('flags a recent recording with no full snapshot as recent and invalid', async () => {
-            const recentStart = dayjs().subtract(1, 'minute')
-            mountWithoutFullSnapshot(recentStart.valueOf(), {
-                ...recordingMetaJson,
-                start_time: recentStart.toISOString(),
-                end_time: dayjs().toISOString(),
-            })
-            await loadFully()
-
-            expect(logic.values.snapshotsInvalid).toBe(true)
-            expect(logic.values.isRecentAndInvalid).toBe(true)
-            expect(logic.values.isOldAndInvalid).toBe(false)
-        })
-
-        it('does not flag a recording that has a full snapshot', async () => {
-            await loadFully()
-
-            expect(logic.values.snapshotsInvalid).toBe(false)
-            expect(logic.values.isRecentAndInvalid).toBe(false)
-            expect(logic.values.isOldAndInvalid).toBe(false)
+            expect({
+                snapshotsInvalid: logic.values.snapshotsInvalid,
+                isRecentAndInvalid: logic.values.isRecentAndInvalid,
+                isOldAndInvalid: logic.values.isOldAndInvalid,
+            }).toEqual(expected)
         })
     })
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { processAllSnapshots, SourceKey, ViewportResolution } from '@posthog/replay-shared'
 
+import { dayjs } from 'lib/dayjs'
 import { convertSnapshotsByWindowId } from 'scenes/session-recordings/__mocks__/recording_snapshots'
 import { sessionRecordingDataCoordinatorLogic } from 'scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic'
 import { sessionRecordingMetaLogic } from 'scenes/session-recordings/player/sessionRecordingMetaLogic'
@@ -22,6 +23,7 @@ import {
 import { sortedRecordingSnapshots } from '../__mocks__/recording_snapshots'
 import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLogic'
 import {
+    BLOB_SOURCE_V2,
     createDifferentiatedQueryHandler,
     overrideSessionRecordingMocks,
     recordingEventsJson,
@@ -264,6 +266,99 @@ describe('sessionRecordingDataCoordinatorLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.loadSnapshots()
             }).toDispatchActions([sessionRecordingEventUsageLogic.actionTypes.reportRecordingLoaded])
+        })
+    })
+
+    describe('missing full snapshot detection', () => {
+        // start is the earlier of meta start_time and the first snapshot timestamp,
+        // so the recent case needs recent snapshot timestamps too
+        const incrementalOnlySnapshotsAsJSONLines = (baseTimestamp: number): string =>
+            `${JSON.stringify({
+                window_id: '187d7c761a0525d-05f175487d4b65-1d525634-384000-187d7c761a149d0',
+                data: [
+                    {
+                        type: 4,
+                        data: { href: 'http://localhost:3000/', width: 2560, height: 1304 },
+                        timestamp: baseTimestamp,
+                    },
+                    {
+                        type: 3,
+                        data: { source: 1, positions: [{ x: 2027, y: 120, id: 22, timeOffset: 0 }] },
+                        timestamp: baseTimestamp + 2000,
+                    },
+                    {
+                        type: 3,
+                        data: { source: 2, type: 2, id: 33, x: 852, y: 133, pointerType: 0 },
+                        timestamp: baseTimestamp + 9000,
+                    },
+                ],
+            })}\n`
+
+        const mountWithoutFullSnapshot = (baseTimestamp: number, metaOverride?: Record<string, unknown>): void => {
+            logic?.unmount()
+            snapshotLogic?.unmount()
+            setupSessionRecordingTest({
+                getMocks: {
+                    '/api/environments/:team_id/session_recordings/:id/snapshots': async (req, res, ctx) => {
+                        const sourceParam = req.url.searchParams.get('source')
+                        if (sourceParam === 'blob_v2' || sourceParam === 'blob') {
+                            return res(ctx.text(incrementalOnlySnapshotsAsJSONLines(baseTimestamp)))
+                        }
+                        return [200, { sources: [BLOB_SOURCE_V2] }]
+                    },
+                    ...(metaOverride
+                        ? { '/api/environments/:team_id/session_recordings/:id': () => [200, metaOverride] }
+                        : {}),
+                },
+            })
+            const props = {
+                sessionRecordingId: '2',
+                blobV2PollingDisabled: true,
+            }
+            logic = sessionRecordingDataCoordinatorLogic(props)
+            snapshotLogic = snapshotDataLogic(props)
+            logic.mount()
+        }
+
+        const loadFully = async (): Promise<void> => {
+            await expectLogic(logic, () => {
+                logic.actions.loadRecordingMeta()
+                logic.actions.loadSnapshots()
+            })
+                .toDispatchActions(['loadRecordingMetaSuccess', 'reportUsageIfFullyLoaded'])
+                .toFinishAllListeners()
+            expect(logic.values.fullyLoaded).toBe(true)
+        }
+
+        it('flags an old recording with no full snapshot as old and invalid', async () => {
+            mountWithoutFullSnapshot(1682952380877)
+            await loadFully()
+
+            expect(logic.values.snapshotsInvalid).toBe(true)
+            expect(logic.values.isRecentAndInvalid).toBe(false)
+            expect(logic.values.isOldAndInvalid).toBe(true)
+        })
+
+        it('flags a recent recording with no full snapshot as recent and invalid', async () => {
+            const recentStart = dayjs().subtract(1, 'minute')
+            mountWithoutFullSnapshot(recentStart.valueOf(), {
+                ...recordingMetaJson,
+                start_time: recentStart.toISOString(),
+                end_time: dayjs().toISOString(),
+            })
+            await loadFully()
+
+            expect(logic.values.snapshotsInvalid).toBe(true)
+            expect(logic.values.isRecentAndInvalid).toBe(true)
+            expect(logic.values.isOldAndInvalid).toBe(false)
+        })
+
+        it('does not flag a recording that has a full snapshot', async () => {
+            await loadFully()
+
+            expect(logic.values.snapshotsInvalid).toBe(false)
+            expect(logic.values.isRecentAndInvalid).toBe(false)
+            expect(logic.values.isOldAndInvalid).toBe(false)
         })
     })
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -447,6 +447,16 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
             },
         ],
 
+        // past the ingestion grace period, a missing full snapshot means the data never arrived,
+        // e.g. the browser closed or went offline before the recording finished uploading
+        isOldAndInvalid: [
+            (s) => [s.start, s.snapshotsInvalid],
+            (start, snapshotsInvalid) => {
+                const lessThanFiveMinutesOld = dayjs().diff(start, 'minute') <= 5
+                return snapshotsInvalid && !lessThanFiveMinutesOld
+            },
+        ],
+
         windowIds: [
             (s) => [s.snapshotsByWindowId],
             (snapshotsByWindowId: Record<number, eventWithTime[]>): number[] => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -450,11 +450,8 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
         // past the ingestion grace period, a missing full snapshot means the data never arrived,
         // e.g. the browser closed or went offline before the recording finished uploading
         isOldAndInvalid: [
-            (s) => [s.start, s.snapshotsInvalid],
-            (start, snapshotsInvalid) => {
-                const lessThanFiveMinutesOld = dayjs().diff(start, 'minute') <= 5
-                return snapshotsInvalid && !lessThanFiveMinutesOld
-            },
+            (s) => [s.snapshotsInvalid, s.isRecentAndInvalid],
+            (snapshotsInvalid, isRecentAndInvalid) => snapshotsInvalid && !isRecentAndInvalid,
         ],
 
         windowIds: [


### PR DESCRIPTION
## Problem

When the initial rrweb full snapshot never reaches our servers, a recording has only incremental events and there is nothing to render. This happens when the browser is closed or goes offline before the first (and largest) recording payload finishes uploading, which is much more likely on slow connections, and the data is unrecoverable.

The player already detects exactly this condition (`snapshotsInvalid`), but only surfaces it for recordings less than 5 minutes old ("We're still working on it"). For anything older it silently rendered a black screen, and pressing play raised the generic "We're unable to play this recording" error telling the user to refresh the page, which can never help in this case.

## Changes

- Adds an `isOldAndInvalid` selector to `sessionRecordingDataCoordinatorLogic`, mirroring `isRecentAndInvalid`: the recording is fully loaded, no window has a full snapshot, and the 5 minute ingestion grace period has passed.
- `PurePlayer` now renders a dedicated state for that case instead of a black frame, explaining that the start-of-recording snapshot never reached PostHog and why, with a link to the troubleshooting docs and a reload escape hatch (useful during ingestion lag).
- The playback-time `noPlayableFullSnapshot` error overlay (hit when only some windows are missing their snapshot) gets specific copy and drops the misleading "refresh the page" advice and reload button for that reason.
- Adds a `session loaded old and invalid` capture mirroring the existing recent-and-invalid telemetry.

Player state when the snapshot is missing and the grace period has passed:

> This recording can't be played
> The snapshot of the screen taken when this recording started never reached PostHog, so there is nothing to play back. This usually happens when the browser is closed or goes offline before the recording finishes uploading.

## How did you test this code?

Authored by an agent; no manual testing claimed. Automated tests run locally:

- New jest coverage in `sessionRecordingDataCoordinatorLogic.test.ts`: old recording without a full snapshot → `isOldAndInvalid`, recent one → `isRecentAndInvalid`, recording with a full snapshot → neither (15/15 passing).
- Existing suites: `sessionRecordingDataCoordinatorLogic.blobv2/performance` and `sessionRecordingPlayerLogic` (75 tests) all pass.
- `tsc --noEmit` clean for the touched files, kea typegen regenerated.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code while investigating a support report of recordings playing back as black screens after slow uploads were interrupted by the browser closing.
- Considered emitting an ingestion warning instead, but capture and the recording consumer process batches incrementally and cannot know a snapshot will never arrive; playback time is the only place this is reliably detectable, and the detection already existed there.
- Reused the existing `isRecentAndInvalid` selector pattern and copy surfaces rather than introducing a new error pathway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
