### PR TITLE
feat(posthog-ai): smaller sandboxes for data-only conversations

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -3,6 +3,7 @@ from typing import Literal, get_args
 SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
+SMALL_DATA_SANDBOX_FEATURE_FLAG = "tasks-small-data-sandbox"
 
 ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions", "auto"]
 CodexPermissionMode = Literal["auto", "read-only", "full-access"]

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -79,10 +79,38 @@ def increment_sandbox_created(runtime: str) -> None:
         pass
 
 
+def increment_sandbox_tier(tier: str, origin_product: str) -> None:
+    """Record a sandbox provision labeled by size tier ("small" / "default") and origin product.
+
+    Both labels are low-cardinality (tier is a two-value set, origin_product is a
+    bounded enum), so the series count stays bounded. Best-effort: a metric failure
+    must never break provisioning.
+    """
+    try:
+        meter = _metric_meter({"tier": tier, "origin_product": origin_product})
+        meter.create_counter(
+            "tasks_process_sandbox_tier",
+            "Sandboxes provisioned for process-task runs by size tier and origin product",
+        ).add(1)
+    except Exception:
+        pass
+
+
 class StepTimer:
-    def __init__(self, step: str, used_snapshot: bool | None = None) -> None:
+    def __init__(
+        self,
+        step: str,
+        used_snapshot: bool | None = None,
+        *,
+        tier: str | None = None,
+        origin_product: str | None = None,
+    ) -> None:
         self.step = step
         self.used_snapshot = used_snapshot
+        # Low-cardinality provisioning labels so the latency histogram can be split
+        # small-vs-default. Only set on the sandbox_creation step.
+        self.tier = tier
+        self.origin_product = origin_product
         self._start_counter: float | None = None
 
     def set_used_snapshot(self, used_snapshot: bool) -> None:
@@ -104,6 +132,10 @@ class StepTimer:
             "used_snapshot": _bool_label(self.used_snapshot),
             "status": "FAILED" if exc_value is not None else "COMPLETED",
         }
+        if self.tier is not None:
+            attributes["tier"] = self.tier
+        if self.origin_product is not None:
+            attributes["origin_product"] = self.origin_product
 
         try:
             _metric_meter(attributes).create_histogram_timedelta(

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -13,6 +13,7 @@ from products.tasks.backend.constants import (
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+    SMALL_DATA_SANDBOX_FEATURE_FLAG,
 )
 from products.tasks.backend.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.models import SandboxEnvironment, Task, TaskRun
@@ -65,6 +66,9 @@ class TaskProcessingContext:
     sandbox_event_ingest_enabled: bool = False
     use_modal_vm_sandbox: bool = False
     use_modal_network_allowlist: bool = False
+    # Captured at workflow start so the sandbox size decision is stable across
+    # activity retries (a mid-run flag flip can't change the provisioned box).
+    small_data_sandbox_enabled: bool = False
 
     @property
     def mode(self) -> str:
@@ -221,6 +225,45 @@ def _is_modal_vm_sandbox_enabled(
         "modal_vm_sandbox_flag_checked",
         run_id=run_id,
         use_modal_vm_sandbox=enabled,
+    )
+    return enabled
+
+
+def _is_small_data_sandbox_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> bool:
+    state_override = (state or {}).get("small_data_sandbox_enabled")
+    if isinstance(state_override, bool):
+        log_with_activity_context(
+            "small_data_sandbox_state_override",
+            run_id=run_id,
+            small_data_sandbox_enabled=state_override,
+        )
+        return state_override
+
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                SMALL_DATA_SANDBOX_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("small_data_sandbox_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context(
+        "small_data_sandbox_flag_checked",
+        run_id=run_id,
+        small_data_sandbox_enabled=enabled,
     )
     return enabled
 
@@ -386,6 +429,17 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"use_modal_network_allowlist: {use_modal_network_allowlist} for this task run",
     )
+    small_data_sandbox_enabled = _is_small_data_sandbox_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"small_data_sandbox_enabled: {small_data_sandbox_enabled} for this task run",
+    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -417,4 +471,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
         use_modal_vm_sandbox=use_modal_vm_sandbox,
         use_modal_network_allowlist=use_modal_network_allowlist,
+        small_data_sandbox_enabled=small_data_sandbox_enabled,
     )

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -17,7 +17,12 @@ from products.tasks.backend.services.connection_token import (
     get_sandbox_jwt_public_key,
 )
 from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
-from products.tasks.backend.temporal.metrics import StepTimer, increment_sandbox_created, increment_snapshot_usage
+from products.tasks.backend.temporal.metrics import (
+    StepTimer,
+    increment_sandbox_created,
+    increment_sandbox_tier,
+    increment_snapshot_usage,
+)
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
 from products.tasks.backend.temporal.process_task.sandbox_credentials import set_git_remote_token
