### PR TITLE
feat(mcp): stamp canonical $mcp_* properties on exec inner tool-call events

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -244,6 +244,13 @@ export class ToolExecutor {
                 await state.reqCtx.trackEvent(
                     AnalyticsEvent.MCP_TOOL_CALL,
                     {
+                        // Canonical $mcp_* mirrors so exec-routed inner calls share the
+                        // same event shape as native tools/call events ($mcp_tool_name is
+                        // what MCP analytics keys on); the snake_case keys spread from
+                        // `properties` below stay for queries written against them.
+                        $mcp_tool_name: toolName,
+                        $mcp_is_error: !properties.success,
+                        $mcp_duration_ms: properties.duration_ms,
                         tool_name: toolName,
                         ...(toolCategory ? { $mcp_tool_category: toolCategory } : {}),
                         ...properties,

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -228,4 +228,33 @@ describe('ToolExecutor', () => {
             expect(result.content[0].text).toContain('not found')
         })
     })
+
+    describe('exec inner-call analytics', () => {
+        it('emits canonical $mcp_* properties on inner tool-call events', async () => {
+            const filteredTools = catalog.getFilteredTools({ scopes: ['*'] }).filter((tool) => tool.name === 'user-get')
+            const state = makeState(filteredTools, { useSingleExec: true })
+
+            // The stub context has no real API, so the inner handler fails — the
+            // inner-call event must still carry the canonical properties.
+            await executor.handleToolCall({ name: 'exec', arguments: { command: 'call user-get {}' } }, state)
+
+            const trackEvent = state.reqCtx.trackEvent as ReturnType<typeof vi.fn>
+            // The inner-call event is emitted via a fire-and-forget async IIFE.
+            await vi.waitFor(() => {
+                if (trackEvent.mock.calls.length === 0) {
+                    throw new Error('trackEvent not called yet')
+                }
+            })
+            const [event, properties] = trackEvent.mock.calls[0]!
+            expect(event).toBe('mcp_tool_call')
+            expect(properties).toMatchObject({
+                $mcp_tool_name: 'user-get',
+                $mcp_is_error: true,
+                $mcp_tool_category: 'Core',
+                tool_name: 'user-get',
+                success: false,
+            })
+            expect(typeof properties.$mcp_duration_ms).toBe('number')
+        })
+    })
 })


### PR DESCRIPTION
## Problem

MCP analytics is becoming a product: customers instrument their MCP server with the `@posthog/mcp` npm package, which emits `mcp_tool_call` events keyed on canonical `$mcp_*` properties (`$mcp_tool_name`, `$mcp_is_error`, `$mcp_duration_ms`). PostHog's own MCP server should emit the same shape — but on the exec inner-call path (single-exec mode, which carries most production traffic) it emits only snake_case keys (`tool_name`, `success`, `duration_ms`).

The visible symptom: in any breakdown of `mcp_tool_call` by `$mcp_tool_name`, every exec-routed real tool call lands in the "no value" bucket, and per-tool dashboards (which filter `$mcp_tool_name IS NOT NULL`) silently drop that traffic entirely. Only the outer `exec` wrapper event is visible.

## Changes

On the exec inner-call emit path, mirror the native `tools/call` event shape:

- `$mcp_tool_name` — the inner tool actually invoked (e.g. `query-logs`), matching what the SDK emits for customer servers
- `$mcp_is_error` — derived from the existing `success` flag
- `$mcp_duration_ms` — mirrors `duration_ms`

The legacy snake_case keys are kept so existing queries keep working. `$mcp_tool_category` was already stamped on this path.

Forward-only: events emitted before this deploys keep the old shape (a companion MCP analytics PR makes the dashboards coalesce both shapes for history).

Note for reviewers: after this rolls out, queries that count `mcp_tool_call` events with `$mcp_tool_name` set will see exec-routed traffic twice per invocation — once as the outer `exec` wrapper, once as the inner real tool. Consumers should exclude `$mcp_tool_name = 'exec'` when counting real tool calls; the companion dashboard PR does this.

## How did you test this code?

I'm an agent (PostHog Code). Added a unit test in `tests/hono/tool-executor.test.ts` driving a real `exec call user-get {}` through `ToolExecutor` in single-exec mode and asserting the inner event carries `$mcp_tool_name`, `$mcp_is_error: true`, `$mcp_tool_category: 'Core'`, numeric `$mcp_duration_ms`, plus the legacy keys. Full `tool-executor` hono suite passes (14/14). oxlint/oxfmt clean. No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code, directed by Daniel. This came out of investigating why the MCP analytics "Top tools" breakdown showed a dominant "no value" slice: the Hono exec inner-call path (`request-context.ts trackEvent`) never set `$mcp_tool_name`, unlike both the native path and the `@posthog/mcp` SDK. Considered also marking the outer `exec` wrapper event with a dedicated property, but rejected it for now — name-based exclusion (`$mcp_tool_name = 'exec'`) is sufficient and avoids growing the event contract. One of three related drafts (server shape fix, dashboard query robustness, SDK category auto-capture).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
