### PR TITLE
fix(mcp): count exec-routed tool calls correctly in MCP analytics queries

### DIFF
--- a/products/mcp_analytics/backend/templates/tool_quality.sql
+++ b/products/mcp_analytics/backend/templates/tool_quality.sql
@@ -1,31 +1,46 @@
 /*
 -- Per-tool quality metrics for the MCP analytics Tool quality tab.
--- One row per $mcp_tool_name with call volume, error rate, latency percentiles,
--- and reach (unique users / sessions / first / last seen).
+-- One row per effective tool name with call volume, error rate, latency
+-- percentiles, and reach (unique users / sessions / first / last seen).
 --
--- Source events: `mcp_tool_call`, emitted by the MCP analytics SDK on every
--- tool invocation. Expected properties:
---   $mcp_tool_name      string
---   $mcp_is_error       boolean
---   $mcp_duration_ms    number (milliseconds)
---   $session_id         string
+-- Source events: `mcp_tool_call`. Events arrive in three property shapes
+-- (mirrored in frontend/mcpEventShape.ts — keep the coalesces in sync):
+--   - native tools/call events: $mcp_tool_name / $mcp_is_error / $mcp_duration_ms
+--   - SDK single-exec events: real tool in $mcp_exec_tool_call_name
+--   - legacy hono exec inner-call events: snake_case tool_name / success / duration_ms
+-- The outer `exec` dispatcher wrapper is excluded: each exec invocation also
+-- emits an inner event for the real tool, so counting both double-counts.
 */
 
 SELECT
-    properties.$mcp_tool_name AS tool,
+    coalesce(
+        nullIf(toString(properties.$mcp_exec_tool_call_name), ''),
+        nullIf(toString(properties.$mcp_tool_name), ''),
+        nullIf(toString(properties.tool_name), '')
+    ) AS tool,
     count() AS total_calls,
-    countIf(toBool(properties.$mcp_is_error)) AS errors,
-    round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct,
-    round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50_duration_ms,
-    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95_duration_ms,
+    countIf(coalesce(toBool(properties.$mcp_is_error), not(toBool(properties.success)), false)) AS errors,
+    round(countIf(coalesce(toBool(properties.$mcp_is_error), not(toBool(properties.success)), false)) * 100.0 / count(), 1) AS error_rate_pct,
+    round(quantile(0.5)(coalesce(toFloat(properties.$mcp_duration_ms), toFloat(properties.duration_ms)))) AS p50_duration_ms,
+    round(quantile(0.95)(coalesce(toFloat(properties.$mcp_duration_ms), toFloat(properties.duration_ms)))) AS p95_duration_ms,
     uniq(distinct_id) AS users,
     countDistinctIf(properties.$session_id, properties.$session_id != '') AS sessions,
     min(timestamp) AS first_seen,
     max(timestamp) AS last_seen
 FROM events
 WHERE event = 'mcp_tool_call'
-    AND properties.$mcp_tool_name IS NOT NULL
-    AND properties.$mcp_tool_name != ''
+    -- Repeats the `tool` coalesce: HogQL resolves SELECT aliases in GROUP BY /
+    -- HAVING but not reliably in WHERE.
+    AND coalesce(
+        nullIf(toString(properties.$mcp_exec_tool_call_name), ''),
+        nullIf(toString(properties.$mcp_tool_name), ''),
+        nullIf(toString(properties.tool_name), '')
+    ) IS NOT NULL
+    AND coalesce(
+        nullIf(toString(properties.$mcp_exec_tool_call_name), ''),
+        nullIf(toString(properties.$mcp_tool_name), ''),
+        nullIf(toString(properties.tool_name), '')
+    ) != 'exec'
     AND {filters}
 GROUP BY tool
 ORDER BY __ORDER_BY__ __ORDER_DIRECTION__

--- a/products/mcp_analytics/backend/templates/tool_quality.sql
+++ b/products/mcp_analytics/backend/templates/tool_quality.sql
@@ -30,7 +30,9 @@ SELECT
 FROM events
 WHERE event = 'mcp_tool_call'
     -- Repeats the `tool` coalesce: HogQL resolves SELECT aliases in GROUP BY /
