### PR TITLE
feat(logs): hog execution primitives for log records

### DIFF
--- a/nodejs/src/cdp/utils/hog-exec.ts
+++ b/nodejs/src/cdp/utils/hog-exec.ts
@@ -25,7 +25,7 @@ export async function execHog(
     })
 }
 
-function execHogImmediate(
+export function execHogImmediate(
     bytecode: any,
     options?: ExecOptions
 ): {

--- a/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-exec.ts
+++ b/nodejs/src/logs-ingestion/transformations/benchmarks/hogvm-exec.ts
@@ -1,52 +1,27 @@
-import crypto from 'crypto'
+import { ExecResult, convertHogToJS } from '@posthog/hogvm'
 
-import { ExecResult, convertHogToJS, exec } from '@posthog/hogvm'
-
-import { createTrackedRE2 } from '../../../utils/tracked-re2'
+import { execHogImmediate } from '../../../cdp/utils/hog-exec'
 import type { BenchGlobals } from './fixtures'
 
-// Mirrors the external bindings of cdp/utils/hog-exec.ts `execHogImmediate` so the benchmark
-// measures the same VM + RE2 + crypto stack the production primitive will use, without
-// importing CDP service code into a dev-only harness.
+// Thin wrapper over the production exec primitive so the benchmark measures the same
+// VM + RE2 + crypto stack the per-record executor uses, including result conversion.
 export function execBenchProgram(
     bytecode: unknown,
     globals: BenchGlobals,
     timeoutMs: number
 ): { execResult?: ExecResult; error?: unknown; durationMs: number } {
-    const start = performance.now()
-    let execResult: ExecResult | undefined
-    let error: unknown
+    const { execResult, error, durationMs } = execHogImmediate(bytecode, {
+        globals,
+        timeout: timeoutMs,
+        maxAsyncSteps: 0,
+        functions: {
+            print: () => {},
+        },
+    })
 
-    try {
-        execResult = exec(bytecode as any, {
-            globals,
-            timeout: timeoutMs,
-            maxAsyncSteps: 0,
-            functions: {
-                print: () => {},
-            },
-            external: {
-                regex: {
-                    match: (regex, str) => createTrackedRE2(regex, undefined, 'logs-bench:regex.match').test(str),
-                    extract: (regex, str) => {
-                        const match = createTrackedRE2(regex, undefined, 'logs-bench:regex.extract').exec(str)
-                        if (!match) {
-                            return ''
-                        }
-                        return match.length > 1 ? (match[1] ?? '') : (match[0] ?? '')
-                    },
-                },
-                crypto,
-            },
-        })
-        if (execResult?.finished) {
-            // The production primitive converts Hog values (Maps) back to plain JS before
-            // merging into the record, so the measured cost includes that conversion.
-            execResult.result = convertHogToJS(execResult.result)
-        }
-    } catch (e) {
-        error = e
+    if (execResult?.finished) {
+        execResult.result = convertHogToJS(execResult.result)
     }
 
-    return { execResult, error, durationMs: performance.now() - start }
+    return { execResult, error, durationMs }
 }

--- a/nodejs/src/logs-ingestion/transformations/hog-log-exec.test.ts
+++ b/nodejs/src/logs-ingestion/transformations/hog-log-exec.test.ts
@@ -1,0 +1,227 @@
+import { compileHog } from '../../cdp/templates/compiler'
+import type { LogRecord } from '../log-record-avro'
+import {
+    MAX_LOG_TRANSFORMATION_PRINT_LOGS,
+    applyTransformResult,
+    buildLogRecordGlobals,
+    executeLogTransformation,
+} from './hog-log-exec'
+
+jest.setTimeout(30_000)
+
+const PROJECT = { id: 1, name: 'test', url: 'http://localhost:8010/project/1' }
+
+const createRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+    uuid: '0197a3f2-1111-7000-8000-000000000001',
+    trace_id: Buffer.from('0123456789abcdef0123456789abcdef', 'hex'),
+    span_id: Buffer.from('0123456789abcdef', 'hex'),
+    trace_flags: 0,
+    timestamp: 1_780_000_000_000_000_000,
+    observed_timestamp: 1_780_000_000_000_000_000,
+    body: 'user jane@example.com logged in',
+    severity_text: 'info',
+    severity_number: 9,
+    service_name: 'auth-api',
+    resource_attributes: { 'k8s.namespace.name': 'auth' },
+    instrumentation_scope: 'auth.sessions',
+    event_name: null,
+    attributes: { 'http.method': 'POST', user_email: 'jane@example.com' },
+    bytes_uncompressed: 120,
+    ...overrides,
+})
+
+const run = async (hog: string, record: LogRecord, inputs: Record<string, unknown> = {}, options = {}) => {
+    const bytecode = await compileHog(hog)
+    const globals = buildLogRecordGlobals(record, PROJECT, inputs)
+    return executeLogTransformation(bytecode, record, globals, options)
+}
+
+describe('hog-log-exec', () => {
+    describe('buildLogRecordGlobals', () => {
+        it('exposes record fields with buffers hex-encoded and nulls normalized', () => {
+            const globals = buildLogRecordGlobals(createRecord({ attributes: null }), PROJECT, { foo: 'bar' })
+
+            expect(globals.record.trace_id).toBe('0123456789abcdef0123456789abcdef')
+            expect(globals.record.span_id).toBe('0123456789abcdef')
+            expect(globals.record.attributes).toEqual({})
+            expect(globals.record.body).toBe('user jane@example.com logged in')
+            expect(globals.inputs).toEqual({ foo: 'bar' })
+            expect(globals.project).toBe(PROJECT)
+        })
+    })
+
+    describe('executeLogTransformation', () => {
+        it('mutates body and attributes in place', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                let rec := record
+                rec.body := replaceAll(rec.body, 'jane@example.com', '[REDACTED]')
+                rec.attributes.user_email := sha256Hex(rec.attributes.user_email)
+                return rec
+                `,
+                record
+            )
+
+            expect(outcome.status).toBe('mutated')
+            expect(record.body).toBe('user [REDACTED] logged in')
+            expect(record.attributes!.user_email).toMatch(/^[a-f0-9]{64}$/)
+            expect(record.attributes!['http.method']).toBe('POST')
+        })
+
+        it('passes resolved inputs through globals', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                let rec := record
+                rec.attributes.tagged := inputs.tag
+                return rec
+                `,
+                record,
+                { tag: 'from-input' }
+            )
+
+            expect(outcome.status).toBe('mutated')
+            expect(record.attributes!.tagged).toBe('from-input')
+        })
+
+        it('drops the record when the transformation returns null', async () => {
+            const outcome = await run(`return null`, createRecord())
+            expect(outcome.status).toBe('dropped')
+        })
+
+        it('ignores read-only fields in the returned record', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                let rec := record
+                rec.service_name := 'spoofed-service'
+                rec.timestamp := 1
+                rec.body := 'changed'
+                return rec
+                `,
+                record
+            )
+
+            expect(outcome.status).toBe('mutated')
+            expect(record.body).toBe('changed')
+            expect(record.service_name).toBe('auth-api')
+            expect(record.timestamp).toBe(1_780_000_000_000_000_000)
+            expect(record.bytes_uncompressed).toBe(120)
+        })
+
+        it.each([
+            ['a string', `return 'nope'`],
+            ['a number', `return 42`],
+            ['a list', `return [1, 2]`],
+            ['a non-string body', `let rec := record\nrec.body := 42\nreturn rec`],
+        ])('fails open without mutating when the result is %s', async (_desc, hog) => {
+            const record = createRecord()
+            const originalBody = record.body
+            const outcome = await run(hog, record)
+
+            expect(outcome.status).toBe('failed')
+            expect(record.body).toBe(originalBody)
+            expect(record.attributes).toEqual(createRecord().attributes)
+        })
+
+        it('stringifies non-string attribute values', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                let rec := record
+                rec.attributes.retry_count := 3
+                return rec
+                `,
+                record
+            )
+
+            expect(outcome.status).toBe('mutated')
+            expect(record.attributes!.retry_count).toBe('3')
+        })
+
+        it('kills runaway programs via the timeout', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                let i := 0
+                while (true) {
+                    i := i + 1
+                }
+                return record
+                `,
+                record,
+                {},
+                { timeoutMs: 5 }
+            )
+
+            expect(outcome.status).toBe('failed')
+            if (outcome.status === 'failed') {
+                expect(outcome.error).toContain('timed out')
+            }
+            expect(outcome.durationMs).toBeGreaterThanOrEqual(4)
+        })
+
+        it('kills memory-hungry programs via the memory limit', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                let s := 'xxxxxxxxxxxxxxxx'
+                for (let i := 0; i < 30; i := i + 1) {
+                    s := concat(s, s)
+                }
+                return record
+                `,
+                record,
+                {},
+                { timeoutMs: 1000 }
+            )
+
+            expect(outcome.status).toBe('failed')
+            if (outcome.status === 'failed') {
+                expect(outcome.error.toLowerCase()).toContain('memory')
+            }
+        })
+
+        it('captures print output up to the cap and redacts sensitive values', async () => {
+            const record = createRecord()
+            const outcome = await run(
+                `
+                for (let i := 0; i < 10; i := i + 1) {
+                    print('iteration', i, 'secret-value')
+                }
+                return record
+                `,
+                record,
+                {},
+                { sensitiveValues: ['secret-value'] }
+            )
+
+            expect(outcome.status).toBe('mutated')
+            expect(outcome.logs).toHaveLength(MAX_LOG_TRANSFORMATION_PRINT_LOGS)
+            expect(outcome.logs[0]).toBe('iteration, 0, ***REDACTED***')
+        })
+    })
+
+    describe('applyTransformResult', () => {
+        it('treats undefined and false like null (drop)', () => {
+            const record = createRecord()
+            expect(applyTransformResult(record, undefined)).toBe('dropped')
+            expect(applyTransformResult(record, false)).toBe('dropped')
+            expect(applyTransformResult(record, null)).toBe('dropped')
+        })
+
+        it('rejects invalid severity_text without mutating', () => {
+            const record = createRecord()
+            expect(applyTransformResult(record, { body: 'new', severity_text: 7 })).toBe('invalid')
+            expect(record.body).toBe('user jane@example.com logged in')
+            expect(record.severity_text).toBe('info')
+        })
+
+        it('allows clearing body to null', () => {
+            const record = createRecord()
+            expect(applyTransformResult(record, { body: null })).toBe('mutated')
+            expect(record.body).toBeNull()
+        })
+    })
+})

