### PR TITLE
fix(logs): match severity_level filter key in drop rules

### DIFF
--- a/nodejs/src/logs-ingestion/sampling/filter-group-match.test.ts
+++ b/nodejs/src/logs-ingestion/sampling/filter-group-match.test.ts
@@ -102,6 +102,19 @@ describe('matchFilterGroup', () => {
             expect(matchFilterGroup(g, baseRecord({ severity_text: 'error' }))).toBe(true)
             expect(matchFilterGroup(g, baseRecord({ severity_text: 'info' }))).toBe(false)
         })
+        it('severity_level is an alias for severity_text (the key the drop-rule UI writes)', () => {
+            // Regression guard: the drop-rule builder persists severity filters as
+            // `{key: 'severity_level', type: 'log'}`. Before the alias existed this
+            // fell through to the `type: 'log'` body fallback and compared the log
+            // BODY against e.g. "info" — so UI-created severity rules never matched.
+            const g = group({
+                values: [{ key: 'severity_level', type: 'log', operator: 'exact', value: ['info'] }],
+            })
+            expect(matchFilterGroup(g, baseRecord({ severity_text: 'info' }))).toBe(true)
+            expect(matchFilterGroup(g, baseRecord({ severity_text: 'error' }))).toBe(false)
+            // Must not match via the body fallback.
+            expect(matchFilterGroup(g, baseRecord({ severity_text: 'error', body: 'info' }))).toBe(false)
+        })
         it('level is an alias for severity_text (UI surfaces it this way)', () => {
             const g = group({
                 values: [{ key: 'level', type: 'log_attribute', operator: 'exact', value: ['info', 'INFO'] }],

--- a/nodejs/src/logs-ingestion/sampling/filter-group-match.ts
+++ b/nodejs/src/logs-ingestion/sampling/filter-group-match.ts
@@ -80,14 +80,16 @@ function lookupRecordValue(filter: PropertyFilterLeaf, record: LogRecord): strin
         // would silently miss real data.
         return record.service_name ?? record.resource_attributes?.['service.name']
     }
-    if (key === 'severity_text' || key === 'level') {
+    if (key === 'severity_text' || key === 'level' || key === 'severity_level') {
         // First-class column wins. Otherwise fall back to attribute storage,
         // trying the SDK convention (`level` — Winston/Pino/Bunyan/log4j2) first
         // and the OTel-style `severity_text` second. The fallback chain does not
         // depend on which key the filter used, so `level: info` and
         // `severity_text: info` always resolve to the same value for the same
         // record (otherwise we'd silently disagree when only one of the two
-        // attribute names is populated).
+        // attribute names is populated). `severity_level` is the logs UI / HogQL
+        // alias and the key the drop-rule builder writes; without this branch it
+        // falls through to the `type: 'log'` body fallback and never matches.
         return record.severity_text ?? record.attributes?.['level'] ?? record.attributes?.['severity_text']
     }
     if (key === 'message' || filter.type === PROPERTY_FILTER_TYPE_LOG) {


### PR DESCRIPTION
## Problem

Severity-based drop rules created through the logs UI never match anything. The drop-rule builder persists severity filters with the logs UI / HogQL alias key `severity_level` (e.g. `{"key": "severity_level", "type": "log", "value": ["info"], "operator": "exact"}`), but the ingestion-side matcher (`filter-group-match.ts`) only recognizes `severity_text` and `level` as severity keys. Unrecognized keys with `type: "log"` fall through to the body fallback — so a "drop info logs" rule compares each log's **body** against the string `"info"` and silently drops nothing. The rule's impact column truthfully reports "~0 dropped", but nothing surfaces that the rule is a no-op.

Found while validating drop-rule billing behavior end-to-end on a local stack: a UI-created severity rule let every matching record through until the stored filter key was rewritten to `severity_text` by hand.

## Changes

- Add `severity_level` to the severity alias branch in `lookupRecordValue`, so it resolves through the same chain as `severity_text` / `level`: first-class column first, then the `level` / `severity_text` attribute fallbacks. All three keys resolve identically for the same record.
- Regression test pinning the exact shape the UI writes (`key: severity_level, type: log`), including an assertion that it does **not** match via the body fallback (the original failure mode).

## How did you test this code?

Agent-authored. Automated tests: new regression case plus the existing matcher suite — 18 tests pass. The broken behavior was also reproduced live on a local stack before the fix (UI-created severity rule dropped nothing; rewriting the stored key to `severity_text` made the same rule work).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) after the bug surfaced during local drop-rules/billing validation. Scoped deliberately to the one-line alias addition + regression test; a follow-up worth considering separately is whether the UI should write `severity_text` directly, and whether rule previews should warn when a filter key is unknown to the ingestion matcher.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*