### PR TITLE
chore(logs): add hogvm benchmark harness for log transformations

### DIFF
--- a/nodejs/src/logs-ingestion/transformations/benchmarks/fixtures.ts
+++ b/nodejs/src/logs-ingestion/transformations/benchmarks/fixtures.ts
@@ -1,0 +1,200 @@
+import type { LogRecord } from '../../log-record-avro'
+
+// Fixtures for benchmarking Hog programs against realistic log records.
+// Record sizes are calibrated to the production average of ~0.9KB uncompressed per record.
+
+export interface BenchProgram {
+    id: string
+    name: string
+    hog: string
+    inputs: Record<string, unknown>
+}
+
+export interface BenchGlobals {
+    project: { id: number; name: string; url: string }
+    record: Record<string, unknown>
+    inputs: Record<string, unknown>
+}
+
+const NOW_NS = 1_780_000_000_000_000_000
+
+export const BENCH_LOG_RECORDS: { id: string; record: LogRecord }[] = [
+    {
+        id: 'plain-body',
+        record: {
+            uuid: '0197a3f2-1111-7000-8000-000000000001',
+            trace_id: null,
+            span_id: null,
+            trace_flags: 0,
+            timestamp: NOW_NS,
+            observed_timestamp: NOW_NS,
+            // sk_fake_ prefix: shaped like a payment-provider secret for the scrub benchmark
+            // without tripping GitHub push protection on a real-looking key.
+            body: 'Failed to authorize request for user jane.doe@example.com with token Bearer sk_fake_abcdef1234567890abcdef1234567890 — retrying with backoff. Previous attempt failed after 1523ms due to upstream timeout from payments-gateway. Contact ops@example.com if this persists across more than three consecutive attempts.',
+            severity_text: 'error',
+            severity_number: 17,
+            service_name: 'payments-api',
+            resource_attributes: {
+                'k8s.namespace.name': 'payments',
+                'k8s.pod.name': 'payments-api-6d8f9c7b4-x2j9q',
+                'deployment.environment': 'production',
+                'cloud.region': 'us-east-1',
+            },
+            instrumentation_scope: 'payments.auth',
+            event_name: null,
+            attributes: {
+                'http.method': 'POST',
+                'http.status_code': '401',
+                'http.route': '/api/v1/charges',
+                'user.email': 'jane.doe@example.com',
+                retry_count: '3',
+                duration_ms: '1523',
+                distinct_id: 'user_8f3k2j1h',
+            },
+            bytes_uncompressed: 880,
+        },
+    },
+    {
+        id: 'json-body',
+        record: {
+            uuid: '0197a3f2-1111-7000-8000-000000000002',
+            trace_id: null,
+            span_id: null,
+            trace_flags: 0,
+            timestamp: NOW_NS,
+            observed_timestamp: NOW_NS,
+            body: JSON.stringify({
+                level: 'info',
+                msg: 'order processed',
+                order_id: 'ord_29f8a3kd02',
+                customer: { id: 'cus_8d3f2', email: 'buyer@example.org', country: 'DE' },
+                items: [
+                    { sku: 'SKU-1001', qty: 2, price_cents: 1999 },
+                    { sku: 'SKU-2044', qty: 1, price_cents: 5499 },
+                ],
+                payment: { provider: 'stripe', token: 'sk_fake_51JxYzabcdef1234567890abcdef12', status: 'captured' },
+                latency_ms: 187,
+                attempt: 1,
+            }),
+            severity_text: 'info',
+            severity_number: 9,
+            service_name: 'orders-worker',
+            resource_attributes: {
+                'k8s.namespace.name': 'commerce',
+                'k8s.pod.name': 'orders-worker-7f6d5c4b3-a1b2c',
+                'deployment.environment': 'production',
+            },
+            instrumentation_scope: 'orders.processor',
+            event_name: null,
+            attributes: {
+                'queue.name': 'orders-high',
+                'messaging.operation': 'process',
+                distinct_id: 'user_2k4j5h6g',
+            },
+            bytes_uncompressed: 920,
+        },
+    },
+    {
+        id: 'fat-attributes',
+        record: {
+            uuid: '0197a3f2-1111-7000-8000-000000000003',
+            trace_id: null,
+            span_id: null,
+            trace_flags: 0,
+            timestamp: NOW_NS,
+            observed_timestamp: NOW_NS,
+            body: 'request completed',
+            severity_text: 'debug',
+            severity_number: 5,
+            service_name: 'edge-router',
+            resource_attributes: {
+                'k8s.namespace.name': 'edge',
+                'k8s.pod.name': 'edge-router-5c4b3a2d1-q9w8e',
+                'deployment.environment': 'production',
+                'cloud.region': 'eu-west-1',
+                'host.name': 'ip-10-0-12-34',
+            },
+            instrumentation_scope: 'edge.http',
+            event_name: null,
+            attributes: Object.fromEntries(
+                Array.from({ length: 30 }, (_, i) => [`dim.field_${i}`, `value-${i}-${'x'.repeat(16)}`])
+            ),
+            bytes_uncompressed: 950,
+        },
+    },
+]
+
+export const BENCH_PROGRAMS: BenchProgram[] = [
+    {
+        id: 'noop',
+        name: 'No-op passthrough (pure invocation overhead)',
+        hog: `return record`,
+        inputs: {},
+    },
+    {
+        id: 'redact-attributes',
+        name: 'Hash selected attribute keys with SHA256',
+        hog: `
+let rec := record
+let keysToRedact := splitByString(',', inputs.redactKeys)
+for (let key in keysToRedact) {
+    let k := trim(key)
+    if (not empty(rec.attributes?.[k])) {
+        rec.attributes[k] := sha256Hex(concat(rec.attributes[k], inputs.salt))
+    }
+}
+return rec
+`,
+        inputs: { redactKeys: 'user.email,distinct_id,card_number', salt: 'bench-salt' },
+    },
+    {
+        id: 'body-regex-scrub',
+        name: 'Regex scrub of emails and secret keys in body',
+        hog: `
+let rec := record
+let body := rec.body
+if (not empty(body)) {
+    for (let pattern in [inputs.emailPattern, inputs.tokenPattern]) {
+        let i := 0
+        let found := extractRegex(body, pattern)
+        while (i < 10 and notEmpty(found)) {
+            body := replaceAll(body, found, '[REDACTED]')
+            found := extractRegex(body, pattern)
+            i := i + 1
+        }
+    }
+    rec.body := body
+}
+return rec
+`,
+        inputs: {
+            emailPattern: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
+            // Non-capturing group: extractRegex returns the first capture group when one
+            // exists, and the scrub needs the whole token match.
+            tokenPattern: 'sk_(?:fake|live|test)_[A-Za-z0-9]{10,}',
+        },
+    },
+    {
+        id: 'conditional-drop',
+        name: 'Drop debug logs from a noisy service',
+        hog: `
+if (record.severity_text == 'debug' and record.service_name == inputs.noisyService) {
+    return null
+}
+return record
+`,
+        inputs: { noisyService: 'edge-router' },
+    },
+]
+
+// Preview of the globals shape planned for log transformations: the log record fields
+// plus project context and resolved inputs. Buffers (trace/span ids) are excluded —
+// the production globals builder will hex-encode them.
+export function buildBenchGlobals(record: LogRecord, inputs: Record<string, unknown>): BenchGlobals {
+    const { trace_id: _t, span_id: _s, ...rest } = record
+    return {
+        project: { id: 1, name: 'bench', url: 'http://localhost:8010/project/1' },
+        record: { ...rest },
+        inputs,
+    }
+}

