### PR TITLE
feat(dashboards): edit insight tile descriptions inline by clicking

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.test.tsx
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom'
 
 import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { initKeaTests } from '~/test/init'
 
 import { InsightMetaContent } from './InsightMeta'
 
@@ -37,6 +40,52 @@ describe('InsightMetaContent', () => {
             <InsightMetaContent title="Test" description={description} compact={false} showDescription={false} />
         )
         expect(container.querySelector('.CardMeta__description')).toBeInTheDocument()
+    })
+
+    describe('inline description editing', () => {
+        beforeEach(() => {
+            initKeaTests()
+        })
+
+        it('renders a static description when onDescriptionSave is not provided', () => {
+            const { container } = render(<InsightMetaContent title="Test" description={description} />)
+            expect(container.querySelector('[data-attr="insight-card-description-inline"]')).toBeNull()
+            expect(container.querySelector('.CardMeta__description')).toBeInTheDocument()
+        })
+
+        it('saves an edited description on blur when onDescriptionSave is provided', async () => {
+            const onDescriptionSave = jest.fn()
+            const { container } = render(
+                <InsightMetaContent title="Test" description={description} onDescriptionSave={onDescriptionSave} />
+            )
+            const field = container.querySelector('[data-attr="insight-card-description-inline"]')
+            expect(field).toBeInTheDocument()
+
+            // Click the rendered description text to enter edit mode
+            await userEvent.click(field!.querySelector('.LemonMarkdown')!)
+            const textarea = field!.querySelector('textarea')
+            expect(textarea).toBeInTheDocument()
+
+            await userEvent.clear(textarea!)
+            await userEvent.type(textarea!, 'Updated description')
+            await userEvent.tab() // Blur the textarea
+
+            expect(onDescriptionSave).toHaveBeenCalledTimes(1)
+            expect(onDescriptionSave).toHaveBeenCalledWith('Updated description')
+        })
+
+        it('does not save on blur when the description is unchanged', async () => {
+            const onDescriptionSave = jest.fn()
+            const { container } = render(
+                <InsightMetaContent title="Test" description={description} onDescriptionSave={onDescriptionSave} />
+            )
+            const field = container.querySelector('[data-attr="insight-card-description-inline"]')
+
+            await userEvent.click(field!.querySelector('.LemonMarkdown')!)
+            await userEvent.tab()
+
+            expect(onDescriptionSave).not.toHaveBeenCalled()
+        })
     })
 
     describe('tile.show_description default-to-show mapping', () => {

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -313,7 +313,7 @@ export function InsightMeta({
     const onMetaSave = canEditInsight
         ? (updates: { name?: string; description?: string }) => {
               updateInsightDirect(insight, updates)
-              if (updates.description && !tile?.show_description && toggleShowDescription) {
+              if (updates.description && tile?.show_description === false && toggleShowDescription) {
                   toggleShowDescription()
               }
               const attribute = updates.name !== undefined ? 'name' : 'description'
@@ -351,6 +351,11 @@ export function InsightMeta({
                         tags={insight.tags}
                         compact={showCompactTile}
                         showDescription={tile?.show_description !== false}
+                        onDescriptionSave={
+                            showEditingControls && onMetaSave
+                                ? (description: string) => onMetaSave({ description })
+                                : undefined
+                        }
                         infoPopover={
                             showCompactTile ? (
                                 <CompactInfoPopover
@@ -652,6 +657,7 @@ export function InsightMetaContent({
     compact,
     showDescription,
     infoPopover,
+    onDescriptionSave,
 }: {
     title: string
     fallbackTitle?: string
@@ -663,6 +669,8 @@ export function InsightMetaContent({
     compact?: boolean
     showDescription?: boolean
     infoPopover?: JSX.Element | null
+    /** When provided, the description becomes editable in place (click to edit, saved on blur). */
+    onDescriptionSave?: (description: string) => void
 }): JSX.Element {
     const titleContent = (
         <>
@@ -698,11 +706,29 @@ export function InsightMetaContent({
     return (
         <>
             {titleEl}
-            {(!compact || showDescription) && !!description && (
-                <LemonMarkdown className="CardMeta__description" lowKeyHeadings>
-                    {description}
-                </LemonMarkdown>
-            )}
+            {(!compact || showDescription) &&
+                !!description &&
+                (onDescriptionSave ? (
+                    <EditableField
+                        name="description"
+                        value={description}
+                        onSave={onDescriptionSave}
+                        placeholder="Enter description (optional)"
+                        saveOnBlur
+                        clickToEdit
+                        multiline
+                        markdown
+                        compactButtons
+                        compactIcon
+                        showEditIconOnHover
+                        className="CardMeta__description"
+                        data-attr="insight-card-description-inline"
+                    />
+                ) : (
+                    <LemonMarkdown className="CardMeta__description" lowKeyHeadings>
+                        {description}
+                    </LemonMarkdown>
+                ))}
             {!compact && tags && tags.length > 0 && <ObjectTags tags={tags} staticOnly />}
             <LemonTableLoader loading={loading} />
         </>

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -172,7 +172,7 @@ export function DashboardItems(): JSX.Element {
         () => ({
             enabled: layoutEditMode && !isMobileView,
             handle: '.CardMeta,.TextCard__body,.ButtonTileCard__body,.WidgetCard__header,.drag-handle',
-            cancel: 'a,table,button,input,.Popover',
+            cancel: 'a,table,button,input,textarea,.Popover,.EditableField',
             bounded: true,
         }),
         [layoutEditMode, isMobileView]
@@ -215,7 +215,7 @@ export function DashboardItems(): JSX.Element {
                       // Don't trigger when clicking obvious interactive controls or readonly rich text (TipTap/LemonMarkdown).
                       if (
                           target.closest(
-                              'input,textarea,button,select,a,p,h4,[contenteditable="true"],[role="textbox"],.ProseMirror,.LemonMarkdown'
+                              'input,textarea,button,select,a,p,h4,[contenteditable="true"],[role="textbox"],.ProseMirror,.LemonMarkdown,.EditableField'
                           )
                       ) {
                           return


### PR DESCRIPTION
## Problem

Editing a tile's description on a dashboard requires opening the info popover or leaving for the insight page. Users expect to click the description text on the tile, type, and have it save when they click away.

## Changes

- Clicking a tile's description now opens an inline editor (markdown supported) that saves on blur — gated to users with insight edit access and non-public placements; everyone else keeps the static text
- Fixed a latent bug where saving a description via the info popover would toggle it hidden on tiles with `show_description` unset (`null` means visible, but the check treated it as hidden)
- Excluded the editable field from tile drag handles (both view-mode drag-to-edit and grid layout-edit drag) so click-to-edit never starts a drag

## How did you test this code?

Authored by an agent; no manual testing claimed. Automated tests run locally:

- Added jest tests in `InsightMeta.test.tsx`: saves on blur when changed, no save when unchanged, static render without the save callback — all passing alongside existing tests
- `DashboardItems.test.tsx` passing
- `tsc --noEmit` clean for the changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Code cloud task); directed by @MattPua
- Reused the existing `EditableField` (`clickToEdit` + `saveOnBlur`) and the existing `onMetaSave` → `updateInsightDirect` persistence path already used by the tile info popover, rather than introducing new state or API calls
- The `show_description === false` fix was found while wiring the inline path: the old `!tile?.show_description` check would have hidden a visible description on every inline save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
