### PR TITLE
feat(taxonomic-filter): mirror pageview URL collapse into legacy picker

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
@@ -181,8 +181,10 @@ describe('PropertyFilters recent selections', () => {
             tabTestId: 'taxonomic-tab-pageview_urls',
             searchQuery: 'example',
             itemTestId: 'prop-filter-pageview_urls-0',
-            expectedRecentPattern: /Current URL.*∋.*example\.com\/pricing/i,
-            expectedValuePattern: /example\.com\/pricing/i,
+            // Pageview URLs collapse to a single `$current_url IContains <query>` shortcut,
+            // so the recorded value is the typed query, not a specific matched URL.
+            expectedRecentPattern: /Current URL.*∋.*example/i,
+            expectedValuePattern: /example/i,
         },
         {
             description: 'screen name',
@@ -288,7 +290,8 @@ describe('PropertyFilters recent selections', () => {
         await openNewFilter()
 
         await waitFor(() => {
-            expectBareKeyBeforeFullRecent(/example\.com\/first/i, /Current URL.*∋.*example\.com\/first/i)
+            // Collapsed to `$current_url IContains 'first'` — the recent shows the query.
+            expectBareKeyBeforeFullRecent(/first/i, /Current URL.*∋.*first/i)
         })
     })
 

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -186,6 +186,7 @@ export function TaxonomicPropertyFilter({
             excludedOperators={excludedOperators}
             selectingKeyOnly={selectingKeyOnly}
             enableKeywordShortcuts
+            collapseUrlsToContainsRow
         />
     )
 

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1047,6 +1047,98 @@ describe('TaxonomicFilter', () => {
         })
     })
 
+    describe('collapseUrlsToContainsRow', () => {
+        function useMockPageviewUrls(urls: string[]): void {
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                    '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                    '/api/environments/:team/events/values': urls.map((name) => ({ name })),
+                },
+            })
+        }
+
+        it('collapses the matching URL list to a single "URL contains" shortcut row', async () => {
+            const user = userEvent.setup()
+            useMockPageviewUrls(['https://example.com/pricing', 'https://example.com/pricing/teams'])
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
+                collapseUrlsToContainsRow: true,
+            })
+
+            const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
+            await user.type(searchInput, 'pricing')
+
+            const firstRow = await waitFor(() => screen.getByTestId('prop-filter-pageview_urls-0'))
+            // The two matching URLs collapse into one row, which is the contains shortcut.
+            expect(firstRow.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')).not.toBeNull()
+            expect(screen.queryByTestId('prop-filter-pageview_urls-1')).not.toBeInTheDocument()
+        })
+
+        it('commits $current_url IContains <query> when the shortcut row is selected', async () => {
+            const user = userEvent.setup()
+            useMockPageviewUrls(['https://example.com/pricing'])
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
+                collapseUrlsToContainsRow: true,
+            })
+
+            const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
+            await user.type(searchInput, 'pricing')
+
+            const row = await waitFor(() => {
+                const el = document.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')
+                expect(el).not.toBeNull()
+                return el as HTMLElement
+            })
+            await user.click(row)
+
+            expect(onChangeMock).toHaveBeenCalledWith(
+                expect.objectContaining({ type: TaxonomicFilterGroupType.PageviewUrls }),
+                'pricing',
+                expect.objectContaining({
+                    _type: 'quick_filter',
+                    propertyKey: '$current_url',
+                    operator: PropertyOperator.IContains,
+                    filterValue: 'pricing',
+                    propertyFilterType: PropertyFilterType.Event,
+                })
+            )
+        })
+
+        it('lists individual URLs (no collapse) when the prop is omitted', async () => {
+            const user = userEvent.setup()
+            useMockPageviewUrls(['https://example.com/pricing'])
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
+            })
+
+            const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
+            await user.type(searchInput, 'pricing')
+
+            await waitFor(() => {
+                expect(screen.getByTestId('prop-filter-pageview_urls-0')).toBeInTheDocument()
+            })
+            expect(document.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')).toBeNull()
+        })
+
+        it('shows no shortcut row when no URL matches the query', async () => {
+            const user = userEvent.setup()
+            useMockPageviewUrls([])
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
+                collapseUrlsToContainsRow: true,
+            })
+
+            const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
+            await user.type(searchInput, 'pricing')
+
+            await waitFor(() => expect(searchInput).toHaveValue('pricing'))
+            expect(screen.queryByText('URL contains "pricing"')).not.toBeInTheDocument()
+            expect(document.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')).toBeNull()
+        })
+    })
+
     describe('category dropdown A/B test', () => {
         let unmountFeatureFlagLogic: (() => void) | null = null
 

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1102,6 +1102,9 @@ describe('TaxonomicFilter', () => {
                     operator: PropertyOperator.IContains,
                     filterValue: 'pricing',
                     propertyFilterType: PropertyFilterType.Event,
+                    // Tagged so commit telemetry can distinguish the URL-contains shortcut
+                    // from keyword shortcuts (parity with the rebuild's wasUrlContainsShortcut).
+                    isContainsShortcut: true,
                 })
             )
         })

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1109,6 +1109,24 @@ describe('TaxonomicFilter', () => {
             )
         })
 
