### PR TITLE
feat(quill-charts): built-in tooltip formats values like the axis

### DIFF
--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -70,7 +70,7 @@ Charts fill their container and need a parent with real dimensions — a `0`-hei
 
 ## Tooltips
 
-The built-in tooltip handles most cases — **reach for a custom `tooltip` render prop only when you need a fundamentally different layout.** By default it formats each value with the y-axis tick formatter (so tooltip and axis agree) and renders non-finite values (NaN gap points) as an em dash.
+The built-in tooltip handles most cases — **reach for a custom `tooltip` render prop only when you need a fundamentally different layout.** By default it formats each value with the primary y-axis tick formatter (so tooltip and axis agree) and renders non-finite values (NaN gap points) as an em dash. On multi-axis (`yAxisId`) charts every row uses the primary formatter — set `valueFormatter` if a secondary axis needs different units.
 
 ```tsx
 <TimeSeriesLineChart

--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -68,6 +68,31 @@ Charts fill their container and need a parent with real dimensions — a `0`-hei
 - `Legend` is presentational: pass `items`, `onItemClick`, `hiddenKeys` — filtering series is the caller's state.
 - y-axis `format`: `numeric | short | percentage | percentage_scaled | currency | duration | duration-ms`, plus `prefix`/`suffix`.
 
+## Tooltips
+
+The built-in tooltip handles most cases — **reach for a custom `tooltip` render prop only when you need a fundamentally different layout.** By default it formats each value with the y-axis tick formatter (so tooltip and axis agree) and renders non-finite values (NaN gap points) as an em dash.
+
+```tsx
+<TimeSeriesLineChart
+  series={series}
+  labels={labels}
+  theme={theme}
+  config={{
+    yTickFormatter: (ms) => formatMs(ms),
+    tooltip: {
+      // Override only to format the tooltip differently from the axis; otherwise omit.
+      valueFormatter: (ms) => formatMs(ms),
+      // Append a contextual footer without rebuilding the whole tooltip.
+      renderExtra: (ctx) => <div className="mt-1 opacity-70">{ctx.dataIndex} calls</div>,
+    },
+  }}
+/>
+```
+
+- `config.tooltip.valueFormatter` — defaults to the resolved y-axis formatter; set it only to diverge from the axis. Non-finite values always render as `—` (don't special-case NaN yourself).
+- `config.tooltip.renderExtra(ctx)` — extra content below the series rows (footers, context).
+- A custom `tooltip` render prop still gets `ctx.formatValue` for axis-consistent formatting.
+
 ## Maintenance
 
 When adding or changing a chart, overlay, or config option, update this guide in the same PR and add a story next to the component.

--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -83,14 +83,14 @@ The built-in tooltip handles most cases — **reach for a custom `tooltip` rende
       // Override only to format the tooltip differently from the axis; otherwise omit.
       valueFormatter: (ms) => formatMs(ms),
       // Append a contextual footer without rebuilding the whole tooltip.
-      renderExtra: (ctx) => <div className="mt-1 opacity-70">{ctx.dataIndex} calls</div>,
+      renderFooter: (ctx) => <div className="mt-1 opacity-70">{ctx.dataIndex} calls</div>,
     },
   }}
 />
 ```
 
 - `config.tooltip.valueFormatter` — defaults to the resolved y-axis formatter; set it only to diverge from the axis. Non-finite values always render as `—` (don't special-case NaN yourself).
-- `config.tooltip.renderExtra(ctx)` — extra content below the series rows (footers, context).
+- `config.tooltip.renderFooter(ctx)` — extra content below the series rows (footers, context).
 - A custom `tooltip` render prop still gets `ctx.formatValue` for axis-consistent formatting.
 
 ## Maintenance

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlotTooltip.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { formatTooltipValue } from '../../core/tooltipFormat'
 import type { TooltipContext } from '../../core/types'
 import { TooltipSurface, TooltipSwatch } from '../../overlays/TooltipSurface'
 import type { BoxPlotAdaptedMeta } from './BoxPlot'
@@ -26,9 +27,6 @@ export interface BoxPlotTooltipProps<Meta = unknown> {
     grouped: boolean
 }
 
-function defaultFormatValue(v: number): string {
-    return Number.isFinite(v) ? v.toLocaleString() : '—'
-}
 
 export function BoxPlotTooltip<Meta = unknown>({
     ctx,
@@ -76,7 +74,7 @@ export function BoxPlotTooltip<Meta = unknown>({
                                 <tr key={row.key}>
                                     <td className="pr-3 opacity-70">{row.label}</td>
                                     <td className="font-medium">
-                                        {defaultFormatValue(entry.datum[row.key] as number)}
+                                        {formatTooltipValue(entry.datum[row.key] as number)}
                                     </td>
                                 </tr>
                             ))}

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.stories.tsx
@@ -150,7 +150,7 @@ export const HoveringInterior: Story = {
 }
 
 /** The built-in tooltip formats values via `config.tooltip.valueFormatter` and appends a
- *  contextual footer via `config.tooltip.renderExtra` — no custom tooltip component needed. */
+ *  contextual footer via `config.tooltip.renderFooter` — no custom tooltip component needed. */
 export const FormattedTooltip: Story = {
     parameters: { layout: 'fullscreen' },
     render: () => {
@@ -161,7 +161,7 @@ export const FormattedTooltip: Story = {
             yTickFormatter: (v) => `${v}ms`,
             tooltip: {
                 valueFormatter: (v) => (v >= 1000 ? `${(v / 1000).toFixed(1)}s` : `${v}ms`),
-                renderExtra: (ctx) => (
+                renderFooter: (ctx) => (
                     <div className="mt-1 opacity-70">{DAYS[ctx.dataIndex]} · p50 / p95 / p99</div>
                 ),
             },

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.stories.tsx
@@ -149,6 +149,41 @@ export const HoveringInterior: Story = {
     },
 }
 
+/** The built-in tooltip formats values via `config.tooltip.valueFormatter` and appends a
+ *  contextual footer via `config.tooltip.renderExtra` — no custom tooltip component needed. */
+export const FormattedTooltip: Story = {
+    parameters: { layout: 'fullscreen' },
+    render: () => {
+        const theme = useReactiveTheme()
+        const config: LineChartConfig = {
+            showGrid: true,
+            showCrosshair: true,
+            yTickFormatter: (v) => `${v}ms`,
+            tooltip: {
+                valueFormatter: (v) => (v >= 1000 ? `${(v / 1000).toFixed(1)}s` : `${v}ms`),
+                renderExtra: (ctx) => (
+                    <div className="mt-1 opacity-70">{DAYS[ctx.dataIndex]} · p50 / p95 / p99</div>
+                ),
+            },
+        }
+        const series: Series[] = [
+            { key: 'p50', label: 'p50', color: '', data: [120, 180, 150, 470, 300, 900, 520] },
+            { key: 'p95', label: 'p95', color: '', data: [400, 600, 520, 1500, 1100, 2400, 1800] },
+        ]
+        return (
+            // eslint-disable-next-line react/forbid-dom-props
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+                <Stage>
+                    <LineChart series={series} labels={DAYS} config={config} theme={theme} />
+                </Stage>
+            </div>
+        )
+    },
+    play: async ({ canvasElement }) => {
+        await playHoverAtFraction(canvasElement, 0.5)
+    },
+}
+
 /** Multi-series hover with one series hidden from the tooltip via `tooltip: false`. */
 export const HoveringMultiSeries: Story = {
     parameters: { layout: 'fullscreen' },

--- a/packages/quill/packages/charts/src/charts/PieChart/PieTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/PieChart/PieTooltip.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { formatTooltipValue } from '../../core/tooltipFormat'
 import type { TooltipContext } from '../../core/types'
 import { TooltipSurface, TooltipSwatch } from '../../overlays/TooltipSurface'
 
@@ -9,17 +10,13 @@ export interface PieTooltipProps<Meta> {
     isPercent?: boolean
 }
 
-function defaultFormatter(v: number): string {
-    return v.toLocaleString()
-}
-
 function formatPercent(fraction: number): string {
     return `${Math.round(fraction * 1000) / 10}%`
 }
 
 export function PieTooltip<Meta>({
     ctx,
-    valueFormatter = defaultFormatter,
+    valueFormatter = formatTooltipValue,
     isPercent = false,
 }: PieTooltipProps<Meta>): React.ReactElement | null {
     const entry = ctx.seriesData[0]

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -127,7 +127,7 @@ export function Chart<Meta = unknown>({
         pinnable: pinnableTooltip = false,
         placement: tooltipPlacement = 'follow-data',
         valueFormatter: tooltipValueFormatter,
-        renderExtra: tooltipRenderExtra,
+        renderFooter: tooltipRenderFooter,
     } = tooltipConfig ?? {}
 
     const margins = useChartMargins({
@@ -289,7 +289,7 @@ export function Chart<Meta = unknown>({
 
                     {tooltipCtx && showTooltip && (
                         <Tooltip
-                            context={{ ...tooltipCtx, formatValue: formatTooltipValueFn, renderExtra: tooltipRenderExtra }}
+                            context={{ ...tooltipCtx, formatValue: formatTooltipValueFn, renderFooter: tooltipRenderFooter }}
                             renderTooltip={renderTooltip}
                             placement={tooltipPlacement}
                         />

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -15,6 +15,7 @@ import { useChartInteraction } from './hooks/useChartInteraction'
 import { useChartMargins } from './hooks/useChartMargins'
 import { useLatest } from './hooks/useLatest'
 import { useResolvedYFormatter } from './hooks/useResolvedYFormatters'
+import { formatTooltipValue } from './tooltipFormat'
 import { useStableResolveValue } from './hooks/useStableResolveValue'
 import type {
     ChartConfig,
@@ -125,6 +126,8 @@ export function Chart<Meta = unknown>({
         enabled: showTooltip = true,
         pinnable: pinnableTooltip = false,
         placement: tooltipPlacement = 'follow-data',
+        valueFormatter: tooltipValueFormatter,
+        renderExtra: tooltipRenderExtra,
     } = tooltipConfig ?? {}
 
     const margins = useChartMargins({
@@ -154,6 +157,12 @@ export function Chart<Meta = unknown>({
     }, [coloredSeries, labels, dimensions, createScalesFn])
 
     const resolvedYFormatter = useResolvedYFormatter(scales, yTickFormatter)
+
+    // Tooltip values format like the y-axis by default (overridable), with non-finite guarded.
+    const formatTooltipValueFn = useMemo<(value: number) => string>(() => {
+        const base = tooltipValueFormatter ?? resolvedYFormatter
+        return (value: number): string => formatTooltipValue(value, base)
+    }, [tooltipValueFormatter, resolvedYFormatter])
 
     const { hoverIndex, hoverPosition, tooltipCtx, handlers } = useChartInteraction<Meta>({
         scales,
@@ -279,7 +288,11 @@ export function Chart<Meta = unknown>({
                     {children}
 
                     {tooltipCtx && showTooltip && (
-                        <Tooltip context={tooltipCtx} renderTooltip={renderTooltip} placement={tooltipPlacement} />
+                        <Tooltip
+                            context={{ ...tooltipCtx, formatValue: formatTooltipValueFn, renderExtra: tooltipRenderExtra }}
+                            renderTooltip={renderTooltip}
+                            placement={tooltipPlacement}
+                        />
                     )}
                 </ChartShell>
             </ChartHoverContext.Provider>

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -15,8 +15,8 @@ import { useChartInteraction } from './hooks/useChartInteraction'
 import { useChartMargins } from './hooks/useChartMargins'
 import { useLatest } from './hooks/useLatest'
 import { useResolvedYFormatter } from './hooks/useResolvedYFormatters'
-import { formatTooltipValue } from './tooltipFormat'
 import { useStableResolveValue } from './hooks/useStableResolveValue'
+import { formatTooltipValue } from './tooltipFormat'
 import type {
     ChartConfig,
     ChartDrawArgs,
@@ -158,7 +158,7 @@ export function Chart<Meta = unknown>({
 
     const resolvedYFormatter = useResolvedYFormatter(scales, yTickFormatter)
 
-    // Tooltip values format like the y-axis by default (overridable), with non-finite guarded.
+    // Matches the primary y-axis formatter; multi-axis (yAxisId) series also use it (see types.ts).
     const formatTooltipValueFn = useMemo<(value: number) => string>(() => {
         const base = tooltipValueFormatter ?? resolvedYFormatter
         return (value: number): string => formatTooltipValue(value, base)

--- a/packages/quill/packages/charts/src/core/tooltipFormat.test.ts
+++ b/packages/quill/packages/charts/src/core/tooltipFormat.test.ts
@@ -1,0 +1,30 @@
+import { formatTooltipValue, TOOLTIP_EMPTY_VALUE } from './tooltipFormat'
+
+describe('formatTooltipValue', () => {
+    it.each([
+        { name: 'NaN renders as the empty placeholder', value: NaN, expected: TOOLTIP_EMPTY_VALUE },
+        { name: 'Infinity renders as the empty placeholder', value: Infinity, expected: TOOLTIP_EMPTY_VALUE },
+        { name: '-Infinity renders as the empty placeholder', value: -Infinity, expected: TOOLTIP_EMPTY_VALUE },
+    ])('$name', ({ value, expected }) => {
+        expect(formatTooltipValue(value)).toBe(expected)
+    })
+
+    it('uses the provided formatter for finite values', () => {
+        expect(formatTooltipValue(470, (v) => `${v}ms`)).toBe('470ms')
+    })
+
+    it('falls back to toLocaleString when no formatter is given', () => {
+        // Assert against toLocaleString() rather than a hardcoded string so the test stays locale-stable.
+        expect(formatTooltipValue(1234)).toBe((1234).toLocaleString())
+    })
+
+    it('does not swallow zero', () => {
+        expect(formatTooltipValue(0)).toBe('0')
+    })
+
+    it('guards non-finite values before the formatter runs', () => {
+        const formatter = jest.fn((v: number) => `${v}`)
+        expect(formatTooltipValue(NaN, formatter)).toBe(TOOLTIP_EMPTY_VALUE)
+        expect(formatter).not.toHaveBeenCalled()
+    })
+})

--- a/packages/quill/packages/charts/src/core/tooltipFormat.ts
+++ b/packages/quill/packages/charts/src/core/tooltipFormat.ts
@@ -1,0 +1,13 @@
+/** Placeholder shown for a value that has no meaningful number — a gap point on a line
+ *  (NaN) or a non-finite result. Tooltips render this instead of "NaN"/"Infinity". */
+export const TOOLTIP_EMPTY_VALUE = '—'
+
+/** Format a series value for a tooltip, guarding non-finite values (NaN, ±Infinity) so gap
+ *  points read as an em dash rather than "NaN". `formatter` defaults to locale-grouped number
+ *  formatting; the chart engine passes the y-axis tick formatter so tooltip and axis agree. */
+export function formatTooltipValue(value: number, formatter?: (value: number) => string): string {
+    if (!Number.isFinite(value)) {
+        return TOOLTIP_EMPTY_VALUE
+    }
+    return formatter ? formatter(value) : value.toLocaleString()
+}

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -140,8 +140,8 @@ export interface TooltipContext<Meta = unknown> {
     isPinned: boolean
     /** Callback to unpin (close) a pinned tooltip. Only present when the tooltip is pinned. */
     onUnpin?: () => void
-    /** Formats a series value for display. The chart engine populates this with the y-axis tick
-     *  formatter (so tooltip values match axis ticks) — or {@link TooltipConfig.valueFormatter}
+    /** Formats a series value for display. The chart engine populates this with the primary y-axis
+     *  tick formatter (so tooltip values match axis ticks) — or {@link TooltipConfig.valueFormatter}
      *  when set — guarding non-finite values as an em dash. {@link DefaultTooltip} uses it, and
      *  custom tooltips can call it for axis-consistent formatting. */
     formatValue?: (value: number) => string
@@ -232,13 +232,15 @@ export interface TooltipConfig {
      *  as the cursor moves between data points; `cursor` tracks the mouse, so the tooltip sits
      *  beside the cursor and the hovered bar (chart.js-style) rather than at a fixed anchor. */
     placement?: 'follow-data' | 'top' | 'cursor'
-    /** Formats series values in the built-in tooltip. Defaults to the y-axis tick formatter so
-     *  the tooltip and axis agree (e.g. both show "1.5s" or "98%"); non-finite values always
-     *  render as an em dash. Set this only to format the tooltip differently from the axis. */
+    /** Formats series values in the built-in tooltip. Defaults to the primary y-axis tick formatter
+     *  so the tooltip and axis agree (e.g. both show "1.5s" or "98%"); non-finite values always
+     *  render as an em dash. On multi-axis (`yAxisId`) charts every row uses this primary formatter —
+     *  set `valueFormatter` to take over formatting if a secondary axis needs different units. */
     valueFormatter?: (value: number) => string
     /** Render extra content below the series rows in the built-in tooltip — e.g. a contextual
      *  footer like "120 calls · 3 errors". Receives the full tooltip context. Avoids hand-rolling
-     *  a whole custom tooltip just to append a line. */
+     *  a whole custom tooltip just to append a line. The context's `Meta` is erased here (plain
+     *  `TooltipContext`) to keep this config non-generic — cast `series.meta` if you need it typed. */
     renderExtra?: (ctx: TooltipContext) => ReactNode
 }
 

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 /** Visual theme colours consumed by chart rendering. */
 export interface ChartTheme {
     colors: string[]
@@ -138,6 +140,15 @@ export interface TooltipContext<Meta = unknown> {
     isPinned: boolean
     /** Callback to unpin (close) a pinned tooltip. Only present when the tooltip is pinned. */
     onUnpin?: () => void
+    /** Formats a series value for display. The chart engine populates this with the y-axis tick
+     *  formatter (so tooltip values match axis ticks) — or {@link TooltipConfig.valueFormatter}
+     *  when set — guarding non-finite values as an em dash. {@link DefaultTooltip} uses it, and
+     *  custom tooltips can call it for axis-consistent formatting. */
+    formatValue?: (value: number) => string
+    /** Extra content rendered by {@link DefaultTooltip} below the series rows — populated from
+     *  {@link TooltipConfig.renderExtra}. Lets consumers add a contextual footer without
+     *  replacing the whole tooltip. */
+    renderExtra?: (ctx: TooltipContext) => ReactNode
 }
 
 /** Computed layout dimensions of the chart, derived from container size and margins. */
@@ -221,6 +232,14 @@ export interface TooltipConfig {
      *  as the cursor moves between data points; `cursor` tracks the mouse, so the tooltip sits
      *  beside the cursor and the hovered bar (chart.js-style) rather than at a fixed anchor. */
     placement?: 'follow-data' | 'top' | 'cursor'
+    /** Formats series values in the built-in tooltip. Defaults to the y-axis tick formatter so
+     *  the tooltip and axis agree (e.g. both show "1.5s" or "98%"); non-finite values always
+     *  render as an em dash. Set this only to format the tooltip differently from the axis. */
+    valueFormatter?: (value: number) => string
+    /** Render extra content below the series rows in the built-in tooltip — e.g. a contextual
+     *  footer like "120 calls · 3 errors". Receives the full tooltip context. Avoids hand-rolling
+     *  a whole custom tooltip just to append a line. */
+    renderExtra?: (ctx: TooltipContext) => ReactNode
 }
 
 /** How the value axis domain is determined (y for vertical/line/area charts, x for horizontal

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -146,9 +146,9 @@ export interface TooltipContext<Meta = unknown> {
      *  custom tooltips can call it for axis-consistent formatting. */
     formatValue?: (value: number) => string
     /** Extra content rendered by {@link DefaultTooltip} below the series rows — populated from
-     *  {@link TooltipConfig.renderExtra}. Lets consumers add a contextual footer without
+     *  {@link TooltipConfig.renderFooter}. Lets consumers add a contextual footer without
      *  replacing the whole tooltip. */
-    renderExtra?: (ctx: TooltipContext) => ReactNode
+    renderFooter?: (ctx: TooltipContext) => ReactNode
 }
 
 /** Computed layout dimensions of the chart, derived from container size and margins. */
@@ -241,7 +241,7 @@ export interface TooltipConfig {
      *  footer like "120 calls · 3 errors". Receives the full tooltip context. Avoids hand-rolling
      *  a whole custom tooltip just to append a line. The context's `Meta` is erased here (plain
      *  `TooltipContext`) to keep this config non-generic — cast `series.meta` if you need it typed. */
-    renderExtra?: (ctx: TooltipContext) => ReactNode
+    renderFooter?: (ctx: TooltipContext) => ReactNode
 }
 
 /** How the value axis domain is determined (y for vertical/line/area charts, x for horizontal

--- a/packages/quill/packages/charts/src/index.ts
+++ b/packages/quill/packages/charts/src/index.ts
@@ -87,6 +87,8 @@ export type { ThemeFromCssOptions } from './core/theme'
 
 // Built-in tooltip (for reference or extension)
 export { DefaultTooltip } from './overlays/DefaultTooltip'
+// Value formatter used by the built-in tooltip — guards non-finite values as an em dash
+export { formatTooltipValue, TOOLTIP_EMPTY_VALUE } from './core/tooltipFormat'
 // Shared tooltip surface — reuse to build custom tooltips with the quill look
 export { TooltipSurface, TooltipSwatch, TOOLTIP_FALLBACK_BG, TOOLTIP_FALLBACK_COLOR } from './overlays/TooltipSurface'
 

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -1,7 +1,10 @@
 import type { TooltipContext } from '../core/types'
+import { formatTooltipValue } from '../core/tooltipFormat'
 import { TooltipSurface, TooltipSwatch } from './TooltipSurface'
 
-export function DefaultTooltip({ label, seriesData }: TooltipContext): React.ReactElement {
+export function DefaultTooltip(ctx: TooltipContext): React.ReactElement {
+    const { label, seriesData, formatValue, renderExtra } = ctx
+    const format = formatValue ?? ((value: number): string => formatTooltipValue(value))
     return (
         <TooltipSurface>
             <div className="font-semibold mb-1">{label}</div>
@@ -9,9 +12,10 @@ export function DefaultTooltip({ label, seriesData }: TooltipContext): React.Rea
                 <div key={s.series.key} className="flex items-center gap-2">
                     <TooltipSwatch color={s.color} />
                     <span>{s.series.label}:</span>
-                    <strong>{s.value.toLocaleString()}</strong>
+                    <strong>{format(s.value)}</strong>
                 </div>
             ))}
+            {renderExtra?.(ctx)}
         </TooltipSurface>
     )
 }

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -3,7 +3,7 @@ import { formatTooltipValue } from '../core/tooltipFormat'
 import { TooltipSurface, TooltipSwatch } from './TooltipSurface'
 
 export function DefaultTooltip(ctx: TooltipContext): React.ReactElement {
-    const { label, seriesData, formatValue, renderExtra } = ctx
+    const { label, seriesData, formatValue, renderFooter } = ctx
     const format = formatValue ?? ((value: number): string => formatTooltipValue(value))
     return (
         <TooltipSurface>
@@ -15,7 +15,7 @@ export function DefaultTooltip(ctx: TooltipContext): React.ReactElement {
                     <strong>{format(s.value)}</strong>
                 </div>
             ))}
-            {renderExtra?.(ctx)}
+            {renderFooter?.(ctx)}
         </TooltipSurface>
     )
 }


### PR DESCRIPTION
## Problem

quill-charts' built-in `DefaultTooltip` rendered each value as a raw `value.toLocaleString()`. That meant consumers hand-rolled their own tooltip components just to:

- add unit suffixes (`%`, `ms`/`s`) so the tooltip matched the axis,
- stop gap points (NaN) from rendering as the literal string `NaN`,
- append a small contextual footer.

The result was duplicated tooltip code across products and tooltips that visibly disagreed with their own axis (e.g. axis tick `1.5s` while the tooltip said `1,500`). We want quill-charts to handle the common case so people don't keep rebuilding tooltips.

## Changes

The built-in tooltip now formats values **the same way the axis does**, by default:

- Each value is formatted with the resolved y-axis tick formatter — tooltip and axis always agree.
- Non-finite values (NaN gap points, ±Infinity) render as an em dash `—` instead of `NaN`.
- Two opt-in hooks on `config.tooltip`:
  - `valueFormatter(value)` — override value formatting independently of the axis (rarely needed).
  - `renderExtra(ctx)` — append a contextual footer (e.g. "120 calls · 3 errors") without replacing the whole tooltip.
- `ctx.formatValue` is also exposed to custom `tooltip` render props, so even bespoke tooltips can format consistently. `formatTooltipValue` is exported for advanced use.

Covers all core charts (line / bar / time-series via the shared engine); radial charts get the non-finite guard for free through the `DefaultTooltip` fallback. Added a `FormattedTooltip` Storybook story and updated the charts `AGENTS.md` guide.

No behavior change for charts that don't set a y-axis formatter and don't opt into the new hooks, except that `NaN` now shows as `—`.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran:

- `pnpm --filter @posthog/quill-charts build` — passes, including the `vite:dts` declaration build (type-checks the package).
- `oxlint` on every changed file — no new warnings (one pre-existing `exhaustive-deps` warning in `Chart.tsx` unrelated to this change).

I did not run the package's unit tests locally (the quill packages have no local test runner configured; they run in CI) and did not manually verify in a browser. The new `FormattedTooltip` story is intended for the Storybook visual-regression suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @sampennington. The work started while simplifying a product's chart tooltips (MCP analytics tool quality tab) — rather than keep a bespoke `FormattedSeriesTooltip` there, we chose to fix it upstream so the library doesn't need per-consumer tooltips.

Key decisions:
- **Default to the axis formatter** rather than introducing a separate tooltip format concept — a tooltip disagreeing with its axis was the core problem, so reusing the resolved y-axis formatter makes the right thing automatic.
- **`formatValue`/`renderExtra` are optional on `TooltipContext`** (not required) to avoid churn in existing context builders and test fixtures; the engine always populates them and `DefaultTooltip` falls back safely.
- **`renderExtra`'s context param is non-generic (`TooltipContext`, not `TooltipContext<Meta>`)** to keep `Meta` out of a contravariant position — otherwise `DefaultTooltip` (Meta=unknown) stops being assignable to the `tooltip` render prop.

This lands first; a follow-up will simplify the MCP analytics charts to drop their custom tooltips in favor of `valueFormatter` + `renderExtra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
