### PR TITLE
chore(flags): remove semver-targeting feature flag

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -319,7 +319,7 @@ export function OperatorValueSelect({
             }
             setCurrentOperator(defaultProperty)
         }
-    }, [propertyDefinition, propertyKey, operator, operatorAllowlist]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [propertyDefinition, propertyKey, operator, operatorAllowlist, type]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const validationError = currentOperator && value ? getValidationError(currentOperator, value, propertyKey) : null
 

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -1,15 +1,12 @@
-import { useValues } from 'kea'
 import { RE2JS } from 're2js'
 import { useEffect, useState } from 'react'
 
 import { LemonBanner, LemonDropdownProps, LemonSelect, LemonSelectProps, LemonSelectSection } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { Link } from 'lib/lemon-ui/Link'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
     allOperatorsMapping,
     chooseOperatorMap,
@@ -194,8 +191,6 @@ export function OperatorValueSelect({
     operatorAllowlist,
     forceSingleSelect,
 }: OperatorValueSelectProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const semverTargetingEnabled = !!featureFlags[FEATURE_FLAGS.SEMVER_TARGETING]
     const lookupKey = type === PropertyFilterType.DataWarehousePersonProperty ? 'id' : 'name'
     const propertyDefinition = propertyDefinitions.find((pd) => pd[lookupKey] === propertyKey)
 
@@ -244,13 +239,9 @@ export function OperatorValueSelect({
 
         const operatorMapping: Record<string, string> = chooseOperatorMap(propertyType)
 
-        let operators = (Object.keys(operatorMapping) as Array<PropertyOperator>).filter((op) => {
-            // Filter out semver operators if feature flag is not enabled
-            if (!semverTargetingEnabled && isOperatorSemver(op)) {
-                return false
-            }
-            return !operatorAllowlist || operatorAllowlist.includes(op)
-        })
+        let operators = (Object.keys(operatorMapping) as Array<PropertyOperator>).filter(
+            (op) => !operatorAllowlist || operatorAllowlist.includes(op)
+        )
 
         // Restrict message log property to only allow exact, is_not, contains, not contains, regex, and not regex operators
         if (propertyKey === 'message' && type === PropertyFilterType.Log) {
@@ -328,7 +319,7 @@ export function OperatorValueSelect({
             }
             setCurrentOperator(defaultProperty)
         }
-    }, [propertyDefinition, propertyKey, operator, operatorAllowlist, semverTargetingEnabled]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, [propertyDefinition, propertyKey, operator, operatorAllowlist]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const validationError = currentOperator && value ? getValidationError(currentOperator, value, propertyKey) : null
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -470,7 +470,6 @@ export const FEATURE_FLAGS = {
     SEARCH_DEBOUNCE_ALL: 'search-debounce-all', // owner: @adamleithp #team-platform-ux
     SEARCH_RE_RANK: 'search-re-rank', // owner: @adamleithp #team-platform-ux
     SEEKBAR_PREVIEW_SCRUBBING: 'seekbar-preview-scrubbing', // owner: @pauldambra #team-replay
-    SEMVER_TARGETING: 'semver-targeting', // owner: #team-feature-flags
     SHOPIFY_DWH: 'shopify-dwh', // owner: #team-warehouse-sources
     SHOW_DATA_PIPELINES_NAV_ITEM: 'show-data-pipelines-nav-item', // owner: @raquelmsmith
     SHOW_REFERRER_FAVICON: 'show-referrer-favicon', // owner: @jordanm-posthog #team-web-analytics


### PR DESCRIPTION
## Problem

The `semver-targeting` flag has been fully rolled out, so the gate is no longer needed. This removes the flag and makes semver operators always available in the property filter UI.

## Changes

- Removes the `SEMVER_TARGETING` feature flag constant from `frontend/src/lib/constants.tsx`
- Removes the `featureFlagLogic` subscription and `semverTargetingEnabled` check from `OperatorValueSelect`, which was filtering out semver operators when the flag was off
- Moves `INSIGHT_SUBSCRIBE_PROMINENT_BUTTON` to its correct alphabetical position in the constants list (drive-by fix)

## How did you test this code?

Verified no remaining references to `semver-targeting` or `SEMVER_TARGETING` across the codebase (frontend, backend, Rust, tests). The `isOperatorSemver` helper remains in use for grouping semver operators in the dropdown UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code to remove the flag. No design decisions were needed; the diff deletes the gate and cleans up the now-unused imports and dependency array entry.