@@ -44,6 +49,24 @@ RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS = {
     "POSTHOG_RESUME_RUN_ID",
     "BASH_ENV",
 }
+
+# Small spec for data-only PostHog AI conversations (no repo, no build, paged results).
+# CPU and memory take effect immediately via Modal's create_kwargs; disk is
+# documentation-only on the Modal backend (the SDK exposes no disk-size knob).
+SMALL_DATA_SANDBOX_CPU_CORES = 1.0
+SMALL_DATA_SANDBOX_MEMORY_GB = 1.0
+SMALL_DATA_SANDBOX_DISK_GB = 10.0
+
+
+def is_data_only_sandbox(ctx: TaskProcessingContext) -> bool:
+    """A data-only sandbox runs a no-repo PostHog AI data Q&A conversation.
+
+    Gated on the origin-product enum member (not a bare literal, so a value rename stays
+    caught) AND no repository — PostHog AI is the only origin that is always and only
+    no-repo. Other origins (Signals, Slack) can also be no-repo but may run real compute,
+    so they must keep the default box.
+    """
+    return ctx.origin_product == Task.OriginProduct.POSTHOG_AI and ctx.repository is None
 
 
 @dataclass
@@ -369,6 +392,22 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
         # The VM template bakes in Docker (and forces the VM runtime), so the agent
         # can run nested containers; the default template has neither.
         use_vm_sandbox = ctx.use_modal_vm_sandbox
+
+        # Shrink the box only for no-repo PostHog AI data Q&A, and only behind the flag.
+        # The decision is captured once in the context at workflow start, so it's stable
+        # across activity retries. Defaults fall through to the SandboxConfig defaults
+        # (4 CPU / 16 GB / 64 GB) for every other flow.
+        use_small_sandbox = is_data_only_sandbox(ctx) and ctx.small_data_sandbox_enabled
+        tier = "small" if use_small_sandbox else "default"
+        sandbox_config_kwargs: dict[str, float] = {}
+        if use_small_sandbox:
+            sandbox_config_kwargs = {
+                "cpu_cores": SMALL_DATA_SANDBOX_CPU_CORES,
+                "memory_gb": SMALL_DATA_SANDBOX_MEMORY_GB,
+                "disk_size_gb": SMALL_DATA_SANDBOX_DISK_GB,
+            }
+        emit_agent_log(ctx.run_id, "debug", f"Provisioning {tier}-tier sandbox")
+
         config = SandboxConfig(
             name=prepared.sandbox_name,
             template=SandboxTemplate.VM_BASE if use_vm_sandbox else SandboxTemplate.DEFAULT_BASE,
@@ -377,6 +416,7 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
             snapshot_external_id=prepared.snapshot_external_id,
             metadata={"task_id": ctx.task_id},
             vm_runtime=use_vm_sandbox,
+            **sandbox_config_kwargs,
         )
 
         # gVisor only — Modal's domain allowlist breaks vm_runtime.
@@ -388,10 +428,17 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
                 f"Using Modal outbound_domain_allowlist ({len(config.outbound_domain_allowlist)} domains) instead of agentsh",
             )
 
-        with StepTimer("sandbox_creation", used_snapshot=prepared.used_snapshot):
+        origin_product = ctx.origin_product or "unknown"
+        with StepTimer(
+            "sandbox_creation",
+            used_snapshot=prepared.used_snapshot,
+            tier=tier,
+            origin_product=origin_product,
+        ):
             sandbox = Sandbox.create(config)
 
         increment_sandbox_created("vm" if use_vm_sandbox else "gvisor")
+        increment_sandbox_tier(tier, origin_product)
 
         credentials = sandbox.get_connect_credentials()
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -8,7 +8,11 @@ from asgiref.sync import async_to_sync
 from posthog.models import OrganizationMembership, User
 from posthog.models.user_integration import UserIntegration
 
-from products.tasks.backend.constants import MODAL_VM_SANDBOX_FEATURE_FLAG, SANDBOX_EVENT_INGEST_FEATURE_FLAG
+from products.tasks.backend.constants import (
+    MODAL_VM_SANDBOX_FEATURE_FLAG,
+    SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+    SMALL_DATA_SANDBOX_FEATURE_FLAG,
+)
 from products.tasks.backend.exceptions import TaskInvalidStateError, TaskNotFoundError
 from products.tasks.backend.models import SandboxEnvironment, Task
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
@@ -16,6 +20,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     TaskProcessingContext,
     _is_modal_vm_sandbox_enabled,
     _is_sandbox_event_ingest_enabled,
+    _is_small_data_sandbox_enabled,
     get_task_processing_context,
 )
 
@@ -386,6 +391,82 @@ class TestGetTaskProcessingContextActivity:
             )
 
         feature_enabled_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "flag_value, expected",
