### PR TITLE
fix(hogql): import HogQLQueryModifiers from posthog.schema in geoip test

### DIFF
--- a/posthog/hogql/transforms/test/test_geoip_dict_fallback.py
+++ b/posthog/hogql/transforms/test/test_geoip_dict_fallback.py
@@ -13,12 +13,11 @@ from django.test import override_settings
 
 from parameterized import parameterized
 
-from posthog.schema import PersonsOnEventsMode
+from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
 from posthog.hogql.hogql import translate_hogql
-from posthog.hogql.modifiers import HogQLQueryModifiers
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer.base import get_geoip_city_postal_dict
 from posthog.hogql.printer.utils import prepare_and_print_ast


### PR DESCRIPTION
## Problem

`test_geoip_dict_fallback.py` (from #63191) imports `HogQLQueryModifiers` from `posthog.hogql.modifiers`, where it only exists under `TYPE_CHECKING`. The import fails at collection time, which kills every Django CI shard on every PR — collection runs over the full suite in each shard.

## Changes

One-line fix: import `HogQLQueryModifiers` from `posthog.schema`, where it actually lives.

## How did you test this code?

I'm an agent; automated checks only: `pytest --collect-only` on the file now collects 47 tests (previously `ImportError` at collection).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while triaging backend CI failures on #63372 — all 22 Django shards failed at collection with this ImportError, on the PR and on master alike. Authored with Claude Code; assignee is the DRI.
