### PR TITLE
feat(error-tracking): add MCP tools for ingestion rate limit settings

### DIFF
--- a/products/error_tracking/backend/presentation/views/settings.py
+++ b/products/error_tracking/backend/presentation/views/settings.py
@@ -46,6 +46,8 @@ class ErrorTrackingSettingsSerializer(serializers.ModelSerializer):
 
 class ErrorTrackingSettingsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "error_tracking"
+    scope_object_read_actions = ["retrieve_settings"]
+    scope_object_write_actions = ["update_settings"]
 
     def _get_or_create_settings(self) -> ErrorTrackingSettings:
         settings, _ = ErrorTrackingSettings.objects.get_or_create(team=self.team)

--- a/products/error_tracking/backend/tests/api/test_settings.py
+++ b/products/error_tracking/backend/tests/api/test_settings.py
@@ -43,11 +43,12 @@ class TestErrorTrackingSettingsAPI(APIBaseTest):
         self.assertEqual(settings.project_rate_limit_bucket_size_minutes, 60)
 
     def test_update_settings_only_changes_provided_fields(self):
-        self.client.patch(
+        setup_response = self.client.patch(
             f"{self._base_url()}/update_settings/",
             {"project_rate_limit_value": 2000, "per_issue_rate_limit_value": 50},
             format="json",
         )
+        self.assertEqual(setup_response.status_code, status.HTTP_200_OK)
         response = self.client.patch(
             f"{self._base_url()}/update_settings/",
             {"per_issue_rate_limit_value": 75},
@@ -58,11 +59,12 @@ class TestErrorTrackingSettingsAPI(APIBaseTest):
         self.assertEqual(response.json()["project_rate_limit_value"], 2000)
 
     def test_update_settings_clears_limit_with_null(self):
-        self.client.patch(
+        setup_response = self.client.patch(
             f"{self._base_url()}/update_settings/",
             {"project_rate_limit_value": 1000},
             format="json",
         )
+        self.assertEqual(setup_response.status_code, status.HTTP_200_OK)
         response = self.client.patch(
             f"{self._base_url()}/update_settings/",
             {"project_rate_limit_value": None},

--- a/products/error_tracking/backend/tests/api/test_settings.py
+++ b/products/error_tracking/backend/tests/api/test_settings.py
@@ -1,0 +1,106 @@
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+from products.error_tracking.backend.models import ErrorTrackingSettings
+
+
+class TestErrorTrackingSettingsAPI(APIBaseTest):
+    def _base_url(self) -> str:
+        return f"/api/projects/{self.team.id}/error_tracking/settings"
+
+    def _personal_api_key(self, scopes: list[str]) -> str:
+        value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="test",
+            user=self.user,
+            secure_value=hash_key_value(value),
+            scopes=scopes,
+        )
+        return value
+
+    def test_retrieve_settings_with_session_auth(self):
+        response = self.client.get(f"{self._base_url()}/retrieve_settings/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("project_rate_limit_value", response.json())
+        self.assertIn("per_issue_rate_limit_value", response.json())
+
+    def test_update_settings_with_session_auth(self):
+        response = self.client.patch(
+            f"{self._base_url()}/update_settings/",
+            {"project_rate_limit_value": 5000, "project_rate_limit_bucket_size_minutes": 60},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["project_rate_limit_value"], 5000)
+
+        settings = ErrorTrackingSettings.objects.get(team=self.team)
+        self.assertEqual(settings.project_rate_limit_value, 5000)
+        self.assertEqual(settings.project_rate_limit_bucket_size_minutes, 60)
+
+    def test_update_settings_only_changes_provided_fields(self):
+        self.client.patch(
+            f"{self._base_url()}/update_settings/",
+            {"project_rate_limit_value": 2000, "per_issue_rate_limit_value": 50},
+            format="json",
+        )
+        response = self.client.patch(
+            f"{self._base_url()}/update_settings/",
+            {"per_issue_rate_limit_value": 75},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["per_issue_rate_limit_value"], 75)
+        self.assertEqual(response.json()["project_rate_limit_value"], 2000)
+
+    def test_update_settings_clears_limit_with_null(self):
+        self.client.patch(
+            f"{self._base_url()}/update_settings/",
+            {"project_rate_limit_value": 1000},
+            format="json",
+        )
+        response = self.client.patch(
+            f"{self._base_url()}/update_settings/",
+            {"project_rate_limit_value": None},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()["project_rate_limit_value"])
+
+    @parameterized.expand(
+        [
+            ("read_scope", ["error_tracking:read"], status.HTTP_200_OK),
+            ("write_scope_satisfies_read", ["error_tracking:write"], status.HTTP_200_OK),
+            ("wrong_scope", ["insight:read"], status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_retrieve_settings_personal_api_key_scopes(self, _name, scopes, expected_status):
+        value = self._personal_api_key(scopes)
+        self.client.logout()
+        response = self.client.get(
+            f"{self._base_url()}/retrieve_settings/",
+            HTTP_AUTHORIZATION=f"Bearer {value}",
+        )
+        self.assertEqual(response.status_code, expected_status)
+
+    @parameterized.expand(
+        [
+            ("write_scope", ["error_tracking:write"], status.HTTP_200_OK),
+            ("read_scope_insufficient", ["error_tracking:read"], status.HTTP_403_FORBIDDEN),
+            ("wrong_scope", ["insight:write"], status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_update_settings_personal_api_key_scopes(self, _name, scopes, expected_status):
+        value = self._personal_api_key(scopes)
+        self.client.logout()
+        response = self.client.patch(
+            f"{self._base_url()}/update_settings/",
+            {"per_issue_rate_limit_value": 100},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {value}",
+        )
+        self.assertEqual(response.status_code, expected_status)

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -314,8 +314,8 @@ tools:
             (`project_rate_limit_value` events per `project_rate_limit_bucket_size_minutes`) and the per-issue rate
             limit (`per_issue_rate_limit_value` events per `per_issue_rate_limit_bucket_size_minutes`). Set a
             `*_rate_limit_value` to null to remove that limit. WARNING: exception events above a rate limit are dropped
-            at ingestion and cannot be recovered. Lowering a limit silently discards volume — confirm the threshold
-            with the user before reducing it.
+            at ingestion and cannot be recovered. Lowering a limit silently discards volume — confirm the threshold with
+            the user before reducing it.
     error-tracking-spike-detection-config-list:
         operation: error_tracking_spike_detection_config_list
         enabled: false

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -283,12 +283,39 @@ tools:
     error-tracking-releases-update:
         operation: error_tracking_releases_update
         enabled: false
-    error-tracking-settings-retrieve-settings-retrieve:
+    error-tracking-settings-get:
         operation: error_tracking_settings_retrieve_settings_retrieve
-        enabled: false
-    error-tracking-settings-update-settings-partial-update:
+        enabled: true
+        scopes:
+            - error_tracking:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get error tracking settings
+        description: >
+            Get the error tracking ingestion settings for the current project. Returns the project-wide and per-issue
+            exception rate limits, where each `*_rate_limit_value` is the maximum events ingested per bucket and each
+            `*_rate_limit_bucket_size_minutes` is the bucket window. A null `*_rate_limit_value` means no limit is set.
+            Read these before updating so you can preserve the fields you don't intend to change.
+    error-tracking-settings-update:
         operation: error_tracking_settings_update_settings_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - error_tracking:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Update error tracking settings
+        description: >
+            Update the error tracking ingestion settings for the current project. Only the fields you include are
+            applied; omitted fields keep their existing values. Use this to set the project-wide rate limit
+            (`project_rate_limit_value` events per `project_rate_limit_bucket_size_minutes`) and the per-issue rate
+            limit (`per_issue_rate_limit_value` events per `per_issue_rate_limit_bucket_size_minutes`). Set a
+            `*_rate_limit_value` to null to remove that limit. WARNING: exception events above a rate limit are dropped
+            at ingestion and cannot be recovered. Lowering a limit silently discards volume — confirm the threshold
+            with the user before reducing it.
     error-tracking-spike-detection-config-list:
         operation: error_tracking_spike_detection_config_list
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2442,6 +2442,34 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-settings-get": {
+        "description": "Get the error tracking ingestion settings for the current project. Returns the project-wide and per-issue exception rate limits, where each `*_rate_limit_value` is the maximum events ingested per bucket and each `*_rate_limit_bucket_size_minutes` is the bucket window. A null `*_rate_limit_value` means no limit is set. Read these before updating so you can preserve the fields you don't intend to change.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Get error tracking settings",
+        "title": "Get error tracking settings",
+        "required_scopes": ["error_tracking:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "error-tracking-settings-update": {
+        "description": "Update the error tracking ingestion settings for the current project. Only the fields you include are applied; omitted fields keep their existing values. Use this to set the project-wide rate limit (`project_rate_limit_value` events per `project_rate_limit_bucket_size_minutes`) and the per-issue rate limit (`per_issue_rate_limit_value` events per `per_issue_rate_limit_bucket_size_minutes`). Set a `*_rate_limit_value` to null to remove that limit. WARNING: exception events above a rate limit are dropped at ingestion and cannot be recovered. Lowering a limit silently discards volume — confirm the threshold with the user before reducing it.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Update error tracking settings",
+        "title": "Update error tracking settings",
+        "required_scopes": ["error_tracking:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-suppression-rules-create": {
         "description": "Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted. Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and cause data loss that is hard to detect after the fact. If unsure, set `sampling_rate` below `1.0` so only a fraction of matches are dropped (e.g. `0.5` drops half) rather than all of them. Confirm with the user before creating any rule that could match more than one distinct error.",
         "category": "Error tracking",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2472,6 +2472,34 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-settings-get": {
+        "description": "Get the error tracking ingestion settings for the current project. Returns the project-wide and per-issue exception rate limits, where each `*_rate_limit_value` is the maximum events ingested per bucket and each `*_rate_limit_bucket_size_minutes` is the bucket window. A null `*_rate_limit_value` means no limit is set. Read these before updating so you can preserve the fields you don't intend to change.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Get error tracking settings",
+        "title": "Get error tracking settings",
+        "required_scopes": ["error_tracking:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "error-tracking-settings-update": {
+        "description": "Update the error tracking ingestion settings for the current project. Only the fields you include are applied; omitted fields keep their existing values. Use this to set the project-wide rate limit (`project_rate_limit_value` events per `project_rate_limit_bucket_size_minutes`) and the per-issue rate limit (`per_issue_rate_limit_value` events per `per_issue_rate_limit_bucket_size_minutes`). Set a `*_rate_limit_value` to null to remove that limit. WARNING: exception events above a rate limit are dropped at ingestion and cannot be recovered. Lowering a limit silently discards volume — confirm the threshold with the user before reducing it.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Update error tracking settings",
+        "title": "Update error tracking settings",
+        "required_scopes": ["error_tracking:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-suppression-rules-create": {
         "description": "Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted. Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and cause data loss that is hard to detect after the fact. If unsure, set `sampling_rate` below `1.0` so only a fraction of matches are dropped (e.g. `0.5` drops half) rather than all of them. Confirm with the user before creating any rule that could match more than one distinct error.",
         "category": "Error tracking",

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 17 enabled ops
+ * PostHog API - MCP 19 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -3494,6 +3494,49 @@ export const ErrorTrackingQueryIssuesListCreateBody = /* @__PURE__ */ zod.object
         .max(errorTrackingQueryIssuesListCreateBodyFilePathMax)
         .optional()
         .describe('Search stack-frame source/file path text.'),
+})
+
+export const ErrorTrackingSettingsRetrieveSettingsRetrieveParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const ErrorTrackingSettingsUpdateSettingsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const ErrorTrackingSettingsUpdateSettingsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    project_rate_limit_value: zod
+        .number()
+        .min(1)
+        .nullish()
+        .describe(
+            'Maximum number of exception events ingested per bucket for the entire project. Null removes the limit.'
+        ),
+    project_rate_limit_bucket_size_minutes: zod
+        .number()
+        .min(1)
+        .nullish()
+        .describe('Bucket window over which the project-wide rate limit applies, in minutes.'),
+    per_issue_rate_limit_value: zod
+        .number()
+        .min(1)
+        .nullish()
+        .describe(
+            'Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit.'
+        ),
+    per_issue_rate_limit_bucket_size_minutes: zod
+        .number()
+        .min(1)
+        .nullish()
+        .describe('Bucket window over which the per-issue rate limit applies, in minutes.'),
 })
 
 export const ErrorTrackingSuppressionRulesListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -17,6 +17,7 @@ import {
     ErrorTrackingQueryIssueCreateBody,
     ErrorTrackingQueryIssueEventsCreateBody,
     ErrorTrackingQueryIssuesListCreateBody,
+    ErrorTrackingSettingsUpdateSettingsPartialUpdateBody,
     ErrorTrackingSuppressionRulesCreateBody,
     ErrorTrackingSuppressionRulesListQueryParams,
     ErrorTrackingSuppressionRulesUpdateBody,
@@ -223,6 +224,57 @@ const errorTrackingIssuesSplitCreate = (): ToolBase<
         const result = await context.api.request<Schemas.ErrorTrackingIssueSplitResponse>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/issues/${encodeURIComponent(String(params.id))}/split/`,
+            body,
+        })
+        return result
+    },
+})
+
+const ErrorTrackingSettingsGetSchema = z.object({})
+
+const errorTrackingSettingsGet = (): ToolBase<
+    typeof ErrorTrackingSettingsGetSchema,
+    Schemas.ErrorTrackingSettings
+> => ({
+    name: 'error-tracking-settings-get',
+    schema: ErrorTrackingSettingsGetSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingSettingsGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ErrorTrackingSettings>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/settings/retrieve_settings/`,
+        })
+        return result
+    },
+})
+
+const ErrorTrackingSettingsUpdateSchema = ErrorTrackingSettingsUpdateSettingsPartialUpdateBody
+
+const errorTrackingSettingsUpdate = (): ToolBase<
+    typeof ErrorTrackingSettingsUpdateSchema,
+    Schemas.ErrorTrackingSettings
+> => ({
+    name: 'error-tracking-settings-update',
+    schema: ErrorTrackingSettingsUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingSettingsUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.project_rate_limit_value !== undefined) {
+            body['project_rate_limit_value'] = params.project_rate_limit_value
+        }
+        if (params.project_rate_limit_bucket_size_minutes !== undefined) {
+            body['project_rate_limit_bucket_size_minutes'] = params.project_rate_limit_bucket_size_minutes
+        }
+        if (params.per_issue_rate_limit_value !== undefined) {
+            body['per_issue_rate_limit_value'] = params.per_issue_rate_limit_value
+        }
+        if (params.per_issue_rate_limit_bucket_size_minutes !== undefined) {
+            body['per_issue_rate_limit_bucket_size_minutes'] = params.per_issue_rate_limit_bucket_size_minutes
+        }
+        const result = await context.api.request<Schemas.ErrorTrackingSettings>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/settings/update_settings/`,
             body,
         })
         return result
@@ -591,6 +643,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-issues-merge-create': errorTrackingIssuesMergeCreate,
     'error-tracking-issues-partial-update': errorTrackingIssuesPartialUpdate,
     'error-tracking-issues-split-create': errorTrackingIssuesSplitCreate,
+    'error-tracking-settings-get': errorTrackingSettingsGet,
+    'error-tracking-settings-update': errorTrackingSettingsUpdate,
     'error-tracking-suppression-rules-create': errorTrackingSuppressionRulesCreate,
     'error-tracking-suppression-rules-list': errorTrackingSuppressionRulesList,
     'error-tracking-suppression-rules-update': errorTrackingSuppressionRulesUpdate,

--- a/services/mcp/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/tests/tools/errorTracking.integration.test.ts
@@ -384,6 +384,82 @@ describe('Error Tracking', { concurrent: false }, () => {
         })
     })
 
+    describe('settings tools', () => {
+        const settingsGetTool = GENERATED_TOOLS['error-tracking-settings-get']!()
+        const settingsUpdateTool = GENERATED_TOOLS['error-tracking-settings-update']!()
+
+        type ErrorTrackingSettingsResult = {
+            project_rate_limit_value?: number | null
+            project_rate_limit_bucket_size_minutes?: number | null
+            per_issue_rate_limit_value?: number | null
+            per_issue_rate_limit_bucket_size_minutes?: number | null
+        }
+
+        // Settings are a single per-team row, so snapshot the originals and restore them after each test
+        // to keep the shared project's rate limits untouched.
+        let originalSettings: ErrorTrackingSettingsResult
+
+        beforeAll(async () => {
+            originalSettings = (await settingsGetTool.handler(context, {})) as ErrorTrackingSettingsResult
+        })
+
+        afterEach(async () => {
+            await settingsUpdateTool.handler(context, {
+                project_rate_limit_value: originalSettings.project_rate_limit_value ?? null,
+                project_rate_limit_bucket_size_minutes: originalSettings.project_rate_limit_bucket_size_minutes ?? null,
+                per_issue_rate_limit_value: originalSettings.per_issue_rate_limit_value ?? null,
+                per_issue_rate_limit_bucket_size_minutes:
+                    originalSettings.per_issue_rate_limit_bucket_size_minutes ?? null,
+            })
+        })
+
+        it('should get the current settings', async () => {
+            const result = (await settingsGetTool.handler(context, {})) as ErrorTrackingSettingsResult
+
+            expect(result).toBeTruthy()
+            expect('project_rate_limit_value' in result).toBe(true)
+            expect('per_issue_rate_limit_value' in result).toBe(true)
+        })
+
+        it('should update the project and per-issue rate limits', async () => {
+            const result = (await settingsUpdateTool.handler(context, {
+                project_rate_limit_value: 5000,
+                project_rate_limit_bucket_size_minutes: 60,
+                per_issue_rate_limit_value: 100,
+                per_issue_rate_limit_bucket_size_minutes: 15,
+            })) as ErrorTrackingSettingsResult
+
+            expect(result.project_rate_limit_value).toBe(5000)
+            expect(result.project_rate_limit_bucket_size_minutes).toBe(60)
+            expect(result.per_issue_rate_limit_value).toBe(100)
+            expect(result.per_issue_rate_limit_bucket_size_minutes).toBe(15)
+        })
+
+        it('should clear a rate limit when set to null', async () => {
+            await settingsUpdateTool.handler(context, { project_rate_limit_value: 1000 })
+
+            const result = (await settingsUpdateTool.handler(context, {
+                project_rate_limit_value: null,
+            })) as ErrorTrackingSettingsResult
+
+            expect(result.project_rate_limit_value).toBeNull()
+        })
+
+        it('should only update the fields provided', async () => {
+            await settingsUpdateTool.handler(context, {
+                project_rate_limit_value: 2000,
+                per_issue_rate_limit_value: 50,
+            })
+
+            const result = (await settingsUpdateTool.handler(context, {
+                per_issue_rate_limit_value: 75,
+            })) as ErrorTrackingSettingsResult
+
+            expect(result.per_issue_rate_limit_value).toBe(75)
+            expect(result.project_rate_limit_value).toBe(2000)
+        })
+    })
+
     describe('symbol-sets list tool', () => {
         const symbolSetsListTool = GENERATED_TOOLS['error-tracking-symbol-sets-list']!()
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-settings-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-settings-get.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {},
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-settings-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-settings-update.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "per_issue_rate_limit_bucket_size_minutes": {
+            "anyOf": [
+                {
+                    "minimum": 1,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Bucket window over which the per-issue rate limit applies, in minutes."
+        },
+        "per_issue_rate_limit_value": {
+            "anyOf": [
+                {
+                    "minimum": 1,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Maximum number of exception events ingested per bucket for each individual issue. Null removes the limit."
+        },
+        "project_rate_limit_bucket_size_minutes": {
+            "anyOf": [
+                {
+                    "minimum": 1,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Bucket window over which the project-wide rate limit applies, in minutes."
+        },
+        "project_rate_limit_value": {
+            "anyOf": [
+                {
+                    "minimum": 1,
+                    "type": "number"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Maximum number of exception events ingested per bucket for the entire project. Null removes the limit."
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
<img width="1153" height="779" alt="image" src="https://github.com/user-attachments/assets/46b20254-70e0-4de7-bed9-e9bbc9479fc2" />

## Problem

The error tracking ingestion rate limits (project-wide and per-issue exception caps) could only be changed through the app UI. There was no MCP surface to read or update them, and the settings viewset actions weren't reachable via personal API key / scoped access.

## Changes

- Add `error-tracking-settings-get` and `error-tracking-settings-update` MCP tools covering the project-wide and per-issue exception rate limits (value + bucket size).
- Allow scoped access to the settings viewset by declaring `scope_object_read_actions` / `scope_object_write_actions` for `retrieve_settings` / `update_settings`.
- Regenerated MCP tool definitions, schema snapshots, and integration tests.

## How did you test this code?

Authored by an agent (Claude Code). Did not run the automated suites locally — they're included (`errorTracking.integration.test.ts`, `test_settings.py`) for CI.
Exercised the new tools against the local PostHog MCP server: `get` returned current settings, `update` applied 300 events/60min project-wide + 100 events/60min per-issue and echoed the values back.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The user directed the work; the backend scope change was made by the user after the MCP tools initially returned 403 (the settings actions weren't scope-accessible). Agent regenerated the MCP codegen artifacts and verified the read/write path end to end against the local MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Exposes error-tracking ingestion rate limit settings via two new MCP tools (`error-tracking-settings-get` and `error-tracking-settings-update`), adds scoped personal API key access to the settings viewset, and includes backend + MCP integration tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4501652cfb92d195e410fdc2258334874677f045.</sup>
<!-- /MENDRAL_SUMMARY -->