### PR TITLE
feat(cdp): add transformation_log hog function type

### DIFF
--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -401,6 +401,7 @@ export type HogFunctionInputSchemaType = {
 export type HogFunctionTypeType =
     | 'destination'
     | 'transformation'
+    | 'transformation_log'
     | 'internal_destination'
     | 'source_webhook'
     | 'warehouse_source_webhook'

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -44,6 +44,10 @@ register_supported_function("postHogUpdateTicket")
 # (nodejs/src/cdp/hog-transformations/hog-transformer.service.ts).
 TRANSFORMATION_AVAILABLE_GLOBALS = {"project", "event", "inputs"}
 
+# Globals available to log transformations, which run per log record in the logs
+# ingestion pipeline and see a log record instead of an event.
+TRANSFORMATION_LOG_AVAILABLE_GLOBALS = {"project", "record", "inputs"}
+
 # Helper functions that the transformer exposes via getTransformationFunctions
 # (nodejs/src/cdp/hog-transformations/transformation-functions.ts). These resolve
 # via GET_GLOBAL when referenced as a closure rather than called inline.
@@ -79,9 +83,19 @@ class TransformationGlobalsValidator(TraversingVisitor):
 
     invalid_globals: set[str]
 
-    def __init__(self):
+    def __init__(
+        self,
+        available_globals: Optional[set[str]] = None,
+        runtime_functions: Optional[set[str]] = None,
+    ):
         super().__init__()
         self.invalid_globals = set()
+        self._available_globals = (
+            available_globals if available_globals is not None else TRANSFORMATION_AVAILABLE_GLOBALS
+        )
+        self._runtime_functions = (
+            runtime_functions if runtime_functions is not None else TRANSFORMATION_RUNTIME_FUNCTIONS
+        )
 
     def visit_field(self, node: ast.Field):
         super().visit_field(node)
@@ -89,8 +103,8 @@ class TransformationGlobalsValidator(TraversingVisitor):
             return
         root = str(node.chain[0])
         if (
-            root in TRANSFORMATION_AVAILABLE_GLOBALS
-            or root in TRANSFORMATION_RUNTIME_FUNCTIONS
+            root in self._available_globals
+            or root in self._runtime_functions
             or root in CORE_SUPPORTED_FUNCTIONS
             or root in PRODUCT_ASYNC_FUNCTIONS
             or root in STL
@@ -168,6 +182,18 @@ def generate_template_bytecode(
                 raise Exception(
                     f"Variable not available in transformations: {names}. "
                     f"Transformations only have access to project, event, and inputs."
+                )
+        elif function_type == "transformation_log":
+            log_validator = TransformationGlobalsValidator(
+                available_globals=TRANSFORMATION_LOG_AVAILABLE_GLOBALS,
+                runtime_functions=set(),
+            )
+            log_validator.visit(node)
+            if log_validator.invalid_globals:
+                names = ", ".join(sorted(log_validator.invalid_globals))
+                raise Exception(
+                    f"Variable not available in log transformations: {names}. "
+                    f"Log transformations only have access to project, record, and inputs."
                 )
         return create_bytecode(node).bytecode
     else:
@@ -477,6 +503,21 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
         # Ensure data is initialized as an empty dict if it's None
         data = data or {}
 
+        if function_type == "transformation_log":
+            # Filter bytecode is compiled against event-shaped globals, which log records
+            # don't have — silently accepting filters would mis-evaluate at ingestion time.
+            # Log transformations express conditions in Hog code instead.
+            disallowed = [
+                key
+                for key in ("events", "actions", "properties", "data_warehouse", "filter_test_accounts")
+                if data.get(key)
+            ]
+            if disallowed:
+                raise serializers.ValidationError(
+                    f"Filters are not supported for log transformations (got: {', '.join(disallowed)}). "
+                    "Use conditions in the Hog code instead."
+                )
+
         if data.get("source") == "events":
             # Don't allow events or actions for person-updates
             data.pop("data_warehouse", None)
@@ -577,6 +618,11 @@ def compile_hog(hog: str, hog_type: str, in_repl: Optional[bool] = False) -> lis
         elif hog_type == "tagger":
             # Taggers classify; they must not perform side effects, so we deliberately exclude
             # CORE_SUPPORTED_FUNCTIONS (fetch, postHogCapture) and PRODUCT_ASYNC_FUNCTIONS.
+            # Stated explicitly so a future refactor can't silently widen the surface.
+            supported_functions = set()
+        elif hog_type == "transformation_log":
+            # Log transformations run synchronously per log record in the logs ingestion
+            # hot path — no async functions (fetch, postHogCapture) can ever be allowed.
             # Stated explicitly so a future refactor can't silently widen the surface.
             supported_functions = set()
 

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -42,6 +42,7 @@ from posthog.plugins.plugin_server_api import create_hog_invocation_test
 from products.cdp.backend.api.hog_function_template import HogFunctionTemplateSerializer
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import (
+    TYPES_WITH_EXECUTION_ORDER,
     TYPES_WITH_JAVASCRIPT_SOURCE,
     HogFunction,
     HogFunctionState,
@@ -54,6 +55,19 @@ from products.cdp.backend.models.plugin import TranspilerError
 MAX_HOG_CODE_SIZE_BYTES = 100 * 1024
 # Maximum number of transformation functions per team
 MAX_TRANSFORMATIONS_PER_TEAM = 20
+# Log transformations execute per log record; volume is orders of magnitude higher than
+# events, so the enabled cap starts much lower.
+MAX_LOG_TRANSFORMATIONS_PER_TEAM = 5
+
+# Per-type caps on *enabled* functions of types that run in the ingestion hot path
+MAX_ENABLED_FUNCTIONS_PER_TEAM_BY_TYPE = {
+    HogFunctionType.TRANSFORMATION: MAX_TRANSFORMATIONS_PER_TEAM,
+    HogFunctionType.TRANSFORMATION_LOG: MAX_LOG_TRANSFORMATIONS_PER_TEAM,
+}
+
+# Gates creation of log transformations while the feature rolls out; sync with
+# FEATURE_FLAGS.LOGS_TRANSFORMATIONS on the frontend
+LOGS_TRANSFORMATIONS_FEATURE_FLAG = "logs-transformations"
 
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -123,7 +137,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         choices=HogFunctionType.choices,
         required=False,
         allow_null=True,
-        help_text="Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.",
+        help_text="Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.",
     )
     inputs_schema = serializers.ListField(
         child=InputsSchemaItemSerializer(required=True),
@@ -281,22 +295,40 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
             self.context.get("view") and self.context["view"].action == "create"
         )
 
+        # Existing functions keep working (and can be updated/disabled) if the flag is
+        # later turned off; only creation is gated.
+        if is_create and hog_type == HogFunctionType.TRANSFORMATION_LOG:
+            if not posthoganalytics.feature_enabled(
+                LOGS_TRANSFORMATIONS_FEATURE_FLAG,
+                str(team.uuid),
+                groups={"organization": str(team.organization.id)},
+                group_properties={
+                    "organization": {
+                        "id": str(team.organization.id),
+                        "created_at": team.organization.created_at,
+                    }
+                },
+                send_feature_flag_events=False,
+            ):
+                raise serializers.ValidationError({"type": "Log transformations are not enabled for this team."})
+
         # Check for transformation limit per team when the function will be enabled
         # We allow unlimited creation of disabled transformations as they don't run during ingestion
-        if hog_type == "transformation" and attrs.get("enabled", False):
+        enabled_cap = MAX_ENABLED_FUNCTIONS_PER_TEAM_BY_TYPE.get(hog_type)
+        if enabled_cap is not None and attrs.get("enabled", False):
             # Don't apply the limit for updates where the function was already enabled
             apply_limit = is_create or (isinstance(self.instance, HogFunction) and not self.instance.enabled)
 
             if apply_limit:
-                # Count enabled and non-deleted transformations
+                # Count enabled and non-deleted functions of the same type
                 transformation_count = HogFunction.objects.filter(
-                    team=team, type="transformation", deleted=False, enabled=True
+                    team=team, type=hog_type, deleted=False, enabled=True
                 ).count()
 
-                if transformation_count >= MAX_TRANSFORMATIONS_PER_TEAM:
+                if transformation_count >= enabled_cap:
                     raise serializers.ValidationError(
                         {
-                            "type": f"Maximum of {MAX_TRANSFORMATIONS_PER_TEAM} enabled transformation functions allowed per team. Please contact support if you need this limit increased, or disable some existing transformations."
+                            "type": f"Maximum of {enabled_cap} enabled {humanize_hog_function_type(hog_type)} functions allowed per team. Please contact support if you need this limit increased, or disable some existing ones."
                         }
                     )
 
@@ -373,14 +405,14 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                 raise serializers.ValidationError({"template_id": f"No template found for id '{template_id}'"})
             validated_data["hog_function_template"] = db_template
 
-        # Handle execution_order for transformation type
-        if validated_data.get("type") == "transformation":
+        # Handle execution_order for types that run sequentially during ingestion
+        if validated_data.get("type") in TYPES_WITH_EXECUTION_ORDER:
             requested_order = validated_data.get("execution_order")
 
             # For transformations, we need to determine the execution_order
             if requested_order is None:
                 # If no order specified, add at the end
-                highest_order = self._get_highest_execution_order(validated_data["team"].id)
+                highest_order = self._get_highest_execution_order(validated_data["team"].id, validated_data["type"])
                 validated_data["execution_order"] = highest_order + 1
 
             # Create the function with the execution_order
@@ -389,10 +421,10 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
             # For non-transformation types, just create normally
             return super().create(validated_data=validated_data)
 
-    def _get_highest_execution_order(self, team_id: int) -> int:
-        """Get the highest execution_order for transformations in a team."""
+    def _get_highest_execution_order(self, team_id: int, hog_type: str) -> int:
+        """Get the highest execution_order among functions of the same type in a team."""
         highest_order = (
-            HogFunction.objects.filter(team_id=team_id, type="transformation", deleted=False)
+            HogFunction.objects.filter(team_id=team_id, type=hog_type, deleted=False)
             .order_by("-execution_order")
             .values_list("execution_order", flat=True)
             .first()
@@ -401,7 +433,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
 
     def update(self, instance: HogFunction, validated_data: dict, *args, **kwargs) -> HogFunction:
         # Handle undeletion or re-enabling by placing at the end when needed
-        if instance.type == "transformation" and (
+        if instance.type in TYPES_WITH_EXECUTION_ORDER and (
             (instance.deleted and validated_data.get("deleted") is False)
             or (
                 not instance.enabled
@@ -409,7 +441,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                 and "execution_order" not in validated_data
             )
         ):
-            highest_order = self._get_highest_execution_order(instance.team_id)
+            highest_order = self._get_highest_execution_order(instance.team_id, instance.type)
             validated_data["execution_order"] = highest_order + 1
 
         # Standard update

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -15,7 +15,11 @@ from posthog.cdp.templates.hog_function_template import sync_template_to_db
 from posthog.cdp.templates.slack.template_slack import template as template_slack
 
 from products.actions.backend.models.action import Action
-from products.cdp.backend.api.hog_function import MAX_HOG_CODE_SIZE_BYTES, MAX_TRANSFORMATIONS_PER_TEAM
+from products.cdp.backend.api.hog_function import (
+    MAX_HOG_CODE_SIZE_BYTES,
+    MAX_LOG_TRANSFORMATIONS_PER_TEAM,
+    MAX_TRANSFORMATIONS_PER_TEAM,
+)
 from products.cdp.backend.api.test.test_hog_function_templates import MOCK_NODE_TEMPLATES
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import DEFAULT_STATE, HogFunction, HogFunctionState
@@ -2560,3 +2564,142 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["error"] == "Backfills are only supported for event-sourced destinations."
+
+
+class TestLogTransformationAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
+    def setUp(self):
+        super().setUp()
+        patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        self.mock_feature_enabled = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _create_log_transformation(self, **kwargs):
+        data = {
+            "name": "Log transformation",
+            "type": "transformation_log",
+            "hog": "return record",
+            "enabled": False,
+            **kwargs,
+        }
+        return self.client.post(f"/api/projects/{self.team.id}/hog_functions/", data=data)
+
+    def test_create_log_transformation(self):
+        response = self._create_log_transformation()
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["type"] == "transformation_log"
+        assert response.json()["execution_order"] == 1
+        assert self.mock_feature_enabled.call_args[0][0] == "logs-transformations"
+
+    def test_creation_blocked_without_feature_flag(self):
+        self.mock_feature_enabled.return_value = False
+
+        response = self._create_log_transformation()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Log transformations are not enabled for this team" in response.json()["detail"]
+
+        # The flag does not gate other types
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "name": "Event transformation",
+                "type": "transformation",
+                "hog": "return event",
+                "enabled": False,
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_updates_allowed_when_feature_flag_is_off(self):
+        function_id = self._create_log_transformation().json()["id"]
+
+        self.mock_feature_enabled.return_value = False
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/{function_id}/",
+            data={"name": "Renamed while flag off"},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+    def test_execution_order_is_scoped_per_type(self):
+        event_response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "name": "Event transformation",
+                "type": "transformation",
+                "hog": "return event",
+                "enabled": False,
+            },
+        )
+        assert event_response.status_code == status.HTTP_201_CREATED, event_response.json()
+        assert event_response.json()["execution_order"] == 1
+
+        # The first log transformation starts its own ordering rather than continuing
+        # the event transformations' sequence
+        log_response = self._create_log_transformation()
+        assert log_response.status_code == status.HTTP_201_CREATED, log_response.json()
+        assert log_response.json()["execution_order"] == 1
+
+        second_log_response = self._create_log_transformation(name="Second log transformation")
+        assert second_log_response.status_code == status.HTTP_201_CREATED
+        assert second_log_response.json()["execution_order"] == 2
+
+    def test_limits_enabled_log_transformations_per_team(self):
+        for i in range(MAX_LOG_TRANSFORMATIONS_PER_TEAM):
+            response = self._create_log_transformation(name=f"Enabled log transformation {i}", enabled=True)
+            assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+        response = self._create_log_transformation(name="One too many", enabled=True)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            f"Maximum of {MAX_LOG_TRANSFORMATIONS_PER_TEAM} enabled transformation log functions"
+            in response.json()["detail"]
+        )
+
+        # Disabled ones can still be created at the limit
+        response = self._create_log_transformation(name="Disabled is fine", enabled=False)
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # The cap is per type: enabled event transformations are not blocked by it
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "name": "Event transformation",
+                "type": "transformation",
+                "hog": "return event",
+                "enabled": True,
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_rejects_filters(self):
+        response = self._create_log_transformation(
+            filters={"events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}]}
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Filters are not supported for log transformations" in response.json()["detail"]
+
+    def test_allows_empty_filters(self):
+        response = self._create_log_transformation(filters={})
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_rejects_inputs_referencing_event_globals(self):
+        response = self._create_log_transformation(
+            inputs_schema=[{"key": "eid", "type": "string", "required": False}],
+            inputs={"eid": {"value": "event = {event.uuid}"}},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "invalid_input",
+            "attr": "inputs__eid",
+            "detail": (
+                "Invalid template: Variable not available in log transformations: event. "
+                "Log transformations only have access to project, record, and inputs."
+            ),
+        }
+
+    def test_allows_inputs_referencing_record_globals(self):
+        response = self._create_log_transformation(
+            inputs_schema=[{"key": "svc", "type": "string", "required": False}],
+            inputs={"svc": {"value": "service = {record.service_name}"}},
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()

--- a/products/cdp/backend/models/hog_functions/hog_function.py
+++ b/products/cdp/backend/models/hog_functions/hog_function.py
@@ -60,17 +60,21 @@ class HogFunctionType(models.TextChoices):
     WAREHOUSE_SOURCE_WEBHOOK = "warehouse_source_webhook"
     SITE_APP = "site_app"
     TRANSFORMATION = "transformation"
+    TRANSFORMATION_LOG = "transformation_log"
 
 
 TYPES_THAT_RELOAD_PLUGIN_SERVER = (
     HogFunctionType.DESTINATION,
     HogFunctionType.TRANSFORMATION,
+    HogFunctionType.TRANSFORMATION_LOG,
     HogFunctionType.INTERNAL_DESTINATION,
     HogFunctionType.SOURCE_WEBHOOK,
     HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK,
 )
 TYPES_WITH_TRANSPILED_FILTERS = (HogFunctionType.SITE_DESTINATION, HogFunctionType.SITE_APP)
 TYPES_WITH_JAVASCRIPT_SOURCE = (HogFunctionType.SITE_DESTINATION, HogFunctionType.SITE_APP)
+# Types that run sequentially during ingestion and are ordered by execution_order
+TYPES_WITH_EXECUTION_ORDER = (HogFunctionType.TRANSFORMATION, HogFunctionType.TRANSFORMATION_LOG)
 
 
 class HogFunction(FileSystemSyncMixin, UUIDTModel):
@@ -144,6 +148,9 @@ class HogFunction(FileSystemSyncMixin, UUIDTModel):
         elif self.type == HogFunctionType.TRANSFORMATION:
             folder = "Unfiled/Transformations"
             href = f"/pipeline/transformations/hog-{self.pk}/configuration"
+        elif self.type == HogFunctionType.TRANSFORMATION_LOG:
+            folder = "Unfiled/Transformations"
+            href = f"/functions/{self.pk}/configuration"
         elif self.type == HogFunctionType.SOURCE_WEBHOOK:
             folder = "Unfiled/Sources"
             href = f"/functions/{self.pk}/configuration"

--- a/products/cdp/frontend/generated/api.schemas.ts
+++ b/products/cdp/frontend/generated/api.schemas.ts
@@ -241,6 +241,7 @@ export type HogFunctionApiInputs = { [key: string]: InputsItemApi }
  * * `warehouse_source_webhook` - Warehouse Source Webhook
  * * `site_app` - Site App
  * * `transformation` - Transformation
+ * * `transformation_log` - Transformation Log
  */
 export type HogFunctionTypeEnumApi = (typeof HogFunctionTypeEnumApi)[keyof typeof HogFunctionTypeEnumApi]
 
@@ -252,6 +253,7 @@ export const HogFunctionTypeEnumApi = {
     WarehouseSourceWebhook: 'warehouse_source_webhook',
     SiteApp: 'site_app',
     Transformation: 'transformation',
+    TransformationLog: 'transformation_log',
 } as const
 
 /**
@@ -373,7 +375,7 @@ export interface MappingsApi {
 
 export interface HogFunctionApi {
     readonly id: string
-    /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
+    /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.
      *
      * * `destination` - Destination
      * * `site_destination` - Site Destination
@@ -381,7 +383,8 @@ export interface HogFunctionApi {
      * * `source_webhook` - Source Webhook
      * * `warehouse_source_webhook` - Warehouse Source Webhook
      * * `site_app` - Site App
-     * * `transformation` - Transformation */
+     * * `transformation` - Transformation
+     * * `transformation_log` - Transformation Log */
     type?: HogFunctionTypeEnumApi | null
     /**
      * Display name for the function.
@@ -450,7 +453,7 @@ export type PatchedHogFunctionApiInputs = { [key: string]: InputsItemApi }
 
 export interface PatchedHogFunctionApi {
     readonly id?: string
-    /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
+    /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.
      *
      * * `destination` - Destination
      * * `site_destination` - Site Destination
@@ -458,7 +461,8 @@ export interface PatchedHogFunctionApi {
      * * `source_webhook` - Source Webhook
      * * `warehouse_source_webhook` - Warehouse Source Webhook
      * * `site_app` - Site App
-     * * `transformation` - Transformation */
+     * * `transformation` - Transformation
+     * * `transformation_log` - Transformation Log */
     type?: HogFunctionTypeEnumApi | null
     /**
      * Display name for the function.

--- a/products/cdp/frontend/generated/api.zod.ts
+++ b/products/cdp/frontend/generated/api.zod.ts
@@ -39,15 +39,16 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                     'warehouse_source_webhook',
                     'site_app',
                     'transformation',
+                    'transformation_log',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
         ),
     name: zod.string().max(hogFunctionsCreateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -283,15 +284,16 @@ export const HogFunctionsUpdateBody = /* @__PURE__ */ zod.object({
                     'warehouse_source_webhook',
                     'site_app',
                     'transformation',
+                    'transformation_log',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
         ),
     name: zod.string().max(hogFunctionsUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -527,15 +529,16 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     'warehouse_source_webhook',
                     'site_app',
                     'transformation',
+                    'transformation_log',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
         ),
     name: zod.string().max(hogFunctionsPartialUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -771,15 +774,16 @@ export const HogFunctionsEnableBackfillsCreateBody = /* @__PURE__ */ zod.object(
                     'warehouse_source_webhook',
                     'site_app',
                     'transformation',
+                    'transformation_log',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
         ),
     name: zod
         .string()
@@ -1046,15 +1050,16 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                             'warehouse_source_webhook',
                             'site_app',
                             'transformation',
+                            'transformation_log',
                         ])
                         .describe(
-                            '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+                            '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
                         ),
                     zod.null(),
                 ])
                 .optional()
                 .describe(
-                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation'
+                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
                 ),
             name: zod
                 .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20415,6 +20415,7 @@ export namespace Schemas {
      * * `warehouse_source_webhook` - Warehouse Source Webhook
      * * `site_app` - Site App
      * * `transformation` - Transformation
+     * * `transformation_log` - Transformation Log
      */
     export type HogFunctionTypeEnum = typeof HogFunctionTypeEnum[keyof typeof HogFunctionTypeEnum];
 
@@ -20427,6 +20428,7 @@ export namespace Schemas {
       WarehouseSourceWebhook: 'warehouse_source_webhook',
       SiteApp: 'site_app',
       Transformation: 'transformation',
+      TransformationLog: 'transformation_log',
     } as const;
 
     /**
@@ -20613,7 +20615,7 @@ export namespace Schemas {
 
     export interface HogFunction {
       readonly id: string;
-      /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
+      /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.
        *
        * * `destination` - Destination
        * * `site_destination` - Site Destination
@@ -20621,7 +20623,8 @@ export namespace Schemas {
        * * `source_webhook` - Source Webhook
        * * `warehouse_source_webhook` - Warehouse Source Webhook
        * * `site_app` - Site App
-       * * `transformation` - Transformation */
+       * * `transformation` - Transformation
+       * * `transformation_log` - Transformation Log */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -31186,7 +31189,7 @@ export namespace Schemas {
 
     export interface PatchedHogFunction {
       readonly id?: string;
-      /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.
+      /** Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.
        *
        * * `destination` - Destination
        * * `site_destination` - Site Destination
@@ -31194,7 +31197,8 @@ export namespace Schemas {
        * * `source_webhook` - Source Webhook
        * * `warehouse_source_webhook` - Warehouse Source Webhook
        * * `site_app` - Site App
-       * * `transformation` - Transformation */
+       * * `transformation` - Transformation
+       * * `transformation_log` - Transformation Log */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -65,15 +65,16 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                     'warehouse_source_webhook',
                     'site_app',
                     'transformation',
+                    'transformation_log',
                 ])
                 .describe(
-                    '* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation'
+                    '* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log'
         ),
     name: zod.string().max(hogFunctionsCreateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -312,15 +313,16 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     'warehouse_source_webhook',
                     'site_app',
                     'transformation',
+                    'transformation_log',
                 ])
                 .describe(
-                    '* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation'
+                    '* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log'
         ),
     name: zod.string().max(hogFunctionsPartialUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -583,15 +585,16 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                             'warehouse_source_webhook',
                             'site_app',
                             'transformation',
+                            'transformation_log',
                         ])
                         .describe(
-                            '* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation'
+                            '* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log'
                         ),
                     zod.null(),
                 ])
                 .optional()
                 .describe(
-                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation'
+                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log'
                 ),
             name: zod
                 .string()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
