### PR TITLE
feat(logs): wire hog log transformations into logs ingestion (default off)

### DIFF
--- a/nodejs/src/logs-ingestion/config.ts
+++ b/nodejs/src/logs-ingestion/config.ts
@@ -4,6 +4,7 @@ import {
     KAFKA_LOGS_INGESTION,
     KAFKA_LOGS_INGESTION_DLQ,
     KAFKA_LOGS_INGESTION_OVERFLOW,
+    KAFKA_LOG_ENTRIES,
     KAFKA_TRACES_CLICKHOUSE,
     KAFKA_TRACES_INGESTION,
     KAFKA_TRACES_INGESTION_DLQ,
@@ -15,6 +16,8 @@ import { LogsProducerName, WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_LOGS_PRODUC
 export type LogsIngestionOutputsConfig = {
     LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC: string
     LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER: LogsProducerName
+    LOGS_INGESTION_OUTPUT_LOG_ENTRIES_TOPIC: string
+    LOGS_INGESTION_OUTPUT_LOG_ENTRIES_PRODUCER: LogsProducerName
     LOGS_INGESTION_OUTPUT_LOGS_PRODUCER: LogsProducerName
     LOGS_INGESTION_OUTPUT_DLQ_PRODUCER: LogsProducerName
 }
@@ -23,6 +26,8 @@ export function getDefaultLogsIngestionOutputsConfig(): LogsIngestionOutputsConf
     return {
         LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC: KAFKA_APP_METRICS_2,
         LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER: WARPSTREAM_INGESTION_PRODUCER,
+        LOGS_INGESTION_OUTPUT_LOG_ENTRIES_TOPIC: KAFKA_LOG_ENTRIES,
+        LOGS_INGESTION_OUTPUT_LOG_ENTRIES_PRODUCER: WARPSTREAM_INGESTION_PRODUCER,
         LOGS_INGESTION_OUTPUT_LOGS_PRODUCER: WARPSTREAM_LOGS_PRODUCER,
         LOGS_INGESTION_OUTPUT_DLQ_PRODUCER: WARPSTREAM_LOGS_PRODUCER,
     }
@@ -49,6 +54,18 @@ export type LogsIngestionConsumerConfig = {
     LOGS_SAMPLING_ENABLED_TEAMS: string
     /** When `true`, sampling always keeps every record (metrics path may still run). */
     LOGS_SAMPLING_KILLSWITCH: boolean
+    /** Comma-separated team IDs, or `*` for all teams, or empty (default) to disable hog log transformations entirely. */
+    LOGS_TRANSFORMATIONS_ENABLED_TEAMS: string
+    /** When `true`, hog log transformations are skipped regardless of the allowlist. */
+    LOGS_TRANSFORMATIONS_KILLSWITCH: boolean
+    /** Hard per-record HogVM kill in milliseconds. */
+    LOGS_TRANSFORMATIONS_HOG_TIMEOUT_MS: number
+    /** Cumulative HogVM time budget per Kafka message; exhaustion skips remaining records (fail-open). */
+    LOGS_TRANSFORMATIONS_MESSAGE_BUDGET_MS: number
+    /** Cumulative HogVM time budget per consumer batch; bounds worst-case added batch latency. */
+    LOGS_TRANSFORMATIONS_BATCH_BUDGET_MS: number
+    /** Max failed invocations whose logs are captured, per function per message. */
+    LOGS_TRANSFORMATIONS_MAX_ERROR_LOGS_PER_FUNCTION: number
     REDIS_URL: string
     REDIS_POOL_MIN_SIZE: number
     REDIS_POOL_MAX_SIZE: number
@@ -75,6 +92,14 @@ export function getDefaultLogsIngestionConsumerConfig(): LogsIngestionConsumerCo
         LOGS_LIMITER_TEAM_REFILL_RATE_KB_PER_SECOND: '',
         LOGS_SAMPLING_ENABLED_TEAMS: '*',
         LOGS_SAMPLING_KILLSWITCH: false,
+        LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '',
+        LOGS_TRANSFORMATIONS_KILLSWITCH: false,
+        LOGS_TRANSFORMATIONS_HOG_TIMEOUT_MS: 10,
+        // A regex-heavy scrub measured ~95µs/record (see transformations/benchmarks/);
+        // 100ms covers one such function over a full ~1,100-record message.
+        LOGS_TRANSFORMATIONS_MESSAGE_BUDGET_MS: 100,
+        LOGS_TRANSFORMATIONS_BATCH_BUDGET_MS: 2000,
+        LOGS_TRANSFORMATIONS_MAX_ERROR_LOGS_PER_FUNCTION: 3,
         // Overlapping fields with CommonConfig, included for standalone usage
         // ok to connect to localhost over plaintext
         // nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport

--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -428,7 +428,7 @@ describe('log-record-avro', () => {
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
             expect(pii).toEqual({ piiReplacements: 0 })
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 
             expect(decoded[0]?.attributes).toEqual({
                 level: '\"info\"',
@@ -477,7 +477,7 @@ describe('log-record-avro', () => {
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
             expect(pii).toEqual({ piiReplacements: 0 })
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 
             expect(decoded).toHaveLength(2)
             expect(decoded[0]?.attributes).toEqual({
@@ -550,7 +550,7 @@ describe('log-record-avro', () => {
             expect(outputBuffer).not.toBe(inputBuffer)
             expect(pii.piiReplacements).toBeGreaterThanOrEqual(1)
 
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
             expect(decoded[0]?.attributes).toBeNull()
             const body = parseJSON(decoded[0]?.body || '{}') as { message?: string }
             expect(body.message).not.toContain('example.com')
@@ -584,7 +584,7 @@ describe('log-record-avro', () => {
                 pii_scrub_logs: true,
             })
             expect(pii.piiReplacements).toBe(1)
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
             expect(decoded[0]?.body).toBe('plain')
             expect(decoded[0]?.attributes).toEqual({ note: PII_REDACTED })
         })
@@ -616,7 +616,7 @@ describe('log-record-avro', () => {
                 pii_scrub_logs: true,
             })
             expect(pii.piiReplacements).toBe(2)
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
             expect(decoded[0]?.attributes).toEqual({
                 level: encodeAttributeCell('info'),
                 message: encodeAttributeCell(PII_REDACTED),
@@ -732,7 +732,7 @@ describe('log-record-avro', () => {
                 pii_scrub_logs: true,
             })
             expect(pii).toEqual({ piiReplacements: 0 })
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
             const body = parseJSON(decoded[0]?.body || '{}') as { meta: { api_key: string }; ok: string }
             // Body is pattern-scrubbed only; nested JSON keys are not redacted by key name.
             expect(body.meta.api_key).toBe('leak-value')
@@ -781,7 +781,7 @@ describe('log-record-avro', () => {
             const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
             const { value: outputBuffer, pii } = await processLogMessageBuffer(inputBuffer, { json_parse_logs: true })
             expect(pii).toEqual({ piiReplacements: 0 })
-            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 
             expect(Object.keys(decoded[0]?.attributes || {}).length).toBe(50)
         })

--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -289,25 +289,35 @@ export async function transformDecodedLogRecordsInPlace(
     return pii
 }
 
+/** Applied to decoded records after the built-in transforms; mutates the array in place
+ * (dropped records are removed). Used to run hog log transformations last. */
+export type LogRecordsTransform = (records: LogRecord[]) => Promise<unknown>
+
 /**
  * Processes an AVRO-encoded log message buffer containing multiple records.
- * Passthrough (no decode) when both json_parse_logs and pii_scrub_logs are off.
- * Otherwise: decode → optional PII scrub on `body` → optional parse bodies → optional JSON enrich → encode.
+ * Passthrough (no decode) when json_parse_logs and pii_scrub_logs are off and no
+ * `recordsTransform` is given.
+ * Otherwise: decode → optional PII scrub on `body` → optional parse bodies → optional JSON enrich
+ * → optional `recordsTransform` (hog log transformations, always last) → encode.
  *
  * When both `json_parse_logs` and `pii_scrub_logs` are on, scrub runs **before** parse/enrich so flattened JSON
  * attributes are derived from the redacted body string. `parseLogBodiesForIngestion` runs only when JSON parse is on.
+ *
+ * `value` is null when `recordsTransform` dropped every record — the caller must not
+ * produce the message downstream.
  */
 export const processLogMessageBuffer = instrumented({
     key: SPAN_LOGS_PROCESS_BUFFER,
     ...logRecordProcessInstrumentOpts,
 })(async function processLogMessageBufferImpl(
     buffer: Buffer,
-    settings: LogsSettings
-): Promise<{ value: Buffer; pii: PiiScrubStats }> {
+    settings: LogsSettings,
+    recordsTransform?: LogRecordsTransform
+): Promise<{ value: Buffer | null; pii: PiiScrubStats }> {
     const jsonParse = settings.json_parse_logs ?? false
     const piiScrub = settings.pii_scrub_logs ?? false
 
-    if (!jsonParse && !piiScrub) {
+    if (!jsonParse && !piiScrub && !recordsTransform) {
         return { value: buffer, pii: EMPTY_PII }
     }
 
@@ -324,6 +334,13 @@ export const processLogMessageBuffer = instrumented({
 
         const pii = await transformDecodedLogRecordsInPlace(records, settings)
 
+        if (recordsTransform) {
+            await recordsTransform(records)
+            if (records.length === 0) {
+                return { value: null, pii }
+            }
+        }
+
         const value = await encodeLogRecordsInstrumented(logRecordType, codec, records)
         return { value, pii }
     } finally {
@@ -337,4 +354,8 @@ export const processLogMessageBuffer = instrumented({
             durationSeconds
         )
     }
-}) as (buffer: Buffer, settings: LogsSettings) => Promise<{ value: Buffer; pii: PiiScrubStats }>
+}) as (
+    buffer: Buffer,
+    settings: LogsSettings,
+    recordsTransform?: LogRecordsTransform
+) => Promise<{ value: Buffer | null; pii: PiiScrubStats }>

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -10,13 +10,15 @@ import { createTeam, getFirstTeam, getTeam, resetTestDatabase } from '~/tests/he
 import { Hub, Team } from '../../src/types'
 import { closeHub, createHub } from '../../src/utils/db/hub'
 import { PostgresUse } from '../../src/utils/db/postgres'
+import { compileHog } from '../cdp/templates/compiler'
+import { HogFunctionType } from '../cdp/types'
 import { KAFKA_APP_METRICS_2, KAFKA_LOGS_CLICKHOUSE, KAFKA_LOGS_INGESTION_DLQ } from '../config/kafka-topics'
 import { APP_METRICS_OUTPUT, AppMetricsOutput } from '../ingestion/common/outputs'
 import { IngestionOutputs } from '../ingestion/outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '../ingestion/outputs/single-ingestion-output'
 import { parseJSON } from '../utils/json-parse'
 import { getDefaultTracesIngestionConsumerConfig } from './config'
-import { LogRecord, encodeLogRecords } from './log-record-avro'
+import { LogRecord, decodeLogRecords, encodeLogRecords } from './log-record-avro'
 import {
     DEFAULT_LOGS_RETENTION_DAYS,
     LogsIngestionConsumer,
@@ -35,6 +37,7 @@ import { compileRuleSet } from './sampling/compile-rules'
 import type { SamplingRulesCache } from './sampling/sampling-rules-cache'
 import { BASE_REDIS_KEY } from './services/logs-rate-limiter.service'
 import { TracesIngestionConsumer } from './traces-ingestion-consumer'
+import { LogsTransformerService } from './transformations/logs-transformer.service'
 
 const DEFAULT_TEST_TIMEOUT = 5000
 jest.setTimeout(DEFAULT_TEST_TIMEOUT)
@@ -122,7 +125,7 @@ describe('LogsIngestionConsumer', () => {
     const createLogsIngestionConsumer = async (
         hub: Hub,
         overrides: any = {},
-        depsPartial: Partial<Pick<LogsIngestionConsumerDeps, 'samplingRulesCache'>> = {}
+        depsPartial: Partial<Pick<LogsIngestionConsumerDeps, 'samplingRulesCache' | 'logsTransformer'>> = {}
     ) => {
         const consumer = new LogsIngestionConsumer(
             hub,
@@ -1695,6 +1698,115 @@ describe('LogsIngestionConsumer', () => {
 
             expect(limiterConfig.LOGS_LIMITER_BUCKET_SIZE_KB).toBe(42)
             expect(limiterConfig.LOGS_LIMITER_REFILL_RATE_KB_PER_SECOND).toBe(7)
+        })
+    })
+
+    describe('hog log transformations', () => {
+        let transformerConsumer: LogsIngestionConsumer
+
+        const buildTransformer = async (hog: string): Promise<LogsTransformerService> => {
+            const fn = {
+                id: '00000000-0000-0000-0000-000000000001',
+                team_id: team.id,
+                name: 'Test log transformation',
+                type: 'transformation_log',
+                enabled: true,
+                bytecode: await compileHog(hog),
+                inputs: {},
+                encrypted_inputs: null,
+                execution_order: 1,
+                created_at: new Date().toISOString(),
+            } as unknown as HogFunctionType
+            const manager = {
+                getHogFunctionsForTeams: jest.fn().mockResolvedValue({ [team.id]: [fn] }),
+                getHogFunctionIdsForTeams: jest.fn().mockResolvedValue({ [team.id]: [fn.id] }),
+            }
+            const monitoring = { queueAppMetric: jest.fn(), queueLogs: jest.fn(), flush: jest.fn() }
+            return new LogsTransformerService(manager as any, monitoring as any, {
+                siteUrl: 'http://localhost:8010',
+                hogTimeoutMs: 10,
+                messageBudgetMs: 100,
+                batchBudgetMs: 2000,
+                maxErrorLogsPerFunctionPerMessage: 3,
+            })
+        }
+
+        afterEach(async () => {
+            await transformerConsumer?.stop()
+        })
+
+        it('applies an enabled transformation to produced records', async () => {
+            const logsTransformer = await buildTransformer(`
+                let rec := record
+                rec.body := replaceAll(rec.body, 'sensitive', '[REDACTED]')
+                return rec
+            `)
+            transformerConsumer = await createLogsIngestionConsumer(
+                hub,
+                { LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '*' },
+                { logsTransformer }
+            )
+
+            const messages = await createKafkaMessages([createLogMessage({ message: 'something sensitive here' })], {
+                token: team.api_token,
+            })
+            await waitForBackgroundTasks(transformerConsumer.processKafkaBatch(messages))
+
+            const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
+            expect(logsMessages).toHaveLength(1)
+            const [, , records] = await decodeLogRecords(logsMessages[0].value as Buffer)
+            expect(records).toHaveLength(1)
+            expect(records[0].body).toContain('[REDACTED]')
+            expect(records[0].body).not.toContain('sensitive')
+        })
+
+        it('does not produce a message when transformations drop every record', async () => {
+            const logsTransformer = await buildTransformer(`return null`)
+            transformerConsumer = await createLogsIngestionConsumer(
+                hub,
+                { LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '*' },
+                { logsTransformer }
+            )
+
+            const messages = await createKafkaMessages([createLogMessage()], { token: team.api_token })
+            await waitForBackgroundTasks(transformerConsumer.processKafkaBatch(messages))
+
+            const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
+            expect(logsMessages).toHaveLength(0)
+            expect(logMessageDroppedCounterSpy).toHaveBeenCalledWith(
+                { reason: 'transformations_all_dropped', team_id: team.id.toString() },
+                1
+            )
+        })
+
+        it('does not run transformations when the team is not in the allowlist', async () => {
+            const logsTransformer = await buildTransformer(`return null`)
+            transformerConsumer = await createLogsIngestionConsumer(
+                hub,
+                { LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '' },
+                { logsTransformer }
+            )
+
+            const messages = await createKafkaMessages([createLogMessage()], { token: team.api_token })
+            await waitForBackgroundTasks(transformerConsumer.processKafkaBatch(messages))
+
+            const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
+            expect(logsMessages).toHaveLength(1)
+        })
+
+        it('does not run transformations when the killswitch is on', async () => {
+            const logsTransformer = await buildTransformer(`return null`)
+            transformerConsumer = await createLogsIngestionConsumer(
+                hub,
+                { LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '*', LOGS_TRANSFORMATIONS_KILLSWITCH: true },
+                { logsTransformer }
+            )
+
+            const messages = await createKafkaMessages([createLogMessage()], { token: team.api_token })
+            await waitForBackgroundTasks(transformerConsumer.processKafkaBatch(messages))
+
+            const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
+            expect(logsMessages).toHaveLength(1)
         })
     })
 })

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -18,12 +18,13 @@ import { logger } from '../utils/logger'
 import { TeamManager } from '../utils/team-manager'
 import { LogsIngestionConsumerConfig } from './config'
 import { type PiiScrubStats } from './log-pii-scrub'
-import { processLogMessageBuffer } from './log-record-avro'
+import { type LogRecordsTransform, processLogMessageBuffer } from './log-record-avro'
 import { LOGS_DLQ_OUTPUT, LOGS_OUTPUT, LogsDlqOutput, LogsOutput } from './outputs/outputs'
 import type { CompiledRuleSet } from './sampling/evaluate'
 import { LogsSamplingService } from './sampling/logs-sampling.service'
 import { SamplingRulesCache } from './sampling/sampling-rules-cache'
 import { LogsRateLimiterService } from './services/logs-rate-limiter.service'
+import { LogsTransformerService, TransformationBatchBudget } from './transformations/logs-transformer.service'
 import { LogsIngestionMessage } from './types'
 
 export interface LogsIngestionConsumerDeps {
@@ -31,6 +32,8 @@ export interface LogsIngestionConsumerDeps {
     quotaLimiting: QuotaLimiting
     /** When set, enabled teams may run head sampling before ClickHouse Kafka produce. */
     samplingRulesCache?: SamplingRulesCache
+    /** When set, enabled teams run hog log transformations after the built-in processing. */
+    logsTransformer?: LogsTransformerService
     /**
      * Resolved outputs registry — must include `LOGS_OUTPUT`, `LOGS_DLQ_OUTPUT`,
      * and `APP_METRICS_OUTPUT`. The producer + topic for each is wired by the
@@ -145,6 +148,8 @@ export class LogsIngestionConsumer {
     private samplingService: LogsSamplingService
     private readonly samplingEnabledTeamsRaw: string
     private readonly samplingKillswitch: boolean
+    private readonly transformationsEnabledTeamsRaw: string
+    private readonly transformationsKillswitch: boolean
 
     protected groupId: string
     protected topic: string
@@ -187,33 +192,67 @@ export class LogsIngestionConsumer {
         this.samplingService = new LogsSamplingService(this.redis, mergedConfig.LOGS_LIMITER_TTL_SECONDS)
         this.samplingEnabledTeamsRaw = mergedConfig.LOGS_SAMPLING_ENABLED_TEAMS
         this.samplingKillswitch = mergedConfig.LOGS_SAMPLING_KILLSWITCH
+        this.transformationsEnabledTeamsRaw = mergedConfig.LOGS_TRANSFORMATIONS_ENABLED_TEAMS
+        this.transformationsKillswitch = mergedConfig.LOGS_TRANSFORMATIONS_KILLSWITCH
     }
 
-    private isSamplingEvalEnabledForTeam(teamId: number): boolean {
-        if (this.samplingKillswitch) {
+    private static teamMatchesAllowlist(raw: string, teamId: number): boolean {
+        const trimmed = (raw || '').trim()
+        if (!trimmed) {
             return false
         }
-        const raw = (this.samplingEnabledTeamsRaw || '').trim()
-        if (!raw) {
-            return false
-        }
-        if (raw === '*') {
+        if (trimmed === '*') {
             return true
         }
-        return raw
+        return trimmed
             .split(',')
             .map((s) => parseInt(s.trim(), 10))
             .filter((n) => !Number.isNaN(n))
             .includes(teamId)
     }
 
+    private isSamplingEvalEnabledForTeam(teamId: number): boolean {
+        if (this.samplingKillswitch) {
+            return false
+        }
+        return LogsIngestionConsumer.teamMatchesAllowlist(this.samplingEnabledTeamsRaw, teamId)
+    }
+
+    private isTransformationsEnabledForTeam(teamId: number): boolean {
+        if (this.transformationsKillswitch || !this.deps.logsTransformer) {
+            return false
+        }
+        return LogsIngestionConsumer.teamMatchesAllowlist(this.transformationsEnabledTeamsRaw, teamId)
+    }
+
+    /**
+     * Builds the hog log transformation hook for a message, or undefined when the team
+     * is not gated in or has no enabled transformation_log functions (the existence
+     * check is an in-process cache hit, preserving the no-decode passthrough).
+     */
+    private async buildRecordsTransform(
+        message: LogsIngestionMessage,
+        batchBudget?: TransformationBatchBudget
+    ): Promise<LogRecordsTransform | undefined> {
+        const transformer = this.deps.logsTransformer
+        if (!transformer || !this.isTransformationsEnabledForTeam(message.teamId)) {
+            return undefined
+        }
+        if (!(await transformer.teamHasTransformations(message.teamId))) {
+            return undefined
+        }
+        return (records) => transformer.transformRecords(message.teamId, records, batchBudget)
+    }
+
     /**
      * Decode + optional head sampling, or passthrough `processLogMessageBuffer`.
-     * `sampling_all_dropped` means do not enqueue to logs output (message fully sampled out).
+     * `all_dropped` means do not enqueue to logs output (every record was sampled out
+     * or dropped by transformations); `reason` distinguishes the source.
      */
     private async resolveLogMessageBufferWithOptionalSampling(
         message: LogsIngestionMessage,
-        logsSettings: LogsSettings
+        logsSettings: LogsSettings,
+        batchBudget?: TransformationBatchBudget
     ): Promise<
         | {
               outcome: 'produce'
@@ -224,7 +263,8 @@ export class LogsIngestionConsumer {
               bytesDroppedByRuleId: Map<string, number>
           }
         | {
-              outcome: 'sampling_all_dropped'
+              outcome: 'all_dropped'
+              reason: 'sampling_all_dropped' | 'transformations_all_dropped'
               pii: PiiScrubStats
               recordsDropped: number
               recordsDroppedByRuleId: Map<string, number>
@@ -238,6 +278,7 @@ export class LogsIngestionConsumer {
             ruleSet = await samplingCache.getCompiledRuleSet(message.teamId)
         }
         const useSamplingPipeline = Boolean(ruleSet && ruleSet.rules.length > 0)
+        const recordsTransform = await this.buildRecordsTransform(message, batchBudget)
 
         trace.getActiveSpan()?.setAttributes({
             'logs.sampling.killswitch': this.samplingKillswitch,
@@ -246,6 +287,7 @@ export class LogsIngestionConsumer {
             'logs.sampling.cache_present': Boolean(samplingCache),
             'logs.sampling.eval_enabled_for_team': samplingEvalEnabled,
             'logs.sampling.compiled_rule_count': ruleSet?.rules.length ?? 0,
+            'logs.transformations.enabled_for_team': Boolean(recordsTransform),
             'logs.sampling.pipeline': useSamplingPipeline
                 ? 'decode_sample_encode'
                 : 'passthrough_processLogMessageBuffer',
@@ -256,7 +298,8 @@ export class LogsIngestionConsumer {
                 message.message.value!,
                 logsSettings,
                 ruleSet,
-                message.teamId
+                message.teamId,
+                recordsTransform
             )
             if (sampled.recordsDropped > 0) {
                 logsSamplingRecordsDroppedCounter.inc({ team_id: message.teamId.toString() }, sampled.recordsDropped)
@@ -266,7 +309,8 @@ export class LogsIngestionConsumer {
             }
             if (sampled.allDropped) {
                 return {
-                    outcome: 'sampling_all_dropped',
+                    outcome: 'all_dropped',
+                    reason: 'sampling_all_dropped',
                     pii: sampled.pii,
                     recordsDropped: sampled.recordsDropped,
                     recordsDroppedByRuleId: sampled.recordsDroppedByRuleId,
@@ -283,7 +327,17 @@ export class LogsIngestionConsumer {
             }
         }
 
-        const res = await processLogMessageBuffer(message.message.value!, logsSettings)
+        const res = await processLogMessageBuffer(message.message.value!, logsSettings, recordsTransform)
+        if (res.value === null) {
+            return {
+                outcome: 'all_dropped',
+                reason: 'transformations_all_dropped',
+                pii: res.pii,
+                recordsDropped: 0,
+                recordsDroppedByRuleId: new Map(),
+                bytesDroppedByRuleId: new Map(),
+            }
+        }
         return {
             outcome: 'produce',
             processedValue: res.value,
@@ -320,11 +374,22 @@ export class LogsIngestionConsumer {
             ...rateLimiterDroppedMessages,
         ])
 
+        // One transformation time budget shared by all messages of this batch
+        const transformationBatchBudget = this.deps.logsTransformer?.startBatch()
+
         return {
             // Produce first so PII replacement counts are folded into `usageStats` before MSK usage emit
             backgroundTask: (async () => {
-                await this.processAndProduceLogMessages(rateLimiterAllowedMessages, usageStats)
+                await this.processAndProduceLogMessages(
+                    rateLimiterAllowedMessages,
+                    usageStats,
+                    transformationBatchBudget
+                )
                 await this.emitUsageMetrics(usageStats)
+                // Best-effort flush of transformation app metrics + function logs; never block the data path
+                await this.deps.logsTransformer?.flush().catch((error) => {
+                    logger.error('Failed to flush logs transformer monitoring', { error: String(error) })
+                })
             })(),
             messages: rateLimiterAllowedMessages,
         }
@@ -451,7 +516,8 @@ export class LogsIngestionConsumer {
 
     private async processAndProduceLogMessages(
         messages: LogsIngestionMessage[],
-        usageStats: UsageStatsByTeam
+        usageStats: UsageStatsByTeam,
+        transformationBatchBudget?: TransformationBatchBudget
     ): Promise<void> {
         const limit = pLimit(MAX_CONCURRENT_MESSAGE_PROCESSES)
         const results = await Promise.allSettled(
@@ -486,11 +552,16 @@ export class LogsIngestionConsumer {
                                     inbound_bytes: message.message.value?.length ?? 0,
                                 }),
                             },
-                            async () => this.resolveLogMessageBufferWithOptionalSampling(message, logsSettings)
+                            async () =>
+                                this.resolveLogMessageBufferWithOptionalSampling(
+                                    message,
+                                    logsSettings,
+                                    transformationBatchBudget
+                                )
                         )
-                        if (resolved.outcome === 'sampling_all_dropped') {
+                        if (resolved.outcome === 'all_dropped') {
                             logMessageDroppedCounter.inc(
-                                { reason: 'sampling_all_dropped', team_id: message.teamId.toString() },
+                                { reason: resolved.reason, team_id: message.teamId.toString() },
                                 1
                             )
                             this.addPiiStatsIntoUsage(usageStats, message.teamId, resolved.pii)

--- a/nodejs/src/logs-ingestion/outputs/registry.ts
+++ b/nodejs/src/logs-ingestion/outputs/registry.ts
@@ -1,4 +1,4 @@
-import { APP_METRICS_OUTPUT } from '../../ingestion/common/outputs'
+import { APP_METRICS_OUTPUT, LOG_ENTRIES_OUTPUT } from '../../ingestion/common/outputs'
 import { IngestionOutputsBuilder } from '../../ingestion/outputs/ingestion-outputs-builder'
 import { LOGS_DLQ_OUTPUT, LOGS_OUTPUT } from './outputs'
 
@@ -8,6 +8,7 @@ import { LOGS_DLQ_OUTPUT, LOGS_OUTPUT } from './outputs'
  * - `LOGS_OUTPUT` — main log data path → topic from `LOGS_INGESTION_CONSUMER_CLICKHOUSE_TOPIC`.
  * - `LOGS_DLQ_OUTPUT` — DLQ for failed messages → topic from `LOGS_INGESTION_CONSUMER_DLQ_TOPIC`.
  * - `APP_METRICS_OUTPUT` — usage metrics → topic from `LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC`.
+ * - `LOG_ENTRIES_OUTPUT` — hog function logs (UI log viewer) → topic from `LOGS_INGESTION_OUTPUT_LOG_ENTRIES_TOPIC`.
  *
  * Per-output producer is env-controlled (`*_PRODUCER` keys) so the route can be
  * flipped between MSK / Warpstream-logs / Warpstream-ingestion without code changes.
@@ -17,6 +18,10 @@ export function createLogsOutputsRegistry() {
         .register(APP_METRICS_OUTPUT, {
             topicKey: 'LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC',
             producerKey: 'LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER',
+        })
+        .register(LOG_ENTRIES_OUTPUT, {
+            topicKey: 'LOGS_INGESTION_OUTPUT_LOG_ENTRIES_TOPIC',
+            producerKey: 'LOGS_INGESTION_OUTPUT_LOG_ENTRIES_PRODUCER',
         })
         .register(LOGS_OUTPUT, {
             topicKey: 'LOGS_INGESTION_CONSUMER_CLICKHOUSE_TOPIC',
@@ -38,6 +43,10 @@ export function createTracesOutputsRegistry() {
         .register(APP_METRICS_OUTPUT, {
             topicKey: 'LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC',
             producerKey: 'LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER',
+        })
+        .register(LOG_ENTRIES_OUTPUT, {
+            topicKey: 'LOGS_INGESTION_OUTPUT_LOG_ENTRIES_TOPIC',
+            producerKey: 'LOGS_INGESTION_OUTPUT_LOG_ENTRIES_PRODUCER',
         })
         .register(LOGS_OUTPUT, {
             topicKey: 'TRACES_INGESTION_CONSUMER_CLICKHOUSE_TOPIC',

--- a/nodejs/src/logs-ingestion/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs-ingestion/sampling/logs-sampling.service.ts
@@ -10,6 +10,7 @@ import { logger } from '~/utils/logger'
 import { type PiiScrubStats } from '../log-pii-scrub'
 import {
     type LogRecord,
+    type LogRecordsTransform,
     decodeLogRecords,
     encodeLogRecords,
     transformDecodedLogRecordsInPlace,
@@ -90,7 +91,8 @@ export class LogsSamplingService {
         buffer: Buffer,
         settings: LogsSettings,
         ruleSet: CompiledRuleSet,
-        teamId?: number
+        teamId?: number,
+        recordsTransform?: LogRecordsTransform
     ): Promise<ProcessBufferWithSamplingResult> {
         const [logRecordType, compressionCodec, records] = await decodeLogRecords(buffer)
         if (!logRecordType) {
@@ -160,6 +162,11 @@ export class LogsSamplingService {
                 }
                 kept.push(record)
             }
+        }
+
+        // Hog log transformations run last, on the records that survived the drop rules
+        if (recordsTransform && kept.length > 0) {
+            await recordsTransform(kept)
         }
 
         trace.getActiveSpan()?.setAttributes({

--- a/nodejs/src/servers/ingestion-logs-server.ts
+++ b/nodejs/src/servers/ingestion-logs-server.ts
@@ -1,5 +1,8 @@
 import { QuotaLimiting } from '~/common/services/quota-limiting.service'
 
+import { HogFunctionManagerService } from '../cdp/services/managers/hog-function-manager.service'
+import { HogFunctionMonitoringService } from '../cdp/services/monitoring/hog-function-monitoring.service'
+import { EncryptedFields } from '../cdp/utils/encryption-utils'
 import { CommonConfig } from '../common/config'
 import { defaultConfig, overrideConfigWithEnv } from '../config/config'
 import { createPosthogRedisConnectionConfig } from '../config/redis-pools'
@@ -21,10 +24,12 @@ import {
 } from '../logs-ingestion/outputs/producers'
 import { createLogsOutputsRegistry } from '../logs-ingestion/outputs/registry'
 import { SamplingRulesCache } from '../logs-ingestion/sampling/sampling-rules-cache'
+import { LogsTransformerService } from '../logs-ingestion/transformations/logs-transformer.service'
 import { PluginServerService, RedisPool } from '../types'
 import { PostgresRouter } from '../utils/db/postgres'
 import { createRedisPoolFromConfig } from '../utils/db/redis'
 import { logger } from '../utils/logger'
+import { PubSub } from '../utils/pubsub'
 import { TeamManager } from '../utils/team-manager'
 import { BaseServerConfig, CleanupResources, NodeServer, ServerLifecycle } from './base-server'
 
@@ -47,7 +52,15 @@ export type IngestionLogsServerConfig = BaseServerConfig &
     KafkaBrokerConfig &
     DatabaseConnectionConfig &
     RedisConnectionsConfig &
-    Pick<CommonConfig, 'LOG_LEVEL' | 'PLUGIN_SERVER_MODE' | 'CLOUD_DEPLOYMENT' | 'HEALTHCHECK_MAX_STALE_SECONDS'>
+    Pick<
+        CommonConfig,
+        | 'LOG_LEVEL'
+        | 'PLUGIN_SERVER_MODE'
+        | 'CLOUD_DEPLOYMENT'
+        | 'HEALTHCHECK_MAX_STALE_SECONDS'
+        | 'ENCRYPTION_SALT_KEYS'
+        | 'SITE_URL'
+    >
 
 export class IngestionLogsServer implements NodeServer {
     readonly lifecycle: ServerLifecycle
@@ -56,6 +69,7 @@ export class IngestionLogsServer implements NodeServer {
     private postgres?: PostgresRouter
     private posthogRedisPool?: RedisPool
     private producerRegistry?: KafkaProducerRegistry<LogsProducerName>
+    private pubsub?: PubSub
 
     constructor(config: Partial<IngestionLogsServerConfig> = {}) {
         this.config = {
@@ -105,7 +119,25 @@ export class IngestionLogsServer implements NodeServer {
         // 2. Resolve outputs (topic + producer per logical name, env-controlled)
         const outputs = createLogsOutputsRegistry().build(this.producerRegistry, this.config)
 
-        // 3. Logs ingestion consumer
+        // 3. Hog log transformations (per-team execution is gated by
+        // LOGS_TRANSFORMATIONS_ENABLED_TEAMS; the services themselves are cheap)
+        this.pubsub = new PubSub(this.posthogRedisPool)
+        await this.pubsub.start()
+        const hogFunctionManager = new HogFunctionManagerService(
+            this.postgres,
+            this.pubsub,
+            new EncryptedFields(this.config.ENCRYPTION_SALT_KEYS)
+        )
+        const hogFunctionMonitoring = new HogFunctionMonitoringService(outputs)
+        const logsTransformer = new LogsTransformerService(hogFunctionManager, hogFunctionMonitoring, {
+            siteUrl: this.config.SITE_URL,
+            hogTimeoutMs: this.config.LOGS_TRANSFORMATIONS_HOG_TIMEOUT_MS,
+            messageBudgetMs: this.config.LOGS_TRANSFORMATIONS_MESSAGE_BUDGET_MS,
+            batchBudgetMs: this.config.LOGS_TRANSFORMATIONS_BATCH_BUDGET_MS,
+            maxErrorLogsPerFunctionPerMessage: this.config.LOGS_TRANSFORMATIONS_MAX_ERROR_LOGS_PER_FUNCTION,
+        })
+
+        // 4. Logs ingestion consumer
         const serviceLoaders: (() => Promise<PluginServerService>)[] = []
 
         serviceLoaders.push(async () => {
@@ -114,6 +146,7 @@ export class IngestionLogsServer implements NodeServer {
                 quotaLimiting,
                 outputs,
                 samplingRulesCache,
+                logsTransformer,
             })
             await consumer.start()
             return consumer.service
@@ -128,6 +161,9 @@ export class IngestionLogsServer implements NodeServer {
             kafkaProducers: [],
             redisPools: [this.posthogRedisPool].filter(Boolean) as RedisPool[],
             postgres: this.postgres,
+            // PubSub holds a client from posthogRedisPool — it must stop in the services
+            // phase, before the base server drains the pool, or stop() hangs.
+            pubsub: this.pubsub,
             additionalCleanup: async () => {
                 await this.producerRegistry?.disconnectAll()
             },


### PR DESCRIPTION
## Problem

Final wiring: thread the `LogsTransformerService` into the logs ingestion consumer so `transformation_log` functions actually run — while shipping completely dark. Transformations run as the last processing stage, after quota, rate limits, drop/sampling rules, built-in PII scrub, and JSON parse, and are gated off by default at the deployment level.

## Changes

- `LOGS_TRANSFORMATIONS_ENABLED_TEAMS` allowlist (comma-separated team ids or `*`, default empty) plus `LOGS_TRANSFORMATIONS_KILLSWITCH`, mirroring the sampling rollout controls; budgets and timeout are env-tunable with defaults from the benchmark numbers (#63374)
- The no-decode passthrough is preserved: a message is only decoded when team settings require it or the team has enabled log transformations (in-process cache hit)
- One shared VM-time budget per consumer batch bounds worst-case added latency; messages whose records are all dropped by transformations are not produced at all
- The server constructs PubSub + `HogFunctionManagerService` (functions hot-reload on save) and `HogFunctionMonitoringService` (app_metrics2 + log_entries outputs); the traces deployment is unaffected

## Roadmap

**This stack — Hog transformations for logs ingestion** (this PR is 5 of 5):

1. #63374 — benchmark harness: measure HogVM cost per log record
2. #63375 — `transformation_log` hog function type (API/model plumbing, feature-flag-gated creation)
3. #63376 — per-record execution primitives (globals shape, writable-field whitelist, drop semantics)
4. #63377 — `LogsTransformerService` (orchestration, VM-time budgets, aggregated metrics)
5. 👉 #63378 — wire into the logs ingestion consumer (default off, team allowlist + killswitch)

**Planned follow-ups (separate PRs, not in this stack):**

- Test-invocation support for the new type (the CDP API invocation endpoint currently only handles event-shaped globals) and generalizing the `rearrange` endpoint's type filter
- Starter templates (PII scrub, drop by severity, attribute rewrite)
- Frontend surface in the logs product (type union, configuration logic branches, testing panel with log-record samples), gated by the `logs-transformations` flag
- HogWatcher integration using aggregated per-message observations with a logs-tuned cost curve (observe-only first, then auto-disable)
- Rollout: production feature flag, per-team allowlist on the logs ingestion deployment, dashboards, public docs

## How did you test this code?

I'm an agent. Automated: ran the logs ingestion consumer Jest suite locally (101 tests pass, including the new transformation-stage tests: allowlist gating, killswitch, decode-only-when-needed, all-dropped messages not produced).

Manual (agent-performed, local dev stack): enabled the allowlist on the local logs consumer, created an enabled `transformation_log` function via the API, sent OTLP logs through the local collector, and verified end to end — body redaction and attribute mutation visible in the logs ClickHouse table, records dropped by the function absent, aggregated `succeeded`/`dropped` rows in `app_metrics2`, Prometheus counters incrementing, and hot reload of function edits via PubSub without a consumer restart. One observation from that testing worth a reviewer's eye: `severity_text` is normalized to lowercase upstream of transformations, so user Hog code must compare lowercase — this should be baked into the future templates/docs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None yet — feature ships dark (empty allowlist). Public docs land with the frontend/GA follow-ups.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) sessions directed by Daniel Visca. Key decisions: deployment-level allowlist + killswitch mirroring the logs sampling rollout pattern rather than a per-team DB toggle; preserve the no-decode fast path so teams without transformations pay nothing; batch-level budget so a worst-case team cannot stall the shared consumer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
