### PR TITLE
feat(logs): LogsTransformerService with per-message budgets and aggregated metrics

### DIFF
--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -229,6 +229,7 @@ export type MinimalAppMetric = {
         | 'fetch'
         | 'billable_invocation'
         | 'dropped'
+        | 'budget_skipped'
         | 'email_queued'
         | 'email_sent'
         | 'email_delivered'

--- a/nodejs/src/logs-ingestion/transformations/logs-transformer.service.test.ts
+++ b/nodejs/src/logs-ingestion/transformations/logs-transformer.service.test.ts
@@ -1,0 +1,353 @@
+import { HogFunctionManagerService } from '../../cdp/services/managers/hog-function-manager.service'
+import { HogFunctionMonitoringService } from '../../cdp/services/monitoring/hog-function-monitoring.service'
+import { compileHog } from '../../cdp/templates/compiler'
+import { HogFunctionType } from '../../cdp/types'
+import type { LogRecord } from '../log-record-avro'
+import { LogsTransformerConfig, LogsTransformerService, TransformationBatchBudget } from './logs-transformer.service'
+
+jest.setTimeout(30_000)
+
+const TEAM_ID = 7
+
+const createRecord = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+    uuid: '0197a3f2-1111-7000-8000-000000000001',
+    trace_id: null,
+    span_id: null,
+    trace_flags: 0,
+    timestamp: 1_780_000_000_000_000_000,
+    observed_timestamp: 1_780_000_000_000_000_000,
+    body: 'user jane@example.com logged in',
+    severity_text: 'info',
+    severity_number: 9,
+    service_name: 'auth-api',
+    resource_attributes: {},
+    instrumentation_scope: null,
+    event_name: null,
+    attributes: { user_email: 'jane@example.com' },
+    bytes_uncompressed: 120,
+    ...overrides,
+})
+
+let functionCounter = 0
+const createFunction = async (hog: string, overrides: Partial<HogFunctionType> = {}): Promise<HogFunctionType> => {
+    functionCounter++
+    return {
+        id: `00000000-0000-0000-0000-00000000000${functionCounter}`,
+        team_id: TEAM_ID,
+        name: `Test fn ${functionCounter}`,
+        type: 'transformation_log',
+        enabled: true,
+        deleted: false,
+        bytecode: await compileHog(hog),
+        inputs: {},
+        inputs_schema: [],
+        encrypted_inputs: null,
+        filters: null,
+        mappings: null,
+        masking: null,
+        template_id: null,
+        execution_order: functionCounter,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        ...overrides,
+    } as unknown as HogFunctionType
+}
+
+describe('LogsTransformerService', () => {
+    let service: LogsTransformerService
+    let manager: jest.Mocked<Pick<HogFunctionManagerService, 'getHogFunctionsForTeams' | 'getHogFunctionIdsForTeams'>>
+    let monitoring: jest.Mocked<Pick<HogFunctionMonitoringService, 'queueAppMetric' | 'queueLogs' | 'flush'>>
+    let config: LogsTransformerConfig
+
+    const setFunctions = (functions: HogFunctionType[]) => {
+        manager.getHogFunctionsForTeams.mockResolvedValue({ [TEAM_ID]: functions })
+        manager.getHogFunctionIdsForTeams.mockResolvedValue({ [TEAM_ID]: functions.map((f) => f.id) })
+    }
+
+    const queuedMetrics = () => monitoring.queueAppMetric.mock.calls.map(([metric]) => metric)
+
+    beforeEach(() => {
+        functionCounter = 0
+        manager = {
+            getHogFunctionsForTeams: jest.fn(),
+            getHogFunctionIdsForTeams: jest.fn(),
+        } as any
+        monitoring = {
+            queueAppMetric: jest.fn(),
+            queueLogs: jest.fn(),
+            flush: jest.fn(),
+        } as any
+        config = {
+            siteUrl: 'http://localhost:8010',
+            hogTimeoutMs: 10,
+            messageBudgetMs: 50,
+            batchBudgetMs: 2000,
+            maxErrorLogsPerFunctionPerMessage: 3,
+        }
+        service = new LogsTransformerService(manager as any, monitoring as any, config)
+    })
+
+    it('does nothing when the team has no transformations', async () => {
+        setFunctions([])
+        const records = [createRecord()]
+
+        const result = await service.transformRecords(TEAM_ID, records)
+
+        expect(result.recordsDropped).toBe(0)
+        expect(records[0].body).toBe('user jane@example.com logged in')
+        expect(monitoring.queueAppMetric).not.toHaveBeenCalled()
+    })
+
+    it('mutates all records and queues one aggregated success metric', async () => {
+        setFunctions([
+            await createFunction(`
+                let rec := record
+                rec.body := replaceAll(rec.body, 'jane@example.com', '[REDACTED]')
+                return rec
+            `),
+        ])
+        const records = [createRecord(), createRecord(), createRecord()]
+
+        const result = await service.transformRecords(TEAM_ID, records)
+
+        expect(result.recordsDropped).toBe(0)
+        expect(records).toHaveLength(3)
+        for (const record of records) {
+            expect(record.body).toBe('user [REDACTED] logged in')
+        }
+        expect(queuedMetrics()).toEqual([
+            expect.objectContaining({ metric_name: 'succeeded', count: 3, team_id: TEAM_ID }),
+        ])
+        expect(monitoring.queueLogs).not.toHaveBeenCalled()
+    })
+
+    it('removes dropped records from the array in place', async () => {
+        setFunctions([
+            await createFunction(`
+                if (record.severity_text == 'debug') {
+                    return null
+                }
+                return record
+            `),
+        ])
+        const records = [
+            createRecord({ severity_text: 'debug' }),
+            createRecord({ severity_text: 'info' }),
+            createRecord({ severity_text: 'debug' }),
+        ]
+        const reference = records
+
+        const result = await service.transformRecords(TEAM_ID, records)
+
+        expect(result.recordsDropped).toBe(2)
+        expect(reference).toHaveLength(1)
+        expect(reference[0].severity_text).toBe('info')
+        expect(result.recordsDroppedByFunctionId.get('00000000-0000-0000-0000-000000000001')).toBe(2)
+        expect(queuedMetrics()).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ metric_name: 'dropped', count: 2 }),
+                expect.objectContaining({ metric_name: 'succeeded', count: 1 }),
+            ])
+        )
+    })
+
+    it('chains transformations in order, each seeing the previous mutation', async () => {
+        setFunctions([
+            await createFunction(`
+                let rec := record
+                rec.attributes.step := 'one'
+                return rec
+            `),
+            await createFunction(`
+                let rec := record
+                rec.attributes.step := concat(rec.attributes.step, '-two')
+                return rec
+            `),
+        ])
+        const records = [createRecord()]
+
+        await service.transformRecords(TEAM_ID, records)
+
+        expect(records[0].attributes!.step).toBe('one-two')
+    })
+
+    it('fails open: annotates the record, keeps it, queues error logs, and continues', async () => {
+        setFunctions([
+            await createFunction(`
+                print('about to explode')
+                throw Error('boom')
+            `),
+            await createFunction(`
+                let rec := record
+                rec.attributes.after := 'ran'
+                return rec
+            `),
+        ])
+        const records = [createRecord()]
+
+        const result = await service.transformRecords(TEAM_ID, records)
+
+        expect(result.recordsDropped).toBe(0)
+        expect(records).toHaveLength(1)
+        expect(records[0].attributes!['$transformations_failed']).toContain('Test fn 1')
+        expect(records[0].attributes!.after).toBe('ran')
+        expect(queuedMetrics()).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ metric_name: 'failed', count: 1 }),
+                expect.objectContaining({ metric_name: 'succeeded', count: 1 }),
+            ])
+        )
+        const [logEntries] = monitoring.queueLogs.mock.calls[0]
+        expect(logEntries.some((entry) => entry.message.includes('about to explode'))).toBe(true)
+        expect(logEntries.some((entry) => entry.level === 'error')).toBe(true)
+    })
+
+    it('caps captured error logs per function per message', async () => {
+        setFunctions([await createFunction(`throw Error('boom')`)])
+        const records = Array.from({ length: 10 }, () => createRecord())
+
+        await service.transformRecords(TEAM_ID, records)
+
+        const [logEntries] = monitoring.queueLogs.mock.calls[0]
+        const errorEntries = logEntries.filter((entry) => entry.level === 'error')
+        expect(errorEntries).toHaveLength(config.maxErrorLogsPerFunctionPerMessage)
+        expect(queuedMetrics()).toEqual(
+            expect.arrayContaining([expect.objectContaining({ metric_name: 'failed', count: 10 })])
+        )
+    })
+
+    it('skips all records and annotates them when the message budget is already exhausted', async () => {
+        config.messageBudgetMs = 0
+        service = new LogsTransformerService(manager as any, monitoring as any, config)
+        setFunctions([await createFunction(`return record`)])
+        const records = [createRecord(), createRecord()]
+
+        const result = await service.transformRecords(TEAM_ID, records)
+
+        expect(result.recordsDropped).toBe(0)
+        expect(records).toHaveLength(2)
+        for (const record of records) {
+            expect(record.attributes!['$transformations_skipped']).toBe('budget')
+        }
+        expect(queuedMetrics()).toEqual([expect.objectContaining({ metric_name: 'budget_skipped', count: 2 })])
+    })
+
+    it('stops transforming once a shared batch budget is exhausted', async () => {
+        setFunctions([await createFunction(`return record`)])
+        const budget = new TransformationBatchBudget(0)
+        const records = [createRecord()]
+
+        await service.transformRecords(TEAM_ID, records, budget)
+
+        expect(records[0].attributes!['$transformations_skipped']).toBe('budget')
+        expect(queuedMetrics()).toEqual([expect.objectContaining({ metric_name: 'budget_skipped', count: 1 })])
+    })
+
+    it('consumes the batch budget across messages', async () => {
+        setFunctions([
+            await createFunction(`
+                let i := 0
+                while (i < 100000) {
+                    i := i + 1
+                }
+                return record
+            `),
+        ])
+        const budget = new TransformationBatchBudget(0.0001)
+
+        const firstMessage = [createRecord()]
+        await service.transformRecords(TEAM_ID, firstMessage, budget)
+        expect(firstMessage[0].attributes!['$transformations_skipped']).toBeUndefined()
+        expect(budget.usedMs).toBeGreaterThan(0)
+
+        const secondMessage = [createRecord()]
+        await service.transformRecords(TEAM_ID, secondMessage, budget)
+        expect(secondMessage[0].attributes!['$transformations_skipped']).toBe('budget')
+    })
+
+    it('resolves static input templates once and applies them', async () => {
+        setFunctions([
+            await createFunction(
+                `
+                let rec := record
+                rec.attributes.tag := inputs.tag
+                return rec
+            `,
+                {
+                    inputs: {
+                        tag: { value: 'static-tag', order: 0 },
+                    },
+                } as any
+            ),
+        ])
+        const records = [createRecord(), createRecord()]
+
+        await service.transformRecords(TEAM_ID, records)
+
+        expect(records[0].attributes!.tag).toBe('static-tag')
+        expect(records[1].attributes!.tag).toBe('static-tag')
+    })
+
+    it('resolves record-referencing input templates per record', async () => {
+        setFunctions([
+            await createFunction(
+                `
+                let rec := record
+                rec.attributes.svc := inputs.svc
+                return rec
+            `,
+                {
+                    inputs: {
+                        svc: {
+                            value: 'service = {record.service_name}',
+                            bytecode: await compileHog(`return f'service = {record.service_name}'`),
+                            order: 0,
+                        },
+                    },
+                } as any
+            ),
+        ])
+        const records = [createRecord({ service_name: 'svc-a' }), createRecord({ service_name: 'svc-b' })]
+
+        await service.transformRecords(TEAM_ID, records)
+
+        expect(records[0].attributes!.svc).toBe('service = svc-a')
+        expect(records[1].attributes!.svc).toBe('service = svc-b')
+    })
+
+    it('redacts encrypted input values from captured logs', async () => {
+        setFunctions([
+            await createFunction(
+                `
+                print('the secret is', inputs.apiKey)
+                throw Error('boom')
+            `,
+                {
+                    encrypted_inputs: { apiKey: { value: 'super-secret-key', order: 0 } },
+                } as any
+            ),
+        ])
+        const records = [createRecord()]
+
+        await service.transformRecords(TEAM_ID, records)
+
+        const [logEntries] = monitoring.queueLogs.mock.calls[0]
+        const printed = logEntries.find((entry) => entry.message.includes('the secret is'))
+        expect(printed?.message).toContain('***REDACTED***')
+        expect(printed?.message).not.toContain('super-secret-key')
+    })
+
+    it('teamHasTransformations uses the cheap id lookup', async () => {
+        manager.getHogFunctionIdsForTeams.mockResolvedValue({ [TEAM_ID]: ['some-id'] })
+        await expect(service.teamHasTransformations(TEAM_ID)).resolves.toBe(true)
+
+        manager.getHogFunctionIdsForTeams.mockResolvedValue({ [TEAM_ID]: [] })
+        await expect(service.teamHasTransformations(TEAM_ID)).resolves.toBe(false)
+        expect(manager.getHogFunctionsForTeams).not.toHaveBeenCalled()
+    })
+
+    it('flush delegates to the monitoring service', async () => {
+        await service.flush()
+        expect(monitoring.flush).toHaveBeenCalled()
+    })
+})

