### PR TITLE
feat(taxonomic-filter): open picker on All and lead with the contains shortcut

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1176,6 +1176,20 @@ describe('TaxonomicFilter', () => {
         })
     })
 
+    it('reopens on the selected category when no Suggested-filters surface is present (control)', async () => {
+        // Guards the activeTab fallback: hosts without a Suggested filters ("All") surface
+        // (control variant, or any picker that doesn't inject it) must still reopen on the
+        // selected item's own category rather than an absent All tab.
+        renderFilter({
+            groupType: TaxonomicFilterGroupType.Events,
+            value: '$pageview',
+            taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions],
+        })
+
+        await waitFor(() => expect(screen.getByTestId('taxonomic-tab-events')).toBeInTheDocument())
+        expectActiveTab('taxonomic-tab-events', 'taxonomic-tab-actions')
+    })
+
     // Spec for the insight series picker in the pill variant: searching a term that matches
     // pageview URLs should make ONE "url contains <query>" shortcut the first row of the
     // aggregated Suggested filters ("All") tab — ahead of raw URL/event rows. Fails today

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1206,6 +1206,25 @@ describe('TaxonomicFilter', () => {
             unmountFeatureFlagLogic = null
         })
 
+        it('reopens on the Data warehouse tab (its own picker), not All, for a data-warehouse selection', async () => {
+            renderFilter({
+                groupType: TaxonomicFilterGroupType.DataWarehouse,
+                value: 'some_table',
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.SuggestedFilters,
+                    TaxonomicFilterGroupType.Events,
+                    TaxonomicFilterGroupType.DataWarehouse,
+                ],
+            })
+
+            // Data warehouse is a config flow (table/column picker) — it should reopen on
+            // its own tab so the user can reconfigure, not drop them on the All surface.
+            const trigger = await screen.findByTestId('taxonomic-category-dropdown-trigger-pill')
+            await waitFor(() => expect(trigger.textContent || '').toMatch(/All|Data warehouse|Events/))
+            expect(trigger).toHaveTextContent('Data warehouse')
+            expect(trigger).not.toHaveTextContent('All')
+        })
+
         it('opens focused on the All tab, not Events, when an event is already selected', async () => {
             renderFilter({
                 groupType: TaxonomicFilterGroupType.Events,

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1176,6 +1176,77 @@ describe('TaxonomicFilter', () => {
         })
     })
 
+    // Spec for the insight series picker in the pill variant: searching a term that matches
+    // pageview URLs should make ONE "url contains <query>" shortcut the first row of the
+    // aggregated Suggested filters ("All") tab — ahead of raw URL/event rows. Fails today
+    // because the series (PageviewEvents) group isn't collapsed and the shortcut never leads.
+    describe('series picker: pageview url-contains shortcut leads (pill variant)', () => {
+        let unmountFeatureFlagLogic: (() => void) | null = null
+
+        beforeEach(() => {
+            unmountFeatureFlagLogic = featureFlagLogic.mount()
+            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN], {
+                [FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]: 'pill',
+            })
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': mockGetEventDefinitions,
+                    '/api/projects/:team/property_definitions': mockGetPropertyDefinitions,
+                    '/api/environments/:team/events/values': [
+                        { name: 'https://app.posthog.com/replay' },
+                        { name: 'https://app.posthog.com/replay/home' },
+                    ],
+                },
+            })
+        })
+
+        afterEach(() => {
+            featureFlagLogic.actions.setFeatureFlags([], {})
+            unmountFeatureFlagLogic?.()
+            unmountFeatureFlagLogic = null
+        })
+
+        it('opens focused on the All tab, not Events, when an event is already selected', async () => {
+            renderFilter({
+                groupType: TaxonomicFilterGroupType.Events,
+                value: '$pageview',
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.SuggestedFilters,
+                    TaxonomicFilterGroupType.Events,
+                    TaxonomicFilterGroupType.Actions,
+                ],
+            })
+
+            // In the pill variant the active category shows in the dropdown trigger; reopening
+            // on an existing event selection should read "All", not "Events".
+            const trigger = await screen.findByTestId('taxonomic-category-dropdown-trigger-pill')
+            // Wait for the dropdown trigger to paint its active-category label before asserting.
+            await waitFor(() => expect(trigger.textContent || '').toMatch(/All|Events|Suggestions/))
+            expect(trigger).toHaveTextContent('All')
+            expect(trigger).not.toHaveTextContent('Events')
+        })
+
+        it('makes the "url contains <query>" shortcut the first Suggested-filters row', async () => {
+            const user = userEvent.setup()
+            renderFilter({
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.SuggestedFilters,
+                    TaxonomicFilterGroupType.PageviewEvents,
+                    TaxonomicFilterGroupType.EventProperties,
+                ],
+                collapseUrlsToContainsRow: true,
+            })
+
+            const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
+            await user.type(searchInput, 'replay')
+
+            const firstRow = await waitFor(() => screen.getByTestId('prop-filter-suggested_filters-0'))
+            // The leading aggregated row should be the single contains shortcut, not a raw URL.
+            expect(firstRow.textContent || '').toMatch(/contains.*replay|replay.*contains/i)
+            expect(firstRow.textContent || '').not.toContain('https://app.posthog.com/replay')
+        })
+    })
+
     describe('category dropdown A/B test', () => {
         let unmountFeatureFlagLogic: (() => void) | null = null
 

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
@@ -42,6 +42,7 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 import { isQuickFilterItem } from 'lib/components/TaxonomicFilter/types'
 import { buildTaxonomicGroups } from 'lib/components/TaxonomicFilter/utils/buildTaxonomicGroups'
+import { isContainsShortcutItem } from 'lib/components/TaxonomicFilter/utils/collapsedContainsRow'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -419,10 +420,13 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         (group: TaxonomicFilterGroup, valueIn: TaxonomicFilterValue | null, item: any) => {
             // Mirror the legacy `taxonomicFilterLogic.selectItem` recent
             // recording so menu commits show up in the dropdown's
-            // "Recent" entry. Quick-filter items are skipped (they're
-            // shortcuts, not filterable definitions); pinned/recent
-            // context wrappers get stripped before persisting.
-            if (valueIn != null && item && !isQuickFilterItem(item)) {
+            // "Recent" entry. Quick-filter items and the synthetic
+            // "URL contains <query>" shortcut are skipped (they're
+            // shortcuts, not filterable definitions — and recording the
+            // shortcut would shadow it on the next search, since the recent
+            // shares its entryKey but lacks the contains label/telemetry);
+            // pinned/recent context wrappers get stripped before persisting.
+            if (valueIn != null && item && !isQuickFilterItem(item) && !isContainsShortcutItem(item)) {
                 const sourceGroupType = hasRecentContext(item) ? item._recentContext.sourceGroupType : group.type
                 const stripped = hasRecentContext(item) ? stripRecentContext(item) : item
                 const cleanItem = {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -33,7 +33,7 @@ import {
 import {
     buildUrlContainsShortcut,
     COLLAPSED_TO_CONTAINS_ROW,
-    isContainsShortcutItem,
+    partitionContainsShortcuts,
 } from 'lib/components/TaxonomicFilter/utils/collapsedContainsRow'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -935,10 +935,8 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 // The "URL contains <query>" shortcut leads the aggregated SuggestedFilters list —
                 // ahead of recents/pinned/top-matches — so a URL search surfaces the contains
                 // suggestion first. Everything else keeps its existing order.
-                const shortcutItems = orderedBase.filter((item) => isContainsShortcutItem(item))
-                const orderedResults = shortcutItems.length
-                    ? [...shortcutItems, ...orderedBase.filter((item) => !isContainsShortcutItem(item))]
-                    : orderedBase
+                const [shortcutItems, otherItems] = partitionContainsShortcuts(orderedBase, (item) => item)
+                const orderedResults = shortcutItems.length ? [...shortcutItems, ...otherItems] : orderedBase
                 return {
                     results: orderedResults,
                     count:

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -33,6 +33,7 @@ import {
 import {
     buildUrlContainsShortcut,
     COLLAPSED_TO_CONTAINS_ROW,
+    isContainsShortcutItem,
 } from 'lib/components/TaxonomicFilter/utils/collapsedContainsRow'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -738,7 +739,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 if (collapseUrlsToContainsRow && COLLAPSED_TO_CONTAINS_ROW.has(listGroupType)) {
                     const trimmed = searchQuery.trim()
                     const hasMatch = trimmed.length > 0 && remoteIsFresh && remoteItems.results.length > 0
-                    return hasMatch ? [buildUrlContainsShortcut(trimmed)] : []
+                    return hasMatch ? [buildUrlContainsShortcut(trimmed, listGroupType)] : []
                 }
                 const results = hasRemoteDataSource ? (remoteIsFresh ? remoteItems.results : []) : localItems.results
                 const realMatches = promoteMatchingProperties(results, searchQuery).slice(0, MAX_TOP_MATCHES_PER_GROUP)
@@ -898,7 +899,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     // stale match from the previous query producing a shortcut for the new one.
                     const remoteIsFresh = (remoteItems.searchQuery ?? '').trim() === trimmed
                     const hasMatch = trimmed.length > 0 && remoteIsFresh && remoteItems.results.length > 0
-                    const results = hasMatch ? [buildUrlContainsShortcut(trimmed)] : []
+                    const results = hasMatch ? [buildUrlContainsShortcut(trimmed, listGroupType)] : []
                     return {
                         results,
                         count: results.length,
@@ -928,8 +929,18 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     ...remoteItems.results,
                     ...topMatches,
                 ]
+                const orderedBase = searchQuery
+                    ? promoteMatchingProperties(combinedResults, searchQuery)
+                    : combinedResults
+                // The "URL contains <query>" shortcut leads the aggregated SuggestedFilters list —
+                // ahead of recents/pinned/top-matches — so a URL search surfaces the contains
+                // suggestion first. Everything else keeps its existing order.
+                const shortcutItems = orderedBase.filter((item) => isContainsShortcutItem(item))
+                const orderedResults = shortcutItems.length
+                    ? [...shortcutItems, ...orderedBase.filter((item) => !isContainsShortcutItem(item))]
+                    : orderedBase
                 return {
-                    results: searchQuery ? promoteMatchingProperties(combinedResults, searchQuery) : combinedResults,
+                    results: orderedResults,
                     count:
                         keywordShortcutItems.length +
                         recentPrefix.length +

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -470,6 +470,88 @@ describe('MenuFilterCombobox', () => {
         })
     })
 
+    // Spec for the insight series picker (e.g. funnel steps include Pageview events):
+    // opening the menu shows "All" with event-context recents/pinned; searching a term
+    // that matches pageview URLs surfaces ONE "url contains <query>" shortcut as the very
+    // first row — ahead of recents, pinned, and event rows. These fail today because the
+    // series (PageviewEvents) group is not collapsed and the shortcut never leads the list.
+    describe('pageview url-contains shortcut leads the series picker All surface', () => {
+        const mockUrlValues = (urls: string[]): void => {
+            apiGet.mockImplementation((url: string) => {
+                if (url.includes('events/values') && url.includes('current_url')) {
+                    return Promise.resolve(urls.map((name) => ({ name })))
+                }
+                return Promise.resolve({ results: [], count: 0 })
+            })
+        }
+
+        it('defaults to the All scope with event-context recents and pinned shown', async () => {
+            mockUrlValues([])
+            renderAll({
+                groupTypes: [TaxonomicFilterGroupType.PageviewEvents, TaxonomicFilterGroupType.Events],
+                recentEntries: [makeEntry(TaxonomicFilterGroupType.Events, 'recent_signup', 'Events')],
+                pinnedEntries: [makeEntry(TaxonomicFilterGroupType.Events, 'pinned_purchase', 'Events')],
+            })
+
+            await waitFor(() => expect(rowTexts().some((t) => t.includes('recent_signup'))).toBe(true))
+            expect(rowTexts().some((t) => t.includes('pinned_purchase'))).toBe(true)
+            expect(screen.getByRole('combobox', { name: 'Filter category' })).toHaveTextContent('All')
+        })
+
+        it('opens focused on All, not the selected item category, when an event is already selected', async () => {
+            apiGet.mockResolvedValue({ results: [], count: 0 })
+            // Reopening the series picker on an existing `$pageview` selection: the menu
+            // should land on the "All" scope, not jump to the Events category.
+            const selectedEntry = makeEntry(TaxonomicFilterGroupType.Events, '$pageview', 'Events')
+            render(
+                <Provider>
+                    <TaxonomicFilterHeadless.Root
+                        taxonomicGroupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]}
+                        onChange={jest.fn()}
+                    >
+                        <MenuFilterCombobox
+                            drillTo="all"
+                            selectedEntry={selectedEntry}
+                            onCommit={jest.fn()}
+                            onBack={jest.fn()}
+                        />
+                    </TaxonomicFilterHeadless.Root>
+                </Provider>
+            )
+
+            const category = await screen.findByRole('combobox', { name: 'Filter category' })
+            // Wait for the Select to paint its active-category label before asserting.
+            await waitFor(() => expect(category.textContent || '').toMatch(/All|Events/))
+            expect(category).toHaveTextContent('All')
+            expect(category).not.toHaveTextContent('Events')
+        })
+
+        it('puts the "url contains <query>" shortcut first, then recent, then pinned', async () => {
+            mockUrlValues(['https://app.posthog.com/replay', 'https://app.posthog.com/replay/home'])
+            renderAll({
+                groupTypes: [TaxonomicFilterGroupType.PageviewEvents, TaxonomicFilterGroupType.Events],
+                recentEntries: [makeEntry(TaxonomicFilterGroupType.Events, 'replay_recent', 'Events')],
+                pinnedEntries: [makeEntry(TaxonomicFilterGroupType.Events, 'replay_pinned', 'Events')],
+                searchQuery: 'replay',
+            })
+
+            // Wait on a stable post-search signal (a matching recent) so the ordering
+            // assertions fail fast rather than timing out waiting for a row that never renders.
+            await waitFor(() => expect(rowTexts().some((t) => t.includes('replay_recent'))).toBe(true))
+            const rows = rowTexts()
+            const shortcutIdx = rows.findIndex((t) => /contains/i.test(t) && /replay/i.test(t))
+            const recentIdx = rows.findIndex((t) => t.includes('replay_recent'))
+            const pinnedIdx = rows.findIndex((t) => t.includes('replay_pinned'))
+
+            // The contains shortcut leads the whole list, ahead of recents/pinned/events.
+            expect(shortcutIdx).toBe(0)
+            expect(recentIdx).toBeGreaterThan(shortcutIdx)
+            expect(pinnedIdx).toBeGreaterThan(recentIdx)
+            // and the raw matched URLs are collapsed away into the single shortcut.
+            expect(rows.some((t) => t.includes('https://app.posthog.com/replay'))).toBe(false)
+        })
+    })
+
     it('drops the recents/pinned prefix once the query no longer matches them', async () => {
         apiGet.mockResolvedValue({ results: [{ id: 1, name: 'autocapture' }], count: 1 })
 

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -526,6 +526,32 @@ describe('MenuFilterCombobox', () => {
             expect(category).not.toHaveTextContent('Events')
         })
 
+        it('leads with the committed selection as the first row when idle (no search)', async () => {
+            apiGet.mockResolvedValue({ results: [{ id: 1, name: 'autocapture' }], count: 1 })
+            // Reopening on an existing selection: the user often just wants to check what's
+            // chosen, so the committed value is the first row even ahead of recents.
+            const selectedEntry = makeEntry(TaxonomicFilterGroupType.Events, 'my_current_event', 'Events')
+            render(
+                <Provider>
+                    <TaxonomicFilterHeadless.Root
+                        taxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                        onChange={jest.fn()}
+                    >
+                        <MenuFilterCombobox
+                            drillTo="all"
+                            selectedEntry={selectedEntry}
+                            recentEntries={[makeEntry(TaxonomicFilterGroupType.Events, 'recent_event', 'Events')]}
+                            onCommit={jest.fn()}
+                            onBack={jest.fn()}
+                        />
+                    </TaxonomicFilterHeadless.Root>
+                </Provider>
+            )
+
+            await waitFor(() => expect(rowTexts().some((t) => t.includes('my_current_event'))).toBe(true))
+            expect(rowTexts()[0]).toContain('my_current_event')
+        })
+
         it('puts the "url contains <query>" shortcut first, then recent, then pinned', async () => {
             mockUrlValues(['https://app.posthog.com/replay', 'https://app.posthog.com/replay/home'])
             renderAll({

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -571,7 +571,9 @@ describe('MenuFilterCombobox', () => {
 
             // The contains shortcut leads the whole list, ahead of recents/pinned/events.
             expect(shortcutIdx).toBe(0)
-            expect(recentIdx).toBeGreaterThan(shortcutIdx)
+            // Assert both rows are actually present (findIndex returns -1 when absent) so a
+            // regression that drops the recent/pinned row fails loudly, not on index arithmetic.
+            expect(recentIdx).toBeGreaterThan(0)
             expect(pinnedIdx).toBeGreaterThan(recentIdx)
             // and the raw matched URLs are collapsed away into the single shortcut.
             expect(rows.some((t) => t.includes('https://app.posthog.com/replay'))).toBe(false)

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -43,7 +43,11 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { useTaxonomicFilterContext } from '../headless/context'
 import { useGroupList } from '../hooks/useGroupList'
 import { TaxonomicDefinitionTypes, TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../types'
-import { COLLAPSED_TO_CONTAINS_ROW, isContainsShortcutItem, urlContainsRowLabel } from '../utils/collapsedContainsRow'
+import {
+    COLLAPSED_TO_CONTAINS_ROW,
+    partitionContainsShortcuts,
+    urlContainsRowLabel,
+} from '../utils/collapsedContainsRow'
 import { promoteMatchingBy } from '../utils/promoteProperties'
 import { MenuFilterHeader } from './Header'
 import { PreviewPane } from './PreviewPane'
@@ -111,6 +115,15 @@ function rowDomId(entry: MenuFilterEntry): string {
     }`
 }
 
+/** Move the element at `index` to the front, preserving the order of the rest.
+ *  No-op when `index <= 0` (already first, or not found via `findIndex` -> -1). */
+function floatToFront<T>(list: T[], index: number): T[] {
+    if (index <= 0) {
+        return list
+    }
+    return [list[index], ...list.slice(0, index), ...list.slice(index + 1)]
+}
+
 function fuseMatchEntries(entries: MenuFilterEntry[], query: string): MenuFilterEntry[] {
     if (entries.length === 0) {
         return []
@@ -153,10 +166,6 @@ export function MenuFilterCombobox({
     // `searchQuery` from the orchestrator's `getGroupListInput`, not from
     // us. Keeping a local mirror just for the controlled input ergonomics.
     const { groups, searchQuery, setSearchQuery } = useTaxonomicFilterContext()
-    // When opening with chips visible (`drillTo='all'`) and a current
-    // selection exists, start on the matching chip so the user lands on
-    // their selection's category by default — they can still tab back to
-    // "All" or any other chip without leaving the combobox.
     // Always open on the drill scope ("All" for the default surface). Reopening with a
     // committed selection used to jump to that item's category; we now lead with "All" so
     // the user lands on recents/pinned + a cross-category search every time (the selection
@@ -337,9 +346,13 @@ export function MenuFilterCombobox({
                 if (trimmedQuery && items.length > 0) {
                     const label = urlContainsRowLabel(trimmedQuery)
                     merged.push({
-                        // `isContainsShortcut` tags this synthetic row so the commit
-                        // telemetry can measure adoption of the contains shortcut vs
-                        // the old per-URL value-picker.
+                        // A plain item (not a QuickFilterItem): the commit reads its value via
+                        // `group.getValue` (the query) and the group `type` drives the host's
+                        // expansion — PageviewUrls -> `$current_url IContains`, PageviewEvents ->
+                        // a `$pageview` event with that filter (ActionFilterRow's group-type
+                        // branch). The legacy list reaches the same filter via the QuickFilterItem
+                        // `eventName` path instead — see `buildUrlContainsShortcut`.
+                        // `isContainsShortcut` tags it for commit telemetry + the lead-first ordering.
                         item: { name: trimmedQuery, isContainsShortcut: true } as unknown as TaxonomicDefinitionTypes,
                         group,
                         name: label,
@@ -471,30 +484,28 @@ export function MenuFilterCombobox({
                     : null
             base = indexed.filter((e) => !!e.group.endpoint || (localMatches?.has(e) ?? false))
         }
+        const scope = showChips ? activeChip : drillTo
         // Promote the committed selection to index 0 so base-ui's
-        // `autoHighlight="always"` lands on it the moment the list
-        // mounts — keyboard nav starts on the selected row, the
-        // preview pane shows the right definition, and `Enter` re-commits
-        // without forcing the user to scroll. Skip when the user has
-        // typed a search query — relevance order should win there.
-        if (!q && selectedRowId) {
-            const idx = base.findIndex((e) => rowDomId(e) === selectedRowId)
-            if (idx > 0) {
-                base = [base[idx], ...base.slice(0, idx), ...base.slice(idx + 1)]
-            }
+        // `autoHighlight="always"` lands on it the moment the list mounts — keyboard nav
+        // starts on the selected row, the preview shows the right definition, and `Enter`
+        // re-commits without scrolling. Skip while searching (relevance wins). The All scope
+        // re-floats after its recents/pinned assembly below, so only do it here for drilled scopes.
+        if (!q && selectedRowId && scope !== 'all') {
+            base = floatToFront(
+                base,
+                base.findIndex((e) => rowDomId(e) === selectedRowId)
+            )
         }
         // Default "All" surface leads with recents/pinned (fixed order), then
         // the cross-tab content with `email`/`url` promotion. Recents/pinned
         // stay above the content rows so users can learn the order.
-        const scope = showChips ? activeChip : drillTo
         if (scope === 'all') {
             const prefixKeys = new Set(recentsPinnedPrefix.map(entryKey))
             const content = prefixKeys.size > 0 ? base.filter((e) => !prefixKeys.has(entryKey(e))) : base
             // The "URL contains <query>" shortcut leads the whole list — ahead of
             // recents/pinned/content — because a URL search almost always means the user
             // wants the contains match. Everything else keeps the recents-then-pinned order.
-            const shortcuts = content.filter((e) => isContainsShortcutItem(e.item))
-            const rest = content.filter((e) => !isContainsShortcutItem(e.item))
+            const [shortcuts, rest] = partitionContainsShortcuts(content, (e) => e.item)
             const assembled = [
                 ...shortcuts,
                 ...recentsPinnedPrefix,
@@ -503,10 +514,10 @@ export function MenuFilterCombobox({
             // Idle (no search): float the committed selection to the very first row so the
             // user can see/verify what's currently chosen without leaving the All surface.
             if (!q && selectedRowId) {
-                const selIdx = assembled.findIndex((e) => rowDomId(e) === selectedRowId)
-                if (selIdx > 0) {
-                    return [assembled[selIdx], ...assembled.slice(0, selIdx), ...assembled.slice(selIdx + 1)]
-                }
+                return floatToFront(
+                    assembled,
+                    assembled.findIndex((e) => rowDomId(e) === selectedRowId)
+                )
             }
             return assembled
         }

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -495,11 +495,20 @@ export function MenuFilterCombobox({
             // wants the contains match. Everything else keeps the recents-then-pinned order.
             const shortcuts = content.filter((e) => isContainsShortcutItem(e.item))
             const rest = content.filter((e) => !isContainsShortcutItem(e.item))
-            return [
+            const assembled = [
                 ...shortcuts,
                 ...recentsPinnedPrefix,
                 ...promoteMatchingBy(rest, searchQuery, (e) => (e.item as { name?: string }).name ?? e.name),
             ]
+            // Idle (no search): float the committed selection to the very first row so the
+            // user can see/verify what's currently chosen without leaving the All surface.
+            if (!q && selectedRowId) {
+                const selIdx = assembled.findIndex((e) => rowDomId(e) === selectedRowId)
+                if (selIdx > 0) {
+                    return [assembled[selIdx], ...assembled.slice(0, selIdx), ...assembled.slice(selIdx + 1)]
+                }
+            }
+            return assembled
         }
         return base
     }, [indexed, searchQuery, selectedRowId, recentsPinnedPrefix, showChips, activeChip, drillTo])

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -43,7 +43,7 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { useTaxonomicFilterContext } from '../headless/context'
 import { useGroupList } from '../hooks/useGroupList'
 import { TaxonomicDefinitionTypes, TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../types'
-import { COLLAPSED_TO_CONTAINS_ROW, urlContainsRowLabel } from '../utils/collapsedContainsRow'
+import { COLLAPSED_TO_CONTAINS_ROW, isContainsShortcutItem, urlContainsRowLabel } from '../utils/collapsedContainsRow'
 import { promoteMatchingBy } from '../utils/promoteProperties'
 import { MenuFilterHeader } from './Header'
 import { PreviewPane } from './PreviewPane'
@@ -157,15 +157,11 @@ export function MenuFilterCombobox({
     // selection exists, start on the matching chip so the user lands on
     // their selection's category by default — they can still tab back to
     // "All" or any other chip without leaving the combobox.
-    const [activeChip, setActiveChip] = useState<DrillCategory>(() => {
-        // Collapsed groups (e.g. Pageview URLs) aren't navigable categories, so a
-        // selection from one lands on "All" — its row still surfaces there via the
-        // selected-entry prepend — instead of stranding the user in a hidden scope.
-        if (drillTo === 'all' && selectedEntry && !COLLAPSED_TO_CONTAINS_ROW.has(selectedEntry.group.type)) {
-            return selectedEntry.group.type
-        }
-        return drillTo
-    })
+    // Always open on the drill scope ("All" for the default surface). Reopening with a
+    // committed selection used to jump to that item's category; we now lead with "All" so
+    // the user lands on recents/pinned + a cross-category search every time (the selection
+    // still surfaces via the selected-entry prepend).
+    const [activeChip, setActiveChip] = useState<DrillCategory>(drillTo)
     // The scope the user is actually looking at: the active chip when chips show
     // (drillTo='all'), otherwise the drilled-to category. Single source for the
     // telemetry group type, empty state, stale-toggle gating, and reset trigger.
@@ -494,9 +490,15 @@ export function MenuFilterCombobox({
         if (scope === 'all') {
             const prefixKeys = new Set(recentsPinnedPrefix.map(entryKey))
             const content = prefixKeys.size > 0 ? base.filter((e) => !prefixKeys.has(entryKey(e))) : base
+            // The "URL contains <query>" shortcut leads the whole list — ahead of
+            // recents/pinned/content — because a URL search almost always means the user
+            // wants the contains match. Everything else keeps the recents-then-pinned order.
+            const shortcuts = content.filter((e) => isContainsShortcutItem(e.item))
+            const rest = content.filter((e) => !isContainsShortcutItem(e.item))
             return [
+                ...shortcuts,
                 ...recentsPinnedPrefix,
-                ...promoteMatchingBy(content, searchQuery, (e) => (e.item as { name?: string }).name ?? e.name),
+                ...promoteMatchingBy(rest, searchQuery, (e) => (e.item as { name?: string }).name ?? e.name),
             ]
         }
         return base

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -42,7 +42,12 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 
 import { useTaxonomicFilterContext } from '../headless/context'
 import { useGroupList } from '../hooks/useGroupList'
-import { TaxonomicDefinitionTypes, TaxonomicFilterGroup, TaxonomicFilterGroupType } from '../types'
+import {
+    OPEN_AS_SELF_ON_REOPEN,
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+} from '../types'
 import {
     COLLAPSED_TO_CONTAINS_ROW,
     partitionContainsShortcuts,
@@ -166,11 +171,17 @@ export function MenuFilterCombobox({
     // `searchQuery` from the orchestrator's `getGroupListInput`, not from
     // us. Keeping a local mirror just for the controlled input ergonomics.
     const { groups, searchQuery, setSearchQuery } = useTaxonomicFilterContext()
-    // Always open on the drill scope ("All" for the default surface). Reopening with a
-    // committed selection used to jump to that item's category; we now lead with "All" so
-    // the user lands on recents/pinned + a cross-category search every time (the selection
-    // still surfaces via the selected-entry prepend).
-    const [activeChip, setActiveChip] = useState<DrillCategory>(drillTo)
+    // Open on the drill scope ("All" for the default surface). Reopening with a committed
+    // selection used to jump to that item's category; we now lead with "All" so the user
+    // lands on recents/pinned + a cross-category search (the selection still surfaces via
+    // the selected-entry prepend). The exception is config/edit flows (data-warehouse
+    // columns reach the combobox as DataWarehouseProperties) — they reopen on their own
+    // chip so the user can reconfigure, mirroring the legacy `activeTab`.
+    const [activeChip, setActiveChip] = useState<DrillCategory>(() =>
+        drillTo === 'all' && selectedEntry && OPEN_AS_SELF_ON_REOPEN.has(selectedEntry.group.type)
+            ? selectedEntry.group.type
+            : drillTo
+    )
     // The scope the user is actually looking at: the active chip when chips show
     // (drillTo='all'), otherwise the drilled-to category. Single source for the
     // telemetry group type, empty state, stale-toggle gating, and reset trigger.

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -251,10 +251,10 @@ export function TaxonomicFilterMenu({
             // dwh-pick list they never visited.
             return { kind: 'dwh-config', table: selected.item, group: selected.group, origin: 'menu' }
         }
-        // Land on the regular combobox with chips visible — the matching
-        // chip auto-selects via `selectedEntry` inside the combobox so the
-        // user keeps full context and can switch categories without
-        // bouncing back to the dropdown menu.
+        // Land on the regular combobox on the "All" scope. The committed selection
+        // floats to the first row (and stays highlighted) so the user can verify it
+        // at a glance, while still seeing recents/pinned and being able to search
+        // across every category.
         return { kind: 'combobox', drillTo: 'all' }
     }, [selected])
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -38,6 +38,7 @@ import {
     ListStorage,
     QuickFilterItem,
     META_GROUP_TYPES,
+    OPEN_AS_SELF_ON_REOPEN,
     SelectedProperties,
     SimpleOption,
     SkeletonItem,
@@ -141,15 +142,6 @@ const SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES = new Set<TaxonomicFilterGroupType
 
 export const DEFAULT_SLOTS_PER_GROUP = 5
 export const MAX_TOP_MATCHES_PER_GROUP = 10
-
-/** Selection types that reopen on their own tab rather than the default "All" surface,
- *  because they're config/edit flows (an expression editor, a data-warehouse table/column
- *  picker) with no simple category value to verify at a glance. */
-const OPEN_AS_SELF_ON_REOPEN: ReadonlySet<TaxonomicFilterGroupType> = new Set([
-    TaxonomicFilterGroupType.HogQLExpression,
-    TaxonomicFilterGroupType.DataWarehouse,
-    TaxonomicFilterGroupType.DataWarehouseProperties,
-])
 
 const TRAFFIC_TYPE_VIRTUAL_PROPERTIES = [
     '$virt_is_bot',

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1659,13 +1659,22 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 if (explicitActiveTab && groupTypes.includes(explicitActiveTab)) {
                     return explicitActiveTab
                 }
-                // If there's an existing filter type (e.g., SQL expression being edited),
-                // use that instead of defaulting to SuggestedFilters
-                if (propsGroupType && groupTypes.includes(propsGroupType)) {
+                // A SQL/HogQL expression being edited has no category "value" to land on,
+                // so reopen on its own tab rather than the All surface.
+                if (
+                    propsGroupType === TaxonomicFilterGroupType.HogQLExpression &&
+                    groupTypes.includes(propsGroupType)
+                ) {
                     return propsGroupType
                 }
+                // Otherwise lead with the All (Suggested filters) surface so reopening on an
+                // existing selection still shows recents/pinned + a cross-category search,
+                // rather than jumping to the selected item's category.
                 if (groupTypes.includes(TaxonomicFilterGroupType.SuggestedFilters)) {
                     return TaxonomicFilterGroupType.SuggestedFilters
+                }
+                if (propsGroupType && groupTypes.includes(propsGroupType)) {
+                    return propsGroupType
                 }
                 return groupTypes.find((t) => !metaGroupTypes.has(t)) ?? groupTypes[0]
             },

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -142,6 +142,15 @@ const SHORTCUT_TO_PROPERTY_FILTER_GROUP_TYPES = new Set<TaxonomicFilterGroupType
 export const DEFAULT_SLOTS_PER_GROUP = 5
 export const MAX_TOP_MATCHES_PER_GROUP = 10
 
+/** Selection types that reopen on their own tab rather than the default "All" surface,
+ *  because they're config/edit flows (an expression editor, a data-warehouse table/column
+ *  picker) with no simple category value to verify at a glance. */
+const OPEN_AS_SELF_ON_REOPEN: ReadonlySet<TaxonomicFilterGroupType> = new Set([
+    TaxonomicFilterGroupType.HogQLExpression,
+    TaxonomicFilterGroupType.DataWarehouse,
+    TaxonomicFilterGroupType.DataWarehouseProperties,
+])
+
 const TRAFFIC_TYPE_VIRTUAL_PROPERTIES = [
     '$virt_is_bot',
     '$virt_traffic_type',
@@ -1659,10 +1668,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 if (explicitActiveTab && groupTypes.includes(explicitActiveTab)) {
                     return explicitActiveTab
                 }
-                // A SQL/HogQL expression being edited has no category "value" to land on,
-                // so reopen on its own tab rather than the All surface.
+                // Config/edit flows have no simple category "value" to verify on the All
+                // surface — reopen them on their own tab: a SQL/HogQL expression lands in its
+                // editor, a data-warehouse selection in its table/column picker.
                 if (
-                    propsGroupType === TaxonomicFilterGroupType.HogQLExpression &&
+                    propsGroupType &&
+                    OPEN_AS_SELF_ON_REOPEN.has(propsGroupType) &&
                     groupTypes.includes(propsGroupType)
                 ) {
                     return propsGroupType

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -356,6 +356,16 @@ export const META_GROUP_TYPES = new Set<TaxonomicFilterGroupType>([
     TaxonomicFilterGroupType.MaxAIContext,
 ])
 
+/** Selection types that reopen on their own tab/panel rather than the default "All" surface,
+ *  because they're config/edit flows (an expression editor, a data-warehouse table/column
+ *  picker) with no simple category value to verify at a glance. Honored by the legacy
+ *  `activeTab` selector and the rebuild menu's `activeChip` initializer alike. */
+export const OPEN_AS_SELF_ON_REOPEN = new Set<TaxonomicFilterGroupType>([
+    TaxonomicFilterGroupType.HogQLExpression,
+    TaxonomicFilterGroupType.DataWarehouse,
+    TaxonomicFilterGroupType.DataWarehouseProperties,
+])
+
 export interface InfiniteListLogicProps extends TaxonomicFilterLogicProps {
     listGroupType: TaxonomicFilterGroupType
 }

--- a/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
@@ -27,8 +27,13 @@ export function urlContainsRowLabel(query: string): string {
  *  same filter the per-URL value picker used to — without listing every matching URL.
  *
  *  For the `PageviewEvents` (series) group the shortcut also carries `eventName:
- *  '$pageview'` so the host expands it into a `$pageview` event plus the property
- *  filter, rather than a bare property filter. */
+ *  '$pageview'`. How that's consumed differs by host, all reaching the same filter:
+ *   - series host (`ActionFilterRow`) expands it into a `$pageview` event + the
+ *     `$current_url IContains` property filter (reads `eventName`);
+ *   - property/universal hosts intentionally ignore `eventName` (a property filter
+ *     can't sprout an event) and commit the bare `$current_url IContains` filter;
+ *   - the rebuild menu commits PageviewEvents via the group `type`, not `eventName`
+ *     (its synthetic row is a plain item, not this QuickFilterItem). */
 export function buildUrlContainsShortcut(query: string, groupType?: TaxonomicFilterGroupType): QuickFilterItem {
     return {
         _type: 'quick_filter',
@@ -42,7 +47,23 @@ export function buildUrlContainsShortcut(query: string, groupType?: TaxonomicFil
     }
 }
 
-/** A row that is the synthetic "URL contains <query>" shortcut (tagged on the item). */
+/** A row that is the synthetic "URL contains <query>" shortcut. Deliberately checks the
+ *  tag directly rather than via `isQuickFilterItem`, because the rebuild menu's shortcut
+ *  is a plain item (not a QuickFilterItem) while the legacy list's is a QuickFilterItem —
+ *  both carry `isContainsShortcut`. */
 export function isContainsShortcutItem(item: unknown): boolean {
     return !!item && typeof item === 'object' && (item as { isContainsShortcut?: boolean }).isContainsShortcut === true
+}
+
+/** Split a list so the synthetic "URL contains <query>" shortcut(s) come first.
+ *  `getItem` maps a list element to its underlying definition item — the rebuild wraps it
+ *  in a `{ item }` entry, the legacy list holds the item directly. Returns `[shortcuts, rest]`
+ *  so callers can either lead with the shortcut or splice other rows (recents/pinned) between. */
+export function partitionContainsShortcuts<T>(list: T[], getItem: (entry: T) => unknown): [T[], T[]] {
+    const shortcuts: T[] = []
+    const rest: T[] = []
+    for (const entry of list) {
+        ;(isContainsShortcutItem(getItem(entry)) ? shortcuts : rest).push(entry)
+    }
+    return [shortcuts, rest]
 }

--- a/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/collapsedContainsRow.ts
@@ -7,9 +7,14 @@ import { QuickFilterItem, TaxonomicFilterGroupType } from '../types'
  *  People filtering by URL overwhelmingly want a contains match, so one synthetic
  *  row (when any URL matches) beats a wall of exact URLs. Shared by the legacy
  *  picker (`infiniteListLogic`) and the rebuild menu (`menu/Combobox`) so both arms
- *  of the experiment collapse identically. */
+ *  of the experiment collapse identically.
+ *
+ *  - `PageviewUrls` is the property-filter flavour ($current_url IContains <query>).
+ *  - `PageviewEvents` is the series flavour: a `$pageview` event filtered by the same
+ *    `$current_url IContains <query>`. Both hit the same URL-values endpoint. */
 export const COLLAPSED_TO_CONTAINS_ROW: ReadonlySet<TaxonomicFilterGroupType> = new Set([
     TaxonomicFilterGroupType.PageviewUrls,
+    TaxonomicFilterGroupType.PageviewEvents,
 ])
 
 export function urlContainsRowLabel(query: string): string {
@@ -18,9 +23,13 @@ export function urlContainsRowLabel(query: string): string {
 
 /** Synthetic row committed as `$current_url IContains <query>`. Returned as a
  *  `QuickFilterItem` so it flows through the existing `isQuickFilterItem` handling
- *  in the property- and universal-filter hosts, committing the same filter the
- *  per-URL value picker used to — without listing every matching URL. */
-export function buildUrlContainsShortcut(query: string): QuickFilterItem {
+ *  in the property-, universal-, and series (ActionFilterRow) hosts, committing the
+ *  same filter the per-URL value picker used to — without listing every matching URL.
+ *
+ *  For the `PageviewEvents` (series) group the shortcut also carries `eventName:
+ *  '$pageview'` so the host expands it into a `$pageview` event plus the property
+ *  filter, rather than a bare property filter. */
+export function buildUrlContainsShortcut(query: string, groupType?: TaxonomicFilterGroupType): QuickFilterItem {
     return {
         _type: 'quick_filter',
         name: urlContainsRowLabel(query),
@@ -29,5 +38,11 @@ export function buildUrlContainsShortcut(query: string): QuickFilterItem {
         propertyKey: '$current_url',
         propertyFilterType: PropertyFilterType.Event,
         isContainsShortcut: true,
+        ...(groupType === TaxonomicFilterGroupType.PageviewEvents ? { eventName: '$pageview' } : {}),
     }
+}
+
+/** A row that is the synthetic "URL contains <query>" shortcut (tagged on the item). */
+export function isContainsShortcutItem(item: unknown): boolean {
+    return !!item && typeof item === 'object' && (item as { isContainsShortcut?: boolean }).isContainsShortcut === true
 }


### PR DESCRIPTION
## Problem

Two behaviours reported from the insight series picker, affecting both the legacy "pill" and the rebuild menu:

1. Reopening the picker on an existing selection (e.g. clicking the event name) jumped straight to that item's **category** (Events) instead of opening on **All** — losing the recents/pinned overview and cross-category search.
2. Searching a term that matches pageview URLs surfaced a wall of raw URLs rather than a single "URL contains \<query\>" shortcut, and it never led the list.

(Builds on #63392, now merged, which mirrored the URL-collapse into the legacy picker.)

## Changes

- **Open on All by default.** Rebuild: the combobox no longer seeds its active chip from the selection. Legacy: `activeTab` prefers the All (Suggested filters) surface over the selected `groupType`.
- **Config flows still open on themselves.** SQL/HogQL expressions and data-warehouse selections (table/column pickers) reopen on their own tab — they have no simple value to verify on the All surface. Captured in `OPEN_AS_SELF_ON_REOPEN`.
- **The contains shortcut leads.** When a search matches pageview URLs, the single `URL contains "<query>"` row is floated to the front of the All surface (ahead of recents/pinned/content) in both variants. The **series** group (`PageviewEvents`) now collapses too — its shortcut carries `eventName: '$pageview'` so hosts expand it into a `$pageview` event plus the `$current_url` filter.
- **Lead with the current selection.** Reopening on a regular selection with no search typed floats the committed value to the first row of the All surface (rebuild) so you can check what's chosen at a glance.

Consequence worth noting: `PageviewEvents` is now hidden as a standalone navigable category in the rebuild (like `PageviewUrls`) — you get the single contains shortcut instead.

## How did you test this code?

I'm an agent (PostHog Code) — automated tests only, no manual UI testing claimed.

- Added RTL coverage (TDD red→green) in `Combobox.test.tsx` and `TaxonomicFilter.test.tsx` for both variants: opens on All when an event is selected; contains shortcut leads then recent/pinned; selection leads when idle; DWH reopens on its own tab.
- All `TaxonomicFilter` / `PropertyFilters` / `UniversalFilters` / `TaxonomicPopover` / `ActionFilter` suites pass (run serially — parallel runs on a loaded box hit worker-starvation timeouts; every file passes in isolation).
- `tsc --noEmit` clean on the changed files; `pnpm format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul D'Ambra reported the open-on-All and shortcut-ordering behaviours from the series picker and directed the work.

Built with PostHog Code, TDD-style: wrote failing RTL tests capturing the spec for both pill and rebuild variants, confirmed they were red for the right reasons, then implemented. Key decisions: data-warehouse and SQL/HogQL reopen on their own tab (config flows) while everything else opens on All; the contains shortcut is floated to position 0 only when a URL search matches; the committed selection leads the idle All surface. Pill parity for "selection as first row" was intentionally left out (the legacy Suggested-filters tab doesn't surface the selection as a row) pending a decision.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