+        [
+            (True, True),
+            (False, False),
+            (None, False),
+        ],
+    )
+    def test_small_data_sandbox_flag_uses_organization_rollout(self, flag_value, expected):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=flag_value,
+        ) as feature_enabled_mock:
+            assert (
+                _is_small_data_sandbox_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is expected
+            )
+
+        feature_enabled_mock.assert_called_once_with(
+            SMALL_DATA_SANDBOX_FEATURE_FLAG,
+            distinct_id="distinct-id",
+            groups={"organization": "organization-id"},
+            group_properties={"organization": {"id": "organization-id"}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    def test_small_data_sandbox_flag_fails_closed(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            side_effect=RuntimeError("flag service failed"),
+        ):
+            assert (
+                _is_small_data_sandbox_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                )
+                is False
+            )
+
+    @pytest.mark.parametrize("override", [True, False])
+    def test_small_data_sandbox_state_override_skips_flag_check(self, override):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=not override,
+        ) as feature_enabled_mock:
+            assert (
+                _is_small_data_sandbox_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    state={"small_data_sandbox_enabled": override},
+                )
+                is override
+            )
+
+        feature_enabled_mock.assert_not_called()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_get_task_processing_context_uses_small_data_sandbox_state_override(self, activity_environment, test_task):
+        task_run = test_task.create_run(extra_state={"small_data_sandbox_enabled": True})
+        input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
+
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=False,
+        ):
+            result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
+
+        assert result.small_data_sandbox_enabled is True
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_uses_sandbox_event_ingest_state_override(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox_tier.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox_tier.py
@@ -1,0 +1,128 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from asgiref.sync import async_to_sync
+
+from products.tasks.backend.models import Task
+from products.tasks.backend.services.sandbox import AgentServerResult, SandboxConfig
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
+    SMALL_DATA_SANDBOX_CPU_CORES,
+    SMALL_DATA_SANDBOX_DISK_GB,
+    SMALL_DATA_SANDBOX_MEMORY_GB,
+    CreateSandboxForRepositoryInput,
+    PrepareSandboxForRepositoryOutput,
+    create_sandbox_for_repository,
+    is_data_only_sandbox,
+)
+
+ALL_ORIGINS = [
+    Task.OriginProduct.POSTHOG_AI,
+    Task.OriginProduct.SIGNAL_REPORT,
+    Task.OriginProduct.SIGNALS_SCOUT,
+    Task.OriginProduct.SLACK,
+    Task.OriginProduct.USER_CREATED,
+]
+
+
+def _make_context(origin_product: str | None, repository: str | None, small_flag: bool) -> TaskProcessingContext:
+    return TaskProcessingContext(
+        task_id="task-1",
+        run_id="run-1",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="org-1",
+        github_integration_id=None,
+        repository=repository,
+        distinct_id="distinct-1",
+        origin_product=origin_product,
+        small_data_sandbox_enabled=small_flag,
+    )
+
+
+def _make_prepared() -> PrepareSandboxForRepositoryOutput:
+    return PrepareSandboxForRepositoryOutput(
+        sandbox_name="sandbox-name",
+        repository=None,
+        github_token="",
+        branch=None,
+        environment_variables={},
+        snapshot_id=None,
+        snapshot_external_id=None,
+        used_snapshot=False,
+        should_create_snapshot=True,
+        shallow_clone=True,
+        image_source="base_image",
+        image_source_label="published sandbox base image",
+    )
+
+
+class TestIsDataOnlySandbox:
+    @pytest.mark.parametrize("origin_product", ALL_ORIGINS)
+    @pytest.mark.parametrize("repository", [None, "posthog/posthog"])
+    def test_truth_table(self, origin_product, repository):
+        ctx = _make_context(origin_product, repository, small_flag=True)
+
+        expected = origin_product == Task.OriginProduct.POSTHOG_AI and repository is None
+
+        assert is_data_only_sandbox(ctx) is expected
+
+    def test_only_posthog_ai_no_repo_is_true(self):
+        assert is_data_only_sandbox(_make_context(Task.OriginProduct.POSTHOG_AI, None, True)) is True
+
+    def test_none_origin_is_false(self):
+        assert is_data_only_sandbox(_make_context(None, None, True)) is False
+
+
+class TestCreateSandboxForRepositoryTier:
+    def _run_and_capture_config(self, ctx: TaskProcessingContext) -> SandboxConfig:
+        captured: dict[str, SandboxConfig] = {}
+
+        def fake_create(config: SandboxConfig):
+            captured["config"] = config
+            sandbox = MagicMock()
+            sandbox.id = "sandbox-id"
+            sandbox.get_connect_credentials.return_value = AgentServerResult(url="https://sandbox", token="token")
+            return sandbox
+
+        input_data = CreateSandboxForRepositoryInput(context=ctx, prepared=_make_prepared())
+
+        module = "products.tasks.backend.temporal.process_task.activities.provision_sandbox"
+        with (
+            patch(f"{module}.Sandbox.create", side_effect=fake_create),
+            patch(f"{module}.get_primary_sandbox_jwt_kid", return_value="kid"),
+            patch(f"{module}.TaskRun.update_state_atomic"),
+            patch(f"{module}.increment_sandbox_created"),
+            patch(f"{module}.increment_sandbox_tier"),
+            patch(f"{module}.emit_agent_log"),
+        ):
+            async_to_sync(create_sandbox_for_repository)(input_data)
+
+        return captured["config"]
+
+    def test_small_spec_when_data_only_and_flag_on(self):
+        ctx = _make_context(Task.OriginProduct.POSTHOG_AI, None, small_flag=True)
+
+        config = self._run_and_capture_config(ctx)
+
+        assert config.cpu_cores == SMALL_DATA_SANDBOX_CPU_CORES == 1.0
+        assert config.memory_gb == SMALL_DATA_SANDBOX_MEMORY_GB == 1.0
+        assert config.disk_size_gb == SMALL_DATA_SANDBOX_DISK_GB == 10.0
+
+    @pytest.mark.parametrize(
+        "origin_product, repository, small_flag",
+        [
+            (Task.OriginProduct.POSTHOG_AI, None, False),  # data-only but flag off
+            (Task.OriginProduct.SIGNALS_SCOUT, None, True),  # non-PostHog-AI no-repo, flag on
+            (Task.OriginProduct.SLACK, None, True),  # non-PostHog-AI no-repo, flag on
+            (Task.OriginProduct.POSTHOG_AI, "posthog/posthog", True),  # PostHog AI with a repo, flag on
+        ],
+    )
+    def test_default_spec_otherwise(self, origin_product, repository, small_flag):
+        ctx = _make_context(origin_product, repository, small_flag=small_flag)
+
+        config = self._run_and_capture_config(ctx)
+
+        assert config.cpu_cores == 4
+        assert config.memory_gb == 16
+        assert config.disk_size_gb == 64


