### PR TITLE
chore(ci): diff from merge-base in playwright flake verification

### DIFF
--- a/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
+++ b/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
@@ -38,7 +38,20 @@ rm -f "$RESULTS_FILE"
 # noise. If a file is moved AND substantively edited in the same PR, the verifier
 # won't catch it — but that's a rare pattern, and the alternative (re-verifying every
 # moved test) blocks routine reorganizations.
-changed_test_files=$(git diff --name-only --diff-filter=AM "$BASE_SHA..HEAD" -- 'playwright/**/*.spec.ts' 'products/*/frontend/e2e/**/*.spec.ts')
+#
+# Diff from the merge-base, not the raw base tip. A two-dot "$BASE_SHA..HEAD" diff
+# compares the two trees directly, so a PR branched off an older master inherits every
+# spec file changed on master since the branch point — re-running dozens of unrelated
+# tests serially blows past the job timeout. The merge-base is the branch point, so the
+# diff yields only the PR's own changes. (Equivalent to three-dot "$BASE_SHA...HEAD",
+# but computed explicitly so a too-shallow fetch degrades to a warning instead of a
+# hard `git diff` failure under `set -e`.)
+merge_base=$(git merge-base "$BASE_SHA" HEAD 2>/dev/null || true)
+if [ -z "$merge_base" ]; then
+    echo "Warning: no merge-base for $BASE_SHA and HEAD (shallow fetch too shallow?) — comparing against $BASE_SHA directly"
+    merge_base="$BASE_SHA"
+fi
+changed_test_files=$(git diff --name-only --diff-filter=AM "$merge_base..HEAD" -- 'playwright/**/*.spec.ts' 'products/*/frontend/e2e/**/*.spec.ts')
 
 if [ -z "$changed_test_files" ]; then
     echo "No changed Playwright test files found — skipping flake verification"

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -544,9 +544,18 @@ jobs:
             - name: Verify changed Playwright tests are stable
               if: success() && github.event_name == 'pull_request'
               shell: bash
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
               run: |
-                  BASE_SHA="${{ github.event.pull_request.base.sha }}"
-                  git fetch --no-tags --prune --depth=50 origin "$BASE_SHA"
+                  # The script diffs from the merge-base of BASE_SHA and HEAD so a PR on an
+                  # older master doesn't inherit specs changed only on master. The merge-base
+                  # must be reachable from *both* tips: this job checks out HEAD at depth 1, so
+                  # deepen both histories (depth=1000 + blob:none mirrors the merge-base fetches
+                  # in the `changes` job). If the branch point is still out of reach, the script
+                  # warns and falls back to BASE_SHA — bounded by its own file-run budget guard.
+                  git fetch --no-tags --prune --depth=1000 --filter=blob:none origin "$BASE_SHA"
+                  git fetch --no-tags --depth=1000 --filter=blob:none origin "$HEAD_SHA"
                   .github/scripts/verify-playwright-new-tests-and-snapshots.sh "$BASE_SHA" 10
 
             # Visual Review: create run + upload snapshots directly from the test job.


### PR DESCRIPTION
## Problem

The verify step compared the PR's head against master's current tip using a two-dot `git diff`. A PR branched off an older master inherited every spec file changed on master since the branch point. Those unrelated tests then ran serially at `--workers=1 --repeat-each=10`, blowing past the 45-minute job timeout. Observed on PR #63326: a one-line constants change picked up 7 spec files from master (296 serial runs), timed out twice.

## Changes

- `verify-playwright-new-tests-and-snapshots.sh` now computes `git merge-base "$BASE_SHA" HEAD` and diffs from that point instead of from `$BASE_SHA` directly. Only tests the PR actually touched are picked up.
- If the merge-base isn't reachable (fetch too shallow), the script logs a warning and falls back to `$BASE_SHA` rather than crashing under `set -e`.
- The verify step in `ci-e2e-playwright.yml` deepens both `BASE_SHA` and `HEAD_SHA` to 1000 commits with `--filter=blob:none`, matching the pattern already used in the `changes` job, so the merge-base is reachable in the normal case.

## How did you test this code?

Verified with throwaway git repos that reproduce the two-dot vs. three-dot behavior. A branch behind master with only master-side spec changes returns those files under a two-dot diff and none under a merge-base diff. Also confirmed that HEAD at depth 1 with base at depth 50 makes `git merge-base` fail, while deepening both to 1000 resolves the merge-base to the branch point correctly. Ran the modified script end-to-end against both cases.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.