### PR TITLE
fix(error-tracking): accept deprecated useQueryV2/useQueryV3 query flags

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17327,6 +17327,14 @@
                 "tags": {
                     "$ref": "#/definitions/QueryLogTags"
                 },
+                "useQueryV2": {
+                    "deprecated": "Ignored — V2 query path was removed. Kept so requests from older clients still validate.",
+                    "type": "boolean"
+                },
+                "useQueryV3": {
+                    "deprecated": "Ignored — V3 is the only query path. Kept so requests from older clients still validate.",
+                    "type": "boolean"
+                },
                 "version": {
                     "description": "version of the node, used for schema migrations",
                     "type": "number"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2794,6 +2794,10 @@ export interface ErrorTrackingQuery extends DataNode<ErrorTrackingQueryResponse>
     personId?: string
     groupKey?: string
     groupTypeIndex?: integer
+    /** @deprecated Ignored — V2 query path was removed. Kept so requests from older clients still validate. */
+    useQueryV2?: boolean
+    /** @deprecated Ignored — V3 is the only query path. Kept so requests from older clients still validate. */
+    useQueryV3?: boolean
     /**
      * Pending fingerprint issue state updates UNIONed into the fingerprint issue state subquery.
      * The backend caps the list at 50 entries; extras are dropped silently.

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -22371,6 +22371,8 @@ class ErrorTrackingQuery(BaseModel):
         title="ErrorTrackingQueryStatus",
     )
     tags: QueryLogTags | None = None
+    useQueryV2: bool | None = None
+    useQueryV3: bool | None = None
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
     volumeResolution: int
     withAggregations: bool | None = None

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -6826,6 +6826,8 @@ export interface ErrorTrackingQueryApi {
     /** Filter by issue status. */
     status?: ErrorTrackingIssueStatusApi | string | null
     tags?: QueryLogTagsApi | null
+    useQueryV2?: boolean | null
+    useQueryV3?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null
     volumeResolution: number

--- a/products/error_tracking/backend/hogql_queries/test/test_query_schema_compat.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_query_schema_compat.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.schema import QueryRequest
+
+
+class TestErrorTrackingQuerySchemaCompat(SimpleTestCase):
+    # Older frontend bundles still send the deprecated query-path flags. The schema must
+    # keep accepting them until no clients send them anymore — removing them breaks every
+    # stale tab with a hard 400 during deploys (extra="forbid").
+    @parameterized.expand([("useQueryV2", False), ("useQueryV3", True)])
+    def test_accepts_deprecated_query_path_flags(self, flag: str, value: bool) -> None:
+        request = QueryRequest.model_validate(
+            {
+                "query": {
+                    "kind": "ErrorTrackingQuery",
+                    "orderBy": "last_seen",
+                    "dateRange": {"date_from": "-7d"},
+                    "volumeResolution": 20,
+                    flag: value,
+                }
+            }
+        )
+        assert getattr(request.query, flag) == value

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6361,6 +6361,8 @@ export interface ErrorTrackingQueryApi {
     /** Filter by issue status. */
     status?: ErrorTrackingIssueStatusApi | string | null
     tags?: QueryLogTagsApi | null
+    useQueryV2?: boolean | null
+    useQueryV3?: boolean | null
     /** version of the node, used for schema migrations */
     version?: number | null
     volumeResolution: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6248,6 +6248,8 @@ export namespace Schemas {
       /** Filter by issue status. */
       status?: ErrorTrackingIssueStatus | string | null;
       tags?: QueryLogTags | null;
+      useQueryV2?: boolean | null;
+      useQueryV3?: boolean | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
       volumeResolution: number;


### PR DESCRIPTION
## Problem

#63007 made V3 the only error tracking query path and removed the `useQueryV2`/`useQueryV3` fields from the `ErrorTrackingQuery` schema. Because the generated pydantic model uses `extra="forbid"`, frontend bundles built before that change — any error tracking tab left open across the deploy — still send `useQueryV3: true` and now get a hard 400 from `/query` (`Extra inputs are not permitted`). Any persisted query carrying the flag would fail permanently, not just during deploy skew.

## Changes

- Re-add `useQueryV2` and `useQueryV3` to `ErrorTrackingQuery` in `schema-general.ts` as `@deprecated` no-op fields, and regenerate `schema.json` / `posthog/schema.py`.
- Nothing reads the flags — V3 remains the only execution path; the backend just tolerates them again. They can be removed for real once no clients send them.
- Add a parameterized regression test asserting `QueryRequest` validates an `ErrorTrackingQuery` carrying either deprecated flag.

## How did you test this code?

- New automated test: `products/error_tracking/backend/hogql_queries/test/test_query_schema_compat.py` (2 passed).
- Reproduced the exact failing production payload against `QueryRequest.model_validate` — rejected before the change, validates after.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal schema backward-compatibility fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a production error report. Root-caused by diffing the schema at the failing deploy commit against the commit history: the validation error appeared the moment #63007 shipped, matching stale clients that still set the rollout flag. Chose to restore the fields as deprecated no-ops (rather than relaxing `extra="forbid"` or stripping unknown keys at the API layer) to keep the fix narrow and the strict schema intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)