### PR TITLE
feat(customer-analytics): Default usage questions to consumption data

### DIFF
--- a/ee/hogai/context/account/context.py
+++ b/ee/hogai/context/account/context.py
@@ -5,6 +5,10 @@ from posthog.models.group.util import get_group_by_key
 from posthog.models.tagged_item import TaggedItem
 from posthog.sync import database_sync_to_async
 
+from products.customer_analytics.backend.constants import (
+    BILLING_SPEND_INSIGHT_SHORT_IDS,
+    BILLING_USAGE_INSIGHT_SHORT_IDS,
+)
 from products.customer_analytics.backend.models import Account
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 
@@ -131,8 +135,14 @@ class AccountContext:
         if group is None:
             return ACCOUNT_ANALYSIS_GROUP_NOT_FOUND_TEMPLATE.format(group_key=account.external_id)
         return ACCOUNT_ANALYSIS_CONNECTED_TEMPLATE.format(
-            group_type_index=group_type_index, group_key=account.external_id
+            group_type_index=group_type_index,
+            group_key=account.external_id,
+            billing_insights_clause=self._billing_insights_clause(),
         )
+
+    def _billing_insights_clause(self) -> str:
+        short_ids = [*BILLING_USAGE_INSIGHT_SHORT_IDS, *BILLING_SPEND_INSIGHT_SHORT_IDS]
+        return f" (saved insight short ids: {', '.join(short_ids)})"
 
     def _account_group_type_index(self) -> int | None:
         try:

--- a/ee/hogai/context/account/context.py
+++ b/ee/hogai/context/account/context.py
@@ -141,8 +141,9 @@ class AccountContext:
         )
 
     def _billing_insights_clause(self) -> str:
-        short_ids = [*BILLING_USAGE_INSIGHT_SHORT_IDS, *BILLING_SPEND_INSIGHT_SHORT_IDS]
-        return f" (saved insight short ids: {', '.join(short_ids)})"
+        usage = ", ".join(BILLING_USAGE_INSIGHT_SHORT_IDS)
+        spend = ", ".join(BILLING_SPEND_INSIGHT_SHORT_IDS)
+        return f" (Usage insight short ids: {usage}; Spend insight short ids: {spend})"
 
     def _account_group_type_index(self) -> int | None:
         try:

--- a/ee/hogai/context/account/prompts.py
+++ b/ee/hogai/context/account/prompts.py
@@ -39,7 +39,10 @@ ACCOUNT_ANALYSIS_CONNECTED_TEMPLATE = """
 <account_analysis_context>
 For your own analysis only — do not repeat these identifiers to the user.
 This account is connected to its product data as group type index {group_type_index}, group key "{group_key}".
-To answer questions about its usage, events, or feature flags, switch to product analytics or SQL and scope the analysis to this group. Its usage trends also live in the account's Usage tab in the Accounts list.
+
+Two different questions, two different data sources — pick the right one:
+- CONSUMPTION and SPEND — how much the account uses PostHog as a product (events ingested, rows synced, recordings, feature-flag requests, exceptions, MRR, cost) — is the DEFAULT for "usage", "volume", "spike", "growth", "cost", and "spend" questions. This lives in warehouse-synced billing data, surfaced by the account's saved Usage and Spend insights{billing_insights_clause} — the same insights behind the Usage and Spend tabs in the Accounts list. To analyze it, read those insights to get their warehouse SQL, then switch to SQL and run an adapted query scoped to this account (its group key is the billing organization_id). Do NOT answer a usage, volume, or spend question by counting group-scoped events.
+- ENGAGEMENT — what the people at this account DO inside the product (pages viewed, features clicked) — is the group-scoped event stream. Only use this when the user explicitly asks about behavior or activity, not consumption. To analyze it, switch to product analytics or SQL and scope to this group.
 </account_analysis_context>
 """.strip()
 

--- a/ee/hogai/context/account/test/test_context.py
+++ b/ee/hogai/context/account/test/test_context.py
@@ -124,7 +124,7 @@ class TestAccountContext(NonAtomicBaseTest):
         # Pins the real short_ids: fails if the constants are deleted, emptied, or changed by accident.
         assert (
             AccountContext(team=self.team)._billing_insights_clause()
-            == " (saved insight short ids: fiJDsKLp, o4I9sdFE, Tjo4bsux)"
+            == " (Usage insight short ids: fiJDsKLp; Spend insight short ids: o4I9sdFE, Tjo4bsux)"
         )
 
     async def test_analysis_not_configured_when_group_type_index_missing(self):

--- a/ee/hogai/context/account/test/test_context.py
+++ b/ee/hogai/context/account/test/test_context.py
@@ -120,6 +120,13 @@ class TestAccountContext(NonAtomicBaseTest):
         assert "group type index 2" in result
         assert 'group key "acme-1"' in result
 