-    -- HAVING but not reliably in WHERE.
+    -- HAVING but not reliably in WHERE. The IS NOT NULL is load-bearing:
+    -- HogQL's != is null-tolerant (NULL != 'exec' keeps the row), so without
+    -- it shapeless events surface as a NULL tool row.
     AND coalesce(
         nullIf(toString(properties.$mcp_exec_tool_call_name), ''),
         nullIf(toString(properties.$mcp_tool_name), ''),

--- a/products/mcp_analytics/backend/tests/test_tool_quality_sql.py
+++ b/products/mcp_analytics/backend/tests/test_tool_quality_sql.py
@@ -95,6 +95,8 @@ class TestToolQualitySQLExecution(ClickhouseTestMixin, APIBaseTest):
         self._seed({"tool_name": "apm-trace-get", "success": False, "duration_ms": 50})
         # Hono outer exec wrapper: must not produce a row.
         self._seed({"$mcp_tool_name": "exec", "$mcp_is_error": False, "$mcp_duration_ms": 999})
+        # Shapeless event (no tool identity under any key): must not produce a row.
+        self._seed({"$mcp_is_error": False})
 
         sql = (
             TOOL_QUALITY_SQL_PATH.read_text()
@@ -104,12 +106,17 @@ class TestToolQualitySQLExecution(ClickhouseTestMixin, APIBaseTest):
         query = parse_select(sql, placeholders={"filters": ast.Constant(value=True)})
         response = execute_hogql_query(query=query, team=self.team)
 
+        columns = response.columns or []
+        total_calls = columns.index("total_calls")
+        errors = columns.index("errors")
+        p50 = columns.index("p50_duration_ms")
+
         rows = {row[0]: row for row in response.results or []}
         assert set(rows) == {"query-logs", "apm-trace-get"}
         # query-logs: the native call + the SDK single-exec call, one of which errored.
-        assert rows["query-logs"][1] == 2
-        assert rows["query-logs"][2] == 1
+        assert rows["query-logs"][total_calls] == 2
+        assert rows["query-logs"][errors] == 1
         # apm-trace-get: the legacy inner-call shape, counted with its error and duration.
-        assert rows["apm-trace-get"][1] == 1
-        assert rows["apm-trace-get"][2] == 1
-        assert rows["apm-trace-get"][4] == 50
+        assert rows["apm-trace-get"][total_calls] == 1
+        assert rows["apm-trace-get"][errors] == 1
+        assert rows["apm-trace-get"][p50] == 50

--- a/products/mcp_analytics/backend/tests/test_tool_quality_sql.py
+++ b/products/mcp_analytics/backend/tests/test_tool_quality_sql.py
@@ -1,4 +1,11 @@
+from datetime import UTC, datetime
 from pathlib import Path
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
 TOOL_QUALITY_SQL_PATH = TEMPLATES_DIR / "tool_quality.sql"
@@ -41,3 +48,68 @@ def test_tool_quality_sql_targets_mcp_tool_call_event() -> None:
 
     assert "event = 'mcp_tool_call'" in sql
     assert "$mcp_tool_name" in sql
+
+
+def test_tool_quality_sql_resolves_all_event_shapes() -> None:
+    sql = TOOL_QUALITY_SQL_PATH.read_text()
+
+    # The effective-tool coalesce must cover all three producer shapes
+    # (mirrored in frontend/mcpEventShape.ts).
+    assert "$mcp_exec_tool_call_name" in sql
+    assert "properties.tool_name" in sql
+    # Legacy exec inner-call events carry `success` instead of $mcp_is_error
+    # and `duration_ms` instead of $mcp_duration_ms.
+    assert "properties.success" in sql
+    assert "properties.duration_ms" in sql
+
+
+def test_tool_quality_sql_excludes_exec_wrapper() -> None:
+    sql = TOOL_QUALITY_SQL_PATH.read_text()
+
+    assert "!= 'exec'" in sql
+
+
+class TestToolQualitySQLExecution(ClickhouseTestMixin, APIBaseTest):
+    def _seed(self, properties: dict) -> None:
+        _create_event(
+            team=self.team,
+            event="mcp_tool_call",
+            distinct_id="seed",
+            timestamp=datetime.now(tz=UTC),
+            properties=properties,
+        )
+
+    def test_aggregates_every_event_shape_and_drops_the_exec_wrapper(self) -> None:
+        # Native tools/call shape (hono tools mode + SDK wrapping path).
+        self._seed({"$mcp_tool_name": "query-logs", "$mcp_is_error": False, "$mcp_duration_ms": 100})
+        # SDK single-exec shape: real tool rides in $mcp_exec_tool_call_name.
+        self._seed(
+            {
+                "$mcp_tool_name": "exec",
+                "$mcp_exec_tool_call_name": "query-logs",
+                "$mcp_is_error": True,
+                "$mcp_duration_ms": 10,
+            }
+        )
+        # Legacy hono exec inner-call shape: snake_case keys only.
+        self._seed({"tool_name": "apm-trace-get", "success": False, "duration_ms": 50})
+        # Hono outer exec wrapper: must not produce a row.
+        self._seed({"$mcp_tool_name": "exec", "$mcp_is_error": False, "$mcp_duration_ms": 999})
+
+        sql = (
+            TOOL_QUALITY_SQL_PATH.read_text()
+            .replace("__ORDER_BY__", "total_calls")
+            .replace("__ORDER_DIRECTION__", "DESC")
+        )
+        query = parse_select(sql, placeholders={"filters": ast.Constant(value=True)})
+        response = execute_hogql_query(query=query, team=self.team)
+
+        rows = {row[0]: row for row in response.results or []}
+        assert set(rows) == {"query-logs", "apm-trace-get"}
+        # query-logs: the native call + the SDK single-exec call, one of which errored.
+        assert rows["query-logs"][1] == 2
+        assert rows["query-logs"][2] == 1
+        # apm-trace-get: the legacy inner-call shape, counted with its error and duration.
+        assert rows["apm-trace-get"][1] == 1
+        assert rows["apm-trace-get"][2] == 1
+        assert rows["apm-trace-get"][4] == 50

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -7,6 +7,7 @@ import { DataTableNode, HogQLQueryResponse, InsightVizNode, NodeKind } from '~/q
 import { BaseMathType, ChartDisplayType, PropertyFilterType, PropertyMathType } from '~/types'
 
 import type { mcpAnalyticsToolDetailLogicType } from './mcpAnalyticsToolDetailLogicType'
+import { EFFECTIVE_TOOL_HOGQL } from './mcpEventShape'
 
 export interface ToolSummary {
     calls: number
@@ -36,12 +37,6 @@ export interface MCPAnalyticsToolDetailLogicProps {
 const NEW_SDK_SOURCE = 'posthog_mcp_analytics'
 
 const DATE_FROM_CURRENT = '-7d'
-
-// HogQL expression that resolves to the *effective* tool name for new-SDK events:
-// the inner tool when the call went through the single-exec wrapper, otherwise
-// the directly-registered tool name. Use anywhere we need to filter/group by tool.
-const EFFECTIVE_TOOL_HOGQL =
-    "coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))"
 
 const NEW_SDK_FILTER = `properties.$mcp_source = '${NEW_SDK_SOURCE}'`
 

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -20,8 +20,8 @@ import type { mcpAnalyticsToolQualityLogicType } from './mcpAnalyticsToolQuality
 import {
     EFFECTIVE_IS_ERROR_HOGQL,
     EFFECTIVE_TOOL_HOGQL,
-    EXCLUDE_EXEC_WRAPPER_FILTER,
-    EXCLUDE_EXEC_WRAPPER_HOGQL,
+    REAL_TOOL_CALL_FILTER,
+    REAL_TOOL_CALL_HOGQL,
 } from './mcpEventShape'
 
 // `$mcp_tool_category` is stamped onto every mcp_tool_call event by the producer
@@ -41,15 +41,16 @@ ORDER BY category
 // Per-category call counts over a fixed 7-day window powering the "share of MCP
 // usage" headline. Rows with an empty category count toward the total but not the
 // in-scope numerator, so uncategorized traffic dilutes the share as expected. The
-// exec dispatcher wrapper is excluded — it always lacks a category and each exec
-// invocation also emits an inner event for the real tool, so counting the wrapper
-// would dilute the share with a duplicate, uncategorizable event per call.
+// denominator keeps only real tool calls (shapeless events and the exec dispatcher
+// wrapper are excluded — the wrapper always lacks a category and each exec
+// invocation also emits an inner event for the real tool, so counting it would
+// dilute the share with a duplicate, uncategorizable event per call).
 const CATEGORY_COUNTS_QUERY = hogql`
 SELECT toString(properties.$mcp_tool_category) AS category, count() AS calls
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL 7 DAY
-    AND ${hogql.raw(EXCLUDE_EXEC_WRAPPER_HOGQL)}
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY category
 `
 
@@ -219,7 +220,7 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                             math: BaseMathType.TotalCount,
                         },
                     ],
-                    properties: [...categoryProperties, EXCLUDE_EXEC_WRAPPER_FILTER],
+                    properties: [...categoryProperties, REAL_TOOL_CALL_FILTER],
                     breakdownFilter: {
                         breakdown_type: 'hogql',
                         breakdown: EFFECTIVE_TOOL_HOGQL,
@@ -253,7 +254,7 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                             math: BaseMathType.TotalCount,
                         },
                     ],
-                    properties: [...categoryProperties, EXCLUDE_EXEC_WRAPPER_FILTER],
+                    properties: [...categoryProperties, REAL_TOOL_CALL_FILTER],
                     breakdownFilter: {
                         breakdown_type: 'hogql',
                         breakdown: EFFECTIVE_IS_ERROR_HOGQL,
@@ -293,7 +294,7 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                     // math_property can't take a HogQL expression, so this chart reads
                     // $mcp_duration_ms only — legacy exec inner-call events (duration_ms
                     // key) drop out of the percentile rather than skew it.
-                    properties: [...categoryProperties, EXCLUDE_EXEC_WRAPPER_FILTER],
+                    properties: [...categoryProperties, REAL_TOOL_CALL_FILTER],
                     trendsFilter: {
                         display: ChartDisplayType.ActionsLineGraph,
                     },

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -17,6 +17,12 @@ import {
 
 import toolQualityQueryTemplate from '../backend/templates/tool_quality.sql?raw'
 import type { mcpAnalyticsToolQualityLogicType } from './mcpAnalyticsToolQualityLogicType'
+import {
+    EFFECTIVE_IS_ERROR_HOGQL,
+    EFFECTIVE_TOOL_HOGQL,
+    EXCLUDE_EXEC_WRAPPER_FILTER,
+    EXCLUDE_EXEC_WRAPPER_HOGQL,
+} from './mcpEventShape'
 
 // `$mcp_tool_category` is stamped onto every mcp_tool_call event by the producer
 // (PostHog's MCP server from its catalog; external servers via the SDK). We read
@@ -34,12 +40,16 @@ ORDER BY category
 
 // Per-category call counts over a fixed 7-day window powering the "share of MCP
 // usage" headline. Rows with an empty category count toward the total but not the
-// in-scope numerator, so uncategorized traffic dilutes the share as expected.
+// in-scope numerator, so uncategorized traffic dilutes the share as expected. The
+// exec dispatcher wrapper is excluded — it always lacks a category and each exec
+// invocation also emits an inner event for the real tool, so counting the wrapper
+// would dilute the share with a duplicate, uncategorizable event per call.
 const CATEGORY_COUNTS_QUERY = hogql`
 SELECT toString(properties.$mcp_tool_category) AS category, count() AS calls
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL 7 DAY
+    AND ${hogql.raw(EXCLUDE_EXEC_WRAPPER_HOGQL)}
 GROUP BY category
 `
 
@@ -209,10 +219,10 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                             math: BaseMathType.TotalCount,
                         },
                     ],
-                    properties: categoryProperties,
+                    properties: [...categoryProperties, EXCLUDE_EXEC_WRAPPER_FILTER],
                     breakdownFilter: {
-                        breakdown_type: 'event',
-                        breakdown: '$mcp_tool_name',
+                        breakdown_type: 'hogql',
+                        breakdown: EFFECTIVE_TOOL_HOGQL,
                         breakdown_limit: 10,
                     },
                     trendsFilter: {
@@ -243,10 +253,10 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                             math: BaseMathType.TotalCount,
                         },
                     ],