--- a/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-exec.ts
+++ b/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-exec.ts
@@ -1,0 +1,52 @@
+import crypto from 'crypto'
+
+import { ExecResult, convertHogToJS, exec } from '@posthog/hogvm'
+
+import { createTrackedRE2 } from '../../../utils/tracked-re2'
+import type { BenchGlobals } from './fixtures'
+
+// Mirrors the external bindings of cdp/utils/hog-exec.ts `execHogImmediate` so the benchmark
+// measures the same VM + RE2 + crypto stack the production primitive will use, without
+// importing CDP service code into a dev-only harness.
+export function execBenchProgram(
+    bytecode: unknown,
+    globals: BenchGlobals,
+    timeoutMs: number
+): { execResult?: ExecResult; error?: unknown; durationMs: number } {
+    const start = performance.now()
+    let execResult: ExecResult | undefined
+    let error: unknown
+
+    try {
+        execResult = exec(bytecode as any, {
+            globals,
+            timeout: timeoutMs,
+            maxAsyncSteps: 0,
+            functions: {
+                print: () => {},
+            },
+            external: {
+                regex: {
+                    match: (regex, str) => createTrackedRE2(regex, undefined, 'logs-bench:regex.match').test(str),
+                    extract: (regex, str) => {
+                        const match = createTrackedRE2(regex, undefined, 'logs-bench:regex.extract').exec(str)
+                        if (!match) {
+                            return ''
+                        }
+                        return match.length > 1 ? (match[1] ?? '') : (match[0] ?? '')
+                    },
+                },
+                crypto,
+            },
+        })
+        if (execResult?.finished) {
+            // The production primitive converts Hog values (Maps) back to plain JS before
+            // merging into the record, so the measured cost includes that conversion.
+            execResult.result = convertHogToJS(execResult.result)
+        }
+    } catch (e) {
+        error = e
+    }
+
+    return { execResult, error, durationMs: performance.now() - start }
+}

