### PR TITLE
fix(persons): guard non-string url search before trimming

### DIFF
--- a/frontend/src/scenes/persons/PersonsScene.tsx
+++ b/frontend/src/scenes/persons/PersonsScene.tsx
@@ -47,7 +47,8 @@ export function PersonsScene(): JSX.Element {
 
     // A UUID-shaped search that returns nothing is often a session ID typed into the wrong field.
     // Session IDs aren't part of the persons query, so point the user to where they are searchable.
-    const searchTerm = (query.source as ActorsQuery | undefined)?.search?.trim()
+    const rawSearch: unknown = (query.source as Partial<ActorsQuery> | undefined)?.search
+    const searchTerm = typeof rawSearch === 'string' ? rawSearch.trim() : undefined
     const searchLooksLikeSessionId = !!searchTerm && isUUIDLike(searchTerm)
 
     useOnMountEffect(() => {


### PR DESCRIPTION
## Problem

When a Persons URL restores a malformed or stale `q` object whose `source.search` is not a string, the page crashes before the table can render. `personsSceneLogic` only verifies that `q` is an object before storing it, so a shared or crafted URL could throw instead of falling back to the normal empty/error state.

This was introduced in #61240, where the session-ID hint added `(query.source as ActorsQuery | undefined)?.search?.trim()`. The cast tells TypeScript `search` is a string, so `.trim()` runs on whatever arbitrary value was restored and throws.

## Changes

Read `search` as `unknown` and only trim it when `typeof rawSearch === 'string'`, otherwise fall back to `undefined`. `searchTerm` keeps its `string | undefined` type so the downstream `searchLooksLikeSessionId` check and `urls.replaySingle(searchTerm!)` link are unaffected.

## How did you test this code?

I'm an agent. This is a small, type-driven guard — I verified the change keeps `searchTerm` typed as `string | undefined` and that all downstream usages still hold. I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8) in response to a code-review finding on #61240. The finding flagged that the `ActorsQuery` cast bypassed type safety on restored URL state; the fix narrows the value at runtime rather than trusting the cast.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
