### PR TITLE
refactor(hogql): drop joined_subquery property breadcrumbs

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -757,10 +757,6 @@ class PropertyType(Type):
     chain: list[str | int]
     field_type: FieldType
 
-    # The property has been moved into a field we query from a joined subquery
-    joined_subquery: Optional[SelectQueryAliasType] = field(default=None, init=False)
-    joined_subquery_field_name: Optional[str] = field(default=None, init=False)
-
     def get_child(self, name: str | int, context: HogQLContext) -> Type:
         return PropertyType(chain=[*self.chain, name], field_type=self.field_type)
 
@@ -768,9 +764,6 @@ class PropertyType(Type):
         return True
 
     def resolve_constant_type(self, context: HogQLContext) -> ConstantType:
-        if self.joined_subquery is not None and self.joined_subquery_field_name is not None:
-            return self.joined_subquery.resolve_column_constant_type(self.joined_subquery_field_name, context)
-
         database_field = self.field_type.resolve_database_field(context)
         if isinstance(database_field, StructDatabaseField):
             nested_field: DatabaseField = database_field

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -135,7 +135,7 @@ class WhereClauseExtractor(CloningVisitor):
 
             if isinstance(node.right, ast.SelectQuery):
                 right = clone_expr(
-                    node.right, clear_types=False, clear_locations=False, inline_subquery_field_names=True
+                    node.right, clear_types=False, clear_locations=False
                 )
             else:
                 right = self.visit(node.right)
@@ -508,7 +508,7 @@ class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
 
         left = self.visit(node.left)
         if isinstance(node.right, ast.SelectQuery):
-            right = clone_expr(node.right, clear_types=False, clear_locations=False, inline_subquery_field_names=True)
+            right = clone_expr(node.right, clear_types=False, clear_locations=False)
         else:
             right = self.visit(node.right)
 

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1252,15 +1252,9 @@ class BasePrinter(Visitor[str]):
         return field_sql
 
     def visit_property_type(self, type: ast.PropertyType):
-        # After lowering, a blob property read is a `PropertyAccess`. A `PropertyType` still reaching the printer is the
-        # leftover OUTER reference to a person/group property that `resolve_lazy_tables` pulled into a join subquery: the
-        # JSON extract now lives inside that subquery (and was lowered there), so this outer node is just an
-        # `alias.column` read of the subquery's result — nothing to lower. (Plus, in the ClickHouse override, a
-        # data-warehouse struct column.) The printer makes no physical-column decision — that moved to
-        # `logical_property_lowering` + the ClickHouse physical passes.
-        if type.joined_subquery is not None and type.joined_subquery_field_name is not None:
-            return f"{self._print_identifier(type.joined_subquery.alias)}.{self._print_identifier(type.joined_subquery_field_name)}"
-
+        # After lowering, a blob property read is a `PropertyAccess`. A `PropertyType` still reaching the printer is a
+        # read the lowering pass declined (in the ClickHouse override, a data-warehouse struct column). The printer
+        # makes no physical-column decision — that moved to `logical_property_lowering` + the ClickHouse physical passes.
         return self._unsafe_json_extract_trim_quotes(self.visit(type.field_type), self._json_property_args(type.chain))
 
     def visit_property_access(self, node: ast.PropertyAccess) -> str:

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -872,12 +872,6 @@ class ClickHousePrinter(BasePrinter):
         return table.table.to_printed_clickhouse(self.context)
 
     def visit_property_type(self, type: ast.PropertyType) -> str:
-        # Respect the joined-subquery projection: if the property has already been
-        # projected through a subquery, defer to base which renders the subquery alias
-        # correctly, rather than re-resolving against the original struct column.
-        if type.joined_subquery is not None and type.joined_subquery_field_name is not None:
-            return super().visit_property_type(type)
-
         # Struct columns (e.g. Parquet structs from the data warehouse) are backed by a ClickHouse
         # Tuple, not a JSON string. Emit chained tupleElement() calls instead of JSONExtractRaw(),
         # which ClickHouse rejects on Tuple arguments. Closes #58480.

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -422,9 +422,6 @@ class PostgresPrinter(BasePrinter):
         return table.to_printed_clickhouse(self.context)
 
     def visit_property_type(self, type: ast.PropertyType):
-        if type.joined_subquery is not None and type.joined_subquery_field_name is not None:
-            return super().visit_property_type(type)
-
         database_field = type.field_type.resolve_database_field(self.context)
         if isinstance(database_field, StructDatabaseField):
             struct_expr = self.visit(type.field_type)

