### PR TITLE
fix(cohorts): propagate Celery soft time limit from cohort inserts

### DIFF
--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -3,9 +3,13 @@ import uuid
 import pytest
 from posthog.test.base import BaseTest
 
+from django.test import override_settings
+
+from celery.exceptions import SoftTimeLimitExceeded
 from parameterized import parameterized
 
 from posthog.clickhouse.client import sync_execute
+from posthog.helpers.batch_iterators import FunctionBatchIterator
 from posthog.models import Person, Team
 
 from products.cohorts.backend.models.cohort import Cohort
@@ -396,6 +400,27 @@ class TestCohort(BaseTest):
         cohort.refresh_from_db()
         assert cohort.people.count() == 1
         assert str(cohort.people.first().uuid) == str(person.uuid)
+
+    @override_settings(DEBUG=False)
+    def test_insert_re_raises_soft_time_limit_exceeded(self):
+        # A Celery soft-time-limit interruption must propagate so the task's time limit
+        # bounds the run. The broad except must not swallow it (DEBUG=False forces the
+        # production path where everything else is swallowed). The finally still finalizes
+        # cohort state before it propagates, so is_calculating is cleared either way.
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
+        cohort.is_calculating = True
+        cohort.save(update_fields=["is_calculating"])
+
+        def _raise_timeout(batch_index: int, batch_size: int) -> list[str]:
+            raise SoftTimeLimitExceeded()
+
+        iterator = FunctionBatchIterator(_raise_timeout, batch_size=10, max_items=10)
+
+        with self.assertRaises(SoftTimeLimitExceeded):
+            cohort._insert_users_list_with_batching(iterator, team_id=self.team.id)
+
+        cohort.refresh_from_db()
+        self.assertFalse(cohort.is_calculating)
 
     @parameterized.expand(
         [

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -406,7 +406,8 @@ class TestCohort(BaseTest):
         # A Celery soft-time-limit interruption must propagate so the task's time limit
         # bounds the run. The broad except must not swallow it (DEBUG=False forces the
         # production path where everything else is swallowed). The finally still finalizes
-        # cohort state before it propagates, so is_calculating is cleared either way.
+        # cohort state before it propagates, recording the timeout as a failed
+        # calculation — not a successful one.
         cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
         cohort.is_calculating = True
         cohort.save(update_fields=["is_calculating"])
@@ -421,6 +422,9 @@ class TestCohort(BaseTest):
 
         cohort.refresh_from_db()
         self.assertFalse(cohort.is_calculating)
+        self.assertEqual(cohort.errors_calculating, 1)
+        self.assertIsNotNone(cohort.last_error_at)
+        self.assertIsNone(cohort.last_calculation)
 
     @parameterized.expand(
         [

--- a/products/cohorts/backend/models/cohort.py
+++ b/products/cohorts/backend/models/cohort.py
@@ -14,6 +14,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 import structlog
+from celery.exceptions import SoftTimeLimitExceeded
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import Feature, tag_queries
@@ -621,6 +622,12 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
                     """
                     cursor.execute(query, params)
 
+        except SoftTimeLimitExceeded:
+            # Let a Celery soft-time-limit interruption propagate so the task's time limit
+            # actually bounds the run. Swallowing it here (as the broad except below would)
+            # leaves the caller's loop running past the limit, since Celery raises it once.
+            # The finally still finalizes cohort state before it propagates.
+            raise
         except Exception as err:
             processing_error = err
             if settings.DEBUG:

--- a/products/cohorts/backend/models/cohort.py
+++ b/products/cohorts/backend/models/cohort.py
@@ -622,11 +622,13 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
                     """
                     cursor.execute(query, params)
 
-        except SoftTimeLimitExceeded:
+        except SoftTimeLimitExceeded as err:
             # Let a Celery soft-time-limit interruption propagate so the task's time limit
             # actually bounds the run. Swallowing it here (as the broad except below would)
             # leaves the caller's loop running past the limit, since Celery raises it once.
-            # The finally still finalizes cohort state before it propagates.
+            # Record it as a processing error so the finally marks the run as failed
+            # rather than a successful calculation.
+            processing_error = err
             raise
         except Exception as err:
             processing_error = err


### PR DESCRIPTION
## Problem

`Cohort._insert_users_list_with_batching` catches everything in a broad `except Exception` and, outside `DEBUG`, swallows it: it records the error, finalizes cohort state in the `finally`, and returns normally. That includes `SoftTimeLimitExceeded`, which Celery raises exactly once when a task passes its `soft_time_limit`. If that signal lands inside an insert flush, swallowing it lets the caller's loop keep running, so the soft limit never bounds the run.

No caller of this helper sets a `soft_time_limit` on master today, so the change is inert for existing callers. The in-flight static-cohort-from-flag cutover (#62763) adds a 4h `soft_time_limit` to its task and pages persons through this helper, and relies on the timeout actually reaching the task. Pulling this out into its own change keeps that PR scoped to the flag cutover and lets the fix land on its own.

## Changes

`_insert_users_list_with_batching` now re-raises `SoftTimeLimitExceeded` ahead of the broad `except Exception`. The `finally` still runs, so cohort state is finalized (`is_calculating` cleared) before the exception propagates to the task.

Re-raising can't change behavior for any existing caller. `SoftTimeLimitExceeded` is only ever raised for a task that sets a `soft_time_limit`, there is no global Celery soft or hard limit, and no current caller of this helper sets one. The request-path callers and the management-command caller are not Celery tasks at all.

## How did you test this code?

Automated test, written and run by an agent (human-directed). No manual testing.

- Added `test_insert_re_raises_soft_time_limit_exceeded` in `posthog/test/test_cohort_model.py`. It drives the helper with a batch iterator that raises `SoftTimeLimitExceeded`, asserts the exception propagates under `DEBUG=False` (the production path), and asserts the cohort is no longer left `is_calculating=True`.
- Verified the test fails against the unpatched helper (exception swallowed, nothing raised) and passes with the fix.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?