@@ -437,7 +437,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -445,7 +445,8 @@
                         "source_webhook",
                         "warehouse_source_webhook",
                         "site_app",
-                        "transformation"
+                        "transformation",
+                        "transformation_log"
                     ],
                     "type": "string"
                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -788,7 +788,7 @@
                 "type": {
                     "anyOf": [
                         {
-                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                             "enum": [
                                 "destination",
                                 "site_destination",
@@ -796,7 +796,8 @@
                                 "source_webhook",
                                 "warehouse_source_webhook",
                                 "site_app",
-                                "transformation"
+                                "transformation",
+                                "transformation_log"
                             ],
                             "type": "string"
                         },
@@ -804,7 +805,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation"
+                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
                 },
                 "updated_at": {
                     "format": "date-time",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
@@ -441,7 +441,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -449,7 +449,8 @@
                         "source_webhook",
                         "warehouse_source_webhook",
                         "site_app",
-                        "transformation"
+                        "transformation",
+                        "transformation_log"
                     ],
                     "type": "string"
                 },
@@ -457,7 +458,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, or transformation.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation"
+            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
         }
     },
     "required": ["id"],


### PR DESCRIPTION
## Problem

Logs customers need custom, code-level control over their log records at ingestion time — scrubbing PII patterns specific to their stack, rewriting attributes, or dropping noise that simple drop rules can't express. The CDP already has exactly the right machinery for this (HogFunctions of type `transformation` for events), so we reuse the model, API, validation, and observability rather than inventing a parallel system.

