### PR TITLE
chore(frontend): ratchet eager graph budgets after bundle-split stack

### DIFF
--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -32,16 +32,16 @@ const ROOTS = [
     {
         root: 'src/index.tsx',
         label: 'entry (logged-out pages, app bootstrap)',
-        // master 2026-06-11: 14.59 MiB / 749 files (post #62923)
-        budgetBytes: 17_000_000,
+        // master 2026-06-12: 14.62 MiB / 751 files
+        budgetBytes: 16_000_000,
         forbidden: ['node_modules/monaco-editor/'],
     },
     {
         root: 'src/scenes/AuthenticatedShell.tsx',
         label: 'authenticated shell (every logged-in page)',
-        // master 2026-06-11: 55.51 MiB / 8,325 files (ratchet down once #62957 / #62967 land)
-        budgetBytes: 64_000_000,
-        forbidden: [],
+        // master 2026-06-12: 34.44 MiB / 5,381 files (post #62957 / #62967 / #63142 / #63146)
+        budgetBytes: 38_000_000,
+        forbidden: ['node_modules/monaco-editor/'],
     },
 ]
 


### PR DESCRIPTION
## Problem

The eager-graph CI check ([#63099](https://github.com/PostHog/posthog/pull/63099)) was introduced with generous budgets while the bundle-splitting work was in flight. That stack has now fully merged (#62923, #62957, #62967, #63142, #63146), and the check's ratchet policy says: when a win lands, lower the budget to lock it in so a regression can't silently eat it back.

## Changes

Measured on current master (input-source bytes from the esbuild metafile):

| Root | When check landed | Now | New budget |
| --- | --- | --- | --- |
| entry (`src/index.tsx`) | 14.59 MiB / 749 files | 14.62 MiB / 751 files | 17 MB -> **16 MB** |
| authenticated shell (`src/scenes/AuthenticatedShell.tsx`) | 55.51 MiB / 8,325 files | **34.44 MiB / 5,381 files** (-38%) | 64 MB -> **38 MB** |

Both new budgets leave ~5% headroom over measured. `node_modules/monaco-editor/` is now forbidden from the authenticated shell graph too (previously entry-only), since #62957 made the code editor a lazy facade.

## How did you test this code?

I'm an agent. Built the frontend on this branch and ran `node bin/check-eager-graph.mjs` — both roots pass under the new budgets and the monaco forbidden check reports no chain into either graph.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

Authored by Claude Code shepherded by @pauldambra. Final step of the bundle-split program tracked in #32479: the splits are merged, this locks them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)