-                    properties: categoryProperties,
+                    properties: [...categoryProperties, EXCLUDE_EXEC_WRAPPER_FILTER],
                     breakdownFilter: {
-                        breakdown_type: 'event',
-                        breakdown: '$mcp_is_error',
+                        breakdown_type: 'hogql',
+                        breakdown: EFFECTIVE_IS_ERROR_HOGQL,
                     },
                     trendsFilter: {
                         display: ChartDisplayType.ActionsLineGraph,
@@ -280,7 +290,10 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                             math_property: '$mcp_duration_ms',
                         },
                     ],
-                    properties: categoryProperties,
+                    // math_property can't take a HogQL expression, so this chart reads
+                    // $mcp_duration_ms only — legacy exec inner-call events (duration_ms
+                    // key) drop out of the percentile rather than skew it.
+                    properties: [...categoryProperties, EXCLUDE_EXEC_WRAPPER_FILTER],
                     trendsFilter: {
                         display: ChartDisplayType.ActionsLineGraph,
                     },

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -7,18 +7,17 @@ import { hogql } from '~/queries/utils'
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
 import type { mcpDashboardOverviewLogicType } from './mcpDashboardOverviewLogicType'
-import { EFFECTIVE_DURATION_HOGQL, EFFECTIVE_IS_ERROR_HOGQL, EFFECTIVE_TOOL_HOGQL } from './mcpEventShape'
+import {
+    EFFECTIVE_DURATION_HOGQL,
+    EFFECTIVE_IS_ERROR_HOGQL,
+    EFFECTIVE_TOOL_HOGQL,
+    REAL_TOOL_CALL_HOGQL,
+} from './mcpEventShape'
 
 // KPI tiles compare this week against the prior week.
 const LOOKBACK_DAYS = 7
 // Breakdowns and trends (activity, tools, harnesses, notable sessions) use a longer 30-day window.
 const BREAKDOWN_DAYS = 30