--- a/nodejs/src/logs-ingestion/transformations/hog-log-exec.ts
+++ b/nodejs/src/logs-ingestion/transformations/hog-log-exec.ts
@@ -1,0 +1,216 @@
+import { convertHogToJS } from '@posthog/hogvm'
+
+import { sanitizeLogMessage } from '../../cdp/utils'
+import { execHogImmediate } from '../../cdp/utils/hog-exec'
+import type { LogRecord } from '../log-record-avro'
+
+// Per-record execution primitives for log transformations. Pure functions, no I/O:
+// orchestration (function fetching, budgets, monitoring) lives in the transformer service.
+
+/** Hard per-record VM kill. ~100x the p99 of realistic scrub programs (see benchmarks/). */
+export const DEFAULT_LOG_TRANSFORMATION_TIMEOUT_MS = 10
+
+/** Log records are ~1KB; transformations have no business allocating anywhere near this. */
+export const LOG_TRANSFORMATION_MEMORY_LIMIT_BYTES = 8 * 1024 * 1024
+
+/** Max captured print() entries per invocation — far lower than destinations' 25,
+ * since a transformation can run hundreds of thousands of times per second. */
+export const MAX_LOG_TRANSFORMATION_PRINT_LOGS = 5
+
+export interface LogTransformationGlobals {
+    project: { id: number; name: string; url: string }
+    record: {
+        body: string | null
+        attributes: Record<string, string>
+        resource_attributes: Record<string, string>
+        severity_text: string | null
+        severity_number: number | null
+        service_name: string | null
+        instrumentation_scope: string | null
+        event_name: string | null
+        timestamp: number | null
+        observed_timestamp: number | null
+        trace_id: string | null
+        span_id: string | null
+    }
+    inputs: Record<string, unknown>
+}
+
+export type LogTransformationOutcome =
+    | { status: 'mutated'; durationMs: number; logs: string[] }
+    | { status: 'dropped'; durationMs: number; logs: string[] }
+    | { status: 'failed'; durationMs: number; logs: string[]; error: string }
+
+export function buildLogRecordGlobals(
+    record: LogRecord,
+    project: LogTransformationGlobals['project'],
+    inputs: Record<string, unknown>
+): LogTransformationGlobals {
+    return {
+        project,
+        record: {
+            body: record.body ?? null,
+            attributes: record.attributes ?? {},
+            resource_attributes: record.resource_attributes ?? {},
+            severity_text: record.severity_text ?? null,
+            severity_number: record.severity_number ?? null,
+            service_name: record.service_name ?? null,
+            instrumentation_scope: record.instrumentation_scope ?? null,
+            event_name: record.event_name ?? null,
+            timestamp: record.timestamp ?? null,
+            observed_timestamp: record.observed_timestamp ?? null,
+            trace_id: record.trace_id ? record.trace_id.toString('hex') : null,
+            span_id: record.span_id ? record.span_id.toString('hex') : null,
+        },
+        inputs,
+    }
+}
+
+function coerceStringMap(value: unknown): Record<string, string> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null
+    }
+    const result: Record<string, string> = {}
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+        if (entry === null || entry === undefined) {
+            continue
+        }
+        result[key] = typeof entry === 'string' ? entry : JSON.stringify(entry)
+    }
+    return result
+}
+
+/**
+ * Merges a transformation's return value back into the record, in place.
+ *
+ * Only `body`, `attributes`, `severity_text`, and `resource_attributes` are writable.
+ * Timestamps, trace/span ids, service identity, and `bytes_uncompressed` are read-only:
+ * billing bytes are computed at capture time, and scrubbing must never change what a
+ * customer is billed.
+ *
+ * Returns 'invalid' (record untouched) when the result is not record-shaped — the
+ * caller treats that as a failure and fails open.
+ */
+export function applyTransformResult(record: LogRecord, execResult: unknown): 'mutated' | 'dropped' | 'invalid' {
+    if (execResult === null || execResult === undefined || execResult === false) {
+        return 'dropped'
+    }
+
+    if (typeof execResult !== 'object' || Array.isArray(execResult)) {
+        return 'invalid'
+    }
+
+    const result = execResult as Record<string, unknown>
+
+    // Validate everything before mutating anything, so an invalid result leaves the
+    // record fully untouched rather than half-applied.
+    let body: string | null | undefined = undefined
+    if ('body' in result) {
+        if (result.body !== null && typeof result.body !== 'string') {
+            return 'invalid'
+        }
+        body = result.body
+    }
+
+    let severityText: string | null | undefined = undefined
+    if ('severity_text' in result) {
+        if (result.severity_text !== null && typeof result.severity_text !== 'string') {
+            return 'invalid'
+        }
+        severityText = result.severity_text
+    }
+
+    let attributes: Record<string, string> | null | undefined = undefined
+    if ('attributes' in result && result.attributes !== null) {
+        attributes = coerceStringMap(result.attributes)
+        if (attributes === null) {
+            return 'invalid'
+        }
+    }
+
+    let resourceAttributes: Record<string, string> | null | undefined = undefined
+    if ('resource_attributes' in result && result.resource_attributes !== null) {
+        resourceAttributes = coerceStringMap(result.resource_attributes)
+        if (resourceAttributes === null) {
+            return 'invalid'
+        }
+    }
+
+    if (body !== undefined) {
+        record.body = body
+    }
+    if (severityText !== undefined) {
+        record.severity_text = severityText
+    }
+    if (attributes !== undefined && attributes !== null) {
+        record.attributes = attributes
+    }
+    if (resourceAttributes !== undefined && resourceAttributes !== null) {
+        record.resource_attributes = resourceAttributes
+    }
+
+    return 'mutated'
+}
+
+export interface ExecuteLogTransformationOptions {
+    timeoutMs?: number
+    /** Values redacted from captured print() output (e.g. secret input values). */
+    sensitiveValues?: string[]
+}
+
+/**
+ * Runs one compiled transformation against one record's globals and merges the result
+ * into the record in place. Synchronous and CPU-only: no async functions are registered,
+ * so customer code cannot perform I/O.
+ */
+export function executeLogTransformation(
+    bytecode: unknown,
+    record: LogRecord,
+    globals: LogTransformationGlobals,
+    options: ExecuteLogTransformationOptions = {}
+): LogTransformationOutcome {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_LOG_TRANSFORMATION_TIMEOUT_MS
+    const logs: string[] = []
+
+    const { execResult, error, durationMs } = execHogImmediate(bytecode, {
+        globals,
+        timeout: timeoutMs,
+        maxAsyncSteps: 0,
+        memoryLimit: LOG_TRANSFORMATION_MEMORY_LIMIT_BYTES,
+        functions: {
+            print: (...args: unknown[]) => {
+                if (logs.length < MAX_LOG_TRANSFORMATION_PRINT_LOGS) {
+                    logs.push(sanitizeLogMessage(args, options.sensitiveValues))
+                }
+            },
+        },
+    })
+
+    if (error || execResult?.error) {
+        return { status: 'failed', durationMs, logs, error: String(error ?? execResult?.error) }
+    }
+
+    if (!execResult?.finished) {
+        // With no async functions registered the VM always runs to completion or throws;
+        // a paused VM here means a bug, not customer error. Treat as failure (fail-open).
+        return { status: 'failed', durationMs, logs, error: 'VM did not finish execution' }
+    }
+
+    const converted = convertHogToJS(execResult.result)
+    const applied = applyTransformResult(record, converted)
+
+    if (applied === 'invalid') {
+        return {
+            status: 'failed',
+            durationMs,
+            logs,
+            error: 'Transformation must return the record (optionally mutated) or null to drop it',
+        }
+    }
+
+    if (applied === 'dropped') {
+        return { status: 'dropped', durationMs, logs }
+    }
+
+    return { status: 'mutated', durationMs, logs }
+}