--- a/nodejs/src/logs-ingestion/transformations/logs-transformer.service.ts
+++ b/nodejs/src/logs-ingestion/transformations/logs-transformer.service.ts
@@ -1,0 +1,429 @@
+import { DateTime } from 'luxon'
+import { Counter, Histogram } from 'prom-client'
+
+import { HogFunctionManagerService } from '../../cdp/services/managers/hog-function-manager.service'
+import { HogFunctionMonitoringService } from '../../cdp/services/monitoring/hog-function-monitoring.service'
+import { HogFunctionType, LogEntry } from '../../cdp/types'
+import { execHogImmediate } from '../../cdp/utils/hog-exec'
+import { yieldEventLoopIfNeeded } from '../../utils/event-loop-yield'
+import { logger } from '../../utils/logger'
+import { UUIDT } from '../../utils/utils'
+import type { LogRecord } from '../log-record-avro'
+import { LogTransformationGlobals, buildLogRecordGlobals, executeLogTransformation } from './hog-log-exec'
+
+export const transformationRecordsCounter = new Counter({
+    name: 'logs_ingestion_transformations_records_total',
+    help: 'Per-record log transformation outcomes',
+    labelNames: ['result'], // succeeded | failed | dropped | budget_skipped
+})
+
+export const transformationVmDurationHistogram = new Histogram({
+    name: 'logs_ingestion_transformations_vm_duration_seconds',
+    help: 'Total HogVM execution time spent on log transformations per Kafka message',
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
+})
+
+export const transformationBudgetExhaustedCounter = new Counter({
+    name: 'logs_ingestion_transformations_budget_exhausted_total',
+    help: 'Transformation time budget exhausted; remaining records passed through untransformed',
+    labelNames: ['scope', 'team_id'], // scope: message | batch
+})
+
+export const transformationUnexpectedErrorsCounter = new Counter({
+    name: 'logs_ingestion_transformations_unexpected_errors_total',
+    help: 'Unexpected (non-customer-code) errors in the logs transformer. Any occurrence should alert.',
+})
+
+export interface LogsTransformerConfig {
+    siteUrl: string
+    /** Hard per-record VM kill */
+    hogTimeoutMs: number
+    /** Cumulative VM time budget per Kafka message */
+    messageBudgetMs: number
+    /** Cumulative VM time budget per consumer batch */
+    batchBudgetMs: number
+    /** Max failed invocations whose print/error logs are captured, per function per message */
+    maxErrorLogsPerFunctionPerMessage: number
+}
+
+/** Tracks cumulative VM time across all messages of one consumer batch. */
+export class TransformationBatchBudget {
+    usedMs = 0
+
+    constructor(private readonly totalMs: number) {}
+
+    get exhausted(): boolean {
+        return this.usedMs >= this.totalMs
+    }
+
+    add(durationMs: number): void {
+        this.usedMs += durationMs
+    }
+}
+
+interface FunctionAggregates {
+    succeeded: number
+    failed: number
+    dropped: number
+    budgetSkipped: number
+    totalDurationMs: number
+    errorLogs: LogEntry[]
+}
+
+const ATTR_TRANSFORMATIONS_FAILED = '$transformations_failed'
+const ATTR_TRANSFORMATIONS_SKIPPED = '$transformations_skipped'
+
+/**
+ * Runs a team's enabled log transformations over the records of one Kafka message,
+ * mutating the array in place (dropped records are removed).
+ *
+ * Failure semantics are fail-open throughout, mirroring events ingestion and the
+ * logs sampling pipeline: a failing transformation annotates the record and passes
+ * it through unchanged. Budgets bound the worst-case added latency; when exhausted,
+ * remaining records skip transformation and are annotated.
+ *
+ * Unlike the events HogTransformerService there are no per-invocation result objects:
+ * at logs volume (100k+ records/s for large teams) metrics are aggregated per
+ * (function, message) and print() output is only kept for failing invocations.
+ */
+export class LogsTransformerService {
+    constructor(
+        private hogFunctionManager: HogFunctionManagerService,
+        private monitoring: HogFunctionMonitoringService,
+        private config: LogsTransformerConfig
+    ) {}
+
+    public startBatch(): TransformationBatchBudget {
+        return new TransformationBatchBudget(this.config.batchBudgetMs)
+    }
+
+    /** Cheap existence check (in-process LazyLoader cache) used to preserve the
+     * no-decode passthrough for teams without transformations. */
+    public async teamHasTransformations(teamId: number): Promise<boolean> {
+        const idsByTeam = await this.hogFunctionManager.getHogFunctionIdsForTeams([teamId], ['transformation_log'])
+        return (idsByTeam[teamId] ?? []).length > 0
+    }
+
+    public async flush(): Promise<void> {
+        await this.monitoring.flush()
+    }
+
+    public async transformRecords(
+        teamId: number,
+        records: LogRecord[],
+        batchBudget?: TransformationBatchBudget
+    ): Promise<{ recordsDropped: number; recordsDroppedByFunctionId: Map<string, number> }> {
+        const recordsDroppedByFunctionId = new Map<string, number>()
+        let recordsDropped = 0
+
+        const functionsByTeam = await this.hogFunctionManager.getHogFunctionsForTeams([teamId], ['transformation_log'])
+        const functions = functionsByTeam[teamId] ?? []
+        if (functions.length === 0 || records.length === 0) {
+            return { recordsDropped, recordsDroppedByFunctionId }
+        }
+
+        const project = {
+            id: teamId,
+            name: '',
+            url: `${this.config.siteUrl}/project/${teamId}`,
+        }
+        const instanceId = new UUIDT().toString()
+        const aggregates = new Map<string, FunctionAggregates>()
+        const inputsCache = new Map<string, Record<string, unknown> | null>()
+        const sensitiveValuesCache = new Map<string, string[]>()
+        let messageVmMs = 0
+        let budgetExhaustedScope: 'message' | 'batch' | null = null
+
+        const kept: LogRecord[] = []
+
+        for (let i = 0; i < records.length; i++) {
+            const record = records[i]
+
+            if (budgetExhaustedScope === null) {
+                if (batchBudget?.exhausted) {
+                    budgetExhaustedScope = 'batch'
+                } else if (messageVmMs >= this.config.messageBudgetMs) {
+                    budgetExhaustedScope = 'message'
+                }
+                if (budgetExhaustedScope !== null) {
+                    transformationBudgetExhaustedCounter.inc({
+                        scope: budgetExhaustedScope,
+                        team_id: String(teamId),
+                    })
+                }
+            }
+
+            if (budgetExhaustedScope !== null) {
+                record.attributes = record.attributes ?? {}
+                record.attributes[ATTR_TRANSFORMATIONS_SKIPPED] = 'budget'
+                transformationRecordsCounter.inc({ result: 'budget_skipped' })
+                for (const fn of functions) {
+                    this.getAggregates(aggregates, fn.id).budgetSkipped++
+                }
+                kept.push(record)
+                continue
+            }
+
+            const dropped = await yieldEventLoopIfNeeded('logs-transformer', () => {
+                return this.transformSingleRecord(record, functions, project, {
+                    teamId,
+                    instanceId,
+                    aggregates,
+                    inputsCache,
+                    sensitiveValuesCache,
+                    recordsDroppedByFunctionId,
+                    addVmMs: (ms) => {
+                        messageVmMs += ms
+                        batchBudget?.add(ms)
+                    },
+                })
+            })
+
+            if (dropped) {
+                recordsDropped++
+            } else {
+                kept.push(record)
+            }
+        }
+
+        // Replace contents in place so callers holding the array reference see the result
+        records.length = 0
+        records.push(...kept)
+
+        transformationVmDurationHistogram.observe(messageVmMs / 1000)
+        this.queueAggregates(teamId, aggregates)
+
+        return { recordsDropped, recordsDroppedByFunctionId }
+    }
+
+    /** Runs every function in execution order against one record. Returns true if dropped. */
+    private transformSingleRecord(
+        record: LogRecord,
+        functions: HogFunctionType[],
+        project: LogTransformationGlobals['project'],
+        ctx: {
+            teamId: number
+            instanceId: string
+            aggregates: Map<string, FunctionAggregates>
+            inputsCache: Map<string, Record<string, unknown> | null>
+            sensitiveValuesCache: Map<string, string[]>
+            recordsDroppedByFunctionId: Map<string, number>
+            addVmMs: (ms: number) => void
+        }
+    ): boolean {
+        for (const fn of functions) {
+            const agg = this.getAggregates(ctx.aggregates, fn.id)
+
+            let outcome
+            try {
+                const globals = buildLogRecordGlobals(record, project, {})
+                globals.inputs = this.resolveInputs(fn, globals, ctx.inputsCache)
+
+                outcome = executeLogTransformation(fn.bytecode, record, globals, {
+                    timeoutMs: this.config.hogTimeoutMs,
+                    sensitiveValues: this.getSensitiveValues(fn, ctx.sensitiveValuesCache),
+                })
+            } catch (error) {
+                // Errors from customer code are contained inside executeLogTransformation;
+                // reaching here means a transformer bug.
+                transformationUnexpectedErrorsCounter.inc()
+                logger.error('⚠️', '[logs-transformer] unexpected error', {
+                    teamId: ctx.teamId,
+                    functionId: fn.id,
+                    error: String(error),
+                })
+                this.annotateFailure(record, fn)
+                agg.failed++
+                transformationRecordsCounter.inc({ result: 'failed' })
+                continue
+            }
+
+            ctx.addVmMs(outcome.durationMs)
+            agg.totalDurationMs += outcome.durationMs
+
+            if (outcome.status === 'failed') {
+                agg.failed++
+                transformationRecordsCounter.inc({ result: 'failed' })
+                this.annotateFailure(record, fn)
+                this.captureErrorLogs(fn, ctx.teamId, ctx.instanceId, agg, outcome.logs, outcome.error)
+                continue
+            }
+
+            if (outcome.status === 'dropped') {
+                agg.dropped++
+                transformationRecordsCounter.inc({ result: 'dropped' })
+                ctx.recordsDroppedByFunctionId.set(fn.id, (ctx.recordsDroppedByFunctionId.get(fn.id) ?? 0) + 1)
+                return true
+            }
+
+            agg.succeeded++
+            transformationRecordsCounter.inc({ result: 'succeeded' })
+        }
+
+        return false
+    }
+
+    /**
+     * Resolves function inputs once per (function, message) and caches them — unless any
+     * input template references the `record` global, in which case resolution happens per
+     * record (cache stores null to remember that decision).
+     */
+    private resolveInputs(
+        fn: HogFunctionType,
+        globals: LogTransformationGlobals,
+        cache: Map<string, Record<string, unknown> | null>
+    ): Record<string, unknown> {
+        const cached = cache.get(fn.id)
+        if (cached) {
+            return cached
+        }
+
+        if (cached === undefined) {
+            // First sight of this function in this message: decide cacheability with a
+            // cheap scan. False positives only cost per-record resolution.
+            const referencesRecord = JSON.stringify(fn.inputs ?? {}).includes('record') === true
+            if (!referencesRecord) {
+                const resolved = this.resolveInputsUncached(fn, globals)
+                cache.set(fn.id, resolved)
+                return resolved
+            }
+            cache.set(fn.id, null)
+        }
+
+        return this.resolveInputsUncached(fn, globals)
+    }
+
+    private resolveInputsUncached(fn: HogFunctionType, globals: LogTransformationGlobals): Record<string, unknown> {
+        const inputs: Record<string, unknown> = {}
+        const allInputs = { ...fn.inputs, ...fn.encrypted_inputs }
+
+        // Inputs can reference earlier inputs, so resolve in declared order
+        const entries = Object.entries(allInputs).sort(([, a], [, b]) => (a?.order ?? -1) - (b?.order ?? -1))
+
+        for (const [key, input] of entries) {
+            if (input?.bytecode && (input.templating ?? 'hog') === 'hog') {
+                const { execResult, error } = execHogImmediate(input.bytecode, {
+                    globals: { ...globals, inputs },
+                    timeout: this.config.hogTimeoutMs,
+                    maxAsyncSteps: 0,
+                })
+                if (error || execResult?.error || !execResult?.finished) {
+                    throw new Error(`Could not resolve input '${key}': ${error ?? execResult?.error}`)
+                }
+                inputs[key] = execResult.result
+            } else {
+                inputs[key] = input?.value
+            }
+        }
+
+        return inputs
+    }
+
+    private getSensitiveValues(fn: HogFunctionType, cache: Map<string, string[]>): string[] {
+        let values = cache.get(fn.id)
+        if (!values) {
+            values = Object.values(fn.encrypted_inputs ?? {})
+                .map((input) => input?.value)
+                .filter((value): value is string => typeof value === 'string' && value.length > 0)
+            cache.set(fn.id, values)
+        }
+        return values
+    }
+
+    private annotateFailure(record: LogRecord, fn: HogFunctionType): void {
+        record.attributes = record.attributes ?? {}
+        const existing = record.attributes[ATTR_TRANSFORMATIONS_FAILED]
+        const identifier = `${fn.name} (${fn.id})`
+        record.attributes[ATTR_TRANSFORMATIONS_FAILED] = existing ? `${existing}, ${identifier}` : identifier
+    }
+
+    private captureErrorLogs(
+        fn: HogFunctionType,
+        teamId: number,
+        instanceId: string,
+        agg: FunctionAggregates,
+        printLogs: string[],
+        error: string
+    ): void {
+        const capturedFailures = agg.errorLogs.filter((log) => log.level === 'error').length
+        if (capturedFailures >= this.config.maxErrorLogsPerFunctionPerMessage) {
+            return
+        }
+
+        const base = {
+            team_id: teamId,
+            log_source: 'hog_function' as const,
+            log_source_id: fn.id,
+            instance_id: instanceId,
+        }
+        for (const message of printLogs) {
+            agg.errorLogs.push({ ...base, level: 'info', message, timestamp: DateTime.now() })
+        }
+        agg.errorLogs.push({ ...base, level: 'error', message: error, timestamp: DateTime.now() })
+    }
+
+    private getAggregates(aggregates: Map<string, FunctionAggregates>, functionId: string): FunctionAggregates {
+        let agg = aggregates.get(functionId)
+        if (!agg) {
+            agg = { succeeded: 0, failed: 0, dropped: 0, budgetSkipped: 0, totalDurationMs: 0, errorLogs: [] }
+            aggregates.set(functionId, agg)
+        }
+        return agg
+    }
+
+    private queueAggregates(teamId: number, aggregates: Map<string, FunctionAggregates>): void {
+        for (const [functionId, agg] of aggregates) {
+            if (agg.succeeded > 0) {
+                this.monitoring.queueAppMetric(
+                    {
+                        team_id: teamId,
+                        app_source_id: functionId,
+                        metric_kind: 'success',
+                        metric_name: 'succeeded',
+                        count: agg.succeeded,
+                    },
+                    'hog_function'
+                )
+            }
+            if (agg.failed > 0) {
+                this.monitoring.queueAppMetric(
+                    {
+                        team_id: teamId,
+                        app_source_id: functionId,
+                        metric_kind: 'failure',
+                        metric_name: 'failed',
+                        count: agg.failed,
+                    },
+                    'hog_function'
+                )
+            }
+            if (agg.dropped > 0) {
+                this.monitoring.queueAppMetric(
+                    {
+                        team_id: teamId,
+                        app_source_id: functionId,
+                        metric_kind: 'other',
+                        metric_name: 'dropped',
+                        count: agg.dropped,
+                    },
+                    'hog_function'
+                )
+            }
+            if (agg.budgetSkipped > 0) {
+                this.monitoring.queueAppMetric(
+                    {
+                        team_id: teamId,
+                        app_source_id: functionId,
+                        metric_kind: 'other',
+                        metric_name: 'budget_skipped',
+                        count: agg.budgetSkipped,
+                    },
+                    'hog_function'
+                )
+            }
+            if (agg.errorLogs.length > 0) {
+                this.monitoring.queueLogs(agg.errorLogs, 'hog_function')
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Something has to orchestrate a team's enabled log transformations over the records of a Kafka message: fetch the right functions, run them in order, enforce time budgets, and report what happened — without letting observability traffic scale with record volume. The events-side `HogTransformerService` is the precedent, but its per-invocation result objects and per-event metrics would melt at log volume, so this service deviates deliberately.

## Changes

Adds `LogsTransformerService`:

- Runs a team's enabled `transformation_log` functions over each record of one message, sequential by `execution_order`, mutating the record array in place; a function returning `null` drops the record
- **Fail-open everywhere**: a failing transformation annotates the record and passes it through unchanged — at no point does customer code failure block or delay log delivery
- **No per-invocation result objects** (the key deviation from events): app metrics are aggregated per (function, message) — `succeeded` / `failed` / `dropped` / `budget_skipped` — so Kafka observability volume is independent of record volume
- `print()`/error logs are captured only for failing invocations, capped per function per message
- Cumulative VM-time budgets per message and per consumer batch; when exhausted, remaining records pass through annotated with `$transformations_skipped` rather than delaying the pipeline (budget defaults grounded in the #63374 measurements)
- Inputs resolved once per (function, message) and cached — unless a template references the `record` global, in which case resolution happens per record
- Prometheus: per-record outcome counters, VM duration histogram, budget-exhaustion and unexpected-error counters

Still unwired — consumer integration lands in #63378.

## Roadmap

**This stack — Hog transformations for logs ingestion** (this PR is 4 of 5):

1. #63374 — benchmark harness: measure HogVM cost per log record
2. #63375 — `transformation_log` hog function type (API/model plumbing, feature-flag-gated creation)
3. #63376 — per-record execution primitives (globals shape, writable-field whitelist, drop semantics)
4. 👉 #63377 — `LogsTransformerService` (orchestration, VM-time budgets, aggregated metrics)
5. #63378 — wire into the logs ingestion consumer (default off, team allowlist + killswitch)

**Planned follow-ups (separate PRs, not in this stack):**

- Test-invocation support for the new type (the CDP API invocation endpoint currently only handles event-shaped globals) and generalizing the `rearrange` endpoint's type filter
- Starter templates (PII scrub, drop by severity, attribute rewrite)
- Frontend surface in the logs product (type union, configuration logic branches, testing panel with log-record samples), gated by the `logs-transformations` flag
- HogWatcher integration using aggregated per-message observations with a logs-tuned cost curve (observe-only first, then auto-disable) — the aggregated design here is what makes that integration possible without per-invocation allocations
- Rollout: production feature flag, per-team allowlist on the logs ingestion deployment, dashboards, public docs

## How did you test this code?

I'm an agent; automated tests only: ran `logs-transformer.service.test.ts` locally (pass) — covers ordering, drop accounting, fail-open annotation, message/batch budget exhaustion (including the `$transformations_skipped` annotation), error-log capping, input caching incl. the record-referencing case, and metric aggregation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None yet — behavior ships dark until the consumer wiring + rollout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) sessions directed by Daniel Visca. Key decisions: aggregate metrics per (function, message) instead of per invocation so observability cost is independent of record volume; budgets instead of a watcher for the first iteration (watcher integration planned as a follow-up on top of the same aggregates); fail-open with annotation rather than fail-closed, mirroring the logs sampling pipeline's posture.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