-
-// Counts each real tool call exactly once across event shapes: resolves to a tool
-// name for every shape (so shapeless noise drops out — NULL fails the comparison)
-// and excludes the exec dispatcher wrapper, which always pairs with an inner event
-// for the real tool.
-const REAL_TOOL_CALL_HOGQL = `${EFFECTIVE_TOOL_HOGQL} != 'exec'`
 
 const KPI_QUERY = hogql`
 SELECT

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -7,25 +7,31 @@ import { hogql } from '~/queries/utils'
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
 import type { mcpDashboardOverviewLogicType } from './mcpDashboardOverviewLogicType'
+import { EFFECTIVE_DURATION_HOGQL, EFFECTIVE_IS_ERROR_HOGQL, EFFECTIVE_TOOL_HOGQL } from './mcpEventShape'
 
 // KPI tiles compare this week against the prior week.
 const LOOKBACK_DAYS = 7
 // Breakdowns and trends (activity, tools, harnesses, notable sessions) use a longer 30-day window.
 const BREAKDOWN_DAYS = 30
 
+// Counts each real tool call exactly once across event shapes: resolves to a tool
+// name for every shape (so shapeless noise drops out — NULL fails the comparison)
+// and excludes the exec dispatcher wrapper, which always pairs with an inner event
+// for the real tool.
+const REAL_TOOL_CALL_HOGQL = `${EFFECTIVE_TOOL_HOGQL} != 'exec'`
+
 const KPI_QUERY = hogql`
 SELECT
     toDate(timestamp) AS bucket,
     countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions,
     count() AS tool_calls,