+        it('collapses URLs in the aggregated Suggested filters tab too', async () => {
+            const user = userEvent.setup()
+            useMockPageviewUrls(['https://example.com/pricing', 'https://example.com/pricing/teams'])
+            renderFilter({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.SuggestedFilters, TaxonomicFilterGroupType.PageviewUrls],
+                collapseUrlsToContainsRow: true,
+            })
+
+            const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
+            await user.type(searchInput, 'pricing')
+
+            // The Suggested filters tab is the default and aggregates each group's top matches —
+            // the URL group must contribute the single shortcut there, not raw URLs.
+            const firstRow = await waitFor(() => screen.getByTestId('prop-filter-suggested_filters-0'))
+            expect(firstRow.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')).not.toBeNull()
+            expect(screen.queryByTestId('prop-filter-suggested_filters-1')).not.toBeInTheDocument()
+        })
+
         it('lists individual URLs (no collapse) when the prop is omitted', async () => {
             const user = userEvent.setup()
             useMockPageviewUrls(['https://example.com/pricing'])
@@ -1127,18 +1145,34 @@ describe('TaxonomicFilter', () => {
 
         it('shows no shortcut row when no URL matches the query', async () => {
             const user = userEvent.setup()
-            useMockPageviewUrls([])
+            // Flag set when the URL values endpoint actually responds (empty), so the negative
+            // assertions below aren't vacuously true before the async fetch path runs.
+            let valuesFetched = false
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                    '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                    '/api/environments/:team/events/values': () => {
+                        valuesFetched = true
+                        return [200, []]
+                    },
+                },
+            })
             renderFilter({
                 taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
                 collapseUrlsToContainsRow: true,
             })
 
             const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
-            await user.type(searchInput, 'pricing')
+            // A query unique to this test so the module-level `apiCache` in infiniteListLogic
+            // can't serve a non-empty response cached by an earlier test under the same URL.
+            await user.type(searchInput, 'nomatchquery')
 
-            await waitFor(() => expect(searchInput).toHaveValue('pricing'))
-            expect(screen.queryByText('URL contains "pricing"')).not.toBeInTheDocument()
-            expect(document.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')).toBeNull()
+            await waitFor(() => expect(valuesFetched).toBe(true))
+            await waitFor(() => {
+                expect(screen.queryByText('URL contains "nomatchquery"')).not.toBeInTheDocument()
+                expect(document.querySelector('[data-attr="taxonomic-shortcut-nomatchquery-property"]')).toBeNull()
+            })
         })
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -61,6 +61,7 @@ export function TaxonomicFilter({
     enableKeywordShortcuts,
     excludedOperators,
     selectingKeyOnly,
+    collapseUrlsToContainsRow,
 }: TaxonomicFilterProps): JSX.Element {
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
@@ -108,6 +109,7 @@ export function TaxonomicFilter({
         enableKeywordShortcuts,
         excludedOperators,
         selectingKeyOnly,
+        collapseUrlsToContainsRow,
     }
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -710,18 +710,36 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             },
         ],
         topMatchesForQuery: [
-            (s) => [s.localItems, s.remoteItems, s.searchQuery, s.hasRemoteDataSource, s.keywordShortcutItems],
+            (s) => [
+                s.localItems,
+                s.remoteItems,
+                s.searchQuery,
+                s.hasRemoteDataSource,
+                s.keywordShortcutItems,
+                s.listGroupType,
+                (_, props: InfiniteListLogicProps) => props.collapseUrlsToContainsRow,
+            ],
             (
                 localItems,
                 remoteItems,
                 searchQuery,
                 hasRemoteDataSource,
-                keywordShortcutItems
+                keywordShortcutItems,
+                listGroupType,
+                collapseUrlsToContainsRow
             ): TaxonomicDefinitionTypes[] => {
                 if (!searchQuery) {
                     return []
                 }
                 const remoteIsFresh = remoteItems.searchQuery === searchQuery
+                // Collapsed groups contribute the single "URL contains <query>" shortcut to the
+                // aggregated SuggestedFilters / "All" tab too — not the raw URL matches — so the
+                // common entry path collapses identically to the dedicated group list above.
+                if (collapseUrlsToContainsRow && COLLAPSED_TO_CONTAINS_ROW.has(listGroupType)) {
+                    const trimmed = searchQuery.trim()
+                    const hasMatch = trimmed.length > 0 && remoteIsFresh && remoteItems.results.length > 0
+                    return hasMatch ? [buildUrlContainsShortcut(trimmed)] : []
+                }
                 const results = hasRemoteDataSource ? (remoteIsFresh ? remoteItems.results : []) : localItems.results
                 const realMatches = promoteMatchingProperties(results, searchQuery).slice(0, MAX_TOP_MATCHES_PER_GROUP)
                 // Shortcuts lead the group's top-match contribution so the aggregated SuggestedFilters

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -876,6 +876,8 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 // states apply.
                 if (collapseUrlsToContainsRow && COLLAPSED_TO_CONTAINS_ROW.has(listGroupType)) {
                     const trimmed = (searchQuery ?? '').trim()
+                    // The remote fetch is debounced and lags the typed query, so guard against a
+                    // stale match from the previous query producing a shortcut for the new one.
                     const remoteIsFresh = (remoteItems.searchQuery ?? '').trim() === trimmed
                     const hasMatch = trimmed.length > 0 && remoteIsFresh && remoteItems.results.length > 0
                     const results = hasMatch ? [buildUrlContainsShortcut(trimmed)] : []

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -30,6 +30,10 @@ import {
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
+import {
+    buildUrlContainsShortcut,
+    COLLAPSED_TO_CONTAINS_ROW,
+} from 'lib/components/TaxonomicFilter/utils/collapsedContainsRow'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
@@ -850,6 +854,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 s.suggestedPinnedMatches,
                 s.suggestedRecentMatches,
                 s.keywordShortcutItems,
+                (_, props: InfiniteListLogicProps) => props.collapseUrlsToContainsRow,
             ],
             (
                 remoteItems,
@@ -861,8 +866,27 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 contextFilteredPinnedItems,
                 suggestedPinnedMatches,
                 suggestedRecentMatches,
-                keywordShortcutItems
+                keywordShortcutItems,
+                collapseUrlsToContainsRow
             ) => {
+                // Collapse URL groups to a single "URL contains <query>" shortcut row
+                // (mirrors the rebuild menu's `COLLAPSED_TO_CONTAINS_ROW`). Only once
+                // the remote fetch for the *current* query has returned at least one
+                // match — otherwise the list is empty and the standard empty/loading
+                // states apply.
+                if (collapseUrlsToContainsRow && COLLAPSED_TO_CONTAINS_ROW.has(listGroupType)) {
+                    const trimmed = (searchQuery ?? '').trim()
+                    const remoteIsFresh = (remoteItems.searchQuery ?? '').trim() === trimmed
+                    const hasMatch = trimmed.length > 0 && remoteIsFresh && remoteItems.results.length > 0
+                    const results = hasMatch ? [buildUrlContainsShortcut(trimmed)] : []
+                    return {
+                        results,
+                        count: results.length,
+                        searchQuery: remoteItems.searchQuery,
+                        queryChanged: remoteItems.queryChanged,
+                        first: remoteItems.first,
+                    }
+                }
                 const isSuggested = listGroupType === TaxonomicFilterGroupType.SuggestedFilters
                 const recentPrefix = isSuggested && !searchQuery ? (contextFilteredRecentItems || []).slice(0, 3) : []
                 const pinnedPrefix = isSuggested && !searchQuery ? (contextFilteredPinnedItems || []).slice(0, 3) : []

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -43,6 +43,7 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { useTaxonomicFilterContext } from '../headless/context'
 import { useGroupList } from '../hooks/useGroupList'
 import { TaxonomicDefinitionTypes, TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../types'
+import { COLLAPSED_TO_CONTAINS_ROW, urlContainsRowLabel } from '../utils/collapsedContainsRow'
 import { promoteMatchingBy } from '../utils/promoteProperties'
 import { MenuFilterHeader } from './Header'
 import { PreviewPane } from './PreviewPane'
@@ -75,15 +76,6 @@ const HIDDEN_FROM_CHIPS: ReadonlySet<TaxonomicFilterGroupType> = new Set([
     TaxonomicFilterGroupType.PinnedFilters,
     TaxonomicFilterGroupType.DataWarehouse,
     TaxonomicFilterGroupType.HogQLExpression,
-])
-
-/** Groups that feed the "all" surface but are collapsed to a single
- *  "URL contains <query>" suggestion rather than listing every matching value,
- *  and are not offered as a standalone chip/category. People filtering by URL
- *  overwhelmingly want a contains match, so one synthetic row (when any URL
- *  matches) beats a wall of exact URLs. */
-const COLLAPSED_TO_CONTAINS_ROW: ReadonlySet<TaxonomicFilterGroupType> = new Set([
-    TaxonomicFilterGroupType.PageviewUrls,
 ])
 
 /** How many recents and pinned each lead the default "All" surface, matching
@@ -347,7 +339,7 @@ export function MenuFilterCombobox({
             // `$current_url IContains <query>`.
             if (COLLAPSED_TO_CONTAINS_ROW.has(group.type)) {
                 if (trimmedQuery && items.length > 0) {
-                    const label = `URL contains "${trimmedQuery}"`
+                    const label = urlContainsRowLabel(trimmedQuery)
                     merged.push({
                         // `isContainsShortcut` tags this synthetic row so the commit
                         // telemetry can measure adoption of the contains shortcut vs

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1145,8 +1145,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         type: TaxonomicFilterGroupType.PageviewUrls,
                         endpoint: `api/environments/${teamId}/events/values/?key=$current_url&event_name=$pageview`,
                         searchAlias: 'value',
-                        getName: (option: SimpleOption) => option.name,
-                        getValue: (option: SimpleOption) => option.name,
+                        getName: (option: SimpleOption | QuickFilterItem) => option.name,
+                        // The collapsed "URL contains <query>" row is a QuickFilterItem whose
+                        // selection value is the typed query, so generic consumers reading the
+                        // committed value get the query (matching the rebuild menu), not the label.
+                        getValue: (option: SimpleOption | QuickFilterItem) =>
+                            isQuickFilterItem(option) ? option.filterValue : option.name,
                         getPopoverHeader: () => `Pageview URL`,
                         minSearchQueryLength: 3,
                         searchDescription: 'URLs seen on pageview events',

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1847,6 +1847,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         filterValue: item.filterValue,
                         propertyFilterType: item.propertyFilterType,
                         eventName: item.eventName,
+                        // Mirrors the rebuild menu's `wasUrlContainsShortcut` so contains-shortcut
+                        // adoption is comparable across arms, not muddied with keyword shortcuts.
+                        wasUrlContainsShortcut: item.isContainsShortcut === true,
                     }),
                 })
 

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -184,9 +184,10 @@ export interface TaxonomicFilterProps {
     /** Collapse URL-shaped groups (Pageview URLs) to a single `URL contains "<query>"`
      *  shortcut row instead of listing every matching URL — mirrors the rebuild menu.
      *  Selecting the row commits `$current_url IContains <query>` via a `QuickFilterItem`,
-     *  so hosts must handle `isQuickFilterItem(item)` in onChange (the property- and
-     *  universal-filter hosts do). Only the rebuild-eligible wrappers opt in, so the
-     *  paths picker keeps its full URL list. */
+     *  so a host must handle `isQuickFilterItem(item)` in onChange to honor the contains
+     *  operator. Only `TaxonomicPropertyFilter` (and the property/universal-filter hosts
+     *  behind it) opts in — that covers every current pageview-URL consumer — so the paths
+     *  picker keeps its full URL list. */
     collapseUrlsToContainsRow?: boolean
 }
 

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -39,6 +39,10 @@ export interface QuickFilterItem {
     propertyFilterType: PropertyFilterType.Event | PropertyFilterType.Person
     eventName?: string
     extraProperties?: (EventPropertyFilter | PersonPropertyFilter)[]
+    /** Set on the collapsed `URL contains "<query>"` row so commit telemetry can
+     *  measure contains-shortcut adoption, matching the rebuild menu's
+     *  `wasUrlContainsShortcut`. */
+    isContainsShortcut?: boolean
 }
 
 export function isQuickFilterItem(item: unknown): item is QuickFilterItem {

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -177,6 +177,13 @@ export interface TaxonomicFilterProps {
      *  - `TaxonomicPropertyFilter` hides the operator+value pair on rows whose group is key-only.
      *  See `SelectingKeyOnly` for the boolean-or-per-group-dict shape. */
     selectingKeyOnly?: SelectingKeyOnly
+    /** Collapse URL-shaped groups (Pageview URLs) to a single `URL contains "<query>"`
+     *  shortcut row instead of listing every matching URL — mirrors the rebuild menu.
+     *  Selecting the row commits `$current_url IContains <query>` via a `QuickFilterItem`,
+     *  so hosts must handle `isQuickFilterItem(item)` in onChange (the property- and
+     *  universal-filter hosts do). Only the rebuild-eligible wrappers opt in, so the
+     *  paths picker keeps its full URL list. */
+    collapseUrlsToContainsRow?: boolean
 }
 
 export interface DataWarehousePopoverField {

--- a/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
@@ -28,5 +28,6 @@ export function buildUrlContainsShortcut(query: string): QuickFilterItem {
         operator: PropertyOperator.IContains,
         propertyKey: '$current_url',
         propertyFilterType: PropertyFilterType.Event,
+        isContainsShortcut: true,
     }
 }

--- a/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
@@ -1,0 +1,32 @@
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { QuickFilterItem, TaxonomicFilterGroupType } from '../types'
+
+/** Groups that collapse to a single "URL contains <query>" suggestion instead of
+ *  listing every matching value, and are not offered as a standalone value picker.
+ *  People filtering by URL overwhelmingly want a contains match, so one synthetic
+ *  row (when any URL matches) beats a wall of exact URLs. Shared by the legacy
+ *  picker (`infiniteListLogic`) and the rebuild menu (`menu/Combobox`) so both arms
+ *  of the experiment collapse identically. */
+export const COLLAPSED_TO_CONTAINS_ROW: ReadonlySet<TaxonomicFilterGroupType> = new Set([
+    TaxonomicFilterGroupType.PageviewUrls,
+])
+
+export function urlContainsRowLabel(query: string): string {
+    return `URL contains "${query}"`
+}
+
+/** Synthetic row committed as `$current_url IContains <query>`. Returned as a
+ *  `QuickFilterItem` so it flows through the existing `isQuickFilterItem` handling
+ *  in the property- and universal-filter hosts, committing the same filter the
+ *  per-URL value picker used to — without listing every matching URL. */
+export function buildUrlContainsShortcut(query: string): QuickFilterItem {
+    return {
+        _type: 'quick_filter',
+        name: urlContainsRowLabel(query),
+        filterValue: query,
+        operator: PropertyOperator.IContains,
+        propertyKey: '$current_url',
+        propertyFilterType: PropertyFilterType.Event,
+    }
+}

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -165,7 +165,6 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     suggestedFiltersLabel={suggestedFiltersLabel}
                     enableKeywordShortcuts={enableKeywordShortcuts}
                     selectingKeyOnly={selectingKeyOnly}
-                    collapseUrlsToContainsRow
                     width={width}
                 />
             }

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -165,6 +165,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     suggestedFiltersLabel={suggestedFiltersLabel}
                     enableKeywordShortcuts={enableKeywordShortcuts}
                     selectingKeyOnly={selectingKeyOnly}
+                    collapseUrlsToContainsRow
                     width={width}
                 />
             }


### PR DESCRIPTION
## Problem

The rebuild menu (#62465) collapses **Pageview URLs** into a single `URL contains "<query>"` shortcut row instead of listing every matching URL — people filtering by URL almost always want a contains match. But that change only landed in the rebuild menu (`menu/Combobox.tsx`, behind `TAXONOMIC_FILTER_MENU_REBUILD`). The legacy `control` and `pill` arms (behind `TAXONOMIC_FILTER_CATEGORY_DROPDOWN`) still showed the full wall of URLs, so the two experiment arms diverged and users on the pill arm still saw the old Pageview URLs list.

This is the "mirror across variants" trap the `modifying-taxonomic-filter` skill warns about: the rebuild reimplements the legacy data layer, there's no test enforcing parity, so a change to one arm silently leaves the other behind.

## Changes

Mirror the collapse into the legacy picker (shared by both `control` and `pill`):

- **New shared util** `utils/collapsedContainsRow.ts` holds the `COLLAPSED_TO_CONTAINS_ROW` set, the `URL contains "<query>"` label, and a `QuickFilterItem` builder. The rebuild `Combobox` now imports the set + label from here instead of defining its own, so both arms say it once.
- **`infiniteListLogic`** collapses the Pageview URLs list to a single `URL contains "<query>"` row once the remote fetch for the current query returns at least one match. The row is a `QuickFilterItem` committing `$current_url IContains <query>` — both selection hosts (`taxonomicPropertyFilterLogic`, `universalFiltersLogic`) already route `isQuickFilterItem` through to that filter, so no host changes were needed.
- **Opt-in, scope-matched to the rebuild.** A new `collapseUrlsToContainsRow` prop is set only by the two rebuild-eligible wrappers — `TaxonomicPopover` and `TaxonomicPropertyFilter`. Paths renders a bare `<TaxonomicFilter>` (and never reaches the rebuild), so it keeps its full URL list for start/end/exclusion point picking — exactly matching where the rebuild collapse already applies.
- The Pageview URLs **category stays navigable** in the legacy tab/pill UI (it's the only entry point to the shortcut, since legacy has no merged "all" surface) — but its contents are now the single contains row rather than the URL list.

Architectural note: the legacy picker is tab-based with no merged "all" surface, so the contains row lives inside the (still-present) Pageview URLs category rather than appearing in a cross-category list the way the rebuild surfaces it. The user-facing outcome — one contains shortcut instead of a wall of URLs — is the same across all three variants.

## How did you test this code?

I'm an agent (PostHog Code). I ran only automated tests — no manual UI testing.

- Added RTL coverage in `TaxonomicFilter.test.tsx` (`collapseUrlsToContainsRow`): collapses matching URLs to one shortcut row; commits `$current_url IContains <query>` on select; lists individual URLs when the prop is omitted; shows no row when nothing matches.
- Updated two `PropertyFilters.component.test.tsx` recents tests that asserted the old per-URL value — they now assert the contains shortcut (the query).
- `hogli test` green for `TaxonomicFilter/`, `PropertyFilters/`, `UniversalFilters/`, `TaxonomicPopover/` (618 tests) and the `paths`/`paths-v2` logic tests (unchanged behavior).
- `pnpm format` clean; `tsc --noEmit` reports no errors in the changed files (after regenerating kea typegen locally).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul D'Ambra noticed the Pageview URLs group still appearing in the pill arm and asked to mirror the rebuild's collapse into the legacy variants.

Built with PostHog Code. Key decisions:
- Traced the collapse to `menu/Combobox.tsx` (rebuild-only) and confirmed via the `modifying-taxonomic-filter` skill that legacy and rebuild are parallel implementations needing a mirrored change.
- Mapped every `PageviewUrls` consumer to determine rebuild-eligibility, which is why the collapse is an opt-in prop scoped to the two wrappers rather than an unconditional change in `infiniteListLogic` (that would have broken the paths URL picker).
- Chose `QuickFilterItem` for the synthetic row (clean display label + value separation, already handled by both hosts) and made the Pageview URLs `getValue` QuickFilterItem-aware so generic consumers receive the query as the committed value, matching the rebuild.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
