### PR TITLE
fix(max): keep homepage AI input text from overlapping buttons

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -114,7 +114,8 @@ function IdleInput(): JSX.Element {
                             }
                         }}
                         autoComplete="off"
-                        className="w-full px-1 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
+                        // pr reserves space for the absolutely-positioned "Tab to search" + arrow buttons so long text doesn't run under them
+                        className="w-full pl-1 pr-32 py-1 text-sm focus:outline-none border-transparent resize-none bg-transparent"
                         autoFocus
                     />
                     <div className="flex items-end shrink-0 absolute right-[0.5rem] bottom-[0.2rem]">


### PR DESCRIPTION
## Problem

When typing a longer prompt in the AI chat input on the home screen, the entered text overlapped the "Tab to search" hint and arrow submit buttons in the bottom-right corner, making both the text and buttons hard to read/click.

**Why:** Reported from a Slack thread — the home-screen composer becomes unusable for anything longer than a short phrase.

## Changes

The idle composer textarea was full-width with only `px-1` padding, while the "Tab to search" + arrow buttons sit `absolute` over its bottom-right. Reserve right padding (`pr-32`) on the textarea so long input wraps before the button cluster, matching the `pr-12`/`pr-20` approach already used by the in-thread `QuestionInput`.

Single-line change in `HomepageInput.tsx`.

## How did you test this code?

I'm an agent. I did not run the app or manual UI testing. The change is a Tailwind padding adjustment mirroring an existing, shipped pattern in `QuestionInput`. A reviewer should eyeball the home-screen composer with a long single-line prompt (and with the hands-free mic button visible) to confirm clearance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Diagnosed the overlap as absolutely-positioned buttons over a full-width textarea with insufficient right padding; chose the minimal fix (reserve right padding) over restructuring the buttons into normal flow, consistent with the existing `QuestionInput` composer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1781357592700209?thread_ts=1781357592.700209&cid=C0ACRAMJUAG)*
