### PR TITLE
refactor(hogql): name unaliased call columns at resolve time

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -869,7 +869,7 @@
 # name: TestQuery.test_select_hogql_expressions.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`,
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -12,7 +12,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import DANGEROUS_NoTeamIdCheckTable, SavedQuery, StructDatabaseField
 from posthog.hogql.database.s3_table import DataWarehouseTable, S3Table
 from posthog.hogql.errors import ImpossibleASTError, InternalHogQLError, QueryError
-from posthog.hogql.escape_sql import escape_clickhouse_identifier, escape_clickhouse_string, safe_identifier
+from posthog.hogql.escape_sql import escape_clickhouse_identifier, escape_clickhouse_string
 from posthog.hogql.functions import ADD_OR_NULL_DATETIME_FUNCTIONS, FIRST_ARG_DATETIME_FUNCTIONS
 from posthog.hogql.functions.embed_text import resolve_embed_text
 from posthog.hogql.functions.udfs import JSON_DROP_KEYS_CLICKHOUSE_NAME
@@ -22,7 +22,6 @@ from posthog.hogql.printer.base import (
     get_geoip_city_postal_dict,
     resolve_field_type,
 )
-from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.restricted_properties import restricted_property_keys_for_table_type
 from posthog.hogql.type_system import parse_sql_runtime_type
 from posthog.hogql.visitor import GetFieldsTraverser, clone_expr
@@ -845,11 +844,13 @@ class ClickHousePrinter(BasePrinter):
                 if not found_aliases.get(alias.alias, None) or not alias.hidden:
                     found_aliases[alias.alias] = alias
 
+        # The printer only surfaces names here — it never derives one. Every selectable column was named during type
+        # resolution (a user-written alias, or the hidden alias the resolver attaches to fields and call columns), so
+        # the name reflects the expression as the user wrote it, not whatever the transforms rewrote it into.
         columns_sql = []
         used_aliases: set[str] = set()
         for column in columns:
             printed_alias: str | None = None
-            dropped_hidden_alias = False
             if isinstance(column, ast.Alias):
                 # It's either a visible alias, or the last hidden alias with this name.
                 if found_aliases.get(column.alias) == column:
@@ -863,23 +864,11 @@ class ClickHousePrinter(BasePrinter):
                     printed_alias = column.alias
                 else:
                     # Non-unique hidden alias. Skip.
-                    dropped_hidden_alias = True
                     column = column.expr
 
             if printed_alias is None:
                 printed_alias = _alias_from_column_type(column)
 
-            if isinstance(column, ast.Call) and not dropped_hidden_alias:
-                with self.context.timings.measure("printer"):
-                    column_alias = safe_identifier(HogQLPrinter(context=self.context).visit(column))
-                # ClickHouse rejects duplicate aliases for different expressions in the
-                # same SELECT. This can happen after "*" expansion if a subquery already
-                # exposes a generated expression name like `toDate(period_end)`.
-                if column_alias not in used_aliases:
-                    column = ast.Alias(alias=column_alias, expr=column)
-                    printed_alias = column_alias
-                else:
-                    printed_alias = None
             columns_sql.append(self.visit(column))
             if printed_alias is not None:
                 used_aliases.add(printed_alias)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2499,6 +2499,41 @@ class TestPrinter(BaseTest):
         self.assertNotIn("ifNull(", sql_with)
         self.assertTrue(sql_with.startswith("notEquals("))
 
