### PR TITLE
feat(error-tracking): capture service exceptions in cymbal services

### DIFF
--- a/rust/cymbal-resolution/src/service/resolve.rs
+++ b/rust/cymbal-resolution/src/service/resolve.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use serde_json::json;
 
 use tokio::sync::mpsc;
 use tonic::{Status, Streaming};
@@ -294,21 +297,21 @@ async fn resolve_one_exception(
             .symbol_resolver
             .resolve_java_exception(team_id, exception)
             .await
-            .map_err(to_unhandled)?
+            .map_err(|err| capture_unhandled(team_id, err))?
     } else if ExceptionResolver::is_dart_exception(&exception) {
         let _permit = acquire_permit(&stage).await?;
         stage
             .symbol_resolver
             .resolve_dart_exception(team_id, exception)
             .await
-            .map_err(to_unhandled)?
+            .map_err(|err| capture_unhandled(team_id, err))?
     } else {
         exception
     };
 
     FrameResolver::resolve_exception_frames(team_id, exception, &debug_images, stage)
         .await
-        .map_err(to_unhandled)
+        .map_err(|err| capture_unhandled(team_id, err))
 }
 
 async fn acquire_permit(
@@ -320,7 +323,9 @@ async fn acquire_permit(
         .map_err(|_| ResolveOneError::Overloaded)
 }
 
-fn to_unhandled(err: UnhandledError) -> ResolveOneError {
+fn capture_unhandled(team_id: i32, err: UnhandledError) -> ResolveOneError {
+    let err = Arc::new(err);
+    common_posthog::capture_exception(err.clone(), [("team_id", json!(team_id))]);
     ResolveOneError::Unhandled(err.to_string())
 }
 

--- a/rust/cymbal/src/router/event.rs
+++ b/rust/cymbal/src/router/event.rs
@@ -48,13 +48,13 @@ fn get_request_id(headers: &HeaderMap) -> String {
 }
 
 pub enum ProcessEventsError {
-    Unhandled(UnhandledError),
+    Unhandled(Arc<UnhandledError>),
     Backpressure,
 }
 
 impl From<UnhandledError> for ProcessEventsError {
     fn from(value: UnhandledError) -> Self {
-        Self::Unhandled(value)
+        Self::Unhandled(Arc::new(value))
     }
 }
 
@@ -216,5 +216,19 @@ pub async fn process_events(
         }
     }
 
-    output.map_err(ProcessEventsError::from)
+    match output {
+        Ok(batch) => Ok(batch),
+        Err(err) => {
+            let err = Arc::new(err);
+            common_posthog::capture_exception(
+                err.clone(),
+                [
+                    ("request_id", json!(request_id)),
+                    ("batch_event_count", json!(batch_event_count)),
+                    ("team_count", json!(team_count)),
+                ],
+            );
+            Err(ProcessEventsError::Unhandled(err))
+        }
+    }
 }

--- a/rust/cymbal/src/router/event.rs
+++ b/rust/cymbal/src/router/event.rs
@@ -52,12 +52,6 @@ pub enum ProcessEventsError {
     Backpressure,
 }
 