--- a/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-log-bench.test.ts
+++ b/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-log-bench.test.ts
@@ -1,0 +1,85 @@
+import { compileHog } from '../../../cdp/templates/compiler'
+import { BENCH_LOG_RECORDS, BENCH_PROGRAMS, buildBenchGlobals } from './fixtures'
+import { execBenchProgram } from './hogvm-exec'
+
+jest.setTimeout(30_000)
+
+describe('hogvm log transformation benchmark programs', () => {
+    // Ceiling is ~40x the expected mean (~25µs/record): generous enough to never flake on a
+    // loaded CI worker, tight enough to catch an order-of-magnitude VM regression.
+    const CEILING_US_PER_RECORD = 1000
+    const ITERATIONS = 200
+    const TIMEOUT_MS = 10
+
+    it.each(BENCH_PROGRAMS.map((p) => [p.id, p] as const))(
+        'program %s executes correctly and under the per-record ceiling',
+        async (_id, program) => {
+            expect.hasAssertions()
+            const bytecode = await compileHog(program.hog)
+
+            for (const { id: recordId, record } of BENCH_LOG_RECORDS) {
+                // Warmup (JIT, RE2 compile)
+                for (let i = 0; i < 50; i++) {
+                    execBenchProgram(bytecode, buildBenchGlobals(record, program.inputs), TIMEOUT_MS)
+                }
+
+                let totalMs = 0
+                for (let i = 0; i < ITERATIONS; i++) {
+                    const globals = buildBenchGlobals(record, program.inputs)
+                    const { error, execResult, durationMs } = execBenchProgram(bytecode, globals, TIMEOUT_MS)
+                    expect(error).toBeUndefined()
+                    expect(execResult?.error).toBeUndefined()
+                    expect(execResult?.finished).toBe(true)
+                    totalMs += durationMs
+                }
+
+                const meanUs = (totalMs / ITERATIONS) * 1000
+                expect(meanUs).toBeLessThan(CEILING_US_PER_RECORD)
+
+                if (process.env.BENCH_DEBUG) {
+                    console.info(`${program.id} × ${recordId}: ${meanUs.toFixed(1)}µs/record`)
+                }
+            }
+        }
+    )
+
+    it('body-regex-scrub redacts emails and secret keys', async () => {
+        const program = BENCH_PROGRAMS.find((p) => p.id === 'body-regex-scrub')!
+        const bytecode = await compileHog(program.hog)
+        const record = BENCH_LOG_RECORDS.find((r) => r.id === 'plain-body')!.record
+
+        const { execResult } = execBenchProgram(bytecode, buildBenchGlobals(record, program.inputs), TIMEOUT_MS)
+
+        const body = (execResult!.result as { body: string }).body
+        expect(body).not.toContain('jane.doe@example.com')
+        expect(body).not.toContain('ops@example.com')
+        expect(body).not.toContain('sk_fake_')
+        expect(body).toContain('[REDACTED]')
+    })
+
+    it('redact-attributes hashes only the configured keys', async () => {
+        const program = BENCH_PROGRAMS.find((p) => p.id === 'redact-attributes')!
+        const bytecode = await compileHog(program.hog)
+        const record = BENCH_LOG_RECORDS.find((r) => r.id === 'plain-body')!.record
+
+        const { execResult } = execBenchProgram(bytecode, buildBenchGlobals(record, program.inputs), TIMEOUT_MS)
+
+        const attributes = (execResult!.result as { attributes: Record<string, string> }).attributes
+        expect(attributes['user.email']).toMatch(/^[a-f0-9]{64}$/)
+        expect(attributes['distinct_id']).toMatch(/^[a-f0-9]{64}$/)
+        expect(attributes['http.method']).toBe('POST')
+    })
+
+    it('conditional-drop returns null for matching records and passes others', async () => {
+        const program = BENCH_PROGRAMS.find((p) => p.id === 'conditional-drop')!
+        const bytecode = await compileHog(program.hog)
+
+        const noisy = BENCH_LOG_RECORDS.find((r) => r.id === 'fat-attributes')!.record
+        const dropped = execBenchProgram(bytecode, buildBenchGlobals(noisy, program.inputs), TIMEOUT_MS)
+        expect(dropped.execResult?.result).toBeNull()
+
+        const kept = BENCH_LOG_RECORDS.find((r) => r.id === 'plain-body')!.record
+        const keptResult = execBenchProgram(bytecode, buildBenchGlobals(kept, program.inputs), TIMEOUT_MS)
+        expect(keptResult.execResult?.result).not.toBeNull()
+    })
+})

