### PR TITLE
fix(data-warehouse): extend digest catch-up lookback past digest day

### DIFF
--- a/products/data_warehouse/backend/external_data_source/notifications.py
+++ b/products/data_warehouse/backend/external_data_source/notifications.py
@@ -20,7 +20,7 @@ logger = structlog.get_logger(__name__)
 MAX_SCHEMAS_PER_DIGEST_EMAIL = 30
 
 
-def get_team_ids_with_recent_sync_failures(lookback: dt.timedelta = dt.timedelta(hours=24)) -> list[int]:
+def get_team_ids_with_recent_sync_failures(lookback: dt.timedelta = dt.timedelta(hours=26)) -> list[int]:
     """Teams with still-failing schemas that have an un-communicated recent failure.
 
     Powers the daily catch-up digest: failures that the one-email-per-day block
@@ -28,6 +28,11 @@ def get_team_ids_with_recent_sync_failures(lookback: dt.timedelta = dt.timedelta
     will never produce another failed run to re-trigger the inline path. A failure
     counts only if it is newer than the schema's `last_error_notified_at` stamp,
     so failures already covered by an earlier digest don't trigger a duplicate.
+
+    The lookback exceeds the 24h digest day on purpose: a failure just after the
+    10:00 UTC rollover, blocked because that digest day's email already went out,
+    is 24h15m+ old by the next catch-up run — a 24h lookback would drop it forever
+    for paused schemas. The stamp check above keeps the wider window duplicate-free.
     """
     cutoff = dt.datetime.now(dt.UTC) - lookback
     # Drive from the schema side: the jobs table grows with every sync run and has

--- a/products/data_warehouse/backend/external_data_source/test/test_notifications.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_notifications.py
@@ -257,6 +257,15 @@ class TestGetTeamIdsWithRecentSyncFailures:
 
         assert get_team_ids_with_recent_sync_failures() == [team.pk]
 
+    def test_includes_failure_blocked_just_after_digest_rollover(self):
+        team = self._create_schema_with_job(
+            schema_status=ExternalDataSchema.Status.FAILED,
+            job_finished_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=24, minutes=10),
+            last_error_notified_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=24, minutes=14),
+        )
+
+        assert get_team_ids_with_recent_sync_failures() == [team.pk]
+
     def test_only_returns_qualifying_teams(self):
         qualifying = self._create_schema_with_job(
             schema_status=ExternalDataSchema.Status.FAILED,


### PR DESCRIPTION
## Problem

The daily catch-up digest flushes sync failures that the one-email-per-digest-day campaign key swallowed, but its 24h lookback doesn't quite cover a full digest day plus the 15-minute cron offset. A failure landing just after the 10:00 UTC digest rollover, when that digest day's email has already been sent, is blocked inline and at the same-day catch-up — and by the next day's 10:15 UTC catch-up it is ~24h10m old, falling outside the 24h window. If the schema was paused by a non-retryable error it never fails again, so the failure is never emailed. Flagged by Codex review on #62874.

## Changes

- Widen the catch-up lookback in `get_team_ids_with_recent_sync_failures` from 24h to 26h (24h digest day + 15m cron offset + jitter margin), with a docstring note explaining why it exceeds the digest day.
- The wider window can't cause duplicate emails: the `finished_at > last_error_notified_at` guard already excludes failures covered by an earlier digest.

## How did you test this code?

I'm an agent. Added `test_includes_failure_blocked_just_after_digest_rollover`, which recreates the missed scenario (failed job 24h10m old, notification stamp older than the failure) and asserts the team is picked up. Ran the full file: `pytest products/data_warehouse/backend/external_data_source/test/test_notifications.py` — 19 passed. `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code session directed by @MarconLP: validated the automated review findings on #62874, confirmed the lookback gap was real by tracing the digest-day boundary (`EXTERNAL_DATA_DIGEST_DAY_BOUNDARY_HOUR_UTC`), the 10:15 UTC catch-up cron, and the campaign-key block, then applied the minimal fix. A second finding (recipient RBAC filtering) was assessed as matching the established pattern across sibling pipeline emails and deliberately left out of scope. Targets the feature branch because the tooling only pushes to `posthog-code/`-prefixed branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
