### PR TITLE
fix(navigation): stop mobile nav toggle from covering account menu

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2360,6 +2360,10 @@ snapshots:
         hash: v1.k794b7964.41dc6774433e2a35b93d9bd50c09a063a61574d8c724b08fb35c158ce53c2c39.6_nuqiXEwUoBq8YSXUWjPeb9d4NNRHRbh9NyiFv2f8s
     layout-impersonation-reason-modal--upgrade-to-read-write--light:
         hash: v1.k794b7964.7686131e8d04113362f587050067e1daa76329becb2e33097cebc43792467919.B37QbmEEFysXtGrVVX0H_WUofFwz8yAI0cJah0GEK9s
+    layout-mobile-navigation--expanded-drawer--dark:
+        hash: v1.k794b7964.642c8c57674f43b77a1bbea2fb1d1d8b75a46b657c66a1d69f5f45a7ef1fb4cd.gkWb2ykP-tYDXp79kwOAJRr6RneDcE7QXmG4VCB5Aik
+    layout-mobile-navigation--expanded-drawer--light:
+        hash: v1.k794b7964.bb2c3b82af3ea1574dcabcbc18ec963c800894e8d8259d363ebcf7c48f3c8398.EZcVnoRQhjV50i4lwpifaFTK1YSIuAate9nClAvqU98
     layout-project-tree-custom-products--all-products--dark:
         hash: v1.k794b7964.29bfbacf987ea6bfd40ea4164bfdfe25c7c954299b44d2bcb37805c96b789573.7zgTNIGYdt6mlDI5-u5tyYd-jVwK1LugReb-My0wK-8
     layout-project-tree-custom-products--all-products--light:

--- a/frontend/src/layout/panel-layout/ai-first/MobileNav.stories.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/MobileNav.stories.tsx
@@ -1,0 +1,64 @@
+import { Meta, StoryObj, type Decorator } from '@storybook/react'
+import { useActions } from 'kea'
+import { useEffect } from 'react'
+
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
+import { mswDecorator } from '~/mocks/browser'
+
+/**
+ * On mobile (viewport < 992px) the project nav becomes a slide-in drawer toggled by a
+ * floating button pinned to the top-left. These stories render the full `App` at a phone
+ * width with the drawer expanded so we capture the nav header: the account menu trigger
+ * has to clear the floating toggle, which previously overlapped it and swallowed taps on
+ * the org logo.
+ */
+const withExpandedMobileNav: Decorator = (Story) => {
+    const { showLayoutNavBar } = useActions(panelLayoutLogic)
+    // The initial urlToAction closes the drawer on mobile, so open it after mount to make
+    // the expanded state stick for the snapshot.
+    useEffect(() => {
+        showLayoutNavBar(true)
+    }, [showLayoutNavBar])
+    return <Story />
+}
+
+const meta: Meta = {
+    component: App,
+    title: 'Layout/Mobile Navigation',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        pageUrl: urls.dashboards(),
+        testOptions: {
+            includeNavigationInSnapshot: true,
+            viewport: { width: 414, height: 896 },
+        },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/dashboard_templates/': {},
+                '/api/projects/:id/integrations': { results: [] },
+                '/api/organizations/:organization_id/pipeline_destinations/': { results: [] },
+                '/api/projects/:id/pipeline_destination_configs/': { results: [] },
+                '/api/projects/:id/batch_exports/': { results: [] },
+                '/api/projects/:id/surveys/': { results: [] },
+                '/api/projects/:id/surveys/responses_count/': { results: [] },
+                '/api/environments/:team_id/exports/': { results: [] },
+                '/api/environments/:team_id/events': { results: [] },
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': {},
+            },
+        }),
+        withExpandedMobileNav,
+    ],
+}
+export default meta
+
+type Story = StoryObj
+
+export const ExpandedDrawer: Story = {}

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -172,6 +172,9 @@ export function Nav(): JSX.Element {
                     <div
                         className={cn('flex gap-1 rounded-md w-full px-2 pt-2 pb-1', {
                             'flex-col items-center pt-2 pb-0': isLayoutNavCollapsed,
+                            // On mobile the fixed open/close toggle sits at top-1 left-1 and overlaps
+                            // the account menu trigger — indent the row so the toggle gets its own gutter.
+                            'pl-10': isMobileLayout,
                         })}
                     >
                         <NewAccountMenu isLayoutNavCollapsed={isLayoutNavCollapsed} />

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -172,8 +172,10 @@ export function Nav(): JSX.Element {
                     <div
                         className={cn('flex gap-1 rounded-md w-full px-2 pt-2 pb-1', {
                             'flex-col items-center pt-2 pb-0': isLayoutNavCollapsed,
-                            // On mobile the fixed open/close toggle sits at top-1 left-1 and overlaps
-                            // the account menu trigger — indent the row so the toggle gets its own gutter.
+                            // On mobile the fixed open/close toggle (PanelLayout.tsx, `fixed top-1 left-1`,
+                            // a default-size iconOnly button) overlaps the account menu trigger. Indent the
+                            // row past it so the toggle gets its own gutter — keep pl-10 ≥ the toggle's left
+                            // offset + width if either changes.
                             'pl-10': isMobileLayout,
                         })}
                     >


### PR DESCRIPTION
## Problem

On mobile, expanding the hamburger menu and tapping the account/org menu often does nothing — the nav just closes again. A user reported being unable to click their account from the expanded hamburger menu.

The root cause: the fixed open/close toggle button (`fixed top-1 left-1`, 30px wide → spans ~4–34px) sits directly on top of the left edge of the account menu trigger, which begins ~8px from the nav's left edge. Tapping the org logo/avatar hits the toggle instead, collapsing the nav.

## Changes

Indent the nav header's top row on mobile (`pl-10`) so the floating toggle button gets its own left gutter and no longer overlaps the account menu trigger or its logo. Desktop layout is unchanged.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not run manual testing — the frontend lint/format toolchain wasn't available in this environment. The change is a single conditional Tailwind class scoped to `isMobileLayout`; the geometry was verified against the toggle button size (30px icon-only at `top-1 left-1`), `--scene-layout-header-height` (40px), and the account trigger's starting offset.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Diagnosed by tracing the mobile nav stack in `PanelLayout.tsx` (the floating toggle at `fixed top-1 left-1 z-760`) and `ai-first/Nav.tsx` (the account menu trigger as the first header element). Considered moving the toggle to the nav's top-right, but both header corners hold interactive controls (account menu left, search right), so reserving a left gutter via header indent on mobile was the least disruptive fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781348031017459?thread_ts=1781348031.017459&cid=C0ACRAMJUAG)*