+    async def test_billing_insights_clause_lists_configured_short_ids(self):
+        # Pins the real short_ids: fails if the constants are deleted, emptied, or changed by accident.
+        assert (
+            AccountContext(team=self.team)._billing_insights_clause()
+            == " (saved insight short ids: fiJDsKLp, o4I9sdFE, Tjo4bsux)"
+        )
+
     async def test_analysis_not_configured_when_group_type_index_missing(self):
         account = await self._create_account(name="Acme Corp", external_id="acme-1")
 

--- a/ee/hogai/core/agent_modes/presets/customer_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/customer_analytics.py
@@ -19,11 +19,19 @@ CUSTOMER_ANALYTICS_MODE_DESCRIPTION = (
     "Use this mode to create and update accounts, assign customer-success roles (CSM, account "
     "executive, account owner), set external-system identifiers and tags, and save and update notes "
     "(call recaps, meeting summaries, investigation recaps) on an account. "
-    "Each account's usage is already available in the Accounts list — in the expanded row's Usage tab — "
-    "so point users there rather than building a new insight for it. "
-    "For other questions about an account's activity or behavior, first look up the account — reading "
-    "it gives you the context needed to analyze it — then switch_mode to product analytics or SQL to "
-    "run the analysis for that account. "
+    "When the user asks about an account's usage, volume, spikes, growth, cost, or spend, they mean "
+    "the account's CONSUMPTION of PostHog as a product — events ingested, data-warehouse rows synced, "
+    "recordings, feature-flag requests, exceptions, MRR, spend — which lives in warehouse-synced billing "
+    "data, surfaced by the account's saved Usage and Spend insights (and the Usage/Spend tabs in the "
+    "Accounts list). This is the DEFAULT for usage questions: look up the account, read the relevant "
+    "saved insight to get its warehouse query, then switch_mode to SQL and adapt that query scoped to the "
+    "account. Do NOT answer a usage or spend question by counting the account's events — the event stream "
+    "measures the people at the account interacting with the product (engagement), not the account's "
+    "product consumption. Only analyze the account's events when the user explicitly asks about behavior "
+    "or activity (what its people do in the product), reading the account first then switching to product "
+    "analytics or SQL. "
+    "For a quick 'show me usage' ask, point users to the account's Usage tab in the Accounts list rather "
+    "than building a new insight. "
     "When the user investigates a single account across several turns — follow-up questions or digging "
     "into an issue — offer once to capture the investigation as a note: a timeline of what was checked "
     "and what you found, saved with upsert_account_notebook. If they decline, don't ask again. "
@@ -58,21 +66,40 @@ POSITIVE_EXAMPLE_ACCOUNT_USAGE_REASONING = """
 2. Surfacing the existing view is faster and consistent with the rest of the product.
 """.strip()
 
-POSITIVE_EXAMPLE_ACCOUNT_ANALYTICS = """
-User: Acme Corp had an MRR spike last month — help me understand why.
-Assistant: Let me dig into what drove Acme Corp's spike.
+POSITIVE_EXAMPLE_ACCOUNT_USAGE_SPIKE = """
+User: Did Acme Corp have a usage spike recently?
+Assistant: Let me check Acme Corp's consumption.
 *Creates a todo list:*
 1. Look up the Acme Corp account (read_data with the account kind)
-2. Switch to product analytics (or SQL) mode
-3. Build an insight — branching off the account's existing usage view — comparing usage by product last month vs the prior period
-4. Identify which products grew and summarize the likely driver of the spike
+2. Read the account's saved Usage insight to get its warehouse query
+3. Switch to SQL mode
+4. Adapt that query scoped to Acme Corp and compare the recent window to the prior period
+5. Identify which consumption metric spiked (events ingested, rows synced, recordings, …) and when
+*Begins working on the first task*
+""".strip()
+
+POSITIVE_EXAMPLE_ACCOUNT_USAGE_SPIKE_REASONING = """
+1. "Usage spike" is a consumption question — it's about how much of PostHog the account consumes (events ingested, rows synced), which lives in the warehouse billing data, not in the account's event stream (that would measure the account's people using the product).
+2. Reading the saved Usage insight first gives the exact warehouse query to adapt, so the analysis stays consistent with the Usage tab instead of being rebuilt from scratch.
+3. The analysis itself runs in SQL mode after the switch, scoped to the account, comparing periods to locate the spike.
+""".strip()
+
+POSITIVE_EXAMPLE_ACCOUNT_ANALYTICS = """
+User: Acme Corp's spend jumped last month — help me understand why.
+Assistant: Let me dig into what drove Acme Corp's spend.
+*Creates a todo list:*
+1. Look up the Acme Corp account (read_data with the account kind)
+2. Read the account's saved Spend insight (and Usage insight) to get their warehouse queries
+3. Switch to SQL mode
+4. Adapt those queries scoped to Acme Corp, comparing last month to the prior period by product
+5. Identify which product's consumption and cost grew and summarize the likely driver
 *Begins working on the first task*
 """.strip()
 
 POSITIVE_EXAMPLE_ACCOUNT_ANALYTICS_REASONING = """
-1. This is a "why" question, not a "what" — the Usage tab shows the account's usage, but here the user wants the explanation behind an MRR change.
-2. MRR is usage-based, so the answer ties to which products' usage grew; that needs a period-over-period comparison the built-in tabs don't provide.
-3. The account is looked up first, then the analysis runs after switching to product analytics or SQL — reusing the existing usage view as a starting point rather than building from scratch.
+1. Spend is consumption-based, so the answer ties to which products' usage grew — both live in the warehouse billing data behind the Spend and Usage insights, not in the account's event stream.
+2. Reading those saved insights first gives the warehouse queries to adapt, keeping the analysis consistent with the Spend/Usage tabs rather than rebuilt from scratch.
+3. The account is looked up first, then the period-over-period comparison runs in SQL mode after the switch — something the built-in tabs don't provide on their own.
 """.strip()
 
 POSITIVE_EXAMPLE_SAVE_NOTE = """
@@ -120,6 +147,9 @@ class CustomerAnalyticsAgentToolkit(AgentToolkit):
     POSITIVE_TODO_EXAMPLES = [
         TodoWriteExample(example=POSITIVE_EXAMPLE_ASSIGN_ROLE, reasoning=POSITIVE_EXAMPLE_ASSIGN_ROLE_REASONING),
         TodoWriteExample(example=POSITIVE_EXAMPLE_ACCOUNT_USAGE, reasoning=POSITIVE_EXAMPLE_ACCOUNT_USAGE_REASONING),
+        TodoWriteExample(
+            example=POSITIVE_EXAMPLE_ACCOUNT_USAGE_SPIKE, reasoning=POSITIVE_EXAMPLE_ACCOUNT_USAGE_SPIKE_REASONING
+        ),
         TodoWriteExample(
             example=POSITIVE_EXAMPLE_ACCOUNT_ANALYTICS, reasoning=POSITIVE_EXAMPLE_ACCOUNT_ANALYTICS_REASONING
         ),

--- a/ee/hogai/core/agent_modes/presets/test/test_customer_analytics.py
+++ b/ee/hogai/core/agent_modes/presets/test/test_customer_analytics.py
@@ -7,6 +7,7 @@ from posthog.schema import AgentMode
 from ee.hogai.context import AssistantContextManager
 from ee.hogai.core.agent_modes.presets.customer_analytics import (
     CUSTOMER_ANALYTICS_MODE_DESCRIPTION,
+    POSITIVE_EXAMPLE_ACCOUNT_USAGE_SPIKE,
     CustomerAnalyticsAgentToolkit,
     customer_analytics_agent,
 )
@@ -41,3 +42,9 @@ class TestCustomerAnalyticsPreset(BaseTest):
 
         for term in _LEAKY_TERMS:
             self.assertNotIn(term.lower(), surface_text)
+
+    def test_usage_spike_example_is_wired_into_todo_examples(self):
+        # A defined-but-unused trajectory example is dead code — it never reaches the agent.
+        wired_examples = [example.example for example in CustomerAnalyticsAgentToolkit.POSITIVE_TODO_EXAMPLES]
+
+        self.assertIn(POSITIVE_EXAMPLE_ACCOUNT_USAGE_SPIKE, wired_examples)

--- a/products/customer_analytics/backend/constants.py
+++ b/products/customer_analytics/backend/constants.py
@@ -2,3 +2,10 @@ DEFAULT_ACTIVITY_EVENT = {"kind": "EventsNode", "event": "$pageview", "name": "$
 
 # Mirrors frontend `FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP`.
 CUSTOMER_ANALYTICS_CSP_FLAG = "customer-analytics-csp"
+
+# Mirrors frontend `BILLING_INSIGHT_SHORT_IDS` in accountBillingLogic.ts. These saved insights read
+# warehouse-synced billing data to report an account's PostHog consumption (events ingested, rows
+# synced, recordings, etc.) and spend (MRR, per-product cost). PostHog-internal: they only resolve
+# in environments where the billing warehouse data exists; elsewhere the agent's lookup falls back.
+BILLING_USAGE_INSIGHT_SHORT_IDS = ["fiJDsKLp"]
+BILLING_SPEND_INSIGHT_SHORT_IDS = ["o4I9sdFE", "Tjo4bsux"]


### PR DESCRIPTION
## Problem

The Customer analytics agent answers account usage/spend questions from the account's group-scoped event stream — that measures engagement (the account's people using the product), not the account's PostHog consumption (events ingested, rows synced, recordings, spend).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Part of https://github.com/PostHog/posthog/issues/61893
## Changes

- Teach the account analysis context the consumption-vs-engagement distinction; usage/volume/spike/cost/spend questions default to warehouse-synced billing data
- Surface the saved Usage/Spend insight short ids in the account context so the agent reads them and adapts their warehouse queries scoped to the account
- Mirror the frontend billing insight short ids as backend constants
- Update the mode description and trajectory examples; add a usage-spike example

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests (`ee/hogai/context/account`, `ee/hogai/core/agent_modes/presets`)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude). Key decision: the agent reuses the saved billing insights as the source of truth for consumption data — reading their warehouse SQL and adapting it — rather than baking warehouse queries into the prompt.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
