### PR TITLE
feat(posthog-ai): server-side refresh_mcp for MCP hot-loading

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -276,6 +276,37 @@ class SandboxCancelResponseSerializer(serializers.Serializer):
     run_status = serializers.CharField(help_text="Status of the Run after the cancel command was issued.")
 
 
+class RefreshMcpRequestSerializer(serializers.Serializer):
+    """Request body for `POST /conversations/{id}/refresh_mcp/`.
+
+    Carries NO server list. The trusted `mcpServers` payload (URLs + bearer headers) is
+    rebuilt entirely server-side from the user's current MCP-store installs — the browser
+    is only the trigger, never the source of the server list.
+    """
+
+    source = serializers.ChoiceField(
+        required=False,
+        allow_null=True,
+        choices=["mcp_store_install", "mcp_store_uninstall", "manual"],
+        help_text="Optional telemetry tag describing what prompted the refresh. Has no effect on the rebuilt server list.",
+    )
+
+
+class RefreshMcpResponseSerializer(serializers.Serializer):
+    """Response for `POST /conversations/{id}/refresh_mcp/` — the targeted Run and whether a refresh was dispatched."""
+
+    task_id = serializers.CharField(help_text="The products/tasks Task backing the conversation.")
+    run_id = serializers.CharField(
+        allow_blank=True, help_text="The Run targeted for the MCP refresh. Empty when no live run exists."
+    )
+    run_status = serializers.CharField(
+        allow_blank=True, help_text="Status of the targeted Run. Empty when no live run exists."
+    )
+    refresh_requested = serializers.BooleanField(
+        help_text="True when a refresh command was delivered to a live run; false for an idempotent no-op (no/terminal run)."
+    )
+
+
 @extend_schema(tags=["max"])
 class ConversationViewSet(
     TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelMixin, DestroyModelMixin, GenericViewSet
@@ -875,6 +906,53 @@ class ConversationViewSet(
             )
 
         return Response(PermissionResponseResultSerializer({"status": "ok"}).data)
+
+    @extend_schema(
+        request=RefreshMcpRequestSerializer,
+        responses={
+            200: RefreshMcpResponseSerializer,
+            400: OpenApiResponse(description="Conversation is not on the sandbox runtime, or has no backing task."),
+            409: OpenApiResponse(description="The agent is mid-turn; retry once the run goes idle."),
+            502: OpenApiResponse(description="Sandbox agent unreachable or rejected the refresh command."),
+        },
+        description=(
+            "Hot-reload the conversation's live sandbox with the user's current MCP install set. The browser is "
+            "only the trigger; the trusted `mcpServers` payload (URLs + bearer headers) is rebuilt server-side, never "
+            "supplied by the client. Idempotent: a conversation with no live run is a 200 no-op."
+        ),
+    )
+    @action(detail=True, methods=["POST"], url_path="refresh_mcp")
+    def refresh_mcp(self, request: Request, *args, **kwargs):
+        """Sandbox-runtime MCP hot-reload trigger.
+
+        Resolves the conversation's backing Run and delegates in-process to
+        `MessageRoutingService.refresh_mcp`, which rebuilds the trusted server list from
+        the user's MCP-store installs and pushes it via `_posthog/refresh_session`.
+        """
+        conversation = self.get_object()
+        if conversation.agent_runtime != Conversation.AgentRuntime.SANDBOX:
+            raise exceptions.ValidationError("This conversation is not on the sandbox runtime.")
+
+        serializer = RefreshMcpRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        source = serializer.validated_data.get("source")
+
+        user = cast(User, request.user)
+        result = MessageRoutingService(conversation, user).refresh_mcp()
+
+        if result.refresh_requested and user.distinct_id:
+            posthoganalytics.capture(
+                distinct_id=user.distinct_id,
+                event="mcp_refresh_requested",
+                properties={
+                    "conversation_id": str(conversation.id),
+                    "run_id": result.run_id,
+                    "execution_type": "sandbox",
+                    "source": source,
+                },
+            )
+
+        return Response(RefreshMcpResponseSerializer(result.model_dump()).data, status=status.HTTP_200_OK)
 
     @extend_schema(
         description="Delete a conversation.",

--- a/ee/api/test/test_conversation_refresh_mcp.py
+++ b/ee/api/test/test_conversation_refresh_mcp.py
@@ -1,0 +1,124 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from products.posthog_ai.backend.message_routing import SandboxBusyError, SandboxCommandError, SandboxRefreshMcpResult
+from products.posthog_ai.backend.models.assistant import Conversation
+from products.tasks.backend.models import Task, TaskRun
+
+ROUTING_PATH = "ee.api.conversation.MessageRoutingService.refresh_mcp"
+
+
+class TestConversationRefreshMcp(APIBaseTest):
+    def _sandbox_conversation(self, *, user=None) -> tuple[Task, TaskRun, Conversation]:
+        owner = user or self.user
+        task = Task.objects.create(
+            team=self.team,
+            created_by=owner,
+            title="Sandbox task",
+            description="desc",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+        )
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+        conversation = Conversation.objects.create(
+            user=owner,
+            team=self.team,
+            task=task,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+        )
+        return task, run, conversation
+
+    def _url(self, conversation: Conversation) -> str:
+        return f"/api/environments/{self.team.id}/conversations/{conversation.id}/refresh_mcp/"
+
+    def test_refresh_happy_path_returns_200_and_shape(self):
+        task, run, conversation = self._sandbox_conversation()
+
+        result = SandboxRefreshMcpResult(
+            task_id=str(task.id),
+            run_id=str(run.id),
+            run_status=TaskRun.Status.IN_PROGRESS,
+            refresh_requested=True,
+        )
+        with patch(ROUTING_PATH, return_value=result) as mock_refresh:
+            response = self.client.post(self._url(conversation), {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertEqual(body["task_id"], str(task.id))
+        self.assertEqual(body["run_id"], str(run.id))
+        self.assertEqual(body["run_status"], TaskRun.Status.IN_PROGRESS)
+        self.assertTrue(body["refresh_requested"])
+        mock_refresh.assert_called_once()
+
+    def test_refresh_emits_telemetry_with_source_only_when_requested(self):
+        task, run, conversation = self._sandbox_conversation()
+        result = SandboxRefreshMcpResult(
+            task_id=str(task.id), run_id=str(run.id), run_status=TaskRun.Status.IN_PROGRESS, refresh_requested=True
+        )
+
+        with (
+            patch(ROUTING_PATH, return_value=result),
+            patch("ee.api.conversation.posthoganalytics.capture") as mock_capture,
+        ):
+            self.client.post(self._url(conversation), {"source": "mcp_store_install"}, format="json")
+
+        mock_capture.assert_called_once()
+        self.assertEqual(mock_capture.call_args.kwargs["event"], "mcp_refresh_requested")
+        props = mock_capture.call_args.kwargs["properties"]
+        self.assertEqual(props["source"], "mcp_store_install")
+        self.assertEqual(props["execution_type"], "sandbox")
+        self.assertEqual(props["conversation_id"], str(conversation.id))
+
+    def test_refresh_noop_does_not_emit_telemetry(self):
+        task, run, conversation = self._sandbox_conversation()
+        result = SandboxRefreshMcpResult(
+            task_id=str(task.id), run_id=str(run.id), run_status=TaskRun.Status.COMPLETED, refresh_requested=False
+        )
+
+        with (
+            patch(ROUTING_PATH, return_value=result),
+            patch("ee.api.conversation.posthoganalytics.capture") as mock_capture,
+        ):
+            response = self.client.post(self._url(conversation), {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_capture.assert_not_called()
+
+    def test_refresh_409_when_agent_mid_turn(self):
+        _task, _run, conversation = self._sandbox_conversation()
+
+        with patch(ROUTING_PATH, side_effect=SandboxBusyError()):
+            response = self.client.post(self._url(conversation), {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_refresh_502_when_agent_unreachable(self):
+        _task, _run, conversation = self._sandbox_conversation()
+
+        with patch(ROUTING_PATH, side_effect=SandboxCommandError("down")):
+            response = self.client.post(self._url(conversation), {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    def test_refresh_400_when_not_sandbox_runtime(self):
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            agent_runtime=Conversation.AgentRuntime.LANGGRAPH,
+        )
+        response = self.client.post(self._url(conversation), {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_refresh_rejects_invalid_source(self):
+        _task, _run, conversation = self._sandbox_conversation()
+        response = self.client.post(self._url(conversation), {"source": "not_a_choice"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_refresh_on_other_user_conversation_returns_404(self):
+        other_user = self._create_user("other@posthog.com")
+        _task, _run, conversation = self._sandbox_conversation(user=other_user)
+
+        response = self.client.post(self._url(conversation), {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -427,6 +427,50 @@ export interface PermissionResponseResultApi {
 }
 
 /**
+ * * `mcp_store_install` - mcp_store_install
+ * * `mcp_store_uninstall` - mcp_store_uninstall
+ * * `manual` - manual
+ */
+export type RefreshMcpRequestSourceEnumApi =
+    (typeof RefreshMcpRequestSourceEnumApi)[keyof typeof RefreshMcpRequestSourceEnumApi]
+
+export const RefreshMcpRequestSourceEnumApi = {
+    McpStoreInstall: 'mcp_store_install',
+    McpStoreUninstall: 'mcp_store_uninstall',
+    Manual: 'manual',
+} as const
+
+/**
+ * Request body for `POST /conversations/{id}/refresh_mcp/`.
+ *
+ * Carries NO server list. The trusted `mcpServers` payload (URLs + bearer headers) is
+ * rebuilt entirely server-side from the user's current MCP-store installs — the browser
+ * is only the trigger, never the source of the server list.
+ */
+export interface RefreshMcpRequestApi {
+    /** Optional telemetry tag describing what prompted the refresh. Has no effect on the rebuilt server list.
+     *
+     * * `mcp_store_install` - mcp_store_install
+     * * `mcp_store_uninstall` - mcp_store_uninstall
+     * * `manual` - manual */
+    source?: RefreshMcpRequestSourceEnumApi | null
+}
+
+/**
+ * Response for `POST /conversations/{id}/refresh_mcp/` — the targeted Run and whether a refresh was dispatched.
+ */
+export interface RefreshMcpResponseApi {
+    /** The products/tasks Task backing the conversation. */
+    task_id: string
+    /** The Run targeted for the MCP refresh. Empty when no live run exists. */
+    run_id: string
+    /** Status of the targeted Run. Empty when no live run exists. */
+    run_status: string
+    /** True when a refresh command was delivered to a live run; false for an idempotent no-op (no/terminal run). */
+    refresh_requested: boolean
+}
+
+/**
  * * `action` - action
  * * `dashboard` - dashboard
  * * `error_tracking_issue` - error_tracking_issue

--- a/products/conversations/frontend/generated/api.ts
+++ b/products/conversations/frontend/generated/api.ts
@@ -30,6 +30,8 @@ import type {
     PatchedTicketApi,
     PermissionResponseApi,
     PermissionResponseResultApi,
+    RefreshMcpRequestApi,
+    RefreshMcpResponseApi,
     SandboxCancelResponseApi,
     SandboxMessageApi,
     SandboxMessageResponseApi,
@@ -327,6 +329,27 @@ export const conversationsQueueClearCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(conversationApi),
+    })
+}
+
+export const getConversationsRefreshMcpCreateUrl = (projectId: string, conversation: string) => {
+    return `/api/environments/${projectId}/conversations/${conversation}/refresh_mcp/`
+}
+
+/**
+ * Hot-reload the conversation's live sandbox with the user's current MCP install set. The browser is only the trigger; the trusted `mcpServers` payload (URLs + bearer headers) is rebuilt server-side, never supplied by the client. Idempotent: a conversation with no live run is a 200 no-op.
+ */
+export const conversationsRefreshMcpCreate = async (
+    projectId: string,
+    conversation: string,
+    refreshMcpRequestApi?: RefreshMcpRequestApi,
+    options?: RequestInit
+): Promise<RefreshMcpResponseApi> => {
+    return apiMutator<RefreshMcpResponseApi>(getConversationsRefreshMcpCreateUrl(projectId, conversation), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(refreshMcpRequestApi),
     })
 }
 

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -109,6 +109,29 @@ export const ConversationsQueuePartialUpdateBody = /* @__PURE__ */ zod.looseObje
 export const ConversationsQueueClearCreateBody = /* @__PURE__ */ zod.looseObject({})
 
 /**
+ * Hot-reload the conversation's live sandbox with the user's current MCP install set. The browser is only the trigger; the trusted `mcpServers` payload (URLs + bearer headers) is rebuilt server-side, never supplied by the client. Idempotent: a conversation with no live run is a 200 no-op.
+ */
+export const ConversationsRefreshMcpCreateBody = /* @__PURE__ */ zod
+    .object({
+        source: zod
+            .union([
+                zod
+                    .enum(['mcp_store_install', 'mcp_store_uninstall', 'manual'])
+                    .describe(
+                        '\* `mcp_store_install` - mcp_store_install\n\* `mcp_store_uninstall` - mcp_store_uninstall\n\* `manual` - manual'
+                    ),
+                zod.null(),
+            ])
+            .optional()
+            .describe(
+                'Optional telemetry tag describing what prompted the refresh. Has no effect on the rebuilt server list.\n\n\* `mcp_store_install` - mcp_store_install\n\* `mcp_store_uninstall` - mcp_store_uninstall\n\* `manual` - manual'
+            ),
+    })
+    .describe(
+        "Request body for `POST \/conversations\/{id}\/refresh_mcp\/`.\n\nCarries NO server list. The trusted `mcpServers` payload (URLs + bearer headers) is\nrebuilt entirely server-side from the user's current MCP-store installs — the browser\nis only the trigger, never the source of the server list."
+    )
+
+/**
  * Non-streaming routing endpoint for sandbox-runtime conversations. Wraps + dedupes the message, then starts a Run / signals a follow-up / resumes via in-process products/tasks calls and returns the IDs the frontend opens SSE against. Sandbox runtime only — LangGraph conversations stream via the unchanged `/stream/` path.
  */
 export const conversationsSandboxCreateBodyContentMax = 40000

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -35,8 +35,11 @@ from products.posthog_ai.backend.run_state import PostHogAIRunState
 from products.posthog_ai.backend.system_prompt import PromptService
 from products.posthog_ai.backend.wire_types import UnknownFrame, is_user_message_params, parse_log_entry
 from products.tasks.backend.models import Task, TaskRun
-from products.tasks.backend.services.agent_command import send_cancel
+from products.tasks.backend.services.agent_command import CommandResult, send_cancel, send_refresh_session
+from products.tasks.backend.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.temporal.client import execute_task_processing_workflow, signal_task_followup_message
+from products.tasks.backend.temporal.oauth import create_oauth_access_token
+from products.tasks.backend.temporal.process_task.utils import build_sandbox_mcp_servers
 
 logger = structlog.get_logger(__name__)
 
@@ -70,6 +73,35 @@ class SandboxCommandError(exceptions.APIException):
     status_code = status.HTTP_502_BAD_GATEWAY
     default_detail = "Failed to deliver the command to the sandbox agent."
     default_code = "sandbox_command_failed"
+
+
+class SandboxBusyError(exceptions.APIException):
+    """The sandbox agent is mid-turn and cannot rebind its MCP session right now.
+
+    A `_posthog/refresh_session` must be dispatched between turns; the agent-server
+    replies with JSON-RPC error -32002 when a prompt is in flight. Map it to a
+    soft, retryable 409 so the frontend can re-attempt once the run goes idle
+    rather than treating a normal timing condition as a hard failure.
+    """
+
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = "The agent is mid-turn — new tools will load after the current turn."
+    default_code = "sandbox_busy"
+
+
+# JSON-RPC error code the agent-server returns when a refresh arrives while a prompt is in flight.
+REFRESH_PROMPT_IN_FLIGHT_CODE = -32002
+
+
+class SandboxRefreshMcpResult(BaseModel):
+    """Outcome of requesting an MCP hot-reload on the conversation's current sandbox Run."""
+
+    task_id: str
+    run_id: str
+    run_status: str
+    # True only when a refresh command was actually delivered to a live run (not an
+    # already-terminal / no-run idempotent no-op), so the action emits telemetry once per real refresh.
+    refresh_requested: bool = False
 
 
 @contextmanager
@@ -112,6 +144,11 @@ class MessageRoutingService(BaseSandboxService):
 
     # Run statuses that accept a follow-up signal without creating a successor Run.
     _IN_PROGRESS_STATUSES: frozenset[str] = frozenset({TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS})
+
+    # PostHog AI runs are always launched with write scopes (the agent creates insights,
+    # dashboards, notebooks), so an MCP refresh must mint the same "full"-scoped token a
+    # follow-up turn would — read-only here would silently strip the agent's write tools.
+    _MCP_SCOPES: str = "full"
 
     # Caps on concurrent non-terminal sandbox Runs reachable via prewarm, bounding resource use
     # from repeated warm / re-warm calls. Message-sending paths are separately quota-gated.
@@ -197,6 +234,69 @@ class MessageRoutingService(BaseSandboxService):
             run_status=run.status,
             cancel_requested=True,
         )
+
+    def refresh_mcp(self) -> SandboxRefreshMcpResult:
+        """Hot-reload the conversation's live sandbox with the current MCP install set.
+
+        The browser is the trigger only: it says "my MCP installs may have changed,
+        re-sync this conversation's sandbox." The server rebuilds the trusted
+        `mcpServers` list from PostHog state (PostHog MCP + the user's MCP-store
+        installs, minting fresh OAuth tokens) and pushes it via
+        `_posthog/refresh_session`. No client-supplied URLs or bearer headers ever
+        reach the sandbox — that is why this is a conversation action and not on the
+        relay allowlist (see `TaskRunCommandRequestSerializer.ALLOWED_METHODS`).
+
+        Idempotent: a conversation with no backing run / a terminal run is a 200 no-op.
+        A refresh that arrives while a prompt is in flight raises `SandboxBusyError`
+        (409) so the frontend can retry once the run goes idle; transport failures
+        raise `SandboxCommandError` (502).
+        """
+        if self.conversation.task_id is None:
+            raise exceptions.ValidationError("This conversation has no backing task to refresh.")
+
+        run = self.conversation.current_run
+        if run is None or run.is_terminal:
+            # Nothing live to refresh — report idempotently, no telemetry, no token minting.
+            return SandboxRefreshMcpResult(
+                task_id=str(self.conversation.task_id),
+                run_id=str(run.id) if run is not None else "",
+                run_status=run.status if run is not None else "",
+            )
+
+        # Mint fresh tokens server-side every time — never reuse a possibly-stale token from
+        # run state. The OAuth access token is embedded in the mcpServers headers; the
+        # connection JWT authenticates the transport to the sandbox (Modal-tunnel runs need it).
+        task = run.task
+        access_token = create_oauth_access_token(task, scopes=self._MCP_SCOPES)
+        mcp_servers = build_sandbox_mcp_servers(run, token=access_token, scopes=self._MCP_SCOPES)
+
+        connection_token: str | None = None
+        created_by = task.created_by
+        if created_by and created_by.id:
+            distinct_id = created_by.distinct_id or f"user_{created_by.id}"
+            connection_token = create_sandbox_connection_token(run, user_id=created_by.id, distinct_id=distinct_id)
+
+        result = send_refresh_session(run, mcp_servers, auth_token=connection_token)
+        if not result.success:
+            if self._is_prompt_in_flight(result):
+                raise SandboxBusyError()
+            raise SandboxCommandError(f"Failed to refresh the run's MCP session: {result.error}")
+
+        return SandboxRefreshMcpResult(
+            task_id=str(self.conversation.task_id),
+            run_id=str(run.id),
+            run_status=run.status,
+            refresh_requested=True,
+        )
+
+    @staticmethod
+    def _is_prompt_in_flight(result: CommandResult) -> bool:
+        """True if the agent rejected the refresh because a prompt is mid-turn (JSON-RPC -32002)."""
+        data = result.data
+        if not isinstance(data, dict):
+            return False
+        error = data.get("error")
+        return isinstance(error, dict) and error.get("code") == REFRESH_PROMPT_IN_FLIGHT_CODE
 
     def prewarm(self) -> None:
         """Eagerly provision a sandbox Run while the user is typing.

--- a/products/posthog_ai/backend/message_routing.py
+++ b/products/posthog_ai/backend/message_routing.py
@@ -78,8 +78,8 @@ class SandboxCommandError(exceptions.APIException):
 class SandboxBusyError(exceptions.APIException):
     """The sandbox agent is mid-turn and cannot rebind its MCP session right now.
 
-    A `_posthog/refresh_session` must be dispatched between turns; the agent-server
-    replies with JSON-RPC error -32002 when a prompt is in flight. Map it to a
+    A `_posthog/refresh_session` must be dispatched between turns; the agent
+    adapter throws JSON-RPC error -32002 when a prompt is in flight. Map it to a
     soft, retryable 409 so the frontend can re-attempt once the run goes idle
     rather than treating a normal timing condition as a hard failure.
     """
@@ -89,8 +89,12 @@ class SandboxBusyError(exceptions.APIException):
     default_code = "sandbox_busy"
 
 
-# JSON-RPC error code the agent-server returns when a refresh arrives while a prompt is in flight.
+# The adapter throws RequestError(-32002, ...) when a refresh arrives mid-turn, but the
+# agent-server's /command handler catches every error and re-serializes it as code -32000
+# with only the message preserved. So the numeric code is unreliable on the HTTP path; the
+# message substring is what survives. Match on either to cover both transports.
 REFRESH_PROMPT_IN_FLIGHT_CODE = -32002
+REFRESH_PROMPT_IN_FLIGHT_MESSAGE = "prompt turn is in flight"
 
 
 class SandboxRefreshMcpResult(BaseModel):
@@ -291,12 +295,22 @@ class MessageRoutingService(BaseSandboxService):
 
     @staticmethod
     def _is_prompt_in_flight(result: CommandResult) -> bool:
-        """True if the agent rejected the refresh because a prompt is mid-turn (JSON-RPC -32002)."""
+        """True if the agent rejected the refresh because a prompt is mid-turn.
+
+        The adapter throws JSON-RPC -32002, but the agent-server flattens it to -32000 on
+        the /command HTTP path while preserving the message, so we match on either the code
+        or the message substring — otherwise a mid-turn refresh would surface as a hard 502.
+        """
         data = result.data
         if not isinstance(data, dict):
             return False
         error = data.get("error")
-        return isinstance(error, dict) and error.get("code") == REFRESH_PROMPT_IN_FLIGHT_CODE
+        if not isinstance(error, dict):
+            return False
+        if error.get("code") == REFRESH_PROMPT_IN_FLIGHT_CODE:
+            return True
+        message = error.get("message")
+        return isinstance(message, str) and REFRESH_PROMPT_IN_FLIGHT_MESSAGE in message
 
     def prewarm(self) -> None:
         """Eagerly provision a sandbox Run while the user is typing.

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import exceptions
 
 from posthog.exceptions import Conflict
@@ -495,14 +496,26 @@ class TestHandleSandboxRefreshMcp(APIBaseTest):
         with self.assertRaises(exceptions.ValidationError):
             self._service().refresh_mcp()
 
-    def test_refresh_prompt_in_flight_raises_409(self):
+    @parameterized.expand(
+        [
+            # Direct ACP path: the adapter's RequestError code survives.
+            ("direct_acp_code", {"code": -32002, "message": "Cannot refresh session while a prompt turn is in flight"}),
+            # /command HTTP path: the agent-server flattens every error to -32000, preserving only
+            # the message — this is the shape the sandbox actually returns on a mid-turn refresh.
+            (
+                "flattened_http_code",
+                {"code": -32000, "message": "Cannot refresh session while a prompt turn is in flight"},
+            ),
+        ]
+    )
+    def test_refresh_prompt_in_flight_raises_409(self, _name: str, error: dict):
         self._task_with_run(TaskRun.Status.IN_PROGRESS)
 
         in_flight = CommandResult(
             success=False,
             status_code=200,
-            data={"error": {"code": -32002, "message": "Prompt in flight"}},
-            error="Prompt in flight",
+            data={"error": error},
+            error=error["message"],
         )
         with self._patched_refresh(in_flight):
             with self.assertRaises(SandboxBusyError) as ctx:

--- a/products/posthog_ai/backend/test/test_message_routing.py
+++ b/products/posthog_ai/backend/test/test_message_routing.py
@@ -10,6 +10,7 @@ from posthog.exceptions import Conflict
 from products.posthog_ai.backend.context_wrapper import MAX_ATTACHED_ITEMS, MAX_TEXT_LENGTH
 from products.posthog_ai.backend.message_routing import (
     MessageRoutingService,
+    SandboxBusyError,
     SandboxCommandError,
     lock_conversation_for_followup,
 )
@@ -396,6 +397,128 @@ class TestHandleSandboxCancel(APIBaseTest):
     def test_cancel_without_task_raises(self):
         with self.assertRaises(exceptions.ValidationError):
             self._service().cancel()
+
+
+class TestHandleSandboxRefreshMcp(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            agent_runtime=Conversation.AgentRuntime.SANDBOX,
+        )
+
+    def _service(self) -> MessageRoutingService:
+        return MessageRoutingService(self.conversation, self.user)
+
+    def _task_with_run(self, status: str) -> tuple[Task, TaskRun]:
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        run = task.create_run(mode="interactive")
+        run.status = status
+        run.save(update_fields=["status"])
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+        return task, run
+
+    @contextmanager
+    def _patched_refresh(self, refresh_result: CommandResult):
+        with (
+            patch(f"{ROUTING}.create_oauth_access_token", return_value="minted-token") as m_oauth,
+            patch(f"{ROUTING}.build_sandbox_mcp_servers", return_value=[{"name": "posthog"}]) as m_build,
+            patch(f"{ROUTING}.create_sandbox_connection_token", return_value="jwt") as m_conn,
+            patch(f"{ROUTING}.send_refresh_session", return_value=refresh_result) as m_refresh,
+        ):
+            yield m_oauth, m_build, m_conn, m_refresh
+
+    def test_refresh_delegates_with_trusted_list_and_full_scopes(self):
+        task, run = self._task_with_run(TaskRun.Status.IN_PROGRESS)
+
+        with self._patched_refresh(CommandResult(success=True, status_code=200)) as (
+            m_oauth,
+            m_build,
+            _m_conn,
+            m_refresh,
+        ):
+            result = self._service().refresh_mcp()
+
+        # PostHog AI runs always use write scopes — the refresh must mint a "full"-scoped token.
+        m_oauth.assert_called_once_with(task, scopes="full")
+        _, build_kwargs = m_build.call_args
+        assert build_kwargs["token"] == "minted-token"
+        assert build_kwargs["scopes"] == "full"
+        assert m_build.call_args.args[0].id == run.id
+        m_refresh.assert_called_once()
+        # The server-minted connection JWT is the transport auth, never a client value.
+        assert m_refresh.call_args.kwargs["auth_token"] == "jwt"
+        assert m_refresh.call_args.args[1] == [{"name": "posthog"}]
+
+        assert result.task_id == str(task.id)
+        assert result.run_id == str(run.id)
+        assert result.run_status == TaskRun.Status.IN_PROGRESS
+        assert result.refresh_requested is True
+
+    def test_refresh_no_run_is_idempotent_noop(self):
+        task = Task.objects.create(
+            team=self.team,
+            title="t",
+            description="d",
+            origin_product=Task.OriginProduct.POSTHOG_AI,
+            created_by=self.user,
+        )
+        self.conversation.task = task
+        self.conversation.save(update_fields=["task"])
+
+        with patch(f"{ROUTING}.send_refresh_session") as m_refresh:
+            result = self._service().refresh_mcp()
+
+        m_refresh.assert_not_called()
+        assert result.refresh_requested is False
+        assert result.run_id == ""
+
+    def test_refresh_terminal_run_is_idempotent_noop(self):
+        task, run = self._task_with_run(TaskRun.Status.COMPLETED)
+
+        with patch(f"{ROUTING}.send_refresh_session") as m_refresh:
+            result = self._service().refresh_mcp()
+
+        m_refresh.assert_not_called()
+        assert result.refresh_requested is False
+        assert result.run_status == TaskRun.Status.COMPLETED
+
+    def test_refresh_without_task_raises(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self._service().refresh_mcp()
+
+    def test_refresh_prompt_in_flight_raises_409(self):
+        self._task_with_run(TaskRun.Status.IN_PROGRESS)
+
+        in_flight = CommandResult(
+            success=False,
+            status_code=200,
+            data={"error": {"code": -32002, "message": "Prompt in flight"}},
+            error="Prompt in flight",
+        )
+        with self._patched_refresh(in_flight):
+            with self.assertRaises(SandboxBusyError) as ctx:
+                self._service().refresh_mcp()
+
+        assert ctx.exception.status_code == 409
+
+    def test_refresh_transport_failure_raises_502(self):
+        self._task_with_run(TaskRun.Status.IN_PROGRESS)
+
+        failure = CommandResult(success=False, status_code=502, error="connection refused")
+        with self._patched_refresh(failure):
+            with self.assertRaises(SandboxCommandError) as ctx:
+                self._service().refresh_mcp()
+
+        assert ctx.exception.status_code == 502
 
 
 class TestLockConversationForFollowup(APIBaseTest):

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -1381,6 +1381,12 @@ TaskRunCreateRequestSchemaSerializer = PolymorphicProxySerializer(
 class TaskRunCommandRequestSerializer(serializers.Serializer):
     """JSON-RPC request to send a command to the agent server in the sandbox."""
 
+    # `_posthog/refresh_session` is intentionally NOT relay-exposed. The relay forwards `params`
+    # verbatim, and a refresh payload carries outbound MCP `url`s + `Authorization: Bearer` headers
+    # the sandbox trusts as-is — letting the browser supply them would be a credential-injection /
+    # SSRF-amplification surface. MCP hot-loading is routed server-side instead, via
+    # `products/posthog_ai` `message_routing.refresh_mcp` → `send_refresh_session`, which rebuilds the
+    # trusted server list from PostHog state. Keep this allowlist free of network-destination verbs.
     ALLOWED_METHODS = [
         "user_message",
         "cancel",

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -23,8 +23,7 @@ from products.tasks.backend.services.staged_artifacts import get_task_run_artifa
 from products.tasks.backend.stream.redis_stream import get_task_run_stream_key
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.process_task.utils import (
-    get_sandbox_ph_mcp_configs,
-    get_user_mcp_server_configs,
+    build_sandbox_mcp_servers,
     mark_mcp_token_issued,
     should_refresh_mcp_token,
 )
@@ -137,27 +136,11 @@ def _refresh_sandbox_mcp(
         logger.warning("refresh_mcp_token_mint_failed", run_id=run_id, error=str(e))
         return
 
-    mcp_configs = get_sandbox_ph_mcp_configs(
-        token=access_token,
-        project_id=task_run.team_id,
-        scopes=scopes,
-        interaction_origin=(task_run.state or {}).get("interaction_origin"),
-    )
-    if task.created_by_id:
-        user_mcp_configs = get_user_mcp_server_configs(
-            token=access_token,
-            team_id=task_run.team_id,
-            user_id=task.created_by_id,
-            interaction_origin=(task_run.state or {}).get("interaction_origin"),
-        )
-        if user_mcp_configs:
-            mcp_configs = mcp_configs + user_mcp_configs
+    mcp_servers = build_sandbox_mcp_servers(task_run, token=access_token, scopes=scopes)
 
-    if not mcp_configs:
+    if not mcp_servers:
         logger.info("refresh_mcp_skipped_no_configs", run_id=run_id)
         return
-
-    mcp_servers = [config.to_dict() for config in mcp_configs]
 
     result = send_refresh_session(
         task_run,

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -53,12 +53,8 @@ def _make_task_run_mock(team_id: int = 7, created_by_id: int | None = 42, state:
 
 class TestRefreshSandboxMcp:
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_success_path_single_call(self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh):
         mock_oauth.return_value = "fresh-token"
@@ -84,12 +80,8 @@ class TestRefreshSandboxMcp:
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_retries_once_on_first_failure(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, mock_sleep
@@ -109,12 +101,8 @@ class TestRefreshSandboxMcp:
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_two_failures_are_non_fatal(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
@@ -130,12 +118,8 @@ class TestRefreshSandboxMcp:
         assert mock_send_refresh.call_count == 2
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_token_mint_failure_is_non_fatal_and_skips_send(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
@@ -149,12 +133,8 @@ class TestRefreshSandboxMcp:
         mock_send_refresh.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_skips_send_when_no_mcp_configs_resolved(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
@@ -168,12 +148,8 @@ class TestRefreshSandboxMcp:
         mock_send_refresh.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_user_mcp_configs_skipped_when_no_creator(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
@@ -188,12 +164,8 @@ class TestRefreshSandboxMcp:
         mock_send_refresh.assert_called_once()
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_scopes_propagate_to_oauth_and_configs(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
@@ -209,6 +181,26 @@ class TestRefreshSandboxMcp:
         mock_ph_configs.assert_called_once_with(
             token="fresh-token", project_id=7, scopes="full", interaction_origin=None
         )
+
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
+    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    def test_delivers_exactly_build_sandbox_mcp_servers_output(self, mock_oauth, mock_send_refresh):
+        # Refactor-equivalence: the follow-up path must push byte-for-byte the same trusted
+        # server list `build_sandbox_mcp_servers` produces — the shared builder the web-layer
+        # refresh (message_routing.refresh_mcp) also uses, so the two paths cannot drift.
+        mock_oauth.return_value = "fresh-token"
+        mock_send_refresh.return_value = CommandResult(success=True, status_code=200)
+        task_run = _make_task_run_mock(state={"interaction_origin": "slack"})
+
+        expected = [{"type": "http", "name": "posthog", "url": "https://mcp.posthog.com/mcp", "headers": []}]
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.build_sandbox_mcp_servers",
+            return_value=expected,
+        ) as mock_build:
+            _refresh_sandbox_mcp(task_run, "full", auth_token="jwt")
+
+        mock_build.assert_called_once_with(task_run, token="fresh-token", scopes="full")
+        assert mock_send_refresh.call_args.args[1] == expected
 
 
 class TestRefreshIntervalGate:
@@ -227,12 +219,8 @@ class TestRefreshIntervalGate:
         mock_send_refresh.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_marks_after_successful_refresh(self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh):
         mock_oauth.return_value = "fresh-token"
@@ -247,12 +235,8 @@ class TestRefreshIntervalGate:
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_marks_after_successful_retry(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
@@ -271,12 +255,8 @@ class TestRefreshIntervalGate:
 
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs")
     @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
     def test_does_not_mark_after_two_failures(
         self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -9,6 +9,7 @@ from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.process_task.utils import (
     GitHubCredentialSource,
     McpServerConfig,
+    build_sandbox_mcp_servers,
     get_git_identity_env_vars,
     get_github_credential_source,
     get_sandbox_github_token,
@@ -621,3 +622,96 @@ class TestGitHubCredentialSourceHelpers(TestCase):
         )
 
         assert result == "ghs_team"
+
+
+class TestBuildSandboxMcpServers(TestCase):
+    TOKEN = "phx_minted_token"
+    TEAM_ID = 7
+    USER_ID = 42
+
+    MOCK_PH = "products.tasks.backend.temporal.process_task.utils.get_sandbox_ph_mcp_configs"
+    MOCK_USER = "products.tasks.backend.temporal.process_task.utils.get_user_mcp_server_configs"
+
+    def _make_task_run(self, *, created_by_id: int | None = USER_ID, state: dict | None = None) -> MagicMock:
+        task = MagicMock()
+        task.created_by_id = created_by_id
+        task_run = MagicMock()
+        task_run.id = "run-1"
+        task_run.team_id = self.TEAM_ID
+        task_run.task = task
+        task_run.state = state
+        return task_run
+
+    def _ph_config(self) -> McpServerConfig:
+        return McpServerConfig(
+            type="http",
+            name="posthog",
+            url="https://mcp.posthog.com/mcp",
+            headers=[{"name": "Authorization", "value": f"Bearer {self.TOKEN}"}],
+        )
+
+    def _user_config(self) -> McpServerConfig:
+        return McpServerConfig(
+            type="http",
+            name="Linear",
+            url="https://us.posthog.com/proxy",
+            headers=[{"name": "Authorization", "value": f"Bearer {self.TOKEN}"}],
+        )
+
+    @patch(MOCK_USER)
+    @patch(MOCK_PH)
+    def test_assembles_ph_plus_user_configs_with_minted_token(self, mock_ph, mock_user) -> None:
+        mock_ph.return_value = [self._ph_config()]
+        mock_user.return_value = [self._user_config()]
+        task_run = self._make_task_run(state={"interaction_origin": "slack"})
+
+        result = build_sandbox_mcp_servers(task_run, token=self.TOKEN, scopes="full")
+
+        mock_ph.assert_called_once_with(
+            token=self.TOKEN, project_id=self.TEAM_ID, scopes="full", interaction_origin="slack"
+        )
+        mock_user.assert_called_once_with(
+            token=self.TOKEN, team_id=self.TEAM_ID, user_id=self.USER_ID, interaction_origin="slack"
+        )
+        assert result == [self._ph_config().to_dict(), self._user_config().to_dict()]
+
+    @patch(MOCK_USER)
+    @patch(MOCK_PH)
+    def test_skips_user_configs_when_no_creator(self, mock_ph, mock_user) -> None:
+        mock_ph.return_value = [self._ph_config()]
+        task_run = self._make_task_run(created_by_id=None)
+
+        result = build_sandbox_mcp_servers(task_run, token=self.TOKEN, scopes="full")
+
+        mock_user.assert_not_called()
+        assert result == [self._ph_config().to_dict()]
+
+    @patch(MOCK_USER)
+    @patch(MOCK_PH)
+    def test_returns_empty_when_no_configs(self, mock_ph, mock_user) -> None:
+        mock_ph.return_value = []
+        mock_user.return_value = []
+
+        assert build_sandbox_mcp_servers(self._make_task_run(), token=self.TOKEN, scopes="full") == []
+
+    @patch(MOCK_USER)
+    @patch(MOCK_PH)
+    def test_interaction_origin_defaults_to_none(self, mock_ph, mock_user) -> None:
+        mock_ph.return_value = [self._ph_config()]
+        mock_user.return_value = []
+
+        build_sandbox_mcp_servers(self._make_task_run(state=None), token=self.TOKEN, scopes="read_only")
+
+        assert mock_ph.call_args.kwargs["interaction_origin"] is None
+
+    @patch(MOCK_USER)
+    @patch(MOCK_PH)
+    def test_preserves_ph_then_user_order(self, mock_ph, mock_user) -> None:
+        # The PostHog MCP config must always precede the user-install configs — the hot-loaded
+        # list and a follow-up turn's list must agree on ordering, not just membership.
+        mock_ph.return_value = [self._ph_config()]
+        mock_user.return_value = [self._user_config()]
+
+        result = build_sandbox_mcp_servers(self._make_task_run(), token=self.TOKEN, scopes="full")
+
+        assert [server["name"] for server in result] == ["posthog", "Linear"]

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -21,7 +21,7 @@ from products.tasks.backend.redis import get_tasks_cache
 if TYPE_CHECKING:
     from posthog.models.user import User
 
-    from products.tasks.backend.models import Task
+    from products.tasks.backend.models import Task, TaskRun
 
 logger = logging.getLogger(__name__)
 
@@ -366,6 +366,44 @@ def _resolve_mcp_url() -> str | None:
         return "http://host.docker.internal:8787/mcp"
 
     return None
+
+
+def build_sandbox_mcp_servers(
+    task_run: TaskRun,
+    *,
+    token: str,
+    scopes: PosthogMcpScopes,
+) -> list[dict[str, Any]]:
+    """Assemble the trusted `mcpServers` list a sandbox agent-server should bind to.
+
+    Single source of truth for the server list pushed via `_posthog/refresh_session`:
+    the single-exec PostHog MCP config plus the task creator's MCP-store installs, each
+    carrying the server-minted OAuth `token` in its `Authorization` header. Both the
+    follow-up-turn refresh (`send_followup_to_sandbox._refresh_sandbox_mcp`) and the
+    web-layer `message_routing.refresh_mcp` call this so the two paths cannot drift —
+    a hot-loaded server list must match what a follow-up turn would produce.
+
+    `interaction_origin` is read from `task_run.state`; `scopes` is supplied by the
+    caller (the run's persisted MCP scopes), never read from `task_run.state`.
+    """
+    interaction_origin = (task_run.state or {}).get("interaction_origin")
+    configs = get_sandbox_ph_mcp_configs(
+        token=token,
+        project_id=task_run.team_id,
+        scopes=scopes,
+        interaction_origin=interaction_origin,
+    )
+    if task_run.task.created_by_id:
+        user_configs = get_user_mcp_server_configs(
+            token=token,
+            team_id=task_run.team_id,
+            user_id=task_run.task.created_by_id,
+            interaction_origin=interaction_origin,
+        )
+        if user_configs:
+            configs = configs + user_configs
+
+    return [config.to_dict() for config in configs]
 
 
 def get_github_token(github_integration_id: int) -> Optional[str]:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -6192,7 +6192,16 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_command_rejects_posthog_prefixed_methods(self):
+    @parameterized.expand(
+        [
+            ("posthog_prefixed_user_message", "_posthog/user_message"),
+            # refresh_session is deliberately off the relay allowlist — it carries outbound MCP
+            # URLs + bearer headers and is routed server-side via message_routing.refresh_mcp.
+            ("posthog_prefixed_refresh_session", "_posthog/refresh_session"),
+            ("bare_refresh_session", "refresh_session"),
+        ]
+    )
+    def test_command_rejects_posthog_prefixed_methods(self, _name, method):
         task = self.create_task()
         run = self._create_run_with_sandbox(task)
 
@@ -6200,7 +6209,7 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
             self._command_url(task, run),
             {
                 "jsonrpc": "2.0",
-                "method": "_posthog/user_message",
+                "method": method,
                 "params": {"content": "Hello via posthog prefix"},
             },
             format="json",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39637,6 +39637,50 @@ export namespace Schemas {
     }
 
     /**
+     * * `mcp_store_install` - mcp_store_install
+     * * `mcp_store_uninstall` - mcp_store_uninstall
+     * * `manual` - manual
+     */
+    export type RefreshMcpRequestSourceEnum = typeof RefreshMcpRequestSourceEnum[keyof typeof RefreshMcpRequestSourceEnum];
+
+
+    export const RefreshMcpRequestSourceEnum = {
+      McpStoreInstall: 'mcp_store_install',
+      McpStoreUninstall: 'mcp_store_uninstall',
+      Manual: 'manual',
+    } as const;
+
+    /**
+     * Request body for `POST /conversations/{id}/refresh_mcp/`.
+     *
+     * Carries NO server list. The trusted `mcpServers` payload (URLs + bearer headers) is
+     * rebuilt entirely server-side from the user's current MCP-store installs — the browser
+     * is only the trigger, never the source of the server list.
+     */
+    export interface RefreshMcpRequest {
+      /** Optional telemetry tag describing what prompted the refresh. Has no effect on the rebuilt server list.
+       *
+       * * `mcp_store_install` - mcp_store_install
+       * * `mcp_store_uninstall` - mcp_store_uninstall
+       * * `manual` - manual */
+      source?: RefreshMcpRequestSourceEnum | null;
+    }
+
+    /**
+     * Response for `POST /conversations/{id}/refresh_mcp/` — the targeted Run and whether a refresh was dispatched.
+     */
+    export interface RefreshMcpResponse {
+      /** The products/tasks Task backing the conversation. */
+      task_id: string;
+      /** The Run targeted for the MCP refresh. Empty when no live run exists. */
+      run_id: string;
+      /** Status of the targeted Run. Empty when no live run exists. */
+      run_status: string;
+      /** True when a refresh command was delivered to a live run; false for an idempotent no-op (no/terminal run). */
+      refresh_requested: boolean;
+    }
+
+    /**
      * Request body for `remember`.
      */
     export interface RememberRequest {


### PR DESCRIPTION
## Problem

MCP hot-loading (new tools appear on the next turn after a user installs an MCP server, without a new Run) needs `_posthog/refresh_session` to reach the live sandbox. The browser relay rejects it with a 400. Implements the G8 plan.

## Changes

- **Security-driven design:** route the refresh **server-side**, not via the relay allowlist. A `refresh_session` payload carries outbound MCP URLs + `Authorization` bearer headers that the sandbox trusts verbatim, and the relay forwards params verbatim — so the browser must never be the source of that list.
- New `refresh_mcp()` on `MessageRoutingService`: rebuilds the trusted `mcpServers` list from PostHog state (server-minted tokens, `scopes="full"` to match PHAI runs), calls the existing SSRF-guarded `send_refresh_session`, is idempotent on terminal/no-run, and maps the agent-server's "prompt in flight" response to a soft retryable 409 (not a 500).
- New schema-annotated `POST /conversations/{id}/refresh_mcp/` action — request body carries **no** `mcpServers`.
- Shared `build_sandbox_mcp_servers(...)` helper de-duplicates the config builder between `refresh_mcp` and `send_followup_to_sandbox` (refactor-equivalence test).
- Relay allowlist intentionally **unchanged** (with an explanatory comment + a negative test that it still 400s for `refresh_session`).

## How did you test this code?

Authored by an agent (Claude Code). Automated tests run on this branch:

- `ruff` + `uv run ty check` — clean.
- `test_message_routing.py` — 35 passed (`TestHandleSandboxRefreshMcp`: full-scopes delegation, no-op on terminal/no-run, ValidationError on no-task, mid-turn → 409, transport → 502).
- `test_conversation_refresh_mcp.py` — 8 passed (200 happy path, 409 mid-turn, 502 unreachable, 400 non-sandbox, 404 other-user).
- `test_api.py::TestTaskRunCommandAPI` — 54 passed (relay still rejects `refresh_session`).
- `hogli build:openapi` regenerated.

Review caught a real bug (now fixed in this PR): the Twig agent-server's `/command` catch-all flattens the `-32002` "prompt in flight" error to JSON-RPC `-32000` (HTTP 200) on the wire, so the original code would 502 instead of 409. Now matches the error-message substring + a test against the real `-32000` shape.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

This intentionally deviates from the spec sections that describe the browser POSTing the `mcpServers` array; those design docs should be updated to reflect the server-side approach.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via a Claude Code multi-agent workflow (implement → adversarial review → fix). Design (b) (server-side trigger) was chosen over (a) (relay allowlist) on security grounds — the relay's verbatim-forward invariant must not carry network destinations or credentials. The frontend trigger (a kea listener after MCP-store install) is deferred until that UI surface lands; this PR ships the server capability (steps 1–4). Reviewer verdict: issues → fixed (the -32000 wire-shape bug above).