### PR DESCRIPTION
## Problem

Running customer Hog code against log records needs a small, predictable execution contract: what the code can see, what it can change, and what its return value means. These primitives are deliberately pure functions with no I/O so they can be tested exhaustively and reused by both the pipeline executor (#63377) and a future test-invocation endpoint.

## Changes

Adds `nodejs/src/logs-ingestion/transformations/hog-log-exec.ts`:

- `buildLogRecordGlobals()` — the globals a transformation sees: `project`, `record` (body, attributes, resource_attributes, severity, service identity, timestamps, hex-encoded trace/span ids), and resolved `inputs`
- `applyTransformResult()` — merges the function's return value back into the record. Only `body`, `attributes`, `severity_text`, and `resource_attributes` are writable; timestamps, trace/span ids, service identity, and `bytes_uncompressed` are read-only because billing bytes are computed at capture time and scrubbing must never change what a customer is billed. Validation happens before any mutation, so an invalid result leaves the record untouched
- Return semantics: return the (optionally mutated) record to keep it, `null`/`false` to drop it; non-record-shaped results are failures (the caller fails open)
- `executeLogTransformation()` — runs one compiled function against one record synchronously, CPU-only: no async functions are registered so customer code cannot perform I/O; hard per-record timeout (default 10ms, ~100× the p99 of realistic scrub programs from #63374), 8MiB memory cap, captured `print()` output limited to 5 entries per invocation

## Roadmap

**This stack — Hog transformations for logs ingestion** (this PR is 3 of 5):

1. #63374 — benchmark harness: measure HogVM cost per log record
2. #63375 — `transformation_log` hog function type (API/model plumbing, feature-flag-gated creation)
3. 👉 #63376 — per-record execution primitives (globals shape, writable-field whitelist, drop semantics)
4. #63377 — `LogsTransformerService` (orchestration, VM-time budgets, aggregated metrics)
5. #63378 — wire into the logs ingestion consumer (default off, team allowlist + killswitch)

**Planned follow-ups (separate PRs, not in this stack):**

- Test-invocation support for the new type (the CDP API invocation endpoint currently only handles event-shaped globals) and generalizing the `rearrange` endpoint's type filter
- Starter templates (PII scrub, drop by severity, attribute rewrite)
- Frontend surface in the logs product (type union, configuration logic branches, testing panel with log-record samples), gated by the `logs-transformations` flag
- HogWatcher integration using aggregated per-message observations with a logs-tuned cost curve (observe-only first, then auto-disable)
- Rollout: production feature flag, per-team allowlist on the logs ingestion deployment, dashboards, public docs

## How did you test this code?

I'm an agent; automated tests only: ran `hog-log-exec.test.ts` locally (pass) — covers globals construction, the writable-field whitelist (read-only fields silently ignored), drop semantics, invalid-result rejection without partial mutation, timeout behavior, and print-capture limits.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None yet — internal execution primitives. The writable-field contract should be documented publicly when the feature ships.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) sessions directed by Daniel Visca. Key decisions: validate-then-mutate so failures can't half-apply; billing-relevant fields read-only by design; sync CPU-only execution (`maxAsyncSteps: 0`) so customer code can't do I/O from the ingestion hot path; timeout and limits derived from the #63374 measurements.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