--- a/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-log-bench.ts
+++ b/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-log-bench.ts
@@ -1,0 +1,100 @@
+import { compileHog } from '../../../cdp/templates/compiler'
+import { BENCH_LOG_RECORDS, BENCH_PROGRAMS, buildBenchGlobals } from './fixtures'
+import { execBenchProgram } from './hogvm-exec'
+
+// Micro-benchmark: TS HogVM cost per log record per transformation program.
+//
+// Run with:
+//   cd nodejs && pnpm exec tsx src/logs-ingestion/transformations/benchmarks/hogvm-log-bench.ts
+//
+// The numbers from this harness parameterize the log transformation budgets
+// (per-record timeout, per-message budget, watcher cost curve). Re-run after
+// hogvm upgrades or when changing the globals shape.
+
+const WARMUP_ITERATIONS = 500
+const ITERATIONS = 5_000
+const TIMEOUT_MS = 10
+
+interface BenchStats {
+    programId: string
+    recordId: string
+    meanUs: number
+    p50Us: number
+    p95Us: number
+    p99Us: number
+    maxUs: number
+}
+
+function percentile(sorted: number[], p: number): number {
+    const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))
+    return sorted[idx]
+}
+
+async function main(): Promise<void> {
+    console.info(`Compiling ${BENCH_PROGRAMS.length} Hog programs via bin/hog...`)
+    const compiled = await Promise.all(
+        BENCH_PROGRAMS.map(async (program) => ({ program, bytecode: await compileHog(program.hog) }))
+    )
+
+    const allStats: BenchStats[] = []
+
+    for (const { program, bytecode } of compiled) {
+        for (const { id: recordId, record } of BENCH_LOG_RECORDS) {
+            // Fresh globals each iteration: transformations mutate the record, and reusing
+            // a scrubbed record would let later iterations skip the regex-replace work.
+            for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+                const result = execBenchProgram(bytecode, buildBenchGlobals(record, program.inputs), TIMEOUT_MS)
+                if (result.error || result.execResult?.error) {
+                    throw new Error(
+                        `Program ${program.id} failed on record ${recordId}: ${result.error ?? result.execResult?.error}`
+                    )
+                }
+            }
+
+            const durationsUs: number[] = []
+            for (let i = 0; i < ITERATIONS; i++) {
+                const globals = buildBenchGlobals(record, program.inputs)
+                const start = performance.now()
+                execBenchProgram(bytecode, globals, TIMEOUT_MS)
+                durationsUs.push((performance.now() - start) * 1000)
+            }
+
+            durationsUs.sort((a, b) => a - b)
+            allStats.push({
+                programId: program.id,
+                recordId,
+                meanUs: durationsUs.reduce((a, b) => a + b, 0) / durationsUs.length,
+                p50Us: percentile(durationsUs, 50),
+                p95Us: percentile(durationsUs, 95),
+                p99Us: percentile(durationsUs, 99),
+                maxUs: durationsUs[durationsUs.length - 1],
+            })
+        }
+    }
+
+    console.info(`\nHogVM per-record execution cost (${ITERATIONS} iterations each, µs):\n`)
+    const header = ['program', 'record', 'mean', 'p50', 'p95', 'p99', 'max']
+    const rows = allStats.map((s) => [
+        s.programId,
+        s.recordId,
+        s.meanUs.toFixed(1),
+        s.p50Us.toFixed(1),
+        s.p95Us.toFixed(1),
+        s.p99Us.toFixed(1),
+        s.maxUs.toFixed(1),
+    ])
+    const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)))
+    console.info(header.map((h, i) => h.padEnd(widths[i])).join('  '))
+    for (const row of rows) {
+        console.info(row.map((c, i) => c.padEnd(widths[i])).join('  '))
+    }
+
+    const overallMean = allStats.reduce((a, s) => a + s.meanUs, 0) / allStats.length
+    console.info(`\nOverall mean across programs/records: ${overallMean.toFixed(1)}µs/record`)
+    console.info('Capacity reference: top org sustains ~250k records/s; 25µs/record ≈ 6 dedicated cores/function.')
+}
+
+main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+})