--- a/posthog/hogql/resolver_utils.py
+++ b/posthog/hogql/resolver_utils.py
@@ -343,19 +343,6 @@ def _recursively_resolve_column(
     elif isinstance(column, ast.FieldTraverserType):
         fields[name] = FieldTraverser(chain=column.chain)
     elif isinstance(column, ast.PropertyType):
-        if column.joined_subquery and column.joined_subquery_field_name:
-            select_type = column.joined_subquery.select_query_type
-            if isinstance(select_type, ast.SelectSetQueryType):
-                for t in select_type.types:
-                    if isinstance(t, ast.SelectQueryType):
-                        subquery_column = t.columns.get(column.joined_subquery_field_name)
-                        if subquery_column:
-                            return _recursively_resolve_column(name, subquery_column, fields, context)
-            else:
-                subquery_column = select_type.columns.get(column.joined_subquery_field_name)
-                if subquery_column:
-                    return _recursively_resolve_column(name, subquery_column, fields, context)
-
         return _recursively_resolve_column(name, column.field_type, fields, context)
     elif isinstance(column, ast.CallType):
         fields[name] = _constant_type_to_database_field(name, column.return_type)

--- a/posthog/hogql/transforms/clickhouse_property_resolution.py
+++ b/posthog/hogql/transforms/clickhouse_property_resolution.py
@@ -534,14 +534,12 @@ class ClickHousePropertyResolver(CloningVisitor):
         # through the alias wrapper to the original `PropertyType`, and a boolean/numeric property gets wrapped by the
         # swapper in a cast (`toBool(transform(toString(...)))`) with the `PropertyType` underneath. Read the property
         # identity off the type — that is the resolver's own binding, so a shadowing alias of the same name can never
-        # be confused with it (its type points at whatever it actually aliases). Skip joined-subquery properties
-        # (lowering skips them too: they print as `alias.field`) and properties whose table is not in the current
-        # FROM (a transform moved the read behind a subquery; the bare column would be out of scope).
+        # be confused with it (its type points at whatever it actually aliases). Skip properties whose table is not in
+        # the current FROM (a transform moved the read behind a subquery; the bare column would be out of scope).
         prop_type = resolve_field_type(expr)
         if (
             isinstance(prop_type, ast.PropertyType)
             and len(prop_type.chain) == 1
-            and prop_type.joined_subquery is None
             and self._property_table_in_scope(prop_type.field_type)
         ):
             return prop_type.field_type, str(prop_type.chain[0])

--- a/posthog/hogql/transforms/lazy_expansion.py
+++ b/posthog/hogql/transforms/lazy_expansion.py
@@ -203,8 +203,6 @@ class LazyDemandCollector(TraversingVisitor):
     def visit_field(self, node: ast.Field):
         node_type = node.type
         if isinstance(node_type, ast.PropertyType):
-            if node_type.joined_subquery is not None:
-                return
             base = _unwrap_to_base_table_type(node_type.field_type.table_type)
             if isinstance(base, (ast.LazyJoinType, ast.LazyTableType)):
                 if self.context.within_non_hogql_query:

--- a/posthog/hogql/transforms/logical_property_lowering.py
+++ b/posthog/hogql/transforms/logical_property_lowering.py
@@ -47,9 +47,6 @@ class LogicalPropertyLowering(CloningVisitor):
         property_type = node.type
         if not isinstance(property_type, ast.PropertyType):
             return None
-        # A repointed person/group property is read as a plain aliased column from its joined subquery, not a property.
-        if property_type.joined_subquery is not None:
-            return None
         chain = property_type.chain
         base_field_type = property_type.field_type
         # Only lower reads off a JSON blob column (`properties` / `person_properties`). Struct/array warehouse columns

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -12,12 +12,11 @@ T_AST = TypeVar("T_AST", bound=AST)
 T_Expr = TypeVar("T_Expr", bound=Expr)
 
 
-def clone_expr(expr: T_AST, clear_types=False, clear_locations=False, inline_subquery_field_names=False) -> T_AST:
+def clone_expr(expr: T_AST, clear_types=False, clear_locations=False) -> T_AST:
     """Clone an expression node."""
     return CloningVisitor(
         clear_types=clear_types,
         clear_locations=clear_locations,
-        inline_subquery_field_names=inline_subquery_field_names,
     ).visit(expr)
 
 
@@ -512,11 +511,9 @@ class CloningVisitor(Visitor[Any]):
         self,
         clear_types: Optional[bool] = True,
         clear_locations: Optional[bool] = False,
-        inline_subquery_field_names: Optional[bool] = False,
     ):
         self.clear_types = clear_types
         self.clear_locations = clear_locations
-        self.inline_subquery_field_names = inline_subquery_field_names
 
     def visit_cte(self, node: ast.CTE):
         return ast.CTE(
@@ -784,21 +781,13 @@ class CloningVisitor(Visitor[Any]):
         )
 
     def visit_field(self, node: ast.Field):
-        field = ast.Field(
+        return ast.Field(
             start=None if self.clear_locations else node.start,
             end=None if self.clear_locations else node.end,
             type=None if self.clear_types else node.type,
             chain=node.chain.copy(),
             from_asterisk=node.from_asterisk,
         )
-        if (
-            self.inline_subquery_field_names
-            and isinstance(node.type, ast.PropertyType)
-            and node.type.joined_subquery is not None
-            and node.type.joined_subquery_field_name is not None
-        ):
-            field.chain = [node.type.joined_subquery_field_name]
-        return field
 
     def visit_columns_expr(self, node: ast.ColumnsExpr):
         return ast.ColumnsExpr(


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay.
     Public OSS repo: no internal customers, incidents, or operational metrics.
-->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) — or — Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
-->
