### PR TITLE
fix(hogql): import HogQLQueryModifiers from posthog.schema in geoip test

### DIFF
--- a/posthog/hogql/transforms/test/test_geoip_dict_fallback.py
+++ b/posthog/hogql/transforms/test/test_geoip_dict_fallback.py
@@ -13,12 +13,11 @@ from django.test import override_settings
 
 from parameterized import parameterized
 
-from posthog.schema import PersonsOnEventsMode
+from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
 from posthog.hogql.hogql import translate_hogql
-from posthog.hogql.modifiers import HogQLQueryModifiers
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer.base import get_geoip_city_postal_dict
 from posthog.hogql.printer.utils import prepare_and_print_ast


### PR DESCRIPTION
## Problem

Master's `ci-backend` has been red since ~21:00 UTC: every Django Core shard aborts at collection with

```
ImportError: cannot import name 'HogQLQueryModifiers' from 'posthog.hogql.modifiers'
  (importing posthog/hogql/transforms/test/test_geoip_dict_fallback.py)
```

Two PRs that were each green on their own merge-bases combined badly: #62726 moved the `HogQLQueryModifiers` import in `posthog/hogql/modifiers.py` behind `TYPE_CHECKING` (cutting the setup-time import chain), and #63191 added a test that still imports the name from that module at runtime. The single collection error kills all 22 shards on master and on every PR rebased onto it.

## Changes

One line: the test imports `HogQLQueryModifiers` from `posthog.schema` (its real home, and how every other runtime consumer imports it), keeping #62726's import-chain win intact. Import block re-sorted by ruff.

## How did you test this code?

I'm an agent; this is a one-line import fix verified by ruff and a syntax check — the failing CI collection error is the reproduction. This unblocks master and every open PR currently inheriting the red Core shards.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while babysitting the metrics stack merge train: all restacked PRs started failing all 22 Core shards identically within ~2 minutes, which pointed at a collection error inherited from master rather than the stack's own changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*