-    countIf(toBool(properties.$mcp_is_error)) AS errors,
-    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95,
+    countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) AS errors,
+    round(quantile(0.95)(${hogql.raw(EFFECTIVE_DURATION_HOGQL)})) AS p95,
     timestamp >= now() - INTERVAL ${hogql.raw(String(LOOKBACK_DAYS))} DAY AS in_current
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL ${hogql.raw(String(LOOKBACK_DAYS * 2))} DAY
-    AND properties.$mcp_tool_name IS NOT NULL
-    AND properties.$mcp_tool_name != ''
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY bucket, in_current
 ORDER BY bucket
 `
@@ -36,18 +42,17 @@ const SESSION_ROWS_QUERY = hogql`
 SELECT
     toString(properties.$mcp_session_id) AS session_id,
     count() AS tool_calls,
-    countIf(toBool(properties.$mcp_is_error)) AS errors,
-    round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct,
+    countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) AS errors,
+    round(countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) * 100.0 / count(), 1) AS error_rate_pct,
     dateDiff('second', min(timestamp), max(timestamp)) AS duration_seconds,
-    uniq(toString(properties.$mcp_tool_name)) AS distinct_tools,
+    uniq(${hogql.raw(EFFECTIVE_TOOL_HOGQL)}) AS distinct_tools,
     max(timestamp) AS last_seen
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_session_id IS NOT NULL
     AND properties.$mcp_session_id != ''
