### PR TITLE
fix(hubspot): treat 401/403 from HubSpot API as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -85,6 +85,13 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
         return {
             "missing or invalid refresh token": "Your HubSpot connection is invalid or expired. Please reconnect it.",
             "missing or unknown hub id": None,
+            # HubSpot's CRM API returns 401/403 when the OAuth grant can't read the requested object
+            # (token revoked, or the connected app is missing a scope like `crm.objects.companies.read`).
+            # `fetch_data` already refreshes the access token once on a 401; if the retried request is
+            # still rejected, the credentials genuinely lack access and retrying can't recover. Match the
+            # stable host, not the per-object URL path (companies/deals/contacts/...), which varies.
+            "401 Client Error: Unauthorized for url: https://api.hubapi.com": "Your HubSpot credentials are no longer authorized. Please reconnect your HubSpot account and ensure it has the required permissions, then try again.",
+            "403 Client Error: Forbidden for url: https://api.hubapi.com": "Your HubSpot credentials do not have permission to access this data. Please reconnect your HubSpot account and ensure it has the required permissions, then try again.",
             # Raised by source_for_pipeline when the source config carries no refresh token at all
             # (integration never connected or lost its token). Retrying cannot recover.
             "Hubspot refresh token not found": "Your HubSpot connection is missing its refresh token. Please reconnect it.",

--- a/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -235,3 +235,21 @@ def test_missing_token_error_is_non_retryable(error_msg: str) -> None:
     assert any(pattern in error_msg for pattern in patterns), (
         f"HubSpot error {error_msg!r} did not match any non-retryable pattern"
     )
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        # Raised by fetch_data when a token refresh succeeds but the retried request is still rejected
+        "401 Client Error: Unauthorized for url: https://api.hubapi.com/crm/v3/properties/companies",
+        "401 Client Error: Unauthorized for url: https://api.hubapi.com/crm/v3/properties/deals",
+        "403 Client Error: Forbidden for url: https://api.hubapi.com/crm/v3/objects/contacts",
+    ],
+)
+def test_unauthorized_error_is_non_retryable(error_msg: str) -> None:
+    """A 401/403 from the HubSpot API means the credentials/OAuth grant can't access the data —
+    retrying can't recover, so it must match a non-retryable pattern."""
+    patterns = HubspotSource().get_non_retryable_errors()
+    assert any(pattern in error_msg for pattern in patterns), (
+        f"HubSpot error {error_msg!r} did not match any non-retryable pattern"
+    )


### PR DESCRIPTION
## Problem

The HubSpot data-warehouse import source surfaces a recurring error in error tracking: `HTTPError: 401 Client Error: Unauthorized for url: https://api.hubapi.com/crm/v3/properties/companies` (also `/deals`, etc.), raised in `posthog/temporal/data_imports/sources/hubspot/helpers.py`.

A 401 (or 403) from the HubSpot CRM API is an authentication/authorization failure: the customer's OAuth grant can't read the requested object — the token was revoked, or the connected app is missing a scope such as `crm.objects.companies.read`. It's a user/upstream condition, not transient infrastructure and not a bug in our request.

`fetch_data` already refreshes the access token once when it sees a 401 and retries. If that refresh **fails**, it raises `Exception("missing or invalid refresh token")`, which is already non-retryable. But if the refresh **succeeds** and the retried request is *still* 401/403 (the grant genuinely lacks access for that object), a raw `HTTPError` propagates — and that message was **not** in the source's `NonRetryableErrors`. The pipeline then treats a permanently-unrecoverable permission failure as retryable.

## Changes

- Add `"401 Client Error: Unauthorized for url: https://api.hubapi.com"` and `"403 Client Error: Forbidden for url: https://api.hubapi.com"` to `HubspotSource.get_non_retryable_errors()`, each with a user-facing "reconnect / grant permissions" message. This mirrors the existing pattern in `posthog/temporal/data_imports/sources/stripe/source.py`.
- Match on the stable host (`https://api.hubapi.com`) rather than the per-object URL path (companies/deals/contacts/…), which varies per request, to keep the match low-false-positive and resilient across endpoints.
- The `"missing or invalid refresh token"` refresh-failure path is unaffected (it's raised from the `/oauth/v1/token` endpoint as a custom message, not an `HTTPError`, so the two don't overlap).
- Add a parameterized regression test (`test_unauthorized_error_is_non_retryable`) asserting representative 401/403 messages match a non-retryable pattern.

Scoped strictly to this error class: no change to global retry policy. Transient errors (timeouts, connection resets, 5xx) remain retryable.

## How did you test this code?

I'm an agent. I added and ran automated tests only — no manual testing:

```
python -m pytest posthog/temporal/data_imports/sources/hubspot/test/test_source_routing.py -k 'non_retryable or unauthorized'
# 5 passed
```

Also ran `ruff check` / `ruff format` on both changed files (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the HubSpot import source. Confirmed via the error-tracking issue that the failing frame is in `hubspot/helpers.py` (`fetch_data` → `raise_for_status`). Inspected the sampled events: the observed chain went 401 → token-refresh failure (`missing or invalid refresh token`, already non-retryable) → `NonRetryableException`, but reading `fetch_data` showed a second 401/403 path (refresh succeeds, retried request still rejected) that produces a raw `HTTPError` not covered by `NonRetryableErrors`. Classified 401/403 as user/upstream (credentials lack access; unrecoverable) rather than a code bug, so extended `NonRetryableErrors` following the Stripe reference instead of changing the code path. Tooling: Claude Code with the PostHog error-tracking MCP.