-impl From<UnhandledError> for ProcessEventsError {
-    fn from(value: UnhandledError) -> Self {
-        Self::Unhandled(Arc::new(value))
-    }
-}
-
 impl IntoResponse for ProcessEventsError {
     fn into_response(self) -> axum::response::Response {
         match self {

--- a/rust/cymbal/tests/posthog_capture.rs
+++ b/rust/cymbal/tests/posthog_capture.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{body::Body, http::Request};
+use common_redis::MockRedisClient;
+use cymbal::{app_context::AppContext, config::Config, router::get_router};
+use httpmock::prelude::*;
+use mockall::predicate;
+use serde_json::json;
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+mod utils;
+use utils::MockS3Client;
+
+const STORAGE_BUCKET: &str = "test-bucket";
+
+// One test per binary: common_posthog::init configures a process-wide global
+// client, so a second init with a different mock server would be ignored.
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn pipeline_failure_is_captured_as_posthog_exception(db: PgPool) {
+    let posthog = MockServer::start_async().await;
+    let capture = posthog
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/i/v0/e/")
+                .body_contains("\"$exception\"")
+                .body_contains("UnhandledError")
+                .body_contains("\"service\":\"cymbal-test\"")
+                .body_contains("\"request_id\"");
+            then.status(200).body("{\"status\": 1}");
+        })
+        .await;
+    // Catch-all so an unexpected payload shape fails the specific assertion
+    // below instead of surfacing as a connection-level SDK error.
+    let fallback = posthog
+        .mock_async(|when, then| {
+            when.path_contains("/");
+            then.status(200).body("{\"status\": 1}");
+        })
+        .await;
+
+    common_posthog::init("cymbal-test", Some("test-api-key"), &posthog.base_url())
+        .await
+        .expect("posthog init");
+
+    let mut config = Config::init_with_defaults().unwrap();
+    config.object_storage_bucket = STORAGE_BUCKET.to_string();
+
+    let mut s3_client = MockS3Client::new();
+    s3_client
+        .expect_ping_bucket()
+        .with(predicate::eq(STORAGE_BUCKET.to_string()))
+        .returning(|_| Ok(()));
+
+    let app_ctx = AppContext::new(
+        &config,
+        Arc::new(s3_client),
+        db.clone(),
+        Arc::new(MockRedisClient::new()),
+    )
+    .await
+    .unwrap();
+    let router = get_router(Arc::new(app_ctx));
+
+    // With the pool closed, the pipeline's first database access fails with
+    // an UnhandledError — the capture funnel under test.
+    db.close().await;
+
+    let event = json!([{
+        "uuid": Uuid::now_v7(),
+        "event": "$exception",
+        "team_id": 1,
+        "timestamp": "2024-01-01T00:00:00Z",
+        "properties": {
+            "$exception_list": [{"type": "Error", "value": "boom"}],
+            "$exception_handled": false,
+        },
+    }]);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .header("content-type", "application/json")
+                .uri("/process")
+                .body(Body::from(serde_json::to_vec(&event).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+
+    // The capture is fire-and-forget; wait for it to reach the mock server.
+    for _ in 0..100 {
+        if capture.hits_async().await > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        capture.hits_async().await,
+        1,
+        "expected a matching $exception capture; total capture requests seen: {}",
+        fallback.hits_async().await
+    );
+}


### PR DESCRIPTION
## Problem

Cymbal is error tracking's own ingestion pipeline, but its failures only surface as logs and metrics — we don't dogfood error tracking for the services that power it. posthog-rs 0.12 ships manual exception capture, so we can close that loop.

## Changes

Stacked on #63355 (posthog-rs 0.12 bump + `common-posthog` crate).

- **cymbal**: capture pipeline `UnhandledError`s at the `/process` error sink — the single funnel every pipeline failure already flows through — with `request_id`, `batch_event_count`, and `team_count` properties. `ProcessEventsError::Unhandled` now carries an `Arc<UnhandledError>` so the capture and the 500 response share the same error without cloning.
- **cymbal-resolution**: `to_unhandled` becomes `capture_unhandled`, capturing the typed error (with its full source chain) before it is stringified for the gRPC response, tagged with `team_id`.
- Deliberately **not** captured: backpressure rejections, overload/invalid-payload/timeout item failures, and stream disconnects — all expected, communicated-to-caller outcomes already covered by metrics.

Captures are personless, stamped with service identity, and bounded by the shared 10/min/process cap from `common-posthog`, which also bounds the self-ingestion loop (cymbal processes the internal project's `$exception` events, i.e. eventually its own captures).

## How did you test this code?

<img width="1432" height="844" alt="CleanShot 2026-06-17 at 01 52 46@2x" src="https://github.com/user-attachments/assets/9544aa2f-6f2c-4388-bcce-ad019eebf4bb" />

+

I'm an agent; automated tests only:

- new integration test drives `/process` into a real pipeline failure (closed PG pool) and asserts the resulting `$exception` capture against a mock PostHog server — exception type chain, `service` property, and request context included
- full cymbal + cymbal-resolution + common-posthog suites pass locally (205 tests)
- `cargo check` / `clippy` / `fmt` clean on touched crates

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal service telemetry only; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by the DRI: capture sinks and exclusion list agreed in an upfront plan review; the deterministic pool-close failure injection for the integration test was chosen over a heavier full-stack harness. A structured second-model review over the stack reported no actionable findings after the in-app frame fix landed in the base PR.
