### PR TITLE
feat(posthog-ai): sandbox tool-card parity for built-in tools

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -197,7 +197,15 @@ function SandboxThread(): JSX.Element {
                         return null
                     }
                     const entry = lookupMcpToolRenderer(message.resolvedKey)
-                    return <entry.Renderer key={item.id} message={message} isLastInGroup />
+                    return (
+                        <entry.Renderer
+                            key={item.id}
+                            message={message}
+                            isLastInGroup
+                            icon={entry.icon}
+                            displayName={entry.displayName}
+                        />
+                    )
                 }
                 if (item.type === 'error') {
                     return (

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -132,6 +132,7 @@ function toolInvocationToMessage(
         rawServerName: invocation.rawServerName,
         rawToolName: invocation.rawToolName,
         innerToolName: invocation.innerToolName,
+        claudeToolName: invocation.claudeToolName,
         rawInput: invocation.input,
         innerInput: invocation.innerInput,
         rawOutput: invocation.output,

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -253,6 +253,8 @@ export interface McpToolCallMessage {
     rawServerName: string
     rawToolName: string
     innerToolName?: string
+    /** Stable SDK tool name from `_meta.claudeCode.toolName` — set for Claude built-ins. */
+    claudeToolName?: string
     /** rawInput at `tool_call` (for `exec`, includes the wrapper `{ command }`). */
     rawInput: Record<string, unknown>
     /** JSON-parsed inner args when `innerToolName` is set. */

--- a/frontend/src/scenes/max/mcpToolRegistry.test.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.test.tsx
@@ -52,4 +52,49 @@ describe('mcpToolRegistry data-tool widgets', () => {
         // A single LLM trace has no inline renderer, so the tool stays on the fallback card.
         expect(mcpToolRegistry.lookup('query-llm-trace')).toBeNull()
     })
+
+    // Claude built-ins are keyed by their stable SDK name and all reuse the fallback renderer; the
+    // registry contributes a friendly displayName + icon (not the wrench fallback's resolvedKey/wrench).
+    const builtinCases: [string, string][] = [
+        ['Read', 'Read'],
+        ['NotebookRead', 'Read'],
+        ['Edit', 'Edit'],
+        ['Write', 'Edit'],
+        ['NotebookEdit', 'Edit'],
+        ['MultiEdit', 'Edit'],
+        ['Grep', 'Search'],
+        ['Glob', 'Search'],
+        ['LS', 'Search'],
+        ['Bash', 'Terminal'],
+        ['BashOutput', 'Terminal'],
+        ['KillShell', 'Terminal'],
+        ['WebSearch', 'Web'],
+        ['WebFetch', 'Web'],
+        ['Task', 'Subagent'],
+        ['Agent', 'Subagent'],
+        ['TaskCreate', 'Tasks'],
+        ['TaskUpdate', 'Tasks'],
+        ['TaskGet', 'Tasks'],
+        ['TaskList', 'Tasks'],
+        ['TodoWrite', 'Tasks'],
+        ['Skill', 'Skill'],
+        ['ToolSearch', 'Tool search'],
+        ['ExitPlanMode', 'Plan'],
+        ['AskUserQuestion', 'Question'],
+    ]
+
+    it.each(builtinCases)('resolves built-in %s to a registered entry with displayName "%s"', (key, displayName) => {
+        // A registered built-in entry exists — the lookup is not the synthesized wrench fallback.
+        const entry = mcpToolRegistry.lookup(key)
+        expect(entry).not.toBeNull()
+        expect(entry?.displayName).toEqual(displayName)
+        expect(lookupMcpToolRenderer(key).displayName).toEqual(displayName)
+    })
+
+    it('still falls back to the wrench card for an unmapped built-in-looking name', () => {
+        expect(mcpToolRegistry.lookup('NotARealTool')).toBeNull()
+        const fallback = lookupMcpToolRenderer('NotARealTool')
+        expect(fallback.displayName).toEqual('NotARealTool')
+        expect(fallback.Renderer).toBe(FallbackMcpToolRenderer)
+    })
 })

--- a/frontend/src/scenes/max/mcpToolRegistry.test.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.test.tsx
@@ -1,3 +1,8 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import type { McpToolCallMessage } from './maxTypes'
 import { lookupMcpToolRenderer, mcpToolRegistry } from './mcpToolRegistry'
 import { CreateInsightWidget } from './messages/adapters/CreateInsightWidget'
 import { ErrorTrackingWidget } from './messages/adapters/ErrorTrackingWidget'
@@ -5,6 +10,19 @@ import { QueryWidget } from './messages/adapters/QueryWidget'
 import { SearchSessionRecordingsWidget } from './messages/adapters/SearchSessionRecordingsWidget'
 import { UpsertDashboardWidget } from './messages/adapters/UpsertDashboardWidget'
 import { FallbackMcpToolRenderer } from './messages/FallbackMcpToolRenderer'
+
+function makeMessage(overrides: Partial<McpToolCallMessage> = {}): McpToolCallMessage {
+    return {
+        id: 'tc-1',
+        resolvedKey: 'Edit',
+        rawServerName: 'posthog',
+        rawToolName: '',
+        rawInput: {},
+        content: [],
+        status: 'completed',
+        ...overrides,
+    }
+}
 
 describe('mcpToolRegistry data-tool widgets', () => {
     const cases: [string, React.ComponentType<any>][] = [
@@ -96,5 +114,44 @@ describe('mcpToolRegistry data-tool widgets', () => {
         const fallback = lookupMcpToolRenderer('NotARealTool')
         expect(fallback.displayName).toEqual('NotARealTool')
         expect(fallback.Renderer).toBe(FallbackMcpToolRenderer)
+    })
+
+    // Render-level: the registry's icon/displayName must actually reach the card, not just the entry.
+    // This is the regression the entry-only assertions above cannot catch — the card hard-coded a
+    // wrench and ignored the entry, so a built-in still rendered identically to the fallback.
+    describe('rendered card consumes the registry entry', () => {
+        it('renders the registry icon (not the wrench) and the displayName as the header', () => {
+            const entry = lookupMcpToolRenderer('Edit')
+            const message = makeMessage({ resolvedKey: 'Edit', title: '' })
+            // Mounted exactly as Thread.tsx mounts it: pass the resolved entry's icon + displayName.
+            render(
+                <entry.Renderer
+                    message={message}
+                    isLastInGroup
+                    icon={<span data-attr="resolved-icon">icon</span>}
+                    displayName={entry.displayName}
+                />
+            )
+            // The friendly displayName is the header label when the wire title is empty.
+            expect(screen.getByText('Edit')).toBeInTheDocument()
+            // The provided icon renders — the card no longer ignores props.icon in favor of the wrench.
+            expect(screen.getByTestId('resolved-icon')).toBeInTheDocument()
+        })
+
+        it('prefers the wire title over the displayName when a title is present', () => {
+            const message = makeMessage({ resolvedKey: 'Edit', title: 'Edit `foo.ts`' })
+            render(<FallbackMcpToolRenderer message={message} displayName="Edit" isLastInGroup />)
+            expect(screen.getByText('Edit `foo.ts`')).toBeInTheDocument()
+        })
+
+        it('falls back to the wrench when mounted without a resolved icon', () => {
+            const { container } = render(
+                <FallbackMcpToolRenderer message={makeMessage({ title: 'Tool call' })} isLastInGroup />
+            )
+            // No sentinel icon was passed, so the header's icon slot holds the hard-coded wrench svg.
+            const iconSlot = container.querySelector('.text-base.flex.items-center')
+            expect(iconSlot).not.toBeNull()
+            expect(iconSlot?.querySelector('svg')).toBeInTheDocument()
+        })
     })
 })

--- a/frontend/src/scenes/max/mcpToolRegistry.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.tsx
@@ -41,6 +41,14 @@ import { FallbackMcpToolRenderer } from './messages/FallbackMcpToolRenderer'
 export interface McpToolRendererProps {
     message: McpToolCallMessage
     isLastInGroup: boolean
+    /**
+     * Resolved registry entry's icon — the registry's contribution to the card. Renderers that fall
+     * through to `FallbackMcpToolRenderer` use it for the header icon (built-ins get their friendly
+     * icon instead of the generic wrench). Optional so direct mounts default to the wrench.
+     */
+    icon?: JSX.Element
+    /** Resolved registry entry's stable display name, used as the header label when no title exists. */
+    displayName?: string
 }
 
 export interface McpToolRegistryEntry {

--- a/frontend/src/scenes/max/mcpToolRegistry.tsx
+++ b/frontend/src/scenes/max/mcpToolRegistry.tsx
@@ -1,21 +1,33 @@
 import type { ComponentType } from 'react'
 
 import {
+    IconAI,
     IconDashboard,
+    IconDocument,
+    IconEye,
     IconFunnels,
+    IconGlobe,
     IconGraph,
     IconLifecycle,
+    IconListCheck,
     IconLlmAnalytics,
+    IconMagicWand,
     IconNotebook,
+    IconPencil,
     IconPerson,
     IconRetention,
     IconRewindPlay,
+    IconSearch,
     IconStickiness,
+    IconTerminal,
     IconTrends,
     IconUserPaths,
     IconWarning,
     IconWrench,
 } from '@posthog/icons'
+
+// IconRobot is not exported from @posthog/icons — it lives only in the legacy lib icon set.
+import { IconRobot } from 'lib/lemon-ui/icons'
 
 import type { McpToolCallMessage } from './maxTypes'
 import { CreateInsightWidget } from './messages/adapters/CreateInsightWidget'
@@ -148,6 +160,35 @@ const QUERY_WRAPPER_TOOLS: { key: string; displayName: string; icon: JSX.Element
 ]
 for (const { key, displayName, icon } of QUERY_WRAPPER_TOOLS) {
     mcpToolRegistry.register({ key, displayName, icon, Renderer: QueryWidget })
+}
+
+// --- Claude built-in tools ---
+// Keyed by the stable SDK tool name (reachable via `_meta.claudeCode.toolName`). All reuse the
+// fallback card — the goal is a friendly title + icon, not a bespoke widget. The fallback header
+// already prefers Twig's rich `title` (e.g. "Edit `foo.ts`"), so these supply the icon and a stable
+// `displayName` for any frame whose title is empty. `MultiEdit`/`Skill` are registered speculatively
+// (not enumerated in Twig's tools.ts) — zero cost if never emitted.
+const BUILTIN_TOOLS: { keys: string[]; displayName: string; icon: JSX.Element }[] = [
+    { keys: ['Read', 'NotebookRead'], displayName: 'Read', icon: <IconEye /> },
+    { keys: ['Edit', 'Write', 'NotebookEdit', 'MultiEdit'], displayName: 'Edit', icon: <IconPencil /> },
+    { keys: ['Grep', 'Glob', 'LS'], displayName: 'Search', icon: <IconSearch /> },
+    { keys: ['Bash', 'BashOutput', 'KillShell'], displayName: 'Terminal', icon: <IconTerminal /> },
+    { keys: ['WebSearch', 'WebFetch'], displayName: 'Web', icon: <IconGlobe /> },
+    { keys: ['Task', 'Agent'], displayName: 'Subagent', icon: <IconRobot /> },
+    {
+        keys: ['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TodoWrite'],
+        displayName: 'Tasks',
+        icon: <IconListCheck />,
+    },
+    { keys: ['Skill'], displayName: 'Skill', icon: <IconMagicWand /> },
+    { keys: ['ToolSearch'], displayName: 'Tool search', icon: <IconSearch /> },
+    { keys: ['ExitPlanMode'], displayName: 'Plan', icon: <IconDocument /> },
+    { keys: ['AskUserQuestion'], displayName: 'Question', icon: <IconAI /> },
+]
+for (const { keys, displayName, icon } of BUILTIN_TOOLS) {
+    for (const key of keys) {
+        mcpToolRegistry.register({ key, displayName, icon, Renderer: FallbackMcpToolRenderer })
+    }
 }
 
 /** Looks up the renderer entry for a resolved tool key, falling back to the generic card. */

--- a/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
+++ b/frontend/src/scenes/max/messages/FallbackMcpToolRenderer.tsx
@@ -45,8 +45,11 @@ function statusBadge(status: McpToolRendererProps['message']['status']): JSX.Ele
  * MCPs, unknown inner tools, malformed `exec` commands. Renders a generic, greppable tool card so
  * the registry can ship incrementally.
  */
-export function FallbackMcpToolRenderer({ message }: McpToolRendererProps): JSX.Element {
-    const headerLabel = message.title || message.innerToolName || message.rawToolName || 'Tool call'
+export function FallbackMcpToolRenderer({ message, icon, displayName }: McpToolRendererProps): JSX.Element {
+    const headerLabel = message.title || message.innerToolName || displayName || message.rawToolName || 'Tool call'
+    // The registry entry contributes the icon (friendly built-in icons, data-tool icons); fall back to
+    // the generic wrench only when the renderer is mounted without a resolved entry.
+    const headerIcon = icon ?? <IconWrench className="text-base" />
     const contentText = message.content.length > 0 ? renderContentBlocks(message.content) : ''
     const outputText =
         message.rawOutput !== undefined && message.rawOutput !== null ? JSON.stringify(message.rawOutput, null, 2) : ''
@@ -56,7 +59,7 @@ export function FallbackMcpToolRenderer({ message }: McpToolRendererProps): JSX.
             type="ai"
             header={
                 <div className="flex items-center gap-1.5 text-sm text-secondary mb-1">
-                    <IconWrench className="text-base" />
+                    <span className="text-base flex items-center">{headerIcon}</span>
                     <span className="font-medium text-default">{headerLabel}</span>
                     {statusBadge(message.status)}
                 </div>

--- a/frontend/src/scenes/max/messages/adapters/CreateInsightWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateInsightWidget.tsx
@@ -8,11 +8,12 @@ import { extractVisualizationArtifact } from './extractors'
  * artifact lands (pending / in-progress / malformed output) we fall back to the generic card so
  * the call still renders something.
  */
-export function CreateInsightWidget({ message, isLastInGroup }: McpToolRendererProps): JSX.Element {
+export function CreateInsightWidget(props: McpToolRendererProps): JSX.Element {
+    const { message } = props
     const artifact = message.status === 'completed' ? extractVisualizationArtifact(message) : null
 
     if (!artifact) {
-        return <FallbackMcpToolRenderer message={message} isLastInGroup={isLastInGroup} />
+        return <FallbackMcpToolRenderer {...props} />
     }
 
     const target = getArtifactOpenTarget(artifact.envelope, artifact.content)

--- a/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/CreateNotebookWidget.tsx
@@ -46,11 +46,12 @@ export function extractNotebook(message: McpToolRendererProps['message']): Noteb
  * ProseMirror document, not the assistant block format `NotebookArtifactAnswer` renders.
  * Pre-completion or malformed output falls back to the generic card.
  */
-export function CreateNotebookWidget({ message, isLastInGroup }: McpToolRendererProps): JSX.Element {
+export function CreateNotebookWidget(props: McpToolRendererProps): JSX.Element {
+    const { message } = props
     const notebook = message.status === 'completed' ? extractNotebook(message) : null
 
     if (!notebook) {
-        return <FallbackMcpToolRenderer message={message} isLastInGroup={isLastInGroup} />
+        return <FallbackMcpToolRenderer {...props} />
     }
 
     return (

--- a/frontend/src/scenes/max/messages/adapters/ErrorTrackingWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/ErrorTrackingWidget.tsx
@@ -9,11 +9,12 @@ import { extractErrorTrackingResponse } from './extractors'
  * pushes filters into the error-tracking scene when it is active). Pre-completion or missing output
  * falls back to the generic card.
  */
-export function ErrorTrackingWidget({ message, isLastInGroup }: McpToolRendererProps): JSX.Element {
+export function ErrorTrackingWidget(props: McpToolRendererProps): JSX.Element {
+    const { message } = props
     const filters = message.status === 'completed' ? extractErrorTrackingResponse(message) : null
 
     if (!filters) {
-        return <FallbackMcpToolRenderer message={message} isLastInGroup={isLastInGroup} />
+        return <FallbackMcpToolRenderer {...props} />
     }
 
     return <ErrorTrackingFiltersWidget toolCallId={message.id} filters={filters} />

--- a/frontend/src/scenes/max/messages/adapters/QueryWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/QueryWidget.tsx
@@ -8,11 +8,12 @@ import { extractQueryResult } from './extractors'
  * `VisualizationWidget` as inline ephemeral visualizations. Pending calls and outputs without an
  * inline renderer fall back to the generic card.
  */
-export function QueryWidget({ message, isLastInGroup }: McpToolRendererProps): JSX.Element {
+export function QueryWidget(props: McpToolRendererProps): JSX.Element {
+    const { message } = props
     const result = message.status === 'completed' ? extractQueryResult(message) : null
 
     if (!result) {
-        return <FallbackMcpToolRenderer message={message} isLastInGroup={isLastInGroup} />
+        return <FallbackMcpToolRenderer {...props} />
     }
 
     return <VisualizationWidget content={result.content} openUrl={result.url} openTooltip="Open as insight" />

--- a/frontend/src/scenes/max/messages/adapters/SearchSessionRecordingsWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/SearchSessionRecordingsWidget.tsx
@@ -8,11 +8,12 @@ import { extractRecordingFilters } from './extractors'
  * in `rawOutput.filters`; `RecordingsWidget` renders the live playlist inline. Pre-completion or a
  * missing filter object falls back to the generic card.
  */
-export function SearchSessionRecordingsWidget({ message, isLastInGroup }: McpToolRendererProps): JSX.Element {
+export function SearchSessionRecordingsWidget(props: McpToolRendererProps): JSX.Element {
+    const { message } = props
     const filters = message.status === 'completed' ? extractRecordingFilters(message) : null
 
     if (!filters) {
-        return <FallbackMcpToolRenderer message={message} isLastInGroup={isLastInGroup} />
+        return <FallbackMcpToolRenderer {...props} />
     }
 
     return <RecordingsWidget toolCallId={message.id} filters={filters} />

--- a/frontend/src/scenes/max/messages/adapters/UpsertDashboardWidget.tsx
+++ b/frontend/src/scenes/max/messages/adapters/UpsertDashboardWidget.tsx
@@ -14,11 +14,12 @@ import { extractDashboard } from './extractors'
  * dashboard embed is deliberately deferred). Pre-completion or malformed output falls back to
  * the generic card.
  */
-export function UpsertDashboardWidget({ message, isLastInGroup }: McpToolRendererProps): JSX.Element {
+export function UpsertDashboardWidget(props: McpToolRendererProps): JSX.Element {
+    const { message } = props
     const dashboard = message.status === 'completed' ? extractDashboard(message) : null
 
     if (!dashboard) {
-        return <FallbackMcpToolRenderer message={message} isLastInGroup={isLastInGroup} />
+        return <FallbackMcpToolRenderer {...props} />
     }
 
     const to = dashboard.url ?? (dashboard.id !== undefined ? urls.dashboard(dashboard.id) : undefined)

--- a/frontend/src/scenes/max/sandboxStreamLogic.test.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.test.ts
@@ -119,9 +119,24 @@ describe('sandboxStreamLogic', () => {
             )
         })
 
-        it('returns the wire name for non-exec MCP tools and built-ins', () => {
+        it('returns the wire name for non-exec MCP tools that carry one', () => {
             expect(resolveToolKey('user-mcp', 'do_thing', {}).resolvedKey).toEqual('do_thing')
-            expect(resolveToolKey('claude', 'TodoWrite', {}).resolvedKey).toEqual('TodoWrite')
+        })
+
+        it.each(['Edit', 'TodoWrite', 'Grep', 'Task'])(
+            'falls back to the SDK %s name when the wire toolName is empty (every Claude built-in)',
+            (sdkName) => {
+                // Built-ins carry no top-level toolName on the wire — only `_meta.claudeCode.toolName`.
+                expect(resolveToolKey('claude', '', {}, sdkName).resolvedKey).toEqual(sdkName)
+            }
+        )
+
+        it('prefers the explicit wire toolName over the SDK name when both are present', () => {
+            expect(resolveToolKey('user-mcp', 'do_thing', {}, 'Edit').resolvedKey).toEqual('do_thing')
+        })
+
+        it('resolves to empty string when neither a wire toolName nor an SDK name is present', () => {
+            expect(resolveToolKey('claude', '', {}).resolvedKey).toEqual('')
         })
     })
 
@@ -350,15 +365,16 @@ describe('sandboxStreamLogic', () => {
     })
 
     describe('streamed tool input', () => {
-        it('folds rawInput arriving on a later update into a non-exec tool call', async () => {
+        it('folds rawInput arriving on a later update into a built-in tool call keyed off _meta', async () => {
+            // Built-ins carry no top-level toolName — the SDK name arrives only on `_meta.claudeCode`.
             const frames: StoredLogEntry[] = [
                 sessionUpdate({
                     sessionUpdate: 'tool_call',
                     toolCallId: 't1',
-                    toolName: 'ToolSearch',
                     title: 'ToolSearch',
                     rawInput: {},
                     status: 'pending',
+                    _meta: { claudeCode: { toolName: 'ToolSearch' } },
                 }),
                 sessionUpdate({
                     sessionUpdate: 'tool_call_update',
@@ -375,6 +391,7 @@ describe('sandboxStreamLogic', () => {
             const invocation = logic.values.toolInvocations.get('t1')
             expect(invocation?.input).toEqual({ query: 'find recordings', max_results: 10 })
             expect(invocation?.resolvedKey).toEqual('ToolSearch')
+            expect(invocation?.claudeToolName).toEqual('ToolSearch')
         })
 
         it('re-resolves the registry key when an exec command streams in after an empty tool_call', async () => {
@@ -404,6 +421,30 @@ describe('sandboxStreamLogic', () => {
             expect(invocation?.innerToolName).toEqual('insight-create')
             expect(invocation?.innerInput).toEqual({ name: 'Signups' })
         })
+
+        it.each(['Edit', 'TodoWrite', 'Grep', 'Task'])(
+            'keys a built-in %s tool_call off _meta.claudeCode.toolName despite an empty wire toolName',
+            async (sdkName) => {
+                const frames: StoredLogEntry[] = [
+                    sessionUpdate({
+                        sessionUpdate: 'tool_call',
+                        toolCallId: 'tb',
+                        title: `${sdkName} \`foo.ts\``,
+                        rawInput: {},
+                        status: 'in_progress',
+                        _meta: { claudeCode: { toolName: sdkName } },
+                    }),
+                ]
+
+                await expectLogic(logic, () => {
+                    frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+                }).toFinishAllListeners()
+
+                const invocation = logic.values.toolInvocations.get('tb')
+                expect(invocation?.resolvedKey).toEqual(sdkName)
+                expect(invocation?.claudeToolName).toEqual(sdkName)
+            }
+        )
 
         it('keeps the resolved input when a later update carries none', async () => {
             const frames: StoredLogEntry[] = [
@@ -562,21 +603,33 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.toolInvocations.get('t2')?.error?.message).toEqual('sandbox crashed')
         })
 
-        it('falls back to the _meta decision reason when a denied update carries no error message', async () => {
+        it('surfaces the _meta.claudeCode denial reason on a failed update with no explicit error', async () => {
             const frames: StoredLogEntry[] = [
                 sessionUpdate({
                     sessionUpdate: 'tool_call',
                     toolCallId: 't3',
-                    serverName: 'posthog',
-                    toolName: 'exec',
-                    rawInput: { command: 'call insight-create {}' },
+                    title: 'Edit `foo.ts`',
+                    rawInput: {},
                     status: 'in_progress',
+                    _meta: { claudeCode: { toolName: 'Edit' } },
                 }),
                 sessionUpdate({
                     sessionUpdate: 'tool_call_update',
                     toolCallId: 't3',
                     status: 'failed',
-                    _meta: { decision_reason: 'User rejected the operation' },
+                    content: [
+                        { type: 'content', content: { type: 'text', text: 'Permission denied: writes blocked' } },
+                    ],
+                    _meta: {
+                        claudeCode: {
+                            toolName: 'Edit',
+                            toolResponse: {
+                                decisionReason: 'Edits are not allowed in read-only mode',
+                                decisionReasonType: 'policy',
+                                message: 'denied',
+                            },
+                        },
+                    },
                 }),
             ]
 
@@ -584,7 +637,9 @@ describe('sandboxStreamLogic', () => {
                 frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
             }).toFinishAllListeners()
 
-            expect(logic.values.toolInvocations.get('t3')?.error?.message).toEqual('User rejected the operation')
+            const invocation = logic.values.toolInvocations.get('t3')
+            expect(invocation?.status).toEqual('failed')
+            expect(invocation?.error?.message).toEqual('Edits are not allowed in read-only mode')
         })
 
         it('upserts a renderable invocation from a terminal update whose tool_call frame was lost', async () => {
@@ -601,6 +656,37 @@ describe('sandboxStreamLogic', () => {
             expect(logic.values.toolInvocations.get('orphan')?.status).toEqual('completed')
             expect(logic.values.threadItems.some((item) => item.toolCallId === 'orphan')).toEqual(true)
             expect(captureSpy.mock.calls.filter((c) => c[0] === 'tool_call_completed')).toHaveLength(0)
+        })
+
+        it('does not throw and keeps no error on the inline-denial path (failed, no _meta)', async () => {
+            const frames: StoredLogEntry[] = [
+                sessionUpdate({
+                    sessionUpdate: 'tool_call',
+                    toolCallId: 't4',
+                    title: 'Bash `rm -rf`',
+                    rawInput: {},
+                    status: 'in_progress',
+                    _meta: { claudeCode: { toolName: 'Bash' } },
+                }),
+                sessionUpdate({
+                    sessionUpdate: 'tool_call_update',
+                    toolCallId: 't4',
+                    status: 'failed',
+                    content: [
+                        { type: 'content', content: { type: 'text', text: 'User refused permission to run Bash' } },
+                    ],
+                }),
+            ]
+
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            const invocation = logic.values.toolInvocations.get('t4')
+            expect(invocation?.status).toEqual('failed')
+            // No _meta and no explicit error → the renderer falls back to the content text; no error.message synthesized.
+            expect(invocation?.error?.message).toBeUndefined()
+            expect(invocation?.contentBlocks).toHaveLength(1)
         })
     })
 
@@ -1192,6 +1278,23 @@ describe('sandboxStreamLogic', () => {
             const record = parsePermissionRequestFrame(frame as unknown as PermissionRequestFrame)
             expect(record?.options.map((o) => o.kind)).toEqual(['allow_once', 'allow_always', 'reject_once'])
             expect(record?.options.find((o) => o.kind === 'reject_once')?.customInput).toEqual(true)
+        })
+
+        it('names the inner tool when the toolCall carries _meta.claudeCode.toolName', () => {
+            const record = parsePermissionRequestFrame({
+                type: 'permission_request',
+                requestId: 'req-2',
+                toolCall: {
+                    toolCallId: 't9',
+                    title: 'Edit `app.ts`',
+                    status: 'pending',
+                    _meta: { claudeCode: { toolName: 'Edit' } },
+                },
+                options: [{ optionId: 'allow_once', name: 'Approve', kind: 'allow_once' }],
+            })
+            expect(record).not.toBeNull()
+            expect(record?.rawToolCall.resolvedKey).toEqual('Edit')
+            expect(record?.rawToolCall.claudeToolName).toEqual('Edit')
         })
 
         it('populates pendingPermissionRequest off a permission_request SSE frame', async () => {

--- a/frontend/src/scenes/max/sandboxStreamLogic.ts
+++ b/frontend/src/scenes/max/sandboxStreamLogic.ts
@@ -128,12 +128,54 @@ interface ResolvedToolKey {
     innerInput?: Record<string, unknown>
 }
 
+/** Reads `_meta.claudeCode` off a tool frame's `_meta` without trusting its shape. */
+function getClaudeCodeMeta(meta: unknown): Record<string, unknown> | undefined {
+    if (typeof meta !== 'object' || meta === null) {
+        return undefined
+    }
+    const claudeCode = (meta as { claudeCode?: unknown }).claudeCode
+    return typeof claudeCode === 'object' && claudeCode !== null ? (claudeCode as Record<string, unknown>) : undefined
+}
+
+/** Stable SDK tool name (`"Edit"`, `"TodoWrite"`) from `_meta.claudeCode.toolName`; undefined when absent. */
+export function extractClaudeToolName(meta: unknown): string | undefined {
+    const claudeCode = getClaudeCodeMeta(meta)
+    return typeof claudeCode?.toolName === 'string' && claudeCode.toolName ? claudeCode.toolName : undefined
+}
+
+/**
+ * Permission-denial reason from `_meta.claudeCode.toolResponse`, preferring `decisionReason` over
+ * the generic `message`. Returns undefined when no `_meta` is present (the inline `canUseTool` path),
+ * so the caller can fall back to the content text / existing error.
+ */
+export function extractDenialReason(meta: unknown): string | undefined {
+    const claudeCode = getClaudeCodeMeta(meta)
+    const toolResponse = claudeCode?.toolResponse
+    if (typeof toolResponse !== 'object' || toolResponse === null) {
+        return undefined
+    }
+    const r = toolResponse as { decisionReason?: unknown; message?: unknown }
+    if (typeof r.decisionReason === 'string' && r.decisionReason) {
+        return r.decisionReason
+    }
+    if (typeof r.message === 'string' && r.message) {
+        return r.message
+    }
+    return undefined
+}
+
 /**
  * Resolves the registry key for a tool call. The single-exec `posthog` MCP server exposes one
  * outer `exec` tool; the inner tool name is parsed out of `rawInput.command`. Non-exec MCP tools
- * and Claude built-ins look up by their wire name directly.
+ * and Claude built-ins look up by their wire name directly. Claude built-ins carry no wire
+ * `toolName`, so `claudeToolName` (from `_meta.claudeCode.toolName`) is preferred as the fallback.
  */
-export function resolveToolKey(serverName: string, toolName: string, input: Record<string, unknown>): ResolvedToolKey {
+export function resolveToolKey(
+    serverName: string,
+    toolName: string,
+    input: Record<string, unknown>,
+    claudeToolName?: string
+): ResolvedToolKey {
     const fullName = `mcp__${serverName}__${toolName}`
 
     if (POSTHOG_EXEC_TOOL_RE.test(fullName) && typeof input.command === 'string') {
@@ -167,7 +209,7 @@ export function resolveToolKey(serverName: string, toolName: string, input: Reco
         return { resolvedKey: innerToolName, innerToolName, innerInput }
     }
 
-    return { resolvedKey: toolName }
+    return { resolvedKey: toolName || claudeToolName || '' }
 }
 
 /**
@@ -257,9 +299,18 @@ export function parsePermissionRequestFrame(
     }
 
     const rawServerName = String(toolCall.serverName ?? 'posthog')
-    const rawToolName = String(toolCall.toolName ?? toolCall.title ?? '')
+    // MCP-tool approval frames stamp the inner SDK tool name under `_meta.claudeCode.toolName`; pass
+    // it through so the card names the inner tool. No-op when absent (the field may not be present yet).
+    const claudeToolName = extractClaudeToolName(toolCall._meta)
+    const wireToolName = String(toolCall.toolName ?? '')
+    const rawToolName = wireToolName || (claudeToolName ? '' : String(toolCall.title ?? ''))
     const input = (toolCall.rawInput ?? toolCall.input ?? {}) as Record<string, unknown>
-    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(rawServerName, rawToolName, input)
+    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(
+        rawServerName,
+        wireToolName,
+        input,
+        claudeToolName
+    )
 
     // Canonical ACP tool name (e.g. `mcp__posthog__exec`, or a built-in like `Bash`). The wire puts
     // it on `_meta.claudeCode.toolName`; the bare fields are the fallback. The default permission
@@ -281,6 +332,7 @@ export function parsePermissionRequestFrame(
             rawToolName,
             innerToolName,
             resolvedKey,
+            claudeToolName,
             input,
             innerInput,
             status: mapAcpStatus(toolCall.status),
@@ -1095,15 +1147,25 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                         break
                     }
                     const rawServerName = String(update.serverName ?? 'posthog')
-                    const rawToolName = String(update.toolName ?? update.title ?? '')
+                    const claudeToolName = extractClaudeToolName(update._meta)
+                    const wireToolName = String(update.toolName ?? '')
+                    // `rawToolName` is the displayed name (wire name, or the human title for built-ins
+                    // that carry no name); the resolver keys off the wire name + SDK name instead.
+                    const rawToolName = wireToolName || (claudeToolName ? '' : String(update.title ?? ''))
                     const input = update.rawInput ?? update.input ?? {}
-                    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(rawServerName, rawToolName, input)
+                    const { resolvedKey, innerToolName, innerInput } = resolveToolKey(
+                        rawServerName,
+                        wireToolName,
+                        input,
+                        claudeToolName
+                    )
                     actions.upsertToolInvocation({
                         toolCallId,
                         rawServerName,
                         rawToolName,
                         innerToolName,
                         resolvedKey,
+                        claudeToolName,
                         input,
                         innerInput,
                         status: mapAcpStatus(update.status),
@@ -1128,12 +1190,14 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                             : update.input && typeof update.input === 'object'
                               ? update.input
                               : undefined
-                    // A rejected call carries its denial reason on `_meta` (ACP adapter v0.42+), not
-                    // `error` — fall back to it so the failed tool card explains why it was denied.
+                    // On a permission denial Twig stamps the reason under `_meta.claudeCode.toolResponse`;
+                    // prefer it for the error when the update carries no explicit error, and fall back to
+                    // the notification-level error (and, for the inline `canUseTool` path that sends no
+                    // `_meta`, to the existing/content error) so neither path regresses.
+                    const denialReason = status === 'failed' ? extractDenialReason(update._meta) : undefined
                     const errorMessage =
                         update.error?.message ??
-                        update._meta?.decision_reason ??
-                        update._meta?.message ??
+                        denialReason ??
                         (status === 'failed' ? notification.error?.message : undefined)
                     const updateContent = Array.isArray(update.content) ? update.content : []
 
@@ -1170,7 +1234,12 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
                     // input building up), so fold the latest rawInput in and re-resolve the registry
                     // key from it rather than freezing the empty input the initial tool_call carried.
                     const reResolved = rawInput
-                        ? resolveToolKey(existing.rawServerName, existing.rawToolName, rawInput)
+                        ? resolveToolKey(
+                              existing.rawServerName,
+                              existing.rawToolName,
+                              rawInput,
+                              existing.claudeToolName
+                          )
                         : undefined
                     actions.updateToolInvocation(toolCallId, {
                         status,

--- a/frontend/src/scenes/max/types/sandboxStreamTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxStreamTypes.ts
@@ -28,6 +28,8 @@ export interface ToolInvocation {
      * `__posthog_exec_*__` sentinel for discovery verbs, or the wire tool name otherwise.
      */
     resolvedKey: string
+    /** Stable SDK tool name from `_meta.claudeCode.toolName` — set for Claude built-ins, which carry no wire `toolName`. */
+    claudeToolName?: string
     /** rawInput at `tool_call` time (for `exec`, includes the wrapper `{ command }`). */
     input: Record<string, unknown>
     /** JSON-parsed inner args when `innerToolName` is set. */

--- a/frontend/src/scenes/max/types/sandboxWireTypes.test.ts
+++ b/frontend/src/scenes/max/types/sandboxWireTypes.test.ts
@@ -177,9 +177,14 @@ const SESSION_UPDATE_CASES: { kind: string; update: Record<string, unknown> }[] 
             status: 'failed',
             error: { message: 'Permission denied by user' },
             _meta: {
-                decision_reason: 'User rejected the permission request',
-                decision_reason_type: 'user_rejection',
-                message: 'Permission denied',
+                claudeCode: {
+                    toolName: 'execute-sql',
+                    toolResponse: {
+                        decisionReason: 'User rejected the permission request',
+                        decisionReasonType: 'user_rejection',
+                        message: 'Permission denied',
+                    },
+                },
             },
         },
     },
@@ -301,14 +306,16 @@ describe('sandboxWireTypes guards', () => {
         }
     )
 
-    it('carries the v0.42 _meta denial reason on failed tool_call_update frames', () => {
+    it('carries the nested _meta.claudeCode denial reason on failed tool_call_update frames', () => {
         const failedCase = SESSION_UPDATE_CASES.find(({ update }) => update.status === 'failed')
         const wireNotification = notificationOf(sessionUpdate(failedCase!.update))
         const body = isSessionUpdateNotification(wireNotification) ? wireNotification.params?.update : undefined
         if (!isKnownSessionUpdate(body) || body.sessionUpdate !== 'tool_call_update') {
             throw new Error('expected a tool_call_update body')
         }
-        expect(body._meta?.decision_reason).toEqual(expect.any(String))
+        const toolResponse = body._meta?.claudeCode?.toolResponse as { decisionReason?: string } | undefined
+        expect(toolResponse?.decisionReason).toEqual(expect.any(String))
+        expect(body._meta?.claudeCode?.toolName).toEqual(expect.any(String))
         expect(body.error?.message).toEqual(expect.any(String))
     })
 

--- a/frontend/src/scenes/max/types/sandboxWireTypes.ts
+++ b/frontend/src/scenes/max/types/sandboxWireTypes.ts
@@ -155,13 +155,25 @@ export interface SessionUpdateToolCall {
     input?: Record<string, unknown>
     locations?: { path: string; line?: number }[]
     content?: unknown[]
+    _meta?: SessionUpdateToolCallMeta
 }
 
-/** Set on failed updates since ACP adapter v0.42 — carries the permission-denial reason. */
+/**
+ * Claude adapter metadata stamped under `_meta.claudeCode` on every Claude tool frame. `toolName`
+ * is the stable SDK tool name (e.g. "Edit", "TodoWrite") — built-ins carry no top-level `toolName`,
+ * so this is the only place the real name is reachable. `toolResponse` is present on a permission
+ * denial and free-form otherwise. Mirrors Twig's `ToolUpdateMeta`.
+ */
+export interface SessionUpdateClaudeCodeMeta {
+    toolName?: string
+    /** Present on a permission denial; free-form on other frames. */
+    toolResponse?: { decisionReason?: string; decisionReasonType?: string; message?: string } | unknown
+    parentToolCallId?: string
+    bashCommand?: string
+}
+
 export interface SessionUpdateToolCallMeta {
-    decision_reason?: string
-    decision_reason_type?: string
-    message?: string
+    claudeCode?: SessionUpdateClaudeCodeMeta
 }
 
 export interface SessionUpdateToolCallUpdate {


### PR DESCRIPTION
## Problem

Two coupled defects in sandbox tool-call rendering: (1) Claude built-in tools (`Edit`, `Read`, `Grep`, `Bash`, `TodoWrite`, …) rendered with a generic wrench icon and no friendly title; (2) `_meta.claudeCode.*` (the stable SDK tool name, and permission-denial reasons) was emitted by the agent but silently dropped because PostHog's type modeled a flat snake_case shape that doesn't match the wire and `resolveToolKey` never read `_meta`. Implements the G5 plan (sub-tasks A + B; the code-diff sub-task C is deferred-until-producer).

## Changes

- Rewrote `SessionUpdateToolCallMeta` to the real nested `claudeCode` shape; added `_meta?` to `SessionUpdateToolCall`.
- `resolveToolKey` now prefers the stable SDK tool name (built-ins send an empty wire `toolName`), persisted as `claudeToolName` on `ToolInvocation`/`McpToolCallMessage`.
- Permission-denial reason is read from `_meta.claudeCode.toolResponse` and surfaced on the failed card (falls back to content text when `_meta` is absent).
- Registry: friendly icon + `displayName` entries for the built-in tool families, plumbed into the rendered card (so an `Edit` call no longer shows a wrench).

## How did you test this code?

Authored by an agent (Claude Code). Automated tests run on this branch:

- `pnpm … format` — clean.
- `typescript:check` — 0 errors in any scoped file (the 33 remaining errors are pre-existing, in `products/tracing/frontend/*`, confirmed on the base branch).
- Jest — 167 passed across `sandboxStreamLogic.test.ts`, `mcpToolRegistry.test.tsx`, `types/sandboxWireTypes.test.ts`, `messages/FallbackMcpToolRenderer.test.ts`. The two tests that encoded the old flat `_meta` / synthesized a `toolName` were rewritten to the empty-`toolName` + nested-`_meta` reality (the plan's correctness gate).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built via a Claude Code multi-agent workflow (implement → adversarial review → fix). Review caught that the built-in icons/displayNames were registered but never actually rendered (the fallback renderer hard-coded the wrench and ignored the registry entry); now fixed and covered by a render-level test. Telemetry note: `tool_qualified_name` for built-ins now reports the stable SDK name (e.g. `Edit`) instead of the human title — intended, but worth knowing for anyone querying that property. Reviewer verdict: issues → fixed.
