### PR TITLE
chore(cohorts): remove unused cohort-email-lookup-clickhouse flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -249,7 +249,6 @@ export const FEATURE_FLAGS = {
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp
     CDP_VERCEL_LOG_DRAIN: 'cdp-vercel-log-drain', // owner: #team-workflows-cdp
     COHORT_CALCULATION_HISTORY: 'cohort-calculation-history', // owner: @gustavo #team-feature-flags
-    COHORT_EMAIL_LOOKUP_CLICKHOUSE: 'cohort-email-lookup-clickhouse', // owner: @gustavo #team-feature-flags
     COHORT_INLINE_CALCULATION: 'inline-cohort-calculation', // owner: #team-analytics-platform, inlines fast dynamic cohort queries instead of using precomputed cohortpeople table
     COHORTS_TAXONOMIC_BASIC_LIST: 'cohorts-taxonomic-basic-list', // owner: @adamleith, picker sends ?basic=true to the cohorts list endpoint (trimmed payload: no filters/query/groups)
     CONDENSED_FILTER_BAR: 'condensed_filter_bar', // owner: @jordanm-posthog #team-web-analytics


### PR DESCRIPTION
## Problem

The `cohort-email-lookup-clickhouse` flag gated the ClickHouse email lookup for cohort CSV imports. #60999 removed the flag check and made the ClickHouse path unconditional, leaving this frontend constant as the only remaining reference. The flag itself is fully rolled out.

## Changes

Removes the orphaned `COHORT_EMAIL_LOOKUP_CLICKHOUSE` entry from `FEATURE_FLAGS` in `frontend/src/lib/constants.tsx`.

## How did you test this code?

No behavior change. A repo-wide search for the constant name and the `cohort-email-lookup-clickhouse` key found no remaining references in frontend, backend, or Rust code.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?