### PR TITLE
feat(data-warehouse): promote 5 sources from beta to GA

### DIFF
--- a/posthog/temporal/data_imports/sources/buildbetter/source.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -90,7 +91,7 @@ class BuildBetterSource(ResumableSource[BuildBetterSourceConfig, BuildBetterResu
         return SourceConfig(
             name=SchemaExternalDataSourceType.BUILD_BETTER,
             label="BuildBetter",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="Connect your BuildBetter workspace to sync interviews, extractions, persons, and companies.",
             iconPath="/static/services/buildbetter.png",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -34,7 +35,7 @@ class KlaviyoSource(ResumableSource[KlaviyoSourceConfig, KlaviyoResumeConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.KLAVIYO,
             label="Klaviyo",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Klaviyo API key to automatically pull your Klaviyo data into the PostHog Data warehouse.
 
 You can create a private API key in your [Klaviyo account settings](https://www.klaviyo.com/settings/account/api-keys).

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -34,7 +35,7 @@ class MailchimpSource(ResumableSource[MailchimpSourceConfig, MailchimpResumeConf
         return SourceConfig(
             name=SchemaExternalDataSourceType.MAILCHIMP,
             label="Mailchimp",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Mailchimp API key to automatically pull your Mailchimp data into the PostHog Data warehouse.
 
 You can create an API key in your [Mailchimp account settings](https://us1.admin.mailchimp.com/account/api/).

--- a/posthog/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/source.py
@@ -2,6 +2,7 @@ from typing import Optional, cast
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -50,7 +51,7 @@ class PinterestAdsSource(ResumableSource[PinterestAdsSourceConfig, PinterestAdsR
             name=SchemaExternalDataSourceType.PINTEREST_ADS,
             label="Pinterest Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Pinterest Ads. Ensure you have granted PostHog access to your Pinterest Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/pinterest-ads).",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/pinterest_ads.png",
             docsUrl="https://posthog.com/docs/cdp/sources/pinterest-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
@@ -23,7 +23,7 @@ class TestPinterestAdsSource:
 
         assert config.name.value == "PinterestAds"
         assert config.label == "Pinterest Ads"
-        assert config.releaseStatus == "beta"
+        assert config.releaseStatus == "ga"
         assert config.featureFlag is None
         assert len(config.fields) == 2
 

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -5,6 +5,7 @@ from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.schema import (
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -57,7 +58,7 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
             caption="Enter your Redshift credentials to automatically pull your Redshift data into the PostHog Data warehouse",
             iconPath="/static/services/redshift.png",
             docsUrl="https://posthog.com/docs/cdp/sources/redshift",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

Five data warehouse sources have matured past beta — they meet the GA bar on adoption/longevity and error rate — but were still surfaced as **beta** via `/api/public_source_configs/`. This promotes their release status so users see them as generally available.

## Changes

One-line `releaseStatus` promotion (beta → GA) for each source's `get_source_config`, switching the value to the `ReleaseStatus.GA` enum (the convention the skill calls for; these five were among the stragglers still using a bare `"beta"` string literal). No connector behavior, schemas, or sync logic changed — status-only.

None of the five had a `featureFlag` or `unreleasedSource` gate, so there was no gating to remove alongside the promotion.

| Source | Change | Adoption / longevity | Error rate (7d) |
| --- | --- | --- | --- |
| Klaviyo | Beta → GA | 86 teams · live 4.4 months | 0.3% |
| Mailchimp | Beta → GA | 47 teams · live 4.3 months | 0.1% |
| BuildBetter | Beta → GA | 1 team · live 3.7 months | 0.0% |
| Pinterest Ads | Beta → GA | 30 teams · live 3.3 months | 0.0% |
| Redshift | Beta → GA | 6 teams · live 4.0 months | 1.0% |

GA bar: 100+ teams **or** live 3+ months, **and** error rate < 2.5% over the last 7 days. Each source clears the longevity threshold (3+ months) and is comfortably under the 2.5% error ceiling.

## How did you test this code?

I'm an agent. I ran the Pinterest source config test (`test_pinterest_source.py::TestPinterestAdsSource::test_get_source_config`), which asserts the surfaced release status — updated its expectation to `"ga"` and it passes. I ran `ruff check` on all modified files (clean). The remaining four sources have no test asserting release status.

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code at the request of the warehouse-sources owner. The task was a batch release-status promotion; the only judgment calls were (1) using the `ReleaseStatus.GA` enum rather than a bare string, per the `implementing-warehouse-sources` skill convention, and (2) confirming none of the five carried a beta gating flag that should be removed in the same change. Verified each source's pipeline location and checked for snapshot/config tests before committing.