-    AND properties.$mcp_tool_name IS NOT NULL
-    AND properties.$mcp_tool_name != ''
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY session_id
 HAVING tool_calls >= 1
 ORDER BY tool_calls DESC
@@ -58,16 +63,15 @@ LIMIT 500
 // compact reliability matrix on the overview. Limited columns + 50 rows.
 const TOOL_ROWS_QUERY = hogql`
 SELECT
-    toString(properties.$mcp_tool_name) AS tool,
+    ${hogql.raw(EFFECTIVE_TOOL_HOGQL)} AS tool,
     count() AS total_calls,
-    countIf(toBool(properties.$mcp_is_error)) AS errors,
-    round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct,
-    round(quantile(0.95)(toFloat(properties.$mcp_duration_ms))) AS p95_duration_ms
+    countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) AS errors,
+    round(countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) * 100.0 / count(), 1) AS error_rate_pct,
+    round(quantile(0.95)(${hogql.raw(EFFECTIVE_DURATION_HOGQL)})) AS p95_duration_ms
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
-    AND properties.$mcp_tool_name IS NOT NULL
-    AND properties.$mcp_tool_name != ''
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY tool
 ORDER BY total_calls DESC
 LIMIT 50
@@ -77,13 +81,14 @@ const HARNESS_ROWS_QUERY = hogql`
 SELECT
     toString(properties.$mcp_client_name) AS client,
     count() AS total_calls,
-    countIf(toBool(properties.$mcp_is_error)) AS errors,
+    countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) AS errors,
     countDistinctIf(toString(properties.$mcp_session_id), toString(properties.$mcp_session_id) != '') AS sessions
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
     AND properties.$mcp_client_name IS NOT NULL
     AND properties.$mcp_client_name != ''
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY client
 ORDER BY total_calls DESC
 LIMIT 200
@@ -93,13 +98,12 @@ LIMIT 200
 const ACTIVITY_QUERY = hogql`
 SELECT
     toDate(timestamp) AS day,
-    countIf(NOT toBool(properties.$mcp_is_error)) AS successes,
-    countIf(toBool(properties.$mcp_is_error)) AS errors
+    countIf(not(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)})) AS successes,
+    countIf(${hogql.raw(EFFECTIVE_IS_ERROR_HOGQL)}) AS errors
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
-    AND properties.$mcp_tool_name IS NOT NULL
-    AND properties.$mcp_tool_name != ''
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY day
 ORDER BY day
 `
