### PR TITLE
fix(mcp): resolve AI consent via users/@me for team-scoped tokens

### DIFF
--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -128,7 +128,10 @@ export class StateManager {
         // with no `current_organization` / `current_team` (newly provisioned
         // accounts, users who left their last org) — fall through to the
         // scoped-org fallback below when either is missing.
-        if (activeOrganization && (scoped_organizations.length === 0 || scoped_organizations.includes(activeOrganization.id))) {
+        if (
+            activeOrganization &&
+            (scoped_organizations.length === 0 || scoped_organizations.includes(activeOrganization.id))
+        ) {
             return activeTeam
                 ? { organizationId: activeOrganization.id, projectId: activeTeam.id }
                 : { organizationId: activeOrganization.id }
@@ -386,11 +389,25 @@ export class StateManager {
     async getAiConsentGiven(): Promise<boolean | undefined> {
         try {
             const org = await this.getCachedOrFetchOrg()
-            if (!org) {
-                return undefined
+            if (org) {
+                const consent = (org as { is_ai_data_processing_approved?: boolean | null })
+                    .is_ai_data_processing_approved
+                return !!consent
             }
-            const consent = (org as { is_ai_data_processing_approved?: boolean | null }).is_ai_data_processing_approved
-            return !!consent
+
+            // Team-scoped tokens (e.g. sandbox OAuth tokens) can never fetch
+            // `/api/organizations/{id}/` — see the guard in getCachedOrFetchOrg.
+            // But `/api/users/@me/` is exempt from team scoping and embeds the
+            // full org serializer (including the consent flag) for the user's
+            // *current* org. That org isn't necessarily the one owning the
+            // scoped project, so only trust the flag when it matches the active
+            // project's owning org; otherwise stay undefined so callers keep
+            // failing closed.
+            const [user, project] = await Promise.all([this.getCachedOrFetchUser(), this.getCachedOrFetchProject()])
+            if (user?.organization && project?.organization === user.organization.id) {
+                return !!user.organization.is_ai_data_processing_approved
+            }
+            return undefined
         } catch {
             return undefined
         }

--- a/services/mcp/src/schema/api.ts
+++ b/services/mcp/src/schema/api.ts
@@ -22,6 +22,10 @@ export interface ApiUser {
     organization: {
         id: string
         name: string
+        // `/api/users/@me/` embeds the full OrganizationSerializer for the
+        // current org, so the consent flag is always present on the wire; it is
+        // optional here because some tests construct partial users.
+        is_ai_data_processing_approved?: boolean | null
     } | null
 }
 

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -493,6 +493,102 @@ describe('StateManager', () => {
         )
     })
 
+    describe('getAiConsentGiven', () => {
+        it.each([
+            [true, true],
+            [false, false],
+            [null, false],
+        ])('returns consent from the fetched org when the org is resolvable (flag %s)', async (flag, expected) => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue({
+                id: 'org-1',
+                name: 'Org 1',
+                is_ai_data_processing_approved: flag,
+            } as any)
+            const userSpy = vi.spyOn(stateManager, 'getCachedOrFetchUser')
+
+            const result = await stateManager.getAiConsentGiven()
+
+            expect(result).toBe(expected)
+            expect(userSpy).not.toHaveBeenCalled()
+        })
+
+        it.each([
+            [true, true],
+            [false, false],
+        ])(
+            'falls back to users/@me consent when the org is unreachable and the current org owns the active project (flag %s)',
+            async (flag, expected) => {
+                // Team-scoped tokens (e.g. sandbox OAuth tokens) can never fetch
+                // `/api/organizations/{id}/`, so getCachedOrFetchOrg yields undefined.
+                vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+                vi.spyOn(stateManager, 'getCachedOrFetchUser').mockResolvedValue({
+                    ...mockUser,
+                    organization: { id: 'org-1', name: 'Org 1', is_ai_data_processing_approved: flag },
+                })
+                vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                    id: 456,
+                    organization: 'org-1',
+                } as any)
+
+                const result = await stateManager.getAiConsentGiven()
+
+                expect(result).toBe(expected)
+            }
+        )
+
+        it("returns undefined when the user's current org does not own the active project", async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockResolvedValue({
+                ...mockUser,
+                organization: { id: 'org-other', name: 'Other Org', is_ai_data_processing_approved: true },
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                id: 456,
+                organization: 'org-1',
+            } as any)
+
+            const result = await stateManager.getAiConsentGiven()
+
+            expect(result).toBeUndefined()
+        })
+
+        it('returns undefined when the user has no current org', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockResolvedValue({ ...mockUser, organization: null })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue({
+                id: 456,
+                organization: 'org-1',
+            } as any)
+
+            const result = await stateManager.getAiConsentGiven()
+
+            expect(result).toBeUndefined()
+        })
+
+        it('returns undefined when no project is resolvable', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockResolvedValue({
+                ...mockUser,
+                organization: { id: 'org-1', name: 'Org 1', is_ai_data_processing_approved: true },
+            })
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue(undefined)
+
+            const result = await stateManager.getAiConsentGiven()
+
+            expect(result).toBeUndefined()
+        })
+
+        it('returns undefined (fail closed) when the fallback fetches throw', async () => {
+            vi.spyOn(stateManager, 'getCachedOrFetchOrg').mockResolvedValue(undefined)
+            vi.spyOn(stateManager, 'getCachedOrFetchUser').mockRejectedValue(new Error('boom'))
+            vi.spyOn(stateManager, 'getCachedOrFetchProject').mockResolvedValue(undefined)
+
+            const result = await stateManager.getAiConsentGiven()
+
+            expect(result).toBeUndefined()
+        })
+    })
+
     describe('getProjectId', () => {
         it('should return cached projectId if available', async () => {
             await cache.set('projectId', 'cached-project-id')


### PR DESCRIPTION
## Problem

Team-scoped tokens (sandbox OAuth tokens minted with `scoped_teams`, used by agent sandboxes) can never fetch `/api/organizations/{id}/` — the backend rejects project-scoped tokens on org endpoints regardless of scopes. `StateManager.getAiConsentGiven()` relied solely on that fetch, so it always returned `undefined` for these sessions and the tool filter stripped every AI-consent-gated tool, even when the organization had approved AI data processing.

## Changes

- `getAiConsentGiven()` now falls back to `/api/users/@me/`, which is exempt from team scoping and embeds the full organization serializer (including `is_ai_data_processing_approved`) for the user's current org.
- The fallback only trusts the flag when the current org actually owns the active project (`project.organization === user.organization.id`); any mismatch, missing org, or fetch failure still returns `undefined`, so the filter keeps failing closed.
- Widened the hand-written `ApiUser.organization` type with the consent flag — the field was already in the wire response, the type was just discarding it. No backend changes and no extra API traffic: both fallback fetches are already cached during session init.

## How did you test this code?

- New parameterized unit tests for `getAiConsentGiven` covering the org-fetch path, the team-scoped fallback (consent true/false), the org-mismatch guard, missing org/project, and fail-closed on fetch errors.
- `vitest run tests/unit/StateManager.test.ts` (50 passed) and `tests/unit/tool-filtering.test.ts` (83 passed), `tsc --noEmit` clean.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## 🤖 LLM context

Authored with Claude Code. Root cause traced from the MCP `StateManager` org-fetch guard to the backend scoped-team enforcement (`check_team_and_org_permissions` exempts `scope_object == "user"` viewsets), which is why `users/@me` is reachable for these tokens while org endpoints are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
