### PR TITLE
feat(replay-vision): use a dedicated gemini key and cleanup sweep

### DIFF
--- a/ee/settings.py
+++ b/ee/settings.py
@@ -100,6 +100,8 @@ LLM_GATEWAY_API_KEY = get_from_env("LLM_GATEWAY_PERSONAL_API_KEY", DEV_API_KEY i
 INKEEP_API_KEY = get_from_env("INKEEP_API_KEY", "")
 MISTRAL_API_KEY = get_from_env("MISTRAL_API_KEY", "")
 GEMINI_API_KEY = get_from_env("GEMINI_API_KEY", "")
+# Dedicated key for Replay Vision (own GCP project for cost/quota isolation); falls back to GEMINI_API_KEY
+REPLAY_VISION_GEMINI_API_KEY = get_from_env("REPLAY_VISION_GEMINI_API_KEY", "")
 PPLX_API_KEY = get_from_env("PPLX_API_KEY", "")
 AZURE_INFERENCE_ENDPOINT = get_from_env("AZURE_INFERENCE_ENDPOINT", "", type_cast=str)
 AZURE_INFERENCE_CREDENTIAL = get_from_env("AZURE_INFERENCE_CREDENTIAL", "", type_cast=str)

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -88,6 +88,9 @@ from products.error_tracking.backend.temporal.symbol_set_cleanup.schedule import
 from products.experiments.backend.temporal.schedule import create_experiment_precompute_canary_schedule
 from products.exports.backend.temporal.subscriptions.types import ScheduleAllSubscriptionsWorkflowInputs
 from products.replay_vision.backend.temporal.estimates import create_replay_vision_estimates_schedule
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep import (
+    create_replay_vision_gemini_cleanup_sweep_schedule,
+)
 from products.replay_vision.backend.temporal.reconciler import create_replay_vision_reconciler_schedule
 from products.signals.backend.temporal.agentic.schedule import create_signals_scout_coordinator_schedule
 from products.tasks.backend.temporal.code_workstreams.schedule import create_evaluate_code_workstreams_schedule
@@ -670,9 +673,10 @@ schedules = [
 ]
 
 if settings.CLOUD_DEPLOYMENT:
-    # Sweeper compares the deployment prefix on each Gemini file's display_name against its own
-    # CLOUD_DEPLOYMENT, so it can't run unscoped (would risk reaping sibling deployments' files).
+    # Gemini uploads only happen in cloud; each sweep reaps only the files tracked in this
+    # deployment's own Redis index, so per-deployment scoping is inherent.
     schedules.append(create_gemini_cleanup_sweep_schedule)
+    schedules.append(create_replay_vision_gemini_cleanup_sweep_schedule)
     schedules.append(create_run_usage_reports_schedule)
 
 if settings.EE_AVAILABLE:

--- a/products/replay_vision/backend/temporal/__init__.py
+++ b/products/replay_vision/backend/temporal/__init__.py
@@ -26,6 +26,10 @@ from products.replay_vision.backend.temporal.activities import (
     upsert_scanner_schedule_activity,
 )
 from products.replay_vision.backend.temporal.estimates import RefreshScannerEstimatesWorkflow
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep import (
+    ReplayVisionGeminiCleanupSweepWorkflow,
+    sweep_gemini_files_activity,
+)
 from products.replay_vision.backend.temporal.reconciler import ReconcileScannerSchedulesWorkflow
 from products.replay_vision.backend.temporal.sweep_workflow import SweepScannerWorkflow
 from products.replay_vision.backend.temporal.workflow import ApplyScannerWorkflow
@@ -34,6 +38,7 @@ WORKFLOWS = [
     ApplyScannerWorkflow,
     ReconcileScannerSchedulesWorkflow,
     RefreshScannerEstimatesWorkflow,
+    ReplayVisionGeminiCleanupSweepWorkflow,
     SweepScannerWorkflow,
 ]
 ACTIVITIES: list[Callable[..., Any]] = [
@@ -59,6 +64,7 @@ ACTIVITIES: list[Callable[..., Any]] = [
     delete_scanner_schedule_activity,
     list_stale_scanner_estimates_activity,
     refresh_scanner_estimate_activity,
+    sweep_gemini_files_activity,
 ]
 
 __all__ = [
@@ -67,6 +73,7 @@ __all__ = [
     "ApplyScannerWorkflow",
     "ReconcileScannerSchedulesWorkflow",
     "RefreshScannerEstimatesWorkflow",
+    "ReplayVisionGeminiCleanupSweepWorkflow",
     "SweepScannerWorkflow",
     "advance_scanner_watermark_activity",
     "call_scanner_provider_activity",
@@ -88,6 +95,7 @@ __all__ = [
     "mark_observation_running_activity",
     "mark_observation_succeeded_activity",
     "refresh_scanner_estimate_activity",
+    "sweep_gemini_files_activity",
     "upload_video_to_gemini_activity",
     "upsert_scanner_schedule_activity",
 ]

--- a/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
+++ b/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
@@ -5,8 +5,6 @@ import time
 import asyncio
 from uuid import UUID
 
-from django.conf import settings
-
 import structlog
 from asgiref.sync import sync_to_async
 from google.genai import types
@@ -20,6 +18,7 @@ from products.replay_vision.backend.models.replay_observation import ReplayObser
 from products.replay_vision.backend.temporal.constants import replay_vision_distinct_id
 from products.replay_vision.backend.temporal.decorators import track_activity
 from products.replay_vision.backend.temporal.errors import FailureKind, ScannerFailureError
+from products.replay_vision.backend.temporal.gemini import gemini_api_key
 from products.replay_vision.backend.temporal.metrics import REPLAY_VISION_PROVIDER_CALL
 from products.replay_vision.backend.temporal.scanners import scanner_from_snapshot
 from products.replay_vision.backend.temporal.scanners.base import BaseScanner, ChipSegment, Segment, TextSegment
@@ -157,7 +156,7 @@ async def _call_with_retry(
     *, scanner: BaseScanner, snapshot: ScannerSnapshot, prompt_parts: list[types.Part], team_id: int
 ) -> BaseModel:
     """One Gemini call, plus at most one retry that appends the validation error to the prompt."""
-    client = genai.AsyncClient(api_key=settings.GEMINI_API_KEY)
+    client = genai.AsyncClient(api_key=gemini_api_key())
     schema_class = scanner.llm_response_schema
     response_schema = schema_class.model_json_schema()
     parts = list(prompt_parts)

--- a/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
+++ b/products/replay_vision/backend/temporal/activities/cleanup_gemini_file.py
@@ -1,15 +1,16 @@
 """Best-effort cleanup of a Gemini file uploaded by `upload_video_to_gemini_activity`."""
 
-from django.conf import settings
-
 import structlog
 from asgiref.sync import sync_to_async
 from google.genai import Client as RawGenAIClient
 from temporalio import activity
 
-from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import is_gemini_file_gone, untrack_uploaded_file
-
 from products.replay_vision.backend.temporal.decorators import track_activity
+from products.replay_vision.backend.temporal.gemini import gemini_api_key
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.tracking import (
+    is_gemini_file_gone,
+    untrack_uploaded_file,
+)
 from products.replay_vision.backend.temporal.types import CleanupGeminiFileInputs
 
 logger = structlog.get_logger(__name__)
@@ -20,7 +21,7 @@ logger = structlog.get_logger(__name__)
 async def cleanup_gemini_file_activity(inputs: CleanupGeminiFileInputs) -> None:
     """Best-effort delete of the uploaded Gemini file; the cleanup sweep retries on transient failure via the tracking key."""
     try:
-        raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
+        raw_client = RawGenAIClient(api_key=gemini_api_key())
         await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=inputs.gemini_file_name)
     except Exception as e:
         if not is_gemini_file_gone(e):

--- a/products/replay_vision/backend/temporal/activities/upload_video_to_gemini.py
+++ b/products/replay_vision/backend/temporal/activities/upload_video_to_gemini.py
@@ -5,8 +5,6 @@ import asyncio
 import tempfile
 from datetime import UTC, datetime
 
-from django.conf import settings
-
 import structlog
 from asgiref.sync import sync_to_async
 from google.genai import (
@@ -16,11 +14,12 @@ from google.genai import (
 from temporalio import activity
 
 from posthog.storage import object_storage
-from posthog.temporal.session_replay.gemini_cleanup_sweep.tracking import track_uploaded_file
 
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.replay_vision.backend.temporal.decorators import track_activity
 from products.replay_vision.backend.temporal.errors import FailureKind, ScannerFailureError
+from products.replay_vision.backend.temporal.gemini import gemini_api_key
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.tracking import track_uploaded_file
 from products.replay_vision.backend.temporal.types import UploadedVideo, UploadVideoToGeminiInputs
 
 logger = structlog.get_logger(__name__)
@@ -53,7 +52,7 @@ async def upload_video_to_gemini_activity(inputs: UploadVideoToGeminiInputs) -> 
             f"ExportedAsset {inputs.asset_id} produced empty video bytes", kind=FailureKind.INTERNAL_ERROR
         )
 
-    raw_client = RawGenAIClient(api_key=settings.GEMINI_API_KEY)
+    raw_client = RawGenAIClient(api_key=gemini_api_key())
     # `tmp_file.write` / `flush` are blocking disk I/O; offload the whole tempfile+upload block off the event loop.
     uploaded_file = await asyncio.to_thread(
         _write_and_upload, raw_client, video_bytes, asset.export_format, workflow_id

--- a/products/replay_vision/backend/temporal/gemini.py
+++ b/products/replay_vision/backend/temporal/gemini.py
@@ -1,0 +1,8 @@
+"""Gemini API key resolution for Replay Vision."""
+
+from django.conf import settings
+
+
+def gemini_api_key() -> str:
+    """Replay Vision's dedicated key (own GCP project), falling back to the shared key where unset."""
+    return settings.REPLAY_VISION_GEMINI_API_KEY or settings.GEMINI_API_KEY

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/__init__.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/__init__.py
@@ -1,0 +1,11 @@
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.activities import sweep_gemini_files_activity
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.schedule import (
+    create_replay_vision_gemini_cleanup_sweep_schedule,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.workflow import ReplayVisionGeminiCleanupSweepWorkflow
+
+__all__ = [
+    "ReplayVisionGeminiCleanupSweepWorkflow",
+    "create_replay_vision_gemini_cleanup_sweep_schedule",
+    "sweep_gemini_files_activity",
+]

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/activities.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/activities.py
@@ -1,0 +1,153 @@
+import asyncio
+from datetime import UTC, datetime
+
+import structlog
+from asgiref.sync import sync_to_async
+from google.genai import Client as RawGenAIClient
+from temporalio import activity
+from temporalio.client import Client, WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.temporal.common.client import async_connect
+
+from products.replay_vision.backend.temporal.gemini import gemini_api_key
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    DELETE_CONCURRENCY,
+    DESCRIBE_CONCURRENCY,
+    MAX_FILES_PER_SWEEP,
+    SWEEP_MIN_AGE,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.tracking import (
+    index_size,
+    is_gemini_file_gone,
+    iter_tracked_files,
+    untrack_uploaded_file,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import (
+    CleanupSweepInputs,
+    CleanupSweepResult,
+    TrackedFile,
+)
+
+logger = structlog.get_logger(__name__)
+
+_TERMINAL_STATUSES = frozenset(
+    {
+        WorkflowExecutionStatus.COMPLETED,
+        WorkflowExecutionStatus.FAILED,
+        WorkflowExecutionStatus.CANCELED,
+        WorkflowExecutionStatus.TERMINATED,
+        WorkflowExecutionStatus.TIMED_OUT,
+    }
+)
+
+
+async def _classify_workflow(temporal: Client, workflow_id: str) -> str:
+    """Returns ``"delete"``, ``"running"``, or ``"error"``."""
+    try:
+        desc = await temporal.get_workflow_handle(workflow_id).describe()
+    except RPCError as e:
+        if e.status == RPCStatusCode.NOT_FOUND:
+            return "delete"
+        return "error"
+    except Exception:
+        return "error"
+
+    if desc.status in _TERMINAL_STATUSES:
+        return "delete"
+    return "running"
+
+
+@activity.defn(name="replay_vision_sweep_gemini_files_activity")
+async def sweep_gemini_files_activity(inputs: CleanupSweepInputs) -> CleanupSweepResult:
+    """Reclaims orphaned Gemini files. Failures counted, never raised."""
+    raw_client = RawGenAIClient(api_key=gemini_api_key())
+    temporal = await async_connect()
+    cutoff = datetime.now(UTC) - SWEEP_MIN_AGE
+
+    total_tracked = await index_size()
+    hit_max_files_cap = total_tracked > MAX_FILES_PER_SWEEP
+
+    scanned = 0
+    skipped_too_young = 0
+    skipped_invalid_value = 0
+    candidates: list[TrackedFile] = []
+    async for tracked in iter_tracked_files(limit=MAX_FILES_PER_SWEEP):
+        scanned += 1
+        if tracked is None:
+            skipped_invalid_value += 1
+            continue
+        if tracked.uploaded_at > cutoff:
+            skipped_too_young += 1
+            continue
+        candidates.append(tracked)
+    activity.heartbeat({"phase": "scanned", "scanned": scanned, "candidates": len(candidates)})
+
+    describe_sem = asyncio.Semaphore(DESCRIBE_CONCURRENCY)
+
+    async def _classify(tracked: TrackedFile) -> tuple[TrackedFile, str]:
+        async with describe_sem:
+            outcome = await _classify_workflow(temporal, tracked.workflow_id)
+            return tracked, outcome
+
+    classifications = await asyncio.gather(*(_classify(t) for t in candidates))
+    activity.heartbeat({"phase": "classified", "classified": len(classifications)})
+
+    to_delete = [t for t, outcome in classifications if outcome == "delete"]
+    skipped_running = sum(1 for _, outcome in classifications if outcome == "running")
+    skipped_temporal_error = sum(1 for _, outcome in classifications if outcome == "error")
+
+    base_result = CleanupSweepResult(
+        scanned=scanned,
+        skipped_too_young=skipped_too_young,
+        skipped_invalid_value=skipped_invalid_value,
+        skipped_running=skipped_running,
+        skipped_temporal_error=skipped_temporal_error,
+        hit_max_files_cap=hit_max_files_cap,
+    )
+
+    delete_sem = asyncio.Semaphore(DELETE_CONCURRENCY)
+
+    async def _delete(tracked: TrackedFile) -> bool:
+        async with delete_sem:
+            try:
+                await sync_to_async(raw_client.files.delete, thread_sensitive=False)(name=tracked.gemini_file_name)
+            except Exception as e:
+                if not is_gemini_file_gone(e):
+                    # Key kept for next-cycle retry; 48h TTL backstops.
+                    logger.exception(
+                        "replay_vision.cleanup_sweep.delete_failed",
+                        gemini_file_name=tracked.gemini_file_name,
+                        workflow_id=tracked.workflow_id,
+                        signals_type="cleanup-sweep",
+                    )
+                    return False
+                # File already gone (e.g., a previous untrack failed). Drop the key so we
+                # don't keep retrying a doomed delete.
+                logger.info(
+                    "replay_vision.cleanup_sweep.delete_already_gone",
+                    gemini_file_name=tracked.gemini_file_name,
+                    workflow_id=tracked.workflow_id,
+                    signals_type="cleanup-sweep",
+                )
+            await untrack_uploaded_file(tracked.gemini_file_name)
+            return True
+
+    delete_results = await asyncio.gather(*(_delete(t) for t in to_delete))
+    deleted = sum(1 for r in delete_results if r)
+    delete_failed = sum(1 for r in delete_results if not r)
+
+    result = base_result.model_copy(update={"deleted": deleted, "delete_failed": delete_failed})
+    logger.info(
+        "replay_vision.cleanup_sweep.cycle_complete",
+        scanned=result.scanned,
+        deleted=result.deleted,
+        skipped_running=result.skipped_running,
+        skipped_too_young=result.skipped_too_young,
+        skipped_invalid_value=result.skipped_invalid_value,
+        skipped_temporal_error=result.skipped_temporal_error,
+        delete_failed=result.delete_failed,
+        hit_max_files_cap=result.hit_max_files_cap,
+        signals_type="cleanup-sweep",
+    )
+    return result

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/constants.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/constants.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+
+SCHEDULE_ID = "replay-vision-gemini-cleanup-sweep-schedule"
+WORKFLOW_ID = "replay-vision-gemini-cleanup-sweep"
+WORKFLOW_NAME = "replay-vision-gemini-cleanup-sweep"
+SCHEDULE_TYPE = "replay-vision-gemini-cleanup-sweep"
+
+SCHEDULE_INTERVAL = timedelta(minutes=5)
+
+REDIS_KEY_PREFIX = "replay-vision:gemini-file:"
+REDIS_INDEX_KEY = "replay-vision:gemini-files-index"
+
+# Matches Gemini's ~48h retention.
+REDIS_KEY_TTL = timedelta(hours=48)
+
+# Skips describing very-recently-started workflows that may not yet be visible to Temporal.
+SWEEP_MIN_AGE = timedelta(seconds=60)
+
+MAX_FILES_PER_SWEEP = 1500
+MGET_BATCH_SIZE = 200
+
+DESCRIBE_CONCURRENCY = 20
+DELETE_CONCURRENCY = 10
+
+WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=20)
+SWEEP_ACTIVITY_TIMEOUT = timedelta(minutes=15)
+SWEEP_ACTIVITY_HEARTBEAT_TIMEOUT = timedelta(minutes=2)

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/schedule.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/schedule.py
@@ -1,0 +1,57 @@
+from django.conf import settings
+
+from temporalio import common
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+from temporalio.common import SearchAttributePair, TypedSearchAttributes
+
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+from posthog.temporal.common.search_attributes import POSTHOG_SCHEDULE_TYPE_KEY
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    SCHEDULE_ID,
+    SCHEDULE_INTERVAL,
+    SCHEDULE_TYPE,
+    WORKFLOW_EXECUTION_TIMEOUT,
+    WORKFLOW_ID,
+    WORKFLOW_NAME,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import CleanupSweepInputs
+
+
+async def create_replay_vision_gemini_cleanup_sweep_schedule(client: Client) -> None:
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_NAME,
+            CleanupSweepInputs(),
+            id=WORKFLOW_ID,
+            task_queue=settings.REPLAY_VISION_TASK_QUEUE,
+            execution_timeout=WORKFLOW_EXECUTION_TIMEOUT,
+            retry_policy=common.RetryPolicy(maximum_attempts=1),
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=SCHEDULE_INTERVAL)]),
+        policy=SchedulePolicy(
+            overlap=ScheduleOverlapPolicy.SKIP,
+            catchup_window=SCHEDULE_INTERVAL,
+        ),
+    )
+    search_attributes = TypedSearchAttributes(
+        search_attributes=[SearchAttributePair(key=POSTHOG_SCHEDULE_TYPE_KEY, value=SCHEDULE_TYPE)]
+    )
+    if await a_schedule_exists(client, SCHEDULE_ID):
+        await a_update_schedule(client, SCHEDULE_ID, schedule, search_attributes=search_attributes)
+    else:
+        await a_create_schedule(
+            client,
+            SCHEDULE_ID,
+            schedule,
+            trigger_immediately=True,
+            search_attributes=search_attributes,
+        )

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/tracking.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/tracking.py
@@ -1,0 +1,118 @@
+"""Redis tracking for Gemini files uploaded by Replay Vision scanner workflows."""
+
+import json
+from collections.abc import AsyncIterator
+from datetime import datetime
+
+from django.conf import settings
+
+import structlog
+from google.genai.errors import APIError
+from redis import asyncio as aioredis
+
+from posthog.redis import get_async_client
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    MGET_BATCH_SIZE,
+    REDIS_INDEX_KEY,
+    REDIS_KEY_PREFIX,
+    REDIS_KEY_TTL,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import TrackedFile
+
+logger = structlog.get_logger(__name__)
+
+
+def is_gemini_file_gone(error: Exception) -> bool:
+    """Whether a Gemini delete failure means the file no longer exists. Gemini reports missing
+    files as 403 PERMISSION_DENIED ("...or it may not exist"), not just 404 — callers should
+    untrack on either instead of retrying a doomed delete."""
+    return isinstance(error, APIError) and error.code in (403, 404)
+
+
+def _redis() -> aioredis.Redis:
+    return get_async_client(settings.REPLAY_VISION_REDIS_URL)
+
+
+def _redis_key_for(gemini_file_name: str) -> str:
+    return f"{REDIS_KEY_PREFIX}{gemini_file_name}"
+
+
+def _to_str(raw: str | bytes) -> str:
+    return raw.decode() if isinstance(raw, bytes) else raw
+
+
+def _to_str_optional(raw: str | bytes | None) -> str | None:
+    return None if raw is None else _to_str(raw)
+
+
+async def track_uploaded_file(gemini_file_name: str, workflow_id: str, uploaded_at: datetime) -> None:
+    """Raises on Redis failure so the caller can roll back the upload."""
+    redis = _redis()
+    payload = json.dumps({"workflow_id": workflow_id, "uploaded_at": uploaded_at.isoformat()})
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.set(_redis_key_for(gemini_file_name), payload, ex=int(REDIS_KEY_TTL.total_seconds()))
+        pipe.zadd(REDIS_INDEX_KEY, {gemini_file_name: uploaded_at.timestamp()})
+        await pipe.execute()
+
+
+async def untrack_uploaded_file(gemini_file_name: str) -> None:
+    """Best-effort: TTL or sweep stale-cleanup handle leftover state on failure."""
+    redis = _redis()
+    try:
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.delete(_redis_key_for(gemini_file_name))
+            pipe.zrem(REDIS_INDEX_KEY, gemini_file_name)
+            await pipe.execute()
+    except Exception:
+        logger.exception(
+            "replay_vision.gemini_cleanup_sweep.untrack_failed",
+            gemini_file_name=gemini_file_name,
+            signals_type="cleanup-sweep",
+        )
+
+
+async def iter_tracked_files(limit: int) -> AsyncIterator[TrackedFile | None]:
+    """Yield up to ``limit`` tracked files, oldest-uploaded first. Bounded server-side via
+    ZRANGE LIMIT so the fetch cost is independent of total backlog. Yields ``None`` for
+    undecodable payloads. Drops stale index entries (per-file key TTL'd out) as it goes."""
+    redis = _redis()
+    raw_members = await redis.zrange(REDIS_INDEX_KEY, 0, limit - 1)
+    file_names: list[str] = [_to_str(m) for m in raw_members]
+    if not file_names:
+        return
+
+    for batch_start in range(0, len(file_names), MGET_BATCH_SIZE):
+        batch = file_names[batch_start : batch_start + MGET_BATCH_SIZE]
+        keys = [_redis_key_for(fn) for fn in batch]
+        raw_values = await redis.mget(*keys)
+        stale: list[str] = []
+        for fn, raw in zip(batch, raw_values):
+            value = _to_str_optional(raw)
+            if value is None:
+                stale.append(fn)
+                continue
+            try:
+                payload = json.loads(value)
+                workflow_id = payload["workflow_id"]
+                uploaded_at = datetime.fromisoformat(payload["uploaded_at"])
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                logger.exception(
+                    "replay_vision.gemini_cleanup_sweep.invalid_value",
+                    gemini_file_name=fn,
+                    signals_type="cleanup-sweep",
+                )
+                yield None
+                continue
+            yield TrackedFile(
+                gemini_file_name=fn,
+                workflow_id=workflow_id,
+                uploaded_at=uploaded_at,
+            )
+        if stale:
+            await redis.zrem(REDIS_INDEX_KEY, *stale)
+
+
+async def index_size() -> int:
+    redis = _redis()
+    return await redis.zcard(REDIS_INDEX_KEY)

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/types.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/types.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class CleanupSweepInputs(BaseModel, frozen=True):
+    pass
+
+
+class CleanupSweepResult(BaseModel, frozen=True):
+    scanned: int = 0
+    deleted: int = 0
+    skipped_running: int = 0
+    skipped_too_young: int = 0
+    skipped_temporal_error: int = 0
+    skipped_invalid_value: int = 0
+    delete_failed: int = 0
+    hit_max_files_cap: bool = False
+
+
+class TrackedFile(BaseModel, frozen=True):
+    gemini_file_name: str
+    workflow_id: str
+    uploaded_at: datetime

--- a/products/replay_vision/backend/temporal/gemini_cleanup_sweep/workflow.py
+++ b/products/replay_vision/backend/temporal/gemini_cleanup_sweep/workflow.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    SWEEP_ACTIVITY_HEARTBEAT_TIMEOUT,
+    SWEEP_ACTIVITY_TIMEOUT,
+    WORKFLOW_NAME,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import CleanupSweepInputs
+
+with workflow.unsafe.imports_passed_through():
+    from products.replay_vision.backend.temporal.gemini_cleanup_sweep.activities import sweep_gemini_files_activity
+
+
+@workflow.defn(name=WORKFLOW_NAME)
+class ReplayVisionGeminiCleanupSweepWorkflow(PostHogWorkflow):
+    inputs_cls = CleanupSweepInputs
+    inputs_optional = True
+
+    @workflow.run
+    async def run(self, inputs: CleanupSweepInputs) -> dict[str, Any]:
+        result = await workflow.execute_activity(
+            sweep_gemini_files_activity,
+            inputs,
+            start_to_close_timeout=SWEEP_ACTIVITY_TIMEOUT,
+            heartbeat_timeout=SWEEP_ACTIVITY_HEARTBEAT_TIMEOUT,
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+        return result.model_dump()

--- a/products/replay_vision/backend/tests/conftest.py
+++ b/products/replay_vision/backend/tests/conftest.py
@@ -1,1 +1,32 @@
-from posthog.temporal.tests.session_replay.conftest import gemini_redis  # noqa: F401
+import pytest
+
+from django.conf import settings
+
+import pytest_asyncio
+from temporalio.testing import ActivityEnvironment
+
+from posthog.redis import get_async_client
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import REDIS_INDEX_KEY, REDIS_KEY_PREFIX
+
+
+async def _drop_gemini_tracking_keys(client) -> None:
+    keys = [k async for k in client.scan_iter(match=f"{REDIS_KEY_PREFIX}*")]
+    if keys:
+        await client.delete(*keys)
+    await client.delete(REDIS_INDEX_KEY)
+
+
+@pytest_asyncio.fixture
+async def gemini_redis():
+    """Async Vision Redis client with the gemini_cleanup_sweep namespace wiped before/after each test."""
+    client = get_async_client(settings.REPLAY_VISION_REDIS_URL)
+    await _drop_gemini_tracking_keys(client)
+    yield client
+    await _drop_gemini_tracking_keys(client)
+
+
+@pytest.fixture
+def activity_environment():
+    """Return a testing temporal ActivityEnvironment."""
+    return ActivityEnvironment()

--- a/products/replay_vision/backend/tests/test_gemini_cleanup_activities.py
+++ b/products/replay_vision/backend/tests/test_gemini_cleanup_activities.py
@@ -1,0 +1,335 @@
+import json
+import datetime as dt
+from dataclasses import dataclass
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from google.genai.errors import APIError
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.activities import sweep_gemini_files_activity
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    MAX_FILES_PER_SWEEP,
+    REDIS_INDEX_KEY,
+    REDIS_KEY_PREFIX,
+    REDIS_KEY_TTL,
+    SWEEP_MIN_AGE,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import CleanupSweepInputs, CleanupSweepResult
+
+_NOW = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.UTC)
+
+
+@dataclass
+class _Outcome:
+    status: WorkflowExecutionStatus | None = None
+    raise_not_found: bool = False
+    raise_rpc_error: bool = False
+
+
+class _StubHandle:
+    def __init__(self, outcome: _Outcome) -> None:
+        self._outcome = outcome
+
+    async def describe(self):
+        if self._outcome.raise_not_found:
+            raise RPCError("not found", RPCStatusCode.NOT_FOUND, b"")
+        if self._outcome.raise_rpc_error:
+            raise RPCError("boom", RPCStatusCode.INTERNAL, b"")
+
+        class _Desc:
+            status = self._outcome.status
+
+        return _Desc()
+
+
+class _StubTemporal:
+    def __init__(self, outcomes: dict[str, _Outcome]) -> None:
+        self._outcomes = outcomes
+
+    def get_workflow_handle(self, workflow_id: str) -> _StubHandle:
+        return _StubHandle(self._outcomes.get(workflow_id, _Outcome(status=WorkflowExecutionStatus.RUNNING)))
+
+
+class _StubFiles:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+        self.delete_raises_for: dict[str, BaseException] = {}
+
+    def delete(self, *, name: str) -> None:
+        if name in self.delete_raises_for:
+            raise self.delete_raises_for[name]
+        self.deleted.append(name)
+
+
+class _StubRawClient:
+    def __init__(self) -> None:
+        self.files = _StubFiles()
+
+
+@pytest.fixture
+def fixed_now():
+    class _FixedDatetime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _NOW if tz is None else _NOW.astimezone(tz)
+
+    with patch(
+        "products.replay_vision.backend.temporal.gemini_cleanup_sweep.activities.datetime",
+        _FixedDatetime,
+    ):
+        yield
+
+
+async def _track(client, *, file_name: str, workflow_id: str, age: dt.timedelta) -> None:
+    uploaded_at = _NOW - age
+    payload = json.dumps({"workflow_id": workflow_id, "uploaded_at": uploaded_at.isoformat()})
+    await client.set(f"{REDIS_KEY_PREFIX}{file_name}", payload, ex=int(REDIS_KEY_TTL.total_seconds()))
+    await client.zadd(REDIS_INDEX_KEY, {file_name: uploaded_at.timestamp()})
+
+
+def _patch_clients(raw_client: _StubRawClient, temporal: _StubTemporal):
+    return (
+        patch(
+            "products.replay_vision.backend.temporal.gemini_cleanup_sweep.activities.RawGenAIClient",
+            return_value=raw_client,
+        ),
+        patch(
+            "products.replay_vision.backend.temporal.gemini_cleanup_sweep.activities.async_connect",
+            new=AsyncMock(return_value=temporal),
+        ),
+    )
+
+
+async def _key_exists(client, file_name: str) -> bool:
+    return bool(await client.exists(f"{REDIS_KEY_PREFIX}{file_name}"))
+
+
+async def _index_has(client, file_name: str) -> bool:
+    return await client.zscore(REDIS_INDEX_KEY, file_name) is not None
+
+
+@pytest.mark.asyncio
+async def test_no_keys_returns_zeros(activity_environment, fixed_now, gemini_redis):
+    raw, tmp = _StubRawClient(), _StubTemporal({})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result == CleanupSweepResult()
+    assert raw.files.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_skips_keys_younger_than_min_age(activity_environment, fixed_now, gemini_redis):
+    await _track(gemini_redis, file_name="files/young", workflow_id="wf-1", age=SWEEP_MIN_AGE / 2)
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-1": _Outcome(status=WorkflowExecutionStatus.COMPLETED)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.scanned == 1
+    assert result.skipped_too_young == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+    assert await _key_exists(gemini_redis, "files/young")
+    assert await _index_has(gemini_redis, "files/young")
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        WorkflowExecutionStatus.COMPLETED,
+        WorkflowExecutionStatus.FAILED,
+        WorkflowExecutionStatus.CANCELED,
+        WorkflowExecutionStatus.TERMINATED,
+        WorkflowExecutionStatus.TIMED_OUT,
+    ],
+)
+@pytest.mark.asyncio
+async def test_deletes_files_for_terminal_workflows(activity_environment, fixed_now, gemini_redis, status):
+    await _track(gemini_redis, file_name="files/old", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-1": _Outcome(status=status)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert raw.files.deleted == ["files/old"]
+    assert not await _key_exists(gemini_redis, "files/old")
+    assert not await _index_has(gemini_redis, "files/old")
+
+
+@pytest.mark.parametrize(
+    "status",
+    [WorkflowExecutionStatus.RUNNING, WorkflowExecutionStatus.CONTINUED_AS_NEW],
+)
+@pytest.mark.asyncio
+async def test_skips_files_for_active_workflows(activity_environment, fixed_now, gemini_redis, status):
+    await _track(gemini_redis, file_name="files/in-use", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-1": _Outcome(status=status)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_running == 1
+    assert result.deleted == 0
+    assert raw.files.deleted == []
+    assert await _key_exists(gemini_redis, "files/in-use")
+    assert await _index_has(gemini_redis, "files/in-use")
+
+
+@pytest.mark.asyncio
+async def test_status_none_is_treated_as_running(activity_environment, fixed_now, gemini_redis):
+    await _track(gemini_redis, file_name="files/maybe-running", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-1": _Outcome(status=None)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_running == 1
+    assert result.deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_deletes_when_workflow_not_found(activity_environment, fixed_now, gemini_redis):
+    await _track(gemini_redis, file_name="files/orphan", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-1": _Outcome(raise_not_found=True)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert raw.files.deleted == ["files/orphan"]
+    assert not await _key_exists(gemini_redis, "files/orphan")
+    assert not await _index_has(gemini_redis, "files/orphan")
+
+
+@pytest.mark.asyncio
+async def test_skips_on_temporal_rpc_error(activity_environment, fixed_now, gemini_redis):
+    await _track(gemini_redis, file_name="files/unknown", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-1": _Outcome(raise_rpc_error=True)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_temporal_error == 1
+    assert result.deleted == 0
+    assert await _key_exists(gemini_redis, "files/unknown")
+    assert await _index_has(gemini_redis, "files/unknown")
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_keeps_redis_state_for_retry(activity_environment, fixed_now, gemini_redis):
+    await _track(gemini_redis, file_name="files/ok", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    await _track(gemini_redis, file_name="files/bad", workflow_id="wf-2", age=SWEEP_MIN_AGE * 10)
+    raw = _StubRawClient()
+    raw.files.delete_raises_for = {"files/bad": RuntimeError("simulated")}
+    tmp = _StubTemporal(
+        {
+            "wf-1": _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+            "wf-2": _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+        }
+    )
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert result.delete_failed == 1
+    assert raw.files.deleted == ["files/ok"]
+    assert not await _key_exists(gemini_redis, "files/ok")
+    assert not await _index_has(gemini_redis, "files/ok")
+    assert await _key_exists(gemini_redis, "files/bad")
+    assert await _index_has(gemini_redis, "files/bad")
+
+
+@pytest.mark.parametrize("code", [403, 404])
+@pytest.mark.asyncio
+async def test_treats_gemini_already_gone_as_success(activity_environment, fixed_now, gemini_redis, code):
+    # If a previous untrack failed and left an orphan key, the actual file may already be gone
+    # from Gemini. Missing files surface as 403 PERMISSION_DENIED ("...or it may not exist")
+    # or 404. Don't keep retrying — drop the key and move on.
+    await _track(gemini_redis, file_name="files/already-gone", workflow_id="wf-1", age=SWEEP_MIN_AGE * 10)
+    raw = _StubRawClient()
+    raw.files.delete_raises_for = {"files/already-gone": APIError(code=code, response_json={})}
+    tmp = _StubTemporal({"wf-1": _Outcome(status=WorkflowExecutionStatus.COMPLETED)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.deleted == 1
+    assert result.delete_failed == 0
+    assert not await _key_exists(gemini_redis, "files/already-gone")
+    assert not await _index_has(gemini_redis, "files/already-gone")
+
+
+@pytest.mark.asyncio
+async def test_invalid_value_counted_separately(activity_environment, fixed_now, gemini_redis):
+    await gemini_redis.set(f"{REDIS_KEY_PREFIX}files/garbage", "not-json")
+    await gemini_redis.zadd(REDIS_INDEX_KEY, {"files/garbage": _NOW.timestamp()})
+    raw, tmp = _StubRawClient(), _StubTemporal({})
+
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.skipped_invalid_value == 1
+    assert result.deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_stale_index_entries_are_cleaned_up(activity_environment, fixed_now, gemini_redis):
+    await gemini_redis.zadd(REDIS_INDEX_KEY, {"files/stale": _NOW.timestamp()})
+    raw, tmp = _StubRawClient(), _StubTemporal({})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.scanned == 0
+    assert result.deleted == 0
+    assert not await _index_has(gemini_redis, "files/stale")
+
+
+@pytest.mark.asyncio
+async def test_hit_max_files_cap_set_when_index_exceeds_limit(activity_environment, fixed_now, gemini_redis):
+    extras = MAX_FILES_PER_SWEEP + 1
+    uploaded_at = _NOW - SWEEP_MIN_AGE * 10
+    pipe = gemini_redis.pipeline()
+    for i in range(extras):
+        fn = f"files/n{i}"
+        pipe.set(
+            f"{REDIS_KEY_PREFIX}{fn}",
+            json.dumps({"workflow_id": "wf-x", "uploaded_at": uploaded_at.isoformat()}),
+            ex=int(REDIS_KEY_TTL.total_seconds()),
+        )
+        pipe.zadd(REDIS_INDEX_KEY, {fn: uploaded_at.timestamp()})
+    await pipe.execute()
+    raw, tmp = _StubRawClient(), _StubTemporal({"wf-x": _Outcome(raise_not_found=True)})
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.hit_max_files_cap is True
+    assert result.scanned == MAX_FILES_PER_SWEEP
+    assert result.deleted == MAX_FILES_PER_SWEEP
+
+
+@pytest.mark.asyncio
+async def test_mixed_cycle_aggregates_correctly(activity_environment, fixed_now, gemini_redis):
+    await _track(gemini_redis, file_name="files/young", workflow_id="wf-young", age=SWEEP_MIN_AGE / 2)
+    await _track(gemini_redis, file_name="files/done", workflow_id="wf-done", age=SWEEP_MIN_AGE * 10)
+    await _track(gemini_redis, file_name="files/running", workflow_id="wf-run", age=SWEEP_MIN_AGE * 10)
+    await _track(gemini_redis, file_name="files/orphan", workflow_id="wf-orphan", age=SWEEP_MIN_AGE * 10)
+    await _track(gemini_redis, file_name="files/error", workflow_id="wf-err", age=SWEEP_MIN_AGE * 10)
+    await gemini_redis.set(f"{REDIS_KEY_PREFIX}files/garbage", "not-json")
+    await gemini_redis.zadd(REDIS_INDEX_KEY, {"files/garbage": _NOW.timestamp()})
+    raw = _StubRawClient()
+    tmp = _StubTemporal(
+        {
+            "wf-done": _Outcome(status=WorkflowExecutionStatus.COMPLETED),
+            "wf-run": _Outcome(status=WorkflowExecutionStatus.RUNNING),
+            "wf-orphan": _Outcome(raise_not_found=True),
+            "wf-err": _Outcome(raise_rpc_error=True),
+        }
+    )
+    p1, p2 = _patch_clients(raw, tmp)
+    with p1, p2:
+        result = await activity_environment.run(sweep_gemini_files_activity, CleanupSweepInputs())
+    assert result.scanned == 6
+    assert result.skipped_too_young == 1
+    assert result.skipped_running == 1
+    assert result.skipped_temporal_error == 1
+    assert result.skipped_invalid_value == 1
+    assert result.deleted == 2
+    assert sorted(raw.files.deleted) == ["files/done", "files/orphan"]

--- a/products/replay_vision/backend/tests/test_gemini_cleanup_tracking.py
+++ b/products/replay_vision/backend/tests/test_gemini_cleanup_tracking.py
@@ -1,0 +1,156 @@
+import json
+import datetime as dt
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    REDIS_INDEX_KEY,
+    REDIS_KEY_PREFIX,
+    REDIS_KEY_TTL,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.tracking import (
+    index_size,
+    iter_tracked_files,
+    track_uploaded_file,
+    untrack_uploaded_file,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import TrackedFile
+
+_NOW = dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=dt.UTC)
+
+
+async def _collect(it) -> list[TrackedFile | None]:
+    return [item async for item in it]
+
+
+@pytest.mark.asyncio
+async def test_track_writes_per_file_key_and_index_entry(gemini_redis):
+    await track_uploaded_file("files/abc", "wf-1", _NOW)
+    raw = await gemini_redis.get(f"{REDIS_KEY_PREFIX}files/abc")
+    assert raw is not None
+    payload = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+    assert payload == {"workflow_id": "wf-1", "uploaded_at": _NOW.isoformat()}
+    assert await gemini_redis.zscore(REDIS_INDEX_KEY, "files/abc") == _NOW.timestamp()
+    ttl = await gemini_redis.ttl(f"{REDIS_KEY_PREFIX}files/abc")
+    assert 0 < ttl <= int(REDIS_KEY_TTL.total_seconds())
+
+
+@pytest.mark.asyncio
+async def test_track_raises_when_redis_pipeline_fails(gemini_redis):
+    failing_pipe = MagicMock()
+    failing_pipe.set = MagicMock()
+    failing_pipe.zadd = MagicMock()
+    failing_pipe.execute = AsyncMock(side_effect=RuntimeError("redis down"))
+    failing_pipe.__aenter__ = AsyncMock(return_value=failing_pipe)
+    failing_pipe.__aexit__ = AsyncMock(return_value=None)
+
+    fake_redis = MagicMock()
+    fake_redis.pipeline = MagicMock(return_value=failing_pipe)
+    with patch(
+        "products.replay_vision.backend.temporal.gemini_cleanup_sweep.tracking.get_async_client",
+        return_value=fake_redis,
+    ):
+        with pytest.raises(RuntimeError, match="redis down"):
+            await track_uploaded_file("files/abc", "wf-1", _NOW)
+
+
+@pytest.mark.asyncio
+async def test_untrack_clears_per_file_key_and_index_entry(gemini_redis):
+    await track_uploaded_file("files/abc", "wf-1", _NOW)
+    await untrack_uploaded_file("files/abc")
+    assert await gemini_redis.exists(f"{REDIS_KEY_PREFIX}files/abc") == 0
+    assert await gemini_redis.zscore(REDIS_INDEX_KEY, "files/abc") is None
+
+
+@pytest.mark.asyncio
+async def test_untrack_swallows_redis_errors(gemini_redis):
+    failing_pipe = MagicMock()
+    failing_pipe.delete = MagicMock()
+    failing_pipe.zrem = MagicMock()
+    failing_pipe.execute = AsyncMock(side_effect=RuntimeError("redis down"))
+    failing_pipe.__aenter__ = AsyncMock(return_value=failing_pipe)
+    failing_pipe.__aexit__ = AsyncMock(return_value=None)
+
+    fake_redis = MagicMock()
+    fake_redis.pipeline = MagicMock(return_value=failing_pipe)
+    with patch(
+        "products.replay_vision.backend.temporal.gemini_cleanup_sweep.tracking.get_async_client",
+        return_value=fake_redis,
+    ):
+        await untrack_uploaded_file("files/abc")
+
+
+@pytest.mark.asyncio
+async def test_iter_yields_tracked_files(gemini_redis):
+    await track_uploaded_file("files/a", "wf-a", _NOW)
+    await track_uploaded_file("files/b", "wf-b", _NOW - dt.timedelta(seconds=10))
+
+    items = await _collect(iter_tracked_files(limit=10))
+    by_name = {t.gemini_file_name: t for t in items if t is not None}
+    assert set(by_name) == {"files/a", "files/b"}
+    assert by_name["files/a"].workflow_id == "wf-a"
+    assert by_name["files/a"].uploaded_at == _NOW
+    assert by_name["files/b"].workflow_id == "wf-b"
+
+
+@pytest.mark.asyncio
+async def test_iter_yields_oldest_first(gemini_redis):
+    await track_uploaded_file("files/new", "wf-new", _NOW)
+    await track_uploaded_file("files/old", "wf-old", _NOW - dt.timedelta(hours=2))
+    await track_uploaded_file("files/middle", "wf-middle", _NOW - dt.timedelta(minutes=30))
+
+    items = await _collect(iter_tracked_files(limit=10))
+    names = [t.gemini_file_name for t in items if t is not None]
+    assert names == ["files/old", "files/middle", "files/new"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-json",  # JSONDecodeError
+        '{"workflow_id": "wf-1"}',  # KeyError on uploaded_at
+        '{"workflow_id": "wf-1", "uploaded_at": "garbage"}',  # ValueError from fromisoformat
+    ],
+)
+@pytest.mark.asyncio
+async def test_iter_yields_none_for_invalid_payload(gemini_redis, value):
+    await gemini_redis.set(f"{REDIS_KEY_PREFIX}files/garbage", value)
+    await gemini_redis.zadd(REDIS_INDEX_KEY, {"files/garbage": _NOW.timestamp()})
+    items = await _collect(iter_tracked_files(limit=10))
+    assert items == [None]
+
+
+@pytest.mark.asyncio
+async def test_iter_cleans_up_stale_index_entries(gemini_redis):
+    await gemini_redis.zadd(REDIS_INDEX_KEY, {"files/stale": _NOW.timestamp()})
+    items = await _collect(iter_tracked_files(limit=10))
+    assert items == []
+    assert await gemini_redis.zscore(REDIS_INDEX_KEY, "files/stale") is None
+
+
+@pytest.mark.asyncio
+async def test_iter_respects_limit(gemini_redis):
+    for i in range(20):
+        await track_uploaded_file(f"files/n{i}", "wf-x", _NOW + dt.timedelta(seconds=i))
+    items = await _collect(iter_tracked_files(limit=5))
+    assert len(items) == 5
+
+
+@pytest.mark.asyncio
+async def test_iter_batches_across_mget_boundary(gemini_redis):
+    n = 250  # > MGET_BATCH_SIZE (200)
+    for i in range(n):
+        await track_uploaded_file(f"files/n{i:04d}", "wf-x", _NOW + dt.timedelta(seconds=i))
+    items = await _collect(iter_tracked_files(limit=n))
+    assert len({t.gemini_file_name for t in items if t is not None}) == n
+
+
+@pytest.mark.asyncio
+async def test_index_size_returns_index_cardinality(gemini_redis):
+    assert await index_size() == 0
+    await track_uploaded_file("files/a", "wf-a", _NOW)
+    await track_uploaded_file("files/b", "wf-b", _NOW)
+    assert await index_size() == 2
+    await untrack_uploaded_file("files/a")
+    assert await index_size() == 1

--- a/products/replay_vision/backend/tests/test_gemini_cleanup_workflow.py
+++ b/products/replay_vision/backend/tests/test_gemini_cleanup_workflow.py
@@ -1,0 +1,55 @@
+import uuid
+
+import pytest
+
+import temporalio.worker
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import WORKFLOW_NAME
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.types import CleanupSweepInputs, CleanupSweepResult
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.workflow import ReplayVisionGeminiCleanupSweepWorkflow
+
+
+@pytest.mark.asyncio
+async def test_workflow_returns_activity_result_as_dict():
+    @activity.defn(name="replay_vision_sweep_gemini_files_activity")
+    async def sweep_mocked(inputs: CleanupSweepInputs) -> CleanupSweepResult:
+        return CleanupSweepResult(
+            scanned=42,
+            deleted=10,
+            skipped_running=5,
+            skipped_too_young=20,
+            skipped_temporal_error=1,
+            skipped_invalid_value=2,
+            delete_failed=1,
+            hit_max_files_cap=True,
+        )
+
+    task_queue = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[ReplayVisionGeminiCleanupSweepWorkflow],
+            activities=[sweep_mocked],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                WORKFLOW_NAME,
+                CleanupSweepInputs(),
+                id=str(uuid.uuid4()),
+                task_queue=task_queue,
+            )
+
+    assert result == {
+        "scanned": 42,
+        "deleted": 10,
+        "skipped_running": 5,
+        "skipped_too_young": 20,
+        "skipped_temporal_error": 1,
+        "skipped_invalid_value": 2,
+        "delete_failed": 1,
+        "hit_max_files_cap": True,
+    }

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -20,10 +20,6 @@ from posthog.models import Organization, Team
 from posthog.models.user import User
 from posthog.redis import get_async_client
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
-from posthog.temporal.session_replay.gemini_cleanup_sweep.constants import (
-    REDIS_INDEX_KEY as _GEMINI_REDIS_INDEX_KEY,
-    REDIS_KEY_PREFIX as _GEMINI_REDIS_KEY_PREFIX,
-)
 
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.replay_vision.backend.api.observation_progress import stream_observation_progress
@@ -63,6 +59,10 @@ from products.replay_vision.backend.temporal.errors import (
     IneligibleSessionError,
     IneligibleSessionKind,
     ScannerFailureError,
+)
+from products.replay_vision.backend.temporal.gemini_cleanup_sweep.constants import (
+    REDIS_INDEX_KEY as _GEMINI_REDIS_INDEX_KEY,
+    REDIS_KEY_PREFIX as _GEMINI_REDIS_KEY_PREFIX,
 )
 from products.replay_vision.backend.temporal.scanners.base import ChipSegment, Segment, TextSegment
 from products.replay_vision.backend.temporal.scanners.classifier import ClassifierOutput


### PR DESCRIPTION
## Problem

Replay Vision shares the Gemini API key with several other products: costs can't be attributed, and its video-heavy traffic competes with other products for rate limits and Files API storage.

## Changes

- New `REPLAY_VISION_GEMINI_API_KEY` setting (key from a dedicated GCP project) with fallback to the shared `GEMINI_API_KEY`, used by the three Gemini call sites
- Dedicated Gemini file cleanup sweep under `products/replay_vision/`, tracking files in the Vision Redis (`replay-vision:*`) and running on `replay-vision-task-queue` — separate from the legacy sweep that also serves the session summary pipeline
- No migration needed: pre-deploy files stay in the legacy index owned by the legacy sweep with the shared key; post-deploy uploads land in the vision index with the vision key

## How did you test this code?

I'm an agent; automated tests only: new sweep tests mirroring the legacy suite (33), plus the full vision `test_temporal.py` (95) and the legacy sweep suite (33) — all pass locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, directed by @TueHaulund. Main decision: a separate sweep per pipeline instead of making the shared sweep key-aware.