@@ -108,13 +112,12 @@ ORDER BY day
 const TOOL_DAILY_QUERY = hogql`
 SELECT
     toDate(timestamp) AS day,
-    toString(properties.$mcp_tool_name) AS tool,
+    ${hogql.raw(EFFECTIVE_TOOL_HOGQL)} AS tool,
     count() AS calls
 FROM events
 WHERE event = 'mcp_tool_call'
     AND timestamp >= now() - INTERVAL ${hogql.raw(String(BREAKDOWN_DAYS))} DAY
-    AND properties.$mcp_tool_name IS NOT NULL
-    AND properties.$mcp_tool_name != ''
+    AND ${hogql.raw(REAL_TOOL_CALL_HOGQL)}
 GROUP BY day, tool
 ORDER BY day
 LIMIT 10000

--- a/products/mcp_analytics/frontend/mcpEventShape.ts
+++ b/products/mcp_analytics/frontend/mcpEventShape.ts
@@ -1,0 +1,30 @@
+import { PropertyFilterType } from '~/types'
+import type { HogQLPropertyFilter } from '~/types'
+
+// `mcp_tool_call` events arrive in three property shapes:
+//   - native tools/call events (hono tools mode + SDK wrapping path): $mcp_tool_name
+//   - SDK single-exec events: $mcp_tool_name = 'exec' with the real tool in
+//     $mcp_exec_tool_call_name
+//   - legacy hono exec inner-call events: only the snake_case tool_name key
+// These fragments resolve every shape so queries neither drop exec-routed calls
+// nor bucket them as "no value".
+export const EFFECTIVE_TOOL_HOGQL =
+    "coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), nullIf(toString(properties.$mcp_tool_name), ''), nullIf(toString(properties.tool_name), ''))"
+
+// Canonical $mcp_is_error where present, legacy `success` otherwise.
+export const EFFECTIVE_IS_ERROR_HOGQL =
+    'coalesce(toBool(properties.$mcp_is_error), not(toBool(properties.success)), false)'
+
+// Canonical $mcp_duration_ms where present, legacy `duration_ms` otherwise.
+export const EFFECTIVE_DURATION_HOGQL =
+    'coalesce(toFloat(properties.$mcp_duration_ms), toFloat(properties.duration_ms))'
+
+// In single-exec mode each invocation emits two events: the outer `exec`
+// dispatcher wrapper and an inner event for the real tool. Excluding the wrapper
+// counts each real call exactly once.
+export const EXCLUDE_EXEC_WRAPPER_HOGQL = `${EFFECTIVE_TOOL_HOGQL} != 'exec'`
+
+export const EXCLUDE_EXEC_WRAPPER_FILTER: HogQLPropertyFilter = {
+    type: PropertyFilterType.HogQL,
+    key: EXCLUDE_EXEC_WRAPPER_HOGQL,
+}

--- a/products/mcp_analytics/frontend/mcpEventShape.ts
+++ b/products/mcp_analytics/frontend/mcpEventShape.ts
@@ -19,12 +19,14 @@ export const EFFECTIVE_IS_ERROR_HOGQL =
 export const EFFECTIVE_DURATION_HOGQL =
     'coalesce(toFloat(properties.$mcp_duration_ms), toFloat(properties.duration_ms))'
 
-// In single-exec mode each invocation emits two events: the outer `exec`
-// dispatcher wrapper and an inner event for the real tool. Excluding the wrapper
-// counts each real call exactly once.
-export const EXCLUDE_EXEC_WRAPPER_HOGQL = `${EFFECTIVE_TOOL_HOGQL} != 'exec'`
+// Keeps exactly the events that represent one real tool call. Two conditions:
+// the IS NOT NULL drops shapeless events (HogQL's != is null-tolerant, so a
+// NULL effective tool would otherwise pass the comparison and surface as a
+// "None" bucket), and != 'exec' drops the single-exec dispatcher wrapper, which
+// always pairs with an inner event for the real tool.
+export const REAL_TOOL_CALL_HOGQL = `${EFFECTIVE_TOOL_HOGQL} IS NOT NULL AND ${EFFECTIVE_TOOL_HOGQL} != 'exec'`
 
-export const EXCLUDE_EXEC_WRAPPER_FILTER: HogQLPropertyFilter = {
+export const REAL_TOOL_CALL_FILTER: HogQLPropertyFilter = {
     type: PropertyFilterType.HogQL,
-    key: EXCLUDE_EXEC_WRAPPER_HOGQL,
+    key: REAL_TOOL_CALL_HOGQL,
 }


### PR DESCRIPTION
## Problem

MCP analytics is heading toward "customers instrument their MCP with our npm package and view it in our dashboard" — which means the dashboard must handle every event shape `mcp_tool_call` actually arrives in. Today there are three:

1. **Native tools/call events** (hono tools mode + the SDK wrapping path): `$mcp_tool_name` / `$mcp_is_error` / `$mcp_duration_ms`
2. **SDK single-exec events**: `$mcp_tool_name = 'exec'` with the real tool in `$mcp_exec_tool_call_name`
3. **Legacy hono exec inner-call events**: only snake_case keys (`tool_name`, `success`, `duration_ms`)

The queries keyed on shape 1 only. Symptoms on production data: the "Top tools" pie is ~48% a giant `exec` slice, the category breakdown shows a dominant "no value" bucket, the tool quality table silently drops every legacy inner-call event, and exec invocations are double-counted (outer wrapper + inner event).

## Changes

- New `frontend/mcpEventShape.ts` with shared HogQL fragments: effective tool name (coalescing all three shapes), effective is-error (`$mcp_is_error` or legacy `success`), effective duration, and an exec-wrapper exclusion filter. The same fragments are mirrored in `tool_quality.sql` (the backend template can't import TS — comments cross-reference both).
- **Tool quality tab**: the table SQL, top-tools breakdown, error trend breakdown, and the category "share of MCP usage" denominator now use the effective fragments and exclude the wrapper. (The duration chart keeps `math_property: $mcp_duration_ms` since trends math can't take an expression — legacy events drop out of the percentile rather than skew it.)
- **Tool detail scene**: its local effective-tool coalesce is replaced by the shared one, adding the missing `tool_name` fallback.
- **Dashboard overview**: all six queries (KPIs, notable sessions, tool reliability matrix, harness rows, activity, tool-daily) switch to the effective fragments and exclude the wrapper, so each real call counts exactly once.

Works retroactively on historical events. Companion PR #63300 makes the server emit canonical properties on the inner-call path going forward, so the legacy fallbacks matter less over time.

## How did you test this code?

I'm an agent (PostHog Code). Added an execution test (`TestToolQualitySQLExecution`) that seeds all four event shapes (native, SDK single-exec, legacy inner-call, outer wrapper) into ClickHouse and runs the actual template through `parse_select` + `execute_hogql_query` — asserting the inner shapes aggregate under their real tool names with correct error/duration values and the wrapper produces no row. Plus text assertions on the template. All 7 tests pass against a fresh test DB. oxlint/oxfmt/ruff clean. No manual UI verification — screenshots owed before this leaves draft.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code, directed by Daniel. Root cause was found by inspecting raw production events: the hono exec inner-call emit path (`request-context.ts trackEvent`) never set `$mcp_tool_name`, so ~half of production traffic was invisible to `$mcp_tool_name`-keyed queries. Coalesce order intentionally puts `$mcp_exec_tool_call_name` first so the SDK's single-event shape resolves to the real tool while the hono outer wrapper (which lacks it) stays `exec` and gets excluded. One of three related drafts (server shape fix #63300, this dashboard fix, SDK category auto-capture).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