This PR is type plumbing only — nothing executes the new type yet; the executor and pipeline wiring land in the rest of the stack.

## Changes

- New HogFunction type `transformation_log`, for transformations that run per log record in the logs ingestion pipeline
- Creation is gated behind the `logs-transformations` feature flag, fail-closed while the flag doesn't exist; updates and disables of existing functions stay allowed so the flag can be turned off without breaking teams
- Enabled cap of 5 per team (log record volume is orders of magnitude higher than events, so the cap starts much lower than transformations' 20); the cap check is generalized into a per-type map
- `execution_order` assignment generalized and scoped per type, so log transformations keep an ordering independent of event transformations
- Filters are rejected for the new type: filter bytecode compiles against event-shaped globals which log records don't have — conditions belong in Hog code
- Input templates are validated against log globals (`project`, `record`, `inputs`), mirroring the event transformation globals validation
- Explicit no-async-functions branch in `compile_hog`

## Roadmap

**This stack — Hog transformations for logs ingestion** (this PR is 2 of 5):

1. #63374 — benchmark harness: measure HogVM cost per log record
2. 👉 #63375 — `transformation_log` hog function type (API/model plumbing, feature-flag-gated creation)
3. #63376 — per-record execution primitives (globals shape, writable-field whitelist, drop semantics)
4. #63377 — `LogsTransformerService` (orchestration, VM-time budgets, aggregated metrics)
5. #63378 — wire into the logs ingestion consumer (default off, team allowlist + killswitch)

**Planned follow-ups (separate PRs, not in this stack):**

- Test-invocation support for the new type (the CDP API invocation endpoint currently only handles event-shaped globals) and generalizing the `rearrange` endpoint's type filter
- Starter templates (PII scrub, drop by severity, attribute rewrite)
- Frontend surface in the logs product (type union, configuration logic branches, testing panel with log-record samples), gated by the `logs-transformations` flag
- HogWatcher integration using aggregated per-message observations with a logs-tuned cost curve (observe-only first, then auto-disable)
- Rollout: production feature flag, per-team allowlist on the logs ingestion deployment, dashboards, public docs

## How did you test this code?

I'm an agent; automated tests only: ran `TestLogTransformationAPI` locally (9 tests, pass) — covers creation, the feature-flag gate (fail-closed, updates allowed when off), the per-type enabled cap, per-type `execution_order` scoping, filters rejection, and input-template globals validation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None yet — the type is feature-flag-gated and has no UI surface. Public docs come with the GA/frontend work.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) sessions directed by Daniel Visca. Key decisions: reuse the HogFunction model/API instead of a new model; reject filters outright rather than build log-shaped filter globals (conditions live in Hog code); gate creation only (not updates) so the flag can be rolled back safely; cap enabled functions at 5/team given per-record execution.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