+    def test_call_column_names_come_from_the_user_expression(self):
+        # An unaliased call column is named once, at resolve time, from the expression as the user wrote it. The
+        # transforms may rewrite the printed expression (materialized columns, null-safe casts), but the name must
+        # not leak the rewritten internals.
+        PropertyDefinition.objects.create(
+            team=self.team, name="is_boolean", property_type="Boolean", type=PropertyDefinition.Type.EVENT
+        )
+        try:
+            from ee.clickhouse.materialized_columns.analyze import materialize
+        except ModuleNotFoundError:
+            self.assertEqual(1 + 2, 3)
+            return
+        materialize("events", "is_boolean")
+
+        printed = self._select("SELECT toBool(properties.is_boolean) FROM events")
+        # The expression lowers to the materialized column read, but the name stays the user-level expression.
+        self.assertIn("AS `toBool(properties.is_boolean)`", printed)
+        self.assertNotIn("AS `toBool(toBool(", printed)
+
+        # The name survives a render-time function rename (toBool prints as accurateCastOrNull).
+        printed = self._select("SELECT toBool(uuid) FROM events")
+        self.assertIn("accurateCastOrNull(events.uuid", printed)
+        self.assertIn("AS `toBool(uuid)`", printed)
+
+    def test_call_column_name_referenced_through_subquery(self):
+        # The resolve-time name is the same one the resolver registers in the column map, so an outer query
+        # (including `SELECT *` expansion) can reference the inner call column by name.
+        printed = self._select(
+            "SELECT `toDate(timestamp)` FROM (SELECT toDate(timestamp) FROM events) ORDER BY `toDate(timestamp)`"
+        )
+        self.assertIn("AS `toDate(timestamp)`", printed)
+
+        printed = self._select("SELECT * FROM (SELECT toDate(timestamp) FROM events)")
+        self.assertIn("AS `toDate(timestamp)`", printed)
+
     def test_field_nullable_boolean(self):
         PropertyDefinition.objects.create(
             team=self.team, name="is_boolean", property_type="Boolean", type=PropertyDefinition.Type.EVENT

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -797,6 +797,17 @@ class Resolver(CloningVisitor):
                 from posthog.hogql.printer import print_prepared_ast
 
                 alias = safe_identifier(print_prepared_ast(node=new_expr, context=self.context, dialect="hogql"))
+                # Attach the name to the column as a hidden alias (the same mechanism plain fields use). This is the
+                # column's one canonical name: assigned here, from the expression as the user wrote it, and carried
+                # through every later transform. The printer surfaces it; it must never derive a name itself, because
+                # by print time transforms have rewritten the tree and a re-derived name would leak the rewritten
+                # internals (and disagree with the name registered in `columns` below).
+                new_expr = ast.Alias(
+                    alias=alias,
+                    expr=new_expr,
+                    hidden=True,
+                    type=ast.FieldAliasType(alias=alias, type=new_expr.type),
+                )
             else:
                 alias = None
 

--- a/posthog/hogql/transforms/test/test_geoip_dict_fallback.py
+++ b/posthog/hogql/transforms/test/test_geoip_dict_fallback.py
@@ -13,12 +13,11 @@ from django.test import override_settings
 
 from parameterized import parameterized
 
-from posthog.schema import PersonsOnEventsMode
+from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
 from posthog.hogql.hogql import translate_hogql
-from posthog.hogql.modifiers import HogQLQueryModifiers
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer.base import get_geoip_city_postal_dict
 from posthog.hogql.printer.utils import prepare_and_print_ast

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
@@ -277,7 +277,7 @@
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_data_warehouse_all_time
   '''
-  SELECT min(toTimeZone(posthog_test_test_table_1.created, 'UTC')) AS `min(toTimeZone(created, 'UTC'))`
+  SELECT min(toTimeZone(posthog_test_test_table_1.created, 'UTC')) AS `min(created)`
   FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.datawarehouse.trendquery/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `prop_1` String, `prop_2` String, `created` DateTime64(3, \'UTC\')') AS posthog_test_test_table_1
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -360,7 +360,7 @@
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_events_and_data_warehouse_all_time
   '''
-  SELECT min(toTimeZone(posthog_test_test_table_1.created, 'UTC')) AS `min(toTimeZone(created, 'UTC'))`
+  SELECT min(toTimeZone(posthog_test_test_table_1.created, 'UTC')) AS `min(created)`
   FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.datawarehouse.trendquery/posthog_test_test_table_1/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `prop_1` String, `prop_2` String, `created` DateTime64(3, \'UTC\')') AS posthog_test_test_table_1
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEventsQueryRunner.test_absolute_date_range
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid
@@ -679,7 +679,7 @@
 # ---
 # name: TestEventsQueryRunner.test_cursor_with_star_select
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid
@@ -753,7 +753,7 @@
 # ---
 # name: TestEventsQueryRunner.test_element_chain_property_filter
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid
@@ -779,7 +779,7 @@
 # ---
 # name: TestEventsQueryRunner.test_presorted_events_table
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid
@@ -805,7 +805,7 @@
 # ---
 # name: TestEventsQueryRunner.test_presorted_events_table_multiple_order_by
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid
@@ -831,7 +831,7 @@
 # ---
 # name: TestEventsQueryRunner.test_presorted_events_table_order_by_event
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid
@@ -857,7 +857,7 @@
 # ---
 # name: TestEventsQueryRunner.test_presorted_events_table_order_by_property
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'), person_mode)`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'), events.person_mode) AS `tuple(uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, person_mode)`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(events.uuid,
                                                 (SELECT events.uuid AS uuid


### PR DESCRIPTION
## Problem

An unaliased call column (`SELECT toBool(uuid) FROM events` — no `AS`) needs a canonical name: outer queries and `SELECT *` expansion reference subquery columns by name, and ClickHouse otherwise derives a name from the rendered SQL text. Today that name is derived **twice, from different trees**:

- the resolver registers the column in the query's column map under the HogQL print of the expression *as the user wrote it* (`resolver.py`, the `CallType` branch);
- the ClickHouse printer independently re-derives it at print time by HogQL-printing the column node *after every transform has rewritten it* (`_print_select_columns`).

The two derivations only agree if no transform ever changes a select column's node — an invariant nobody enforces and that the lowering passes erode. Where they diverge, the printed alias leaks the physical internals of the rewritten tree. For `SELECT toBool(properties.is_boolean)` with a materialized column, master prints:

```sql
... AS `toBool(toBool(transform(toString(nullIf(nullIf(mat_is_boolean, ''), 'null')), ['true', 'false'], [1, 0], NULL)))`
```

That string is unreadable, doesn't match the printed expression (which says `accurateCastOrNull`), and — more importantly — no longer matches the name the resolver registered, so a name-based reference from an outer query would break. Every future pass that rewrites call columns widens this gap.

## Changes

Assign the name **once, at resolve time, from the user-level expression**, and make the printer purely surface names rather than derive them:

- **Resolver**: where the column map name is already computed for an unaliased call column, also attach it to the node as a hidden alias — the same mechanism plain field columns use (`SELECT properties.x` already gets a hidden `x` alias this way). The name then rides through every transform untouched, and the registered column-map name and the printed alias are the same string by construction.
- **ClickHouse printer**: delete the call-column aliasing block from `_print_select_columns`. The existing hidden-alias surfacing logic (visibility + duplicate-name handling) now covers call columns exactly as it covers fields.

For the example above, the printed SQL becomes:

```sql
... AS `toBool(properties.is_boolean)`
```

The HogQL dialect, Postgres, and DuckDB printers render hidden aliases bare, so their output is unchanged. `.ambr` snapshots regenerate in CI where rewritten call columns previously carried derived names.

This is also the prerequisite for re-landing #63333 (comparison null-semantics lowering, closed): with naming fixed at resolve time, comparisons that lower to `ifNull(...)` calls stay nameless in projections — exactly like today — instead of growing derived aliases of the lowered tree.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran:

- Full `posthog/hogql/printer/test/test_printer.py` suite passes (678 tests) — output is byte-identical everywhere the resolve-time and print-time names already agreed, which is everything the suite covers.
- New tests pin the fix: the materialized-boolean case names as `toBool(properties.is_boolean)` (not the lowered tree), the name survives a render-time function rename (`toBool` → `accurateCastOrNull`), and a call column referenced by name through a subquery (explicitly and via `SELECT *`) still resolves and prints consistently.
- Broader suites (resolver, query execution, transforms, metadata) are left to CI per review workflow, which also regenerates the affected snapshots.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @aspicer. This came out of the post-mortem of #63333: lowering comparisons into calls exposed that the printer invents column names from the post-transform tree, producing giant unreadable aliases. Rather than suppress the symptom there, this fixes the root cause — single name derivation at resolve time — which stands alone as a fix for master's existing leaked-internals aliases and unblocks re-landing the null-semantics lowering with no projection-output change.