### PR DESCRIPTION
## Problem

We want to let logs customers run their own Hog transformations (custom PII scrubbing, attribute rewriting, record dropping) inside the logs ingestion pipeline. Unlike event transformations, this code runs per log record in the ingestion hot path, and log volume is orders of magnitude higher than event volume — so before executing any customer code there, we need real measurements of what the TS HogVM costs per record.

## Changes

Adds a benchmark harness (no production code changes):

- Realistic ~0.9KB log record fixtures and representative customer programs: no-op passthrough, attribute hashing (sha256), body regex scrub (emails + secret-shaped tokens), and conditional drop. Secret-shaped fixtures use an `sk_fake_` prefix so they exercise the scrub pattern without tripping secret scanning.
- A runner measuring per-record VM cost. Measured locally (M-series, 5k iterations): invocation overhead ~3µs/record, conditional drop 1–3µs, attribute sha256 17–24µs, full body regex scrub 31–95µs (p99 130–285µs).
- A deliberately generous Jest ceiling test (<1ms/record mean) that catches order-of-magnitude VM regressions without CI flake.

These numbers parameterize the per-record timeout, per-message budget, and the future watcher cost curve in the rest of the stack.

## Roadmap

**This stack — Hog transformations for logs ingestion** (this PR is 1 of 5):

1. 👉 #63374 — benchmark harness: measure HogVM cost per log record
2. #63375 — `transformation_log` hog function type (API/model plumbing, feature-flag-gated creation)
3. #63376 — per-record execution primitives (globals shape, writable-field whitelist, drop semantics)
4. #63377 — `LogsTransformerService` (orchestration, VM-time budgets, aggregated metrics)
5. #63378 — wire into the logs ingestion consumer (default off, team allowlist + killswitch)

**Planned follow-ups (separate PRs, not in this stack):**

- Test-invocation support for the new type (the CDP API invocation endpoint currently only handles event-shaped globals) and generalizing the `rearrange` endpoint's type filter
- Starter templates (PII scrub, drop by severity, attribute rewrite)
- Frontend surface in the logs product (type union, configuration logic branches, testing panel with log-record samples), gated by the `logs-transformations` flag
- HogWatcher integration using aggregated per-message observations with a logs-tuned cost curve (observe-only first, then auto-disable)
- Rollout: production feature flag, per-team allowlist on the logs ingestion deployment, dashboards, public docs

## How did you test this code?

I'm an agent; automated tests only: ran the new Jest suite locally (`nodejs/src/logs-ingestion/transformations/benchmarks/`) — 7 tests pass, including the regression ceiling test and correctness assertions for the scrub/hash/drop programs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — benchmark harness only. Public docs for log transformations will come with the GA/frontend work.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) sessions directed by Daniel Visca. The harness was built first, ahead of the rest of the stack, so the budget defaults in #63377/#63378 are grounded in measured per-record costs rather than guesses. Fixture "secrets" were switched to an `sk_fake_` prefix after GitHub push protection (correctly) flagged realistic-looking key shapes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