### PR DESCRIPTION
## Problem

Every tasks-runtime sandbox is provisioned identically (4 CPU / 16 GB), even for PostHog AI (Max) conversations, which are pure data Q&A over MCP tools — no repo, no build, no coding toolchain. That is wasted spend and boot latency on every turn. Implements the G1 plan (`docs/internal/posthog-ai-migration/plans/G1-small-data-sandboxes.md`).

## Changes

- New `is_data_only_sandbox(ctx)` rule gating on `origin_product == POSTHOG_AI` **and** `repository is None` — so it never misfires onto Signals/Slack no-repo *compute* agents.
- Small tier **1 CPU / 1 GB / 10 GB disk** applied at sandbox-config build time, behind a new org-scoped rollout flag `tasks-small-data-sandbox` (default **off**), resolved once at workflow start (deterministic across retries) using the existing `_is_modal_vm_sandbox_enabled` template.
- Telemetry: `increment_sandbox_tier(tier, origin_product)` counter + `tier`/`origin_product` labels on the `sandbox_creation` step timer.
- Modal SDK 1.5.0 `Sandbox.create` exposes **no** disk parameter (verified via `inspect`), so `disk_size_gb=10` is documentation-only on the Modal backend; CPU and memory are the levers that take effect. `modal_sandbox.py` is intentionally unchanged.

## How did you test this code?

Authored by an agent (Claude Code). Automated tests run on this branch:

- `ruff check` / `ruff format --check` on all 6 changed files — clean.
- New `test_provision_sandbox_tier.py` — 17 passed: parameterized `is_data_only_sandbox` truth table over `{POSTHOG_AI, SIGNAL_REPORT, SIGNALS_SCOUT, SLACK, USER_CREATED} × {None, repo}` (only `(POSTHOG_AI, None)` is true), plus config-build assertions (1/1/10 when data-only + flag-on, defaults otherwise).
- New `_is_small_data_sandbox_enabled` tests — passed (state-override, fail-closed, flag on/off).

Note: some transactional DB tests in `test_get_task_processing_context.py` error in this environment (`structlog … setLevel`); confirmed identical on the base branch (pre-existing, unrelated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via a Claude Code multi-agent workflow (implement → adversarial review → fix), one branch per plan off `feat/posthog-ai-sandboxes`. Chosen design: implicit derivation from `(origin_product, repository)` rather than a new wire field (PostHog AI is the only always-no-repo origin), routed through a single helper so a future explicit-tier switch is a one-function change. 1 GB RAM is the aggressive part of the spec — the plan calls for empirical validation behind the flag before widening, with a 2 CPU / 4 GB fallback (config-only). Reviewer verdict: pass.
